### PR TITLE
Revert "Misc: Add `regression` label to the issue if a previously working version is defined"

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -41,11 +41,6 @@ jobs:
             } else if (body.includes("### Bug type\n\nDocs (mudblazor.com)")) {
               labels.push("docs");
               console.log("Bug type: docs.");
-            } 
-            
-            if (body.match(/Version \(working\)\n\n.+/)) {
-              labels.push("regression");
-              console.log("Bug is a regression.");
             }
             
             if(labels.length != 0) {


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#11524

getting tripped up on the "No response" https://github.com/MudBlazor/MudBlazor/issues/11574#issuecomment-3024801619