### PR TITLE
MudDataGrid: improved doc about sorting on complex fields (#9041)

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -125,6 +125,17 @@
                     In both <i>active</i> modes, single columns can be excluded from sorting by setting the <CodeInline>Sortable</CodeInline> property to false for that column.
                     When SortMode is set to <CodeInline>SortMode.None</CodeInline> sorting is disabled globally and setting the <CodeInline>Sortable</CodeInline> property on a column has no effect.<br /><br />
                     You can also use the <CodeInline>SortBy</CodeInline> parameter on a <CodeInline>TemplateColumn</CodeInline> to allow sorting on that column.
+                    <br /><br />
+                    When using <CodeInline>PropertyColumn</CodeInline>, if the <CodeInline>Property</CodeInline> lambda expression returns directly a field of the object,
+                    the <CodeInline>SortDefinition</CodeInline>'s <CodeInline>SortBy</CodeInline> will return the Field's <CodeInline>nameof</CodeInline>.
+                    Instead, if the Property lamda expression contains a complex value, the SortBy will return the column GUID.
+                    In this case, if you need to retrieve the column, you have several options:
+                    <MudList T="string" Dense>
+                        <MudListItem>- Set the Title for the TemplateColumn, then get a ref of your MudDataGrid, iterate through RenderedColumns, find the TemplateColumn by that GUID, and extract the title.</MudListItem>
+                        <MudListItem>- Create your own TemplateColumn by inheriting <code>Column&lt;T&gt;</code> and override how the PropertyName behaves and use your own logic instead of the random guid.</MudListItem>
+                        <MudListItem>- Embed a <CodeInline>CellTemplate</CodeInline> inside the PropertyColumn and have the lambda expression of PropertyColumn return the simple field while
+                            writing the ad-hoc logic inside CellTemplate.</MudListItem>
+                    </MudList>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="my-1">Changing the SortMode at runtime will reset any former sort orders on all columns.</MudAlert>
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -126,15 +126,14 @@
                     When SortMode is set to <CodeInline>SortMode.None</CodeInline> sorting is disabled globally and setting the <CodeInline>Sortable</CodeInline> property on a column has no effect.<br /><br />
                     You can also use the <CodeInline>SortBy</CodeInline> parameter on a <CodeInline>TemplateColumn</CodeInline> to allow sorting on that column.
                     <br /><br />
-                    When using <CodeInline>PropertyColumn</CodeInline>, if the <CodeInline>Property</CodeInline> lambda expression returns directly a field of the object,
-                    the <CodeInline>SortDefinition</CodeInline>'s <CodeInline>SortBy</CodeInline> will return the Field's <CodeInline>nameof</CodeInline>.
+                    When using <CodeInline>PropertyColumn</CodeInline>, if the <CodeInline>Property</CodeInline> lambda expression returns a <b>primitive type</b>, 
+                    the <CodeInline>SortDefinition</CodeInline>'s <CodeInline>SortBy</CodeInline> will return the Property's <CodeInline>nameof</CodeInline> value.
                     Instead, if the Property lamda expression contains a complex value, the SortBy will return the column GUID.
                     In this case, if you need to retrieve the column, you have several options:
                     <MudList T="string" Dense>
-                        <MudListItem>- Set the Title for the TemplateColumn, then get a ref of your MudDataGrid, iterate through RenderedColumns, find the TemplateColumn by that GUID, and extract the title.</MudListItem>
-                        <MudListItem>- Create your own TemplateColumn by inheriting <code>Column&lt;T&gt;</code> and override how the PropertyName behaves and use your own logic instead of the random guid.</MudListItem>
-                        <MudListItem>- Embed a <CodeInline>CellTemplate</CodeInline> inside the PropertyColumn and have the lambda expression of PropertyColumn return the simple field while
-                            writing the ad-hoc logic inside CellTemplate.</MudListItem>
+                        <MudListItem>- <b>Embed a CellTemplate within the PropertyColumn</b>: Use the lambda expression of the PropertyColumn to return the primitive Property value, while implementing the more complex, ad-hoc logic in the embedded CellTemplate.</MudListItem>
+                        <MudListItem>- <b>Title lookup via GUID</b>: Assign a Title to the TemplateColumn, and a reference to the MudDataGrid using <code>@@ref</code>. Iterate over the RenderedColumns to find the TemplateColumn by matching its unique identifier (where PropertyName == SortDefinition.SortBy), and extract its Title.</MudListItem>
+                        <MudListItem>- <b>Create a custom TemplateColumn</b>: Inherit from the Column base class and override the PropertyName's default behavior and implement your own custom logic instead of relying on a randomly generated identifier</MudListItem>
                     </MudList>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="my-1">Changing the SortMode at runtime will reset any former sort orders on all columns.</MudAlert>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridServerSideExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridServerSideExample.razor
@@ -1,5 +1,4 @@
 @using System.Net.Http.Json
-@using System.Threading
 @using MudBlazor.Examples.Data.Models
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
@@ -14,10 +13,18 @@
     <Columns>
         <PropertyColumn Property="x => x.Number" Title="Nr" />
         <PropertyColumn Property="x => x.Sign" />
-        <PropertyColumn Property="x => x.Name" />
+        <TemplateColumn Title="@(nameof(Element.Name))" Sortable="true">
+            <CellTemplate>
+                <MudText>@(context.Item.Name ?? "-")</MudText>
+            </CellTemplate>
+        </TemplateColumn>
         <PropertyColumn Property="x => x.Position" />
         <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
-        <PropertyColumn Property="x => x.Group" Title="Category" />
+        <PropertyColumn Property="x => x.Group" Title="Category" Sortable="true">
+            <CellTemplate>
+                @(context.Item.Group ?? "-")
+            </CellTemplate>
+        </PropertyColumn>
     </Columns>
     <PagerContent>
         <MudDataGridPager T="Element" />
@@ -66,12 +73,6 @@
                         o => o.Sign
                     );
                     break;
-                case nameof(Element.Name):
-                    data = data.OrderByDirection(
-                        sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
-                        o => o.Name
-                    );
-                    break;
                 case nameof(Element.Position):
                     data = data.OrderByDirection(
                         sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
@@ -83,6 +84,24 @@
                         sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
                         o => o.Molar
                     );
+                    break;
+                case nameof(Element.Group):
+                    data = data.OrderByDirection(
+                        sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
+                        o => o.Group
+                    );
+                    break;
+                default:
+                    var sortByColumn = dataGrid.RenderedColumns.First(c => c.PropertyName == sortDefinition.SortBy);
+                    switch (sortByColumn.Title) 
+                    {
+                        case nameof(Element.Name):
+                            data = data.OrderByDirection(
+                                sortDefinition.Descending ? SortDirection.Descending : SortDirection.Ascending,
+                                o => o.Name
+                            );
+                            break; 
+                    }
                     break;
             }
         }


### PR DESCRIPTION
## Description
In issue https://github.com/MudBlazor/MudBlazor/issues/9041, the user reports that sorting does not work as expected when using the MudDataGrid component with a TemplateColumn set to Sortable="true". The problem arises because the TemplateColumn does not automatically map to a property, making it unclear how to perform server-side sorting based on the column’s content.

In that issue, various solutions are proposed, the simplest of which involves using the lambda expression of the PropertyColumn to return the primitive property value while implementing more complex, ad-hoc logic within the embedded CellTemplate. This approach ensures that the PropertyColumn maps to a property, making server-side sorting straightforward.

This PR adds to the documentation the relevant information that can be extrapolated from issue https://github.com/MudBlazor/MudBlazor/issues/9041.

Resolves https://github.com/MudBlazor/MudBlazor/issues/9041

## How Has This Been Tested?
I deployed the server project and I've browsed to the documentation page I've modified, and I've seen that modifications had been applied successfully.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
