### PR TITLE
LineChart: Recalculate scale on series visibility changed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartHideSeriesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartHideSeriesTest.razor
@@ -1,0 +1,21 @@
+﻿<div>
+    <MudCheckBox @bind-Value="_recalculateScale" Label="Recalculate scale"></MudCheckBox>
+    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" XAxisLabels="@XAxisLabels" CanHideSeries="true"
+              RecalculateScaleOnSeriesVisibilityChanged="_recalculateScale"
+              Width="100%" Height="350px"></MudChart>
+</div>
+
+@code {
+    public static string __description__ = "Hiding 'Series 3' should cause the chart to re-calculate the scale for the y-axis";
+
+    private bool _recalculateScale = true;
+
+    public List<ChartSeries> Series =
+    [
+        new() { Name = "Series 1", Data = [90, 79, 72, 69, 62, 62, 55, 65, 70] },
+        new() { Name = "Series 2", Data = [10, 41, 35, 51, 49, 62, 69, 91, 148] },
+        new() { Name = "Series 3", Data = [10, 41, 35, 500, 49, 62, 69, 91, 500] }
+    ];
+
+    public string[] XAxisLabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"];
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartHideSeriesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartHideSeriesTest.razor
@@ -1,7 +1,7 @@
 ﻿<div>
     <MudCheckBox @bind-Value="_recalculateScale" Label="Recalculate scale"></MudCheckBox>
     <MudChart ChartType="ChartType.Line" ChartSeries="@Series" XAxisLabels="@XAxisLabels" CanHideSeries="true"
-              RecalculateScaleOnSeriesVisibilityChanged="_recalculateScale"
+              DynamicRescaling="_recalculateScale"
               Width="100%" Height="350px"></MudChart>
 </div>
 

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -280,7 +280,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.XAxisLabels, xAxisLabels)
                 .Add(p => p.CanHideSeries, true)
-                .Add(p => p.RecalculateScaleOnSeriesVisibilityChanged, true));
+                .Add(p => p.DynamicRescaling, true));
 
             // The y-axis scale goes up to 520
             comp.Markup.Should().Contain(">520</text>");
@@ -328,7 +328,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.XAxisLabels, xAxisLabels)
                 .Add(p => p.CanHideSeries, true)
-                .Add(p => p.RecalculateScaleOnSeriesVisibilityChanged, false));
+                .Add(p => p.DynamicRescaling, false));
 
             // The y-axis scale goes up to 520
             comp.Markup.Should().Contain(">520</text>");

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -280,7 +280,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.XAxisLabels, xAxisLabels)
                 .Add(p => p.CanHideSeries, true)
-                .Add(p=> p.RecalculateScaleOnSeriesVisibilityChanged, true));
+                .Add(p => p.RecalculateScaleOnSeriesVisibilityChanged, true));
 
             // The y-axis scale goes up to 520
             comp.Markup.Should().Contain(">520</text>");
@@ -328,7 +328,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.XAxisLabels, xAxisLabels)
                 .Add(p => p.CanHideSeries, true)
-                .Add(p=> p.RecalculateScaleOnSeriesVisibilityChanged, false));
+                .Add(p => p.RecalculateScaleOnSeriesVisibilityChanged, false));
 
             // The y-axis scale goes up to 520
             comp.Markup.Should().Contain(">520</text>");

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -260,5 +260,101 @@ namespace MudBlazor.UnitTests.Charts
                 }
             }
         }
+
+        [Test]
+        public void LineChartWithHiddenSeriesShouldRedraw()
+        {
+            var chartSeries = new List<ChartSeries>()
+            {
+                new () { Name = "Series 1", Data = [90, 79, -72, 69, 62, 62, -55, 65, 70] },
+                new () { Name = "Series 2", Data = [10, 41, 35, 51, 49, 62, -69, 91, -148] },
+                new () { Name = "Series 3", Data = [10, 41, 35, 51, 500, 62, -69, 91, 500] }
+            };
+
+            string[] xAxisLabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"];
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.XAxisLabels, xAxisLabels)
+                .Add(p => p.CanHideSeries, true)
+                .Add(p=> p.RecalculateScaleOnSeriesVisibilityChanged, true));
+
+            // The y-axis scale goes up to 520
+            comp.Markup.Should().Contain(">520</text>");
+            comp.Markup.Should().NotContain(">100</text>");
+
+            comp.Instance.ChartSeries.First(s => s.Name == "Series 3").Visible.Should().BeTrue();
+
+            var path = comp.Find("path.mud-chart-line");
+            var d = path.GetAttribute("d");
+
+            // The line for "Series 1"
+            d.Should().Contain("M 30 211.5441 L 103.75 216.3162 L 177.5 281.8235 L 251.25 220.6544 L 325 223.6912 L 398.75 223.6912 L 472.5 274.4485 L 546.25 222.3897 L 620 220.2206");
+
+            comp.FindAll(".mud-chart-legend-item input")[2].Change(false);
+
+            comp.Instance.ChartSeries.First(s => s.Name == "Series 3").Visible.Should().BeFalse();
+
+            // The y-axis scale goes up to 100
+            comp.Markup.Should().Contain(">100</text>");
+            comp.Markup.Should().NotContain(">520</text>");
+
+            path = comp.Find("path.mud-chart-line");
+            d = path.GetAttribute("d");
+
+            // The line for "Series 1" has been redrawn
+            d.Should().Contain("M 30 36.3462 L 103.75 48.8269 L 177.5 220.1538 L 251.25 60.1731 L 325 68.1154 L 398.75 68.1154 L 472.5 200.8654 L 546.25 64.7115 L 620 59.0385");
+        }
+
+        [Test]
+        public void LineChartWithHiddenSeriesShouldNotRedraw()
+        {
+            var chartSeries = new List<ChartSeries>()
+            {
+                new () { Name = "Series 1", Data = [90, 79, -72, 69, 62, 62, -55, 65, 70] },
+                new () { Name = "Series 2", Data = [10, 41, 35, 51, 49, 62, -69, 91, -148] },
+                new () { Name = "Series 3", Data = [10, 41, 35, 51, 500, 62, -69, 91, 500] }
+            };
+
+            string[] xAxisLabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"];
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.Height, "350px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.XAxisLabels, xAxisLabels)
+                .Add(p => p.CanHideSeries, true)
+                .Add(p=> p.RecalculateScaleOnSeriesVisibilityChanged, false));
+
+            // The y-axis scale goes up to 520
+            comp.Markup.Should().Contain(">520</text>");
+            comp.Markup.Should().NotContain(">100</text>");
+
+            comp.Instance.ChartSeries.First(s => s.Name == "Series 3").Visible.Should().BeTrue();
+
+            var path = comp.Find("path.mud-chart-line");
+            var d = path.GetAttribute("d");
+
+            // The line for "Series 1"
+            d.Should().Contain("M 30 211.5441 L 103.75 216.3162 L 177.5 281.8235 L 251.25 220.6544 L 325 223.6912 L 398.75 223.6912 L 472.5 274.4485 L 546.25 222.3897 L 620 220.2206");
+
+            comp.FindAll(".mud-chart-legend-item input")[2].Change(false);
+
+            comp.Instance.ChartSeries.First(s => s.Name == "Series 3").Visible.Should().BeFalse();
+
+            // The y-axis scale still goes up to 520
+            comp.Markup.Should().Contain(">520</text>");
+            comp.Markup.Should().NotContain(">100</text>");
+
+            path = comp.Find("path.mud-chart-line");
+            d = path.GetAttribute("d");
+
+            // The line for "Series 1" has not been redrawn
+            d.Should().Contain("M 30 211.5441 L 103.75 216.3162 L 177.5 281.8235 L 251.25 220.6544 L 325 223.6912 L 398.75 223.6912 L 472.5 274.4485 L 546.25 222.3897 L 620 220.2206");
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -62,10 +62,14 @@ namespace MudBlazor.Charts
             if (gridYUnits <= 0)
                 gridYUnits = 20;
 
-            if (_series.SelectMany(series => series.Data).Any())
+            var chartSeries = MudChartParent is { CanHideSeries: true, RecalculateScaleOnSeriesVisibilityChanged: true } ?
+                _series.Where(s => s.Visible).ToList() :
+                _series;
+
+            if (chartSeries.SelectMany(series => series.Data).Any())
             {
-                var minY = _series.SelectMany(series => series.Data).Min();
-                var maxY = _series.SelectMany(series => series.Data).Max();
+                var minY = chartSeries.SelectMany(series => series.Data).Min();
+                var maxY = chartSeries.SelectMany(series => series.Data).Max();
 
                 var includeYAxisZeroPoint = MudChartParent?.ChartOptions.YAxisRequireZeroPoint ?? false;
                 if (includeYAxisZeroPoint)
@@ -88,7 +92,7 @@ namespace MudBlazor.Charts
                     numHorizontalLines = highestHorizontalLine - lowestHorizontalLine + 1;
                 }
 
-                numVerticalLines = _series.Max(series => series.Data.Length);
+                numVerticalLines = chartSeries.Max(series => series.Data.Length);
             }
             else
             {

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -62,7 +62,7 @@ namespace MudBlazor.Charts
             if (gridYUnits <= 0)
                 gridYUnits = 20;
 
-            var chartSeries = MudChartParent is { CanHideSeries: true, RecalculateScaleOnSeriesVisibilityChanged: true } ?
+            var chartSeries = MudChartParent is { CanHideSeries: true, DynamicRescaling: true } ?
                 _series.Where(s => s.Visible).ToList() :
                 _series;
 

--- a/src/MudBlazor/Components/Chart/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/MudChartBase.cs
@@ -147,7 +147,7 @@ public abstract class MudChartBase : MudComponentBase
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Chart.Behavior)]
-    public bool RecalculateScaleOnSeriesVisibilityChanged { get; set; } = false;
+    public bool DynamicRescaling { get; set; } = false;
 
     internal List<MudHeatMapCell> MudHeatMapCells { get; set; } = [];
 

--- a/src/MudBlazor/Components/Chart/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/MudChartBase.cs
@@ -142,6 +142,13 @@ public abstract class MudChartBase : MudComponentBase
     [Category(CategoryTypes.Chart.Behavior)]
     public bool CanHideSeries { get; set; } = false;
 
+    /// <summary>
+    /// If <see cref="CanHideSeries"/> is <c>true</c>, this property determines whether the chart will recalculate the scale when a series is hidden or shown.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Chart.Behavior)]
+    public bool RecalculateScaleOnSeriesVisibilityChanged { get; set; } = false;
+
     internal List<MudHeatMapCell> MudHeatMapCells { get; set; } = [];
 
     internal void AddCell(MudHeatMapCell cell)

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -54,6 +54,10 @@
     margin: auto;
   }
 
+  & .mud-chart-line path {
+    transition: 0.2s
+  }
+
   & .mud-chart-legend {
     display: flex;
     padding: 10px 0px;
@@ -87,6 +91,7 @@
     }
   }
 }
+
 
 .mud-charts-yaxis {
   fill: var(--mud-palette-text-primary);


### PR DESCRIPTION
On a `LineChart`, recalculate - and redraw - the scale for the y-axis when a series visibility changes - specially when the series has values that are on a different magnitude compared to the other series.

## Description
On a `LineChart`, when we have series with max and min values that vary too much between each other and we hide one of the series, it's useful to have the series that are still visible to redraw and have their scales re-calculated (see video).

https://github.com/user-attachments/assets/e60a7186-4a69-4e2f-b933-c0ed0e5a5288

I added a parameter to `MudChartBase` called `RecalculateScaleOnSeriesVisibilityChanged` that enables this feature when set to `true`. I'm not completely happy with the name, but I couldn't think of a better one. And I'm not 100% sure I put it in the right place.

This is my first contribution to an open source project. You will not hurt my feelings if you throw the whole thing in the garbage if I did something stupid :-)

## How Has This Been Tested?
Visually and I created two new unit tests.


## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
