### PR TITLE
MudMenu: Fix submenu activators being too wide

### DIFF
--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -28,10 +28,10 @@
 
 .mud-menu-list {
   padding: 4px 0;
-  display: grid;
 
   > .mud-menu {
     width: 100%;
+    display: inline;
   }
 
   > .mud-divider {

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -28,6 +28,8 @@
 
 .mud-menu-list {
   padding: 4px 0;
+  display: flex;
+  flex-direction: column;
 
   > .mud-menu {
     width: 100%;

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -28,8 +28,7 @@
 
 .mud-menu-list {
   padding: 4px 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
 
   > .mud-menu {
     width: 100%;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

The submenu in the example was taking up too much space. Changing the display type is the lazy fix.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before:
![image](https://github.com/user-attachments/assets/a70072d6-c128-4f81-a441-f73f2c6f8d72)


After:
![image](https://github.com/user-attachments/assets/c790bd3b-11ad-41b2-99fb-2aecf431caf7)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
