### PR TITLE
MudPopover: Fix MudList Scroll Issue

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -571,6 +571,7 @@ window.mudpopoverHelper = {
                         // set newMaxHeight to be minimum of 3x overflow padding, by default 72px (or 3 items roughly)
                         newMaxHeight = Math.max(newMaxHeight, window.mudpopoverHelper.overflowPadding * 3);
                         popoverContentNode.style.maxHeight = (newMaxHeight) + 'px';
+                        firstChild.style.maxHeight = (newMaxHeight) + 'px';
                         popoverContentNode.mudHeight = "setmaxheight";
                     }
                 }


### PR DESCRIPTION
This change ensures that the `firstChild` element of the popover respects the same maximum height constraint as the popover content by setting its `maxHeight` to `newMaxHeight` instead of inherit which causes a redraw every time the mouse exits the popover.


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #11667 by adjusting the max-height at the mud-list level instead of letting it inherit. When it inherits it causes a redraw which puts the top scrolled item back to the top. 

You can test in PopoverFlipDirectionTest.razor with/without this change. The attached issue happens quicker and easier to reproduce since Nested Lists are separate popovers (Causing an immediate redraw every time your mouse activates a nested menu item.
**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
