### PR TITLE
MudPopover: Restrict Max Height Adjustments

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -526,14 +526,15 @@ window.mudpopoverHelper = {
                 }
 
                 const firstChild = popoverContentNode.firstElementChild;
-
+                console.log(firstChild);
                 // adjust the popover position/maxheight if it or firstChild does not have a max-height set (even if set to 'none')
                 // exceeds the bounds and doesn't have a max-height set by the user
                 // maxHeight adjustments stop the minute popoverNode is no longer inside the window
                 // Check if max-height is set on popover or firstChild
                 const hasMaxHeight = popoverContentNode.style.maxHeight != '' || (firstChild && firstChild.style.maxHeight != '');
+                const isList = firstChild?.classList?.contains("mud-list") ?? false;
 
-                if (!hasMaxHeight) {
+                if (!hasMaxHeight && isList) {
                     // in case of a reflow check it should show from top properly
                     let shouldShowFromTop = false;
                     // calculate new max height if it exceeds bounds

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -568,6 +568,8 @@ window.mudpopoverHelper = {
                             top = window.mudpopoverHelper.overflowPadding;                          
                             offsetY = 0;
                         }
+                        // set newMaxHeight to be minimum of 3x overflow padding, by default 72px (or 3 items roughly)
+                        newMaxHeight = Math.max(newMaxHeight, window.mudpopoverHelper.overflowPadding * 3);
                         popoverContentNode.style.maxHeight = (newMaxHeight) + 'px';
                         popoverContentNode.mudHeight = "setmaxheight";
                     }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -526,7 +526,7 @@ window.mudpopoverHelper = {
                 }
 
                 const firstChild = popoverContentNode.firstElementChild;
-                console.log(firstChild);
+
                 // adjust the popover position/maxheight if it or firstChild does not have a max-height set (even if set to 'none')
                 // exceeds the bounds and doesn't have a max-height set by the user
                 // maxHeight adjustments stop the minute popoverNode is no longer inside the window

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -532,7 +532,7 @@ window.mudpopoverHelper = {
                 // maxHeight adjustments stop the minute popoverNode is no longer inside the window
                 // Check if max-height is set on popover or firstChild
                 const hasMaxHeight = popoverContentNode.style.maxHeight != '' || (firstChild && firstChild.style.maxHeight != '');
-                const isList = firstChild?.classList?.contains("mud-list") ?? false;
+                const isList = firstChild && firstChild.classList && firstChild.classList.contains("mud-list");
 
                 if (!hasMaxHeight && isList) {
                     // in case of a reflow check it should show from top properly


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #11675 
Re-introduce the automatic max-height adjustments to just mud-lists as it was originally intended. 
Restricted max-height to 3x overflowPadding (defaults to 24px)

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
