### PR TITLE
Improve accessibility labels and localize picker buttons

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -133,11 +133,11 @@ namespace MudBlazor.UnitTests.Components
         private IHtmlInputElement GetColorInput(IRenderedComponent<SimpleColorPickerTest> comp, int index, int expectedCount = 4) => GetColorInputs(comp, expectedCount)[index];
 
         [Test]
-        public void ColorPickerOpenButtonAriaLabel()
+        public void ColorPickerOpenButtonDefaultAriaLabel()
         {
             var comp = Context.RenderComponent<MudColorPicker>();
             var openButton = comp.Find(".mud-input-adornment button");
-            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Color Picker");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4316,10 +4316,10 @@ namespace MudBlazor.UnitTests.Components
             //check if dialog is open
             comp.FindAll("div.mud-dialog-container").Should().NotBeEmpty();
             //find button with arialabel close in dialog
-            var closeButton = comp.Find("button[aria-label=\"Close dialog\"]");
+            var closeButton = comp.Find("button[aria-label=\"Close\"]");
             closeButton.Should().NotBeNull();
             //click close button
-            comp.Find("button[aria-label=\"Close dialog\"]").Click();
+            comp.Find("button[aria-label=\"Close\"]").Click();
             //check if dialog is closed
             comp.FindAll("div.mud-dialog-container").Should().BeEmpty();
         }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -41,11 +41,11 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DatePickerOpenButtonAriaLabel()
+        public void DatePickerOpenButtonDefaultAriaLabel()
         {
             var comp = Context.RenderComponent<DatePickerValidationTest>();
             var openButton = comp.Find(".mud-input-adornment button");
-            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Picker");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -80,11 +80,11 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DateRangePickerOpenButtonAriaLabel()
+        public void DateRangePickerOpenButtonDefaultAriaLabel()
         {
             var comp = Context.RenderComponent<MudDateRangePicker>();
             var openButton = comp.Find(".mud-input-adornment button");
-            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Date Range Picker");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -37,11 +37,11 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void TimePickerOpenButtonAriaLabel()
+        public void TimePickerOpenButtonDefaultAriaLabel()
         {
             var comp = Context.RenderComponent<MudTimePicker>();
             var openButton = comp.Find(".mud-input-adornment button");
-            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open Time Picker");
+            openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
 
         [Test]

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -103,7 +103,7 @@
                                 {
                                     <div class="mud-picker-color-dot mud-picker-color-dot-current mud-ripple"
                                          @onclick="ToggleCollection"
-                                         aria-label="@Localizer[LanguageResource.MudColorPicker_ToggleCollection]">
+                                         aria-label="@(_collectionOpen ? @Localizer[LanguageResource.MudColorPicker_HideSwatches] : @Localizer[LanguageResource.MudColorPicker_ShowSwatches])">
                                         <div class="mud-picker-color-fill" style="@($"background: {_value?.ToString(MudColorOutputFormats.RGBA)};")"></div>
                                     </div>
                                 }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -54,7 +54,6 @@ namespace MudBlazor
             ShowToolbar = false;
             Value = "#594ae2"; // MudBlazor Blue
             Text = GetColorTextValue();
-            AdornmentAriaLabel = "Open Color Picker";
             using var registerScope = CreateRegisterScope();
             _throttleIntervalState = registerScope.RegisterParameter<int>(nameof(ThrottleInterval))
                 .WithParameter(() => ThrottleInterval)
@@ -307,6 +306,7 @@ namespace MudBlazor
         {
             base.OnInitialized();
             SetThrottle(_throttleIntervalState.Value);
+            AdornmentAriaLabel ??= Localizer[Resources.LanguageResource.MudColorPicker_Open];
         }
 
         private void OnThrottleIntervalParameterChanged(ParameterChangedEventArgs<int> args)

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -22,7 +22,6 @@ namespace MudBlazor
             Culture = CultureInfo.CurrentCulture
         })
         {
-            AdornmentAriaLabel = "Open Date Picker";
             _mudPickerCalendarContentElementId = Identifier.Create();
         }
 
@@ -707,6 +706,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            AdornmentAriaLabel ??= Localizer[Resources.LanguageResource.MudBaseDatePicker_Open];
             CurrentView = OpenTo;
 
             if (HighlightedDate is not null) return;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -29,7 +29,6 @@ namespace MudBlazor
                 .WithChangeHandler(RecalculateValidDays);
 
             DisplayMonths = 2;
-            AdornmentAriaLabel = "Open Date Range Picker";
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -29,7 +29,6 @@ namespace MudBlazor
             Converter.SetFunc = OnSet;
             ((DefaultConverter<TimeSpan?>)Converter).Format = Format24Hours;
             AdornmentIcon = Icons.Material.Filled.AccessTime;
-            AdornmentAriaLabel = "Open Time Picker";
         }
 
         private string OnSet(TimeSpan? timespan)
@@ -548,6 +547,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            AdornmentAriaLabel ??= Localizer[LanguageResource.MudTimePicker_Open];
             UpdateTimeSetFromTime();
             _currentView = OpenTo;
             _initialHour = _timeSet.Hour;

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItemToggleButton.razor
@@ -1,16 +1,18 @@
-﻿@namespace MudBlazor
+﻿@using MudBlazor.Resources
+@namespace MudBlazor
 @inherits MudComponentBase
+@inject InternalMudLocalizer Localizer
 
 <div @attributes="UserAttributes" class="mud-treeview-item-arrow" @ondblclick="OnDoubleClick" @ondblclick:stopPropagation="true">
-    @if (Visible) {
-        <MudIconButton
-                       Disabled="@Disabled"
+    @if (Visible)
+    {
+        <MudIconButton Disabled="@Disabled"
                        OnClick="@ToggleAsync"
                        Icon="@(Loading ? LoadingIcon : ExpandedIcon)"
                        Color="@(Loading ? LoadingIconColor : ExpandedIconColor)"
                        Class="@Classname"
-                       Style="@Style" 
-                       />
+                       Style="@Style"
+                       aria-label="@(Expanded ? @Localizer[LanguageResource.MudTreeView_CollapseItem] : @Localizer[LanguageResource.MudTreeView_ExpandItem])" />
     }
 </div>
 

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -259,13 +259,13 @@
     <value>Toggle {0}</value>
   </data>
   <data name="MudAlert_Close" xml:space="preserve">
-    <value>Close alert</value>
+    <value>Close</value>
   </data>
   <data name="MudChip_Close" xml:space="preserve">
-    <value>Close chip</value>
+    <value>Close</value>
   </data>
   <data name="MudColorPicker_Close" xml:space="preserve">
-    <value>Close picker</value>
+    <value>Close</value>
   </data>
   <data name="MudColorPicker_SpectrumView" xml:space="preserve">
     <value>Spectrum</value>
@@ -319,7 +319,7 @@
     <value>Previous page</value>
   </data>
   <data name="MudRatingItem_Label" xml:space="preserve">
-    <value>{0} Rating</value>
+    <value>{0} rating</value>
   </data>
   <data name="MudCarousel_Index" xml:space="preserve">
     <value>Index {0}</value>
@@ -331,7 +331,7 @@
     <value>Previous</value>
   </data>
   <data name="MudDialog_Close" xml:space="preserve">
-    <value>Close dialog</value>
+    <value>Close</value>
   </data>
   <data name="MudInput_Clear" xml:space="preserve">
     <value>Clear</value>
@@ -343,7 +343,7 @@
     <value>Increment</value>
   </data>
   <data name="MudPageContentNavigation_NavMenu" xml:space="preserve">
-    <value>Table of contents</value>
+    <value>Contents</value>
   </data>
   <data name="MudTablePager_FirstPage" xml:space="preserve">
     <value>First page</value>
@@ -358,7 +358,7 @@
     <value>Previous page</value>
   </data>
   <data name="MudSnackbar_Close" xml:space="preserve">
-    <value>Close snackbar</value>
+    <value>Close</value>
   </data>
   <data name="MudDataGridPager_RowsPerPage" xml:space="preserve">
     <value>Rows per page:</value>
@@ -391,7 +391,7 @@
     <value>Open filters</value>
   </data>
   <data name="MudDataGrid_ToggleGroupExpansion" xml:space="preserve">
-    <value>Toggle group expansion</value>
+    <value>Toggle group</value>
   </data>
   <data name="MudDataGrid_RemoveFilter" xml:space="preserve">
     <value>Remove filter</value>
@@ -409,7 +409,7 @@
     <value>Last page</value>
   </data>
   <data name="MudDataGrid_ShowColumnOptions" xml:space="preserve">
-    <value>Show column options</value>
+    <value>Column options</value>
   </data>
   <data name="Converter_InvalidBoolean" xml:space="preserve">
     <value>Not a valid boolean</value>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -276,8 +276,11 @@
   <data name="MudColorPicker_PaletteView" xml:space="preserve">
     <value>Palette</value>
   </data>
-  <data name="MudColorPicker_ToggleCollection" xml:space="preserve">
-    <value>Toggle collection</value>
+  <data name="MudColorPicker_ShowSwatches" xml:space="preserve">
+    <value>Show swatches</value>
+  </data>
+  <data name="MudColorPicker_HideSwatches" xml:space="preserve">
+    <value>Hide swatches</value>
   </data>
   <data name="MudColorPicker_HueSlider" xml:space="preserve">
     <value>Hue slider</value>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -450,4 +450,10 @@
   <data name="HeatMap_More" xml:space="preserve">
     <value>More</value>
   </data>
+  <data name="MudTreeView_ExpandItem" xml:space="preserve">
+    <value>Expand</value>
+  </data>
+  <data name="MudTreeView_CollapseItem" xml:space="preserve">
+    <value>Collapse</value>
+  </data>
 </root>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -459,4 +459,13 @@
   <data name="MudTreeView_CollapseItem" xml:space="preserve">
     <value>Collapse</value>
   </data>
+  <data name="MudTimePicker_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="MudBaseDatePicker_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="MudColorPicker_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
 </root>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -124,7 +124,7 @@
     <value>Clear</value>
   </data>
   <data name="MudDataGrid_AddFilter" xml:space="preserve">
-    <value>Add Filter</value>
+    <value>Add filter</value>
   </data>
   <data name="MudDataGrid_Cancel" xml:space="preserve">
     <value>Cancel</value>
@@ -136,22 +136,22 @@
     <value>Save</value>
   </data>
   <data name="MudDataGrid_HideAll" xml:space="preserve">
-    <value>Hide All</value>
+    <value>Hide all</value>
   </data>
   <data name="MudDataGrid_ShowAll" xml:space="preserve">
-    <value>Show All</value>
+    <value>Show all</value>
   </data>
   <data name="MudDataGrid_Columns" xml:space="preserve">
     <value>Columns</value>
   </data>
   <data name="MudDataGrid_ExpandAllGroups" xml:space="preserve">
-    <value>Expand All Groups</value>
+    <value>Expand all groups</value>
   </data>
   <data name="MudDataGrid_CollapseAllGroups" xml:space="preserve">
-    <value>Collapse All Groups</value>
+    <value>Collapse all groups</value>
   </data>
   <data name="MudDataGrid_RefreshData" xml:space="preserve">
-    <value>Refresh Data</value>
+    <value>Refresh data</value>
   </data>
   <data name="MudDataGrid_True" xml:space="preserve">
     <value>true</value>
@@ -247,10 +247,10 @@
     <value>Value</value>
   </data>
   <data name="MudDataGrid_MoveDown" xml:space="preserve">
-    <value>Move Down</value>
+    <value>Move down</value>
   </data>
   <data name="MudDataGrid_MoveUp" xml:space="preserve">
-    <value>Move Up</value>
+    <value>Move up</value>
   </data>
   <data name="MudDataGrid_Sort" xml:space="preserve">
     <value>Sort</value>
@@ -259,13 +259,13 @@
     <value>Toggle {0}</value>
   </data>
   <data name="MudAlert_Close" xml:space="preserve">
-    <value>Close Alert</value>
+    <value>Close alert</value>
   </data>
   <data name="MudChip_Close" xml:space="preserve">
-    <value>Close Chip</value>
+    <value>Close chip</value>
   </data>
   <data name="MudColorPicker_Close" xml:space="preserve">
-    <value>Close Picker</value>
+    <value>Close picker</value>
   </data>
   <data name="MudColorPicker_SpectrumView" xml:space="preserve">
     <value>Spectrum</value>
@@ -277,16 +277,16 @@
     <value>Palette</value>
   </data>
   <data name="MudColorPicker_ToggleCollection" xml:space="preserve">
-    <value>Toggle Collection</value>
+    <value>Toggle collection</value>
   </data>
   <data name="MudColorPicker_HueSlider" xml:space="preserve">
-    <value>Hue Slider</value>
+    <value>Hue slider</value>
   </data>
   <data name="MudColorPicker_AlphaSlider" xml:space="preserve">
-    <value>Alpha Slider</value>
+    <value>Alpha slider</value>
   </data>
   <data name="MudColorPicker_ModeSwitch" xml:space="preserve">
-    <value>Switch Mode</value>
+    <value>Switch mode</value>
   </data>
   <data name="MudBaseDatePicker_PrevYear" xml:space="preserve">
     <value>Previous year {0}</value>
@@ -343,7 +343,7 @@
     <value>Increment</value>
   </data>
   <data name="MudPageContentNavigation_NavMenu" xml:space="preserve">
-    <value>Table of Contents</value>
+    <value>Table of contents</value>
   </data>
   <data name="MudTablePager_FirstPage" xml:space="preserve">
     <value>First page</value>
@@ -385,31 +385,31 @@
     <value>Complete</value>
   </data>
   <data name="MudDataGrid_ClearFilter" xml:space="preserve">
-    <value>Clear Filter</value>
+    <value>Clear filter</value>
   </data>
   <data name="MudDataGrid_OpenFilters" xml:space="preserve">
-    <value>Open Filters</value>
+    <value>Open filters</value>
   </data>
   <data name="MudDataGrid_ToggleGroupExpansion" xml:space="preserve">
-    <value>Toggle Group Expansion</value>
+    <value>Toggle group expansion</value>
   </data>
   <data name="MudDataGrid_RemoveFilter" xml:space="preserve">
-    <value>Remove Filter</value>
+    <value>Remove filter</value>
   </data>
   <data name="MudDataGridPager_FirstPage" xml:space="preserve">
-    <value>First Page</value>
+    <value>First page</value>
   </data>
   <data name="MudDataGridPager_PreviousPage" xml:space="preserve">
-    <value>Previous Page</value>
+    <value>Previous page</value>
   </data>
   <data name="MudDataGridPager_NextPage" xml:space="preserve">
-    <value>Next Page</value>
+    <value>Next page</value>
   </data>
   <data name="MudDataGridPager_LastPage" xml:space="preserve">
-    <value>Last Page</value>
+    <value>Last page</value>
   </data>
   <data name="MudDataGrid_ShowColumnOptions" xml:space="preserve">
-    <value>Show Column Options</value>
+    <value>Show column options</value>
   </data>
   <data name="Converter_InvalidBoolean" xml:space="preserve">
     <value>Not a valid boolean</value>


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

- Changes "Toggle Collection" to "Show swatches" or "Hide swatches" depending on state
- Tree view toggle now has an aria label that changes depending on expand state - Fixes #11095
- Picker adornment buttons are now localizable - Fixes #11442
- ARIA labels have been optimized for screen readers by reducing the length of the strings
- ARIA action labels are now "Sentence cased" instead of "Title Cased"

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->


## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
