### PR TITLE
MudChat: Prevent Ripple Overflow Block when Clickable

### DIFF
--- a/src/MudBlazor/Styles/components/_chat.scss
+++ b/src/MudBlazor/Styles/components/_chat.scss
@@ -136,6 +136,7 @@ $default-foreground: var(--mud-palette-text-primary);
     min-height: 2.75rem;
 
     &.mud-chat-bubble-clickable {
+      overflow: unset !important;
       cursor: pointer;
       user-select: none;
       -webkit-appearance: none;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
When a MudChatBubble was clickable the ripple effect cuts off overflow blocking the ::before element from showing. Added a specific unset to the bubble in that scenario.
Resolves #11249 
I added a line to the mud-chat-bubble-clickable to unset overflow for the chat bubble. Prevents ripple from blocking the arrow.
`.mud-chat-bubble-clickable { overflow: unset !important; }`

Before
![Screenshot 2025-06-04 103609](https://github.com/user-attachments/assets/d87b97dd-2b1a-45ac-8438-ca8d7bf90aea)

After
![Screenshot 2025-06-04 103629](https://github.com/user-attachments/assets/f143f629-850f-4d37-830e-a40ee4654377)


## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
