### PR TITLE
Input Text Adornment : Render an button when AdornmentClick exist

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputAdornmentTextWithOnClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Input/InputAdornmentTextWithOnClickTest.razor
@@ -1,0 +1,15 @@
+﻿<br/>
+<MudTextField @bind-Value="Text"
+                AdornmentText="Click Here"
+                Adornment="Adornment.End"
+                OnAdornmentClick="AdornmentClick"/>
+
+@code {
+    public static string __description__ = "Input Adornment Text Button Test";
+    private string Text { get; set; } = "Text";
+
+    void AdornmentClick()
+    {
+        Text = "Adornment Clicked";
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -31,7 +31,7 @@ public class InputTests : BunitTest
             .Add(x => x.AdornmentText, "Click Here")
             .Add(x => x.Adornment, Adornment.End)
             .Add(x => x.OnAdornmentClick, () => { }));
-        comp.Find("button.mud-button-text").Should().NotBeNull("Should render an button");
+        comp.Find("button.mud-input-adornment-text-button").Should().NotBeNull("Should render an button");
     }
 #nullable disable
 }

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -21,5 +21,17 @@ public class InputTests : BunitTest
         comp.SetParametersAndRender(p => p.Add(x => x.ReadOnly, true)); //no clear button when readonly
         comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
     }
+
+    [Test]
+
+    public void AdornmentTextWithOnAdornmentClickShouldBeButton()
+    {
+        var comp = Context.RenderComponent<MudInput<string>>(p => p
+            .Add(x => x.Text, "some value")
+            .Add(x => x.AdornmentText, "Click Here")
+            .Add(x => x.Adornment, Adornment.End)
+            .Add(x => x.OnAdornmentClick, () => { }));
+        comp.Find("button.mud-button-text").Should().NotBeNull("Should render an button");
+    }
 #nullable disable
 }

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -6,7 +6,8 @@
     {
         @if (AdornmentClick.HasDelegate)
         {
-            <MudButton Size="@Size" 
+            <MudButton Class="mud-input-adornment-text-button mud-no-activator"
+                        Size="@Size" 
                        Color="@Color" 
                        OnClick="@AdornmentClick" 
                        tabindex="-1">

--- a/src/MudBlazor/Components/Input/MudInputAdornment.razor
+++ b/src/MudBlazor/Components/Input/MudInputAdornment.razor
@@ -4,11 +4,23 @@
 <div class="@Classname">
     @if (!string.IsNullOrWhiteSpace(Text))
     {
-        <MudText Class="mud-input-adornment-text"
-                 Color="@Color"
-                 tabindex="-1">
-            @Text
-        </MudText>
+        @if (AdornmentClick.HasDelegate)
+        {
+            <MudButton Size="@Size" 
+                       Color="@Color" 
+                       OnClick="@AdornmentClick" 
+                       tabindex="-1">
+                @Text
+            </MudButton>
+        }
+        else
+        {
+            <MudText Class="mud-input-adornment-text"
+                     Color="@Color"
+                     tabindex="-1">
+                @Text
+            </MudText>
+        }
     }
     else if (!string.IsNullOrWhiteSpace(Icon))
     {


### PR DESCRIPTION
## Description
I changed the logical when the Adornment is an Text and has an OnAdornmentClick event, so it will render and MudButton with an OnClick event instead of just an MudText
Fixes #3848 

## How Has This Been Tested?
I wrote an test to check if the rendered component of Input with OnAdornmentClick and AdornmentText have an 'button' element with class 'mud-button-text'. And below theres a video of a visual test based on the reproduction of the issue

https://github.com/user-attachments/assets/b4a69a36-6a9a-4687-bba9-1db38b1434f9


## Type of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
