### PR TITLE
MudMenu: Position At Cursor Flip Logic

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuFlipTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuFlipTest.razor
@@ -8,12 +8,12 @@
 </MudPaper>
 
 <MudMenu @ref="contextMenu"
-AnchorOrigin="@Origin.BottomLeft"
-Dense
-TransformOrigin="@Origin.BottomLeft"
-PopoverClass="menu-popover"
-DropdownSettings="@dropdownSettings"
-PositionAtCursor>
+         AnchorOrigin="@Origin.BottomLeft"
+         Dense
+         TransformOrigin="@Origin.BottomLeft"
+         PopoverClass="menu-popover"
+         DropdownSettings="@dropdownSettings"
+         PositionAtCursor>
     <MudMenuItem Label="Enlist" />
     <MudMenuItem Label="Barracks" />
     <MudMenuItem Label="Armory" />
@@ -35,11 +35,11 @@ PositionAtCursor>
     private MudMenu contextMenu = null!;
     protected DropdownSettings dropdownSettings => new DropdownSettings() { OverflowBehavior = OverflowBehavior.FlipAlways };
 
-    private async void ListItem_Clicked(MouseEventArgs e)
+    private async Task ListItem_Clicked(MouseEventArgs e)
     {
         if (contextMenu != null)
         {
             await contextMenu.OpenMenuAsync(e);
-        }        
+        }
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuFlipTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuFlipTest.razor
@@ -1,0 +1,45 @@
+﻿<MudPaper Width="300px">
+    <MudList T="string" Dense>
+        @for (int i = 0; i < 20; i++)
+        {
+            <MudListItem Text=@($"Item {i}") OnClick="ListItem_Clicked" />
+        }
+    </MudList>
+</MudPaper>
+
+<MudMenu @ref="contextMenu"
+AnchorOrigin="@Origin.BottomLeft"
+Dense
+TransformOrigin="@Origin.BottomLeft"
+PopoverClass="menu-popover"
+DropdownSettings="@dropdownSettings"
+PositionAtCursor>
+    <MudMenuItem Label="Enlist" />
+    <MudMenuItem Label="Barracks" />
+    <MudMenuItem Label="Armory" />
+    <MudMenuItem Label="Enlist" />
+    <MudMenuItem Label="Barracks" />
+    <MudMenuItem Label="Armory" />
+    <MudMenuItem Label="Enlist" />
+    <MudMenuItem Label="Barracks" />
+    <MudMenuItem Label="Armory" />
+    <MudMenuItem Label="Enlist" />
+    <MudMenuItem Label="Barracks" />
+    <MudMenuItem Label="Armory" />
+    <MudMenuItem Label="Enlist" />
+    <MudMenuItem Label="Barracks" />
+    <MudMenuItem Label="Armory" />
+</MudMenu>
+
+@code {
+    private MudMenu contextMenu = null!;
+    protected DropdownSettings dropdownSettings => new DropdownSettings() { OverflowBehavior = OverflowBehavior.FlipAlways };
+
+    private async void ListItem_Clicked(MouseEventArgs e)
+    {
+        if (contextMenu != null)
+        {
+            await contextMenu.OpenMenuAsync(e);
+        }        
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuFlipTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuFlipTest.razor
@@ -7,12 +7,12 @@
     </MudList>
 </MudPaper>
 
-<MudMenu @ref="contextMenu"
+<MudMenu @ref="_contextMenu"
          AnchorOrigin="@Origin.BottomLeft"
          Dense
          TransformOrigin="@Origin.BottomLeft"
          PopoverClass="menu-popover"
-         DropdownSettings="@dropdownSettings"
+         DropdownSettings="@_dropdownSettings"
          PositionAtCursor>
     <MudMenuItem Label="Enlist" />
     <MudMenuItem Label="Barracks" />
@@ -32,14 +32,14 @@
 </MudMenu>
 
 @code {
-    private MudMenu contextMenu = null!;
-    protected DropdownSettings dropdownSettings => new DropdownSettings() { OverflowBehavior = OverflowBehavior.FlipAlways };
+    private MudMenu _contextMenu = null!;
+    private readonly DropdownSettings _dropdownSettings = new DropdownSettings() { OverflowBehavior = OverflowBehavior.FlipAlways };
 
     private async Task ListItem_Clicked(MouseEventArgs e)
     {
-        if (contextMenu != null)
+        if (_contextMenu != null)
         {
-            await contextMenu.OpenMenuAsync(e);
+            await _contextMenu.OpenMenuAsync(e);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -434,7 +434,7 @@ namespace MudBlazor.UnitTests.Components
             popover.ClassList.Should().Contain("mud-popover-anchor-top-left");
             popover.ClassList.Should().Contain("mud-popover-position-override");
 
-            popover.OuterHtml.Should().Contain("top:0px;left:0px;");
+            popover.OuterHtml.Should().Contain("data-pc-x=\"0\" data-pc-y=\"0\"");
 
             await Context.Renderer.Dispatcher.InvokeAsync(mudMenuContext.CloseMenuAsync);
         }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -71,7 +71,7 @@
     @* The portal has to include the cascading values inside because it's not able to teletransport the cascade *@
     <MudPopover Open="@_openState.Value"
                 Class="@PopoverClassname"
-                Style="@Stylename"
+                UserAttributes="@PositionAttributes"
                 MaxHeight="@MaxHeight"
                 AnchorOrigin="@GetAnchorOrigin()"
                 TransformOrigin="@TransformOrigin"

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -76,8 +76,11 @@ namespace MudBlazor
         /// <summary>
         /// Inline data attributes for positioning the menu at the cursor's location.
         /// </summary>
-        private Dictionary<string, object> PositionAttributes =>
-            new() { { "data-pc-x", _openPosition.Left.ToString() }, { "data-pc-y", _openPosition.Top.ToString() } };
+        private Dictionary<string, object> PositionAttributes => new()
+        {
+            { "data-pc-x", _openPosition.Left.ToString() },
+            { "data-pc-y", _openPosition.Top.ToString() },
+        };
 
         /// <summary>
         /// The text shown for this menu.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -74,13 +74,10 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
-        /// Inline styles for positioning the menu at the cursor's location.
+        /// Inline data attributes for positioning the menu at the cursor's location.
         /// </summary>
-        protected string Stylename =>
-            new StyleBuilder()
-                .AddStyle("top", _openPosition.Top.ToPx(), PositionAtCursor)
-                .AddStyle("left", _openPosition.Left.ToPx(), PositionAtCursor)
-                .Build();
+        private Dictionary<string, object> PositionAttributes =>
+            new() { { "data-pc-x", _openPosition.Left.ToString() }, { "data-pc-y", _openPosition.Top.ToString() } };
 
         /// <summary>
         /// The text shown for this menu.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
@@ -74,12 +76,23 @@ namespace MudBlazor
                 .Build();
 
         /// <summary>
+        /// Inline styles for positioning the menu at the cursor's location.
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        [Obsolete($"Will be removed in future, replaced by {nameof(PositionAttributes)}.")]
+        protected string Stylename =>
+            new StyleBuilder()
+                .AddStyle("top", _openPosition.Top.ToPx(), PositionAtCursor)
+                .AddStyle("left", _openPosition.Left.ToPx(), PositionAtCursor)
+                .Build();
+
+        /// <summary>
         /// Inline data attributes for positioning the menu at the cursor's location.
         /// </summary>
         private Dictionary<string, object> PositionAttributes => new()
         {
-            { "data-pc-x", _openPosition.Left.ToString() },
-            { "data-pc-y", _openPosition.Top.ToString() },
+            { "data-pc-x", _openPosition.Left.ToString(CultureInfo.InvariantCulture) },
+            { "data-pc-y", _openPosition.Top.ToString(CultureInfo.InvariantCulture) }
         };
 
         /// <summary>

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -176,7 +176,6 @@ window.mudpopoverHelper = {
                 top = boundingRect.top + boundingRect.height;
             }
         }
-
         return {
             top: top, left: left, offsetX: offsetX, offsetY: offsetY, anchorY: top, anchorX: left
         };
@@ -278,6 +277,23 @@ window.mudpopoverHelper = {
             const zIndexAuto = popoverNodeStyle.getPropertyValue('z-index') === 'auto';
             const classListArray = Array.from(classList);
 
+            if (isPositionOverride) {
+                const positiontop = parseInt(popoverContentNode.getAttribute('data-pc-y')) || boundingRect.top;
+                const positionleft = parseInt(popoverContentNode.getAttribute('data-pc-x')) || boundingRect.left;
+                const scrollLeft = window.scrollX;
+                const scrollTop = window.scrollY;
+
+                // bounding rect for flipping
+                boundingRect = {
+                    left: positionleft - scrollLeft,
+                    top: positiontop - scrollTop,
+                    right: positionleft + 1,
+                    bottom: positiontop + 1,
+                    width: 1,
+                    height: 1
+                };
+            }
+
             // calculate position based on opening anchor/transform
             const position = window.mudpopoverHelper.calculatePopoverPosition(classListArray, boundingRect, selfRect);
             let left = position.left; // X-coordinate of the popover
@@ -301,30 +317,6 @@ window.mudpopoverHelper = {
             if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
                 popoverContentNode.style.maxHeight = null;
                 popoverContentNode.mudHeight = null;
-            }
-
-            // get the top/left/ from popoverContentNode if the popover has been hardcoded for position
-            if (isPositionOverride) {
-                top = parseInt(popoverContentNode.getAttribute('data-pc-y')) || top;
-                left = parseInt(popoverContentNode.getAttribute('data-pc-x')) || left;                
-
-                // no offset when hardcoded
-                offsetX = 0;
-                offsetY = 0;
-
-                // anchor position is the same as top/left without scroll
-                anchorX = left - (window.scrollX > 0 ? window.scrollX : 0);
-                anchorY = top - (window.scrollY > 0 ? window.scrollY : 0);
-
-                // bounding rect for flipping
-                boundingRect = {
-                    left: left,
-                    top: top,
-                    right: left + selfRect.width,
-                    bottom: top + selfRect.height,
-                    width: selfRect.width,
-                    height: selfRect.height
-                };
             }
 
             // flipping logic
@@ -584,9 +576,7 @@ window.mudpopoverHelper = {
             if (isPositionFixed) {
                 popoverContentNode.style['position'] = 'fixed';
             }
-            else if (!classList.contains('mud-popover-fixed') && !isPositionOverride) {
-                // position override calculates position by mouse cursor position
-                // easy to test in Docs menu buttom position at cusor
+            else if (!classList.contains('mud-popover-fixed')) {
                 offsetX += window.scrollX;
                 offsetY += window.scrollY
             }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -312,9 +312,9 @@ window.mudpopoverHelper = {
                 offsetX = 0;
                 offsetY = 0;
 
-                // anchor position is the same as top/left
-                anchorY = top;
-                anchorX = left;
+                // anchor position is the same as top/left without scroll
+                anchorX = left - (window.scrollX > 0 ? window.scrollX : 0);
+                anchorY = top - (window.scrollY > 0 ? window.scrollY : 0);
 
                 // bounding rect for flipping
                 boundingRect = {
@@ -584,7 +584,9 @@ window.mudpopoverHelper = {
             if (isPositionFixed) {
                 popoverContentNode.style['position'] = 'fixed';
             }
-            else if (!classList.contains('mud-popover-fixed')) {
+            else if (!classList.contains('mud-popover-fixed') && !isPositionOverride) {
+                // position override calculates position by mouse cursor position
+                // easy to test in Docs menu buttom position at cusor
                 offsetX += window.scrollX;
                 offsetY += window.scrollY
             }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -101,41 +101,14 @@ window.mudpopoverHelper = {
 
     // used to calculate the position of the popover
     calculatePopoverPosition: function (list, boundingRect, selfRect) {
-        let top = 0;
-        let left = 0;
-        if (list.indexOf('mud-popover-anchor-top-left') >= 0) {
-            left = boundingRect.left;
-            top = boundingRect.top;
-        } else if (list.indexOf('mud-popover-anchor-top-center') >= 0) {
-            left = boundingRect.left + boundingRect.width / 2;
-            top = boundingRect.top;
-        } else if (list.indexOf('mud-popover-anchor-top-right') >= 0) {
-            left = boundingRect.left + boundingRect.width;
-            top = boundingRect.top;
+        let top = boundingRect.top;     // default for mud-popover-anchor-top-left
+        let left = boundingRect.left;   // default for mud-popover-anchor-top-left
 
-        } else if (list.indexOf('mud-popover-anchor-center-left') >= 0) {
-            left = boundingRect.left;
-            top = boundingRect.top + boundingRect.height / 2;
-        } else if (list.indexOf('mud-popover-anchor-center-center') >= 0) {
-            left = boundingRect.left + boundingRect.width / 2;
-            top = boundingRect.top + boundingRect.height / 2;
-        } else if (list.indexOf('mud-popover-anchor-center-right') >= 0) {
-            left = boundingRect.left + boundingRect.width;
-            top = boundingRect.top + boundingRect.height / 2;
-
-        } else if (list.indexOf('mud-popover-anchor-bottom-left') >= 0) {
-            left = boundingRect.left;
-            top = boundingRect.top + boundingRect.height;
-        } else if (list.indexOf('mud-popover-anchor-bottom-center') >= 0) {
-            left = boundingRect.left + boundingRect.width / 2;
-            top = boundingRect.top + boundingRect.height;
-        } else if (list.indexOf('mud-popover-anchor-bottom-right') >= 0) {
-            left = boundingRect.left + boundingRect.width;
-            top = boundingRect.top + boundingRect.height;
-        }
+        const isPositionOverride = list.indexOf('mud-popover-position-override') >= 0;
 
         let offsetX = 0;
         let offsetY = 0;
+        // transform origin
 
         if (list.indexOf('mud-popover-top-left') >= 0) {
             offsetX = 0;
@@ -168,6 +141,40 @@ window.mudpopoverHelper = {
         } else if (list.indexOf('mud-popover-bottom-right') >= 0) {
             offsetX = -selfRect.width;
             offsetY = -selfRect.height;
+        }
+
+        if (!isPositionOverride) {
+            // anchor origin, don't flip anchors on position override
+            if (list.indexOf('mud-popover-anchor-top-left') >= 0) {
+                left = boundingRect.left;
+                top = boundingRect.top;
+            } else if (list.indexOf('mud-popover-anchor-top-center') >= 0) {
+                left = boundingRect.left + boundingRect.width / 2;
+                top = boundingRect.top;
+            } else if (list.indexOf('mud-popover-anchor-top-right') >= 0) {
+                left = boundingRect.left + boundingRect.width;
+                top = boundingRect.top;
+
+            } else if (list.indexOf('mud-popover-anchor-center-left') >= 0) {
+                left = boundingRect.left;
+                top = boundingRect.top + boundingRect.height / 2;
+            } else if (list.indexOf('mud-popover-anchor-center-center') >= 0) {
+                left = boundingRect.left + boundingRect.width / 2;
+                top = boundingRect.top + boundingRect.height / 2;
+            } else if (list.indexOf('mud-popover-anchor-center-right') >= 0) {
+                left = boundingRect.left + boundingRect.width;
+                top = boundingRect.top + boundingRect.height / 2;
+
+            } else if (list.indexOf('mud-popover-anchor-bottom-left') >= 0) {
+                left = boundingRect.left;
+                top = boundingRect.top + boundingRect.height;
+            } else if (list.indexOf('mud-popover-anchor-bottom-center') >= 0) {
+                left = boundingRect.left + boundingRect.width / 2;
+                top = boundingRect.top + boundingRect.height;
+            } else if (list.indexOf('mud-popover-anchor-bottom-right') >= 0) {
+                left = boundingRect.left + boundingRect.width;
+                top = boundingRect.top + boundingRect.height;
+            }
         }
 
         return {
@@ -298,11 +305,17 @@ window.mudpopoverHelper = {
 
             // get the top/left/ from popoverContentNode if the popover has been hardcoded for position
             if (isPositionOverride) {
-                left = parseInt(popoverContentNode.style['left']) || left;
-                top = parseInt(popoverContentNode.style['top']) || top;
-                // no offset when hardcoded 
+                top = parseInt(popoverContentNode.getAttribute('data-pc-y')) || top;
+                left = parseInt(popoverContentNode.getAttribute('data-pc-x')) || left;                
+
+                // no offset when hardcoded
                 offsetX = 0;
                 offsetY = 0;
+
+                // anchor position is the same as top/left
+                anchorY = top;
+                anchorX = left;
+
                 // bounding rect for flipping
                 boundingRect = {
                     left: left,
@@ -313,6 +326,7 @@ window.mudpopoverHelper = {
                     height: selfRect.height
                 };
             }
+
             // flipping logic
             if (isFlipOnOpen || isFlipAlways) {
 
@@ -573,12 +587,6 @@ window.mudpopoverHelper = {
             else if (!classList.contains('mud-popover-fixed')) {
                 offsetX += window.scrollX;
                 offsetY += window.scrollY
-            }
-
-            if (isPositionOverride) {
-                // no offset if popover position is hardcoded
-                offsetX = 0;
-                offsetY = 0;
             }
 
             popoverContentNode.style['left'] = (left + offsetX) + 'px';


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Position at cursor setting for popover was previously using style tags that were being overridden inside the popover javascript causing a loop. The loop was closed previously by ignoring offsets, however offsets are needed to flip. 
Changed styles to data attributes so it doesn't overwrite itself constantly.
Added anchor X/Y to position override for flip logic.
Changed logic to never try and flip anchor when position at cursor is used (anchor is a point and not a rectangle)
Removed the offset override. 
Resolves #11433 

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
Visually tested in BSS/WASM docs and viewers

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
