### PR TITLE
MudProgressCircular: Calculate view box size based on stroke width

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Progress/MudProgressCircularWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Progress/MudProgressCircularWidthTest.razor
@@ -1,0 +1,12 @@
+﻿<MudProgressCircular Color="Color.Default" Indeterminate="true" StrokeWidth="@_width" Size="Size.Large">
+    <ChildContent>
+        @_width
+    </ChildContent>
+</MudProgressCircular>
+<MudSlider Class="mt-4" @bind-Value="@_width" Min="0" Max="20">@($"Stroke-Width: {_width}")</MudSlider>
+
+@code {
+    public static string __description__ = "Circle should render correctly with increasing stroke width";
+
+    int _width = 2;
+}

--- a/src/MudBlazor.UnitTests/Components/ProgressCircularTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressCircularTests.cs
@@ -1,7 +1,4 @@
-﻿
-using System;
-using System.Globalization;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -76,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase(true)]
-        [TestCase(true)]
+        [TestCase(false)]
         public void TestClassesForRounded(bool rounded)
         {
             var comp = Context.RenderComponent<MudProgressCircular>(x => x.Add(y => y.Rounded, rounded));
@@ -95,7 +92,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase(true)]
-        [TestCase(true)]
+        [TestCase(false)]
         public void TestClassesForIntermediate(bool indeterminate)
         {
             var comp = Context.RenderComponent<MudProgressCircular>(x => x.Add(y => y.Indeterminate, indeterminate));
@@ -105,10 +102,12 @@ namespace MudBlazor.UnitTests.Components
             if (indeterminate)
             {
                 container.ClassList.Should().Contain("mud-progress-indeterminate");
+                container.ClassList.Should().NotContain("mud-progress-static");
             }
             else
             {
-                container.ClassList.Should().NotContain("mud-progress-static");
+                container.ClassList.Should().Contain("mud-progress-static");
+                container.ClassList.Should().NotContain("mud-progress-indeterminate");
             }
 
             var circleContainer = comp.Find(".mud-progress-circular-circle");
@@ -116,10 +115,12 @@ namespace MudBlazor.UnitTests.Components
             if (indeterminate)
             {
                 circleContainer.ClassList.Should().Contain("mud-progress-indeterminate");
+                circleContainer.ClassList.Should().NotContain("mud-progress-static");
             }
             else
             {
-                circleContainer.ClassList.Should().NotContain("mud-progress-static");
+                circleContainer.ClassList.Should().Contain("mud-progress-static");
+                circleContainer.ClassList.Should().NotContain("mud-progress-indeterminate");
             }
         }
 
@@ -147,6 +148,39 @@ namespace MudBlazor.UnitTests.Components
             var container = comp.Find(".mud-progress-circular");
 
             container.ClassList.Should().Contain($"mud-{expectedString}-text");
+        }
+
+        [Test]
+        [TestCase(3, "22.5 22.5 43 43")]
+        [TestCase(5, "21.5 21.5 45 45")]
+        [TestCase(10, "19 19 50 50")]
+        [TestCase(1, "23.5 23.5 41 41")]
+        [TestCase(0, "24 24 40 40")]
+        public void MudProgressCircular_ShouldHaveCorrectViewBox_BasedOnStrokeWidth(int strokeWidth, string expectedViewBox)
+        {
+            var comp = Context.RenderComponent<MudProgressCircular>(parameters => parameters
+                .Add(p => p.StrokeWidth, strokeWidth)
+            );
+
+            // Find the SVG element
+            var svgElement = comp.Find("svg");
+            svgElement.Should().NotBeNull();
+
+            // Check the viewBox attribute
+            var viewBoxAttribute = svgElement.GetAttribute("viewBox");
+            viewBoxAttribute.Should().Be(expectedViewBox);
+
+            // Test with Indeterminate = true as well
+            var compIndeterminate = Context.RenderComponent<MudProgressCircular>(parameters => parameters
+                .Add(p => p.StrokeWidth, strokeWidth)
+                .Add(p => p.Indeterminate, true)
+            );
+
+            var svgElementIndeterminate = compIndeterminate.Find("svg");
+            svgElementIndeterminate.Should().NotBeNull();
+
+            var viewBoxAttributeIndeterminate = svgElementIndeterminate.GetAttribute("viewBox");
+            viewBoxAttributeIndeterminate.Should().Be(expectedViewBox);
         }
     }
 }

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor
@@ -12,7 +12,7 @@
      @attributes="UserAttributes">
     @if (Indeterminate)
     {
-        <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
+        <svg class="mud-progress-circular-svg" viewBox="@_viewBox">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth"></circle>
         </svg>
 
@@ -22,7 +22,7 @@
     }
     else
     {
-        <svg class="mud-progress-circular-svg" viewBox="22 22 44 44">
+        <svg class="mud-progress-circular-svg" viewBox="@_viewBox">
             <circle class="@SvgClassname" cx="44" cy="44" r="20" fill="none" stroke-width="@StrokeWidth" style="stroke-dasharray: @MagicNumber; stroke-dashoffset: @_svgValue;"></circle>
         </svg>
 

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -19,6 +19,9 @@ namespace MudBlazor
         private int _svgValue;
         private readonly ParameterState<double> _valueState;
         private const int MagicNumber = 126; // weird, but required for the SVG to work
+        private string _viewBox = string.Empty;
+        private const double CircleRadius = 20.0;
+        private const double CircleCenter = 44.0;
 
         protected string Classname =>
             new CssBuilder("mud-progress-circular")
@@ -145,6 +148,20 @@ namespace MudBlazor
         {
             base.OnInitialized();
             _svgValue = ToSvgValue(_valueState.Value);
+        }
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            var strokeWidth = Math.Max(0, StrokeWidth);
+            var viewBoxSize = (2 * CircleRadius) + strokeWidth;
+            var viewBoxMin = CircleCenter - (viewBoxSize / 2.0);
+
+            var size = ToS(viewBoxSize);
+            var min = ToS(viewBoxMin);
+
+            _viewBox = $"{min} {min} {size} {size}";
         }
 
         private int ToSvgValue(double value)


### PR DESCRIPTION
## Description
Currently the view box size remains static while the stroke width value can be changed. This can result in a stroke width that eventually renders the circle outside the bounds of the view box. This PR adjusts the view box size based on the value of the stroke width. 

Resolves #11550 

## How Has This Been Tested?
Visually and Unit test

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

![image](https://github.com/user-attachments/assets/cad117de-c981-4e6b-907a-ac73ab5c11c4)
![image](https://github.com/user-attachments/assets/c5cbbfd4-8ac2-4da7-9cf3-b803687dae17)
![image](https://github.com/user-attachments/assets/8b5dd14a-c5c0-4351-b9e6-b6b2ee752c45)

## Checklist
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
