### PR TITLE
Build: Remove code of conduct checkboxes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -15,8 +15,6 @@ body:
           required: true
         - label: I tried in private/incognito browser
           required: true
-        - label: I agree to follow the [Code of Conduct](https://github.com/MudBlazor/MudBlazor/blob/dev/CODE_OF_CONDUCT.md)
-          required: true
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -18,10 +18,3 @@ body:
     attributes:
       label: Alternatives and examples
       description: Other solutions you tried, or links/screenshots of similar features.
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      options:
-        - label: I agree to follow the [Code of Conduct](https://github.com/MudBlazor/MudBlazor/blob/dev/CODE_OF_CONDUCT.md)
-          required: true


### PR DESCRIPTION
It already exists on GitHub natively in the form of a notice at the end "Remember, contributions to this repository should follow its contributing guidelines and code of conduct."


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [X] Other

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`)
- My code follows the code style of this project
- I've added relevant tests
