### PR TITLE
MudTable: Enable `WrapContent` for `ToolBarContent`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TablePagingTest1.razor
@@ -1,8 +1,7 @@
-<MudTable @ref="_filteredTable" Items="_states" Filter="new Func<string, bool>(FilterFunc)">
+﻿<MudTable @ref="_filteredTable" Items="_states" Filter="new Func<string, bool>(FilterFunc)">
      <ToolBarContent>
-        <MudText>Filtered Item Count: @FilteredItemCount</MudText>
-        <MudSpacer />
-        <MudTextField id="searchString" @bind-Value="_searchString" Placeholder="Search"></MudTextField>
+        <MudText Class="my-4">Filtered Item Count: @FilteredItemCount</MudText>
+        <MudTextField id="searchString" Class="mb-4" @bind-Value="_searchString" Placeholder="Search" FullWidth></MudTextField>
     </ToolBarContent>
     <RowTemplate>
         <MudTd>@context</MudTd>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -11,7 +11,7 @@
     <CascadingValue Value="TableContext" IsFixed="true">
         @if (ToolBarContent != null)
         {
-            <MudToolBar Class="mud-table-toolbar">
+            <MudToolBar Class="mud-table-toolbar" WrapContent>
                 @ToolBarContent
             </MudToolBar>
         }


### PR DESCRIPTION
## Description
Remove fixed height restriction on the `ToolBarContent` of a `MudTable` by enabling `WrapContent` 
Resolves: #11529 

## How Has This Been Tested?
Visually 

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

Basic example (Two Line Content)
```razor
 <ToolBarContent>
    <MudText>
        Filtered Item Count: @FilteredItemCount
    </MudText>
    <MudTextField id="searchString"
                  @bind-Value="_searchString"
                  Placeholder="Search" FullWidth />
</ToolBarContent>
```
Before:
![image](https://github.com/user-attachments/assets/f57fd1fe-7d6c-4beb-8b64-c0f607188f35)

After:
![image](https://github.com/user-attachments/assets/36441ec4-a954-4c9c-a85b-24befd50375f)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
