### PR TITLE
MudSelect: Always call `FieldChanged` when `MultiSelection=true`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectMultiSelectFieldChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectMultiSelectFieldChangedTest.razor
@@ -1,0 +1,51 @@
+@using MudBlazor.Utilities
+<MudPopoverProvider />
+
+<MudForm FieldChanged="v => FormFieldChangedEventArgs = v">
+<MudSelect T="State" Label="US States" MultiSelection="true" @bind-SelectedValues="_options">
+    @foreach (var state in States)
+    {
+        <MudSelectItem T="State" Value="@state">@state</MudSelectItem>
+    }
+</MudSelect>
+</MudForm>
+
+@code {
+    public static string __description__ = "FieldChanged should trigger when T != string and MultiSelect=true";
+    private IEnumerable<State> _options = new HashSet<State> { new("Alaska") };
+
+    public State[] States { get; init; } =
+    [
+        new("Alabama"), new("Alaska"), new("Arizona"), new("Arkansas"), new("California"),
+        new("Colorado"), new("Connecticut"), new("Delaware"), new("Florida"), new("Georgia"),
+        new("Hawaii"), new("Idaho"), new("Illinois"), new("Indiana"), new("Iowa"), new("Kansas"),
+        new("Kentucky"), new("Louisiana"), new("Maine"), new("Maryland"), new("Massachusetts"),
+        new("Michigan"), new("Minnesota"), new("Mississippi"), new("Missouri"), new("Montana"),
+        new("Nebraska"), new("Nevada"), new("New Hampshire"), new("New Jersey"), new("New Mexico"),
+        new("New York"), new("North Carolina"), new("North Dakota"), new("Ohio"), new("Oklahoma"),
+        new("Oregon"), new("Pennsylvania"), new("Rhode Island"), new("South Carolina"), new("South Dakota"),
+        new("Tennessee"), new("Texas"), new("Utah"), new("Vermont"), new("Virginia"),
+        new("Washington"), new("West Virginia"), new("Wisconsin"), new("Wyoming")
+    ];
+
+    public class State(string name) : IEquatable<State>
+    {
+
+        public string Name { get; } = name;
+
+        public bool Equals(State? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Name == other.Name;
+        }
+
+        public override bool Equals(object? obj) => obj is State state && Equals(state);
+
+        public override int GetHashCode() => Name.GetHashCode();
+
+        public override string ToString() => Name;
+    }
+
+    public FormFieldChangedEventArgs? FormFieldChangedEventArgs { get; private set; }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1609,6 +1609,25 @@ namespace MudBlazor.UnitTests.Components
                     break;
             }
         }
+        
+        [Test]
+        public void SelectMultiSelectFieldChangedTest()
+        {
+            var comp = Context.RenderComponent<SelectMultiSelectFieldChangedTest>();
+
+            //default values
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull();
+
+            //open the popover
+            var input = comp.Find("div.mud-input-control");
+            input.MouseDown();
+            
+            //click an item and see the value change
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            comp.Find(".mud-list-item").Click();
+
+            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().BeEquivalentTo(comp.Instance.States.Take(2).Reverse());
+        }
 #nullable disable
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1609,7 +1609,7 @@ namespace MudBlazor.UnitTests.Components
                     break;
             }
         }
-        
+
         [Test]
         public void SelectMultiSelectFieldChangedTest()
         {
@@ -1621,7 +1621,7 @@ namespace MudBlazor.UnitTests.Components
             //open the popover
             var input = comp.Find("div.mud-input-control");
             input.MouseDown();
-            
+
             //click an item and see the value change
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             comp.Find(".mud-list-item").Click();

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -442,9 +442,9 @@ namespace MudBlazor
                     }
                 }
 
-                var newValue = new HashSet<T?>(_selectedValues, _comparer);
-                SelectedValuesChanged.InvokeAsync(newValue);
-                FieldChanged(newValue);
+                var newValues = new HashSet<T?>(_selectedValues, _comparer);
+                SelectedValuesChanged.InvokeAsync(newValues);
+                FieldChanged(newValues);
                 if (MultiSelection && typeof(T) == typeof(string))
                     SetValueAsync((T?)(object?)Text, updateText: false).CatchAndLog();
             }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -441,7 +441,10 @@ namespace MudBlazor
                         SetTextAsync(string.Join(Delimiter, _selectedValues.Select(Converter.Set)), updateValue: false).CatchAndLog();
                     }
                 }
-                SelectedValuesChanged.InvokeAsync(new HashSet<T?>(_selectedValues, _comparer));
+
+                var newValue = new HashSet<T?>(_selectedValues, _comparer);
+                SelectedValuesChanged.InvokeAsync(newValue);
+                FieldChanged(newValue);
                 if (MultiSelection && typeof(T) == typeof(string))
                     SetValueAsync((T?)(object?)Text, updateText: false).CatchAndLog();
             }
@@ -810,6 +813,7 @@ namespace MudBlazor
 
             HighlightItemForValueAsync(value);
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
+            FieldChanged(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
                 await SetValueAsync((T?)(object?)Text, updateText: false);
             await InvokeAsync(StateHasChanged);
@@ -1053,6 +1057,7 @@ namespace MudBlazor
             await BeginValidateAsync();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(_selectedValues);
+            FieldChanged(_selectedValues);
             await OnClearButtonClick.InvokeAsync(e);
         }
 
@@ -1254,6 +1259,7 @@ namespace MudBlazor
             await BeginValidateAsync();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(_selectedValues);
+            FieldChanged(_selectedValues);
         }
 
         /// <summary>
@@ -1302,6 +1308,7 @@ namespace MudBlazor
             _selectedValues = selectedValues; // need to force selected values because Blazor overwrites it under certain circumstances due to changes of Text or Value
             await BeginValidateAsync();
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
+            FieldChanged(SelectedValues);
             if (MultiSelection && typeof(T) == typeof(string))
                 SetValueAsync((T?)(object?)Text, updateText: false).CatchAndLog();
         }
@@ -1393,7 +1400,9 @@ namespace MudBlazor
             }
             else
             {
-                await SelectedValuesChanged.InvokeAsync(new HashSet<T?>(SelectedValues!, _comparer));
+                var newValues = new HashSet<T?>(SelectedValues!, _comparer);
+                await SelectedValuesChanged.InvokeAsync(newValues);
+                FieldChanged(newValues);
             }
         }
     }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md

Testing sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail and why. -->
<!-- Note any issues that are resolved by this PR -->
<!-- e.g. resolves #1337 or fixes #9310. -->

When using complex objects and MultiSelection, `FieldChanged` will not be triggered: https://try.mudblazor.com/snippet/QkQJugGyrnMzfgYg

If using strings and MultiSelection, `FieldChanged` **will** be triggered: https://try.mudblazor.com/snippet/cumzEgmpzlCHQSWe

This PR attempts to match the behavior of both by manually triggering `FieldChanged` where appropriate.

## How Has This Been Tested?
<!-- All PRs should implement unit tests if possible. -->
<!-- Please describe how you tested your changes. -->
<!-- Have you created new tests or updated existing ones? -->
<!-- e.g. unit | visually | none -->

Still working on units tests

## Type of Changes
<!-- What type of changes does your code introduce? Put an `x` in only one box that applies best: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests.
