### PR TITLE
Docs: Update render mode warning

### DIFF
--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -100,7 +100,7 @@
                     <SectionHeader Class="mt-6">
                         <Description>
                             <MudAlert Class="mt-4" Severity="Severity.Warning">
-                                If you experience issues such as certain menus not appearing, your render mode may be configured incorrectly.
+                                If you experience issues such as certain components not responding to user interactions, your render mode may be configured incorrectly.
                                 Static rendering is not supported and the rendering mode must be interactive.
                                 <MudLink Href="https://learn.microsoft.com/aspnet/core/blazor/components/render-modes" Target="_blank">Learn about render modes</MudLink>
                                 or


### PR DESCRIPTION
## Description
Reduce possible confusion on static and interactive component support.

A Discord user stated the following 
> I did not think rendermode had anything to do with tabs since the text in the second link just mentions "certain menus", and I associate tabs with layout, not menus.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
