### PR TITLE
MudRadioGroup: Correct `ResetAsync` and Backspace Behavior

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest8.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupTest8.razor
@@ -1,0 +1,22 @@
+﻿<MudRadioGroup @bind-Value="_option">
+    <MudRadio Value="true" Color="Color.Primary">Primary</MudRadio>
+    <MudRadio Value="false" Color="Color.Secondary">Secondary</MudRadio>
+</MudRadioGroup>
+
+<MudRadioGroup T="bool?" @bind-Value="_options">
+    <MudRadio T="bool?" Value="true" Color="Color.Primary">Primary</MudRadio>
+    <MudRadio T="bool?" Value="false" Color="Color.Secondary">Secondary</MudRadio>
+    <MudRadio T="bool?" Value="null" Color="Color.Primary">Primary</MudRadio>
+</MudRadioGroup>
+
+<MudRadioGroup T="bool?" @bind-Value="_options2">
+    <MudRadio T="bool?" Value="true" Color="Color.Primary">Primary</MudRadio>
+    <MudRadio T="bool?" Value="false" Color="Color.Secondary">Secondary</MudRadio>
+</MudRadioGroup>
+
+
+@code {
+    private bool _option = true;
+    private bool? _options = false;
+    private bool? _options2 = false;
+}

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -240,6 +240,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void RadioTest_KeyboardInput2()
+        {
+            var comp = Context.RenderComponent<RadioGroupTest8>();
+
+            var radio = comp.FindComponent<MudRadioGroup<bool>>();
+            var nullableRadio = comp.FindComponents<MudRadioGroup<bool?>>().First();
+            var nullableRadio2 = comp.FindComponents<MudRadioGroup<bool?>>().Last();
+            radio.Instance.Value.Should().Be(true);
+            nullableRadio.Instance.Value.Should().Be(false);
+            radio.Instance._selectedRadio.Should().NotBeNull();
+            nullableRadio.Instance._selectedRadio.Should().NotBeNull();
+
+            var inputs = comp.FindAll("input").ToArray();
+            comp.FindAll("input")[0].KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.FindAll("input")[4].KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.FindAll("input")[6].KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            radio.Instance.Value.Should().Be(false);
+            nullableRadio.Instance.Value.Should().Be(null);
+            nullableRadio2.Instance.Value.Should().Be(null);
+            radio.Instance._selectedRadio.Should().NotBeNull();
+            nullableRadio.Instance._selectedRadio.Should().NotBeNull();
+            nullableRadio2.Instance._selectedRadio.Should().BeNull();
+        }
+
+        [Test]
         public async Task RadioTest_Other()
         {
             var comp = Context.RenderComponent<RadioGroupTest1>();

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -197,9 +197,9 @@ namespace MudBlazor
             }
         }
 
-        protected override async Task ResetValueAsync()
+        protected override Task ResetValueAsync()
         {
-            await SetSelectedOptionAsync(default(T), true);
+            return SetSelectedOptionAsync(default(T), true);
         }
 
         private static T? GetValueOrDefault(MudRadio<T>? radio)

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
     /// <typeparam name="T">The type of value being selected.</typeparam>
     public partial class MudRadioGroup<T> : MudFormComponent<T, T>, IMudRadioGroup
     {
-        private MudRadio<T>? _selectedRadio;
+        internal MudRadio<T>? _selectedRadio;
         private HashSet<MudRadio<T>> _radios = new();
 
         public MudRadioGroup() : base(new Converter<T, T>()) { }
@@ -197,15 +197,9 @@ namespace MudBlazor
             }
         }
 
-        protected override Task ResetValueAsync()
+        protected override async Task ResetValueAsync()
         {
-            if (_selectedRadio is not null)
-            {
-                _selectedRadio.SetChecked(false);
-                _selectedRadio = null;
-            }
-
-            return base.ResetValueAsync();
+            await SetSelectedOptionAsync(default(T), true);
         }
 
         private static T? GetValueOrDefault(MudRadio<T>? radio)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Fix #11369 . The MudRadioGroup's overridden ResetAsync behavior was false. It tried to handle value and item seperately that makes inconsistent value and item result. Value change should not be handle outside of the method. The wrong ResetAsync behavior also affected the backspace key behavior, which called the method.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Added a test that backspace key now properly working with nullable and non-nullable value types with different set of options.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
