### PR TITLE
MudElement: Add dark mode support

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Element/ElementPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Element/ElementPage.razor
@@ -45,7 +45,16 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Dark/light mode styling">
+                <Description>
+                    By default the html elements will not follow MudBlazor's dark/light theme mode. To enable this set <CodeInline>FollowThemeColorScheme</CodeInline> to <CodeInline>true</CodeInline>. The left side of this example will not follow MudBlazor's theme and the right side will (Toggle MudBlazor's theme to see the difference).
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(MudElementThemeStyleExample)" ShowCode="false">
+                <MudElementThemeStyleExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>
-
-

--- a/src/MudBlazor.Docs/Pages/Components/Element/Examples/MudElementThemeStyleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Element/Examples/MudElementThemeStyleExample.razor
@@ -1,0 +1,20 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudStack Row="true">
+    <MudPaper Outlined="true" Class="pa-4">
+        <MudStack>
+            <MudElement HtmlTag="input" Style="border: solid 1px gray" value="Default style" />
+            <MudElement HtmlTag="input" Style="border: solid 1px gray" type="date" />
+            <MudElement HtmlTag="input" type="radio" name="A" />
+            <MudElement HtmlTag="input" type="checkbox" name="B" />
+        </MudStack>
+    </MudPaper>
+    <MudPaper Outlined="true" Class="pa-4">
+        <MudStack>
+            <MudElement FollowThemeColorScheme="true" HtmlTag="input" Style="border: solid 1px gray" value="I follow MudBlazor" />
+            <MudElement FollowThemeColorScheme="true" HtmlTag="input" Style="border: solid 1px gray" type="date" />
+            <MudElement FollowThemeColorScheme="true" HtmlTag="input" type="radio" name="A" />
+            <MudElement FollowThemeColorScheme="true" HtmlTag="input" type="checkbox" name="B" />
+        </MudStack>
+    </MudPaper>
+</MudStack>

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -93,9 +93,9 @@ namespace MudBlazor
             if (FollowThemeColorScheme)
             {
                 string StyleWithColorScheme = new StyleBuilder()
-                .AddStyle(Style)
-                .AddStyle("color-scheme", "var(--mud-native-html-color-scheme)", FollowThemeColorScheme)
-                .Build();
+                    .AddStyle(Style)
+                    .AddStyle("color-scheme", "var(--mud-native-html-color-scheme)", FollowThemeColorScheme)
+                    .Build();
                 builder.AddAttribute(seq++, "style", StyleWithColorScheme);
             }
             else

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -88,14 +88,20 @@ namespace MudBlazor
             // Splatted attributes.
             builder.AddMultipleAttributes(seq++, UserAttributes!);
 
-            string StyleWithColorScheme = new StyleBuilder()
+            // Add class and style attributes.
+            builder.AddAttribute(seq++, "class", Class);
+            if (FollowThemeColorScheme)
+            {
+                string StyleWithColorScheme = new StyleBuilder()
                 .AddStyle(Style)
                 .AddStyle("color-scheme", "var(--mud-native-html-color-scheme)", FollowThemeColorScheme)
                 .Build();
-
-            // Add class and style attributes.
-            builder.AddAttribute(seq++, "class", Class);
-            builder.AddAttribute(seq++, "style", StyleWithColorScheme);
+                builder.AddAttribute(seq++, "style", StyleWithColorScheme);
+            }
+            else
+            {
+                builder.AddAttribute(seq++, "style", Style);
+            }
 
             // Add event attributes.
             builder.AddEventStopPropagationAttribute(seq++, "onclick", !ClickPropagation);

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -63,6 +64,16 @@ namespace MudBlazor
         [Category(CategoryTypes.Button.Behavior)]
         public bool PreventDefault { get; set; }
 
+        /// <summary>
+        /// Makes the html element follow the dark/light mode of the application.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Button.Appearance)]
+        public bool FollowThemeColorScheme { get; set; } = false;
+
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
@@ -77,9 +88,14 @@ namespace MudBlazor
             // Splatted attributes.
             builder.AddMultipleAttributes(seq++, UserAttributes!);
 
+            string StyleWithColorScheme = new StyleBuilder()
+                .AddStyle(Style)
+                .AddStyle("color-scheme", "var(--mud-native-html-color-scheme)", FollowThemeColorScheme)
+                .Build();
+
             // Add class and style attributes.
             builder.AddAttribute(seq++, "class", Class);
-            builder.AddAttribute(seq++, "style", Style);
+            builder.AddAttribute(seq++, "style", StyleWithColorScheme);
 
             // Add event attributes.
             builder.AddEventStopPropagationAttribute(seq++, "onclick", !ClickPropagation);


### PR DESCRIPTION
## Description
Allows for `MudElement` base html controls to follow MudBlazor's dark/light mode with the `FollowThemeColorScheme` property. By default, it is turned off. 

## How Has This Been Tested?
Visually

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

**New doc example showing dark mode support when the `FollowThemeColorScheme` property is true**
![image](https://github.com/user-attachments/assets/ce917b83-875d-4546-ae8f-ea760c7b6f66)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
