### PR TITLE
MudToggleGroup: Selection Tracking

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ToggleGroup/ToggleGroupInterceptValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ToggleGroup/ToggleGroupInterceptValueTest.razor
@@ -1,0 +1,52 @@
+﻿<MudToggleGroup T="AttendanceStatus" SelectionMode="SelectionMode.SingleSelection"
+                Value="UserAttendanceStatus"
+                ValueChanged="@(status => OnAttendanceStatusChanged(status))">
+    <MudToggleItem Text="Attendance.Update.ToggleGroup.Yes"
+                    Value="@(AttendanceStatus.Accepted)"/>
+    <MudToggleItem Text="Attendance.Update.ToggleGroup.No"
+                    Value="@(AttendanceStatus.Declined)"/>
+    <MudToggleItem Text="Attendance.Update.ToggleGroup.Maybe"
+                    Value="@(AttendanceStatus.Maybe)"/>    
+</MudToggleGroup>
+<MudPaper Class="mud-width-full">
+    <MudText>@UserAttendanceStatus.ToString()</MudText>
+</MudPaper>
+<MudRadioGroup @bind-Value="_updateStatus">
+    <MudTooltip Text="Value and Visual Selection Should Change">
+        <MudRadio Class="simulate-success" Value="true">Simulate Success</MudRadio>
+    </MudTooltip>
+    <MudTooltip Text="Value and Visual Selection Should Revert to Previous">
+        <MudRadio Class="simulate-failure" Value="false">Simulate Failure</MudRadio>
+    </MudTooltip>   
+</MudRadioGroup>
+@code {
+    public static string __description__ = "Visual Test for intercepted ValueChanged ToggleGroup";
+    public enum AttendanceStatus { Accepted, Declined, Maybe }
+    public AttendanceStatus UserAttendanceStatus { get; private set; } = AttendanceStatus.Declined;
+    private bool _updateStatus = true;
+    private AttendanceStatus prevStatus = default!;
+
+    protected override void OnInitialized()
+    {
+        prevStatus = UserAttendanceStatus;
+    }
+
+    private void OnAttendanceStatusChanged(AttendanceStatus newStatus)
+    {
+        Console.WriteLine(prevStatus.ToString() + " -> " + newStatus.ToString());
+        // _updateStatus is a simulated success, !_updateStatus is a simulated failure
+        if (_updateStatus)
+        {
+            // success
+            prevStatus = newStatus;
+            UserAttendanceStatus = newStatus;
+        }
+        else
+        {
+            // fail
+            UserAttendanceStatus = prevStatus;
+        }
+        StateHasChanged();
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -290,6 +290,9 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
+        /// <summary>
+        /// This test will fail if selection isn't working without someone being subscribed to the ValueChanged event
+        /// </summary>
         [Test]
         [TestCase(SelectionMode.SingleSelection)]
         [TestCase(SelectionMode.ToggleSelection)]
@@ -492,6 +495,11 @@ namespace MudBlazor.UnitTests.Components
             toggleGroup.Value.Should().BeNull();
         }
 
+        /// <summary>
+        /// This test is based on https://github.com/MudBlazor/MudBlazor/issues/11384
+        /// When a ToggleGroupItem is clicked, the value should be set or intercepted via the ValueChanged event
+        /// This test verifies that both scenarios update the ToggleGroupItem Selected state
+        /// </summary>
         [Test]
         public void ToggleGroup_ToggleSelectionTest()
         {

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -314,6 +314,11 @@ namespace MudBlazor.UnitTests.Components
                 var currentItem = items[i];
                 currentItem.Selected.Should().BeTrue();
                 items.Except([currentItem]).All(x => !x.Selected).Should().BeTrue();
+                if (selMode == SelectionMode.ToggleSelection)
+                {
+                    comp.FindAll(".mud-toggle-item").GetItemByIndex(i).Click();
+                    currentItem.Selected.Should().BeFalse();
+                }
             }
         }
 

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -486,5 +486,60 @@ namespace MudBlazor.UnitTests.Components
             toggleGroup.Values.Should().BeEquivalentTo(["a"]);
             toggleGroup.Value.Should().BeNull();
         }
+
+        [Test]
+        public void ToggleGroup_ToggleSelectionTest()
+        {
+            var comp = Context.RenderComponent<ToggleGroupInterceptValueTest>();
+            IElement GetYesButton() => comp.FindAll(".mud-toggle-group .mud-toggle-item")[0];
+            IElement GetNoButton() => comp.FindAll(".mud-toggle-group .mud-toggle-item")[1];
+            IElement GetMaybeButton() => comp.FindAll(".mud-toggle-group .mud-toggle-item")[2];
+
+            var toggleGroup = comp.FindComponent<MudToggleGroup<ToggleGroupInterceptValueTest.AttendanceStatus>>();
+            // verify 3 ToggleGroupItems
+            var nodes = comp.FindAll(".mud-toggle-group .mud-toggle-item");
+            nodes.Count.Should().Be(3);
+            GetYesButton().ClassList.Should().NotContain("mud-toggle-item-selected");
+            GetNoButton().ClassList.Should().Contain("mud-toggle-item-selected");
+            GetMaybeButton().ClassList.Should().NotContain("mud-toggle-item-selected");
+
+            // verify initial state
+            comp.Instance.UserAttendanceStatus.Should().Be(ToggleGroupInterceptValueTest.AttendanceStatus.Declined);
+
+            var success = comp.Find(".simulate-success input"); // radio button
+            var failure = comp.Find(".simulate-failure input"); // radio button
+
+            // start in success mode
+            var successStatus = comp.Find(".simulate-success .mud-button-root");
+            successStatus.ClassList.Should().Contain("mud-checked");
+            var failureStatus = comp.Find(".simulate-failure .mud-button-root");
+            failureStatus.ClassList.Should().NotContain("mud-checked");
+
+            // change to yes
+            GetYesButton().Click();
+            comp.WaitForAssertion(() => GetYesButton().ClassList.Should().Contain("mud-toggle-item-selected"));
+            GetNoButton().ClassList.Should().NotContain("mud-toggle-item-selected");
+            GetMaybeButton().ClassList.Should().NotContain("mud-toggle-item-selected");
+            comp.Instance.UserAttendanceStatus.Should().Be(ToggleGroupInterceptValueTest.AttendanceStatus.Accepted);
+
+            // change to maybe
+            GetMaybeButton().Click();
+            comp.WaitForAssertion(() => GetYesButton().ClassList.Should().NotContain("mud-toggle-item-selected"));
+            GetNoButton().ClassList.Should().NotContain("mud-toggle-item-selected");
+            GetMaybeButton().ClassList.Should().Contain("mud-toggle-item-selected");
+            comp.Instance.UserAttendanceStatus.Should().Be(ToggleGroupInterceptValueTest.AttendanceStatus.Maybe);
+
+            // simulate failure where it saves last success
+            failure.Click();
+
+            // click yes with failure enabled to simulate no change
+            GetYesButton().Click();
+            // check value has not changed, should still be maybe
+            comp.WaitForAssertion(() => comp.Instance.UserAttendanceStatus.Should().Be(ToggleGroupInterceptValueTest.AttendanceStatus.Maybe, "Value should not have changed form Maybe"));
+            // check selected has not changed, should still be maybe
+            GetYesButton().ClassList.Should().NotContain("mud-toggle-item-selected", "Selection should not have changed from maybe.");
+            GetNoButton().ClassList.Should().NotContain("mud-toggle-item-selected", "Selection should not have changed from maybe.");
+            GetMaybeButton().ClassList.Should().Contain("mud-toggle-item-selected", "Selection should still be maybe.");
+        }
     }
 }

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -317,13 +317,16 @@ namespace MudBlazor
             }
         }
 
-        private void OnValueChanged()
+        private void OnValueChanged(ParameterChangedEventArgs<T?> args)
         {
             // perform Selection after user consumes Value Changed logic
-            ApplySelectionState();
+            var selectedItem = _items.FirstOrDefault(x => EqualityComparer<T>.Default.Equals(x.Value, args.Value));
+            var previousItem = _items.FirstOrDefault(x => EqualityComparer<T>.Default.Equals(x.Value, args.LastValue));
+            if (selectedItem != null) ApplySelectionState(selectedItem);
+            if (previousItem != null) ApplySelectionState(previousItem);
         }
 
-        private void OnValuesChanged()
+        private void OnValuesChanged(ParameterChangedEventArgs<IEnumerable<T?>?> args)
         {
             // perform Selection after user consumes Values Changed logic
             ApplySelectionState();
@@ -391,13 +394,7 @@ namespace MudBlazor
                 await _value.SetValueAsync(itemValue);
             }
 
-            // unselect previous item if not null and not the same as current item
-            if (previousItem != null && previousItem != item)
-            {
-                ApplySelectionState(previousItem);
-            }
-
-            ApplySelectionState(item);
+            // WithChangeHandler will update the selection state if the value/values changed
         }
 
         protected internal IEnumerable<MudToggleItem<T>> GetItems() => _items;

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -377,6 +377,10 @@ namespace MudBlazor
                 }
 
                 await _values.SetValueAsync(selectedValues);
+                if (!ValuesChanged.HasDelegate)
+                {
+                    ApplySelectionState();
+                }
             }
             else if (SelectionMode == SelectionMode.ToggleSelection)
             {
@@ -395,6 +399,17 @@ namespace MudBlazor
             }
 
             // WithChangeHandler will update the selection state if the value/values changed
+            // but only if the user subscribes to it via bind or directly
+            // change handler is needed so the user can change the value programmatically            
+            if (!ValueChanged.HasDelegate)
+            {
+                // unselect previous item if not null and not the same as current item
+                if (previousItem != null && previousItem != item)
+                {
+                    ApplySelectionState(previousItem);
+                }
+                ApplySelectionState(item);
+            }
         }
 
         protected internal IEnumerable<MudToggleItem<T>> GetItems() => _items;

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -381,6 +381,7 @@ namespace MudBlazor
                 {
                     ApplySelectionState();
                 }
+                return;
             }
             else if (SelectionMode == SelectionMode.ToggleSelection)
             {
@@ -400,7 +401,8 @@ namespace MudBlazor
 
             // WithChangeHandler will update the selection state if the value/values changed
             // but only if the user subscribes to it via bind or directly
-            // change handler is needed so the user can change the value programmatically            
+            // change handler is needed so the user can change the value programmatically and
+            // the selection state still be updated
             if (!ValueChanged.HasDelegate)
             {
                 // unselect previous item if not null and not the same as current item


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
This PR allows the user to intercept the ValueChanged event and have it properly update the UI. The ChangeHandler will fire anytime ValueChanged is subscribed to and will update the SelectedState automatically. It's detrimental to Apply the SelectionState in the Toggle method because the user might intercept that Value and change it to something else. That fires before the Toggle Method finishes causing the selection to be wrong even though the value is right. So we check if there is a subscription (the Value is bound) and if not update the UI with the selected item.
Resolves #11384 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Used TDD wrote a test that failed then fixed code until it passed.

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
