### PR TITLE
MudTable: Maintains group row state when group list is modified

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupingNestedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupingNestedTest.razor
@@ -1,0 +1,48 @@
+﻿<MudTable @ref="TableInstance" T="Item" Items="Items" GroupBy="@_groupDefinition">
+    <GroupHeaderTemplate>
+        <MudTh>@context.Key</MudTh>
+    </GroupHeaderTemplate>
+    <RowTemplate>
+        <MudTh>@context.Label</MudTh>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public MudTable<Item>? TableInstance { get; private set; }
+
+    public List<Item>? Items { get; set; } = [
+        new Item { Group = "G1", Nested = "N1", Label = "A" },
+        new Item { Group = "G1", Nested = "N1", Label = "B" },
+        new Item { Group = "G1", Nested = "N2", Label = "C" },
+        new Item { Group = "G2", Nested = "N1", Label = "D" },
+        new Item { Group = "G2", Nested = "N1", Label = "E" },
+        new Item { Group = "G2", Nested = "N2", Label = "F" },
+        new Item { Group = "G3", Nested = "N1", Label = "G" },
+        new Item { Group = "G3", Nested = "N1", Label = "H" },
+        new Item { Group = "G3", Nested = "N2", Label = "I" }
+    ];
+
+    private TableGroupDefinition<Item> _groupDefinition = new() {
+        Indentation = false,
+        Expandable = true,
+        IsInitiallyExpanded = false,
+        Selector = e => e.Group,
+        InnerGroup = new TableGroupDefinition<Item> {
+            Indentation = false,
+            Expandable = true,
+            IsInitiallyExpanded = false,
+            Selector = e => e.Group + " > " + e.Nested,
+        }
+    };
+
+    public class Item
+    {
+        public required string Label { get; set; }
+
+        public required string Group { get; set; }
+
+        public required string Nested { get; set; }
+
+        public override string ToString() => $"({Group} > {Nested}) {Label}";
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupingTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupingTest3.razor
@@ -1,0 +1,40 @@
+﻿<MudTable @ref="TableInstance" T="Item" Items="Items" GroupBy="@_groupDefinition">
+    <GroupHeaderTemplate>
+        <MudTh>@context.Key</MudTh>
+    </GroupHeaderTemplate>
+    <RowTemplate>
+        <MudTh>@context.Label</MudTh>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public MudTable<Item>? TableInstance { get; private set; }
+
+    public List<Item>? Items { get; set; } = [
+        new Item { Group = "One", Label = "A"  },
+        new Item { Group = "One", Label = "B"  },
+        new Item { Group = "One", Label = "C"  },
+        new Item { Group = "Two", Label = "D"  },
+        new Item { Group = "Two", Label = "E"  },
+        new Item { Group = "Two", Label = "F"  },
+        new Item { Group = "Three", Label = "G"  },
+        new Item { Group = "Three", Label = "H"  },
+        new Item { Group = "Three", Label = "I"  }
+    ];
+
+    private TableGroupDefinition<Item> _groupDefinition = new() {
+        Indentation = false,
+        Expandable = true,
+        IsInitiallyExpanded = false,
+        Selector = e => e.Group
+    };
+
+    public class Item
+    {
+        public required string Label { get; set; }
+
+        public required string Group { get; set; }
+
+        public override string ToString() => $"({Group}) {Label}";
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2117,6 +2117,128 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A table with 3 unexpanded groups. The first group is expanded, next removed.
+        /// The other groups remain unexpanded.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/MudBlazor/MudBlazor/issues/10250
+        /// </remarks>
+        [Test]
+        public void TableGrouping_ExpandFirstGroupAndRemoveIt_OtherGroupsRemainUnexpanded()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<TableGroupingTest3>();
+            var table = comp.Instance.TableInstance;
+            comp.Render();
+
+            // Assert : Three groups are unexpanded
+
+            table.Context.GroupRows.Count.Should().Be(3);
+            table.Context.GroupRows.ElementAt(0).Expanded.Should().BeFalse();
+            table.Context.GroupRows.ElementAt(1).Expanded.Should().BeFalse();
+            table.Context.GroupRows.ElementAt(2).Expanded.Should().BeFalse();
+
+            // Act : Expend the first group
+
+            comp.FindAll("button")[0].Click();
+
+            // Assert : Only the first group is expanded
+
+            table.Context.GroupRows.Count.Should().Be(3);
+            table.Context.GroupRows.ElementAt(0).Expanded.Should().BeTrue();
+            table.Context.GroupRows.ElementAt(1).Expanded.Should().BeFalse();
+            table.Context.GroupRows.ElementAt(2).Expanded.Should().BeFalse();
+
+            // Act : Remove the first group
+
+            comp.Instance.Items.RemoveAll(i => i.Group == "One");
+            comp.Render();
+
+            // Assert : Two groups are unexpanded
+
+            table.Context.GroupRows.Count.Should().Be(2);
+            table.Context.GroupRows.ElementAt(0).Expanded.Should().BeFalse();
+            table.Context.GroupRows.ElementAt(1).Expanded.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A table with unexpanded groups and unexpanded nested groups.
+        /// The first group and its first nested group are expanded. Then remove the first nested group.
+        /// The other nested group remains unexpanded.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/MudBlazor/MudBlazor/issues/10250
+        /// </remarks>
+        [Test]
+        public void TableGrouping_ExpandFirstNestedGroupAndRemoveIt_OtherNestedGroupsRemainUnexpanded()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<TableGroupingNestedTest>();
+            var table = comp.Instance.TableInstance;
+            comp.Render();
+
+            // Assert : All groups are unexpanded
+
+            {
+                var groups = table.Context.GroupRows;
+                groups.Count.Should().Be(3);
+                groups.Single(g => g.Items.Key.ToString() == "G1").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G3").Expanded.Should().BeFalse();
+            }
+
+            // Act : Expend the first group
+
+            comp.FindAll("button")[0].Click();
+
+            // Assert : Only the first group is expanded
+
+            {
+                var groups = table.Context.GroupRows;
+                groups.Count.Should().Be(5);
+                groups.Single(g => g.Items.Key.ToString() == "G1").Expanded.Should().BeTrue();
+                groups.Single(g => g.Items.Key.ToString() == "G1 > N1").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G1 > N2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G3").Expanded.Should().BeFalse();
+            }
+
+            // Act : Expand the first nested group in the first group
+
+            comp.FindAll("button")[1].Click();
+
+            // Assert : Only the first group and its first nested group are expanded
+
+            {
+                var groups = table.Context.GroupRows;
+                groups.Count.Should().Be(5);
+                groups.Single(g => g.Items.Key.ToString() == "G1").Expanded.Should().BeTrue();
+                groups.Single(g => g.Items.Key.ToString() == "G1 > N1").Expanded.Should().BeTrue();
+                groups.Single(g => g.Items.Key.ToString() == "G1 > N2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G3").Expanded.Should().BeFalse();
+            }
+
+            // Act : Remove the first nested group in first group
+
+            comp.Instance.Items.RemoveAll(i => i.Group == "G1" && i.Nested == "N1");
+            comp.Render();
+
+            // Assert : Only the first group is expanded and its remaining nested group is unexpanded
+
+            {
+                var groups = table.Context.GroupRows;
+                groups.Count.Should().Be(4);
+                groups.Single(g => g.Items.Key.ToString() == "G1").Expanded.Should().BeTrue();
+                groups.Single(g => g.Items.Key.ToString() == "G1 > N2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G2").Expanded.Should().BeFalse();
+                groups.Single(g => g.Items.Key.ToString() == "G3").Expanded.Should().BeFalse();
+            }
+        }
+
+        /// <summary>
         /// Tests the grouping behavior and ensure that it won't break anything else.
         /// </summary>
         /// <returns></returns>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -50,7 +50,7 @@
                                 {
                                     @HeaderContent
                                 }
-                                
+
                                 @if (Columns != null)
                                 {
                                     @Columns(Def)
@@ -82,10 +82,10 @@
                     {
                         @foreach (var group in GroupItemsPage)
                         {
-                            <MudTableGroupRow GroupDefinition="GroupBy" Items="group" Checkable="MultiSelection" SelectionChangeable="SelectionChangeable"
-                                              HeaderClass="@GroupHeaderClass" HeaderStyle="@GroupHeaderStyle" 
-                                              FooterClass="@GroupFooterClass" FooterStyle="@GroupFooterStyle"
-                                              HeaderTemplate="@GroupHeaderTemplate" FooterTemplate="@GroupFooterTemplate" T="T"  />
+                            <MudTableGroupRow @key="group.Key" T="T" GroupDefinition="GroupBy" Items="group"
+                                              Checkable="MultiSelection" SelectionChangeable="SelectionChangeable"
+                                              HeaderClass="@GroupHeaderClass" HeaderStyle="@GroupHeaderStyle" HeaderTemplate="@GroupHeaderTemplate"
+                                              FooterClass="@GroupFooterClass" FooterStyle="@GroupFooterStyle" FooterTemplate="@GroupFooterTemplate" />
                         }
                     }
                     else
@@ -105,31 +105,31 @@
                                    {
                                         <CascadingValue Value="@Validator" IsFixed="true">
                                            @if(RowEditingTemplate != null)
-										    {
-											    @RowEditingTemplate(item)
-										    }
-										    @if (Columns != null)
-										    {
+                                            {
+                                                @RowEditingTemplate(item)
+                                            }
+                                            @if (Columns != null)
+                                            {
                                                 @Columns(item)
-										    }
+                                            }
                                         </CascadingValue>
                                    }
                                    else
                                    {
-                                       if (RowTemplate != null)
-										{
-											@RowTemplate(item)
-										}
-										@if (Columns != null)
-										{
+                                        if (RowTemplate != null)
+                                        {
+	                                        @RowTemplate(item)
+                                        }
+                                        @if (Columns != null)
+                                        {
                                             @Columns(item)
-										}
+                                        }
                                    }
                                </MudTr>
                                @if (ChildRowContent != null)
                                {
                                    @ChildRowContent(item)
-                               }   
+                               }
                                @{ rowIndex++; }
                             </MudVirtualize>
                         }
@@ -170,7 +170,7 @@
                                 }
                                 @if (Columns != null)
                                 {
-                                        @Columns(Def)
+                                    @Columns(Def)
                                 }
                             </MudTFootRow>
                         }
@@ -194,10 +194,10 @@
     {
         var rowIndex = 0;
 
-         RenderFragment rootNode =
+        RenderFragment rootNode =
             @<text>
-        <MudVirtualize Enabled="@Virtualize" Items="@source?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item" ChildContent="@child()">
-        </MudVirtualize>
+                <MudVirtualize Enabled="@Virtualize" Items="@source?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item" ChildContent="@child()">
+                </MudVirtualize>
             </text>;
 
          RenderFragment<T> child() => item =>
@@ -205,32 +205,32 @@
              @{
                 var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, rowIndex)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).Build();
                 var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, rowIndex)).Build();
-             } 
+             }
              <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" Checkable="MultiSelection" SelectionChangeable="SelectionChangeable" Editable="IsItemEditable(item)" Expandable="expandable"
                     Checked="Context.Selection.Contains(item)" CheckedChanged="((value) => { var x = item; OnRowCheckboxChanged(value, x); })">
                     @if ((!ReadOnly) && Editable && Equals(_editingItem, item))
                     {
                         <CascadingValue Value="@Validator" IsFixed="true">
                             @if(RowEditingTemplate != null)
-							{
-								@RowEditingTemplate(item)
-							}
-							@if (Columns != null)
-							{
+                            {
+	                            @RowEditingTemplate(item)
+                            }
+                            @if (Columns != null)
+                            {
                                 @Columns(item)
-							}
+                            }
                         </CascadingValue>
                     }
                     else
                     {
                         if (RowTemplate != null)
-						{
-							@RowTemplate(item)
-						}
-						@if (Columns != null)
-						{
+                        {
+	                        @RowTemplate(item)
+                        }
+                        @if (Columns != null)
+                        {
                             @Columns(item)
-						}
+                        }
                     }
                 </MudTr>
                 @if (ChildRowContent != null)
@@ -238,9 +238,7 @@
                     @ChildRowContent(item)
                 }
                 @{rowIndex++;}
-        </text>
-    ;
-
+        </text>;
 
         return rootNode;
     }

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -6,7 +6,7 @@
 @*HEADER:*@
 @if (HeaderTemplate != null && GroupDefinition != null)
 {
-<tr class="@HeaderClassname" @onclick="@OnRowClick" style="@HeaderStyle" @attributes="@UserAttributes">        
+<tr class="@HeaderClassname" @onclick="@OnRowClick" style="@HeaderStyle" @attributes="@UserAttributes">
     @if ((GroupDefinition?.IsThisOrParentExpandable ?? false) || (Context?.Table?.MultiSelection ?? false))
     {
         <MudTd>
@@ -38,7 +38,7 @@
 }
 else
 {
-<MudText @attributes="@UserAttributes">@("There aren't any group definition to use with this component.")</MudText>
+    <MudText @attributes="@UserAttributes">@("There aren't any group definition to use with this component.")</MudText>
 }
 
 @if (Expanded)
@@ -50,10 +50,11 @@ else
     {
         @foreach (var group in _innerGroupItems)
         {
-            <MudTableGroupRow GroupDefinition="GroupDefinition.InnerGroup" Items="@group" Checkable="@Checkable" SelectionChangeable="SelectionChangeable"
-                              HeaderClass="@HeaderClass" HeaderStyle="@HeaderStyle"
-                              FooterClass="@FooterClass" FooterStyle="@FooterStyle"
-                              HeaderTemplate="@HeaderTemplate" FooterTemplate="@FooterTemplate" T="T" @attributes="@UserAttributes" />
+            <MudTableGroupRow @key="group.Key" T="T" GroupDefinition="GroupDefinition.InnerGroup" Items="@group"
+                              Checkable="@Checkable" SelectionChangeable="SelectionChangeable"
+                              HeaderClass="@HeaderClass" HeaderStyle="@HeaderStyle" HeaderTemplate="@HeaderTemplate"
+                              FooterClass="@FooterClass" FooterStyle="@FooterStyle" FooterTemplate="@FooterTemplate"
+                              @attributes="@UserAttributes" />
         }
     }
     else
@@ -74,7 +75,6 @@ else
             {
                 <MudTd />
             }
-
         </tr>
     }
 }


### PR DESCRIPTION
Fixes #10250

This PR add `@key` on `MudTableGroupRow` generated by `MudTable` to maintains the state.

**Checklist:**
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.