### PR TITLE
MudMenu: Hide popover overflow

### DIFF
--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -90,7 +90,7 @@
   margin-inline-end: 36px;
 }
 
-// Prevent menu item hover effects peeking through the popover when it's rounded.
+// Prevent menu item hover effects peeking through rounded popovers.
 .mud-popover:has(> .mud-menu-list) {
   overflow: hidden;
 }

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -89,3 +89,8 @@
 .mud-menu-list:has(.mud-menu-submenu-icon) .mud-menu-item:not(:has(.mud-menu-submenu-icon)) .mud-menu-item-text {
   margin-inline-end: 36px;
 }
+
+// Prevent menu item hover effects peeking through the popover when it's rounded.
+.mud-popover:has(.mud-menu-list) {
+  overflow: hidden;
+}

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -91,6 +91,6 @@
 }
 
 // Prevent menu item hover effects peeking through the popover when it's rounded.
-.mud-popover:has(.mud-menu-list) {
+.mud-popover:has(> .mud-menu-list) {
   overflow: hidden;
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Narrower version of #9993. Only affects the Menu (if it's a **direct descendant** for max compatibility against custom implementations) instead of all popovers indiscriminately. Does not apply to regular lists, only menu lists.

Snippet and images still apply.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/user-attachments/assets/4aa37a82-3a2a-4c3c-a48f-0e149b64709b)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
