### PR TITLE
Build: Add stale issue management

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -1,0 +1,43 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 */3 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+env:
+  DEBUG_MODE: ${{ vars.ENABLE_STALE_ACTIONS != 'true' }} # Debug mode is on unless the workflow is explicitly enabled.
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark/close stale issues
+        uses: actions/stale@v9
+        with:
+          # Only target issues with certain labels
+          any-of-labels: 'info required,needs example,needs screenshot'
+          
+          # Days before an issue is marked stale
+          days-before-stale: 21
+          
+          # Days before a stale issue is closed
+          days-before-close: 7
+          
+          # Message to post when marking an issue as stale
+          stale-issue-message: |
+            This issue has been marked as stale because more info is needed.
+
+            It will be automatically closed if no response is received.
+
+          # Don't process pull requests, only issues
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          
+          # Apply a label when marking as stale
+          stale-issue-label: 'stale'
+          
+          # Enable debug mode (no actual changes when true)
+          debug-only: ${{ env.DEBUG_MODE }}
+          
+          # Limit the number of operations per run to avoid hitting API limits and minimize risk from bad configuration
+          operations-per-run: 10


### PR DESCRIPTION
## Add automated stale issue management workflow

This PR introduces a GitHub Actions workflow that automatically manages issues awaiting additional information from authors.

### **How it works:**
1. Scans for issues with target labels that haven't had author activity
2. Immediately adds "stale" label and posts warning message
3. Closes issues later if no response from author
4. Only processes issues (not PRs)

### **Safety features:**
- **Debug mode by default**: No actual changes made unless `ENABLE_STALE_ACTIONS=true` is set
- **Controlled activation**: Repository admins must explicitly enable live mode
- **Rate limiting**: Limited operations per run to minimize risk

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`)
- My code follows the code style of this project
- I've added relevant tests
