### PR TITLE
MudGlobal: Add PopoverDefaults.ModalOverlay to control Modal parameters

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -375,7 +375,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool Modal { get; set; } = true;
+        public bool Modal { get; set; } = MudGlobal.PopoverDefaults.ModalOverlay;
 
         /// <summary>
         /// Determines the width of this Popover dropdown in relation to the parent container.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -350,7 +350,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.PopupBehavior)]
-        public bool Modal { get; set; } = true;
+        public bool Modal { get; set; } = MudGlobal.PopoverDefaults.ModalOverlay;
 
         /// <summary>
         /// The <see cref="MudMenuItem" /> components within this menu.

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -431,7 +431,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public bool Modal { get; set; } = true;
+        public bool Modal { get; set; } = MudGlobal.PopoverDefaults.ModalOverlay;
 
         /// <summary>
         /// The location the popover opens, relative to its container.

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -287,7 +287,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool Modal { get; set; } = true;
+        public bool Modal { get; set; } = MudGlobal.PopoverDefaults.ModalOverlay;
 
         /// <summary>
         /// The content within this component, typically a list of <see cref="MudSelectItem{T}"/> components.
@@ -1042,7 +1042,7 @@ namespace MudBlazor
         /// Occurs when the <c>Clear</c> button has been clicked.
         /// </summary>
         /// <remarks>
-        /// This is the first event raised when the clear button is clicked.  
+        /// This is the first event raised when the clear button is clicked.
         /// The <see cref="SelectedValues"/> are cleared and the <see cref="OnClearButtonClick"/> event is raised.
         /// </remarks>
         protected async ValueTask SelectClearButtonClickHandlerAsync(MouseEventArgs e)
@@ -1109,9 +1109,9 @@ namespace MudBlazor
         /// The icon to display whether all, none, or some items are selected.
         /// </summary>
         /// <remarks>
-        /// Only applies when <see cref="MultiSelection"/> is <c>true</c>.  
+        /// Only applies when <see cref="MultiSelection"/> is <c>true</c>.
         /// If all items are selected, <see cref="CheckedIcon"/> is returned.
-        /// If no items are selected, <see cref="UncheckedIcon"/> is returned.  
+        /// If no items are selected, <see cref="UncheckedIcon"/> is returned.
         /// Otherwise, <see cref="IndeterminateIcon"/> is returned.
         /// </remarks>
         protected string SelectAllCheckBoxIcon

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -131,10 +131,12 @@ public static class MudGlobal
         public static int Elevation { get; set; } = 8;
 
         /// <summary>
-        /// The default value of <see cref="MudOverlay.Modal"/> for components that use a
-        /// <see cref="MudOverlay"/> to detect clicks outside a <see cref="MudPopover"/>, such as
-        /// <see cref="MudSelect{T}"/>.
+        /// Prevents interaction with background elements.
         /// </summary>
+        /// <remarks>
+        /// Only applies to components that use a <see cref="MudPopover"/> in conjunction with a <see cref="MudOverlay"/>
+        /// to close the popover when a user clicks outside, such as <see cref="MudSelect{T}"/>.
+        /// </remarks>
         public static bool ModalOverlay { get; set; } = true;
     }
 

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -129,6 +129,13 @@ public static class MudGlobal
         /// The amount of drop shadow to apply to <see cref="MudPopover"/>.
         /// </summary>
         public static int Elevation { get; set; } = 8;
+
+        /// <summary>
+        /// The default value of <see cref="MudOverlay.Modal"/> for components that use a
+        /// <see cref="MudOverlay"/> to detect clicks outside a <see cref="MudPopover"/>, such as
+        /// <see cref="MudSelect{T}"/>.
+        /// </summary>
+        public static bool ModalOverlay { get; set; } = true;
     }
 
     /// <summary>
@@ -152,7 +159,7 @@ public static class MudGlobal
     public static class TooltipDefaults
     {
         /// <summary>
-        /// The amount of time in milliseconds to wait from opening the <see cref="MudTooltip"/> before beginning to perform the transition. 
+        /// The amount of time in milliseconds to wait from opening the <see cref="MudTooltip"/> before beginning to perform the transition.
         /// </summary>
         public static TimeSpan Delay { get; set; } = TransitionDefaults.Delay;
 
@@ -175,7 +182,7 @@ public static class MudGlobal
         public static TimeSpan Delay { get; set; } = TimeSpan.Zero;
 
         /// <summary>
-        /// The amount of time in milliseconds to wait from opening the popover before beginning to perform the transition. 
+        /// The amount of time in milliseconds to wait from opening the popover before beginning to perform the transition.
         /// </summary>
         public static TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
     }


### PR DESCRIPTION
## Description
Added the global default property `ModalOverlay` in `PopoverDefaults`, which controls the default value of the parameter `Modal` for the following components,:

- `MudMenu`
- `MudSelect`
- `MudAutocomplete`
- `MudPicker`

`Modal` was added with #10893.

**Note:** `MudOverlay` also contains a `Modal` parameter, but is such a "versatile" component that I don't see much use in having a modifiable default for it directly.

## How Has This Been Tested?
Unit | Visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)


## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
