### PR TITLE
MudColorPicker: Reduce default throttle

### DIFF
--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -296,11 +296,11 @@ namespace MudBlazor
         /// The delay, in milliseconds, between updates to the selected color when <see cref="DragEffect"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>300</c> milliseconds between updates.
+        /// Defaults to <c>50</c> milliseconds between updates.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
-        public int ThrottleInterval { get; set; } = 300;
+        public int ThrottleInterval { get; set; } = 50;
 
         /// <inheritdoc />
         protected override void OnInitialized()


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

I think we were too cautious before at the expense of user experience, especially when taking into account the throttle was for Server but still enabled on WASM.
 
## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

After/Before:


https://github.com/user-attachments/assets/db477d2b-6ea8-4925-876f-86595022655c



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
