### PR TITLE
MudTableSortLabel: Added support for default SortDirection

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSortingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSortingExample.razor
@@ -5,11 +5,11 @@
 
 <MudTable Items="@Elements" Hover="true" SortLabel="Sort By">
     <HeaderContent>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Number)">Nr</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel Enabled="@enabled" SortBy="new Func<Element, object>(x=>x.Sign)">Sign</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortBy="new Func<Element, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Molar)">Mass</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortDirectionStart="@sortDirectionStart" SortBy="new Func<Element, object>(x=>x.Number)">Nr</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortDirectionStart="@sortDirectionStart" Enabled="@enabled" SortBy="new Func<Element, object>(x => x.Sign)">Sign</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortDirectionStart="@sortDirectionStart" InitialDirection="SortDirection.Ascending" SortBy="new Func<Element, object>(x => x.Name)">Name</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortDirectionStart="@sortDirectionStart" SortBy="new Func<Element, object>(x => x.Position)">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortDirectionStart="@sortDirectionStart" SortBy="new Func<Element, object>(x => x.Molar)">Mass</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd DataLabel="Nr">@context.Number</MudTd>
@@ -24,10 +24,17 @@
 </MudTable>
 
 <MudSwitch @bind-Value="enabled" Color="Color.Info">Enable sorting on the Sign Column</MudSwitch>
+<MudSelect T="SortDirection" Label="SortDirectionStart" @bind-Value="sortDirectionStart">
+    <MudSelectItem Value="SortDirection.Ascending">Ascending</MudSelectItem>
+    <MudSelectItem Value="SortDirection.Descending">Descending</MudSelectItem>
+</MudSelect>
 
 @code {
+
     private bool enabled = true;
     private IEnumerable<Element> Elements = new List<Element>();
+
+    private SortDirection sortDirectionStart = SortDirection.Ascending;
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -20,7 +20,7 @@
         <DocsPageSection>
             <SectionHeader Title="Click Event and display for selected Row">
                 <Description>
-                    The <CodeInline>RowClassFunc</CodeInline> function can be used to customize the display of the selected row. <CodeInline>RowClickEvent</CodeInline> is triggered each time the row is clicked. 
+                    The <CodeInline>RowClassFunc</CodeInline> function can be used to customize the display of the selected row. <CodeInline>RowClickEvent</CodeInline> is triggered each time the row is clicked.
                     In addition to that the <CodeInline>RowClass</CodeInline> can be used to apply a general row style independent of the selection state. In this example we show a pointer curser.
                 </Description>
             </SectionHeader>
@@ -81,13 +81,14 @@
 
         <DocsPageSection>
             <SectionHeader Title="Sorting">
-                    <Description>
-                        To enable sorting, add <CodeInline>&lt;MudTableSortLabel></CodeInline> to the header cells and define a function that simply returns the value which should be sorted by when sorting by the specific column.
-                        You can also specify whether default ordering direction should be ascending or descending by specifying the <CodeInline>&lt;InitialDirection></CodeInline> parameter of <CodeInline>&lt;MudTableSortLabel></CodeInline>.<br />
-                        Click on a header to sort the table by that column, then click to cycle through sorting directions.
-                        By default, sorting directions are ascending, descending and unsorted; if you want to cycle through ascending and descending only, you need to specify the <CodeInline>&lt;AllowUnsorted></CodeInline> parameter of the <CodeInline>&lt;MudTable></CodeInline>.
-                        Sorting can be allowed and disallowed on the column level with the property <CodeInline>Enabled</CodeInline>.
-                    </Description>
+                <Description>
+                    To enable sorting, add <CodeInline>&lt;MudTableSortLabel></CodeInline> to the header cells and define a function that simply returns the value which should be sorted by when sorting by the specific column.
+                    You can also specify whether default ordering direction should be ascending or descending by specifying the <CodeInline>&lt;InitialDirection></CodeInline> parameter of <CodeInline>&lt;MudTableSortLabel></CodeInline>.<br />
+                    Click on a header to sort the table by that column, then click to cycle through sorting directions.
+                    Sorting direction when the user first clicks the header is controlled by the <CodeInline>&lt;SortDirectionStart></CodeInline> parameter.
+                    By default, sorting directions are ascending, descending and unsorted. If you want to cycle through ascending and descending only, you need to specify the <CodeInline>&lt;AllowUnsorted></CodeInline> parameter of the <CodeInline>&lt;MudTable></CodeInline>.
+                    Sorting can be allowed and disallowed on the column level with the property <CodeInline>Enabled</CodeInline>.
+                </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableSortingExample)" ShowCode="false" Block="true" FullWidth="true">
                 <TableSortingExample />
@@ -110,7 +111,7 @@
         <DocsPageSection>
             <SectionHeader Title="Cell Class">
                 <Description>
-                    If you want to apply a particular style to all the cells in the table define a CSS class and use it in the <CodeInline>CellClass</CodeInline> parameter. 
+                    If you want to apply a particular style to all the cells in the table define a CSS class and use it in the <CodeInline>CellClass</CodeInline> parameter.
                     Separate multiple classes with spaces.
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2562,5 +2562,25 @@ namespace MudBlazor.UnitTests.Components
             icon.ClassList.Contains("mud-direction-asc").Should().Be(direction == SortDirection.Ascending);
             icon.ClassList.Contains("mud-direction-desc").Should().Be(direction == SortDirection.Descending);
         }
+
+        [Test]
+        [TestCase(SortDirection.None)]
+        [TestCase(SortDirection.Ascending)]
+        [TestCase(SortDirection.Descending)]
+        public void TableSortDirectionStartLabelDirectionClasses(SortDirection startDirection)
+        {
+            var comp = Context.RenderComponent<MudTableSortLabel<string>>(parameters => parameters
+                .Add(p => p.SortDirectionStart, startDirection)
+            );
+
+            comp.Instance.ToggleSortDirection();
+            comp.Render();
+
+            var icon = comp.Find(".mud-table-sort-label-icon");
+
+            icon.ClassList.Should().Contain("mud-table-sort-label-icon");
+            icon.ClassList.Contains("mud-direction-asc").Should().Be(startDirection is SortDirection.None or SortDirection.Ascending);
+            icon.ClassList.Contains("mud-direction-desc").Should().Be(startDirection == SortDirection.Descending);
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -59,6 +59,15 @@ namespace MudBlazor
         public SortDirection InitialDirection { get; set; } = SortDirection.None;
 
         /// <summary>
+        /// The sort direction when the user first clicks the sort header.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="SortDirection.Ascending"/>. <see cref="SortDirection.None"/> is not supported and will overriden to <see cref="SortDirection.Ascending"/> if set
+        /// </remarks>
+        [Parameter]
+        public SortDirection SortDirectionStart { get; set; } = SortDirection.Ascending;
+
+        /// <summary>
         /// Allows sorting by this column.
         /// </summary>
         /// <remarks>
@@ -147,9 +156,11 @@ namespace MudBlazor
 
             return SortDirection switch
             {
-                SortDirection.None => UpdateSortDirectionAsync(SortDirection.Ascending),
-                SortDirection.Ascending => UpdateSortDirectionAsync(SortDirection.Descending),
-                SortDirection.Descending => UpdateSortDirectionAsync(Table?.AllowUnsorted ?? false
+                SortDirection.None => UpdateSortDirectionAsync(SortDirectionStart),
+                SortDirection.Ascending => UpdateSortDirectionAsync(Table?.AllowUnsorted == true && SortDirectionStart == SortDirection.Descending
+                    ? SortDirection.None
+                    : SortDirection.Descending),
+                SortDirection.Descending => UpdateSortDirectionAsync(Table?.AllowUnsorted == true && SortDirectionStart == SortDirection.Ascending
                     ? SortDirection.None
                     : SortDirection.Ascending),
                 _ => throw new NotImplementedException()
@@ -159,6 +170,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            SortDirectionStart = SortDirectionStart == SortDirection.None ? SortDirection.Ascending : SortDirectionStart;
             Context?.SortLabels.Add(this);
             Context?.InitializeSorting();
         }


### PR DESCRIPTION
Added support for default SortDirection on MudTableSortLabel

## Description
Introduced new variable called SortDirectionStart to MudTableSortLabel. This variable determines the default sort direction when the user first cliks the sort label. This is useful for tables where users want their data ordered descending first and want to avoid double clicks

Solves similar issue as [#11030](https://github.com/MudBlazor/MudBlazor/issues/11030) for MudTable

## How Has This Been Tested?
Added new Unit Test "TableSortDirectionStartLabelDirectionClasses" and tested through documentation-page

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
