### PR TITLE
MudDialog: Fix close button overlaping text (#11387)

### DIFF
--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -75,9 +75,15 @@
   max-height: calc(100dvh - var(--mud-appbar-height));
   overflow-y: auto;
 
-  &.mud-dialog-rtl .mud-dialog-title .mud-button-close {
+  &.mud-dialog-rtl .mud-dialog-title {
+    &:has(.mud-button-close) {
+      padding-left: 48px;
+    }
+
+    &.mud-button-close {
     right: unset;
     left: 8px;
+    }
   }
 
   & .mud-dialog-title {
@@ -89,13 +95,17 @@
     border-top-right-radius: var(--mud-default-borderradius);
 
     + * > .mud-dialog-content {
-      border-radius: 0
+      border-radius: 0;
     }
 
     & .mud-button-close {
       top: 8px;
       right: 8px;
       position: absolute;
+    }
+
+    &:has(.mud-button-close) {
+      padding-right: 48px;
     }
   }
 


### PR DESCRIPTION
# Description
Resolves https://github.com/MudBlazor/MudBlazor/issues/11387

# How Has This Been Tested?
Visually

## Before
![image](https://github.com/user-attachments/assets/377cb140-7cb7-4342-a655-e414b22b3ba7)

## After
![image](https://github.com/user-attachments/assets/bdc7a17f-5f33-4dc1-ad87-c2f635921526)

# Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

# Checklist
- [x] The PR is submitted to the correct branch (dev).
- [x] My code follows the code style of this project.