### PR TITLE
Build: Remove `info required` label after author responds

### DIFF
--- a/.github/workflows/issue-info-required-status.yml
+++ b/.github/workflows/issue-info-required-status.yml
@@ -1,0 +1,28 @@
+name: Remove 'Info Required' Label
+
+on:
+  issue_comment:
+    types: [created] # Trigger only when a new comment is created
+
+jobs:
+  remove_label_on_author_comment:
+    runs-on: ubuntu-latest
+
+    # This 'if' condition ensures the job only runs when all criteria are met:
+    # 1. The comment author is the same as the issue author.
+    # 2. The issue currently has the label "info required".
+    if: |
+      github.event.comment.user.login == github.event.issue.user.login &&
+      contains(github.event.issue.labels.*.name, 'info required')
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Remove "info required" label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+      run: |
+        echo "Removing 'info required' label from issue #$ISSUE_NUMBER"
+        gh issue edit "$ISSUE_NUMBER" --remove-label "info required"


### PR DESCRIPTION
The label is kind of an "ignore for now" sign so we don't want to leave it on issues were the author has made changes from the feedback provided by a maintainer or the triage bot.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**Type of change:**

- [ ] Bug fix
- [ ] New feature
- [X] Other

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`)
- My code follows the code style of this project
- I've added relevant tests
