### PR TITLE
MudDataGrid: Add hierarchy visibility toggled parameter

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyVisibilityToggledTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyVisibilityToggledTest.razor
@@ -1,0 +1,33 @@
+﻿@using MudBlazor
+@using System.Collections.Generic
+@using MudBlazor.Utilities
+
+<MudDataGrid T="Model" Items="@Items" HierarchyVisibilityToggled="@OnHierarchyVisibilityToggled">
+    <Columns>
+        <HierarchyColumn />
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+    </Columns>
+    <ChildRowContent>
+        <MudText>Child content for @context.Item.Name</MudText>
+    </ChildRowContent>
+</MudDataGrid>
+
+@code {
+    public record Model(string Name, int Age);
+
+    public List<Model> Items = new()
+    {
+        new Model("John", 25),
+        new Model("Jane", 30),
+        new Model("Bob", 35)
+    };
+
+    public List<DataGridHierarchyVisibilityToggledEventArgs<Model>> ToggledEvents = [];
+
+    private Task OnHierarchyVisibilityToggled(DataGridHierarchyVisibilityToggledEventArgs<Model> args)
+    {
+        ToggledEvents.Add(args);
+        return Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5424,5 +5424,58 @@ namespace MudBlazor.UnitTests.Components
             cells[3].TextContent.Should().Be("A");
             cells[6].TextContent.Should().Be("B");
         }
+
+        [Test]
+        public async Task DataGrid_HierarchyVisibilityToggled_SingleRowToggle()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyVisibilityToggledTest.Model>>();
+            var testComponent = comp.Instance;
+
+            await comp.InvokeAsync(() => dataGrid.Instance
+                .ToggleHierarchyVisibilityAsync(dataGrid.Instance.Items.First()));
+
+            testComponent.ToggledEvents.Should().HaveCount(1);
+            testComponent.ToggledEvents[0].Item.Name.Should().Be("John");
+            testComponent.ToggledEvents[0].Expanded.Should().BeTrue();
+
+            await comp.InvokeAsync(() => dataGrid.Instance
+                .ToggleHierarchyVisibilityAsync(dataGrid.Instance.Items.First()));
+
+            testComponent.ToggledEvents.Should().HaveCount(2);
+            testComponent.ToggledEvents[1].Item.Name.Should().Be("John");
+            testComponent.ToggledEvents[1].Expanded.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task DataGrid_HierarchyVisibilityToggled_CollapseAll()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyVisibilityToggledTest.Model>>();
+            var testComponent = comp.Instance;
+
+
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllHierarchy());
+            testComponent.ToggledEvents.Clear();
+
+            await comp.InvokeAsync(() => dataGrid.Instance.CollapseAllHierarchy());
+
+            testComponent.ToggledEvents.Should().HaveCount(3);
+            testComponent.ToggledEvents.Select(x => x.Item.Name).Should().BeEquivalentTo(["John", "Jane", "Bob"]);
+        }
+
+        [Test]
+        public async Task DataGrid_HierarchyVisibilityToggled_ExpandAll()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyVisibilityToggledTest.Model>>();
+            var testComponent = comp.Instance;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.ExpandAllHierarchy());
+
+            testComponent.ToggledEvents.Should().HaveCount(3);
+            testComponent.ToggledEvents.Should().OnlyContain(x => x.Expanded == true);
+            testComponent.ToggledEvents.Select(x => x.Item.Name).Should().BeEquivalentTo(["John", "Jane", "Bob"]);
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
@@ -13,10 +13,16 @@ namespace MudBlazor.Utilities
         /// <summary>
         /// The item whose visibility was changed.
         /// </summary>
-        public T Item { get; set; }
+        public T Item { get; }
         /// <summary>
-        /// If <code>true</code> item was expanded, otherwise collapsed
+        /// If <c>true</c> item was expanded, otherwise collapsed
         /// </summary>
-        public bool Expanded { get; set; }
+        public bool Expanded { get; }
+
+        public DataGridHierarchyVisibilityToggledEventArgs(T item, bool expanded)
+        {
+            Item = item;
+            Expanded = expanded;
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Utilities
+{
+    /// <summary>
+    /// Represents the information related to a <see cref="MudDataGrid{T}.HierarchyVisibilityToggled"/> event.
+    /// </summary>
+    /// <typeparam name="T">The item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
+    public class DataGridHierarchyVisibilityToggledEventArgs<T>
+    {
+        /// <summary>
+        /// The item whose visibility was changed.
+        /// </summary>
+        public T Item { get; set; }
+        /// <summary>
+        /// If <code>true</code> item was expanded, otherwise collapsed
+        /// </summary>
+        public bool Expanded { get; set; }
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2375,12 +2375,10 @@ namespace MudBlazor
         /// </summary>
         public async Task ExpandAllHierarchy()
         {
-            foreach (var item in FilteredItems)
+            var expandedItems = FilteredItems.Where(x => !_buttonDisabledFunc(x) && _openHierarchies.Add(x));
+            foreach (var item in expandedItems)
             {
-                if (!_buttonDisabledFunc(item) && _openHierarchies.Add(item))
-                {
-                    await HierarchyVisibilityToggled.InvokeAsync(new(item, true));
-                }
+                await HierarchyVisibilityToggled.InvokeAsync(new(item, true));
             }
             await InvokeAsync(StateHasChanged);
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1386,7 +1386,7 @@ namespace MudBlazor
                 var first = _openHierarchies.First();
                 foreach (var item in _openHierarchies.Skip(1))
                 {
-                    await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = false });
+                    await HierarchyVisibilityToggled.InvokeAsync(new(item, false));
                 }
                 _openHierarchies.Clear();
                 _openHierarchies.Add(first);
@@ -2379,7 +2379,7 @@ namespace MudBlazor
             {
                 if (!_buttonDisabledFunc(item) && _openHierarchies.Add(item))
                 {
-                    await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = true });
+                    await HierarchyVisibilityToggled.InvokeAsync(new(item, true));
                 }
             }
             await InvokeAsync(StateHasChanged);
@@ -2392,7 +2392,7 @@ namespace MudBlazor
         {
             foreach (var openedHierarchy in _openHierarchies.Where(x => !_buttonDisabledFunc(x)).ToList())
             {
-                await HierarchyVisibilityToggled.InvokeAsync(new() { Item = openedHierarchy, Expanded = false });
+                await HierarchyVisibilityToggled.InvokeAsync(new(openedHierarchy, false));
                 _openHierarchies.Remove(openedHierarchy);
             }
             await InvokeAsync(StateHasChanged);
@@ -2409,7 +2409,7 @@ namespace MudBlazor
             {
                 foreach (var openedHierarchy in _openHierarchies.Where(x => !x.Equals(item)))
                 {
-                    await HierarchyVisibilityToggled.InvokeAsync(new() { Item = openedHierarchy, Expanded = false });
+                    await HierarchyVisibilityToggled.InvokeAsync(new(openedHierarchy, false));
                 }
                 _openHierarchies.Clear();
             }
@@ -2418,11 +2418,11 @@ namespace MudBlazor
             if (!_openHierarchies.Remove(item))
             {
                 _openHierarchies.Add(item);
-                await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = true });
+                await HierarchyVisibilityToggled.InvokeAsync(new(item, true));
             }
             else
             {
-                await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = false });
+                await HierarchyVisibilityToggled.InvokeAsync(new(item, false));
             }
 
             await InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -335,6 +335,12 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<FormFieldChangedEventArgs> FormFieldChanged { get; set; }
 
+        /// <summary>
+        /// Occurs when hierarchy visibility toggled.
+        /// </summary>
+        [Parameter]
+        public EventCallback<DataGridHierarchyVisibilityToggledEventArgs<T>> HierarchyVisibilityToggled { get; set; }
+
         #endregion
 
         #region Parameters
@@ -1378,6 +1384,10 @@ namespace MudBlazor
             if (_openHierarchies.Count > 0)
             {
                 var first = _openHierarchies.First();
+                foreach (var item in _openHierarchies.Skip(1))
+                {
+                    await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = false });
+                }
                 _openHierarchies.Clear();
                 _openHierarchies.Add(first);
                 await InvokeAsync(StateHasChanged);
@@ -2365,8 +2375,13 @@ namespace MudBlazor
         /// </summary>
         public async Task ExpandAllHierarchy()
         {
-            _openHierarchies.Clear();
-            _openHierarchies.UnionWith(FilteredItems.Where(x => !_buttonDisabledFunc(x)));
+            foreach (var item in FilteredItems)
+            {
+                if (!_buttonDisabledFunc(item) && _openHierarchies.Add(item))
+                {
+                    await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = true });
+                }
+            }
             await InvokeAsync(StateHasChanged);
         }
 
@@ -2375,7 +2390,11 @@ namespace MudBlazor
         /// </summary>
         public async Task CollapseAllHierarchy()
         {
-            _openHierarchies.RemoveWhere(x => !_buttonDisabledFunc(x));
+            foreach (var openedHierarchy in _openHierarchies.Where(x => !_buttonDisabledFunc(x)).ToList())
+            {
+                await HierarchyVisibilityToggled.InvokeAsync(new() { Item = openedHierarchy, Expanded = false });
+                _openHierarchies.Remove(openedHierarchy);
+            }
             await InvokeAsync(StateHasChanged);
         }
 
@@ -2388,6 +2407,10 @@ namespace MudBlazor
             // if ExpandSingleRow is true, clear all open hierarchies, which will immediately add the item that was clicked.
             if (_expandSingleRowState.Value)
             {
+                foreach (var openedHierarchy in _openHierarchies.Where(x => !x.Equals(item)))
+                {
+                    await HierarchyVisibilityToggled.InvokeAsync(new() { Item = openedHierarchy, Expanded = false });
+                }
                 _openHierarchies.Clear();
             }
 
@@ -2395,6 +2418,11 @@ namespace MudBlazor
             if (!_openHierarchies.Remove(item))
             {
                 _openHierarchies.Add(item);
+                await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = true });
+            }
+            else
+            {
+                await HierarchyVisibilityToggled.InvokeAsync(new() { Item = item, Expanded = false });
             }
 
             await InvokeAsync(StateHasChanged);


### PR DESCRIPTION
Add `HierarchyVisibilityToggled` parameter on MudDataGrid component, that allows user to perform custom actions when row is expanded/collapsed. The parameter is triggered when grid row is expanded or collapsed.

**Checklist:**
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
