### PR TITLE
MudText : Disabled parameter

### DIFF
--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -13,18 +13,26 @@ public partial class MudText : MudComponentBase
     protected string Classname =>
         new CssBuilder("mud-typography")
             .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
-            .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default && Color != Color.Inherit)
+            .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default && Color != Color.Inherit && !Disabled)
+            .AddClass("mud-text-disabled", Disabled)
             .AddClass("mud-typography-gutterbottom", GutterBottom)
             .AddClass($"mud-typography-align-{ConvertAlign(Align).ToDescriptionString()}", Align != Align.Inherit)
             .AddClass("d-inline", Inline)
             .AddClass(Class)
             .Build();
 
-    /// <summary>
-    /// Whether text is displayed right-to-left.
-    /// </summary>
     [CascadingParameter(Name = "RightToLeft")]
     public bool RightToLeft { get; set; }
+
+    /// <summary>
+    /// Applies disabled style to the element.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.FormComponent.Appearance)]
+    public bool Disabled { get; set; }
 
     /// <summary>
     /// The theme style of the text.


### PR DESCRIPTION
## Description
To maintain full consistency of disabled controls, a ```Disabled``` parameter has been added to the ```MudText``` control. This allows all elements to be displayed and to look as disabled.

## How Has This Been Tested?
This has only been tested visually.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Here's an example to show a situation with MudRadio.

![Exemple](https://github.com/user-attachments/assets/983461ff-fba5-428b-9e8c-90898b2f5d9a)

```csharp
<div class="d-flex flex-column">
    <div class="d-flex mt-5">
        <MudText Disabled="true" Class="mr-2 mt-3">Category types:</MudText>
        <MudRadioGroup Disabled="true" T="bool">
            <MudRadio Value="true">Lux</MudRadio>
            <MudRadio Value="true">Ultra</MudRadio>
            <MudRadio Value="true">VIP</MudRadio>
        </MudRadioGroup>
    </div>
    <div class="d-flex mt-5">
        <MudText Disabled="false" Class="mr-2 mt-3">Category types:</MudText>
        <MudRadioGroup Disabled="false" T="bool">
            <MudRadio Value="true">Lux</MudRadio>
            <MudRadio Value="true">Ultra</MudRadio>
            <MudRadio Value="true">VIP</MudRadio>
        </MudRadioGroup>
    </div>
</div>
```

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.