### PR TITLE
Fix logo for dark mode for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,10 @@
-# ![MudBlazor](content/MudBlazor-GitHub-NoBg.png)
+﻿<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="content/MudBlazor-GitHub-NoBg-Dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="content/MudBlazor-GitHub-NoBg.png">
+    <img alt="MudBlazor" src="content/MudBlazor-GitHub-NoBg.png">
+  </picture>
+</h1>
 
 <!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,6 @@
 </h1>
 
 <!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
-
-- [](#)
 - [Information and Guidelines for Contributors](#information-and-guidelines-for-contributors)
   - [Code of Conduct](#code-of-conduct)
   - [Minimal Prerequisites to Compile from Source](#minimal-prerequisites-to-compile-from-source)


### PR DESCRIPTION
## Description
Adds dark mode logo so it is easier to read. Aligns with README.md logo image. (Also cleaned up unused bullet point)

Original commit I referenced: https://github.com/MudBlazor/MudBlazor/commit/3076bc87f5f0b8cb0cf9570c888aaeb36f54911c

## How Has This Been Tested?
Visually tested

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

**Before:**
![image](https://github.com/user-attachments/assets/f1dc62c9-f90f-4356-8dfc-7e729cf8310d)

**After:**
![image](https://github.com/user-attachments/assets/862125f9-b639-494e-97f9-cdb7c40f0951)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
