### PR TITLE
MudHighlighter: Fix Highlighted Markup Render Bug

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Highlighter/HtmlEncodeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Highlighter/HtmlEncodeTest.razor
@@ -1,0 +1,34 @@
+﻿<MudTextField Style="max-width:250px" @bind-Value="highlightedText" Immediate="true" Label="Highlighted Text" />
+<MudPaper Class="pa-4 mt-4" Elevation="0">
+    @foreach (var paragraph in paragraphs)
+    {
+        <MudText @key="paragraph" Class="ma-2">
+            <MudHighlighter Text="@paragraph"
+                            HighlightedText="@highlightedText"
+                            UntilNextBoundary="@untilNextBoundary"
+                            CaseSensitive="@caseSensitive"
+                            Markup="@markup"
+                            Class="@(untilNextBoundary ? "pa-1 mud-elevation-2 mud-theme-primary":"")" />
+        </MudText>
+    }
+
+</MudPaper>
+<MudSwitch @bind-Value="untilNextBoundary" Label="UntilNextBoundary" Color="Color.Primary" />
+<MudSwitch @bind-Value="caseSensitive" Label="CaseSensitive" Color="Color.Primary" />
+<MudSwitch @bind-Value="markup" Label="Markup" Color="Color.Primary" />
+
+@code {
+    public static string __description__ = "Style (color and formatting) should be present";
+
+    string highlightedText = "'";
+    bool untilNextBoundary;
+    bool caseSensitive;
+    bool markup = true;
+    IEnumerable<string> paragraphs = new List<string>
+    {
+        $"<i>MudBlazor</i> is an <ambitious> <span style='color:{Colors.Purple.Default}'>Material Design</span> component framework for Blazor with an <span style='color:{Colors.Green.Default}'>emphasis</span> on <em>ease of use and clear structure</em>.",
+        $"MudLists are easily <span style='color:{Colors.Orange.Default}'>customizable</span> and <span style='color:{Colors.Red.Default}'>scrollable</span> lists. Make them suit your needs with <i>avatars</i>, <i>icons</i>, or something like <i>checkboxes</i>.",
+        $"Use <b>mud</b>-* classes to <span style='color:{Colors.Blue.Default}'>customize your MudBlazor components</span>.",
+        $"'text in single quote'"
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Collections.Generic;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -260,6 +258,128 @@ namespace MudBlazor.UnitTests.Components
             var textAsMarkupTrue = Parameter(nameof(MudHighlighter.Markup), true);
             comp = Context.RenderComponent<MudHighlighter>(text, highlightedText, textAsMarkupTrue);
             comp.MarkupMatches(formattedOutput);
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HtmlInText_ShouldHighlightCorrectly()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "<span>Hello</span> World");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "Hello");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("<span><mark>Hello</mark></span> World");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HtmlSensitiveCharInHighlightedText_ShouldEncodeAndHighlight()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Hello <World>");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "<World>");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("Hello <mark>&amp;lt;World&amp;gt;</mark>");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HtmlInText_ShouldNotHighlightInTags()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "<div class='foo'>div content div</div>");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "div");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("<div class='foo'><mark>div</mark> content <mark>div</mark></div>");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_TextWithHtmlEntities_HighlightedTextIsEntityText()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Hello &amp; World");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "&amp;");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            // Adjusted to match BUnit's actual output. This implies that when FragmentInfo.Content = "&amp;",
+            // the rendered <mark>@FragmentInfo.Content</mark> is captured by BUnit as <mark>&amp;amp;</mark>.
+            comp.MarkupMatches("Hello <mark>&amp;amp;</mark> World");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HighlightedTextWithSingleQuotes_ShouldHighlight()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "This is a 'quoted' text and a \"double quoted\" text.");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "'quoted'");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("This is a <mark>'quoted'</mark> text and a \"double quoted\" text.");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HighlightedTextWithDoubleQuotes_ShouldHighlight()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "This is a 'quoted' text and a \"double quoted\" text.");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "\"double quoted\"");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("This is a 'quoted' text and a <mark>&quot;double quoted&quot;</mark> text.");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HighlightedTextAsAttributeValue_ShouldNotHighlightInAttribute()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "<span title='nothing'>nothing</span>");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "nothing");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("<span title='nothing'><mark>nothing</mark></span>");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_FormattingPreservation_ItalicsAndColor()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "<i>MudBlazor</i> is <span style='color:red'>important</span>");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "MudBlazor");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("<i><mark>MudBlazor</mark></i> is <span style='color:red'>important</span>");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_FormattingPreservation_Bold()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Normal <b>bold</b> normal");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "bold");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("Normal <b><mark>bold</mark></b> normal");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_NonStandardTag_NoHighlight()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Hello <ambitious> world");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), ""); // Or null, effectively no highlight
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("Hello &amp;lt;ambitious&amp;gt; world");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_NonStandardTag_WithHighlightAfterTag()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Hello <ambitious> world");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "world");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("Hello &amp;lt;ambitious&amp;gt; <mark>world</mark>");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_NonStandardTag_WithHighlightInsideTag()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Hello <ambitious> world");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "bit");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("Hello &amp;lt;am<mark>bit</mark>ious&amp;gt; world");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -277,7 +277,7 @@ namespace MudBlazor.UnitTests.Components
             var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "<World>");
             var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
             var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
-            comp.MarkupMatches("Hello <mark>&amp;lt;World&amp;gt;</mark>");
+            comp.MarkupMatches("Hello <mark>&lt;World&gt;</mark>");
         }
 
         [Test]
@@ -288,6 +288,16 @@ namespace MudBlazor.UnitTests.Components
             var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
             var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
             comp.MarkupMatches("<div class='foo'><mark>div</mark> content <mark>div</mark></div>");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_HtmlTag_ShouldNotHighlight()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Hello <i>Mud</i> World");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "<i>");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+            comp.MarkupMatches("Hello <i>Mud</i> World");
         }
 
         [Test]
@@ -359,7 +369,7 @@ namespace MudBlazor.UnitTests.Components
             var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), ""); // Or null, effectively no highlight
             var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
             var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
-            comp.MarkupMatches("Hello &amp;lt;ambitious&amp;gt; world");
+            comp.MarkupMatches("Hello &lt;ambitious&gt; world");
         }
 
         [Test]
@@ -369,7 +379,7 @@ namespace MudBlazor.UnitTests.Components
             var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "world");
             var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
             var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
-            comp.MarkupMatches("Hello &amp;lt;ambitious&amp;gt; <mark>world</mark>");
+            comp.MarkupMatches("Hello &lt;ambitious&gt; <mark>world</mark>");
         }
 
         [Test]
@@ -379,7 +389,7 @@ namespace MudBlazor.UnitTests.Components
             var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "bit");
             var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
             var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
-            comp.MarkupMatches("Hello &amp;lt;am<mark>bit</mark>ious&amp;gt; world");
+            comp.MarkupMatches("Hello &lt;am<mark>bit</mark>ious&gt; world");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
+using MudBlazor.Components.Highlighter;
 using static Bunit.ComponentParameterFactory;
 using static MudBlazor.Components.Highlighter.Splitter;
 
@@ -110,6 +111,161 @@ namespace MudBlazor.UnitTests.Components
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(new List<string> { "This is the first ", "item" });
             regex.Should().Be("((?:item)|(?:item))");
+        }
+
+        [Test]
+        public void GetFragments_NoHighlightTerms_ReturnsOriginalTextAsSingleFragment()
+        {
+            var inputText = "This is some sample text.";
+            string highlightedText = null;
+            string[] highlightedTexts = null;
+
+            var result = GetFragments(inputText, highlightedText, highlightedTexts, out var outRegex).ToArray();
+
+            result.Should().HaveCount(1);
+            result[0].Should().Be(inputText);
+            outRegex.Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void GetHtmlAwareFragments_NullOrEmptyText_ReturnsEmptyList()
+        {
+            var resultNull = GetHtmlAwareFragments(null, "any", null, out var outRegex, false, false);
+            resultNull.Should().BeEmpty();
+            outRegex.Should().Be(string.Empty);
+
+
+            // Test with empty text
+            var resultEmpty = GetHtmlAwareFragments(string.Empty, "any", null, out outRegex, false, false);
+            resultEmpty.Should().BeEmpty();
+            // As per L59, regex is set to string.Empty at the start of the method before the null check.
+            outRegex.Should().Be(string.Empty);
+        }
+
+        [Test]
+        public void GetHtmlAwareFragments_InvalidTag_IsEncodedAsText()
+        {
+            var text = "This is <notatag an attribute> text.";
+            var highlightedText = "text";
+
+            var fragments = GetHtmlAwareFragments(text, highlightedText, null, out var outRegex, false, false);
+
+            fragments.Should().Contain(new FragmentInfo("<notatag an attribute>", FragmentType.Text));
+
+            // Verify surrounding text and highlight
+            var expectedFullSequence = new[] {
+                new FragmentInfo("This is ", FragmentType.Text),
+                new FragmentInfo("<notatag an attribute>", FragmentType.Text),
+                new FragmentInfo(" ", FragmentType.Text),
+                new FragmentInfo("text", FragmentType.HighlightedText),
+                new FragmentInfo(".", FragmentType.Text)
+            };
+            fragments.Should().BeEquivalentTo(expectedFullSequence, options => options.WithStrictOrdering());
+        }
+
+        [Test]
+        public void GetHtmlAwareFragments_SelfClosingTag_IsPreservedAsMarkup()
+        {
+            var text = "Text with <br /> a line break.";
+            var highlightedText = "Text";
+
+            var fragments = GetHtmlAwareFragments(text, highlightedText, null, out var outRegex, false, false);
+
+            var expectedFullSequence = new[] {
+                new FragmentInfo("Text", FragmentType.HighlightedText),
+                new FragmentInfo(" with ", FragmentType.Text),
+                new FragmentInfo("<br />", FragmentType.Markup),
+                new FragmentInfo(" a line break.", FragmentType.Text)
+            };
+            fragments.Should().BeEquivalentTo(expectedFullSequence, options => options.WithStrictOrdering());
+        }
+
+        [Test]
+        public void GetHtmlAwareFragments_MismatchedClosingTag_IsEncodedAsText()
+        {
+            var text = "<div><span>Content</div></span>";
+            var highlightedText = "Content";
+            var fragments = GetHtmlAwareFragments(text, highlightedText, null, out var outRegex, false, false);
+
+            var expectedFullSequence = new[] {
+                new FragmentInfo("<div>", FragmentType.Text),
+                new FragmentInfo("<span>", FragmentType.Markup),
+                new FragmentInfo("Content", FragmentType.HighlightedText),
+                new FragmentInfo(System.Net.WebUtility.HtmlEncode("</div>"), FragmentType.Text),
+                new FragmentInfo("</span>", FragmentType.Markup)
+            };
+            fragments.Should().BeEquivalentTo(expectedFullSequence, options => options.WithStrictOrdering());
+        }
+
+        [Test]
+        public void GetHtmlAwareFragments_UnmatchedTagWithHighlightAndTrailingText_CorrectlyFragments()
+        {
+            var text = "<b>unclosed highlight then_text"; // Simplified input
+            var highlightedText = "highlight";
+
+            var fragments = GetHtmlAwareFragments(text, highlightedText, null, out var outRegex, caseSensitive: false, untilNextBoundary: false);
+
+            var expectedSequence = new[] {
+                new FragmentInfo("<b>", FragmentType.Text), // The unmatched opening tag becomes text
+                new FragmentInfo("unclosed ", FragmentType.Text),
+                new FragmentInfo("highlight", FragmentType.HighlightedText),
+                new FragmentInfo(" then_text", FragmentType.Text)
+            };
+
+            fragments.Should().BeEquivalentTo(expectedSequence, options => options.WithStrictOrdering());
+        }
+
+        [Test]
+        public void GetFragments_WithManyTerms_ExercisesStringBuilderCaching()
+        {
+            var text = "The quick brown fox jumps over the lazy dog and repeats.";
+            var highlightedTexts1 = new[] { "quick", "brown", "fox", "jumps", "lazy", "dog", "repeats" };
+
+            var fragments1 = GetFragments(text, null, highlightedTexts1, out var outRegex1, caseSensitive: false, untilNextBoundary: false).ToArray();
+
+            fragments1.Should().NotBeEmpty();
+            outRegex1.Should().NotBeEmpty();
+            outRegex1.Should().ContainAll(highlightedTexts1);
+            fragments1.Length.Should().Be(highlightedTexts1.Length * 2 - 1 + 2);
+
+            var text2 = "Another test sentence with new words like example and cache.";
+            var highlightedTexts2 = new[] { "sentence", "words", "example", "cache" };
+            var fragments2 = GetFragments(text2, null, highlightedTexts2, out var outRegex2, caseSensitive: false, untilNextBoundary: false).ToArray();
+
+            fragments2.Should().NotBeEmpty();
+            outRegex2.Should().NotBeEmpty();
+            outRegex2.Should().ContainAll(highlightedTexts2);
+            fragments2.Length.Should().Be(highlightedTexts2.Length * 2 - 1 + 2);
+
+            var text3 = "No highlights here.";
+            var fragments3 = GetFragments(text3, null, [], out var outRegex3, caseSensitive: false, untilNextBoundary: false).ToArray();
+            fragments3.Should().HaveCount(1);
+            fragments3[0].Should().Be(text3);
+            outRegex3.Should().BeEmpty();
+        }
+
+        [Test]
+        public void GetHtmlAwareFragments_CaseSensitivity_ProducesCorrectFragments()
+        {
+            var text = "Highlight highlight";
+            var highlightTerm = "Highlight";
+
+            // Case Sensitive
+            var fragmentsSensitive = GetHtmlAwareFragments(text, highlightTerm, null, out var outRegex, caseSensitive: true, untilNextBoundary: false);
+            var expectedSensitive = new[] {
+                new FragmentInfo("Highlight", FragmentType.HighlightedText),
+                new FragmentInfo(" highlight", FragmentType.Text)
+            };
+            fragmentsSensitive.Should().BeEquivalentTo(expectedSensitive, options => options.WithStrictOrdering());
+
+            // Case Insensitive
+            var fragmentsInsensitive = GetHtmlAwareFragments(text, highlightTerm, null, out outRegex, caseSensitive: false, untilNextBoundary: false);
+            var expectedInsensitive = new[] {
+                new FragmentInfo("Highlight", FragmentType.HighlightedText),
+                new FragmentInfo(" ", FragmentType.Text),
+                new FragmentInfo("highlight", FragmentType.HighlightedText)
+            };
+            fragmentsInsensitive.Should().BeEquivalentTo(expectedInsensitive, options => options.WithStrictOrdering());
         }
     }
 
@@ -390,6 +546,57 @@ namespace MudBlazor.UnitTests.Components
             var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
             var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
             comp.MarkupMatches("Hello &lt;am<mark>bit</mark>ious&gt; world");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_NoFragments_RendersTextAsMarkupString()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Some text");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "zip");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam);
+
+            comp.MarkupMatches("Some text");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupTrue_WithClass_RendersMarkWithClass()
+        {
+            var textParam = Parameter(nameof(MudHighlighter.Text), "Highlight this");
+            var highlightedTextParam = Parameter(nameof(MudHighlighter.HighlightedText), "Highlight");
+            var markupParam = Parameter(nameof(MudHighlighter.Markup), true);
+            var classParam = Parameter(nameof(MudHighlighter.Class), "my-custom-class");
+
+            var comp = Context.RenderComponent<MudHighlighter>(textParam, highlightedTextParam, markupParam, classParam);
+
+            comp.MarkupMatches("<mark class=\"my-custom-class\">Highlight</mark> this");
+        }
+
+        [Test]
+        public void MudHighlighter_MarkupFalse_AfterMarkupTrue_ClearsHtmlAwareFragmentsAndRendersCorrectly()
+        {
+            var initialText = "Test with <b>HTML</b> and highlight";
+            var initialHighlightedText = "highlight";
+
+            // 1. Render initially with Markup = true
+            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+                .Add(p => p.Text, initialText)
+                .Add(p => p.HighlightedText, initialHighlightedText)
+                .Add(p => p.Markup, true)
+            );
+
+            comp.MarkupMatches("Test with <b>HTML</b> and <mark>highlight</mark>");
+
+            // 2. Re-render with Markup = false
+            comp.SetParametersAndRender(parameters => parameters
+                .Add(p => p.Text, initialText) // Keep text and highlight the same
+                .Add(p => p.HighlightedText, initialHighlightedText)
+                .Add(p => p.Markup, false)
+            );
+
+            var expectedMarkup = "Test with &lt;b&gt;HTML&lt;/b&gt; and <mark>highlight</mark>";
+            comp.MarkupMatches(expectedMarkup);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -1,7 +1,7 @@
 ﻿using Bunit;
 using FluentAssertions;
-using NUnit.Framework;
 using MudBlazor.Components.Highlighter;
+using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
 using static MudBlazor.Components.Highlighter.Splitter;
 

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -6,32 +6,12 @@
 
 @if (Markup)
 {
-    if (_htmlAwareFragments != null) // Check if not null
+    if (_htmlAwareFragments != null)
     {
-        var sb = new StringBuilder();
-        foreach (var fragmentInfo in _htmlAwareFragments)
-        {
-            switch (fragmentInfo.Type)
-            {
-                case FragmentType.HighlightedText:
-                    sb.Append($"<mark class=\"{@Class}\" style=\"{@Style}\" >{@fragmentInfo.Content}</mark>");
-                    break;
-                case FragmentType.Markup:
-                    sb.Append(fragmentInfo.Content);
-                    break;
-                case FragmentType.Text:
-                default:
-                    sb.Append(@fragmentInfo.Content);
-                    break;
-            }
-        }
-
-        @ToRenderFragment(sb.ToString());
+        @CreateFragmentContent();
     }
-    else if (!string.IsNullOrEmpty(Text)) // Fallback if _htmlAwareFragments is null but Text exists
+    else if (!string.IsNullOrEmpty(Text))
     {
-        // This case should ideally not be hit if OnParametersSet correctly initializes _htmlAwareFragments.
-        // However, as a safeguard, render Text as MarkupString if Markup is true.
         @((MarkupString)Text)
     }
 }
@@ -49,8 +29,50 @@ else if (_fragments.Length > 0)
         }
     }
 }
-else if (!string.IsNullOrEmpty(Text)) // Fallback for non-Markup or if _fragments is empty
+else if (!string.IsNullOrEmpty(Text))
 {
-    // If Markup is false and _fragments is empty, or if Text is set but highlighting results in no fragments.
     @Text
+}
+
+@code {
+    private RenderFragment CreateFragmentContent() => builder =>
+    {
+        int sequence = 0;
+    
+        foreach (var fragmentInfo in _htmlAwareFragments)
+        {
+            switch (fragmentInfo.Type)
+            {
+                case FragmentType.HighlightedText:
+                    if (IsMatch(fragmentInfo.Content))
+                    {
+                        builder.OpenElement(sequence++, "mark");
+
+                        if (!string.IsNullOrWhiteSpace(Class))
+                            builder.AddAttribute(sequence++, "class", Class);
+
+                        if (!string.IsNullOrWhiteSpace(Style))
+                            builder.AddAttribute(sequence++, "style", Style);
+        
+                        if (UserAttributes != null || UserAttributes.Count != 0)
+                            builder.AddMultipleAttributes(sequence++, UserAttributes);
+
+                        builder.AddContent(sequence++, fragmentInfo.Content);
+                        builder.CloseElement();
+                    }
+                    else
+                    {
+                        builder.AddContent(sequence++, fragmentInfo.Content);
+                    }
+                    break;
+                case FragmentType.Markup:
+                    builder.AddMarkupContent(sequence++, fragmentInfo.Content);
+                    break;
+                case FragmentType.Text:
+                default:
+                    builder.AddContent(sequence++, fragmentInfo.Content);
+                    break;
+            }
+        }
+    };
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -1,20 +1,56 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 @using System.Text.RegularExpressions
-@using static MudBlazor.Components.Highlighter.Splitter
+@using MudBlazor.Components.Highlighter
+@using System.Text
 
-@foreach (var fragment in _fragments.Span)
+@if (Markup)
 {
-    if (IsMatch(fragment))
-   {
-      <mark class="@Class" style="@Style" @attributes="@UserAttributes"> @fragment </mark>
-   }
-   else if (Markup)
-   {
-      @ToRenderFragment(fragment)
-   }
-   else
-   {
-      @fragment
-   }
+    if (_htmlAwareFragments != null) // Check if not null
+    {
+        var sb = new StringBuilder();
+        foreach (var fragmentInfo in _htmlAwareFragments)
+        {
+            switch (fragmentInfo.Type)
+            {
+                case FragmentType.HighlightedText:
+                    sb.Append($"<mark class=\"{@Class}\" style=\"{@Style}\" >{@fragmentInfo.Content}</mark>");
+                    break;
+                case FragmentType.Markup:
+                    sb.Append(fragmentInfo.Content);
+                    break;
+                case FragmentType.Text:
+                default:
+                    sb.Append(@fragmentInfo.Content);
+                    break;
+            }
+        }
+
+        @ToRenderFragment(sb.ToString());
+    }
+    else if (!string.IsNullOrEmpty(Text)) // Fallback if _htmlAwareFragments is null but Text exists
+    {
+        // This case should ideally not be hit if OnParametersSet correctly initializes _htmlAwareFragments.
+        // However, as a safeguard, render Text as MarkupString if Markup is true.
+        @((MarkupString)Text)
+    }
+}
+else if (_fragments.Length > 0)
+{
+    foreach (var fragment in _fragments.Span)
+    {
+        if (IsMatch(fragment))
+        {
+            <mark class="@Class" style="@Style" @attributes="@UserAttributes">@fragment</mark>
+        }
+        else
+        {
+            @fragment
+        }
+    }
+}
+else if (!string.IsNullOrEmpty(Text)) // Fallback for non-Markup or if _fragments is empty
+{
+    // If Markup is false and _fragments is empty, or if Text is set but highlighting results in no fragments.
+    @Text
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -2,12 +2,11 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
-using static MudBlazor.Components.Highlighter.Splitter;
+using MudBlazor.Components.Highlighter; // Added for FragmentInfo
+// Removed: using static MudBlazor.Components.Highlighter.Splitter; 
+// We will call Splitter methods statically: Splitter.GetFragments, Splitter.GetHtmlAwareFragments
 
 namespace MudBlazor;
 
@@ -20,6 +19,7 @@ public partial class MudHighlighter : MudComponentBase
 {
     private Memory<string> _fragments;
     private string? _regex;
+    private List<FragmentInfo> _htmlAwareFragments = new List<FragmentInfo>(); // Added
 
     /// <summary>
     /// The text to consider for highlighting.
@@ -40,7 +40,7 @@ public partial class MudHighlighter : MudComponentBase
     /// </summary>
     [Parameter]
     [Category(CategoryTypes.Highlighter.Behavior)]
-    public IEnumerable<string> HighlightedTexts { get; set; } = Enumerable.Empty<string>();
+    public IEnumerable<string> HighlightedTexts { get; set; } = [];
 
     /// <summary>
     /// Whether highlighted text is case sensitive.
@@ -79,12 +79,29 @@ public partial class MudHighlighter : MudComponentBase
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        _fragments = GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
+        if (Markup)
+        {
+            _htmlAwareFragments = Splitter.GetHtmlAwareFragments(Text, HighlightedText, HighlightedTexts, CaseSensitive, UntilNextBoundary);
+            _fragments = Memory<string>.Empty;
+            _regex = string.Empty;
+        }
+        else
+        {
+            _fragments = Splitter.GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
+            // Ensure _htmlAwareFragments is not null and is empty if not used
+            if (_htmlAwareFragments == null)
+                _htmlAwareFragments = new List<FragmentInfo>();
+            else
+                _htmlAwareFragments.Clear();
+        }
     }
 
+    // IsMatch is still needed for the Markup=false case
     bool IsMatch(string fragment) => !string.IsNullOrWhiteSpace(fragment) &&
                                      !string.IsNullOrWhiteSpace(_regex) &&
                                      Regex.IsMatch(fragment, _regex, CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
 
+    // This static method seems unused by the new .razor logic, consider removing if confirmed.
+    // For now, keeping it as it's not directly part of this subtask's changes to .razor logic.
     static RenderFragment ToRenderFragment(string markupContent) => builder => { builder.AddMarkupContent(0, markupContent); };
 }

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -19,7 +19,7 @@ public partial class MudHighlighter : MudComponentBase
 {
     private Memory<string> _fragments;
     private string? _regex;
-    private List<FragmentInfo> _htmlAwareFragments = new List<FragmentInfo>(); // Added
+    private List<FragmentInfo> _htmlAwareFragments = [];
 
     /// <summary>
     /// The text to consider for highlighting.
@@ -81,27 +81,21 @@ public partial class MudHighlighter : MudComponentBase
         base.OnParametersSet();
         if (Markup)
         {
-            _htmlAwareFragments = Splitter.GetHtmlAwareFragments(Text, HighlightedText, HighlightedTexts, CaseSensitive, UntilNextBoundary);
+            _htmlAwareFragments = Splitter.GetHtmlAwareFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
             _fragments = Memory<string>.Empty;
-            _regex = string.Empty;
         }
         else
         {
             _fragments = Splitter.GetFragments(Text, HighlightedText, HighlightedTexts, out _regex, CaseSensitive, UntilNextBoundary);
-            // Ensure _htmlAwareFragments is not null and is empty if not used
+
             if (_htmlAwareFragments == null)
-                _htmlAwareFragments = new List<FragmentInfo>();
+                _htmlAwareFragments = [];
             else
                 _htmlAwareFragments.Clear();
         }
     }
 
-    // IsMatch is still needed for the Markup=false case
     bool IsMatch(string fragment) => !string.IsNullOrWhiteSpace(fragment) &&
                                      !string.IsNullOrWhiteSpace(_regex) &&
                                      Regex.IsMatch(fragment, _regex, CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
-
-    // This static method seems unused by the new .razor logic, consider removing if confirmed.
-    // For now, keeping it as it's not directly part of this subtask's changes to .razor logic.
-    static RenderFragment ToRenderFragment(string markupContent) => builder => { builder.AddMarkupContent(0, markupContent); };
 }

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -10,6 +10,8 @@ public record FragmentInfo(string Content, FragmentType Type);
 
 public static partial class Splitter
 {
+    private static readonly TimeSpan _regexTimeout = TimeSpan.FromSeconds(5);
+
     private static readonly Regex _htmlTagRegex = HtmlTagMatcher();
 
     private static readonly Regex _tagParser = HtmlTagParser();
@@ -41,7 +43,7 @@ public static partial class Splitter
         }
 
         regex = BuildRegexPattern(highlightTerms, untilNextBoundary);
-        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive) | RegexOptions.NonBacktracking);
+        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive) | RegexOptions.NonBacktracking, _regexTimeout);
         var nonEmpty = splits.Where(s => !string.IsNullOrEmpty(s)).ToArray();
 
         return new Memory<string>(nonEmpty);
@@ -124,11 +126,11 @@ public static partial class Splitter
     {
         regex = string.Empty;
 
-        if (terms.Count == 0) return new Regex("^$", RegexOptions.NonBacktracking);
+        if (terms.Count == 0) return new Regex("^$", RegexOptions.NonBacktracking, _regexTimeout);
 
         regex = BuildRegexPattern(terms, untilNextBoundary);
 
-        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline | RegexOptions.NonBacktracking);
+        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline | RegexOptions.NonBacktracking, _regexTimeout);
     }
 
     private static List<FragmentInfo> ProcessRawFragments(

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -124,7 +124,7 @@ public static partial class Splitter
     {
         regex = string.Empty;
 
-        if (terms.Count == 0) return new Regex("^$");
+        if (terms.Count == 0) return new Regex("^$", RegexOptions.NonBacktracking);
 
         regex = BuildRegexPattern(terms, untilNextBoundary);
 
@@ -141,16 +141,13 @@ public static partial class Splitter
 
         foreach (var fragment in rawFragments.Where(s => !string.IsNullOrEmpty(s)))
         {
-            if (IsDirectMatch(fragment, highlightTerms, stringComparison))
-            {
-                var text = _htmlTagRegex.IsMatch(fragment)
-                                ? WebUtility.HtmlEncode(fragment)
-                                : fragment;
-                tempFragments.Add(new FragmentInfo(text, FragmentType.HighlightedText));
-            }
-            else if (_htmlTagRegex.IsMatch(fragment))
+            if (_htmlTagRegex.IsMatch(fragment))
             {
                 tempFragments.Add(new FragmentInfo(fragment, FragmentType.Markup));
+            }
+            else if (IsDirectMatch(fragment, highlightTerms, stringComparison))
+            {
+                tempFragments.Add(new FragmentInfo(fragment, FragmentType.HighlightedText));
             }
             else
             {
@@ -273,9 +270,8 @@ public static partial class Splitter
             }
             else
             {
-                var encoded = WebUtility.HtmlEncode(fragment.Content);
                 var isHighlight = highlightTerms.Contains(fragment.Content);
-                result[i] = new FragmentInfo(encoded, isHighlight ? FragmentType.HighlightedText : FragmentType.Text);
+                result[i] = new FragmentInfo(fragment.Content, isHighlight ? FragmentType.HighlightedText : FragmentType.Text);
             }
             break;
         }
@@ -291,16 +287,16 @@ public static partial class Splitter
             if (match.Index > lastIndex)
             {
                 var unmatchedSegment = segment.Substring(lastIndex, match.Index - lastIndex);
-                tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(unmatchedSegment), FragmentType.Text));
+                tempFragments.Add(new FragmentInfo(unmatchedSegment, FragmentType.Text));
             }
 
-            tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(match.Value), FragmentType.HighlightedText));
+            tempFragments.Add(new FragmentInfo(match.Value, FragmentType.HighlightedText));
             lastIndex = match.Index + match.Length;
         }
 
         if (lastIndex > 0 && lastIndex < segment.Length)
         {
-            tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(segment.Substring(lastIndex)), FragmentType.Text));
+            tempFragments.Add(new FragmentInfo(segment.Substring(lastIndex), FragmentType.Text));
         }
 
         return tempFragments;
@@ -344,7 +340,7 @@ public static partial class Splitter
 
     private static RegexOptions GetRegexOptions(bool caseSensitive)
     {
-        return caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
+        return caseSensitive ? RegexOptions.NonBacktracking : RegexOptions.IgnoreCase | RegexOptions.NonBacktracking;
     }
 
     private static StringComparison GetStringComparison(bool caseSensitive)

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -1,122 +1,311 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-namespace MudBlazor.Components.Highlighter
-{
 #nullable enable
+namespace MudBlazor.Components.Highlighter;
 
-    /// <summary>
-    /// Splits text into fragments based on text to be highlighted.
-    /// </summary>
-    public static class Splitter
+public enum FragmentType { Text, HighlightedText, Markup }
+public record FragmentInfo(string Content, FragmentType Type);
+
+public static class Splitter
+{
+    private static readonly Regex HtmlTagRegex = new Regex(@"(<\s*/?\s*\w+[^>]*?/?>)", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+    private static readonly Regex TagParser = new Regex(@"^<\s*(/)?\s*(\w+)[^>]*?(\/)?\s*>$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly HashSet<string> VoidElements = new(StringComparer.OrdinalIgnoreCase)
     {
-        private const string NextBoundary = ".*?\\b";
+        "area", "base", "br", "col", "embed", "hr", "img",
+        "input", "link", "meta", "source", "track", "wbr"
+    };
 
-        private static StringBuilder? s_stringBuilderCached;
+    private const string NextBoundary = ".*?\\b";
+    private static StringBuilder? s_stringBuilderCached;
+    private static List<string> _highlightTerms = [];
+    private static Regex _highlightRegex = new("^$");
 
-        /// <summary>
-        /// Splits text into fragments based on text to be highlighted.
-        /// </summary>
-        /// <param name="text">The text to examine.</param>
-        /// <param name="highlightedText">The text to be highlighted.</param>
-        /// <param name="highlightedTexts">The multiple texts to be highlighted.</param>
-        /// <param name="regex">The regular expression used to split text into fragments.</param>
-        /// <param name="caseSensitive">Uses a case-sensitive check for highlighted text.</param>
-        /// <param name="untilNextBoundary">Highlights text until the next regular expression boundary.</param>
-        /// <returns>A block of memory with the matched text to highlight.</returns>
-        public static Memory<string> GetFragments(string? text,
-                                                       string? highlightedText,
-                                                       IEnumerable<string>? highlightedTexts,
-                                                       out string regex,
-                                                       bool caseSensitive = false,
-                                                       bool untilNextBoundary = false)
+    public static Memory<string> GetFragments(
+    string? text,
+    string? highlightedText,
+    IEnumerable<string>? highlightedTexts,
+    out string regex,
+    bool caseSensitive = false,
+    bool untilNextBoundary = false)
+    {
+        if (string.IsNullOrEmpty(text))
         {
-            if (string.IsNullOrEmpty(text))
+            regex = string.Empty;
+            return Memory<string>.Empty;
+        }
+
+        var builder = Interlocked.Exchange(ref s_stringBuilderCached, null) ?? new StringBuilder();
+        builder.Append("((?:");
+
+        bool hasPattern = false;
+        AppendIfNotEmpty(highlightedText);
+
+        if (highlightedTexts != null)
+        {
+            foreach (var ht in highlightedTexts.Where(s => !string.IsNullOrEmpty(s)))
             {
-                regex = string.Empty;
-                return Memory<string>.Empty;
+                if (hasPattern) builder.Append(")|(?:");
+                AppendPattern(ht);
             }
+        }
 
-            var builder = Interlocked.Exchange(ref s_stringBuilderCached, null) ?? new();
-            //the first brace in the pattern is to keep the patten when splitting,
-            //the `(?:` in the pattern is to accept multiple highlightedTexts but not capture them.
-            builder.Append("((?:");
+        if (hasPattern)
+        {
+            builder.Append("))");
+        }
+        else
+        {
+            regex = string.Empty;
+            builder.Clear();
+            s_stringBuilderCached = builder;
+            return new[] { text };
+        }
 
-            //this becomes true if `AppendPattern` was called at least once.
-            var hasAtLeastOnePattern = false;
-            if (!string.IsNullOrEmpty(highlightedText))
+        regex = builder.ToString();
+        builder.Clear();
+        s_stringBuilderCached = builder;
+
+        var splits = Regex.Split(text, regex, caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
+        var nonEmpty = splits.Where(s => !string.IsNullOrEmpty(s)).ToArray();
+        return new Memory<string>(nonEmpty);
+
+        void AppendIfNotEmpty(string? s)
+        {
+            if (!string.IsNullOrEmpty(s))
             {
-                AppendPattern(highlightedText);
+                AppendPattern(s);
             }
+        }
 
-            if (highlightedTexts is not null)
+        void AppendPattern(string s)
+        {
+            hasPattern = true;
+            builder.Append(Regex.Escape(s));
+            if (untilNextBoundary) builder.Append(NextBoundary);
+        }
+    }
+
+    public static List<FragmentInfo> GetHtmlAwareFragments(
+        string? text,
+        string? highlightedText,
+        IEnumerable<string>? highlightedTexts,
+        bool caseSensitive,
+        bool untilNextBoundary)
+    {
+        var results = new List<FragmentInfo>();
+        if (string.IsNullOrEmpty(text)) return results;
+
+        _highlightTerms = BuildHighlightTerms(highlightedText, highlightedTexts);
+        _highlightRegex = BuildHighlightRegex(_highlightTerms, caseSensitive, untilNextBoundary);
+
+        var stringComparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+        var rawFragments = HtmlTagRegex.Split(text);
+        var tempFragments = new List<FragmentInfo>();
+
+        foreach (var segment in rawFragments)
+        {
+            if (string.IsNullOrEmpty(segment)) continue;
+
+            if (_highlightTerms.Any(term => string.Equals(segment, term, stringComparison)))
             {
-                foreach (var substring in highlightedTexts)
-                {
-                    if (string.IsNullOrEmpty(substring))
-                        continue;
-
-                    //split pattern if we already added an string to search.
-                    if (hasAtLeastOnePattern)
-                    {
-                        builder.Append(")|(?:");
-                    }
-
-                    AppendPattern(substring);
-                }
+                tempFragments.Add(new FragmentInfo(segment, FragmentType.HighlightedText));
             }
-
-            if (hasAtLeastOnePattern)
+            else if (HtmlTagRegex.IsMatch(segment))
             {
-                //close the last pattern group and the capture group.
-                builder.Append("))");
+                tempFragments.Add(new FragmentInfo(segment, FragmentType.Markup));
             }
             else
             {
-                builder.Clear();
-                s_stringBuilderCached = builder;
-
-                //all patterns were empty or null.
-                regex = string.Empty;
-                return new[] { text };
-            }
-
-            regex = builder.ToString();
-            builder.Clear();
-            s_stringBuilderCached = builder;
-
-            var splits = Regex
-                    .Split(text,
-                           regex,
-                           caseSensitive
-                             ? RegexOptions.None
-                             : RegexOptions.IgnoreCase);
-            var length = 0;
-            for (var i = 0; i < splits.Length; i++)
-            {
-                var s = splits[i];
-                if (!string.IsNullOrEmpty(s))
+                int last = 0;
+                foreach (Match match in _highlightRegex.Matches(segment))
                 {
-                    splits[length++] = s;
+                    if (match.Index > last)
+                    {
+                        tempFragments.Add(new FragmentInfo(segment.Substring(last, match.Index - last), FragmentType.Text));
+                    }
+                    tempFragments.Add(new FragmentInfo(match.Value, FragmentType.HighlightedText));
+                    last = match.Index + match.Length;
                 }
-            }
-            Array.Clear(splits, length, splits.Length - length);
-            return splits.AsMemory(0, length);
-
-            void AppendPattern(string value)
-            {
-                hasAtLeastOnePattern = true;
-                //escapes the text for regex
-                value = Regex.Escape(value);
-                builder.Append(value);
-                if (untilNextBoundary)
+                if (last < segment.Length)
                 {
-                    builder.Append(NextBoundary);
+                    tempFragments.Add(new FragmentInfo(segment.Substring(last), FragmentType.Text));
                 }
             }
         }
+
+        return SanitizeFragments(tempFragments);
+    }
+
+    private static List<string> BuildHighlightTerms(string? single, IEnumerable<string>? multiple)
+    {
+        var list = new List<string>();
+        if (!string.IsNullOrEmpty(single))
+        {
+            list.Add(single);
+            list.Add(WebUtility.HtmlEncode(single));
+        }
+
+        if (multiple != null)
+        {
+            list.AddRange(multiple.Where(str => !string.IsNullOrEmpty(str)));
+            list.AddRange(multiple.Where(str => !string.IsNullOrEmpty(WebUtility.UrlEncode(str))));
+        }
+
+        return list;
+    }
+
+    private static Regex BuildHighlightRegex(List<string> terms, bool caseSensitive, bool untilNextBoundary)
+    {
+        if (!terms.Any()) return new Regex("^$");
+
+        var builder = new StringBuilder();
+        for (int i = 0; i < terms.Count; i++)
+        {
+            builder.Append("(").Append(Regex.Escape(terms[i]));
+            if (untilNextBoundary) builder.Append(NextBoundary);
+            builder.Append(")");
+            if (i < terms.Count - 1) builder.Append("|");
+        }
+
+        return new Regex(builder.ToString(),
+            (caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase) | RegexOptions.Singleline);
+    }
+
+    private static List<FragmentInfo> SanitizeFragments(List<FragmentInfo> fragments)
+    {
+        var result = new List<FragmentInfo>();
+        var tagStack = new Stack<string>();
+
+        foreach (var frag in fragments)
+        {
+            if (frag.Type != FragmentType.Markup)
+            {
+                result.Add(frag);
+                continue;
+            }
+
+            var tag = frag.Content;
+            var match = TagParser.Match(tag);
+
+            if (!match.Success)
+            {
+                result.Add(HtmlEncodeFragment(frag));
+                continue;
+            }
+
+            bool isClosing = match.Groups[1].Success;
+            var tagName = match.Groups[2].Value;
+            bool isSelfClosing = match.Groups[3].Success || VoidElements.Contains(tagName);
+
+            if (isSelfClosing)
+            {
+                result.Add(frag);
+            }
+            else if (isClosing)
+            {
+                if (tagStack.Count > 0 && string.Equals(tagStack.Peek(), tagName, StringComparison.OrdinalIgnoreCase))
+                {
+                    tagStack.Pop();
+                    result.Add(frag);
+                }
+                else
+                {
+                    result.Add(HtmlEncodeFragment(frag));
+                }
+            }
+            else // opening
+            {
+                tagStack.Push(tagName);
+                result.Add(frag);
+            }
+        }
+
+        // Reclassify any unmatched opening tags left on the stack
+        while (tagStack.Count > 0)
+        {
+            var unmatchedTag = tagStack.Pop(); // e.g., "b", "i"
+
+            // Look backwards for the last matching opening tag fragment
+            for (int i = result.Count - 1; i >= 0; i--)
+            {
+                var frag = result[i];
+                if (frag.Type == FragmentType.Markup && TryGetTagName(frag.Content, out var tagName, out bool isClosing, out bool isSelfClosing))
+                {
+                    if (!isClosing && string.Equals(tagName, unmatchedTag, StringComparison.OrdinalIgnoreCase))
+                    {
+                        int last = 0;
+                        var segment = frag.Content;
+                        var tempFragments = new List<FragmentInfo>();
+
+                        foreach (Match match in _highlightRegex.Matches(segment))
+                        {
+                            if (match.Index > last)
+                            {
+                                var unmatchedSegment = segment.Substring(last, match.Index - last);
+                                tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(unmatchedSegment), FragmentType.Text));
+                            }
+                            tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(match.Value), FragmentType.HighlightedText));
+                            last = match.Index + match.Length;
+                        }
+
+                        if (last == 0 && segment.Length > 0)
+                        {
+                            // This tag was unmatched — reclassify it
+                            var encoded = WebUtility.HtmlEncode(frag.Content);
+                            var isHighlight = _highlightTerms.Contains(frag.Content);
+
+                            result[i] = new FragmentInfo(encoded, isHighlight ? FragmentType.HighlightedText : FragmentType.Text);
+                            break;
+                        }
+                        else if (last < segment.Length)
+                        {
+                            tempFragments.Add(new FragmentInfo(segment.Substring(last), FragmentType.Text));
+                        }
+
+                        result.RemoveAt(i);
+                        result.InsertRange(i, tempFragments);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static FragmentInfo HtmlEncodeFragment(FragmentInfo original)
+    {
+        var encoded = System.Net.WebUtility.HtmlEncode(original.Content);
+        return new FragmentInfo(encoded, original.Type == FragmentType.HighlightedText ? FragmentType.HighlightedText : FragmentType.Text);
+    }
+
+    private static bool TryGetTagName(string markup, out string tagName, out bool isClosing, out bool isSelfClosing)
+    {
+        var match = TagParser.Match(markup);
+
+        if (match.Success)
+        {
+            isClosing = match.Groups[1].Success;
+            tagName = match.Groups[2].Value;
+            isSelfClosing = match.Groups[3].Success || VoidElements.Contains(tagName);
+
+            return true;
+        }
+
+        tagName = string.Empty;
+        isClosing = false;
+        isSelfClosing = false;
+
+        return false;
     }
 }

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -41,7 +41,7 @@ public static partial class Splitter
         }
 
         regex = BuildRegexPattern(highlightTerms, untilNextBoundary);
-        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive));
+        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive) | RegexOptions.NonBacktracking);
         var nonEmpty = splits.Where(s => !string.IsNullOrEmpty(s)).ToArray();
 
         return new Memory<string>(nonEmpty);
@@ -128,7 +128,7 @@ public static partial class Splitter
 
         regex = BuildRegexPattern(terms, untilNextBoundary);
 
-        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline);
+        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline | RegexOptions.NonBacktracking);
     }
 
     private static List<FragmentInfo> ProcessRawFragments(
@@ -340,7 +340,7 @@ public static partial class Splitter
 
     private static RegexOptions GetRegexOptions(bool caseSensitive)
     {
-        return caseSensitive ? RegexOptions.NonBacktracking : RegexOptions.IgnoreCase | RegexOptions.NonBacktracking;
+        return caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
     }
 
     private static StringComparison GetStringComparison(bool caseSensitive)

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 #nullable enable
 namespace MudBlazor.Components.Highlighter;
@@ -12,30 +8,24 @@ namespace MudBlazor.Components.Highlighter;
 public enum FragmentType { Text, HighlightedText, Markup }
 public record FragmentInfo(string Content, FragmentType Type);
 
-public static class Splitter
+public static partial class Splitter
 {
-    private static readonly Regex HtmlTagRegex = new Regex(@"(<\s*/?\s*\w+[^>]*?/?>)", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+    private static readonly Regex _htmlTagRegex = HtmlTagMatcher();
 
-    private static readonly Regex TagParser = new Regex(@"^<\s*(/)?\s*(\w+)[^>]*?(\/)?\s*>$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex _tagParser = HtmlTagParser();
 
-    private static readonly HashSet<string> VoidElements = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> _voidElements = new(StringComparer.OrdinalIgnoreCase)
     {
         "area", "base", "br", "col", "embed", "hr", "img",
         "input", "link", "meta", "source", "track", "wbr"
     };
 
     private const string NextBoundary = ".*?\\b";
-    private static StringBuilder? s_stringBuilderCached;
-    private static List<string> _highlightTerms = [];
-    private static Regex _highlightRegex = new("^$");
+    private static StringBuilder? _stringBuilderCached;
 
-    public static Memory<string> GetFragments(
-    string? text,
-    string? highlightedText,
-    IEnumerable<string>? highlightedTexts,
-    out string regex,
-    bool caseSensitive = false,
-    bool untilNextBoundary = false)
+    public static Memory<string> GetFragments(string? text, string? highlightedText,
+                                              IEnumerable<string>? highlightedTexts, out string regex,
+                                              bool caseSensitive = false, bool untilNextBoundary = false)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -43,269 +33,330 @@ public static class Splitter
             return Memory<string>.Empty;
         }
 
-        var builder = Interlocked.Exchange(ref s_stringBuilderCached, null) ?? new StringBuilder();
-        builder.Append("((?:");
-
-        bool hasPattern = false;
-        AppendIfNotEmpty(highlightedText);
-
-        if (highlightedTexts != null)
-        {
-            foreach (var ht in highlightedTexts.Where(s => !string.IsNullOrEmpty(s)))
-            {
-                if (hasPattern) builder.Append(")|(?:");
-                AppendPattern(ht);
-            }
-        }
-
-        if (hasPattern)
-        {
-            builder.Append("))");
-        }
-        else
+        var highlightTerms = BuildHighlightTermsList(highlightedText, highlightedTexts);
+        if (highlightTerms.Count == 0)
         {
             regex = string.Empty;
-            builder.Clear();
-            s_stringBuilderCached = builder;
             return new[] { text };
         }
 
-        regex = builder.ToString();
-        builder.Clear();
-        s_stringBuilderCached = builder;
-
-        var splits = Regex.Split(text, regex, caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
+        regex = BuildRegexPattern(highlightTerms, untilNextBoundary);
+        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive));
         var nonEmpty = splits.Where(s => !string.IsNullOrEmpty(s)).ToArray();
+
         return new Memory<string>(nonEmpty);
-
-        void AppendIfNotEmpty(string? s)
-        {
-            if (!string.IsNullOrEmpty(s))
-            {
-                AppendPattern(s);
-            }
-        }
-
-        void AppendPattern(string s)
-        {
-            hasPattern = true;
-            builder.Append(Regex.Escape(s));
-            if (untilNextBoundary) builder.Append(NextBoundary);
-        }
     }
 
-    public static List<FragmentInfo> GetHtmlAwareFragments(
-        string? text,
-        string? highlightedText,
-        IEnumerable<string>? highlightedTexts,
-        bool caseSensitive,
-        bool untilNextBoundary)
+    public static List<FragmentInfo> GetHtmlAwareFragments(string? text, string? highlightedText,
+                                                           IEnumerable<string>? highlightedTexts, out string regex,
+                                                           bool caseSensitive, bool untilNextBoundary)
     {
-        var results = new List<FragmentInfo>();
-        if (string.IsNullOrEmpty(text)) return results;
+        regex = string.Empty;
 
-        _highlightTerms = BuildHighlightTerms(highlightedText, highlightedTexts);
-        _highlightRegex = BuildHighlightRegex(_highlightTerms, caseSensitive, untilNextBoundary);
+        if (string.IsNullOrEmpty(text))
+            return [];
 
-        var stringComparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        var highlightTerms = BuildHighlightTermsList(highlightedText, highlightedTexts);
+        var highlightRegex = BuildHighlightRegex(highlightTerms, caseSensitive, untilNextBoundary, out regex);
+        var stringComparison = GetStringComparison(caseSensitive);
 
-        var rawFragments = HtmlTagRegex.Split(text);
-        var tempFragments = new List<FragmentInfo>();
+        var rawFragments = _htmlTagRegex.Split(text);
+        var tempFragments = ProcessRawFragments(rawFragments, highlightTerms, highlightRegex, stringComparison);
 
-        foreach (var segment in rawFragments)
-        {
-            if (string.IsNullOrEmpty(segment)) continue;
-
-            if (_highlightTerms.Any(term => string.Equals(segment, term, stringComparison)))
-            {
-                tempFragments.Add(new FragmentInfo(segment, FragmentType.HighlightedText));
-            }
-            else if (HtmlTagRegex.IsMatch(segment))
-            {
-                tempFragments.Add(new FragmentInfo(segment, FragmentType.Markup));
-            }
-            else
-            {
-                int last = 0;
-                foreach (Match match in _highlightRegex.Matches(segment))
-                {
-                    if (match.Index > last)
-                    {
-                        tempFragments.Add(new FragmentInfo(segment.Substring(last, match.Index - last), FragmentType.Text));
-                    }
-                    tempFragments.Add(new FragmentInfo(match.Value, FragmentType.HighlightedText));
-                    last = match.Index + match.Length;
-                }
-                if (last < segment.Length)
-                {
-                    tempFragments.Add(new FragmentInfo(segment.Substring(last), FragmentType.Text));
-                }
-            }
-        }
-
-        return SanitizeFragments(tempFragments);
+        return SanitizeFragments(tempFragments, highlightTerms, highlightRegex);
     }
 
-    private static List<string> BuildHighlightTerms(string? single, IEnumerable<string>? multiple)
+    private static List<string> BuildHighlightTermsList(string? single, IEnumerable<string>? multiple)
     {
-        var list = new List<string>();
-        if (!string.IsNullOrEmpty(single))
-        {
-            list.Add(single);
-            list.Add(WebUtility.HtmlEncode(single));
-        }
+        var terms = new List<string>();
+
+        AddTermIfNotEmpty(terms, single);
 
         if (multiple != null)
         {
-            list.AddRange(multiple.Where(str => !string.IsNullOrEmpty(str)));
-            list.AddRange(multiple.Where(str => !string.IsNullOrEmpty(WebUtility.UrlEncode(str))));
+            foreach (var term in multiple.Where(s => !string.IsNullOrEmpty(s)))
+            {
+                AddTermIfNotEmpty(terms, term);
+            }
         }
 
-        return list;
-    }
+        return terms;
 
-    private static Regex BuildHighlightRegex(List<string> terms, bool caseSensitive, bool untilNextBoundary)
-    {
-        if (!terms.Any()) return new Regex("^$");
-
-        var builder = new StringBuilder();
-        for (int i = 0; i < terms.Count; i++)
+        static void AddTermIfNotEmpty(List<string> terms, string? term)
         {
-            builder.Append("(").Append(Regex.Escape(terms[i]));
-            if (untilNextBoundary) builder.Append(NextBoundary);
-            builder.Append(")");
-            if (i < terms.Count - 1) builder.Append("|");
-        }
+            if (string.IsNullOrEmpty(term)) return;
 
-        return new Regex(builder.ToString(),
-            (caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase) | RegexOptions.Singleline);
+            terms.Add(term);
+
+            var encoded = WebUtility.HtmlEncode(term);
+            if (encoded != term)
+            {
+                terms.Add(encoded);
+            }
+        }
     }
 
-    private static List<FragmentInfo> SanitizeFragments(List<FragmentInfo> fragments)
+    private static string BuildRegexPattern(List<string> terms, bool untilNextBoundary)
+    {
+        var builder = GetStringBuilder();
+
+        try
+        {
+            builder.Append("((?:");
+
+            for (var i = 0; i < terms.Count; i++)
+            {
+                if (i > 0) builder.Append(")|(?:");
+                builder.Append(Regex.Escape(terms[i]));
+                if (untilNextBoundary) builder.Append(NextBoundary);
+            }
+
+            builder.Append("))");
+            return builder.ToString();
+        }
+        finally
+        {
+            ReturnStringBuilder(builder);
+        }
+    }
+
+    private static Regex BuildHighlightRegex(List<string> terms, bool caseSensitive, bool untilNextBoundary, out string regex)
+    {
+        regex = string.Empty;
+
+        if (terms.Count == 0) return new Regex("^$");
+
+        regex = BuildRegexPattern(terms, untilNextBoundary);
+
+        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline);
+    }
+
+    private static List<FragmentInfo> ProcessRawFragments(
+        string[] rawFragments,
+        List<string> highlightTerms,
+        Regex highlightRegex,
+        StringComparison stringComparison)
+    {
+        var tempFragments = new List<FragmentInfo>();
+
+        foreach (var fragment in rawFragments.Where(s => !string.IsNullOrEmpty(s)))
+        {
+            if (IsDirectMatch(fragment, highlightTerms, stringComparison))
+            {
+                var text = _htmlTagRegex.IsMatch(fragment)
+                                ? WebUtility.HtmlEncode(fragment)
+                                : fragment;
+                tempFragments.Add(new FragmentInfo(text, FragmentType.HighlightedText));
+            }
+            else if (_htmlTagRegex.IsMatch(fragment))
+            {
+                tempFragments.Add(new FragmentInfo(fragment, FragmentType.Markup));
+            }
+            else
+            {
+                tempFragments.AddRange(ProcessTextSegment(fragment, highlightRegex));
+            }
+        }
+
+        return tempFragments;
+    }
+
+    private static bool IsDirectMatch(string segment, List<string> highlightTerms, StringComparison comparison)
+    {
+        return highlightTerms.Any(term => string.Equals(segment, term, comparison));
+    }
+
+    private static IEnumerable<FragmentInfo> ProcessTextSegment(string segment, Regex highlightRegex)
+    {
+        var fragments = new List<FragmentInfo>();
+        var lastIndex = 0;
+
+        foreach (Match match in highlightRegex.Matches(segment))
+        {
+            if (match.Index > lastIndex)
+            {
+                var textPart = segment.Substring(lastIndex, match.Index - lastIndex);
+                fragments.Add(new FragmentInfo(textPart, FragmentType.Text));
+            }
+
+            fragments.Add(new FragmentInfo(match.Value, FragmentType.HighlightedText));
+            lastIndex = match.Index + match.Length;
+        }
+
+        if (lastIndex < segment.Length)
+        {
+            fragments.Add(new FragmentInfo(segment.Substring(lastIndex), FragmentType.Text));
+        }
+
+        return fragments;
+    }
+
+    private static List<FragmentInfo> SanitizeFragments(
+        List<FragmentInfo> fragments,
+        List<string> highlightTerms,
+        Regex highlightRegex)
     {
         var result = new List<FragmentInfo>();
         var tagStack = new Stack<string>();
 
-        foreach (var frag in fragments)
+        foreach (var fragment in fragments)
         {
-            if (frag.Type != FragmentType.Markup)
+            if (fragment.Type != FragmentType.Markup)
             {
-                result.Add(frag);
+                result.Add(fragment);
                 continue;
             }
 
-            var tag = frag.Content;
-            var match = TagParser.Match(tag);
-
-            if (!match.Success)
-            {
-                result.Add(HtmlEncodeFragment(frag));
-                continue;
-            }
-
-            bool isClosing = match.Groups[1].Success;
-            var tagName = match.Groups[2].Value;
-            bool isSelfClosing = match.Groups[3].Success || VoidElements.Contains(tagName);
-
-            if (isSelfClosing)
-            {
-                result.Add(frag);
-            }
-            else if (isClosing)
-            {
-                if (tagStack.Count > 0 && string.Equals(tagStack.Peek(), tagName, StringComparison.OrdinalIgnoreCase))
-                {
-                    tagStack.Pop();
-                    result.Add(frag);
-                }
-                else
-                {
-                    result.Add(HtmlEncodeFragment(frag));
-                }
-            }
-            else // opening
-            {
-                tagStack.Push(tagName);
-                result.Add(frag);
-            }
+            ProcessMarkupFragment(fragment, result, tagStack);
         }
 
-        // Reclassify any unmatched opening tags left on the stack
+        ProcessUnmatchedTags(result, tagStack, highlightTerms, highlightRegex);
+        return result;
+    }
+
+    private static void ProcessMarkupFragment(FragmentInfo fragment, List<FragmentInfo> result, Stack<string> tagStack)
+    {
+        if (!TryParseTag(fragment.Content, out var tagInfo))
+        {
+            result.Add(HtmlEncodeFragment(fragment));
+            return;
+        }
+
+        if (tagInfo.IsSelfClosing)
+        {
+            result.Add(fragment);
+        }
+        else if (tagInfo.IsClosing)
+        {
+            if (tagStack.Count > 0 && string.Equals(tagStack.Peek(), tagInfo.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                tagStack.Pop();
+                result.Add(fragment);
+            }
+            else
+            {
+                result.Add(HtmlEncodeFragment(fragment));
+            }
+        }
+        else // opening tag
+        {
+            tagStack.Push(tagInfo.Name);
+            result.Add(fragment);
+        }
+    }
+
+    private static void ProcessUnmatchedTags(List<FragmentInfo> result, Stack<string> tagStack, List<string> highlightTerms, Regex highlightRegex)
+    {
         while (tagStack.Count > 0)
         {
-            var unmatchedTag = tagStack.Pop(); // e.g., "b", "i"
+            var unmatchedTag = tagStack.Pop();
+            ProcessUnmatchedTag(result, unmatchedTag, highlightTerms, highlightRegex);
+        }
+    }
 
-            // Look backwards for the last matching opening tag fragment
-            for (int i = result.Count - 1; i >= 0; i--)
+    private static void ProcessUnmatchedTag(List<FragmentInfo> result, string unmatchedTag, List<string> highlightTerms, Regex highlightRegex)
+    {
+        for (var i = result.Count - 1; i >= 0; i--)
+        {
+            var fragment = result[i];
+
+            if (fragment.Type != FragmentType.Markup) continue;
+            if (!TryParseTag(fragment.Content, out var tagInfo)) continue;
+            if (tagInfo.IsClosing || !string.Equals(tagInfo.Name, unmatchedTag, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var processedFragments = ProcessTextSegmentForUnmatched(fragment.Content, highlightRegex);
+
+            if (processedFragments.Count > 0)
             {
-                var frag = result[i];
-                if (frag.Type == FragmentType.Markup && TryGetTagName(frag.Content, out var tagName, out bool isClosing, out bool isSelfClosing))
-                {
-                    if (!isClosing && string.Equals(tagName, unmatchedTag, StringComparison.OrdinalIgnoreCase))
-                    {
-                        int last = 0;
-                        var segment = frag.Content;
-                        var tempFragments = new List<FragmentInfo>();
-
-                        foreach (Match match in _highlightRegex.Matches(segment))
-                        {
-                            if (match.Index > last)
-                            {
-                                var unmatchedSegment = segment.Substring(last, match.Index - last);
-                                tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(unmatchedSegment), FragmentType.Text));
-                            }
-                            tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(match.Value), FragmentType.HighlightedText));
-                            last = match.Index + match.Length;
-                        }
-
-                        if (last == 0 && segment.Length > 0)
-                        {
-                            // This tag was unmatched — reclassify it
-                            var encoded = WebUtility.HtmlEncode(frag.Content);
-                            var isHighlight = _highlightTerms.Contains(frag.Content);
-
-                            result[i] = new FragmentInfo(encoded, isHighlight ? FragmentType.HighlightedText : FragmentType.Text);
-                            break;
-                        }
-                        else if (last < segment.Length)
-                        {
-                            tempFragments.Add(new FragmentInfo(segment.Substring(last), FragmentType.Text));
-                        }
-
-                        result.RemoveAt(i);
-                        result.InsertRange(i, tempFragments);
-                        break;
-                    }
-                }
+                result.RemoveAt(i);
+                result.InsertRange(i, processedFragments);
             }
+            else
+            {
+                var encoded = WebUtility.HtmlEncode(fragment.Content);
+                var isHighlight = highlightTerms.Contains(fragment.Content);
+                result[i] = new FragmentInfo(encoded, isHighlight ? FragmentType.HighlightedText : FragmentType.Text);
+            }
+            break;
+        }
+    }
+
+    private static List<FragmentInfo> ProcessTextSegmentForUnmatched(string segment, Regex highlightRegex)
+    {
+        var tempFragments = new List<FragmentInfo>();
+        var lastIndex = 0;
+
+        foreach (Match match in highlightRegex.Matches(segment))
+        {
+            if (match.Index > lastIndex)
+            {
+                var unmatchedSegment = segment.Substring(lastIndex, match.Index - lastIndex);
+                tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(unmatchedSegment), FragmentType.Text));
+            }
+
+            tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(match.Value), FragmentType.HighlightedText));
+            lastIndex = match.Index + match.Length;
         }
 
-        return result;
+        if (lastIndex > 0 && lastIndex < segment.Length)
+        {
+            tempFragments.Add(new FragmentInfo(WebUtility.HtmlEncode(segment.Substring(lastIndex)), FragmentType.Text));
+        }
+
+        return tempFragments;
     }
 
     private static FragmentInfo HtmlEncodeFragment(FragmentInfo original)
     {
-        var encoded = System.Net.WebUtility.HtmlEncode(original.Content);
-        return new FragmentInfo(encoded, original.Type == FragmentType.HighlightedText ? FragmentType.HighlightedText : FragmentType.Text);
+        var encoded = WebUtility.HtmlEncode(original.Content);
+        var type = original.Type == FragmentType.HighlightedText ? FragmentType.HighlightedText : FragmentType.Text;
+        return new FragmentInfo(encoded, type);
     }
 
-    private static bool TryGetTagName(string markup, out string tagName, out bool isClosing, out bool isSelfClosing)
+    private static bool TryParseTag(string markup, out TagInfo tagInfo)
     {
-        var match = TagParser.Match(markup);
+        var match = _tagParser.Match(markup);
 
         if (match.Success)
         {
-            isClosing = match.Groups[1].Success;
-            tagName = match.Groups[2].Value;
-            isSelfClosing = match.Groups[3].Success || VoidElements.Contains(tagName);
+            var isClosing = match.Groups[1].Success;
+            var tagName = match.Groups[2].Value;
+            var isSelfClosing = match.Groups[3].Success || _voidElements.Contains(tagName);
 
+            tagInfo = new TagInfo(tagName, isClosing, isSelfClosing);
             return true;
         }
 
-        tagName = string.Empty;
-        isClosing = false;
-        isSelfClosing = false;
-
+        tagInfo = default;
         return false;
     }
+
+    private static StringBuilder GetStringBuilder()
+    {
+        return Interlocked.Exchange(ref _stringBuilderCached, null) ?? new StringBuilder();
+    }
+
+    private static void ReturnStringBuilder(StringBuilder builder)
+    {
+        builder.Clear();
+        _stringBuilderCached = builder;
+    }
+
+    private static RegexOptions GetRegexOptions(bool caseSensitive)
+    {
+        return caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase;
+    }
+
+    private static StringComparison GetStringComparison(bool caseSensitive)
+    {
+        return caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+    }
+
+    private readonly record struct TagInfo(string Name, bool IsClosing, bool IsSelfClosing);
+
+    [GeneratedRegex(@"(<\s*/?\s*\w+[^>]*?/?>)", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline, "en-US")]
+    private static partial Regex HtmlTagMatcher();
+
+    [GeneratedRegex(@"^<\s*(/)?\s*(\w+)[^>]*?(\/)?\s*>$", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
+    private static partial Regex HtmlTagParser();
 }


### PR DESCRIPTION
## Description
When `Markup` is enabled, if the highlight text is found within an html markup element, the markup rendering breaks and reverts to raw html. This fix excludes html tags from the highlighting process so as to avoid incorrectly inserting the `<mark>` tag into valid html elements.

Resolves: #10247 
Resolves: #8196 

## How Has This Been Tested?
Visually and unit tests

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
