### PR TITLE
MudTablePager: Add thousands separator for all_items

### DIFF
--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -122,10 +122,10 @@ namespace MudBlazor
                     return InfoFormat
                         .Replace("{first_item}", $"{firstItem}")
                         .Replace("{last_item}", $"{lastItem}")
-                        .Replace("{all_items}", $"{filteredItemsCount}");
+                        .Replace("{all_items}", $"{filteredItemsCount:N0}");
                 }
 
-                return Localizer[LanguageResource.MudDataGridPager_InfoFormat, firstItem, lastItem, filteredItemsCount];
+                return Localizer[LanguageResource.MudDataGridPager_InfoFormat, firstItem, lastItem, $"{filteredItemsCount:N0}"];
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Added thousands separator for _all_items_ of MudTablePager

## How Has This Been Tested?
It has only been tested visually.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
### Example
**Note**: the string interpolation `$"{filteredItemsCount:N0}"` uses `CultureInfo.CurrentCulture` by default.
In this environment, the culture is set to `it-IT` (Italian), so the thousands separator is a dot (`.`).
For example, 88088 will be formatted as 88.088.
The output may vary depending on the culture settings of the environment where the application is running.

Before
![image](https://github.com/user-attachments/assets/7aceae94-b16d-4b2c-8bda-8031370289ca)

After
![image](https://github.com/user-attachments/assets/097a3d6f-74a3-4ddf-8583-f3eea6ee3b5c)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
