### PR TITLE
MudField: AdornmentAria and ShrinkLabel

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldLabelPlaceholderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Field/Examples/FieldLabelPlaceholderExample.razor
@@ -1,22 +1,68 @@
-﻿@namespace MudBlazor.Docs.Examples
+﻿@using MudBlazor.Resources
+@using MudBlazor.Utilities
+@inject InternalMudLocalizer Localizer
+@namespace MudBlazor.Docs.Examples
+
+<style>
+    .mud-input-control.mud-field .mud-input>input.mud-input-root-outlined {
+        padding: 0px 14px;
+    }
+</style>
 
 <MudGrid>
-    <MudItem xs="12" md="6" lg="4">       
-        <MudField Label="What am I?" ChildContent="@content"
-                  Variant="Variant.Outlined">            
-        </MudField>
-        <br/>
-        <MudSwitch T="bool" Color="Color.Primary" ValueChanged="@((b) => content=b?rf1:null)" /> Switch between Label and Placeholder
+    <MudItem xs="12" md="6" lg="4">
+        <MudStack>
+            <MudField Label="What am I?" ChildContent="@content"
+                      Variant="Variant.Outlined">
+            </MudField>
+            <MudText Typo="Typo.button">ChildContent</MudText>
+            <MudStack Row AlignItems="AlignItems.Center">
+                <MudSwitch T="bool" Label="Label" LabelPlacement="Placement.Start" Color="Color.Primary" ValueChanged="@((b) => content = b ? null : rf1)" />
+                Placeholder
+            </MudStack>
+        </MudStack>
     </MudItem>
-    <MudItem xs="12" md="6" lg="4">       
+    <MudItem xs="12" md="6" lg="4">
         <MudField Label="Pick a color" Variant="Variant.Outlined">
-            <input type="color" @bind-value="color"/><span class="ml-3">@color</span>
+            <input type="color" @bind-value="color" /><span class="ml-3">@color</span>
         </MudField>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudStack>
+            <MudField Label="ShrinkLabel Override" Variant="Variant.Outlined" AdornmentAriaLabel="info icon"
+                      AdornmentIcon="@Icons.Material.Filled.Info" AdornmentColor="Color.Info"
+                      ShrinkLabel="@_shrinkLabel" Adornment="Adornment.End">
+                <MudStack Row Class="mud-input"
+                          Spacing="2" AlignItems="AlignItems.Center" tabindex="-1">
+                    <input class="@InputClassname" />
+                    <MudIconButton Color="@Color.Default"
+                                   Icon="@Icons.Material.Filled.Clear"
+                                   Size="@Size.Small"
+                                   aria-label="@Localizer[LanguageResource.MudInput_Clear]"
+                                   tabindex="-1"
+                                   @onmousedown:stopPropagation />
+                </MudStack>
+            </MudField>
+            <MudText Typo="Typo.button">ShrinkLabel</MudText>
+            <MudStack Row AlignItems="AlignItems.Center">
+                <MudSwitch @bind-Value="@_shrinkLabel" Label="Label" LabelPlacement="Placement.Start" Color="Color.Primary" />
+                Placeholder
+            </MudStack>
+        </MudStack>
     </MudItem>
 </MudGrid>
 
 @code {
     RenderFragment content = null;
     RenderFragment rf1 = @<MudText Typo="@Typo.h6">I Am Field</MudText>;
-    string color="#6cf014";
+    string color = "#6cf014";
+    private bool _shrinkLabel = false;
+
+    protected string InputClassname =>
+        new CssBuilder("mud-input-slot")
+            .AddClass("mud-input-root")
+            .AddClass($"mud-input-root-{Variant.Outlined.ToDescriptionString()}")
+            .AddClass($"mud-input-root-adorned-{Adornment.End.ToDescriptionString()}")
+            .AddClass($"mud-input-root-margin-{Margin.Normal.ToDescriptionString()}")
+            .Build();
 }

--- a/src/MudBlazor.Docs/Pages/Components/Field/FieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Field/FieldPage.razor
@@ -7,8 +7,8 @@
         <DocsPageSection>
             <SectionHeader Title="Basic Usage">
                 <Description>
-                    MudField provides the foundation for creating custom input controls with consistent styling and behavior. 
-                    It offers the same visual variants as <MudLink Href="/components/textfield">text fields</MudLink> and 
+                    MudField provides the foundation for creating custom input controls with consistent styling and behavior.
+                    It offers the same visual variants as <MudLink Href="/components/textfield">text fields</MudLink> and
                     <MudLink Href="/components/numericfield">numeric fields</MudLink> while allowing you to embed any custom content.
                     Fields support labels, helper text, validation states, and adornments just like other input components.
                 </Description>
@@ -44,24 +44,28 @@
         <DocsPageSection>
             <SectionHeader Title="Advanced Usage">
                 <Description>
-                    Build custom input controls by leveraging MudField's flexible content system.
-                    When <CodeInline>ChildContent</CodeInline> is null, the label automatically becomes a placeholder,
-                    enabling dynamic behavior based on content or adornment.
-
-                    Use the <CodeInline>ShrinkLabel</CodeInline> parameter to override this behavior:
-                    when set to <CodeInline>true</CodeInline>, the label remains inside the field regardless of state,
-                    which is useful when you want to suppress automatic shrinking without causing the content to re-render
-                    or you want to maintain a custom portion of your ChildContent such as an extra ending adornment.
-
-                    Anytime the <CodeInline Tag="true">MudField</CodeInline> has focus within the label will shrink and 
-                    not act as a placeholder.
+                    <MudText HtmlTag="p">
+                        Build custom input controls by leveraging MudField's flexible content system.
+                        When <CodeInline>ChildContent</CodeInline> is null, the label automatically becomes a placeholder,
+                        enabling dynamic behavior based on content or adornment.
+                    </MudText>
+                    <MudText HtmlTag="p">
+                        Use the <CodeInline>ShrinkLabel</CodeInline> parameter to override this behavior:
+                        when set to <CodeInline>true</CodeInline>, the label remains inside the field regardless of state,
+                        which is useful when you want to suppress automatic shrinking without causing the content to re-render
+                        or you want to maintain a custom portion of your ChildContent such as an extra ending adornment.
+                    </MudText>
+                    <MudText HtmlTag="p">
+                        Anytime the <CodeInline Tag="true">MudField</CodeInline> has focus within the label will shrink and
+                        not act as a placeholder.
+                    </MudText>
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(FieldLabelPlaceholderExample)" ShowCode="false">
                 <FieldLabelPlaceholderExample />
             </SectionContent>
             <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                <strong>Related Components:</strong> For ready-made input controls, see <MudLink Href="/components/textfield">TextField</MudLink> and 
+                <strong>Related Components:</strong> For ready-made input controls, see <MudLink Href="/components/textfield">TextField</MudLink> and
                 <MudLink Href="/components/numericfield">NumericField</MudLink> which are built nearly identical to <CodeInline Tag="true">MudField</CodeInline>,
                 except they have a built-in <c>input</c>.
             </MudAlert>

--- a/src/MudBlazor.Docs/Pages/Components/Field/FieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Field/FieldPage.razor
@@ -44,9 +44,17 @@
         <DocsPageSection>
             <SectionHeader Title="Advanced Usage">
                 <Description>
-                    Build custom input controls by leveraging MudField's flexible content system. When <CodeInline>ChildContent</CodeInline> is null, 
-                    the label automatically becomes a placeholder, enabling dynamic behavior based on content state.
-                    This example demonstrates creating a custom color picker input using native HTML controls within a MudField wrapper.
+                    Build custom input controls by leveraging MudField's flexible content system.
+                    When <CodeInline>ChildContent</CodeInline> is null, the label automatically becomes a placeholder,
+                    enabling dynamic behavior based on content or adornment.
+
+                    Use the <CodeInline>ShrinkLabel</CodeInline> parameter to override this behavior:
+                    when set to <CodeInline>true</CodeInline>, the label remains inside the field regardless of state,
+                    which is useful when you want to suppress automatic shrinking without causing the content to re-render
+                    or you want to maintain a custom portion of your ChildContent such as an extra ending adornment.
+
+                    Anytime the <CodeInline Tag="true">MudField</CodeInline> has focus within the label will shrink and 
+                    not act as a placeholder.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(FieldLabelPlaceholderExample)" ShowCode="false">
@@ -54,7 +62,8 @@
             </SectionContent>
             <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                 <strong>Related Components:</strong> For ready-made input controls, see <MudLink Href="/components/textfield">TextField</MudLink> and 
-                <MudLink Href="/components/numericfield">NumericField</MudLink> which are built on top of MudField.
+                <MudLink Href="/components/numericfield">NumericField</MudLink> which are built nearly identical to <CodeInline Tag="true">MudField</CodeInline>,
+                except they have a built-in <c>input</c>.
             </MudAlert>
         </DocsPageSection>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Field/FieldStartAdornmentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Field/FieldStartAdornmentTest.razor
@@ -1,0 +1,16 @@
+﻿<MudStack>
+    <MudField Label="What am I? (0)" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Outlined.Info" />            
+    <MudField Label="What am I? (1)" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Outlined.Info" />
+    <MudField Label="What am I? (2)" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Outlined.Info">
+        <MudText>Some Content Here</MudText>
+    </MudField> 
+    <MudField Label="What am I? (3)" Adornment="Adornment.Start" ShrinkLabel="true" AdornmentIcon="@Icons.Material.Outlined.Info" />
+    <MudField Label="What am I? (4)" Adornment="Adornment.End" ShrinkLabel="true" AdornmentIcon="@Icons.Material.Outlined.Info">
+        <MudText>Some Content Here</MudText>
+    </MudField>
+</MudStack>
+
+@code {
+    public static string __description__ = "Issue 7533, testing that the Start Adornment is not going two lines with the label";
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Field/FieldTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Field/FieldTest.razor
@@ -5,7 +5,7 @@
 
 <MudGrid>
     <MudItem xs="12" sm="6" md="4">
-        <MudField Label="Standard" Variant="Variant.Text" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Api"></MudField>
+        <MudField Label="Standard" Variant="Variant.Text" AdornmentAriaLabel="test-aria" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Api"></MudField>
     </MudItem>
     <MudItem xs="12" sm="6" md="4">
         <MudField Label="Filled" Variant="Variant.Filled" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Api"></MudField>

--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -27,6 +27,19 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void FieldTest_ShouldRender_AriaAdornment()
+        {
+            var comp = Context.RenderComponent<FieldTest>();
+            var fields = comp.FindAll(".mud-grid .mud-input-control.mud-field");
+            fields.Should().HaveCount(3);
+            fields[0].ClassList.Should().Contain("mud-input-text-with-label");
+            fields[0].TextContent.Trim().Should().Be("Standard");
+            var adornmentAria = comp.Find(".mud-grid .mud-input-control.mud-field svg.mud-input-adornment-icon");
+            // get what adornmentAria aria-label says
+            adornmentAria.GetAttribute("aria-label").Trim().Should().Be("test-aria");
+        }
+
+        [Test]
         public void FieldTests_ShrinkLabel()
         {
             // Issue 7533, when ChildContent is null, the mud-shrink class is applied

--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents.Field;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class FieldTests : BunitTest
+    {
+        [Test]
+        public void FieldTest_ShouldRender_Variants()
+        {
+            var comp = Context.RenderComponent<FieldTest>();
+            var fields = comp.FindAll(".mud-grid .mud-input-control.mud-field");
+            fields.Should().HaveCount(3);
+            fields[0].ClassList.Should().Contain("mud-input-text-with-label");
+            fields[0].TextContent.Trim().Should().Be("Standard");
+            fields[1].ClassList.Should().Contain("mud-input-filled-with-label");
+            fields[1].TextContent.Trim().Should().Be("Filled");
+            fields[2].ClassList.Should().Contain("mud-input-outlined-with-label");
+            fields[2].TextContent.Trim().Should().Be("OutlinedOutlined"); // Outlined includes a special fieldset label
+        }
+
+        [Test]
+        public void FieldTests_ShrinkLabel()
+        {
+            // Issue 7533, when Child Content is null, the mud-shrink class is applied
+            // Bug - the mud-shrink class should always be applied unless overridden
+            var comp = Context.RenderComponent<FieldStartAdornmentTest>();
+            // find all the mud-fields inner area
+            var fields = comp.FindAll(".mud-input-control.mud-field > .mud-input-control-input-container > .mud-input");
+            var fieldLabels = comp.FindAll(".mud-input-control.mud-field > .mud-input-control-input-container label");
+            fields.Should().HaveCount(5);
+
+            // mud-shrink tells it to display at top
+            // with end adornment
+            fields[0].ClassList.Should().Contain("mud-shrink");
+            fieldLabels[0].TextContent.Trim().Should().Contain("What am I? (0)");
+            // with start adornment            
+            fields[1].ClassList.Should().Contain("mud-shrink");
+            fieldLabels[1].TextContent.Trim().Should().Be("What am I? (1)");
+            // content
+            fields[2].ClassList.Should().Contain("mud-shrink");
+            fields[2].TextContent.Trim().Should().Be("Some Content Here");
+            fieldLabels[2].TextContent.Trim().Should().Be("What am I? (2)");
+
+            // with shrink label override
+            //start adornment
+            fields[3].ClassList.Should().NotContain("mud-shrink");
+            fieldLabels[3].TextContent.Trim().Should().Be("What am I? (3)");
+            // content and end adornment
+            fields[4].ClassList.Should().NotContain("mud-shrink");
+            fields[4].TextContent.Trim().Should().Be("Some Content Here");
+            fieldLabels[4].TextContent.Trim().Should().Be("What am I? (4)");
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -29,19 +29,18 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FieldTests_ShrinkLabel()
         {
-            // Issue 7533, when Child Content is null, the mud-shrink class is applied
-            // Bug - the mud-shrink class should always be applied unless overridden
+            // Issue 7533, when ChildContent is null, the mud-shrink class is applied
+            // Add a shrink label override to the field in addition to the ChildContent
             var comp = Context.RenderComponent<FieldStartAdornmentTest>();
             // find all the mud-fields inner area
             var fields = comp.FindAll(".mud-input-control.mud-field > .mud-input-control-input-container > .mud-input");
             var fieldLabels = comp.FindAll(".mud-input-control.mud-field > .mud-input-control-input-container label");
             fields.Should().HaveCount(5);
 
-            // mud-shrink tells it to display at top
-            // with end adornment
-            fields[0].ClassList.Should().Contain("mud-shrink");
+            // with end adornment no content
+            fields[0].ClassList.Should().NotContain("mud-shrink");
             fieldLabels[0].TextContent.Trim().Should().Contain("What am I? (0)");
-            // with start adornment            
+            // with start adornment        
             fields[1].ClassList.Should().Contain("mud-shrink");
             fieldLabels[1].TextContent.Trim().Should().Be("What am I? (1)");
             // content

--- a/src/MudBlazor/Components/Field/MudField.razor
+++ b/src/MudBlazor/Components/Field/MudField.razor
@@ -14,6 +14,7 @@
                                    Size="@IconSize"
                                    Text="@AdornmentText"
                                    Placement="@Adornment.Start"
+                                   AriaLabel="@AdornmentAriaLabel"
                                    AdornmentClick="@OnAdornmentClick" />
             }
             <div class="@InnerClassname">
@@ -27,6 +28,7 @@
                                    Size="@IconSize"
                                    Text="@AdornmentText"
                                    Placement="@Adornment.End"
+                                   AriaLabel="@AdornmentAriaLabel"
                                    AdornmentClick="@OnAdornmentClick" />
             }
             @if (Variant == Variant.Outlined)

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -234,10 +234,10 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// <para>When <c>false</c>, the label behaves like a placeholder and shrinks only if there is content or an adornment at the start.</para>
-        /// <para>When <c>true</c>, the label does not shrink and remains inside the field regardless of content, which may result in overlap.</para>
+        /// <para>When <c>true</c>, the label does not shrink and remains as a placeholder regardless of content, which may result in overlap.</para>
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public bool ShrinkLabel { get; set; } = false;
+        public bool ShrinkLabel { get; set; }
     }
 }

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor
     /// <seealso cref="MudTextField{T}"/>
     public partial class MudField : MudComponentBase
     {
-        private bool _shrinkLabel = false;
         protected string Classname =>
             new CssBuilder("mud-input")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
@@ -24,7 +23,7 @@ namespace MudBlazor
                 // Apply "mud-shrink" only if ShrinkLabel is false AND
                 // (there is content OR the adornment is at the start)
                 .AddClass("mud-shrink",
-                    !_shrinkLabel &&
+                    !ShrinkLabel &&
                          (ChildContent != null || Adornment == Adornment.Start))
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-input-error", Error && !string.IsNullOrEmpty(ErrorText))
@@ -240,14 +239,5 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public bool ShrinkLabel { get; set; } = false;
-
-        protected override void OnParametersSet()
-        {
-            base.OnParametersSet();
-            if (_shrinkLabel != ShrinkLabel)
-            {
-                _shrinkLabel = ShrinkLabel;
-            }
-        }
     }
 }

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -12,6 +12,7 @@ namespace MudBlazor
     /// <seealso cref="MudTextField{T}"/>
     public partial class MudField : MudComponentBase
     {
+        private bool _shrinkLabel = false;
         protected string Classname =>
             new CssBuilder("mud-input")
                 .AddClass($"mud-input-{Variant.ToDescriptionString()}")
@@ -19,7 +20,12 @@ namespace MudBlazor
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
                 .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
                 .AddClass("mud-input-underline", () => Underline && Variant != Variant.Outlined)
-                .AddClass("mud-shrink", () => (!ShrinkLabel))
+                // Without the mud-shrink class, the label will become a placeholder
+                // Apply "mud-shrink" only if ShrinkLabel is false AND
+                // (there is content OR the adornment is at the start)
+                .AddClass("mud-shrink",
+                    !_shrinkLabel &&
+                         (ChildContent != null || Adornment == Adornment.Start))
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-input-error", Error && !string.IsNullOrEmpty(ErrorText))
                 .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
@@ -224,15 +230,24 @@ namespace MudBlazor
         public bool Underline { get; set; } = true;
 
         /// <summary>
-        /// Controls whether the label is displayed inside or above the field when an inside element does not have focus.
+        /// Controls whether the label is displayed inside the field or shrinks above it when the field does not have focus.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>. 
-        /// <para>When <c>false</c>, the label remains above the field regardless of content.</para>
-        /// <para>When <c>true</c>, the label always shrinks into the field (could collide with content) unless it has focus.</para>   
+        /// Defaults to <c>false</c>.
+        /// <para>When <c>false</c>, the label behaves like a placeholder and shrinks only if there is content or an adornment at the start.</para>
+        /// <para>When <c>true</c>, the label does not shrink and remains inside the field regardless of content, which may result in overlap.</para>
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public bool ShrinkLabel { get; set; } = false;
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            if (_shrinkLabel != ShrinkLabel)
+            {
+                _shrinkLabel = ShrinkLabel;
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
                 .AddClass($"mud-input-adorned-{Adornment.ToDescriptionString()}", Adornment != Adornment.None)
                 .AddClass($"mud-input-margin-{Margin.ToDescriptionString()}", () => Margin != Margin.None)
                 .AddClass("mud-input-underline", () => Underline && Variant != Variant.Outlined)
-                .AddClass("mud-shrink", () => !string.IsNullOrWhiteSpace(ChildContent?.ToString()) || Adornment == Adornment.Start)
+                .AddClass("mud-shrink", () => (!ShrinkLabel))
                 .AddClass("mud-disabled", Disabled)
                 .AddClass("mud-input-error", Error && !string.IsNullOrEmpty(ErrorText))
                 .AddClass($"mud-typography-{Typo.ToDescriptionString()}")
@@ -178,6 +178,16 @@ namespace MudBlazor
         public Color AdornmentColor { get; set; } = Color.Default;
 
         /// <summary>
+        /// The <c>aria-label</c> for the adornment.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string? AdornmentAriaLabel { get; set; }
+
+        /// <summary>
         /// The size of the icon.
         /// </summary>
         /// <remarks>
@@ -212,5 +222,17 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Field.Appearance)]
         public bool Underline { get; set; } = true;
+
+        /// <summary>
+        /// Controls whether the label is displayed inside or above the field when an inside element does not have focus.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>. 
+        /// <para>When <c>false</c>, the label remains above the field regardless of content.</para>
+        /// <para>When <c>true</c>, the label always shrinks into the field (could collide with content) unless it has focus.</para>   
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public bool ShrinkLabel { get; set; } = false;
     }
 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #7270 
Resolves #5146 
Resolves #7533 
AdornmentAria was missing from MudField, added the property.
Added an override for ShrinkLabel behavior and updated documentation. This does not affect previous behavior, but allows someone using the MudField to force the label into Placeholder position by setting ShrinkLabel to true. 
Added unit tests
Updated Documentation:

<img width="1362" height="574" alt="Screenshot 2025-07-17 013941" src="https://github.com/user-attachments/assets/f1017a18-ad3c-45c8-9747-928f34d90f2f" />

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
