### PR TITLE
MudTable: Add LoadingContentBody render fragment

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateBodyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateBodyExample.razor
@@ -4,7 +4,9 @@
 @namespace MudBlazor.Docs.Examples
 @inject HttpClient httpClient
 
-<MudTable ServerData="ServerReload" Dense="true" Hover="true">
+<MudTable ServerData="ServerReload" Dense="true" Hover="true"
+    LoadingContent="@(useLoadingContentBody ? null : loadingContent)"
+    LoadingContentBody="@(useLoadingContentBody ? loadingContentBody : null)">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Periodic Elements</MudText>
     </ToolBarContent>
@@ -25,7 +27,17 @@
     <NoRecordsContent>
         <MudText>No records found</MudText>
     </NoRecordsContent>
-    <LoadingContentBody>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+<MudSwitch @bind-Value="@useLoadingContentBody">Use Loading Content Body</MudSwitch>
+
+@code {
+    private bool useLoadingContentBody = true;
+
+    private readonly RenderFragment loadingContent = @<MudSkeleton/>;
+    private readonly RenderFragment loadingContentBody = @<text>
         @for (int r = 0; r < 4; r++) // 4 fake rows
         {
             <MudTr>
@@ -35,13 +47,8 @@
                 }
             </MudTr>
         }
-    </LoadingContentBody>
-    <PagerContent>
-        <MudTablePager />
-    </PagerContent>
-</MudTable>
+    </text>;
 
-@code {
     /// <summary>
     /// Here we simulate a perpetual loading for the purpose of the example.
     /// </summary>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateBodyExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableServerSidePaginateBodyExample.razor
@@ -1,0 +1,58 @@
+﻿@using System.Net.Http.Json
+@using MudBlazor.Examples.Data.Models
+@using System.Threading
+@namespace MudBlazor.Docs.Examples
+@inject HttpClient httpClient
+
+<MudTable ServerData="ServerReload" Dense="true" Hover="true">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Periodic Elements</MudText>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortLabel="nr_field" T="Element">Nr</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="sign_field" T="Element">Sign</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="name_field" T="Element">Name</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="position_field" T="Element">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortLabel="mass_field" T="Element">Molar mass</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        <MudText>No records found</MudText>
+    </NoRecordsContent>
+    <LoadingContentBody>
+        @for (int r = 0; r < 4; r++) // 4 fake rows
+        {
+            <MudTr>
+                @for (int c = 0; c < 5; c++) // 5 columns as above
+                {
+                    <MudTd><MudSkeleton/></MudTd>
+                }
+            </MudTr>
+        }
+    </LoadingContentBody>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+@code {
+    /// <summary>
+    /// Here we simulate a perpetual loading for the purpose of the example.
+    /// </summary>
+    private async Task<TableData<Element>> ServerReload(TableState state, CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            await Task.Delay(1000, token);
+        }
+        return new TableData<Element>() { TotalItems = 0, Items = Enumerable.Empty<Element>() };
+    }
+}
+
+

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -188,11 +188,11 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Loading Content Body">
+            <SectionHeader Title="Loading Content">
                 <Description>
                     Use <CodeInline>LoadingContent</CodeInline> to define what is shown when data is loading and no rows are currently available.
                     This renders inside a single table row with one spanning cell, which makes it simple for messages or placeholders but not suitable for simulating multiple rows or columns.
-                    <br />
+                    <br><br>
                     For more complex layouts, use <CodeInline>LoadingContentBody</CodeInline>.
                     This renders directly in the table body and gives you full control to create rows and columns (e.g., with <CodeInline>MudTr</CodeInline> and <CodeInline>MudTd</CodeInline>), without affecting the loading animation itself.
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -188,6 +188,19 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Loading Content Body">
+                <Description>
+                    Use the <CodeInline>LoadingContent</CodeInline> to determine the displayed value when data is loading and there are no previous rows loaded.
+                    Previous examples of server usage used this property. This property displays content as a single cell in a table, so it doesn't support emulating multiple columns or rows.
+                    Use instead <CodeInline>LoadingContentBody</CodeInline> to display arbitrary table content, as it allows to write rows and columns.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(TableServerSidePaginateBodyExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TableServerSidePaginateBodyExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Record Type Support">
                 <Description>
                     By default, mutable <CodeInline>record</CodeInline> types do not work with multi-selection or editing. This is due to the way record equality works. To support multi-selection or editing of records in a <CodeInline>MudTable</CodeInline>,

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -190,9 +190,11 @@
         <DocsPageSection>
             <SectionHeader Title="Loading Content Body">
                 <Description>
-                    Use the <CodeInline>LoadingContent</CodeInline> to determine the displayed value when data is loading and there are no previous rows loaded.
-                    Previous examples of server usage used this property. This property displays content as a single cell in a table, so it doesn't support emulating multiple columns or rows.
-                    Use instead <CodeInline>LoadingContentBody</CodeInline> to display arbitrary table content, as it allows to write rows and columns.
+                    Use <CodeInline>LoadingContent</CodeInline> to define what is shown when data is loading and no rows are currently available.
+                    This renders inside a single table row with one spanning cell, which makes it simple for messages or placeholders but not suitable for simulating multiple rows or columns.
+                    <br />
+                    For more complex layouts, use <CodeInline>LoadingContentBody</CodeInline>.
+                    This renders directly in the table body and gives you full control to create rows and columns (e.g., with <CodeInline>MudTr</CodeInline> and <CodeInline>MudTd</CodeInline>), without affecting the loading animation itself.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableServerSidePaginateBodyExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingBodyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingBodyTest.razor
@@ -1,0 +1,85 @@
+﻿<MudTable Items="@_elements" Hover="true" Breakpoint="Breakpoint.Sm"
+          Loading="@_isLoading" Filter="new Func<Element, bool>(FilterFunc)" Striped>
+    <ToolBarContent>
+        <MudTextField id="searchString" @bind-Value="_searchString" Placeholder="Search"></MudTextField>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>Nr</MudTh>
+        <MudTh>Sign</MudTh>
+        <MudTh>Name</MudTh>
+        <MudTh>Position</MudTh>
+        <MudTh>Molar mass</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Nr">@context.Number</MudTd>
+        <MudTd DataLabel="Sign">@context.Sign</MudTd>
+        <MudTd DataLabel="Name">@context.Name</MudTd>
+        <MudTd DataLabel="Position">@context.Position</MudTd>
+        <MudTd DataLabel="Molar mass">@context.Molar</MudTd>
+    </RowTemplate>
+    <NoRecordsContent>No matching records found</NoRecordsContent>
+    <LoadingContentBody>
+        @for (int r = 0; r < 4; r++) // 4 fake rows
+        {
+            <MudTr>
+                @for (int c = 0; c < 5; c++) // 5 columns as above
+                {
+                    <MudTd><MudSkeleton /></MudTd>
+                }
+            </MudTr>
+        }
+    </LoadingContentBody>
+</MudTable>
+
+<MudSwitch id="switch" @bind-Value="_isLoading">Show Loading</MudSwitch>
+
+ @code {
+    public static string __description__ = @"
+                                                   When loading is set to true, a progress bar should appear in the table header,
+                                                   which would not affect the striped table.
+                                                   Dynamically added columns should not affect number of cells in the loader row.
+                                           ";
+
+    private bool _isLoading;
+    private string? _searchString;
+    private IEnumerable<Element> _elements = new List<Element>();
+
+    protected override void OnInitialized()
+    {
+        _elements = new List<Element>
+        {
+            new() { Molar = "A", Sign = "A", Name = "A", Number = "A", Position = "A"},
+            new() { Molar = "B", Sign = "B", Name = "B", Number = "B", Position = "B"},
+        };
+    }
+
+    private bool FilterFunc(Element element)
+    {
+        if (string.IsNullOrWhiteSpace(_searchString))
+            return true;
+        if (element.Number.Contains(_searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Sign.Contains(_searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Name.Contains(_searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Position.Contains(_searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (element.Molar.Contains(_searchString, StringComparison.OrdinalIgnoreCase))
+            return true;
+        return false;
+    }
+
+    public class Element
+    {
+        public required string Number { get; set; }
+
+        public required string Sign { get; set; }
+
+        public required string Name { get; set; }
+
+        public required string Position { get; set; }
+
+        public required string Molar { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingBodyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableLoadingBodyTest.razor
@@ -1,7 +1,7 @@
 ﻿<MudTable Items="@_elements" Hover="true" Breakpoint="Breakpoint.Sm"
           Loading="@_isLoading" Filter="new Func<Element, bool>(FilterFunc)" Striped>
     <ToolBarContent>
-        <MudTextField id="searchString" @bind-Value="_searchString" Placeholder="Search"></MudTextField>
+        <MudTextField id="searchString" @bind-Value="_searchString" Placeholder="Search" Immediate="true"></MudTextField>
     </ToolBarContent>
     <HeaderContent>
         <MudTh>Nr</MudTh>
@@ -40,8 +40,8 @@
                                                    Dynamically added columns should not affect number of cells in the loader row.
                                            ";
 
-    private bool _isLoading;
-    private string? _searchString;
+    private bool _isLoading = true;
+    private string? _searchString = "ABC";
     private IEnumerable<Element> _elements = new List<Element>();
 
     protected override void OnInitialized()

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Check if if empty row text is correct
+        /// Check if if empty row text is correct when using LoadingContent
         /// </summary>
         [Test]
         public void TableHeadContentTest()
@@ -279,6 +279,37 @@ namespace MudBlazor.UnitTests.Components
             switchElement.Change(true);
             comp.FindAll("tr").Count.Should().Be(3);
             comp.FindAll("tr")[2].TextContent.Should().Be("Loading...");
+        }
+
+        /// <summary>
+        /// Check if if empty row text is correct when using LoadingContentBody
+        /// </summary>
+        [Test]
+        public void TableHeadContentBodyTest()
+        {
+            var comp = Context.RenderComponent<TableLoadingBodyTest>();
+            var searchString = comp.Find("#searchString");
+            var switchElement = comp.Find("#switch");
+
+            // It should be equal to 3 = two rows + header row
+            comp.FindAll("tr").Count.Should().Be(3);
+
+            // There should be no skeletons.
+            comp.FindAll(".mud-skeleton").Count.Should().Be(0);
+
+            // Filter out all table rows
+            searchString.Change("ZZZ");
+
+            // It should be equal to 2 = two rows + header row
+            comp.FindAll("tr").Count.Should().Be(2);
+            comp.FindAll("tr")[1].TextContent.Should().Be("No matching records found");
+
+            // It should be equal to 6 = 4 loading rows + header row + loading row
+            switchElement.Change(true);
+            comp.FindAll("tr").Count.Should().Be(6);
+
+            // It should be equal to 20 = 4 rows * 5 colmns
+            comp.FindAll(".mud-skeleton").Count.Should().Be(20);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -291,6 +291,9 @@ namespace MudBlazor.UnitTests.Components
             var searchString = comp.Find("#searchString");
             var switchElement = comp.Find("#switch");
 
+            searchString.Input(null);
+            switchElement.Change(false);
+
             // It should be equal to 3 = two rows + header row
             comp.FindAll("tr").Count.Should().Be(3);
 
@@ -298,7 +301,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-skeleton").Count.Should().Be(0);
 
             // Filter out all table rows
-            searchString.Change("ZZZ");
+            searchString.Input("ZZZ");
 
             // It should be equal to 2 = two rows + header row
             comp.FindAll("tr").Count.Should().Be(2);

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Check if if empty row text is correct when using LoadingContent
+        /// Check if empty row text is correct when using LoadingContent
         /// </summary>
         [Test]
         public void TableHeadContentTest()
@@ -282,7 +282,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Check if if empty row text is correct when using LoadingContentBody
+        /// Check if empty row text is correct when using LoadingContentBody
         /// </summary>
         [Test]
         public void TableHeadContentBodyTest()

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -60,7 +60,7 @@
                         @if (Loading)
                         {
                             <tr class="mud-table-row">
-                                <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent is not null ? "mud-table-loading" : "")">
+                                <th colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
                                     <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                                 </th>
                             </tr>
@@ -71,7 +71,7 @@
                 {
                     <thead class="@HeadClassname">
                         <tr class="mud-table-row">
-                            <th colspan="1000" class="@(CurrentPageItems.Any() || LoadingContent is not null ? "mud-table-loading" : "")">
+                            <th colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
                                 <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                             </th>
                         </tr>
@@ -134,24 +134,29 @@
                             </MudVirtualize>
                         }
                     }
-                    @if(!(CurrentPageItems is not null && CurrentPageItems.Any())
-                        && (Loading ? LoadingContent != null : NoRecordsContent != null)
-                    )
+                    @if (!(CurrentPageItems is not null && CurrentPageItems.Any()))
                     {
-                        <tr>
-                            <th colspan="1000" class="mud-table-empty-row">
-                                <div Class="my-3">
-                                    @if(Loading)
-                                    {
-                                        @LoadingContent
-                                    }
-                                    else
-                                    {
-                                        @NoRecordsContent
-                                    }
-                                </div>
-                            </th>
-                        </tr>
+                        if (Loading && LoadingContentBody != null)
+                        {
+                            @LoadingContentBody
+                        }
+                        else if (Loading ? LoadingContent != null : NoRecordsContent != null)
+                        {                            
+                            <tr>
+                                <th colspan="1000" class="mud-table-empty-row">
+                                    <div Class="my-3">
+                                        @if(Loading)
+                                        {
+                                            @LoadingContent
+                                        }
+                                        else
+                                        {
+                                            @NoRecordsContent
+                                        }
+                                    </div>
+                                </th>
+                            </tr>    
+                        }
                     }
                 </tbody>
                 @if (FooterContent != null || Columns != null)

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -139,9 +139,23 @@ namespace MudBlazor
         /// <summary>
         /// The content shown while table data is loading and the table has no rows.
         /// </summary>
+        /// <remarks>
+        /// This is what is shown when <c>Loading</c> is set to <c>true</c> and the table has no rows.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]
         public RenderFragment? LoadingContent { get; set; }
+
+        /// <summary>
+        /// The content shown while table data is loading and the table has no rows. 
+        /// </summary>
+        /// <remarks>
+        /// This is what is shown when <c>Loading</c> is set to <c>true</c> and the table has no rows, this will override 
+        /// <see cref="LoadingContent"/> if not null.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Data)]
+        public RenderFragment? LoadingContentBody { get; set; }
 
         /// <summary>
         /// Shows a horizontal scroll bar if the content exceeds the maximum width.

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -137,21 +137,29 @@ namespace MudBlazor
         public RenderFragment? NoRecordsContent { get; set; }
 
         /// <summary>
-        /// The content shown while table data is loading and the table has no rows.
+        /// The content shown while <c>Loading</c> is <c>true</c> and the table has no rows.
         /// </summary>
         /// <remarks>
-        /// This is what is shown when <c>Loading</c> is set to <c>true</c> and the table has no rows.
+        /// Rendered as a single table row containing one cell that spans the table width.
+        /// Use this for simple messages or placeholders (for example "Loading…").<br/>
+        /// This content is displayed in addition to the table's loading animation.<br/>
+        /// For multi-row or multi-column loading layouts, use <see cref="LoadingContentBody"/> instead.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]
         public RenderFragment? LoadingContent { get; set; }
 
         /// <summary>
-        /// The content shown while table data is loading and the table has no rows. 
+        /// The content shown while <c>Loading</c> is <c>true</c> and the table has no rows.
         /// </summary>
         /// <remarks>
-        /// This is what is shown when <c>Loading</c> is set to <c>true</c> and the table has no rows, this will override 
-        /// <see cref="LoadingContent"/> if not null.
+        /// Rendered directly into the table body at the top.
+        /// You must supply valid table row/cell markup (for example <c>&lt;MudTr&gt;</c> and <c>&lt;MudTd&gt;</c>).
+        /// If you place plain text or non-table markup here most browsers will ignore it.
+        /// Use this when you need to produce arbitrary rows and columns while the table is loading.<br/>
+        /// This content is displayed in addition to the table's loading animation.<br/>
+        /// For a single row column loading layout or text, use <see cref="LoadingContent"/> instead.<br/>
+        /// This value is optional, and will override <see cref="LoadingContent"/> if not <c>null</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -297,7 +297,7 @@ namespace MudBlazor
         /// Displays a loading animation while <c>ServerData</c> executes.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  Becomes <c>true</c> before <c>ServerData</c> is called, then becomes <c>false</c>.  When <c>true</c>, either a <see cref="MudProgressLinear"/> is displayed or custom content if <c>LoadingContent</c> or <c>LoadingContextBody</c> is set.
+        /// Defaults to <c>false</c>.  Becomes <c>true</c> before <c>ServerData</c> is called, then becomes <c>false</c>.  When <c>true</c>, either a <see cref="MudProgressLinear"/> is displayed or custom content if <c>LoadingContent</c> or <c>LoadingContentBody</c> is set.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]
@@ -307,7 +307,7 @@ namespace MudBlazor
         /// The color of the <see cref="MudProgressLinear"/> while <see cref="Loading"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Info"/>.  Has no effect if <c>LoadingContent</c> or <c>LoadingcontentBody</c> is set.
+        /// Defaults to <see cref="Color.Info"/>.  Has no effect if <c>LoadingContent</c> or <c>LoadingContentBody</c> is set.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -297,7 +297,7 @@ namespace MudBlazor
         /// Displays a loading animation while <c>ServerData</c> executes.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  Becomes <c>true</c> before <c>ServerData</c> is called, then becomes <c>false</c>.  When <c>true</c>, either a <see cref="MudProgressLinear"/> is displayed or custom content if <c>LoadingContent</c> is set.
+        /// Defaults to <c>false</c>.  Becomes <c>true</c> before <c>ServerData</c> is called, then becomes <c>false</c>.  When <c>true</c>, either a <see cref="MudProgressLinear"/> is displayed or custom content if <c>LoadingContent</c> or <c>LoadingContextBody</c> is set.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]
@@ -307,7 +307,7 @@ namespace MudBlazor
         /// The color of the <see cref="MudProgressLinear"/> while <see cref="Loading"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Info"/>.  Has no effect if <c>LoadingContent</c> is set.
+        /// Defaults to <see cref="Color.Info"/>.  Has no effect if <c>LoadingContent</c> or <c>LoadingcontentBody</c> is set.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Data)]


### PR DESCRIPTION
# Description
Resolves [11664](https://github.com/MudBlazor/MudBlazor/issues/11664).

Currently, `MudTable` only supports displaying as a loading content a single cell.
This PR add support to display an arbitrary number of rows and columns as a loading content using the new property `LoadingContentBody`.

I additionally improved the documentation of `LoadingContent` with a remark.

# How Has This Been Tested?
I implemented an additional unit case in `TableTests.cs`, not sure if I should add more.

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# API Change
```diff
public partial class MudTable
{
+        /// <summary>
+        /// The content shown while table data is loading and the table has no rows. 
+        /// </summary>
+        /// <remarks>
+        /// This is what is shown when <c>Loading</c> is set to <c>true</c> and the table has no rows, this will override 
+        /// <see cref="LoadingContent"/> if not null.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Data)]
+        public RenderFragment? LoadingContentBody { get; set; }
}
```

Before:

![Before](https://github.com/user-attachments/assets/b2c4d889-e324-4709-a743-c505f371e79f)

After:

![After](https://github.com/user-attachments/assets/29c1f491-7a48-4ef3-8db8-91bf8c7f20e8)


<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

**Checklist:**
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the style of this project.
- [x] I've added relevant tests or tested on existing ones.