### PR TITLE
MudCheckBox: Use disabled style on text

### DIFF
--- a/src/MudBlazor/Styles/components/_checkbox.scss
+++ b/src/MudBlazor/Styles/components/_checkbox.scss
@@ -17,7 +17,7 @@
     }
   }
 
-  .mud-disabled:focus-visible, .mud-disabled:active {
+  &.mud-disabled, .mud-disabled:focus-visible, .mud-disabled:active {
     cursor: default;
     background-color: transparent !important;
 


### PR DESCRIPTION
## Description
When the ```MudCheckbox``` is deactivated, the text associated with the component must have the color associated with this status. Like the ```MudRadio``` component.

## How Has This Been Tested?
It has only been tested visually. One scss file has been updated.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Here is an example.

![No](https://github.com/user-attachments/assets/a6b45655-b9ee-4c84-b3f8-d2ed4197b5d4)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
