### PR TITLE
MudTable: Add TableClass parameter #11351

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -13,6 +13,15 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class TableTests : BunitTest
     {
+        [Test]
+        public void CustomTableClass()
+        {
+            var comp = Context.RenderComponent<TableRowClickTest>();
+            var table = comp.FindComponent<MudTable<int>>();
+            table.SetParametersAndRender(parameters=> parameters.Add(x=> x.TableClass, "table-custom-class"));
+            table.Markup.Should().Contain("class=\"mud-table-root table-custom-class\"");
+        }
+
         /// <summary>
         /// OnRowClick event callback should be fired regardless of the selection state
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -18,7 +18,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<TableRowClickTest>();
             var table = comp.FindComponent<MudTable<int>>();
-            table.SetParametersAndRender(parameters=> parameters.Add(x=> x.TableClass, "table-custom-class"));
+            table.SetParametersAndRender(parameters => parameters.Add(x => x.TableClass, "table-custom-class"));
             table.Markup.Should().Contain("class=\"mud-table-root table-custom-class\"");
         }
 

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -29,7 +29,7 @@
             </div>
         }
         <div class="mud-table-container @TableContainerClass" style="@TableContainerStyle @(GetHorizontalScrollbarStyle())">
-            <table class="mud-table-root @TableClass">
+            <table class="@TableClassname">
                 @if (ColGroup != null)
                 {
                     <colgroup>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -29,7 +29,7 @@
             </div>
         }
         <div class="mud-table-container @TableContainerClass" style="@TableContainerStyle @(GetHorizontalScrollbarStyle())">
-            <table class="mud-table-root">
+            <table class="mud-table-root @TableClass">
                 @if (ColGroup != null)
                 {
                     <colgroup>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -384,6 +384,7 @@ namespace MudBlazor
         /// The custom CSS classes to apply to the table.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.Table.Appearance)]
         public string? TableClass { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -33,6 +29,11 @@ namespace MudBlazor
 
         [MemberNotNullWhen(true, nameof(ServerData))]
         internal override bool HasServerData => ServerData is not null;
+
+        protected string TableClassname =>
+            new CssBuilder("mud-table-root")
+                .AddClass(TableClass)
+                .Build();
 
         /// <summary>
         /// The columns for each row in this table.

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -381,6 +381,12 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// The custom CSS classes to apply to the table.
+        /// </summary>
+        [Parameter]
+        public string? TableClass { get; set; }
+
+        /// <summary>
         /// The content for the header of each group when <see cref="GroupBy"/> is set.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Description
This PR adds a new `TableClass` parameter to `MudTable<T>`, allowing consumers to apply custom CSS classes directly to the rendered `<table>` element.
Fixes #11351 .

## How Has This Been Tested?
Tested on production site that uses a Bootstrap template and classes successfully applied to html table element.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [ ] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
