### PR TITLE
Docs: Asset cache busting strategies

### DIFF
--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleNet8.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleNet8.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-<link href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" rel="stylesheet" />
+<link href="_content/MudBlazor/MudBlazor.min.css?v=@(MudBlazor.Metadata.Version)" rel="stylesheet" />

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleWasmStandalone.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleWasmStandalone.razor
@@ -1,0 +1,5 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+<!-- Important: Increment the version parameter whenever you update MudBlazor to prevent caching issues -->
+<link href="_content/MudBlazor/MudBlazor.min.css?v=1" rel="stylesheet" />

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -65,11 +65,34 @@
                     <SectionHeader Title="Add References">
                         <Description>Add the following to your HTML head section, it's either <CodeInline>index.html</CodeInline> or <CodeInline>_Layout.cshtml</CodeInline>/<CodeInline>_Host.cshtml</CodeInline>/<CodeInline>App.razor</CodeInline> depending on whether you're running WebAssembly or Server.</Description>
                     </SectionHeader>
-                    <SectionContent Code="@nameof(InstallationManualCssFontsExample)" />
+                    <SectionContent Codes="@([
+                        new CodeFile(".NET 9", nameof(InstallationManualCssFontsExample)),
+                        new CodeFile(".NET 8", nameof(InstallationManualCssFontsExampleNet8)), 
+                        new CodeFile("WebAssembly Standalone", nameof(InstallationManualCssFontsExampleWasmStandalone)),
+                    ])" />
                     <SectionHeader Class="mt-6">
                         <Description>Next, add the MudBlazor js file next to the default Blazor script at the end:</Description>
                     </SectionHeader>
-                    <SectionContent Code="@nameof(InstallScriptManual)" />
+                    <SectionContent Codes="@([
+                        new CodeFile(".NET 9", nameof(InstallScriptManual)),
+                        new CodeFile(".NET 8", nameof(InstallScriptManualNet8)),
+                        new CodeFile("WebAssembly Standalone", nameof(InstallScriptManualWasmStandalone)),
+                    ])" />
+                    <SectionHeader Class="mt-6">
+                        <Description>
+                            On .NET 9 or later, ensure that the <CodeInline>app.MapStaticAssets()</CodeInline> middleware
+                            is enabled so that <CodeInline>@@Assets[""]</CodeInline> can fingerprint the files. When upgrading from
+                            an earlier .NET release this does not happen automatically.
+                        </Description>
+                    </SectionHeader>
+                    <SectionHeader Class="mt-6">
+                        <Description>
+                            <MudAlert Class="mt-4" Severity="Severity.Warning">
+                                Please make sure you've implemented a suitable cache busting strategy for all scripts and stylesheets as seen above.
+                                Otherwise your users will experience caching related issues when you update MudBlazor.
+                            </MudAlert>
+                        </Description>
+                    </SectionHeader>
                 </DocsPageSection>
 
                 <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualCode.html
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualCode.html
@@ -1,7 +1,7 @@
 ﻿<div class="mud-codeblock">
     <div class="html">
 <pre>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">script</span> <span class="htmlAttributeName">src</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">_content/MudBlazor/MudBlazor.min.js</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span><span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">/script</span><span class="htmlTagDelimiter">&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">script</span> <span class="htmlAttributeName">src</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue"><span class="atSign">&#64;</span>Assets[&quot;_content/MudBlazor/MudBlazor.min.js&quot;]</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span><span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">script</span><span class="htmlTagDelimiter">&gt;</span>
 </pre>
     </div>
 </div>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualNet8.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualNet8.razor
@@ -1,0 +1,3 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@* Dummy file do not remove, needed for content section *@

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualNet8Code.html
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualNet8Code.html
@@ -1,0 +1,7 @@
+﻿<div class="mud-codeblock">
+    <div class="html">
+<pre>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">script</span> <span class="htmlAttributeName">src</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">_content/MudBlazor/MudBlazor.min.css?v=<span class="atSign">&#64;</span>(MudBlazor.Metadata.Version)</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span><span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">script</span><span class="htmlTagDelimiter">&gt;</span>
+</pre>
+    </div>
+</div>

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualWasmStandalone.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualWasmStandalone.razor
@@ -1,0 +1,3 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+@* Dummy file do not remove, needed for content section *@

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualWasmStandaloneCode.html
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/ManualMarkdown/InstallScriptManualWasmStandaloneCode.html
@@ -1,0 +1,8 @@
+﻿<div class="mud-codeblock">
+    <div class="html">
+<pre>
+<span class="htmlComment">&lt;!-- Important: Increment the version parameter whenever you update MudBlazor to prevent caching issues --&gt;</span>
+<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">script</span> <span class="htmlAttributeName">src</span><span class="htmlOperator">=</span><span class="quot">&quot;</span><span class="htmlAttributeValue">_content/MudBlazor/MudBlazor.min.css?v=1</span><span class="quot">&quot;</span><span class="htmlTagDelimiter">&gt;</span><span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">script</span><span class="htmlTagDelimiter">&gt;</span>
+</pre>
+    </div>
+</div>

--- a/src/MudBlazor/Services/Version.cs
+++ b/src/MudBlazor/Services/Version.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+/// <summary>
+/// Provides metadata about the MudBlazor library.
+/// </summary>
+public static class Metadata
+{
+    /// <summary>
+    /// The current version number of MudBlazor.
+    /// </summary>
+    public static string Version { get; } = typeof(Metadata).Assembly.GetName().Version?.ToString(3) ?? "unknown";
+}


### PR DESCRIPTION
## Description

I've added suitable cache busting strategies for all supported .NET versions.

For the .NET 8 strategy, this tiny class provides easy access to the MudBlazor version:

```cs
public static class Metadata
{
    /// <summary>
    /// The current version number of MudBlazor.
    /// </summary>
    public static string Version { get; } = typeof(Metadata).Assembly.GetName().Version?.ToString(3) ?? "unknown";
}
```

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->
visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

### Before

![image](https://github.com/user-attachments/assets/ae2731f4-6280-437f-93ab-42e96ac89819)

### After

.NET 9 with static asset fingerprinting:

![image](https://github.com/user-attachments/assets/e997b33b-8aab-4730-9751-d743c774eba0)

.NET 8 naive cache busting strategy by appending the MudBlazor version:

![image](https://github.com/user-attachments/assets/9cd578ab-edab-4877-8b71-58029923b323)

WASM standalone currently requires manually incementing the version when updating MudBlazor (.NET 10 will add a proper solution):

![image](https://github.com/user-attachments/assets/c4c08c84-826b-45cd-9425-c6c5ab5e7b77)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
