### PR TITLE
MudFileUpload: Add file size validation

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
@@ -1,4 +1,4 @@
-﻿<MudFileUpload T="IReadOnlyList<IBrowserFile>" MaximumFileCount="100" @bind-Files="Files">
+﻿<MudFileUpload @ref="FileUpload" T="IReadOnlyList<IBrowserFile>" MaximumFileCount="100" MaxFileSize="@MaxFileSize" @bind-Files="Files">
     <SelectedTemplate>
         <div>
             Select Template
@@ -7,5 +7,9 @@
 </MudFileUpload>
 
 @code {
+    public required MudFileUpload<IReadOnlyList<IBrowserFile>> FileUpload { get; set; }
     public IReadOnlyList<IBrowserFile>? Files { get; private set; }
+
+    [Parameter]
+    public long? MaxFileSize { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadMultipleFilesTest.razor
@@ -1,4 +1,4 @@
-﻿<MudFileUpload @ref="FileUpload" T="IReadOnlyList<IBrowserFile>" MaximumFileCount="100" MaxFileSize="@MaxFileSize" @bind-Files="Files">
+﻿<MudFileUpload T="IReadOnlyList<IBrowserFile>" MaximumFileCount="100" MaxFileSize="@MaxFileSize" @bind-Files="Files">
     <SelectedTemplate>
         <div>
             Select Template
@@ -7,7 +7,6 @@
 </MudFileUpload>
 
 @code {
-    public required MudFileUpload<IReadOnlyList<IBrowserFile>> FileUpload { get; set; }
     public IReadOnlyList<IBrowserFile>? Files { get; private set; }
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadSingleFileTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadSingleFileTest.razor
@@ -1,0 +1,15 @@
+﻿<MudFileUpload @ref="FileUpload" T="IBrowserFile" MaxFileSize="@MaxFileSize" @bind-Files="File">
+    <SelectedTemplate>
+        <div>
+            Select Template
+        </div>
+    </SelectedTemplate>
+</MudFileUpload>
+
+@code {
+    public required MudFileUpload<IBrowserFile> FileUpload { get; set; }
+    public IBrowserFile? File { get; private set; }
+
+    [Parameter]
+    public long? MaxFileSize { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadSingleFileTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadSingleFileTest.razor
@@ -1,4 +1,4 @@
-﻿<MudFileUpload @ref="FileUpload" T="IBrowserFile" MaxFileSize="@MaxFileSize" @bind-Files="File">
+﻿<MudFileUpload T="IBrowserFile" MaxFileSize="@MaxFileSize" @bind-Files="File">
     <SelectedTemplate>
         <div>
             Select Template
@@ -7,7 +7,6 @@
 </MudFileUpload>
 
 @code {
-    public required MudFileUpload<IBrowserFile> FileUpload { get; set; }
     public IBrowserFile? File { get; private set; }
 
     [Parameter]

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -451,12 +451,13 @@ namespace MudBlazor.UnitTests.Components
 
             var file = CreateDummyFile("test.txt", 150);
             var input = comp.FindComponent<InputFile>();
+            var fileUpload = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
 
             input.UploadFiles(file);
 
             comp.Instance.File.Should().BeNull(); // File should be rejected
-            comp.Instance.FileUpload.Error.Should().BeTrue();
-            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.Error.Should().BeTrue();
+            fileUpload.ErrorText.Should().Be("File 'test.txt' exceeds the maximum allowed size of 100 bytes.");
         }
 
         [Test]
@@ -466,14 +467,15 @@ namespace MudBlazor.UnitTests.Components
 
             var file = CreateDummyFile("test.txt", 200);
             var input = comp.FindComponent<InputFile>();
+            var fileUpload = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
 
             input.UploadFiles(file);
 
             comp.Instance.File.Should().NotBeNull();
             comp.Instance.File.Name.Should().Be("test.txt");
             comp.Instance.File.Size.Should().Be(200);
-            comp.Instance.FileUpload.Error.Should().BeFalse();
-            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
+            fileUpload.Error.Should().BeFalse();
+            fileUpload.ErrorText.Should().BeNullOrEmpty();
         }
 
         [Test]
@@ -485,6 +487,7 @@ namespace MudBlazor.UnitTests.Components
             var file2 = CreateDummyFile("test2.txt", 70);
 
             var input = comp.FindComponent<InputFile>();
+            var fileUpload = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>().Instance;
 
             input.UploadFiles(file1, file2);
 
@@ -492,8 +495,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Files.Count.Should().Be(2);
             comp.Instance.Files[0].Name.Should().Be("test1.txt");
             comp.Instance.Files[1].Name.Should().Be("test2.txt");
-            comp.Instance.FileUpload.Error.Should().BeFalse();
-            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
+            fileUpload.Error.Should().BeFalse();
+            fileUpload.ErrorText.Should().BeNullOrEmpty();
         }
 
         [Test]
@@ -506,6 +509,7 @@ namespace MudBlazor.UnitTests.Components
             var file3 = CreateDummyFile("test3.txt", 70);
 
             var input = comp.FindComponent<InputFile>();
+            var fileUpload = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>().Instance;
 
             input.UploadFiles(file1, file2, file3);
 
@@ -514,8 +518,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Files.Count.Should().Be(2);
             comp.Instance.Files.Should().Contain(f => f.Name == "test1.txt");
             comp.Instance.Files.Should().Contain(f => f.Name == "test3.txt");
-            comp.Instance.FileUpload.Error.Should().BeTrue();
-            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.Error.Should().BeTrue();
+            fileUpload.ErrorText.Should().Be("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
         }
 
         [Test]
@@ -529,12 +533,13 @@ namespace MudBlazor.UnitTests.Components
             var input = comp.FindComponent<InputFile>();
 
             input.UploadFiles(file1, file2);
+            var fileUpload = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>().Instance;
 
             comp.Instance.Files.Should().NotBeNull(); // It will be an empty list
             comp.Instance.Files.Count.Should().Be(0);
-            comp.Instance.FileUpload.Error.Should().BeTrue();
+            fileUpload.Error.Should().BeTrue();
 
-            var validationErrors = comp.Instance.FileUpload.ValidationErrors;
+            var validationErrors = fileUpload.ValidationErrors;
             validationErrors.Should().HaveCount(2);
             validationErrors.Should().Contain("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
             validationErrors.Should().Contain("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
@@ -549,6 +554,7 @@ namespace MudBlazor.UnitTests.Components
             var file2 = CreateDummyFile("test2.txt", 300);
 
             var input = comp.FindComponent<InputFile>();
+            var fileUpload = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>().Instance;
 
             input.UploadFiles(file1, file2);
 
@@ -556,8 +562,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Files.Count.Should().Be(2);
             comp.Instance.Files[0].Name.Should().Be("test1.txt");
             comp.Instance.Files[1].Name.Should().Be("test2.txt");
-            comp.Instance.FileUpload.Error.Should().BeFalse();
-            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
+            fileUpload.Error.Should().BeFalse();
+            fileUpload.ErrorText.Should().BeNullOrEmpty();
         }
 
         [Test]
@@ -574,16 +580,19 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert initial error state
             comp.Instance.Files.Should().BeEmpty();
-            comp.Instance.FileUpload.Error.Should().BeTrue();
-            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
 
-            await comp.InvokeAsync(comp.Instance.FileUpload.ClearAsync);
+            var fileUpload = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>().Instance;
+
+            fileUpload.Error.Should().BeTrue();
+            fileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+
+            await comp.InvokeAsync(fileUpload.ClearAsync);
 
             // Assert cleared state
             comp.Instance.Files.Should().BeNull();
-            comp.Instance.FileUpload.Error.Should().BeFalse(); // Errors should be cleared
-            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
-            comp.Instance.FileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
+            fileUpload.Error.Should().BeFalse(); // Errors should be cleared
+            fileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
+            fileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
         }
 
         [Test]
@@ -594,21 +603,22 @@ namespace MudBlazor.UnitTests.Components
             var file1 = CreateDummyFile("test1.txt", 200);
 
             var input = comp.FindComponent<InputFile>();
+            var fileUpload = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
 
             input.UploadFiles(file1);
 
             // Assert initial error state
             comp.Instance.File.Should().BeNull();
-            comp.Instance.FileUpload.Error.Should().BeTrue();
-            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.Error.Should().BeTrue();
+            fileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
 
-            await comp.InvokeAsync(comp.Instance.FileUpload.ResetValidation);
+            await comp.InvokeAsync(fileUpload.ResetValidation);
 
             // Assert cleared state
             comp.Instance.File.Should().BeNull();
-            comp.Instance.FileUpload.Error.Should().BeFalse(); // Errors should be cleared
-            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
-            comp.Instance.FileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
+            fileUpload.Error.Should().BeFalse(); // Errors should be cleared
+            fileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
+            fileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -428,5 +428,170 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.FilesChangedCount.Should().Be(2);
             comp.Instance.OnFilesChangedCount.Should().Be(2);
         }
+
+        private static InputFileContent CreateDummyFile(string fileName, long size)
+        {
+            var content = new byte[size];
+            var file = new DummyBrowserFile(fileName, DateTimeOffset.Now, size, "application/octet-stream", content);
+
+            return InputFileContent.CreateFromBinary(file.Content, file.Name, null, file.ContentType);
+        }
+
+        [Test]
+        public void MaxFileSize_SingleFile_WithinLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+
+            var file = CreateDummyFile("test.txt", 50);
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file);
+
+            comp.Instance.Files.Should().NotBeNull();
+            comp.Instance.Files[0].Name.Should().Be("test.txt");
+            comp.Instance.Files[0].Size.Should().Be(50);
+        }
+
+        [Test]
+        public void MaxFileSize_SingleFile_ExceedsLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+
+            var file = CreateDummyFile("test.txt", 150);
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file);
+
+            comp.Instance.Files.Should().BeEmpty(); // File should be rejected
+            comp.Instance.FileUpload.Error.Should().BeTrue();
+            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test.txt' exceeds the maximum allowed size of 100 bytes.");
+        }
+
+        [Test]
+        public void MaxFileSize_SingleFile_NoLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
+
+            var file = CreateDummyFile("test.txt", 200);
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file);
+
+            comp.Instance.Files.Should().NotBeNull();
+            comp.Instance.Files[0].Name.Should().Be("test.txt");
+            comp.Instance.Files[0].Size.Should().Be(200);
+            comp.Instance.FileUpload.Error.Should().BeFalse();
+            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void MaxFileSize_MultipleFiles_AllWithinLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+
+            var file1 = CreateDummyFile("test1.txt", 50);
+            var file2 = CreateDummyFile("test2.txt", 70);
+
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file1, file2);
+
+            comp.Instance.Files.Should().NotBeNull();
+            comp.Instance.Files.Count.Should().Be(2);
+            comp.Instance.Files[0].Name.Should().Be("test1.txt");
+            comp.Instance.Files[1].Name.Should().Be("test2.txt");
+            comp.Instance.FileUpload.Error.Should().BeFalse();
+            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void MaxFileSize_MultipleFiles_SomeExceedLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+
+            var file1 = CreateDummyFile("test1.txt", 50);
+            var file2 = CreateDummyFile("test2.txt", 120);
+            var file3 = CreateDummyFile("test3.txt", 70);
+
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file1, file2, file3);
+
+            // Assertions after OnChangeAsync
+            comp.Instance.Files.Should().NotBeNull();
+            comp.Instance.Files.Count.Should().Be(2);
+            comp.Instance.Files.Should().Contain(f => f.Name == "test1.txt");
+            comp.Instance.Files.Should().Contain(f => f.Name == "test3.txt");
+            comp.Instance.FileUpload.Error.Should().BeTrue();
+            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
+        }
+
+        [Test]
+        public void MaxFileSize_MultipleFiles_AllExceedLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+
+            var file1 = CreateDummyFile("test1.txt", 120);
+            var file2 = CreateDummyFile("test2.txt", 150);
+
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file1, file2);
+
+            comp.Instance.Files.Should().NotBeNull(); // It will be an empty list
+            comp.Instance.Files.Count.Should().Be(0);
+            comp.Instance.FileUpload.Error.Should().BeTrue();
+
+            var validationErrors = comp.Instance.FileUpload.ValidationErrors;
+            validationErrors.Should().HaveCount(2);
+            validationErrors.Should().Contain("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+            validationErrors.Should().Contain("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
+        }
+
+        [Test]
+        public void MaxFileSize_MultipleFiles_NoLimit()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
+
+            var file1 = CreateDummyFile("test1.txt", 200);
+            var file2 = CreateDummyFile("test2.txt", 300);
+
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file1, file2);
+
+            comp.Instance.Files.Should().NotBeNull();
+            comp.Instance.Files.Count.Should().Be(2);
+            comp.Instance.Files[0].Name.Should().Be("test1.txt");
+            comp.Instance.Files[1].Name.Should().Be("test2.txt");
+            comp.Instance.FileUpload.Error.Should().BeFalse();
+            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task MaxFileSize_ClearValidationAfterError()
+        {
+            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100));
+
+            var file1 = CreateDummyFile("test1.txt", 200);
+            var file2 = CreateDummyFile("test2.txt", 300);
+
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file1, file2);
+
+            // Assert initial error state
+            comp.Instance.Files.Should().BeEmpty();
+            comp.Instance.FileUpload.Error.Should().BeTrue();
+            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+
+            await comp.InvokeAsync(() => comp.Instance.FileUpload.ClearAsync());
+
+            // Assert cleared state
+            comp.Instance.Files.Should().BeNull();
+            comp.Instance.FileUpload.Error.Should().BeFalse(); // Errors should be cleared
+            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
+            comp.Instance.FileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -2,22 +2,14 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
-using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.FileUpload;
 using NUnit.Framework;
 
@@ -440,29 +432,29 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_SingleFile_WithinLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file = CreateDummyFile("test.txt", 50);
             var input = comp.FindComponent<InputFile>();
 
             input.UploadFiles(file);
 
-            comp.Instance.Files.Should().NotBeNull();
-            comp.Instance.Files[0].Name.Should().Be("test.txt");
-            comp.Instance.Files[0].Size.Should().Be(50);
+            comp.Instance.File.Should().NotBeNull();
+            comp.Instance.File.Name.Should().Be("test.txt");
+            comp.Instance.File.Size.Should().Be(50);
         }
 
         [Test]
         public void MaxFileSize_SingleFile_ExceedsLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file = CreateDummyFile("test.txt", 150);
             var input = comp.FindComponent<InputFile>();
 
             input.UploadFiles(file);
 
-            comp.Instance.Files.Should().BeEmpty(); // File should be rejected
+            comp.Instance.File.Should().BeNull(); // File should be rejected
             comp.Instance.FileUpload.Error.Should().BeTrue();
             comp.Instance.FileUpload.ErrorText.Should().Be("File 'test.txt' exceeds the maximum allowed size of 100 bytes.");
         }
@@ -470,16 +462,16 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_SingleFile_NoLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
+            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
 
             var file = CreateDummyFile("test.txt", 200);
             var input = comp.FindComponent<InputFile>();
 
             input.UploadFiles(file);
 
-            comp.Instance.Files.Should().NotBeNull();
-            comp.Instance.Files[0].Name.Should().Be("test.txt");
-            comp.Instance.Files[0].Size.Should().Be(200);
+            comp.Instance.File.Should().NotBeNull();
+            comp.Instance.File.Name.Should().Be("test.txt");
+            comp.Instance.File.Size.Should().Be(200);
             comp.Instance.FileUpload.Error.Should().BeFalse();
             comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty();
         }
@@ -585,10 +577,35 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.FileUpload.Error.Should().BeTrue();
             comp.Instance.FileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
 
-            await comp.InvokeAsync(() => comp.Instance.FileUpload.ClearAsync());
+            await comp.InvokeAsync(comp.Instance.FileUpload.ClearAsync);
 
             // Assert cleared state
             comp.Instance.Files.Should().BeNull();
+            comp.Instance.FileUpload.Error.Should().BeFalse(); // Errors should be cleared
+            comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
+            comp.Instance.FileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
+        }
+
+        [Test]
+        public async Task MaxFileSize_ResetValidationAfterError()
+        {
+            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100));
+
+            var file1 = CreateDummyFile("test1.txt", 200);
+
+            var input = comp.FindComponent<InputFile>();
+
+            input.UploadFiles(file1);
+
+            // Assert initial error state
+            comp.Instance.File.Should().BeNull();
+            comp.Instance.FileUpload.Error.Should().BeTrue();
+            comp.Instance.FileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+
+            await comp.InvokeAsync(comp.Instance.FileUpload.ResetValidation);
+
+            // Assert cleared state
+            comp.Instance.File.Should().BeNull();
             comp.Instance.FileUpload.Error.Should().BeFalse(); // Errors should be cleared
             comp.Instance.FileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
             comp.Instance.FileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -650,7 +650,7 @@ namespace MudBlazor
         /// <remarks>
         /// When called, the <see cref="Error"/>, <see cref="ErrorText"/>, and <see cref="ValidationErrors"/> properties are all reset.
         /// </remarks>
-        public void ResetValidation()
+        public virtual void ResetValidation()
         {
             Error = false;
             ValidationErrors.Clear();

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using MudBlazor.Interfaces;
+using MudBlazor.Resources;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -26,6 +27,9 @@ namespace MudBlazor
         [Inject]
         private IJSRuntime JsRuntime { get; set; } = null!;
 
+        [Inject]
+        private InternalMudLocalizer Localizer { get; set; } = null!;
+
         /// <summary>
         /// Creates a new instance.
         /// </summary>
@@ -39,11 +43,6 @@ namespace MudBlazor
 
         private readonly string _id = Identifier.Create();
         private readonly List<string> _validationErrors = [];
-        private readonly Dictionary<string, object> _errorTokens = new(StringComparer.OrdinalIgnoreCase)
-        {
-            { "fileName", string.Empty },
-            { "fileSize", 0 }
-        };
 
         protected string Classname =>
             new CssBuilder("mud-file-upload")
@@ -170,14 +169,6 @@ namespace MudBlazor
         public long? MaxFileSize { get; set; }
 
         /// <summary>
-        /// The error message template used when a file exceeds the maximum allowed size.
-        /// </summary>
-        /// <remarks>
-        /// Placeholders <c>{fileName}</c> and <c>{fileSize}</c> can be used to insert the file name and size, respectively.
-        /// </remarks>
-        public string? FileSizeErrorTemplate { get; set; } = "File '{fileName}' exceeds the maximum allowed size of {fileSize} bytes.";
-
-        /// <summary>
         /// Prevents the user from uploading files.
         /// </summary>
         /// <remarks>
@@ -232,73 +223,22 @@ namespace MudBlazor
             _numberOfActiveFileInputs++;
 
             if (GetDisabledState())
-            {
                 return;
-            }
 
-            var hasErrorTemplate = !string.IsNullOrWhiteSpace(FileSizeErrorTemplate);
+            await ProcessFileChangeAsync(args);
+        }
 
+        private async Task ProcessFileChangeAsync(InputFileChangeEventArgs args)
+        {
             T? value;
+
             if (typeof(T) == typeof(IReadOnlyList<IBrowserFile>))
             {
-                IReadOnlyCollection<IBrowserFile> initialNewFiles = [];
-
-                initialNewFiles = args.GetMultipleFiles(MaximumFileCount);
-
-                var validFiles = new List<IBrowserFile>();
-
-                if (MaxFileSize.HasValue)
-                {
-                    foreach (var file in initialNewFiles)
-                    {
-                        if (file.Size > MaxFileSize.Value && hasErrorTemplate)
-                        {
-                            _errorTokens["fileName"] = file.Name;
-                            _validationErrors.Add(FileSizeErrorTemplate!.ReplaceTokens(_errorTokens));
-                        }
-                        else
-                        {
-                            validFiles.Add(file);
-                        }
-                    }
-                }
-                else
-                {
-                    validFiles.AddRange(initialNewFiles);
-                }
-
-                var newFilesCollection = validFiles.AsReadOnly();
-
-                if (AppendMultipleFiles && _filesState.Value is IReadOnlyList<IBrowserFile> oldFiles)
-                {
-                    var allFiles = oldFiles.Concat(newFilesCollection).ToList();
-                    value = (T)(object)allFiles.AsReadOnly();
-                }
-                else
-                {
-                    value = (T)(object)newFilesCollection;
-                }
+                value = (T?)(object)ProcessMultipleFiles(args.GetMultipleFiles(MaximumFileCount));
             }
             else if (typeof(T) == typeof(IBrowserFile))
             {
-                if (args.FileCount == 1)
-                {
-                    var file = args.File;
-                    if (MaxFileSize.HasValue && file.Size > MaxFileSize.Value && hasErrorTemplate)
-                    {
-                        _errorTokens["fileName"] = file.Name;
-                        _validationErrors.Add(FileSizeErrorTemplate!.ReplaceTokens(_errorTokens));
-                        value = default;
-                    }
-                    else
-                    {
-                        value = (T)file;
-                    }
-                }
-                else
-                {
-                    value = default;
-                }
+                value = (T?)ProcessSingleFile(args.FileCount == 1 ? args.File : null);
             }
             else
             {
@@ -307,10 +247,46 @@ namespace MudBlazor
 
             await NotifyValueChangedAsync(value);
 
-            if (!Error || !SuppressOnChangeWhenInvalid) // only trigger FilesChanged if validation passes or SuppressOnChangeWhenInvalid is false
-            {
+            if (!Error || !SuppressOnChangeWhenInvalid)
                 await OnFilesChanged.InvokeAsync(args);
+        }
+
+        private IReadOnlyList<IBrowserFile> ProcessMultipleFiles(IReadOnlyCollection<IBrowserFile> files)
+        {
+            var validFiles = new List<IBrowserFile>();
+
+            foreach (var file in files)
+            {
+                if (MaxFileSize.HasValue && file.Size > MaxFileSize.Value)
+                {
+                    _validationErrors.Add(Localizer[LanguageResource.MudFileUpload_FileSizeError, file.Name, MaxFileSize.Value.ToString()]);
+                }
+                else
+                {
+                    validFiles.Add(file);
+                }
             }
+
+            var newFiles = validFiles.AsReadOnly();
+
+            if (AppendMultipleFiles && _filesState.Value is IReadOnlyList<IBrowserFile> oldFiles)
+                return oldFiles.Concat(newFiles).ToList().AsReadOnly();
+
+            return newFiles;
+        }
+
+        private IBrowserFile? ProcessSingleFile(IBrowserFile? file)
+        {
+            if (file == null)
+                return null;
+
+            if (MaxFileSize.HasValue && file.Size > MaxFileSize.Value)
+            {
+                _validationErrors.Add(Localizer[LanguageResource.MudFileUpload_FileSizeError, file.Name, MaxFileSize.Value.ToString()]);
+                return null;
+            }
+
+            return file;
         }
 
         protected override void OnInitialized()
@@ -321,11 +297,6 @@ namespace MudBlazor
             }
 
             base.OnInitialized();
-
-            if (MaxFileSize.HasValue)
-            {
-                _errorTokens["fileSize"] = MaxFileSize.Value;
-            }
         }
 
         private async Task NotifyValueChangedAsync(T? value)

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -208,7 +208,7 @@ namespace MudBlazor
 
             _validationErrors.Clear();
             _numberOfActiveFileInputs = 1;
-            
+
             await NotifyValueChangedAsync(default);
             await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInput.resetValue", GetActiveInputId());
         }

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -38,6 +38,12 @@ namespace MudBlazor
         }
 
         private readonly string _id = Identifier.Create();
+        private readonly List<string> _validationErrors = [];
+        private readonly Dictionary<string, object> _errorTokens = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "fileName", string.Empty },
+            { "fileSize", 0 }
+        };
 
         protected string Classname =>
             new CssBuilder("mud-file-upload")
@@ -154,6 +160,24 @@ namespace MudBlazor
         public int MaximumFileCount { get; set; } = 10;
 
         /// <summary>
+        /// The maximum file size in bytes.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c> (no limit). When a file exceeds this limit, the upload for that file will be prevented.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FileUpload.Behavior)]
+        public long? MaxFileSize { get; set; }
+
+        /// <summary>
+        /// The error message template used when a file exceeds the maximum allowed size.
+        /// </summary>
+        /// <remarks>
+        /// Placeholders <c>{fileName}</c> and <c>{fileSize}</c> can be used to insert the file name and size, respectively.
+        /// </remarks>
+        public string? FileSizeErrorTemplate { get; set; } = "File '{fileName}' exceeds the maximum allowed size of {fileSize} bytes.";
+
+        /// <summary>
         /// Prevents the user from uploading files.
         /// </summary>
         /// <remarks>
@@ -180,7 +204,11 @@ namespace MudBlazor
 
         public async Task ClearAsync()
         {
+            ValidationErrors.RemoveAll(_validationErrors.Contains);
+
+            _validationErrors.Clear();
             _numberOfActiveFileInputs = 1;
+            
             await NotifyValueChangedAsync(default);
             await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInput.resetValue", GetActiveInputId());
         }
@@ -208,23 +236,69 @@ namespace MudBlazor
                 return;
             }
 
+            var hasErrorTemplate = !string.IsNullOrWhiteSpace(FileSizeErrorTemplate);
+
             T? value;
             if (typeof(T) == typeof(IReadOnlyList<IBrowserFile>))
             {
-                var newFiles = args.GetMultipleFiles(MaximumFileCount);
+                IReadOnlyCollection<IBrowserFile> initialNewFiles = [];
+
+                initialNewFiles = args.GetMultipleFiles(MaximumFileCount);
+
+                var validFiles = new List<IBrowserFile>();
+
+                if (MaxFileSize.HasValue)
+                {
+                    foreach (var file in initialNewFiles)
+                    {
+                        if (file.Size > MaxFileSize.Value && hasErrorTemplate)
+                        {
+                            _errorTokens["fileName"] = file.Name;
+                            _validationErrors.Add(FileSizeErrorTemplate!.ReplaceTokens(_errorTokens));
+                        }
+                        else
+                        {
+                            validFiles.Add(file);
+                        }
+                    }
+                }
+                else
+                {
+                    validFiles.AddRange(initialNewFiles);
+                }
+
+                var newFilesCollection = validFiles.AsReadOnly();
+
                 if (AppendMultipleFiles && _filesState.Value is IReadOnlyList<IBrowserFile> oldFiles)
                 {
-                    var allFiles = oldFiles.Concat(newFiles).ToList();
+                    var allFiles = oldFiles.Concat(newFilesCollection).ToList();
                     value = (T)(object)allFiles.AsReadOnly();
                 }
                 else
                 {
-                    value = (T)newFiles;
+                    value = (T)(object)newFilesCollection;
                 }
             }
             else if (typeof(T) == typeof(IBrowserFile))
             {
-                value = args.FileCount == 1 ? (T)args.File : default;
+                if (args.FileCount == 1)
+                {
+                    var file = args.File;
+                    if (MaxFileSize.HasValue && file.Size > MaxFileSize.Value && hasErrorTemplate)
+                    {
+                        _errorTokens["fileName"] = file.Name;
+                        _validationErrors.Add(FileSizeErrorTemplate!.ReplaceTokens(_errorTokens));
+                        value = default;
+                    }
+                    else
+                    {
+                        value = (T)file;
+                    }
+                }
+                else
+                {
+                    value = default;
+                }
             }
             else
             {
@@ -247,6 +321,11 @@ namespace MudBlazor
             }
 
             base.OnInitialized();
+
+            if (MaxFileSize.HasValue)
+            {
+                _errorTokens["fileSize"] = MaxFileSize.Value;
+            }
         }
 
         private async Task NotifyValueChangedAsync(T? value)
@@ -260,5 +339,21 @@ namespace MudBlazor
         protected override T? ReadValue() => _filesState.Value;
 
         protected override Task WriteValueAsync(T? value) => _filesState.SetValueAsync(value);
+
+        protected override async Task ValidateValue()
+        {
+            await base.ValidateValue();
+
+            ValidationErrors = [.. ValidationErrors, .. _validationErrors];
+            Error = ValidationErrors.Count > 0;
+            ErrorText = ValidationErrors.FirstOrDefault();
+        }
+
+        public override void ResetValidation()
+        {
+            _validationErrors.Clear();
+
+            base.ResetValidation();
+        }
     }
 }

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -468,4 +468,7 @@
   <data name="MudColorPicker_Open" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="MudFileUpload_FileSizeError" xml:space="preserve">
+    <value>File '{0}' exceeds the maximum allowed size of {1} bytes.</value>
+  </data>
 </root>

--- a/src/MudBlazor/Utilities/StringHelpers.cs
+++ b/src/MudBlazor/Utilities/StringHelpers.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using System.Text.RegularExpressions;
 
 namespace MudBlazor.Utilities;
 
@@ -18,43 +17,4 @@ internal static partial class StringHelpers
             ? Math.Round(value, 4).ToString(CultureInfo.InvariantCulture)
             : Math.Round(value, 4).ToString(format);
     }
-
-    /// <summary>
-    /// Replaces named tokens in a template string with values from a dictionary.
-    /// </summary>
-    /// <param name="template">The string template containing tokens, e.g., "Hello, {name}!".</param>
-    /// <param name="values">A dictionary where the key is the token name and the value is the replacement object.</param>
-    /// <returns>A formatted string with all tokens replaced.</returns>
-    public static string ReplaceTokens(this string template, Dictionary<string, object> values)
-    {
-        if (string.IsNullOrEmpty(template) || values == null || values.Count == 0)
-        {
-            return template;
-        }
-
-        return _tokenRegex.Replace(template, match =>
-        {
-            var tokenName = match.Groups["name"].Value;
-
-            if (values.TryGetValue(tokenName, out var value))
-            {
-                // Check if a format string was provided (e.g., ":N0").
-                if (match.Groups["format"].Success)
-                {
-                    var formatString = match.Groups["format"].Value;
-
-                    return string.Format(CultureInfo.CurrentCulture, $"{{0:{formatString}}}", value);
-                }
-
-                return value?.ToString() ?? string.Empty;
-            }
-
-            // If the token is not found in the dictionary, leave it as is in the template.
-            return match.Value;
-        });
-    }
-    private static readonly Regex _tokenRegex = CreateTokenRegex();
-
-    [GeneratedRegex(@"\{(?<name>\w+)(:(?<format>[^}]+))?\}", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
-    private static partial Regex CreateTokenRegex();
 }

--- a/src/MudBlazor/Utilities/StringHelpers.cs
+++ b/src/MudBlazor/Utilities/StringHelpers.cs
@@ -1,9 +1,10 @@
 ﻿using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace MudBlazor.Utilities;
 
 #nullable enable
-internal static class StringHelpers
+internal static partial class StringHelpers
 {
     /// <summary>
     /// Converts a double value to its string representation, rounded to 4 decimal places.
@@ -17,4 +18,43 @@ internal static class StringHelpers
             ? Math.Round(value, 4).ToString(CultureInfo.InvariantCulture)
             : Math.Round(value, 4).ToString(format);
     }
+
+    /// <summary>
+    /// Replaces named tokens in a template string with values from a dictionary.
+    /// </summary>
+    /// <param name="template">The string template containing tokens, e.g., "Hello, {name}!".</param>
+    /// <param name="values">A dictionary where the key is the token name and the value is the replacement object.</param>
+    /// <returns>A formatted string with all tokens replaced.</returns>
+    public static string ReplaceTokens(this string template, Dictionary<string, object> values)
+    {
+        if (string.IsNullOrEmpty(template) || values == null || values.Count == 0)
+        {
+            return template;
+        }
+
+        return _tokenRegex.Replace(template, match =>
+        {
+            var tokenName = match.Groups["name"].Value;
+
+            if (values.TryGetValue(tokenName, out var value))
+            {
+                // Check if a format string was provided (e.g., ":N0").
+                if (match.Groups["format"].Success)
+                {
+                    var formatString = match.Groups["format"].Value;
+
+                    return string.Format(CultureInfo.CurrentCulture, $"{{0:{formatString}}}", value);
+                }
+
+                return value?.ToString() ?? string.Empty;
+            }
+
+            // If the token is not found in the dictionary, leave it as is in the template.
+            return match.Value;
+        });
+    }
+    private static readonly Regex _tokenRegex = CreateTokenRegex();
+
+    [GeneratedRegex(@"\{(?<name>\w+)(:(?<format>[^}]+))?\}", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
+    private static partial Regex CreateTokenRegex();
 }


### PR DESCRIPTION
## Description
Add a new parameter `MaxFileSize` that allows the user to set a file size limit for validating/restricting file uploads.

Resolves: #11393

## How Has This Been Tested?
Visually and unit tests

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![image](https://github.com/user-attachments/assets/2b9b1f94-f440-489e-946e-3f918cc1ae65)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
