### PR TITLE
Docs: Remove tooltip delay

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -1,7 +1,5 @@
 ﻿<div class="d-flex align-center flex-grow-1 d-md-none">
-    <MudTooltip Text="Drawer">
-        <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start" aria-label="Open drawer" />
-    </MudTooltip>
+    <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start" aria-label="Toggle drawer" />
     <MudSpacer />
     <NavLink ActiveClass="d-flex align-center" href="/">
         <MudBlazorLogo Class="docs-mudblazor-logo" />
@@ -83,7 +81,7 @@
     }
     <AppbarButtons />
     <MudTooltip Text="GitHub">
-        <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" aria-label="Open GitHub repository" />
+        <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" aria-label="Go to GitHub repo" />
     </MudTooltip>
 </div>
 

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -81,7 +81,7 @@
     }
     <AppbarButtons />
     <MudTooltip Text="GitHub">
-        <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" aria-label="Go to GitHub repo" />
+        <MudIconButton Href="https://github.com/MudBlazor/MudBlazor/" Target="_blank" Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Edge="Edge.End" aria-label="Open GitHub repository" />
     </MudTooltip>
 </div>
 

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -38,9 +38,9 @@ public partial class AppbarButtons : IDisposable
     /// </summary>
     public string DarkLightModeButtonText => LayoutService.CurrentDarkLightMode switch
     {
-        DarkLightMode.Dark => "Switch to System mode",
-        DarkLightMode.Light => "Switch to Dark mode",
-        _ => "Switch to Light mode"
+        DarkLightMode.Dark => "Auto mode",
+        DarkLightMode.Light => "Dark mode",
+        _ => "Light mode"
     };
 
     /// <summary>

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -26,7 +26,7 @@ public partial class AppbarButtons : IDisposable
     /// <summary>
     /// Gets the text for the RTL toggle button, indicating the next state.
     /// </summary>
-    public string RtlButtonText => LayoutService.IsRTL ? "Switch to Left-to-right" : "Switch to Right-to-left";
+    public string RtlButtonText => LayoutService.IsRTL ? "Left-to-right" : "Right-to-left";
 
     /// <summary>
     /// Gets the icon for the RTL toggle button.

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor.cs
@@ -10,11 +10,6 @@ namespace MudBlazor.Docs.Shared
         [Inject]
         private LayoutService LayoutService { get; set; }
 
-        static MainLayout()
-        {
-            MudGlobal.TooltipDefaults.Delay = TimeSpan.FromMilliseconds(500);
-        }
-
         protected override void OnInitialized()
         {
             LayoutService.MajorUpdateOccurred += OnMajorUpdateOccured;

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -7,9 +7,7 @@
 <MudLayout>
     <MudRTLProvider RightToLeft="_rightToLeft">
         <MudAppBar Elevation="0">
-            <MudTooltip Text="Toggle drawer">
-                <MudIconButton Icon="@Icons.Material.Filled.Menu" Edge="Edge.Start" OnClick="DocsDrawerToggle" aria-label="Toggle drawer" />
-            </MudTooltip>
+            <MudIconButton Icon="@Icons.Material.Filled.Menu" Edge="Edge.Start" OnClick="DocsDrawerToggle" aria-label="Toggle drawer" />
             <MudSpacer />
             <MudAutocomplete @ref="_autocomplete" T="Type" Placeholder="Search all tests" SearchFunc="Search" Variant="Variant.Outlined" ValueChanged="OnSearchResult" Class="docs-search-bar" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentAriaLabel="Search">
                 <ItemTemplate Context="result">
@@ -173,7 +171,7 @@
 
     private string ThemeIcon => _isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode;
 
-    private string ThemeLabel => _isDarkMode ? "Switch to light theme" : "Switch to dark theme";
+    private string ThemeLabel => _isDarkMode ? "Light mode" : "Dark mode";
 
     private void DocsDrawerToggle() => _drawerOpen = !_drawerOpen;
 

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayout.razor
@@ -5,10 +5,3 @@
 <MudSnackbarProvider/>
 
 @Body
-
-@code {
-    static MainLayout()
-    {
-        MudGlobal.TooltipDefaults.Delay = TimeSpan.FromMilliseconds(500);
-    }
-}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

It was previously a second which was too long, then I halved it, but now I want to make tooltips show up instantly as it seems to be a more common pattern on modern sites and I think it helps with accessibility without getting in the way. I also think obvious ones like toggling a drawer or a close button don't need tooltips because they're already recognizable. In addition, this syncs up the docs experience with the default tooltip behavior so it's more intuitive for the developer.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

https://github.com/user-attachments/assets/6b991cba-8bad-454f-8e43-23e5eb09a8c2



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
