### PR TITLE
MudBaseInput: Fix expired ParameterView in inherited components

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -675,10 +675,10 @@ namespace MudBlazor
         /// <inheritdoc />
         public override async Task SetParametersAsync(ParameterView parameters)
         {
-            await base.SetParametersAsync(parameters);
-
             var hasText = parameters.Contains<string>(nameof(Text));
             var hasValue = parameters.Contains<T>(nameof(Value));
+
+            await base.SetParametersAsync(parameters);
 
             // Refresh Value from Text
             if (hasText && !hasValue)


### PR DESCRIPTION
Resolve #11605 by saving state of the `parameterView` before awaiting base `SetParametersAsync`. I'm 90% sure that it shouldn't brake anything, because I assume that `parameterView` is readonly, so it doesn't matter when we're saving the state of parameters. But correct me if I wrong.

**Checklist:**

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the style of this project.
- [ ] I've added relevant tests or tested on existing ones.
