### PR TITLE
MudAutocomplete: Fix `AutoFocus` not opening item list

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1130,7 +1130,6 @@ namespace MudBlazor
         /// </summary>
         public override ValueTask FocusAsync()
         {
-            _handleNextFocus = true; // Let the event handler know it was not triggered by the user.
             return _elementReference.FocusAsync();
         }
 
@@ -1174,6 +1173,7 @@ namespace MudBlazor
         private async Task ListItemOnClickAsync(T item)
         {
             await SelectOptionAsync(item);
+            _handleNextFocus = true; // Let the event handler know it doesn't need to do anything.
             await FocusAsync();
         }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

If you opened the search dialog, which uses AutoFocus, the menu list would not open despite the input having focus:

![image](https://github.com/user-attachments/assets/d36070ec-ba15-4244-bc6d-65125a48f8b2)

We now explicitly mark the focus event as needing to be handled instead of doing it every time `FocusAsync` is called (which is only done in two places, one of those being AutoFocus!).

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/user-attachments/assets/5b0e4f1a-45f8-465c-a061-60ee07106ba4)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
