### PR TITLE
MudDataGrid: AllowUnsorted Default Behavior 

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1105,10 +1105,10 @@ namespace MudBlazor
         /// Allows a sort direction of <see cref="SortDirection.None"/> in addition to <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.  When <c>false</c>, the sort mode will only toggle between <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
+        /// Defaults to <c>false</c>.  When <c>false</c>, the sort mode will only toggle between <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
         /// </remarks>
         [Parameter]
-        public bool AllowUnsorted { get; set; } = true;
+        public bool AllowUnsorted { get; set; } = false;
 
         #region Properties
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1102,10 +1102,12 @@ namespace MudBlazor
         #endregion
 
         /// <summary>
-        /// Allows a sort direction of <see cref="SortDirection.None"/> in addition to <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
+        /// Determines whether an unsorted state (<see cref="SortDirection.None"/>) is allowed when toggling sort directions.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  When <c>false</c>, the sort mode will only toggle between <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
+        /// Defaults to <c>false</c>. When <c>false</c>, the sort direction toggles only between 
+        /// <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
+        /// When <c>true</c>, a third toggle state, <see cref="SortDirection.None"/>, is included.
         /// </remarks>
         [Parameter]
         public bool AllowUnsorted { get; set; } = false;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
PR #11443 added a new feature to AllowUnsorted and incorrectly set the default to true causing a Breaking Change. This reverts just the default behavior.

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`)
- My code follows the code style of this project
- I've added relevant tests
