### PR TITLE
MudExpansionPanel: Add toggle keyboard hotkeys, Add ability to remove content from DOM

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelKeyboardTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelKeyboardTest.razor
@@ -1,0 +1,8 @@
+﻿<MudExpansionPanels>
+	<MudExpansionPanel Text="Panel 1" KeepContentAlive="true">
+		<MudButton Variant="Variant.Filled">Button 1</MudButton>
+	</MudExpansionPanel>
+	<MudExpansionPanel Text="Panel 2" KeepContentAlive="true">
+		<MudButton Variant="Variant.Filled">Button 2</MudButton>
+	</MudExpansionPanel>
+</MudExpansionPanels>

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -15,12 +15,12 @@
         </div>
         @if (!HideIcon)
         {
-            <MudIcon Icon="@Icon" class="@(_expandedState.Value? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")" />
+            <MudIcon Icon="@Icon" class="@(_expandedState.Value ? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")" />
         }
     </div>
     <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
-		@if (KeepContentAlive || _expandedState.Value)
-		{
+        @if (KeepContentAlive || _expandedState.Value)
+        {
             <div class="@PanelContentClassname" hidden="@(!_expandedState.Value)">
                 @ChildContent
             </div>

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-    <div class="@HeaderClassname" @onclick="ToggleExpansionAsync">
+	<div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="0" @onkeydown="HandleKeyDown">
         <div class="mud-expand-panel-text">
             @if (TitleContent is not null)
             {
@@ -19,8 +19,11 @@
         }
     </div>
     <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
-        <div class="@PanelContentClassname">
-            @ChildContent
-        </div>
+		@if (_expandedState.Value)
+		{
+			<div class="@PanelContentClassname">
+				@ChildContent
+			</div>
+		}
     </MudCollapse>
 </div>

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-	<div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="0" @onkeydown="HandleKeyDown">
+    <div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="@(Disabled ? null : "0")" @onkeydown="HandleKeyDown">
         <div class="mud-expand-panel-text">
             @if (TitleContent is not null)
             {
@@ -19,11 +19,11 @@
         }
     </div>
     <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
-		@if (_expandedState.Value)
-		{
-			<div class="@PanelContentClassname">
-				@ChildContent
-			</div>
-		}
+        @if (!RemoveContentOnCollapse || _expandedState.Value)
+        {
+            <div class="@PanelContentClassname" hidden="@(!_expandedState.Value)" aria-hidden="@(!_expandedState.Value)">
+                @ChildContent
+            </div>
+        }
     </MudCollapse>
 </div>

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-    <div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="@(Disabled ? null : "0")" @onkeydown="HandleKeyDown">
+    <div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="@(Disabled ? null : "0")" @onkeydown="HandleKeyDownAsync">
         <div class="mud-expand-panel-text">
             @if (TitleContent is not null)
             {
@@ -19,9 +19,9 @@
         }
     </div>
     <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
-        @if (!RemoveContentOnCollapse || _expandedState.Value)
-        {
-            <div class="@PanelContentClassname" hidden="@(!_expandedState.Value)" aria-hidden="@(!_expandedState.Value)">
+		@if (KeepContentAlive || _expandedState.Value)
+		{
+            <div class="@PanelContentClassname" hidden="@(!_expandedState.Value)">
                 @ChildContent
             </div>
         }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -156,14 +154,11 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// If true, the panel content is removed from the DOM when collapsed.
+        /// When true, the content remains in the DOM even when the panel is collapsed.
         /// </summary>
-        /// <remarks>
-        /// Defaults to false for backwards compatibility. When true, this can improve performance at the cost of component re-rendering.
-        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ExpansionPanel.Behavior)]
-        public bool RemoveContentOnCollapse { get; set; } = false;
+        public bool KeepContentAlive { get; set; } = true;
 
         /// <summary>
         /// The next panel is currently expanded.
@@ -265,7 +260,7 @@ namespace MudBlazor
             }
         }
 
-        private async Task HandleKeyDown(KeyboardEventArgs e)
+        private async Task HandleKeyDownAsync(KeyboardEventArgs e)
         {
             if (Disabled)
             {

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -251,6 +252,14 @@ namespace MudBlazor
             if (disposing)
             {
                 Parent?.RemovePanel(this);
+            }
+        }
+
+        private async Task HandleKeyDown(KeyboardEventArgs e)
+        {
+            if (e.Key == "Enter" || e.Key == " ")
+            {
+                await ToggleExpansionAsync();
             }
         }
     }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -156,6 +156,16 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
+        /// If true, the panel content is removed from the DOM when collapsed.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to false for backwards compatibility. When true, this can improve performance at the cost of component re-rendering.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.ExpansionPanel.Behavior)]
+        public bool RemoveContentOnCollapse { get; set; } = false;
+
+        /// <summary>
         /// The next panel is currently expanded.
         /// </summary>
         public bool NextPanelExpanded { get; set; }
@@ -257,6 +267,11 @@ namespace MudBlazor
 
         private async Task HandleKeyDown(KeyboardEventArgs e)
         {
+            if(Disabled)
+            {
+                return;
+            }
+            
             if (e.Key == "Enter" || e.Key == " ")
             {
                 await ToggleExpansionAsync();

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -267,11 +267,11 @@ namespace MudBlazor
 
         private async Task HandleKeyDown(KeyboardEventArgs e)
         {
-            if(Disabled)
+            if (Disabled)
             {
                 return;
             }
-            
+
             if (e.Key == "Enter" || e.Key == " ")
             {
                 await ToggleExpansionAsync();


### PR DESCRIPTION
fix(MudExpansionPanel): improve accessibility for keyboard and mouse interaction

- Makes header focusable and responsive to Enter/Space keys
- Prevents tab navigation into collapsed panel content
- Aligns behavior with accessibility standards (WCAG)

Tested locally in MudBlazor.Docs to confirm behaviour across input methods.

## Description

This PR enhances accessibility in `MudExpansionPanel` when using custom `TitleContent`. The default behavior does not support keyboard interaction or proper focus handling, particularly when the panel is collapsed. This results in users being unable to toggle the panel via keyboard or inadvertently tabbing into visually hidden content.

**Changes include:**
- Making the header focusable when custom content is used
- Allowing toggling via `Enter` and `Space`
- Preventing tab order from entering content when collapsed
- Preserving click behavior on both container and text elements

These changes improve usability for keyboard and screen reader users and follow accessibility best practices.

## How Has This Been Tested?

Tested locally by running the MudBlazor docs site using the edited source code:
- Verified focus behavior and keyboard toggling with `Tab`, `Enter`, and `Space`
- Confirmed tab order skips collapsed content
- Manually tested pointer interactions with both whitespace and inner text
- No console errors and no impact to existing styles or features

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests (manual/visual verification in Docs).

## Related Issues
- Closes #11530 