### PR TITLE
MudMenu: Revert previous refactor

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -698,53 +698,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Menu_PointerEvents_Cancellation()
-        {
-            // This method uses CatchAndLog to allow async events to run syncronously so we can test timing
-            // Set a predictable hover delay for testing
-            var hoverDelay = 300;
-            MudGlobal.MenuDefaults.HoverDelay = hoverDelay;
-
-            var comp = Context.RenderComponent<MenuWithNestingTest>();
-
-            // Open the main menu first
-            comp.Find("button:contains('1')").Click();
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(1, "Main menu should be open");
-
-            // 1. Test cancellation of SHOW debounce
-
-            var menus = comp.FindComponents<MudMenu>();
-            var menu = menus.FirstOrDefault(x => x.Instance.Label == "1.3").Instance;
-            menu.Should().NotBeNull();
-
-            // Start hover, then leave before debounce completes
-            menu.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
-            menu._showDebouncer.Cancel();
-
-            // Wait for original show debounce to have completed
-            await Task.Delay(hoverDelay + 100);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(1,
-                "Submenu should not open because show debounce was cancelled by pointer leave");
-
-            // 2. Test cancellation of HIDE debounce
-
-            // First, open the submenu properly, use await since we are testing this
-            await menu.PointerEnterAsync(new PointerEventArgs());
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "Submenu should be open");
-
-            // Start leave sequence, but re-enter before hide completes
-            menu.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(hoverDelay / 2);
-            menu._hideDebouncer.Cancel();
-
-            // Wait for what would have been the full hide delay
-            await Task.Delay(hoverDelay + 100);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2,
-                "Submenu should still be open because hide debounce was cancelled by re-entering");
-        }
-
-        [Test]
         public async Task Menu_PointerEvents_MultipleLevels()
         {
             // This method uses CatchAndLog to allow async events to run syncronously so we can test timing

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -378,6 +378,10 @@ namespace MudBlazor
         /// </summary>
         internal bool GetDense() => Dense || ParentMenu?.GetDense() == true;
 
+        /// <summary>
+        /// Determines the positioning origin for the menu popover.
+        /// This method establishes where the menu will appear relative to its activator or the cursor.
+        /// </summary>
         protected Origin GetAnchorOrigin()
         {
             if (AnchorOrigin is not null)
@@ -387,21 +391,34 @@ namespace MudBlazor
 
             if (ParentMenu is not null)
             {
+                // Sub-menus typically open to the right of their parent, so TopRight is appropriate.
                 return Origin.TopRight;
             }
             else if (PositionAtCursor)
             {
+                // When positioning at the cursor, the menu should originate from the TopLeft of the cursor.
                 return Origin.TopLeft;
             }
 
+            // Default behavior for a top-level menu is to open below its activator.
             return Origin.BottomLeft;
         }
 
+        /// <summary>
+        /// Registers a child menu with this menu, allowing for hierarchical menu management.
+        /// This is crucial for controlling the open/close state of nested menus.
+        /// </summary>
+        /// <param name="child">The child <see cref="MudMenu"/> to register.</param>
         protected void RegisterChild(MudMenu child)
         {
             _subMenus.Add(child);
         }
 
+        /// <summary>
+        /// Unregisters a child menu from this menu.
+        /// This is called when a child menu is disposed or removed, maintaining accurate tracking of nested menus.
+        /// </summary>
+        /// <param name="child">The child <see cref="MudMenu"/> to unregister.</param>
         protected void UnregisterChild(MudMenu child)
         {
             _subMenus.Remove(child);
@@ -410,6 +427,8 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
+
+            // If this menu is a sub-menu, register it with its parent.
             ParentMenu?.RegisterChild(this);
         }
 
@@ -422,6 +441,7 @@ namespace MudBlazor
 
         /// <summary>
         /// Closes this menu and any descendants if it's a nested menu.
+        /// It ensures that all nested menus are also closed when a parent menu is closed.
         /// </summary>
         public async Task CloseMenuAsync()
         {
@@ -439,6 +459,7 @@ namespace MudBlazor
 
         /// <summary>
         /// Closes all menus in the hierarchy, starting from the top-most parent.
+        /// This is useful for dismissing all open menus with a single action, such as clicking outside the menu area.
         /// </summary>
         public async Task CloseAllMenusAsync()
         {
@@ -489,7 +510,8 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Closes siblings before opening as a "mouse over" menu.
+        /// Closes sibling menus before opening as a "mouse over" menu.
+        /// This prevents multiple sub-menus at the same level from being open simultaneously when hovering.
         /// This is called in place of <see cref="OpenMenuAsync"/> if the menu activator is implicitly rendered for the submenu.
         /// </summary>
         protected async Task OpenSubMenuAsync(EventArgs args)
@@ -540,6 +562,10 @@ namespace MudBlazor
                 : OpenMenuAsync(args);
         }
 
+        /// <summary>
+        /// Determines if the menu should respond to hover events.
+        /// This prevents hover-related actions on devices that don't support traditional hovering (e.g., touchscreens).
+        /// </summary>
         private bool IsHoverable(PointerEventArgs args)
         {
             // If hover isn't explicitly enabled (or implicitly by being a submenu) there's no work to be done.
@@ -559,6 +585,7 @@ namespace MudBlazor
 
         /// <summary>
         /// Handles the pointer entering either the activator or the menu list.
+        /// This initiates a hover delay before opening the menu to provide a more forgiving user experience.
         /// </summary>
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
@@ -582,7 +609,7 @@ namespace MudBlazor
                 }
                 catch (TaskCanceledException)
                 {
-                    // Hover action was canceled.
+                    // Hover action was canceled, meaning another action (like moving the pointer away) occurred.
                     return;
                 }
             }
@@ -595,6 +622,7 @@ namespace MudBlazor
 
         /// <summary>
         /// Handles the pointer leaving either the activator or the menu list.
+        /// This introduces a delay before closing the menu to allow smooth transitions between nested menus.
         /// </summary>
         private async Task PointerLeaveAsync(PointerEventArgs args)
         {
@@ -602,11 +630,13 @@ namespace MudBlazor
 
             CancelPendingActions();
 
+            // Only close if the menu is transient (e.g., hover-activated) and is hoverable.
             if (!_isTransient || !IsHoverable(args))
             {
                 return;
             }
 
+            // Add a delay if one is configured.
             if (MudGlobal.MenuDefaults.HoverDelay > 0)
             {
                 _leaveCts = new();
@@ -618,17 +648,22 @@ namespace MudBlazor
                 }
                 catch (TaskCanceledException)
                 {
-                    // Leave action was canceled.
+                    // Leave action was canceled, meaning the pointer re-entered the menu area.
                     return;
                 }
             }
 
+            // Close the menu only if the pointer is no longer over this menu or any of its sub-menus.
             if (!HasPointerOver(this))
             {
                 await CloseMenuAsync();
             }
         }
 
+        /// <summary>
+        /// Recursively checks if the pointer is currently over this menu or any of its sub-menus.
+        /// This is crucial for determining when to close hover-activated menus.
+        /// </summary>
         protected bool HasPointerOver(MudMenu menu)
         {
             if (menu._isPointerOver)
@@ -639,7 +674,8 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Use if another action is started or explicitly called.
+        /// Cancels any pending hover or leave actions.
+        /// This is called when a new menu action is initiated, preventing conflicting or stale operations.
         /// </summary>
         private void CancelPendingActions()
         {
@@ -651,14 +687,17 @@ namespace MudBlazor
 
         /// <summary>
         /// Implementation of IActivatable.Activate, toggles the menu.
+        /// This method serves as the entry point for activating the menu via an external activator.
         /// </summary>
         void IActivatable.Activate(object activator, MouseEventArgs args)
         {
+            // Prevent activation if the activator button has a specific CSS class that marks it as non-activatable.
             if (activator is MudBaseButton activatorButton &&
                 (activatorButton.Class?.Contains("mud-no-activator") ?? false))
             {
                 return;
             }
+
             ToggleMenuAsync(args).CatchAndLog();
         }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -380,23 +380,25 @@ namespace MudBlazor
 
         /// <summary>
         /// Determines the positioning origin for the menu popover.
-        /// This method establishes where the menu will appear relative to its activator or the cursor.
         /// </summary>
+        /// <remarks>
+        /// This establishes where the menu will appear relative to its activator or the cursor.
+        /// </remarks>
         protected Origin GetAnchorOrigin()
         {
             if (AnchorOrigin is not null)
             {
+                // Use the defined anchor origin if set.
                 return AnchorOrigin.Value;
             }
 
             if (ParentMenu is not null)
             {
-                // Sub-menus typically open to the right of their parent, so TopRight is appropriate.
+                // Sub-menus typically open to the right of their parent.
                 return Origin.TopRight;
             }
             else if (PositionAtCursor)
             {
-                // When positioning at the cursor, the menu should originate from the TopLeft of the cursor.
                 return Origin.TopLeft;
             }
 
@@ -441,8 +443,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Closes this menu and any descendants if it's a nested menu.
-        /// It ensures that all nested menus are also closed when a parent menu is closed.
         /// </summary>
+        /// <remarks>
+        /// It ensures that all nested menus are also closed when a parent menu is closed.
+        /// </remarks>
         public async Task CloseMenuAsync()
         {
             CancelPendingActions();
@@ -459,8 +463,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Closes all menus in the hierarchy, starting from the top-most parent.
-        /// This is useful for dismissing all open menus with a single action, such as clicking outside the menu area.
         /// </summary>
+        /// <remarks>
+        /// This is useful for dismissing all open menus with a single action, such as clicking outside the menu area.
+        /// </remarks>
         public async Task CloseAllMenusAsync()
         {
             // Traverse up the menu hierarchy to find the top-most parent.
@@ -511,9 +517,11 @@ namespace MudBlazor
 
         /// <summary>
         /// Closes sibling menus before opening as a "mouse over" menu.
-        /// This prevents multiple sub-menus at the same level from being open simultaneously when hovering.
-        /// This is called in place of <see cref="OpenMenuAsync"/> if the menu activator is implicitly rendered for the submenu.
+        /// It prevents multiple sub-menus at the same level from being open simultaneously when hovering.
         /// </summary>
+        /// <remarks>
+        /// This is called in place of <see cref="OpenMenuAsync"/> if the menu activator is implicitly rendered for the submenu.
+        /// </remarks>
         protected async Task OpenSubMenuAsync(EventArgs args)
         {
             // Close siblings (and self) first.
@@ -564,8 +572,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Determines if the menu should respond to hover events.
-        /// This prevents hover-related actions on devices that don't support traditional hovering (e.g., touchscreens).
         /// </summary>
+        /// <remarks>
+        /// This prevents hover-related actions on devices that don't support traditional hovering (e.g., touchscreens).
+        /// </remarks>
         private bool IsHoverable(PointerEventArgs args)
         {
             // If hover isn't explicitly enabled (or implicitly by being a submenu) there's no work to be done.
@@ -585,8 +595,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Handles the pointer entering either the activator or the menu list.
-        /// This initiates a hover delay before opening the menu to provide a more forgiving user experience.
         /// </summary>
+        /// <remarks>
+        /// This initiates a hover delay before opening the menu to provide a more forgiving user experience.
+        /// </remarks>
         private async Task PointerEnterAsync(PointerEventArgs args)
         {
             _isPointerOver = true;
@@ -604,7 +616,6 @@ namespace MudBlazor
 
                 try
                 {
-                    // Wait a bit to allow the cursor to move over the activator if the user isn't trying to open it.
                     await Task.Delay(MudGlobal.MenuDefaults.HoverDelay, _hoverCts.Token);
                 }
                 catch (TaskCanceledException)
@@ -622,8 +633,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Handles the pointer leaving either the activator or the menu list.
-        /// This introduces a delay before closing the menu to allow smooth transitions between nested menus.
         /// </summary>
+        /// <remarks>
+        /// This introduces a delay before closing the menu to allow smooth transitions between nested menus.
+        /// </remarks>
         private async Task PointerLeaveAsync(PointerEventArgs args)
         {
             _isPointerOver = false;
@@ -643,7 +656,6 @@ namespace MudBlazor
 
                 try
                 {
-                    // Wait a bit to allow the cursor to move from the activator to the items popover.
                     await Task.Delay(MudGlobal.MenuDefaults.HoverDelay, _leaveCts.Token);
                 }
                 catch (TaskCanceledException)
@@ -662,8 +674,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Recursively checks if the pointer is currently over this menu or any of its sub-menus.
-        /// This is crucial for determining when to close hover-activated menus.
         /// </summary>
+        /// <remarks>
+        /// This is crucial for determining when to close hover-activated menus.
+        /// </remarks>
         protected bool HasPointerOver(MudMenu menu)
         {
             if (menu._isPointerOver)
@@ -675,11 +689,14 @@ namespace MudBlazor
 
         /// <summary>
         /// Cancels any pending hover or leave actions.
-        /// This is called when a new menu action is initiated, preventing conflicting or stale operations.
         /// </summary>
+        /// <remarks>
+        /// This is called when a new menu action is initiated, preventing conflicting or stale operations.
+        /// </remarks>
         private void CancelPendingActions()
         {
             // ReSharper disable MethodHasAsyncOverload
+            // Cancels any ongoing hover-to-open or leave-to-close delays.
             _leaveCts?.Cancel();
             _hoverCts?.Cancel();
             // ReSharper restore MethodHasAsyncOverload
@@ -687,8 +704,10 @@ namespace MudBlazor
 
         /// <summary>
         /// Implementation of IActivatable.Activate, toggles the menu.
-        /// This method serves as the entry point for activating the menu via an external activator.
         /// </summary>
+        /// <remarks>
+        /// This method serves as the entry point for activating the menu via an external activator.
+        /// </remarks>
         void IActivatable.Activate(object activator, MouseEventArgs args)
         {
             // Prevent activation if the activator button has a specific CSS class that marks it as non-activatable.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -85,7 +85,7 @@ namespace MudBlazor
         private Dictionary<string, object> PositionAttributes => new()
         {
             { "data-pc-x", _openPosition.Left.ToString(CultureInfo.InvariantCulture) },
-            { "data-pc-y", _openPosition.Top.ToString(CultureInfo.InvariantCulture) }
+            { "data-pc-y", _openPosition.Top.ToString(CultureInfo.InvariantCulture) },
         };
 
         /// <summary>
@@ -449,6 +449,7 @@ namespace MudBlazor
         /// </remarks>
         public async Task CloseMenuAsync()
         {
+            // Discard any pending pointer actions so the menu doesn't re-open or try to close twice.
             CancelPendingActions();
 
             // Recursively close all child menus.
@@ -457,6 +458,7 @@ namespace MudBlazor
                 await child.CloseMenuAsync();
             }
 
+            // Now close this menu itself.
             await _openState.SetValueAsync(false);
             await InvokeAsync(StateHasChanged);
         }
@@ -505,12 +507,13 @@ namespace MudBlazor
 
             _isTransient = transient;
 
-            // Set the menu position if the event has cursor coordinates.
+            // Set the menu position to the cursor if the event has coordinates.
             if (args is MouseEventArgs mouseEventArgs)
             {
                 _openPosition = (mouseEventArgs.PageY, mouseEventArgs.PageX);
             }
 
+            // Officially open the menu.
             await _openState.SetValueAsync(true);
             await InvokeAsync(StateHasChanged);
         }
@@ -603,6 +606,7 @@ namespace MudBlazor
         {
             _isPointerOver = true;
 
+            // Prevent conflicting actions.
             CancelPendingActions();
 
             if (!IsHoverable(args))
@@ -641,9 +645,10 @@ namespace MudBlazor
         {
             _isPointerOver = false;
 
+            // Prevent conflicting actions.
             CancelPendingActions();
 
-            // Only close if the menu is transient (e.g., hover-activated) and is hoverable.
+            // Only close if the menu is transient (e.g. hover-activated) and is hoverable.
             if (!_isTransient || !IsHoverable(args))
             {
                 return;

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities;
-using MudBlazor.Utilities.Debounce;
 
 namespace MudBlazor
 {
@@ -25,14 +24,11 @@ namespace MudBlazor
         private (double Top, double Left) _openPosition;
         private bool _isPointerOver;
         private bool _isTransient;
-        internal DebounceDispatcher _showDebouncer;
-        internal DebounceDispatcher _hideDebouncer;
+        private CancellationTokenSource? _hoverCts;
+        private CancellationTokenSource? _leaveCts;
 
         public MudMenu()
         {
-            _showDebouncer = new DebounceDispatcher(MudGlobal.MenuDefaults.HoverDelay);
-            _hideDebouncer = new DebounceDispatcher(MudGlobal.MenuDefaults.HoverDelay);
-
             using var registerScope = CreateRegisterScope();
             _openState = registerScope.RegisterParameter<bool>(nameof(Open))
                 .WithParameter(() => Open)
@@ -75,9 +71,6 @@ namespace MudBlazor
                 .AddClass("mud-disabled", Disabled)
                 .Build();
 
-        /// <summary>
-        /// Inline styles for positioning the menu at the cursor's location.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         [Obsolete($"Will be removed in future, replaced by {nameof(PositionAttributes)}.")]
         protected string Stylename =>
@@ -567,56 +560,73 @@ namespace MudBlazor
         /// <summary>
         /// Handles the pointer entering either the activator or the menu list.
         /// </summary>
-        internal async Task PointerEnterAsync(PointerEventArgs args)
+        private async Task PointerEnterAsync(PointerEventArgs args)
         {
             _isPointerOver = true;
+
+            CancelPendingActions();
 
             if (!IsHoverable(args))
             {
                 return;
             }
 
-            // Cancel any pending hide operation
-            _hideDebouncer.Cancel();
-
-            // Schedule the show operation with debouncing
-            await _showDebouncer.DebounceAsync(async () =>
+            if (MudGlobal.MenuDefaults.HoverDelay > 0)
             {
-                if (!_openState.Value)
+                _hoverCts = new();
+
+                try
                 {
-                    await OpenSubMenuAsync(args);
+                    // Wait a bit to allow the cursor to move over the activator if the user isn't trying to open it.
+                    await Task.Delay(MudGlobal.MenuDefaults.HoverDelay, _hoverCts.Token);
                 }
-            });
+                catch (TaskCanceledException)
+                {
+                    // Hover action was canceled.
+                    return;
+                }
+            }
+
+            if (!_openState.Value)
+            {
+                await OpenSubMenuAsync(args);
+            }
         }
 
         /// <summary>
         /// Handles the pointer leaving either the activator or the menu list.
         /// </summary>
-        internal async Task PointerLeaveAsync(PointerEventArgs args)
+        private async Task PointerLeaveAsync(PointerEventArgs args)
         {
             _isPointerOver = false;
-            var isSubmenu = ParentMenu is not null;
-            if (!isSubmenu && ActivationEvent != MouseEvent.MouseOver)
-            {
-                return; // main menu that doesn't use mouseover
-            }
+
+            CancelPendingActions();
 
             if (!_isTransient || !IsHoverable(args))
             {
                 return;
             }
 
-            // Cancel any pending show operation
-            _showDebouncer.Cancel();
-
-            // Schedule the hide operation with debouncing
-            await _hideDebouncer.DebounceAsync(async () =>
+            if (MudGlobal.MenuDefaults.HoverDelay > 0)
             {
-                if (!HasPointerOver(this))
+                _leaveCts = new();
+
+                try
                 {
-                    await CloseMenuAsync();
+                    // Wait a bit to allow the cursor to move from the activator to the items popover.
+                    await Task.Delay(MudGlobal.MenuDefaults.HoverDelay, _leaveCts.Token);
                 }
-            });
+                catch (TaskCanceledException)
+                {
+                    // Leave action was canceled.
+                    return;
+                }
+            }
+
+            if (!HasPointerOver(this))
+            {
+                await CloseMenuAsync();
+            }
         }
 
         protected bool HasPointerOver(MudMenu menu)
@@ -633,8 +643,10 @@ namespace MudBlazor
         /// </summary>
         private void CancelPendingActions()
         {
-            _showDebouncer.Cancel();
-            _hideDebouncer.Cancel();
+            // ReSharper disable MethodHasAsyncOverload
+            _leaveCts?.Cancel();
+            _hoverCts?.Cancel();
+            // ReSharper restore MethodHasAsyncOverload
         }
 
         /// <summary>
@@ -659,7 +671,11 @@ namespace MudBlazor
         {
             if (disposing)
             {
-                CancelPendingActions();
+                _hoverCts?.Cancel();
+                _hoverCts?.Dispose();
+
+                _leaveCts?.Cancel();
+                _leaveCts?.Dispose();
 
                 ParentMenu?.UnregisterChild(this);
             }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

Fixes #11159 by partially reverting #11117.

The menu logic can be difficult to get around due to the complexity and was broken by the refactor. I don't think the DebounceDispatcher is actually handling the cancellations properly and I want to preserve the more flexible method used previously instead of trying to build on that class.

I tried to include all fixes and improvements made to the code that aren't related to the refactor. No other changes were made by me other than restoring the old code and improving the comments for the future.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

unit

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->



https://github.com/user-attachments/assets/b6822e7d-d4fd-4dc5-bcb0-b86852580b06


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
