### PR TITLE
MudToggleItem: Enforce direct parent hierarchy

### DIFF
--- a/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
@@ -50,7 +50,7 @@ namespace MudBlazor.UnitTests.UserAttributes
             {
                 nameof(MudPopover), nameof(MudStep), nameof(MudContextualActionBar), nameof(MudHeatMapCell),
                 "Column`1", "FooterCell`1", "HeaderCell`1", "FilterHeaderCell`1", "SelectColumn`1",
-                "HierarchyColumn`1", "PropertyColumn`2", "TemplateColumn`1",
+                "HierarchyColumn`1", "PropertyColumn`2", "TemplateColumn`1", "MudToggleItem`1",
             };
 
             foreach (var componentType in mudComponentTypes)

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor
@@ -8,17 +8,17 @@
            Class="@Classname"
            Style="@Style"
            OnClick="HandleOnClickAsync"
-           Size="@(Parent?.Size ?? Size.Medium)"
-           Color="@(Parent?.Color ?? Color.Default)"
+           Size="AssertedParent.Size"
+           Color="AssertedParent.Color"
            Variant="@(Selected ? Variant.Filled : Variant.Outlined)"
-           Disabled="Disabled || (Parent?.Disabled ?? false)"
-           Ripple="Parent?.Ripple == true">
+           Disabled="Disabled || AssertedParent.Disabled"
+           Ripple="AssertedParent.Ripple">
     @if (!string.IsNullOrWhiteSpace(GetCurrentIcon()))
     {
         <MudIcon Class="@CheckMarkClassname"
                  Disabled="Disabled"
                  Icon="@GetCurrentIcon()"
-                 Size="Parent?.Size ?? Size.Medium" />
+                 Size="AssertedParent.Size" />
     }
     @if (ChildContent is not null)
     {

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         /// The <see cref="MudToggleGroup{T}"/> hosting this item.
         /// </summary>
         [CascadingParameter]
-        public MudToggleGroup<T>? NullableParent { get; set; }
+        private MudToggleGroup<T>? NullableParent { get; set; }
 
         /// <summary>
         /// The <see cref="MudToggleGroup{T}"/> hosting this item, but validated to be non-null.

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -19,26 +19,31 @@ namespace MudBlazor
     public partial class MudToggleItem<T> : MudComponentBase, IDisposable
     {
         protected string Classname => new CssBuilder("mud-toggle-item")
-            .AddClass(Parent?.SelectedClass, Selected && !string.IsNullOrEmpty(Parent?.SelectedClass))
+            .AddClass(Parent.SelectedClass, Selected && !string.IsNullOrEmpty(Parent.SelectedClass))
             .AddClass("mud-toggle-item-selected", Selected)
-            .AddClass("mud-toggle-item-vertical", Parent?.Vertical == true)
-            .AddClass("mud-toggle-item-delimiter", Parent?.Delimiters == true)
-            .AddClass("mud-toggle-item-fixed", Parent?.CheckMark == true && Parent?.FixedContent == true)
-            .AddClass($"mud-toggle-item-size-{(Parent?.Size ?? Size.Medium).ToDescriptionString()}")
-            .AddClass("mud-ripple", Parent?.Ripple == true)
+            .AddClass("mud-toggle-item-vertical", Parent.Vertical)
+            .AddClass("mud-toggle-item-delimiter", Parent.Delimiters)
+            .AddClass("mud-toggle-item-fixed", Parent.CheckMark && Parent.FixedContent)
+            .AddClass($"mud-toggle-item-size-{Parent.Size.ToDescriptionString()}")
+            .AddClass("mud-ripple", Parent.Ripple)
             .AddClass("mud-typography-input")
             .AddClass(Class)
             .Build();
 
         protected string CheckMarkClassname => new CssBuilder("mud-toggle-item-check-icon")
-            .AddClass(Parent?.CheckMarkClass)
+            .AddClass(Parent.CheckMarkClass)
             .Build();
 
         /// <summary>
         /// The <see cref="MudToggleGroup{T}"/> hosting this item.
         /// </summary>
         [CascadingParameter]
-        public MudToggleGroup<T>? Parent { get; set; }
+        public MudToggleGroup<T>? NullableParent { get; set; }
+
+        /// <summary>
+        /// The <see cref="MudToggleGroup{T}"/> hosting this item, but validated to be non-null.
+        /// </summary>
+        private MudToggleGroup<T> Parent => NullableParent ?? throw new InvalidOperationException($"{nameof(MudToggleItem<T>)} must be used within a {nameof(MudToggleGroup<T>)}.");
 
         /// <summary>
         /// Prevents the user from interacting with this item.
@@ -105,7 +110,7 @@ namespace MudBlazor
 
         private string? GetCurrentIcon()
         {
-            if (Parent?.CheckMark != true)
+            if (Parent.CheckMark != true)
             {
                 return null;
             }
@@ -115,7 +120,7 @@ namespace MudBlazor
                 return SelectedIcon;
             }
 
-            if (UnselectedIcon is null && Parent?.FixedContent == true)
+            if (UnselectedIcon is null && Parent.FixedContent == true)
             {
                 return Icons.Custom.Uncategorized.Empty;
             }
@@ -123,11 +128,18 @@ namespace MudBlazor
             return UnselectedIcon;
         }
 
-        /// <inheritdoc />
         protected override void OnInitialized()
         {
             base.OnInitialized();
-            Parent?.Register(this);
+
+            if (Parent is null)
+            {
+
+            }
+            else
+            {
+                Parent.Register(this);
+            }
         }
 
         /// <summary>
@@ -162,10 +174,7 @@ namespace MudBlazor
 
         protected async Task HandleOnClickAsync()
         {
-            if (Parent is not null)
-            {
-                await Parent.ToggleItemAsync(this);
-            }
+            await Parent.ToggleItemAsync(this);
         }
     }
 }

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -19,31 +19,31 @@ namespace MudBlazor
     public partial class MudToggleItem<T> : MudComponentBase, IDisposable
     {
         protected string Classname => new CssBuilder("mud-toggle-item")
-            .AddClass(Parent.SelectedClass, Selected && !string.IsNullOrEmpty(Parent.SelectedClass))
+            .AddClass(AssertedParent.SelectedClass, Selected && !string.IsNullOrEmpty(AssertedParent.SelectedClass))
             .AddClass("mud-toggle-item-selected", Selected)
-            .AddClass("mud-toggle-item-vertical", Parent.Vertical)
-            .AddClass("mud-toggle-item-delimiter", Parent.Delimiters)
-            .AddClass("mud-toggle-item-fixed", Parent.CheckMark && Parent.FixedContent)
-            .AddClass($"mud-toggle-item-size-{Parent.Size.ToDescriptionString()}")
-            .AddClass("mud-ripple", Parent.Ripple)
+            .AddClass("mud-toggle-item-vertical", AssertedParent.Vertical)
+            .AddClass("mud-toggle-item-delimiter", AssertedParent.Delimiters)
+            .AddClass("mud-toggle-item-fixed", AssertedParent.CheckMark && AssertedParent.FixedContent)
+            .AddClass($"mud-toggle-item-size-{AssertedParent.Size.ToDescriptionString()}")
+            .AddClass("mud-ripple", AssertedParent.Ripple)
             .AddClass("mud-typography-input")
             .AddClass(Class)
             .Build();
 
         protected string CheckMarkClassname => new CssBuilder("mud-toggle-item-check-icon")
-            .AddClass(Parent.CheckMarkClass)
+            .AddClass(AssertedParent.CheckMarkClass)
             .Build();
 
         /// <summary>
-        /// The <see cref="MudToggleGroup{T}"/> hosting this item.
+        /// The <see cref="MudToggleGroup{T}"/> hosting this item if one exists.
         /// </summary>
         [CascadingParameter]
-        private MudToggleGroup<T>? NullableParent { get; set; }
+        public MudToggleGroup<T>? Parent { get; set; }
 
         /// <summary>
         /// The <see cref="MudToggleGroup{T}"/> hosting this item, but validated to be non-null.
         /// </summary>
-        private MudToggleGroup<T> Parent => NullableParent ?? throw new InvalidOperationException($"{nameof(MudToggleItem<T>)} must be used within a {nameof(MudToggleGroup<T>)}.");
+        private MudToggleGroup<T> AssertedParent => Parent ?? throw new InvalidOperationException($"{nameof(MudToggleItem<T>)} must be used within a {nameof(MudToggleGroup<T>)}.");
 
         /// <summary>
         /// Prevents the user from interacting with this item.
@@ -110,7 +110,7 @@ namespace MudBlazor
 
         private string? GetCurrentIcon()
         {
-            if (!Parent.CheckMark)
+            if (!AssertedParent.CheckMark)
             {
                 return null;
             }
@@ -120,7 +120,7 @@ namespace MudBlazor
                 return SelectedIcon;
             }
 
-            if (UnselectedIcon is null && Parent.FixedContent)
+            if (UnselectedIcon is null && AssertedParent.FixedContent)
             {
                 return Icons.Custom.Uncategorized.Empty;
             }
@@ -131,7 +131,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
-            Parent.Register(this);
+            AssertedParent.Register(this);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace MudBlazor
             if (disposing)
             {
                 // Don't assume we have a parent during disposal.
-                NullableParent?.Unregister(this);
+                Parent?.Unregister(this);
             }
         }
 
@@ -167,7 +167,7 @@ namespace MudBlazor
 
         protected async Task HandleOnClickAsync()
         {
-            await Parent.ToggleItemAsync(this);
+            await AssertedParent.ToggleItemAsync(this);
         }
     }
 }

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -110,7 +110,7 @@ namespace MudBlazor
 
         private string? GetCurrentIcon()
         {
-            if (Parent.CheckMark != true)
+            if (!Parent.CheckMark)
             {
                 return null;
             }
@@ -120,7 +120,7 @@ namespace MudBlazor
                 return SelectedIcon;
             }
 
-            if (UnselectedIcon is null && Parent.FixedContent == true)
+            if (UnselectedIcon is null && Parent.FixedContent)
             {
                 return Icons.Custom.Uncategorized.Empty;
             }

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -131,15 +131,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
-
-            if (Parent is null)
-            {
-
-            }
-            else
-            {
-                Parent.Register(this);
-            }
+            Parent.Register(this);
         }
 
         /// <summary>
@@ -149,7 +141,8 @@ namespace MudBlazor
         {
             if (disposing)
             {
-                Parent?.Unregister(this);
+                // Don't assume we have a parent during disposal.
+                NullableParent?.Unregister(this);
             }
         }
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

You should never have a lone toggle item and it breaks the styles so why design the code around that?

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

```
crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: MudToggleItem must be used within a MudToggleGroup.
System.InvalidOperationException: MudToggleItem must be used within a MudToggleGroup.
   at MudBlazor.MudToggleItem`1[[System.String, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].get_Parent() in C:\Users\danch\source\repos\MudBlazor\src\MudBlazor\Components\Toggle\MudToggleItem.razor.cs:line 46
   at MudBlazor.MudToggleItem`1[[System.String, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].OnInitialized() in C:\Users\danch\source\repos\MudBlazor\src\MudBlazor\Components\Toggle\MudToggleItem.razor.cs:line 135
   at Microsoft.AspNetCore.Components.ComponentBase.RunInitAndSetParametersAsync()
   at MudBlazor.State.ParameterContainer.SetParametersAsync(Func`2 baseSetParametersAsync, ParameterView parameters) in C:\Users\danch\source\repos\MudBlazor\src\MudBlazor\State\ParameterContainer.cs:line 84
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [ ] I've added relevant tests.
