### PR TITLE
MudTable: Added ForceLoadingContent parameter to show LoadingContent even with items in table

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -57,7 +57,7 @@
                                 }
                             </MudTHeadRow>
                         }
-                        @if (Loading)
+                        @if (Loading && !ForceLoadingContent)
                         {
                             <tr class="mud-table-row">
                                 <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent is not null ? "mud-table-loading" : "")">
@@ -67,7 +67,7 @@
                         }
                     </thead>
                 }
-                else if (Loading)
+                else if (Loading && !ForceLoadingContent)
                 {
                     <thead class="@HeadClassname">
                         <tr class="mud-table-row">
@@ -90,7 +90,16 @@
                     }
                     else
                     {
-                        @if (CurrentPageItems != null && CurrentPageItems.Any())
+                        @if (ForceLoadingContent && LoadingContent != null && Loading) 
+                        {
+                            <tr>
+                                <th colspan="1000" class="mud-table-empty-row">
+                                    <div Class="my-3">
+                                            @LoadingContent
+                                    </div>
+                                </th>
+                            </tr>
+                        } else if (CurrentPageItems != null && CurrentPageItems.Any())
                         {
                             var rowIndex = 0;
                                 <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
@@ -134,8 +143,8 @@
                             </MudVirtualize>
                         }
                     }
-                    @if(!(CurrentPageItems is not null && CurrentPageItems.Any())
-                        && (Loading ? LoadingContent != null : NoRecordsContent != null)
+                    @if((CurrentPageItems is null || !CurrentPageItems.Any())
+                        && (Loading ? LoadingContent != null && !ForceLoadingContent : NoRecordsContent != null)
                     )
                     {
                         <tr>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -144,6 +144,13 @@ namespace MudBlazor
         public RenderFragment? LoadingContent { get; set; }
 
         /// <summary>
+        /// Forces the loading content to be shown even if the table has rows and also disables the default loading progress row.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.Table.Data)]
+        public bool ForceLoadingContent { get; set; } = false;
+
+        /// <summary>
         /// Shows a horizontal scroll bar if the content exceeds the maximum width.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Description
Added new ForceLoadingContent parameter that will force LoadingContent to show when Loading is true regardless if there are items in the table or not. 

When there is a large table of scrollable data and filtering can take time, it was not showing the specified LoadingContent and the loading progress animation was not always obvious based on theme/CSS used.

Also removed the default loading progress bar if ForceLoadingContent is set to true and there is a LoadingContent added. It follows if you have specified a LoadingContent that you want to show even if there is data, then it is redundant to also have the default loading progress animation.


## How Has This Been Tested?
Visually tested in an external project referencing this new build.

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Table with data
![image](https://github.com/user-attachments/assets/c8040361-9593-47ac-936c-2cc0882c2396)

Table with data when setting Loading to true (from a filter/search).
![image](https://github.com/user-attachments/assets/4fc3587d-ad10-431d-bb8e-aa49408986d7)



## Checklist
- [ ] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
