### PR TITLE
Add `d-contents` display class, Fix missing gap between MessageBox action buttons

### DIFF
--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor
@@ -28,7 +28,7 @@
         }
     </DialogContent>
     <DialogActions>
-        <div tabindex="-1">
+        <div tabindex="-1" class="d-contents">
             <MudFocusTrap DefaultFocus="DefaultFocus.LastChild">
                 @if (CancelButton is not null)
                 {

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -118,17 +118,12 @@
   & .mud-dialog-actions {
     flex: 0 0 auto;
     display: flex;
+    gap: 8px;
     padding: 8px;
     align-items: center;
     justify-content: flex-end;
     border-bottom-left-radius: var(--mud-default-borderradius);
     border-bottom-right-radius: var(--mud-default-borderradius);
-
-    & > :not(:first-child) {
-      margin-left: 8px;
-      margin-inline-start: 8px;
-      margin-inline-end: unset;
-    }
   }
 }
 

--- a/src/MudBlazor/Styles/utilities/layout/_display.scss
+++ b/src/MudBlazor/Styles/utilities/layout/_display.scss
@@ -1,4 +1,4 @@
-﻿@import '../../abstracts/variables';
+@import '../../abstracts/variables';
 
 @mixin display-mixin ($breakpoint) {
   .d-#{$breakpoint}none {
@@ -35,6 +35,10 @@
 
   .d-#{$breakpoint}inline-flex {
     display: inline-flex !important;
+  }
+
+  .d-#{$breakpoint}contents {
+    display: contents !important;
   }
 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

We were missing a class for `display: contents` and the gap in the message box action buttons was not the same as the dialog because of the extra div in the way. Adding `d-contents` lets the style pass through.

I also replaced the inline margin implementation with a cleaner use of `gap` since it was already a flex display. It's unlikely that many people are relying on the old behaviour.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Before

![image](https://github.com/user-attachments/assets/55611865-1ebc-4968-8276-cb86d84ca0c2)

After

![image](https://github.com/user-attachments/assets/cdd69d80-8df9-4b01-a00c-96992f21b5ab)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
