### PR TITLE
MudDataGrid: Make Column Methods Public

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1426,7 +1426,12 @@ namespace MudBlazor
             GroupItems();
         }
 
-        internal void AddColumn(Column<T> column)
+        /// <summary>
+        /// Adds a column to this grid. Hierarchy and select columns are added to the beginning of the list, while other columns are added to the end.
+        /// </summary>
+        /// <param name="column"></param>
+        /// <param name="newIndex">(optional) The index where you wish to place the column, by default it is at the end.</param>
+        public void AddColumn(Column<T> column, int? newIndex = null)
         {
             if (column.Tag?.ToString() == "hierarchy-column")
             {
@@ -1443,6 +1448,11 @@ namespace MudBlazor
                 {
                     RenderedColumns.Insert(0, column);
                 }
+            }
+            // else if newIndex is not null and a valid index, insert the column at that index
+            else if (newIndex != null && newIndex.Value >= 0 && newIndex.Value <= RenderedColumns.Count)
+            {
+                RenderedColumns.Insert(newIndex.Value, column);
             }
             else
             {
@@ -2025,7 +2035,11 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
-        private void ColumnUp(Column<T> column)
+        /// <summary>
+        /// Moves the specified column up in the rendered columns list by 1.
+        /// </summary>
+        /// <param name="column">The specified column to move.</param>
+        public void ColumnUp(Column<T> column)
         {
             var index = RenderedColumns.IndexOf(column);
             if (index > 0)
@@ -2036,7 +2050,11 @@ namespace MudBlazor
             DropContainerHasChanged();
         }
 
-        private void ColumnDown(Column<T> column)
+        /// <summary>
+        /// Moves the specified column down in the rendered columns list by 1.
+        /// </summary>
+        /// <param name="column">The specified column to move.</param>
+        public void ColumnDown(Column<T> column)
         {
             var index = RenderedColumns.IndexOf(column);
             if (index < RenderedColumns.Count - 1)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1473,7 +1473,13 @@ namespace MudBlazor
             }
         }
 
-        internal void RemoveColumn(Column<T> column)
+        /// <summary>
+        /// Removes the specified column from the collection of rendered columns.
+        /// </summary>
+        /// <remarks>This method removes the specified column from the <c>RenderedColumns</c> collection. 
+        /// If the column is not present in the collection, no action is taken.</remarks>
+        /// <param name="column">The column to remove. Must not be null.</param>
+        public void RemoveColumn(Column<T> column)
         {
             RenderedColumns.Remove(column);
         }


### PR DESCRIPTION
…index property to AddColumn.


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #11570 by making `ColumnUp` , `ColumnDown` , `RemoveColumn` , and `AddColumn` public methods in MudDataGrid. Added an optional parameter to AddColumn for a New Index. 
 
**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
