### PR TITLE
MudDialog: Fix Inline Dialog Title Refresh

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogTitleRefreshTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogTitleRefreshTest.razor
@@ -1,0 +1,45 @@
+﻿<div class="d-flex">
+    <MudButton OnClick="OpenDialog" Variant="Variant.Filled" Color="Color.Primary">
+        Show Dialog
+    </MudButton>
+</div>
+
+<MudDialog @bind-Visible="DialogVisible" Options="_dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            @DialogTitle
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudProgressLinear Color="Color.Primary" Striped="true" Size="Size.Large" Class="my-7" Value="@DialogProgress" />
+    </DialogContent>
+</MudDialog>
+
+@code {
+    public static string __description__ = "Dialog title should update along with Progress Bar content";
+
+    private readonly DialogOptions _dialogOptions = new() { FullWidth = true };
+    private int DialogProgress { get; set; } = 0;
+    private bool DialogVisible { get; set; } = false;
+    private string DialogTitle { get; set; } = "Initial state";
+
+    private async Task OpenDialog()
+    {
+        DialogVisible = true;
+
+        for (int i = 0; i <= 10; i++)
+        {
+            await Task.Delay(150); // Simulate some work
+            DialogProgress = i * 10; // Simulate progress update
+            DialogTitle = $"Progress: {DialogProgress}%";
+            StateHasChanged();
+        }
+
+        // Keep dialog open for a bit to observe final title
+        await Task.Delay(2000);
+
+        DialogVisible = false;
+        DialogProgress = 0;
+        DialogTitle = "Initial state";
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1341,6 +1341,43 @@ namespace MudBlazor.UnitTests.Components
             await Task.Delay(1000);
             comp.FindComponents<MudDialog>().Count.Should().Be(1);
         }
+
+        [Test]
+        public async Task Dialog_TitleContent_And_ProgressBar_ShouldUpdate()
+        {
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            comp.Markup.Trim().Should().BeEmpty();
+
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            var comp1 = Context.RenderComponent<InlineDialogTitleRefreshTest>();
+
+            comp1.Find("button").Click();
+
+            var dialog = comp.Find("div.mud-dialog");
+
+            dialog.Should().NotBeNull();
+            dialog.TextContent.Trim().Should().Be("Initial state"); // Initial title
+            comp.FindComponent<MudProgressLinear>().Instance.Value.Should().Be(0); // Initial progress value - 0
+
+            // Wait for mid-progress (simulate that loop is progressing)
+            await Task.Delay(1000);
+            //comp.Render();
+
+            dialog = comp.Find("div.mud-dialog");
+            dialog.TextContent.Should().Contain("Progress"); //change from "Initial state" to "Progress"
+            
+            var progressComponent = comp.FindComponent<MudProgressLinear>();
+            var progressValue = progressComponent.Instance.Value;
+            progressValue.Should().BeGreaterThan(0).And.BeLessThan(100);
+
+            // Wait for dialog to close and state reset
+            await Task.Delay(3000); // Ensure loop finishes
+            comp.Render();
+
+            // Assert the dialog is now hidden
+            comp.Markup.Trim().Should().NotContain("mud-dialog");
+        }
     }
 
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1366,7 +1366,7 @@ namespace MudBlazor.UnitTests.Components
 
             dialog = comp.Find("div.mud-dialog");
             dialog.TextContent.Should().Contain("Progress"); //change from "Initial state" to "Progress"
-            
+
             var progressComponent = comp.FindComponent<MudProgressLinear>();
             var progressValue = progressComponent.Instance.Value;
             progressValue.Should().BeGreaterThan(0).And.BeLessThan(100);

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -275,6 +275,10 @@ namespace MudBlazor
                     {
                         // Forward render update to instance
                         (_reference.Dialog as IMudStateHasChanged)?.StateHasChanged();
+
+                        //forward render update to instance container
+                        if (_reference.Dialog is MudDialog { DialogInstance: not null } dialog)
+                            await InvokeAsync(dialog.DialogInstance!.StateHasChanged);
                     }
                     else
                     {


### PR DESCRIPTION
## Description
When using an inline dialog, users are unable to access the `DialogInstance` parameter which is required for refreshing the Dialog Title via a `StateHasChanged` call. This change automatically calls `StateHasChanged` on the `DialogInstance` in cases of inline dialogs, similar to how `StateHasChanged` is automatically called on the `IDialogReference`

## How Has This Been Tested?
Visually + Unit test

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
