### PR TITLE
MudText : Disabled parameter

### DIFF
--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -31,14 +31,10 @@ public partial class MudText : MudComponentBase
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Applies theme typography styles to the element.
+    /// The theme style of the text.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// The rendered HTML tag is determined by the theme unless <see cref="HtmlTag"/> is set.
-    /// The tag affects the display type and the applicability of properties like <see cref="Align"/> and <see cref="GutterBottom"/>.
-    /// </para>
-    /// Defaults to <see cref="Typo.body1"/> which uses the block-level <c>p</c> element.
+    /// Defaults to <see cref="Typo.body1"/>. Uses the theme HTML tag unless <see cref="HtmlTag"/> is set.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Text.Appearance)]

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -21,13 +21,13 @@ public partial class MudText : MudComponentBase
     public bool RightToLeft { get; set; }
 
     /// <summary>
-    /// Allows the component to look disabled or not.
+    /// Applies disabled style to the element.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
     [Parameter]
-    [Category(CategoryTypes.FormComponent.Behavior)]
+    [Category(CategoryTypes.FormComponent.Appearance)]
     public bool Disabled { get; set; }
 
     /// <summary>

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -9,7 +9,8 @@ public partial class MudText : MudComponentBase
     protected string Classname =>
         new CssBuilder("mud-typography")
             .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
-            .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default && Color != Color.Inherit)
+            .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default && Color != Color.Inherit && !Disabled)
+            .AddClass("mud-text-disabled", Disabled)
             .AddClass("mud-typography-gutterbottom", GutterBottom)
             .AddClass($"mud-typography-align-{ConvertAlign(Align).ToDescriptionString()}", Align != Align.Inherit)
             .AddClass("d-inline", Inline)
@@ -18,6 +19,16 @@ public partial class MudText : MudComponentBase
 
     [CascadingParameter(Name = "RightToLeft")]
     public bool RightToLeft { get; set; }
+
+    /// <summary>
+    /// Allows the component to look disabled or not.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.FormComponent.Behavior)]
+    public bool Disabled { get; set; }
 
     /// <summary>
     /// Applies theme typography styles to the element.


### PR DESCRIPTION
## Description
To maintain full consistency of disabled controls, a ```Disabled``` parameter has been added to the ```MudText``` control. This allows all elements to be displayed and to look as disabled.

## How Has This Been Tested?
This has only been tested visually.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Here's an example to show a situation with MudRadio.

![Exemple](https://github.com/user-attachments/assets/983461ff-fba5-428b-9e8c-90898b2f5d9a)

```csharp
<div class="d-flex flex-column">
    <div class="d-flex mt-5">
        <MudText Disabled="true" Class="mr-2 mt-3">Category types:</MudText>
        <MudRadioGroup Disabled="true" T="bool">
            <MudRadio Value="true">Lux</MudRadio>
            <MudRadio Value="true">Ultra</MudRadio>
            <MudRadio Value="true">VIP</MudRadio>
        </MudRadioGroup>
    </div>
    <div class="d-flex mt-5">
        <MudText Disabled="false" Class="mr-2 mt-3">Category types:</MudText>
        <MudRadioGroup Disabled="false" T="bool">
            <MudRadio Value="true">Lux</MudRadio>
            <MudRadio Value="true">Ultra</MudRadio>
            <MudRadio Value="true">VIP</MudRadio>
        </MudRadioGroup>
    </div>
</div>
```

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
