### PR TITLE
MudToggleGroup: Refactor borders, Add border opacity support

### DIFF
--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -79,7 +79,8 @@ namespace MudBlazor
             .AddClass("mud-toggle-group-vertical", Vertical)
             .AddClass($"mud-toggle-group-size-{Size.ToDescriptionString()}")
             .AddClass("mud-toggle-group-rtl", RightToLeft)
-            .AddClass($"border mud-border-{Color.ToDescriptionString()} border-solid", Outlined)
+            .AddClass($"mud-toggle-group-{Color.ToDescriptionString()}")
+            .AddClass("mud-toggle-group-outlined", Outlined)
             .AddClass("mud-disabled", Disabled)
             .AddClass(Class)
             .Build();

--- a/src/MudBlazor/Styles/components/_togglegroup.scss
+++ b/src/MudBlazor/Styles/components/_togglegroup.scss
@@ -4,47 +4,56 @@
   display: grid;
   overflow: hidden;
   box-sizing: border-box;
-  border-width: 0;
   border-radius: var(--mud-default-borderradius);
 
   & > .mud-toggle-item {
     box-shadow: none;
     border-width: inherit;
-    border-style: none;
     border-color: inherit;
     border-radius: 0;
   }
 }
 
-.mud-toggle-group-horizontal {
-  &:not(.mud-toggle-group-rtl) {
+.mud-toggle-group-outlined {
+  border-width: 1px;
+  border-color: rgb(from var(--mud-palette-text-primary) r g b / var(--mud-palette-border-opacity));
+
+  @each $color in $mud-palette-colors {
+    &.mud-toggle-group-#{$color} {
+      border-color: rgb(from var(--mud-palette-#{$color}) r g b / var(--mud-palette-border-opacity));
+    }
+  }
+
+  &.mud-toggle-group-horizontal {
+    &:not(.mud-toggle-group-rtl) {
+      > .mud-toggle-item:not(:first-child), > :not(:first-child) .mud-toggle-item {
+        &.mud-toggle-item-delimiter {
+          border-left-style: solid !important;
+        }
+
+        margin-left: -1px;
+      }
+    }
+
+    &.mud-toggle-group-rtl {
+      > .mud-toggle-item:not(:last-child), > :not(:last-child) .mud-toggle-item {
+        &.mud-toggle-item-delimiter {
+          border-left-style: solid !important;
+        }
+
+        margin-left: -1px;
+      }
+    }
+  }
+
+  &.mud-toggle-group-vertical {
     > .mud-toggle-item:not(:first-child), > :not(:first-child) .mud-toggle-item {
       &.mud-toggle-item-delimiter {
-        border-left-style: solid !important;
+        border-top-style: solid !important;
       }
 
-      margin-left: -1px;
+      margin-top: -1px;
     }
-  }
-
-  &.mud-toggle-group-rtl {
-    > .mud-toggle-item:not(:last-child), > :not(:last-child) .mud-toggle-item {
-      &.mud-toggle-item-delimiter {
-        border-left-style: solid !important;
-      }
-
-      margin-left: -1px;
-    }
-  }
-}
-
-.mud-toggle-group-vertical {
-  > .mud-toggle-item:not(:first-child), > :not(:first-child) .mud-toggle-item {
-    &.mud-toggle-item-delimiter {
-      border-top-style: solid !important;
-    }
-
-    margin-top: -1px;
   }
 }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

- Adds CSS classes similar to existing Button ones and uses them to move the border styling to the stylesheet
- Adds support for the new border opacity palette value which the buttons already had
- Refactors delimiter styles to depend on parent being outlined which fixes delimiters appearing on hover

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

visually

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

![image](https://github.com/user-attachments/assets/0f3d733d-c06c-4d94-8be0-c6297b7464e3)

![image](https://github.com/user-attachments/assets/9f71acc9-580d-45b2-bc0d-c09b4aabc6c2)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
