### PR TITLE
MudAutocomplete: Fix Strict mode regression

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1491,7 +1491,7 @@ namespace MudBlazor.UnitTests.Components
             var items = comp.FindComponents<MudListItem<AutocompleteStrictFalseTest.State>>().ToArray();
             items.Length.Should().Be(10);
             var item = items.SingleOrDefault(x => x.Markup.Contains(californiaString));
-            items.ToList().IndexOf(item).Should().Be(4);
+            items.ToList().IndexOf(item).Should().Be(5);
             comp.WaitForAssertion(() => items.Single(s => s.Markup.Contains(californiaString)).Find(listItemQuerySelector).ClassList.Should().Contain(selectedItemClassName));
 
             await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Escape" })); // Close autocomplete.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -742,10 +742,25 @@ namespace MudBlazor
                 // Get range of items based off selected item so the selected item can be scrolled to when strict is set to false
                 if (!Strict && searchedItems.Length != 0 && !EqualityComparer<T>.Default.Equals(Value, default(T)))
                 {
-                    int split = (MaxItems.Value / 2) + 1;
+                    int maxItems = MaxItems.Value;
                     int valueIndex = Array.IndexOf(searchedItems, Value);
-                    int endIndex = Math.Min(valueIndex + split, searchedItems.Length);
-                    int startIndex = endIndex - Math.Min(MaxItems.Value, searchedItems.Length);
+
+                    // Center the selected item in the list if possible
+                    int half = maxItems / 2;
+                    int startIndex = valueIndex - half;
+                    int endIndex = startIndex + maxItems;
+
+                    // Adjust if out of bounds
+                    if (startIndex < 0)
+                    {
+                        startIndex = 0;
+                        endIndex = Math.Min(maxItems, searchedItems.Length);
+                    }
+                    else if (endIndex > searchedItems.Length)
+                    {
+                        endIndex = searchedItems.Length;
+                        startIndex = Math.Max(0, endIndex - maxItems);
+                    }
 
                     searchedItems = searchedItems.Take(new Range(startIndex, endIndex)).ToArray();
                 }


### PR DESCRIPTION
## Description
PR #11049 introduced a regression which caused an error on some use cases of a strict autocomplete. This PR fixes that, reverts the test back to before #11049, and refactors/optimizes the code.

## How Has This Been Tested?
Tested with existing test.

**Current behavior:**
![autocompleteregression](https://github.com/user-attachments/assets/59365860-2206-4888-a1dd-c7b6490ff1bd)

**Fixed behavior:**
![autocompleteregressionfix](https://github.com/user-attachments/assets/8afce060-454e-4867-8d71-ae35ff4339b0)

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
