### PR TITLE
MudTabs: Ensure Custom Sorting Works Without Explicit SortDirection

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
@@ -42,16 +42,16 @@ else if (SortKeys is not null)
         </MudTabs>
     }
 }
-else if (SortComparer is not null && SortDirection is not null)
+else if (SortComparer is not null && SortDirection.HasValue)
 {
     @* custom comparer - SortDirection is ignored for custom comparer *@
-    <MudTabs SortDirection="SortDirection" SortComparer="SortComparer">
+    <MudTabs SortDirection="SortDirection.Value" SortComparer="SortComparer">
         <MudTabPanel Tag="@( "Y" )" SortKey="3" Text="Apple"></MudTabPanel>
         <MudTabPanel Tag="@( "Z" )" SortKey="2" Text="Banana"></MudTabPanel>
         <MudTabPanel Tag="@( "X" )" SortKey="1" Text="Cherry"></MudTabPanel>
     </MudTabs>
 }
-else if (SortComparer is not null && SortDirection is null)
+else if (SortComparer is not null)
 {
     @* custom comparer - SortDirection is not used with custom comparer and can be unspecified *@
     <MudTabs SortComparer="SortComparer">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/LabelSortTest.razor
@@ -42,9 +42,19 @@ else if (SortKeys is not null)
         </MudTabs>
     }
 }
-else if (SortComparer is not null)
+else if (SortComparer is not null && SortDirection is not null)
 {
-    <MudTabs SortDirection="MudBlazor.SortDirection.Descending" SortComparer="SortComparer">
+    @* custom comparer - SortDirection is ignored for custom comparer *@
+    <MudTabs SortDirection="SortDirection" SortComparer="SortComparer">
+        <MudTabPanel Tag="@( "Y" )" SortKey="3" Text="Apple"></MudTabPanel>
+        <MudTabPanel Tag="@( "Z" )" SortKey="2" Text="Banana"></MudTabPanel>
+        <MudTabPanel Tag="@( "X" )" SortKey="1" Text="Cherry"></MudTabPanel>
+    </MudTabs>
+}
+else if (SortComparer is not null && SortDirection is null)
+{
+    @* custom comparer - SortDirection is not used with custom comparer and can be unspecified *@
+    <MudTabs SortComparer="SortComparer">
         <MudTabPanel Tag="@( "Y" )" SortKey="3" Text="Apple"></MudTabPanel>
         <MudTabPanel Tag="@( "Z" )" SortKey="2" Text="Banana"></MudTabPanel>
         <MudTabPanel Tag="@( "X" )" SortKey="1" Text="Cherry"></MudTabPanel>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -96,7 +96,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-tabs-panels > div")[0].GetAttribute("style").Should().Be("display:none;");
             comp.FindAll("div.mud-tabs-panels > div")[1].GetAttribute("style").Should().Be("display:contents;");
             comp.FindAll("div.mud-tabs-panels > div")[2].GetAttribute("style").Should().Be("display:none;");
-            // click second button twice and show button click counters. the click of the first button should still be evident 
+            // click second button twice and show button click counters. the click of the first button should still be evident
             comp.FindAll("button")[1].Click();
             comp.FindAll("button")[1].Click();
             comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
@@ -1475,21 +1475,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void LabelSorting_CustomSortComparer()
+        public void LabelSorting_CustomSortComparerIgnoresSortDirection()
         {
             /* ***
              * All labels should be present and in Tag order, ignoring SortDirection and Keys.
-             * For this test the Tabs.SortDirection is set to Descending in markup, and the SortKeys
+             * For this test the Tabs.SortDirection is set to Descending, and the SortKeys
              * are set to Apple=3, Banana=2, Cherry=1, so there is no combination of SortKey, Label
              * or SortDirection that could ellicit the same sort order as we get from TestComparer.
              */
             var comp = Context.RenderComponent<LabelSortTest>(
-                            ComponentParameter.CreateParameter("SortComparer", new LabelSortTest.TestComparer())
+                            ComponentParameter.CreateParameter("SortComparer", new LabelSortTest.TestComparer()),
+                            ComponentParameter.CreateParameter("SortDirection", SortDirection.Descending)
                         );
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("Cherry");
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("Apple");
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("Banana");
+        }
+
+        [Test]
+        public void LabelSorting_CustomSortComparerWorksWithoutSortDirection()
+        {
+            /* ***
+             * All labels should be present and in Tag order, SortDirection and Keys are unspecified.
+             * For this test the Tabs.SortDirection is left unset, and the SortKeys
+             * are set to Apple=3, Banana=2, Cherry=1, so there is no combination of SortKey, Label
+             * or SortDirection that could ellicit the same sort order as we get from TestComparer.
+             */
+            var comp = Context.RenderComponent<LabelSortTest>(
+                            ComponentParameter.CreateParameter("SortComparer", new LabelSortTest.TestComparer()),
+                            ComponentParameter.CreateParameter("SortDirection", null)
+                        );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" ).Count.Should().Be( 3 );
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" )[0].InnerHtml.Should().Be("Cherry");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" )[1].InnerHtml.Should().Be("Apple");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" )[2].InnerHtml.Should().Be("Banana");
         }
 
         [Test]
@@ -1510,7 +1530,7 @@ namespace MudBlazor.UnitTests.Components
             divs[3].InnerHtml.Should().Be("Four");
             // no scroll bar should show
             comp.FindAll(".mud-tabs-scroll-button").Should().BeEmpty();
-            // enable drag and drop 
+            // enable drag and drop
             var cbox = comp.Find("div.drag-drop-class input");
             cbox.Change(true);
             comp.SetParametersAndRender();
@@ -1550,7 +1570,7 @@ namespace MudBlazor.UnitTests.Components
             divs[2].Click(); // activate Three
             divs = comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab");
             comp.WaitForAssertion(() => divs[2].ClassList.Contains("mud-tab-active").Should().BeTrue());
-            // enable drag and drop 
+            // enable drag and drop
             var cbox = comp.Find("div.drag-drop-class input");
             cbox.Change(true);
             comp.SetParametersAndRender(p => p.Add(p => p.ActiveTabClass, "test-active"));

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1506,10 +1506,10 @@ namespace MudBlazor.UnitTests.Components
                             ComponentParameter.CreateParameter("SortComparer", new LabelSortTest.TestComparer()),
                             ComponentParameter.CreateParameter("SortDirection", null)
                         );
-            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" ).Count.Should().Be( 3 );
-            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" )[0].InnerHtml.Should().Be("Cherry");
-            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" )[1].InnerHtml.Should().Be("Apple");
-            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab" )[2].InnerHtml.Should().Be("Banana");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[0].InnerHtml.Should().Be("Cherry");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[1].InnerHtml.Should().Be("Apple");
+            comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab")[2].InnerHtml.Should().Be("Banana");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -60,7 +60,7 @@ namespace MudBlazor
         public bool EnableDragAndDrop { get; set; }
 
         /// <summary>
-        /// When <see cref="EnableDragAndDrop" /> is set to true, this event will be raised when an item is dropped. 
+        /// When <see cref="EnableDragAndDrop" /> is set to true, this event will be raised when an item is dropped.
         /// The dropped item is provided in the <see cref="MudItemDropInfo{T}"/> and will have already been moved to its new position.
         /// </summary>
         [Parameter]
@@ -283,7 +283,7 @@ namespace MudBlazor
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
-        /// This fragment is placed between tabHeader and panels. 
+        /// This fragment is placed between tabHeader and panels.
         /// It can be used to display additional content like an address line in a browser.
         /// The active tab will be the content of this RenderFragement
         /// </summary>
@@ -373,7 +373,7 @@ namespace MudBlazor
         public EventCallback<int> ActivePanelIndexChanged { get; set; }
 
         /// <summary>
-        /// A read-only list of the panels within this component. 
+        /// A read-only list of the panels within this component.
         /// </summary>
         /// <remarks>
         /// Tab panels are controlled by either adding more <see cref="MudTabPanel"/> components in the Razor page, or by using the <see cref="MudDynamicTabs"/> component instead.
@@ -655,7 +655,7 @@ namespace MudBlazor
 
         private void SortPanels()
         {
-            if (_panels.Count == 0 || SortDirection == SortDirection.None)
+            if (_panels.Count == 0 || (SortDirection == SortDirection.None && SortComparer is null))
                 return;
 
             _panels.Sort(GetTabSortExpression);


### PR DESCRIPTION
This is a bug fix for Issue #11616 
The `MudTabs::SortPanels()` method has a guard to bypass the sorting system in the event that there are no panels, and no `SortDirection` is specified. However, when applying a custom `SortComparer` the `SortDirection` is not used, so it will generally not be specified (and is ignored in any case). The guard prevents normal operation of the `SortComparer` in the most common use-case.

The guard has been adjusted to include a check that no `SortComparer` is specified if the bypass is to be effective.

A unit test was present to check that the `SortDirection` did not influence the `SortComparer` but no test was applied for the case where no `SortDirection` was specified at all, leading to the bug. A new test has been added for this scenario.

Additionally, some line ending standardisation was applied automatically in some comments.