### PR TITLE
MudTextField: Fix excessive height with AutoGrow, Outlined, Dense, and Adornment

### DIFF
--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -466,6 +466,7 @@
     }
 
     &.mud-input-root-margin-dense {
+      margin-top: 0px;
       padding-top: 10.5px;
       padding-bottom: 10.5px;
       mask-image: linear-gradient(to bottom,


### PR DESCRIPTION
## Description
Resolves #11516 
The cursor was starting in the second line. After the fix, it starts on the first one.

## How Has This Been Tested?
It has been tested in localhost

## Type of Changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

before:
![image](https://github.com/user-attachments/assets/9c9dae0f-34e6-43ab-97c9-251ade3ba4f6)

after:
![image](https://github.com/user-attachments/assets/0d4b7637-2f88-4cbd-9e8b-f4cc46d2275b)


## Checklist
- [x ] The PR is submitted to the correct branch (`dev`).
- [x ] My code follows the code style of this project.
- [ x] I've added relevant tests.
