### PR TITLE
MudDialog: Fix CloseOnEscapeKey Not Triggered After Backdrop Click

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/CloseOnEscapeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/CloseOnEscapeTest.razor
@@ -1,0 +1,43 @@
+﻿@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<MudButton OnClick="@OpenDialog" Variant="Variant.Filled" Color="Color.Primary">Open Dialog (Test Esc Key)</MudButton>
+
+@code {
+    private async Task OpenDialog()
+    {
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            BackdropClick = true,
+        };
+
+        // Define a RenderFragment for the dialog content directly
+        RenderFragment dialogContent = builder =>
+        {
+            builder.OpenComponent<MudText>(0);
+            builder.AddAttribute(1, "ChildContent", (RenderFragment)(b => b.AddContent(2, "Click the overlay (I shouldn't close), then press Esc. Or click inside me, then press Esc.")));
+            builder.CloseComponent();
+            // Add a button to ensure focus can shift to an interactive element within the dialog
+            builder.OpenComponent<MudButton>(3);
+            builder.AddAttribute(4, "Variant", Variant.Filled);
+            builder.AddAttribute(5, "Class", "ma-4");
+            builder.AddAttribute(6, "OnClick", EventCallback.Factory.Create<MouseEventArgs>(this, () => Snackbar.Add("Button clicked", Severity.Info)));
+            builder.AddAttribute(7, "ChildContent", (RenderFragment)(b => b.AddContent(8, "Test Button")));
+            builder.CloseComponent();
+        };
+
+        var parameters = new DialogParameters
+        {
+            [nameof(MudDialog.DialogContent)] = dialogContent, // Pass the RenderFragment
+            [nameof(MudDialog.OnBackdropClick)] = new EventCallback<MouseEventArgs>(null, (MouseEventArgs args) =>
+            {
+                Snackbar.Add("Overlay clicked! Dialog should still be open. Now try pressing Escape.", Severity.Info);
+                // This handler intentionally does not close the dialog, to test refocus.
+            })
+        };
+
+        // Use the built-in MudDialog and pass content and handlers through parameters
+        var dialog = await DialogService.ShowAsync<MudDialog>("Test Escape Key", parameters, options);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogCloseOnEscapeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogCloseOnEscapeTest.razor
@@ -4,6 +4,8 @@
 <MudButton OnClick="@OpenDialog" Variant="Variant.Filled" Color="Color.Primary">Open Dialog (Test Esc Key)</MudButton>
 
 @code {
+    public static string __description__ = "Open Dialog -> Click overlay -> Press Esc";
+
     private async Task OpenDialog()
     {
         var options = new DialogOptions

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -558,11 +558,11 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dialogReference = service.Show<DialogToggleFullscreen>());
             dialogReference.Should().NotBe(null);
 
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen outline-none");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
         }
 
         ///-------------------------------
@@ -908,11 +908,11 @@ namespace MudBlazor.UnitTests.Components
             var dialogReference = await dialogReferenceLazy.Value;
             dialogReference.Should().NotBe(null);
 
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen outline-none");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -558,11 +558,11 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dialogReference = service.Show<DialogToggleFullscreen>());
             dialogReference.Should().NotBe(null);
 
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen outline-none");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
         }
 
         ///-------------------------------
@@ -908,11 +908,11 @@ namespace MudBlazor.UnitTests.Components
             var dialogReference = await dialogReferenceLazy.Value;
             dialogReference.Should().NotBe(null);
 
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen outline-none");
             comp.Find("button").Click();
-            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
+            comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm outline-none");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1,8 +1,11 @@
 ﻿using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.UnitTests.TestComponents;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
+using Moq;
 using MudBlazor.UnitTests.TestComponents.Dialog;
 using NUnit.Framework;
 
@@ -1343,48 +1346,85 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Dialog_FocusAndEscapeKeyHandling_Test()
+        public async Task HandleBackgroundClickAsync_Should_Call_RefocusDialogAsync_When_BackdropClick_Disabled()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
-            var service = Context.Services.GetRequiredService<IDialogService>();
+            // Arrange
             IDialogReference dialogReference = null;
 
-            // Test with CloseOnEscapeKey = true
-            var optionsTrue = new DialogOptions { CloseOnEscapeKey = true };
+            var jsRuntimeMock = new Mock<IJSRuntime>();
 
-            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>("Test Dialog True", optionsTrue));
+            jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus", It.IsAny<object[]>()));
+
+            Context.Services.AddSingleton(jsRuntimeMock.Object);
+
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+            var dialogOptions = new DialogOptions { BackdropClick = false, CloseOnEscapeKey = true };
+
+            //Act
+            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>("Test Dialog True", dialogOptions));
+
+            jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus",
+                It.Is<object[]>(args =>
+                    args.Length == 2 &&
+                    args[0] is ElementReference &&
+                    args[1] is bool)),
+                Times.AtMost(1)); // Focus should be called once when dialog is opened (FocusTrap)
 
             comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog is open
-            var dialogPanelTrue = comp.Find("div.mud-dialog");
-            dialogPanelTrue.GetAttribute("tabindex").Should().Be("-1");
+            comp.Find("div.mud-overlay").Click(); // Simulate a click on the backdrop
 
-            var mudDialogContainerInstanceTrue = comp.FindComponent<MudDialogContainer>().Instance;
-            await comp.InvokeAsync(() => mudDialogContainerInstanceTrue.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown" }));
+            //Assert
+            comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog should still be open
 
-            comp.Markup.Trim().Should().BeEmpty(); // Dialog should be closed
-            var resultTrue = await dialogReference!.Result;
-            resultTrue.Canceled.Should().BeTrue();
+            jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus",
+                It.Is<object[]>(args =>
+                    args.Length == 2 &&
+                    args[0] is ElementReference &&
+                    args[1] is bool)),
+                Times.AtMost(2)); // Focus should be called once when dialog is opened and once when backdrop is clicked (refouus)
+        }
 
-            // Test with CloseOnEscapeKey = false
-            var optionsFalse = new DialogOptions { CloseOnEscapeKey = false };
-            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>("Test Dialog False", optionsFalse));
+        [Test]
+        public async Task HandleBackgroundClickAsync_Should_Call_OnBackdropClick_And_RefocusDialog_When_Delegate_Defined()
+        {
+            // Arrange
+            var jsRuntimeMock = new Mock<IJSRuntime>();
+
+            jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus", It.IsAny<object[]>()));
+
+            Context.Services.AddSingleton(jsRuntimeMock.Object);
+
+            var comp = Context.RenderComponent<MudDialogProvider>();
+
+            // Create a dialog component with OnBackdropClick delegate
+            var dialogComponent = Context.RenderComponent<DialogCloseOnEscapeTest>();
+
+            // Act
+            await dialogComponent.FindComponent<MudButton>().Find("button").ClickAsync(new MouseEventArgs()); // Open the dialog
+
+            jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus",
+                It.Is<object[]>(args =>
+                    args.Length == 2 &&
+                    args[0] is ElementReference &&
+                    args[1] is bool)),
+                Times.AtMost(1)); // Focus should be called once when dialog is opened
 
             comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog is open
-            var dialogPanelFalse = comp.Find("div.mud-dialog");
-            dialogPanelFalse.GetAttribute("tabindex").Should().Be("-1"); // Still should have tabindex
 
-            var mudDialogContainerInstanceFalse = comp.FindComponent<MudDialogContainer>().Instance;
-            await comp.InvokeAsync(() => mudDialogContainerInstanceFalse.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown" }));
+            await comp.Find("div.mud-overlay").ClickAsync(new MouseEventArgs()); // Simulate a click on the backdrop
 
-            comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog should STILL be open
+            // Assert
+            comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog should still be open (not closed)
 
-            comp.FindAll("button")[0].Click(); // Click "Cancel" button in DialogOkCancel
-            var resultFalse = await dialogReference!.Result;
-            resultFalse.Canceled.Should().BeTrue(); // Ensure it closed as expected from the button click
-            comp.Markup.Trim().Should().BeEmpty();
+            jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus",
+                It.Is<object[]>(args =>
+                    args.Length == 2 &&
+                    args[0] is ElementReference &&
+                    args[1] is bool)),
+                Times.AtMost(2)); // Focus should be called once when dialog opens and once for refocus after backdrop click
         }
     }
-
     internal class CustomDialogService : DialogService
     {
         public override IDialogReference CreateReference() => new CustomDialogReference(Guid.NewGuid(), this);

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1341,6 +1341,48 @@ namespace MudBlazor.UnitTests.Components
             await Task.Delay(1000);
             comp.FindComponents<MudDialog>().Count.Should().Be(1);
         }
+
+        [Test]
+        public async Task Dialog_FocusAndEscapeKeyHandling_Test()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+            IDialogReference dialogReference = null;
+
+            // Test with CloseOnEscapeKey = true
+            var optionsTrue = new DialogOptions { CloseOnEscapeKey = true };
+
+            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>("Test Dialog True", optionsTrue));
+
+            comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog is open
+            var dialogPanelTrue = comp.Find("div.mud-dialog");
+            dialogPanelTrue.GetAttribute("tabindex").Should().Be("-1");
+
+            var mudDialogContainerInstanceTrue = comp.FindComponent<MudDialogContainer>().Instance;
+            await comp.InvokeAsync(() => mudDialogContainerInstanceTrue.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown" }));
+
+            comp.Markup.Trim().Should().BeEmpty(); // Dialog should be closed
+            var resultTrue = await dialogReference!.Result;
+            resultTrue.Canceled.Should().BeTrue();
+
+            // Test with CloseOnEscapeKey = false
+            var optionsFalse = new DialogOptions { CloseOnEscapeKey = false };
+            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>("Test Dialog False", optionsFalse));
+
+            comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog is open
+            var dialogPanelFalse = comp.Find("div.mud-dialog");
+            dialogPanelFalse.GetAttribute("tabindex").Should().Be("-1"); // Still should have tabindex
+
+            var mudDialogContainerInstanceFalse = comp.FindComponent<MudDialogContainer>().Instance;
+            await comp.InvokeAsync(() => mudDialogContainerInstanceFalse.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown" }));
+
+            comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog should STILL be open
+
+            comp.FindAll("button")[0].Click(); // Click "Cancel" button in DialogOkCancel
+            var resultFalse = await dialogReference!.Result;
+            resultFalse.Canceled.Should().BeTrue(); // Ensure it closed as expected from the button click
+            comp.Markup.Trim().Should().BeEmpty();
+        }
     }
 
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -8,7 +8,7 @@
 }
 
 <div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @GetPosition()">
-    <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" />
+    <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" @onmouseup="OnMouseUp" />
     <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style" tabindex="-1">
         @if (!GetHideHeader())
         {

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -9,7 +9,7 @@
 
 <div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @GetPosition()">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" />
-    <div id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style">
+    <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style" tabindex="-1">
         @if (!GetHideHeader())
         {
             <div class="@TitleClassname">

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -115,6 +115,7 @@ namespace MudBlazor
                 .AddClass("mud-dialog-width-full", GetFullWidth() && !GetFullScreen())
                 .AddClass("mud-dialog-fullscreen", GetFullScreen())
                 .AddClass("mud-dialog-rtl", RightToLeft)
+                .AddClass("outline-none")
                 .AddClass(_dialog?.Class)
                 .Build();
 
@@ -158,6 +159,12 @@ namespace MudBlazor
                 // Since the event originates from KeyInterceptor it will not cause a render automatically.
                 await InvokeAsync(StateHasChanged);
             }
+        }
+
+        public async void OnMouseUp(MouseEventArgs args)
+        {
+            if (args.Button > 0)
+                await RefocusDialogAsync();
         }
 
         internal async Task HandleKeyUpAsync(KeyboardEventArgs args)
@@ -236,7 +243,7 @@ namespace MudBlazor
 
         private async Task RefocusDialogAsync()
         {
-            if (!_disposed)
+            if (GetCloseOnEscapeKey() && !_disposed)
             {
                 await _dialogContainerReference.FocusAsync();
             }

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -219,24 +219,26 @@ namespace MudBlazor
         {
             if (!GetBackdropClick())
             {
-                if (!_disposed)
-                    await _dialogContainerReference.FocusAsync(); // Refocus the dialog panel if backdrop clicked
-
+                await RefocusDialogAsync();
                 return;
             }
 
             if (_dialog is not null && _dialog.OnBackdropClick.HasDelegate)
             {
                 await _dialog.OnBackdropClick.InvokeAsync(args);
-
-                if (!_disposed)
-                {
-                    await _dialogContainerReference.FocusAsync(); // Refocus the dialog panel if backdrop click did not close the dialog
-                }
+                await RefocusDialogAsync();
             }
             else
             {
                 ((IMudDialogInstance)this).Cancel();
+            }
+        }
+
+        private async Task RefocusDialogAsync()
+        {
+            if (!_disposed)
+            {
+                await _dialogContainerReference.FocusAsync();
             }
         }
 

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -26,6 +26,7 @@ namespace MudBlazor
     {
         private bool _disposed;
         private MudDialog? _dialog;
+        private ElementReference _dialogContainerReference;
         private readonly ParameterState<DialogOptions> _dialogOptionsState;
         private readonly ParameterState<string?> _titleState;
         private readonly string _elementId = Identifier.Create("dialog");
@@ -217,15 +218,26 @@ namespace MudBlazor
         private async Task HandleBackgroundClickAsync(MouseEventArgs args)
         {
             if (!GetBackdropClick())
-                return;
-
-            if (_dialog is null || !_dialog.OnBackdropClick.HasDelegate)
             {
-                ((IMudDialogInstance)this).Cancel();
+                if (!_disposed)
+                    await _dialogContainerReference.FocusAsync(); // Refocus the dialog panel if backdrop clicked
+                
                 return;
             }
 
-            await _dialog.OnBackdropClick.InvokeAsync(args);
+            if (_dialog is not null && _dialog.OnBackdropClick.HasDelegate)
+            {
+                await _dialog.OnBackdropClick.InvokeAsync(args);
+
+                if (!_disposed)
+                {
+                    await _dialogContainerReference.FocusAsync(); // Refocus the dialog panel if backdrop click did not close the dialog
+                }
+            }
+            else
+            {
+                ((IMudDialogInstance)this).Cancel();
+            }
         }
 
         private string GetPosition()

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -221,7 +221,7 @@ namespace MudBlazor
             {
                 if (!_disposed)
                     await _dialogContainerReference.FocusAsync(); // Refocus the dialog panel if backdrop clicked
-                
+
                 return;
             }
 

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -115,7 +115,6 @@ namespace MudBlazor
                 .AddClass("mud-dialog-width-full", GetFullWidth() && !GetFullScreen())
                 .AddClass("mud-dialog-fullscreen", GetFullScreen())
                 .AddClass("mud-dialog-rtl", RightToLeft)
-                .AddClass("outline-none")
                 .AddClass(_dialog?.Class)
                 .Build();
 

--- a/src/MudBlazor/Styles/components/_dialog.scss
+++ b/src/MudBlazor/Styles/components/_dialog.scss
@@ -74,6 +74,7 @@
   max-height: calc(100vh - var(--mud-appbar-height)); // keep as fallback
   max-height: calc(100dvh - var(--mud-appbar-height));
   overflow-y: auto;
+  outline-style: none;
 
   &.mud-dialog-rtl .mud-dialog-title .mud-button-close {
     right: unset;


### PR DESCRIPTION
## Description
Clicking on the dialog overlay shifts the focus from the dialog container, preventing the close on escape key interceptor from picking up the escape key press. This change refocuses the dialog container when the overlay is clicked.

Resolves: #11502 

## How Has This Been Tested?
Visually and unit test

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Reproduction: https://try.mudblazor.com/snippet/QOcpaUvOIiVRDZNg

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
