### PR TITLE
Line chart: Fix index out of bounds error

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -613,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(ChartType.StackedBar)]
         [TestCase(ChartType.HeatMap)]
         [Test]
-        public void NoLable_Chart_IsValid(ChartType chart)
+        public void NoLabel_Chart_IsValid(ChartType chart)
         {
             var series = new List<ChartSeries>()
             {

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -606,5 +606,31 @@ namespace MudBlazor.UnitTests.Components
             heatmap.Instance._maxValue.Should().Be(max.HasValue ? max : .98);
         }
 
+        [TestCase(ChartType.Donut)]
+        [TestCase(ChartType.Line)]
+        [TestCase(ChartType.Pie)]
+        [TestCase(ChartType.Bar)]
+        [TestCase(ChartType.StackedBar)]
+        [TestCase(ChartType.HeatMap)]
+        [Test]
+        public void NoLable_Chart_IsValid(ChartType chart)
+        {
+            var series = new List<ChartSeries>()
+            {
+                new() { Name = "Series 1", Data = [90, 79, 72, 69, 62, 62, 55, 65, 70] },
+                new() { Name = "Series 2", Data = [10, 41, 35, 51, 49, 62, 69, 91, 148] },
+            };
+
+            double[] data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
+
+            var isRadial = chart == ChartType.Donut || chart == ChartType.Pie;
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                              .Add(p => p.ChartType, chart)
+                              .Add(p => p.ChartOptions, new ChartOptions { InterpolationOption = InterpolationOption.Periodic })
+                              .Add(p => p.ChartSeries, !isRadial ? series : null)
+                              .Add(p => p.InputData, isRadial ? data : null));
+
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -139,7 +139,7 @@ namespace MudBlazor.Charts
                 };
                 _verticalLines.Add(line);
 
-                var xLabels = i < XAxisLabels.Length ? XAxisLabels[i] : "";
+                var xLabels = i < XAxisLabels.Length ? XAxisLabels[i] : string.Empty;
                 var lineValue = new SvgText()
                 {
                     X = x,
@@ -204,13 +204,16 @@ namespace MudBlazor.Charts
                                 continue;
                             }
 
+                            var index = j / interpolationResolution;
+                            var xLabels = index < XAxisLabels.Length ? XAxisLabels[index] : string.Empty;
+
                             chartDataCircles.Add(new()
                             {
                                 Index = j,
                                 CX = x,
                                 CY = y,
                                 LabelX = x,
-                                LabelXValue = XAxisLabels[j / interpolationResolution],
+                                LabelXValue = xLabels,
                                 LabelY = y,
                                 LabelYValue = dataValue.ToString(series.DataMarkerTooltipYValueFormat),
                             });


### PR DESCRIPTION
## Description
Fixes an array access error for interpolated line charts with no labels. 
The label array was being accessed even though it was empty. 

## How Has This Been Tested?
Unit test added

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
