### PR TITLE
MudSimpleTable: Remove redundant bottom border from the last row header

### DIFF
--- a/src/MudBlazor/Styles/components/_simpletable.scss
+++ b/src/MudBlazor/Styles/components/_simpletable.scss
@@ -15,7 +15,7 @@
       display: table-row-group;
 
       > tr:last-child {
-        > td {
+        > td, > th {
           border-bottom: none;
         }
       }


### PR DESCRIPTION
**Description**
There is an extra bottom border under the last `<th>` (row header) in the table. It makes the table look weird.
I changed the CSS so the last row header (`<th scope="row">`) does not show a bottom border.

**Type of change:**

- [x] Bug fix
- [ ] New feature
- [ ] Other

Code sample to show the issue:
```razor
<MudSimpleTable Dense Elevation="0">
    <tbody>

    <tr>
        <th scope="row">Row Header A</th>
        <td>Something</td>
    </tr>

    <tr>
        <th scope="row">Row Header B</th>
        <td>Something Else</td>
    </tr>

    <tr>
        <th scope="row">Row Header C</th>
        <td>Something Something</td>
    </tr>
    </tbody>
</MudSimpleTable>

```
Before:
<img width="322" height="157" alt="image_2025-07-10_17-52-43" src="https://github.com/user-attachments/assets/5218ad27-913b-4961-8999-a687e02061e2" />
After:
<img width="318" height="146" alt="image_2025-07-10_17-52-43 (2)" src="https://github.com/user-attachments/assets/6d5dcd06-c24d-4445-a28a-9d987eda3c89" />


**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`)
- [x] My code follows the code style of this project
- [ ] I've added relevant tests
