### PR TITLE
Docs: Prevent cookie dialog being mangled by ad blockers

### DIFF
--- a/src/MudBlazor.Docs/Pages/Consent/Prompt/MudCookieConsentPrompt.razor
+++ b/src/MudBlazor.Docs/Pages/Consent/Prompt/MudCookieConsentPrompt.razor
@@ -1,8 +1,8 @@
 ﻿@inherits BytexDigital.Blazor.Components.CookieConsent.Dialogs.Prompt.CookieConsentPromptComponentBase
 
-<div class="cookie-consent-container">
+<div class="cookie-consent__container">
     <MudPaper Class="cookie-consent" Elevation="16">
-        <div class="cookie-consent-content">
+        <div class="cookie-consent__body">
             <MudText Typo="Typo.subtitle1">
                 We use cookies to enhance your experience and analyze site traffic.
                 By clicking "Accept All" you consent to the use of additional cookies.
@@ -10,7 +10,7 @@
             </MudText>
         </div>
 
-        <div class="cookie-consent-actions">
+        <div class="cookie-consent__actions">
             <MudButton OnClick="async () => await AcceptAsync(false)" Variant="Variant.Filled" DropShadow="false" Color="Color.Default">
                 Only Necessary
             </MudButton>

--- a/src/MudBlazor.Docs/Pages/Consent/Prompt/MudCookieConsentPrompt.razor
+++ b/src/MudBlazor.Docs/Pages/Consent/Prompt/MudCookieConsentPrompt.razor
@@ -1,8 +1,8 @@
 ﻿@inherits BytexDigital.Blazor.Components.CookieConsent.Dialogs.Prompt.CookieConsentPromptComponentBase
 
-<div class="cookie-consent__container">
-    <MudPaper Class="cookie-consent" Elevation="16">
-        <div class="cookie-consent__body">
+<div class="mud-cc-container">
+    <MudPaper Class="mud-cc-content" Elevation="16">
+        <div class="mud-cc-body">
             <MudText Typo="Typo.subtitle1">
                 We use cookies to enhance your experience and analyze site traffic.
                 By clicking "Accept All" you consent to the use of additional cookies.
@@ -10,7 +10,7 @@
             </MudText>
         </div>
 
-        <div class="cookie-consent__actions">
+        <div class="mud-cc-actions">
             <MudButton OnClick="async () => await AcceptAsync(false)" Variant="Variant.Filled" DropShadow="false" Color="Color.Default">
                 Only Necessary
             </MudButton>

--- a/src/MudBlazor.Docs/Styles/components/_consent.scss
+++ b/src/MudBlazor.Docs/Styles/components/_consent.scss
@@ -1,4 +1,4 @@
-.cookie-consent__container {
+.mud-cc-container {
   display: flex;
   justify-content: center;
   position: fixed;
@@ -9,7 +9,7 @@
   z-index: var(--mud-zindex-popover);
 }
 
-.cookie-consent {
+.mud-cc-content {
   display: flex;
   flex-direction: column;
   padding: 1em;
@@ -19,14 +19,14 @@
   border-radius: 0.25rem;
 }
 
-.cookie-consent__body {
+.mud-cc-body {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1rem;
 }
 
-.cookie-consent__actions {
+.mud-cc-actions {
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/MudBlazor.Docs/Styles/components/_consent.scss
+++ b/src/MudBlazor.Docs/Styles/components/_consent.scss
@@ -1,4 +1,4 @@
-.cookie-consent-container {
+.cookie-consent__container {
   display: flex;
   justify-content: center;
   position: fixed;
@@ -19,14 +19,14 @@
   border-radius: 0.25rem;
 }
 
-.cookie-consent-content {
+.cookie-consent__body {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1rem;
 }
 
-.cookie-consent-actions {
+.cookie-consent__actions {
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Our class names were very generic before and some overzealous filter lists would pick up some of them but not all, leaving the dialog like this:

<img width="230" alt="image" src="https://github.com/user-attachments/assets/99a310e7-10f7-42ea-b593-c86513cd3895" />

The names have now been obscured slightly so it would have to be intentionally blocked, which is fine and better than being broken by default.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
