### PR TITLE
MudTabs: Fix slider misalignment when component is scaled

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests.Components
 
                 styleAttr.Should().Be("transform:translateX(-0px);");
 
-                GetSliderValue(comp).Should().Be(i * 250.0);
+                GetSliderValue(comp).Should().BeApproximately(i * (1.0/6.0)*100, 0.00001);
             }
         }
 
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
             var styleAttr = toolbarWrapper.GetAttribute("style");
 
             styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-            GetSliderValue(comp).Should().Be(2 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -290,7 +290,7 @@ namespace MudBlazor.UnitTests.Components
             var styleAttr = toolbarWrapper.GetAttribute("style");
 
             styleAttr.Should().Be($"transform:translateY(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-            GetSliderValue(comp, "top").Should().Be(2 * 100.0);
+            GetSliderValue(comp, "top").Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -330,7 +330,7 @@ namespace MudBlazor.UnitTests.Components
                 var styleAttr = toolbarWrapper.GetAttribute("style");
 
                 styleAttr.Should().Be($"transform:translateX(-{expectedTranslations[i].ToString(CultureInfo.InvariantCulture)}px);");
-                GetSliderValue(comp).Should().Be(i * 100.0);
+                GetSliderValue(comp).Should().BeApproximately((i/6.0) * 100.0, 0.00001);
             }
         }
 
@@ -470,7 +470,7 @@ namespace MudBlazor.UnitTests.Components
                 var styleAttr = toolbarWrapper.GetAttribute("style");
 
                 styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-                GetSliderValue(comp).Should().Be(5 * 100.0);
+                GetSliderValue(comp).Should().BeApproximately((5.0/6.0) * 100.0, 0.00001);
             }
         }
 
@@ -493,12 +493,12 @@ namespace MudBlazor.UnitTests.Components
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().Be(1 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((1.0/6.0) * 100.0, 0.00001);
 
             observer.UpdateTotalPanelSize(200.0);
 
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().Be(1 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((1.0/6.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -677,12 +677,12 @@ namespace MudBlazor.UnitTests.Components
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().Be(1 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((1.0/6.0) * 100.0, 0.00001);
 
             observer.UpdatePanelSize(0, 200.0);
 
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().Be(200.0);
+            GetSliderValue(comp).Should().BeApproximately((2.0/7.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -698,14 +698,14 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
-
+            
             comp.Instance.SetPanelActive(4);
 
-            GetSliderValue(comp).Should().Be(4 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately( (4.0 / 6.0) * 100.0, 0.00001);
 
             await comp.Instance.AddPanel();
 
-            GetSliderValue(comp).Should().Be(4 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((4.0 / 7.0) * 100.0, 0.00001);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
@@ -739,7 +739,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.SetPanelActive(2);
 
-            GetSliderValue(comp).Should().Be(2 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
@@ -756,7 +756,7 @@ namespace MudBlazor.UnitTests.Components
             styleAttr.Should().Be($"transform:translateX(-100px);");
 
             var sliderValue = GetSliderValue(comp);
-            GetSliderValue(comp).Should().Be(1 * 100.0);
+            GetSliderValue(comp).Should().BeApproximately((1.0/5.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -784,7 +784,7 @@ namespace MudBlazor.UnitTests.Components
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
                 styleAttr.Should().Be($"transform:translateX(-100px);");
-                GetSliderValue(comp).Should().Be(2 * 100.0);
+                GetSliderValue(comp).Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
             }
 
             await comp.Instance.RemovePanel(5);
@@ -797,7 +797,7 @@ namespace MudBlazor.UnitTests.Components
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
                 styleAttr.Should().Be($"transform:translateX(-100px);");
-                GetSliderValue(comp).Should().Be(2 * 100.0);
+                GetSliderValue(comp).Should().BeApproximately((2.0/5.0) * 100.0, 0.00001);
             }
         }
 
@@ -1249,7 +1249,7 @@ namespace MudBlazor.UnitTests.Components
             var styleAttribute = slider.GetAttribute("style");
             var indexToSplit = styleAttribute.IndexOf($"{attribute}:");
             var substring = styleAttribute.Substring(indexToSplit + attribute.Length + 1).Split(';')[0];
-            substring = substring.Remove(substring.Length - 2);
+            substring = substring.Remove(substring.Length - 1);
             var value = double.Parse(substring, CultureInfo.InvariantCulture);
 
             return value;

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -698,7 +698,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
             var comp = Context.RenderComponent<ScrollableTabsTest>();
-            
+
             comp.Instance.SetPanelActive(4);
 
             GetSliderValue(comp).Should().BeApproximately((4.0 / 6.0) * 100.0, 0.00001);

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests.Components
 
                 styleAttr.Should().Be("transform:translateX(-0px);");
 
-                GetSliderValue(comp).Should().BeApproximately(i * (1.0/6.0)*100, 0.00001);
+                GetSliderValue(comp).Should().BeApproximately(i * (1.0 / 6.0) * 100, 0.00001);
             }
         }
 
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
             var styleAttr = toolbarWrapper.GetAttribute("style");
 
             styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-            GetSliderValue(comp).Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((2.0 / 6.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -290,7 +290,7 @@ namespace MudBlazor.UnitTests.Components
             var styleAttr = toolbarWrapper.GetAttribute("style");
 
             styleAttr.Should().Be($"transform:translateY(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-            GetSliderValue(comp, "top").Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
+            GetSliderValue(comp, "top").Should().BeApproximately((2.0 / 6.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -330,7 +330,7 @@ namespace MudBlazor.UnitTests.Components
                 var styleAttr = toolbarWrapper.GetAttribute("style");
 
                 styleAttr.Should().Be($"transform:translateX(-{expectedTranslations[i].ToString(CultureInfo.InvariantCulture)}px);");
-                GetSliderValue(comp).Should().BeApproximately((i/6.0) * 100.0, 0.00001);
+                GetSliderValue(comp).Should().BeApproximately((i / 6.0) * 100.0, 0.00001);
             }
         }
 
@@ -470,7 +470,7 @@ namespace MudBlazor.UnitTests.Components
                 var styleAttr = toolbarWrapper.GetAttribute("style");
 
                 styleAttr.Should().Be($"transform:translateX(-{expectedTranslation.ToString(CultureInfo.InvariantCulture)}px);");
-                GetSliderValue(comp).Should().BeApproximately((5.0/6.0) * 100.0, 0.00001);
+                GetSliderValue(comp).Should().BeApproximately((5.0 / 6.0) * 100.0, 0.00001);
             }
         }
 
@@ -493,12 +493,12 @@ namespace MudBlazor.UnitTests.Components
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().BeApproximately((1.0/6.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((1.0 / 6.0) * 100.0, 0.00001);
 
             observer.UpdateTotalPanelSize(200.0);
 
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().BeApproximately((1.0/6.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((1.0 / 6.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -677,12 +677,12 @@ namespace MudBlazor.UnitTests.Components
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().BeApproximately((1.0/6.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((1.0 / 6.0) * 100.0, 0.00001);
 
             observer.UpdatePanelSize(0, 200.0);
 
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
-            GetSliderValue(comp).Should().BeApproximately((2.0/7.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((2.0 / 7.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -701,7 +701,7 @@ namespace MudBlazor.UnitTests.Components
             
             comp.Instance.SetPanelActive(4);
 
-            GetSliderValue(comp).Should().BeApproximately( (4.0 / 6.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((4.0 / 6.0) * 100.0, 0.00001);
 
             await comp.Instance.AddPanel();
 
@@ -739,7 +739,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.SetPanelActive(2);
 
-            GetSliderValue(comp).Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((2.0 / 6.0) * 100.0, 0.00001);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
@@ -756,7 +756,7 @@ namespace MudBlazor.UnitTests.Components
             styleAttr.Should().Be($"transform:translateX(-100px);");
 
             var sliderValue = GetSliderValue(comp);
-            GetSliderValue(comp).Should().BeApproximately((1.0/5.0) * 100.0, 0.00001);
+            GetSliderValue(comp).Should().BeApproximately((1.0 / 5.0) * 100.0, 0.00001);
         }
 
         [Test]
@@ -784,7 +784,7 @@ namespace MudBlazor.UnitTests.Components
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
                 styleAttr.Should().Be($"transform:translateX(-100px);");
-                GetSliderValue(comp).Should().BeApproximately((2.0/6.0) * 100.0, 0.00001);
+                GetSliderValue(comp).Should().BeApproximately((2.0 / 6.0) * 100.0, 0.00001);
             }
 
             await comp.Instance.RemovePanel(5);
@@ -797,7 +797,7 @@ namespace MudBlazor.UnitTests.Components
                 toolbarWrapper.HasAttribute("style").Should().Be(true);
                 var styleAttr = toolbarWrapper.GetAttribute("style");
                 styleAttr.Should().Be($"transform:translateX(-100px);");
-                GetSliderValue(comp).Should().BeApproximately((2.0/5.0) * 100.0, 0.00001);
+                GetSliderValue(comp).Should().BeApproximately((2.0 / 5.0) * 100.0, 0.00001);
             }
         }
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -28,8 +28,8 @@ namespace MudBlazor
         private bool _nextButtonDisabled;
         private bool _showScrollButtons;
         private ElementReference _tabsContentSize;
-        private double _sliderSize;
-        private double _sliderPosition;
+        private double _sliderSizePercentage;
+        private double _sliderPositionPercentage;
         private double _tabBarContentSize;
         private double _allTabsSize;
         private double _scrollPosition;
@@ -706,20 +706,20 @@ namespace MudBlazor
 
         protected string SliderStyle => RightToLeft
             ? new StyleBuilder()
-                .AddStyle("width", _sliderSize.ToPx(), Position is Position.Top or Position.Bottom)
-                .AddStyle("right", _sliderPosition.ToPx(), Position is Position.Top or Position.Bottom)
+                .AddStyle("width", $"{_sliderSizePercentage}%", Position is Position.Top or Position.Bottom)
+                .AddStyle("right", $"{_sliderPositionPercentage}%", Position is Position.Top or Position.Bottom)
                 .AddStyle("transition", SliderAnimation ? "right .3s cubic-bezier(.64,.09,.08,1);" : "none", Position is Position.Top or Position.Bottom)
                 .AddStyle("transition", SliderAnimation ? "top .3s cubic-bezier(.64,.09,.08,1);" : "none", IsVerticalTabs())
-                .AddStyle("height", _sliderSize.ToPx(), IsVerticalTabs())
-                .AddStyle("top", _sliderPosition.ToPx(), IsVerticalTabs())
+                .AddStyle("height", $"{_sliderSizePercentage}%", IsVerticalTabs())
+                .AddStyle("top", $"{_sliderPositionPercentage}%", IsVerticalTabs())
                 .Build()
             : new StyleBuilder()
-                .AddStyle("width", _sliderSize.ToPx(), Position is Position.Top or Position.Bottom)
-                .AddStyle("left", _sliderPosition.ToPx(), Position is Position.Top or Position.Bottom)
+                .AddStyle("width", $"{_sliderSizePercentage}%", Position is Position.Top or Position.Bottom)
+                .AddStyle("left", $"{_sliderPositionPercentage}%", Position is Position.Top or Position.Bottom)
                 .AddStyle("transition", SliderAnimation ? "left .3s cubic-bezier(.64,.09,.08,1);" : "none", Position is Position.Top or Position.Bottom)
                 .AddStyle("transition", SliderAnimation ? "top .3s cubic-bezier(.64,.09,.08,1);" : "none", IsVerticalTabs())
-                .AddStyle("height", _sliderSize.ToPx(), IsVerticalTabs())
-                .AddStyle("top", _sliderPosition.ToPx(), IsVerticalTabs())
+                .AddStyle("height", $"{_sliderSizePercentage}%", IsVerticalTabs())
+                .AddStyle("top", $"{_sliderPositionPercentage}%", IsVerticalTabs())
                 .Build();
 
         private bool IsVerticalTabs()
@@ -809,11 +809,11 @@ namespace MudBlazor
                 return;
             }
 
-            _sliderPosition = GetLengthOfPanelItems(ActivePanel);
-            _sliderSize = GetRelevantSize(ActivePanel.PanelRef);
+            _sliderPositionPercentage = (GetLengthOfPanelItems(ActivePanel) / _allTabsSize) * 100;
+            _sliderSizePercentage = (GetPanelLength(ActivePanel) / _allTabsSize) * 100;
         }
 
-        private bool IsSliderPositionDetermined => (_activePanelIndex > 0 && _sliderPosition > 0) ||
+        private bool IsSliderPositionDetermined => (_activePanelIndex > 0 && _sliderPositionPercentage > 0) ||
                                                    IsFirstVisiblePanel(ActivePanel);
 
         private void GetTabBarContentSize() => _tabBarContentSize = GetRelevantSize(_tabsContentSize);


### PR DESCRIPTION
To prevent issues with page scaling, the slider underneath a tab's position and scale are set to a percentage based on the active tabs size relative to the size of all panels.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
Fixes #11404
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

## How Has This Been Tested?
A scale of 0.75 was applied in the MainLayout.razor to reproduce the bug then tested visually.

Visual testing for fixed width tabs:
Pre-fix:
![pre-fix-1](https://github.com/user-attachments/assets/ecf3d596-10c4-4d4e-a82e-937ba6f69449)
Post fix:
![post-fix-1](https://github.com/user-attachments/assets/456c57f9-247f-4bb8-9e2c-17efecd53078)

Visual testing for variable width and vertical tabs:
Pre-fix:
![pre-fix-2](https://github.com/user-attachments/assets/deb41e65-0688-47d6-bef2-a06101e6a4af)
Post fix:
![post-fix-2](https://github.com/user-attachments/assets/489b07a9-ae10-4061-815f-0a6d5ae24b5d)

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests. (Updated existing tests to expect percentage values instead of pixel values. Due to floating point precision error, checking for approxomations with a precision of 0.00001)
