### PR TITLE
Pickers: Use `InputDefaults` for inputs in `Picker` components

### DIFF
--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -35,7 +35,8 @@
                                   PlaceholderEnd="@PlaceholderEnd"
                                   SeparatorIcon="@SeparatorIcon"
                                   Clearable="@(Clearable && !GetReadOnlyState())"
-                                  Underline="@Underline" />
+                                  Underline="@Underline"
+                                  ShrinkLabel="@ShrinkLabel" />
                </InputContent>
            </MudInputControl>;
 

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -26,7 +26,11 @@ namespace MudBlazor
         }
 
         protected string Classname => MudInputCssHelper.GetClassname(this,
-            () => !string.IsNullOrEmpty(Text) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(PlaceholderStart) || !string.IsNullOrWhiteSpace(PlaceholderEnd));
+            () => !string.IsNullOrEmpty(Text)
+                  || Adornment == Adornment.Start
+                  || !string.IsNullOrWhiteSpace(PlaceholderStart)
+                  || !string.IsNullOrWhiteSpace(PlaceholderEnd)
+                  || ShrinkLabel);
 
         internal override InputType GetInputType() => InputType;
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -36,6 +36,7 @@
                        Clearable="@(Clearable && !GetReadOnlyState())"
                        OnClearButtonClick="@(async () => await ClearAsync())"
                        TextUpdateSuppression="@(Editable && !GetReadOnlyState())"
+                       ShrinkLabel="@ShrinkLabel"
                        @onclick="OnClickAsync" />;
 
 #nullable enable

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -295,11 +295,11 @@ namespace MudBlazor
         /// The display variant of the text input.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Variant.Text"/>.
+        /// Defaults to <see cref="Variant.Text"/> in <see cref="MudGlobal.InputDefaults.Variant"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Variant Variant { get; set; } = Variant.Text;
+        public Variant Variant { get; set; } = MudGlobal.InputDefaults.Variant;
 
         /// <summary>
         /// The location of the <see cref="AdornmentIcon"/> for the input.
@@ -391,11 +391,25 @@ namespace MudBlazor
         public RenderFragment<MudPicker<T>>? PickerActions { get; set; }
 
         /// <summary>
-        /// Applies vertical spacing.
+        /// The amount of vertical spacing for the text input.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Margin.None"/> in <see cref="MudGlobal.InputDefaults.Margin"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Margin Margin { get; set; } = Margin.None;
+        public Margin Margin { get; set; } = MudGlobal.InputDefaults.Margin;
+
+        /// <summary>
+        /// Shows the label inside the text input if no <see cref="Text"/> is specified.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c> in <see cref="MudGlobal.InputDefaults.ShrinkLabel"/>.
+        /// When <c>true</c>, the label will not move into the input when the input is empty.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public bool ShrinkLabel { get; set; } = MudGlobal.InputDefaults.ShrinkLabel;
 
         /// <summary>
         /// The mask to apply to input values when <see cref="Editable"/> is <c>true</c>.


### PR DESCRIPTION
## Description
We came across a few instances where some `InputDefaults` weren't applied to text inputs present in `Picker`s, this PR fixes those instances.

## How Has This Been Tested?
Visually by changing globals and comparing behaviour (mainly shrink labels) with live site.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
