### PR TITLE
MudDataGrid: Filters and Options Popover changed to Position At Cursor

### DIFF
--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -142,7 +142,7 @@ else if (Column != null && !Column.HiddenState.Value)
         @if (filterable && DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
         {
             <MudOverlay @bind-Visible="@_filtersMenuVisible" AutoClose />
-            <MudPopover Open="@_filtersMenuVisible" AnchorOrigin="@Origin.BottomRight" TransformOrigin="@Origin.TopRight" Class="pa-4 column-filter-popup">
+            <MudPopover UserAttributes="@DataGrid?.PositionAttributes" Open="@_filtersMenuVisible" AnchorOrigin="@Origin.BottomRight" TransformOrigin="@Origin.TopRight" Class="pa-4 column-filter-popup mud-popover-position-override">
                 @if (Column.FilterTemplate != null)
                 {
                     @Column.FilterTemplate(Column.FilterContext) 

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -401,7 +401,7 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
         }
 
-        internal void AddFilter()
+        internal void AddFilter(MouseEventArgs args)
         {
             var filterDefinition = Column?.FilterContext.FilterDefinition;
             if (DataGrid.FilterMode == DataGridFilterMode.Simple && filterDefinition != null)
@@ -410,6 +410,8 @@ namespace MudBlazor
                 {
                     DataGrid.FilterDefinitions.Add(filterDefinition.Clone());
                 }
+                DataGrid._openPosition.Top = args.PageY;
+                DataGrid._openPosition.Left = args.PageX;
                 DataGrid.OpenFilters();
             }
             else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
@@ -419,12 +421,18 @@ namespace MudBlazor
             }
         }
 
-        internal void OpenFilters()
+        internal void OpenFilters(MouseEventArgs args)
         {
             if (DataGrid.FilterMode == DataGridFilterMode.Simple)
+            {
+                DataGrid._openPosition.Top = args.PageY;
+                DataGrid._openPosition.Left = args.PageX;
                 DataGrid.OpenFilters();
+            }
             else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
             {
+                DataGrid._openPosition.Top = args.PageY;
+                DataGrid._openPosition.Left = args.PageX;
                 _filtersMenuVisible = true;
                 DataGrid.DropContainerHasChanged();
             }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -401,7 +401,7 @@ namespace MudBlazor
             DataGrid.DropContainerHasChanged();
         }
 
-        internal void AddFilter(MouseEventArgs args)
+        internal void AddFilter(MouseEventArgs args = null)
         {
             var filterDefinition = Column?.FilterContext.FilterDefinition;
             if (DataGrid.FilterMode == DataGridFilterMode.Simple && filterDefinition != null)
@@ -410,8 +410,11 @@ namespace MudBlazor
                 {
                     DataGrid.FilterDefinitions.Add(filterDefinition.Clone());
                 }
-                DataGrid._openPosition.Top = args.PageY;
-                DataGrid._openPosition.Left = args.PageX;
+                if (args != null)
+                {
+                    DataGrid._openPosition.Top = args.PageY;
+                    DataGrid._openPosition.Left = args.PageX;
+                }
                 DataGrid.OpenFilters();
             }
             else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
@@ -421,18 +424,24 @@ namespace MudBlazor
             }
         }
 
-        internal void OpenFilters(MouseEventArgs args)
+        internal void OpenFilters(MouseEventArgs args = null)
         {
             if (DataGrid.FilterMode == DataGridFilterMode.Simple)
             {
-                DataGrid._openPosition.Top = args.PageY;
-                DataGrid._openPosition.Left = args.PageX;
+                if (args != null)
+                {
+                    DataGrid._openPosition.Top = args.PageY;
+                    DataGrid._openPosition.Left = args.PageX;
+                }
                 DataGrid.OpenFilters();
             }
             else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
             {
-                DataGrid._openPosition.Top = args.PageY;
-                DataGrid._openPosition.Left = args.PageX;
+                if (args != null)
+                {
+                    DataGrid._openPosition.Top = args.PageY;
+                    DataGrid._openPosition.Left = args.PageX;
+                }
                 _filtersMenuVisible = true;
                 DataGrid.DropContainerHasChanged();
             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -62,7 +62,7 @@
                                     <MudOverlay @bind-Visible="@_filtersMenuVisible" AutoClose OnClosed="@CloseFilters"></MudOverlay>
                                     <tr class="mud-table-row" style="visibility: collapse; opacity: 0;overflow: hidden;">
                                         <th colspan="@RenderedColumns.Count" class="mud-table-cell mud-filter-panel-cell">
-                                            <MudPopover Open="@_filtersMenuVisible" Paper="true" Class="filters-panel pa-2" OverflowBehavior="OverflowBehavior.FlipAlways" AnchorOrigin="Origin.TopLeft"
+                                            <MudPopover UserAttributes="@PositionAttributes" Open="@_filtersMenuVisible" Paper="true" Class="filters-panel pa-2 mud-popover-position-override" OverflowBehavior="OverflowBehavior.FlipAlways" AnchorOrigin="Origin.TopLeft"
                                                         TransformOrigin="Origin.TopLeft" Elevation="4" Style="width:700px;max-width:700px;" MaxHeight="400">
                                                 @if (FilterTemplate == null)
                                                 {
@@ -92,7 +92,7 @@
                                     <MudOverlay @bind-Visible="_columnsPanelVisible" AutoClose></MudOverlay>
                                     <tr class="mud-table-row" style="visibility: collapse; opacity: 0; overflow: hidden;">
                                         <th colspan="@RenderedColumns.Count" class="mud-table-cell mud-filter-panel-cell">
-                                            <MudPopover Open="@_columnsPanelVisible" Paper="true" Class="mud-data-grid-columns-panel px-2" OverflowBehavior="OverflowBehavior.FlipAlways"
+                                            <MudPopover UserAttributes="@PositionAttributes" Open="@_columnsPanelVisible" Paper="true" Class="mud-data-grid-columns-panel px-2 mud-popover-position-override" OverflowBehavior="OverflowBehavior.FlipAlways"
                                                         AnchorOrigin="Origin.TopLeft"
                                                         TransformOrigin="Origin.TopLeft" Elevation="4"
                                                         Style="max-width:700px;" MaxHeight="400">
@@ -154,11 +154,11 @@
 
                                                                 @if (context.HeaderCell.hasFilter)
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@(e => context?.HeaderCell.OpenFilters())"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@(e => context?.HeaderCell.OpenFilters(e))"></MudIconButton>
                                                                 }
                                                                 else
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@(e => context?.HeaderCell.AddFilter())"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@(e => context?.HeaderCell.AddFilter(e))"></MudIconButton>
                                                                 }
 
                                                                 @if (ColumnsPanelReordering)
@@ -321,7 +321,7 @@
     @<text>
         <MudMenu Icon="@Icons.Material.Outlined.Settings" Size="Size.Small" Dense="true">
             <MudMenuItem OnClick="@dataGrid.ShowColumnsPanel">@Localizer[LanguageResource.MudDataGrid_Columns]</MudMenuItem>
-                @if (dataGrid.Groupable)
+                @if (dataGrid.IsGrouped)
                 {
                     <MudMenuItem OnClick="@dataGrid.ExpandAllGroupsAsync">@Localizer[LanguageResource.MudDataGrid_ExpandAllGroups]</MudMenuItem>
                     <MudMenuItem OnClick="@dataGrid.CollapseAllGroupsAsync">@Localizer[LanguageResource.MudDataGrid_CollapseAllGroups]</MudMenuItem>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -42,10 +42,20 @@ namespace MudBlazor
         internal Dictionary<GroupKey, bool> _groupExpansionsDict = [];
         private GridData<T> _serverData = new() { TotalItems = 0, Items = Array.Empty<T>() };
         private Func<IFilterDefinition<T>> _defaultFilterDefinitionFactory = () => new FilterDefinition<T>();
+        internal (double Top, double Left) _openPosition;
 
         private readonly ParameterState<T> _selectedItemState;
         private readonly ParameterState<HashSet<T>> _selectedItemsState;
         private readonly ParameterState<bool> _expandSingleRowState;
+
+        /// <summary>
+        /// Inline data attributes for positioning the menu at the cursor's location.
+        /// </summary>
+        internal Dictionary<string, object> PositionAttributes => new()
+        {
+            { "data-pc-x", _openPosition.Left.ToString(CultureInfo.InvariantCulture) },
+            { "data-pc-y", _openPosition.Top.ToString(CultureInfo.InvariantCulture) }
+        };
 
         public MudDataGrid()
         {
@@ -1977,8 +1987,10 @@ namespace MudBlazor
         /// <summary>
         /// Shows a panel that lets you show, hide, filter, groupedColumns, sort and re-arrange columns.
         /// </summary>
-        public void ShowColumnsPanel()
+        public void ShowColumnsPanel(MouseEventArgs args)
         {
+            _openPosition.Top = args.PageY;
+            _openPosition.Left = args.PageX;
             _columnsPanelVisible = true;
             StateHasChanged();
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -42,7 +42,7 @@ namespace MudBlazor
         internal Dictionary<GroupKey, bool> _groupExpansionsDict = [];
         private GridData<T> _serverData = new() { TotalItems = 0, Items = Array.Empty<T>() };
         private Func<IFilterDefinition<T>> _defaultFilterDefinitionFactory = () => new FilterDefinition<T>();
-        internal (double Top, double Left) _openPosition;
+        internal (double Top, double Left) _openPosition = (0, 0);
 
         private readonly ParameterState<T> _selectedItemState;
         private readonly ParameterState<HashSet<T>> _selectedItemsState;
@@ -1987,10 +1987,13 @@ namespace MudBlazor
         /// <summary>
         /// Shows a panel that lets you show, hide, filter, groupedColumns, sort and re-arrange columns.
         /// </summary>
-        public void ShowColumnsPanel(MouseEventArgs args)
+        public void ShowColumnsPanel(MouseEventArgs args = null)
         {
-            _openPosition.Top = args.PageY;
-            _openPosition.Left = args.PageX;
+            if (args != null)
+            {
+                _openPosition.Top = args.PageY;
+                _openPosition.Left = args.PageX;
+            }
             _columnsPanelVisible = true;
             StateHasChanged();
         }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->
Thanks to #11437 flip logic is corrected and now position a popover at cursor respects flip logic
Resolves #10373 by opening column options menu and filters menu at cursor instead of always first row left side.

Before:
![Screenshot 2025-06-04 134328](https://github.com/user-attachments/assets/b99c63d8-bc83-4306-a3c8-6433df6099ed)
![Screenshot 2025-06-04 134444](https://github.com/user-attachments/assets/16839dde-f1fd-46c4-9654-498e4223e148)

After:
![Screenshot 2025-06-04 134509](https://github.com/user-attachments/assets/0bb11451-452a-409d-bcf1-086a07a7b596)
![Screenshot 2025-06-04 134526](https://github.com/user-attachments/assets/011e5cf7-5266-4f16-b9b7-fff8974e8cd7)

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
