### PR TITLE
Datagrid: Support Dateonly filter

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridDateOnlyFilterTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridDateOnlyFilterTest.razor
@@ -1,0 +1,20 @@
+<MudDataGrid Items="@_people" Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterRow">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" />
+        <PropertyColumn Property="x => x.Age" Title="Age" />
+        <PropertyColumn Property="x => x.HiredOn" Title="Hired On" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = @"Test DateOnly filtering in DataGrid";
+    public record Model(string Name, int? Age, DateOnly? HiredOn);
+    
+    private readonly IEnumerable<Model> _people =
+    [
+        new("Sam", 56, new DateOnly(2020, 3, 10)),
+        new("Alicia", 54, null),
+        new("Ira", 27, new DateOnly(2011, 1, 2)),
+        new("John", 32, new DateOnly(2022, 6, 15))
+    ];
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2790,6 +2790,9 @@ namespace MudBlazor.UnitTests.Components
             // check the number of filters displayed in the filters panel is 1
             comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(1);
 
+            // Wait for the filter panel to render properly
+            comp.WaitForState(() => comp.FindAll(".filter-operator").Count > 0, timeout: TimeSpan.FromSeconds(5));
+
             await comp.Find(".filter-operator").MouseDownAsync(new MouseEventArgs());
 
             //set operator to CONTAINS
@@ -2802,6 +2805,9 @@ namespace MudBlazor.UnitTests.Components
 
             //set operator to NOT CONTAINS
             FilterButton().Click();
+
+            // Wait for the filter panel to render properly
+            comp.WaitForState(() => comp.FindAll(".filter-operator").Count > 0, timeout: TimeSpan.FromSeconds(5));
 
             await comp.Find(".filter-operator").MouseDownAsync(new MouseEventArgs());
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2236,6 +2236,285 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void FilterDefinitionDateOnlyTest()
+        {
+            var comp = Context.RenderComponent<DataGridDateOnlyFilterTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridDateOnlyFilterTest.Model>>();
+            var dateColumn = dataGrid.Instance.GetColumnByPropertyName("HiredOn");
+            var testDate = new DateOnly(2020, 3, 10);
+
+            #region FilterOperator.DateOnly.Is
+
+            var filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.Is,
+                Value = testDate
+            };
+            var func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+            func.Invoke(new("Ira", 27, new DateOnly(2011, 1, 2))).Should().BeFalse();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.Is,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.IsNot
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.IsNot,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeFalse();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+            func.Invoke(new("Ira", 27, new DateOnly(2011, 1, 2))).Should().BeTrue();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.IsNot,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.After
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.After,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeFalse();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+            func.Invoke(new("John", 32, new DateOnly(2022, 6, 15))).Should().BeTrue();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.After,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.OnOrAfter
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.OnOrAfter,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+            func.Invoke(new("John", 32, new DateOnly(2022, 6, 15))).Should().BeTrue();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.OnOrAfter,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.Before
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.Before,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeFalse();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+            func.Invoke(new("Ira", 27, new DateOnly(2011, 1, 2))).Should().BeTrue();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.Before,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.OnOrBefore
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.OnOrBefore,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+            func.Invoke(new("Ira", 27, new DateOnly(2011, 1, 2))).Should().BeTrue();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.OnOrBefore,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.Empty
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.Empty,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeFalse();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+            func.Invoke(new("Ira", 27, new DateOnly(2011, 1, 2))).Should().BeFalse();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.Empty,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeFalse();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+
+            #endregion
+
+            #region FilterOperator.DateOnly.NotEmpty
+
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.NotEmpty,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+            func.Invoke(new("Ira", 27, new DateOnly(2011, 1, 2))).Should().BeTrue();
+
+            // null value
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = FilterOperator.DateOnly.NotEmpty,
+                Value = null
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeFalse();
+
+            #endregion
+
+            // null operator
+            filterDefinition = new FilterDefinition<DataGridDateOnlyFilterTest.Model>
+            {
+                Column = dateColumn,
+                Operator = null,
+                Value = testDate
+            };
+            func = filterDefinition.GenerateFilterFunction(new FilterOptions
+            {
+                FilterCaseSensitivity = dataGrid.Instance.FilterCaseSensitivity
+            });
+            func.Invoke(new("Sam", 56, testDate)).Should().BeTrue();
+            func.Invoke(new("Joe", 32, null)).Should().BeTrue();
+        }
+
+        [Test]
         public void FilterDefinitionNumberTest()
         {
             var comp = Context.RenderComponent<DataGridFiltersTest>();

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -148,7 +148,7 @@ namespace MudBlazor.UnitTests.Components
             // close by click on ok button
             comp.Find(".mud-message-box button").Click();
 
-            comp.Markup.Trim().Should().BeEmpty();
+            comp.WaitForAssertion(() => comp.Markup.Trim().Should().BeEmpty(), timeout: TimeSpan.FromSeconds(5));
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Other/TypeIdentifierTests.cs
+++ b/src/MudBlazor.UnitTests/Other/TypeIdentifierTests.cs
@@ -97,6 +97,20 @@ namespace MudBlazor.UnitTests.Other
         [TestCase(null, false)]
         [TestCase(typeof(int), false)]
         [TestCase(typeof(int?), false)]
+        [TestCase(typeof(DateOnly), true)]
+        [TestCase(typeof(DateOnly?), true)]
+        [TestCase(typeof(DateTime), false)]
+        [TestCase(typeof(DateTime?), false)]
+        public void IsDateOnly_Test(Type type, bool expected)
+        {
+            var isDateOnly = TypeIdentifier.IsDateOnly(type);
+            isDateOnly.Should().Be(expected);
+        }
+
+        [Test]
+        [TestCase(null, false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(int?), false)]
         [TestCase(typeof(Guid), true)]
         [TestCase(typeof(Guid?), true)]
         public void IsGuid_Test(Type type, bool expected)

--- a/src/MudBlazor/Components/DataGrid/FieldType.cs
+++ b/src/MudBlazor/Components/DataGrid/FieldType.cs
@@ -38,6 +38,11 @@ namespace MudBlazor
         public bool IsDateTime { get; init; }
 
         /// <summary>
+        /// Whether the <see cref="InnerType"/> represents a date only.
+        /// </summary>
+        public bool IsDateOnly { get; init; }
+
+        /// <summary>
         /// Whether the <see cref="InnerType"/> represents a true/false value.
         /// </summary>
         public bool IsBoolean { get; init; }
@@ -59,6 +64,7 @@ namespace MudBlazor
                 IsNumber = TypeIdentifier.IsNumber(type),
                 IsEnum = TypeIdentifier.IsEnum(type),
                 IsDateTime = TypeIdentifier.IsDateTime(type),
+                IsDateOnly = TypeIdentifier.IsDateOnly(type),
                 IsBoolean = TypeIdentifier.IsBoolean(type),
                 IsGuid = TypeIdentifier.IsGuid(type)
             };

--- a/src/MudBlazor/Components/DataGrid/FilterExpressionGenerator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterExpressionGenerator.cs
@@ -103,6 +103,25 @@ public static class FilterExpressionGenerator
             };
         }
 
+        if (fieldType.IsDateOnly)
+        {
+            if (filter.Value is null && filter.Operator != FilterOperator.DateOnly.Empty && filter.Operator != FilterOperator.DateOnly.NotEmpty)
+                return x => true;
+
+            return filter.Operator switch
+            {
+                FilterOperator.DateOnly.Is => propertyExpression.GenerateBinary<T>(ExpressionType.Equal, filter.Value),
+                FilterOperator.DateOnly.IsNot => propertyExpression.GenerateBinary<T>(ExpressionType.NotEqual, filter.Value),
+                FilterOperator.DateOnly.After => propertyExpression.GenerateBinary<T>(ExpressionType.GreaterThan, filter.Value),
+                FilterOperator.DateOnly.OnOrAfter => propertyExpression.GenerateBinary<T>(ExpressionType.GreaterThanOrEqual, filter.Value),
+                FilterOperator.DateOnly.Before => propertyExpression.GenerateBinary<T>(ExpressionType.LessThan, filter.Value),
+                FilterOperator.DateOnly.OnOrBefore => propertyExpression.GenerateBinary<T>(ExpressionType.LessThanOrEqual, filter.Value),
+                FilterOperator.DateOnly.Empty => propertyExpression.GenerateBinary<T>(ExpressionType.Equal, null),
+                FilterOperator.DateOnly.NotEmpty => propertyExpression.GenerateBinary<T>(ExpressionType.NotEqual, null),
+                _ => x => true
+            };
+        }
+
         if (fieldType.IsDateTime)
         {
             if (filter.Value is null && filter.Operator != FilterOperator.DateTime.Empty && filter.Operator != FilterOperator.DateTime.NotEmpty)

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -42,11 +42,15 @@
                         <MudSelectItem T="bool?" Value="@(false)">@Localizer[LanguageResource.MudDataGrid_False]</MudSelectItem>
                     </MudSelect>
                 }
+                else if (fieldType.IsDateOnly && !(@operator ?? "").EndsWith("empty"))
+                {
+                    <MudDatePicker Date="@valueDateOnlyForPicker" DateChanged="@DateOnlyValueChangedAsync" Margin="@Margin.Dense" />
+                }
                 else if (fieldType.IsDateTime && !(@operator ?? "").EndsWith("empty"))
                 {
                     <MudGrid Spacing="0">
                         <MudItem xs="7">
-                            <MudDatePicker Date="@valueDate" DateChanged="@DateValueChangedAsync" Margin="@Margin.Dense" />
+                            <MudDatePicker Date="@valueDateTimeForPicker" DateChanged="@DateTimeValueChangedAsync" Margin="@Margin.Dense" />
                         </MudItem>
                         <MudItem xs="5">
                             <MudTimePicker Time="@valueTime" TimeChanged="@TimeValueChangedAsync" Margin="@Margin.Dense" />

--- a/src/MudBlazor/Components/DataGrid/FilterOperator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterOperator.cs
@@ -185,6 +185,52 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Represents filters which are available for date only values.
+        /// </summary>
+        public static class DateOnly
+        {
+            /// <summary>
+            /// Find values matching the filter date.
+            /// </summary>
+            public const string Is = "is";
+
+            /// <summary>
+            /// Find values different from the filter date.
+            /// </summary>
+            public const string IsNot = "is not";
+
+            /// <summary>
+            /// Find values after the filter date.
+            /// </summary>
+            public const string After = "is after";
+
+            /// <summary>
+            /// Find values on or after the filter date.
+            /// </summary>
+            public const string OnOrAfter = "is on or after";
+
+            /// <summary>
+            /// Find values before the filter date.
+            /// </summary>
+            public const string Before = "is before";
+
+            /// <summary>
+            /// Find values on or before the filter date.
+            /// </summary>
+            public const string OnOrBefore = "is on or before";
+
+            /// <summary>
+            /// Find null values.
+            /// </summary>
+            public const string Empty = "is empty";
+
+            /// <summary>
+            /// Find any non-null value.
+            /// </summary>
+            public const string NotEmpty = "is not empty";
+        }
+
+        /// <summary>
         /// Represents filters which are available for Guid values.
         /// </summary>
         public static class Guid
@@ -248,6 +294,20 @@ namespace MudBlazor
                 return new[]
                 {
                     Boolean.Is,
+                };
+            }
+            if (fieldType.IsDateOnly)
+            {
+                return new[]
+                {
+                    DateOnly.Is,
+                    DateOnly.IsNot,
+                    DateOnly.After,
+                    DateOnly.OnOrAfter,
+                    DateOnly.Before,
+                    DateOnly.OnOrBefore,
+                    DateOnly.Empty,
+                    DateOnly.NotEmpty,
                 };
             }
             if (fieldType.IsDateTime)

--- a/src/MudBlazor/Components/DataGrid/TypeIdentifier.cs
+++ b/src/MudBlazor/Components/DataGrid/TypeIdentifier.cs
@@ -88,6 +88,23 @@ namespace MudBlazor
             return underlyingType is not null && underlyingType == typeof(DateTime);
         }
 
+        public static bool IsDateOnly(Type? type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+
+            if (type == typeof(DateOnly))
+            {
+                return true;
+            }
+
+            var underlyingType = Nullable.GetUnderlyingType(type);
+
+            return underlyingType is not null && underlyingType == typeof(DateOnly);
+        }
+
         public static bool IsBoolean(Type? type)
         {
             if (type is null)


### PR DESCRIPTION
## Description
Resolves #7741 
Adds `DateOnly` filtering support to MudDataGrid, showing only a date picker for `DateOnly` type

  ## How Has This Been Tested?
  **Unit Tests:**
  - Added `FilterDefinitionDateOnlyTest()` covering all DateOnly filter operators
  - Added `TypeIdentifierTests` for DateOnly type identification
  - Verified all existing unit tests pass

**Visual Test:**
  - Added test component `DataGridDateOnlyFilterTest` for UI validation
  - Verified DateOnly fields show only DatePicker (no TimePicker)
  - Verified DateTime fields continue to show both DatePicker and TimePicker
  - Tested all filter operators work correctly with DateOnly values

  ## Type of Changes
  - [x] New feature (no breaking changes)
![Screenshot 2025-06-22 172206](https://github.com/user-attachments/assets/b710f373-8ce5-4335-9eef-3d5f9f3cfc6c)

## Checklist
- [X] The PR is submitted to the correct branch (`dev`).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.
