### PR TITLE
Charts: Add LabelFontSize to AxisChartOptions

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
@@ -30,6 +30,9 @@
         </MudStack>
     </MudItem>
     <MudItem md="6" xs="12">
+        <MudTextField @bind-Value="_axisChartOptions.LabelFontSize" Label="Label Font Size"></MudTextField>
+    </MudItem>
+    <MudItem md="6" xs="12">
         <MudStack>
             <MudText Typo="Typo.body1">Legend Position</MudText>
             <MudRadioGroup T="Position" @bind-Value="_legendPosition">

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -632,5 +632,29 @@ namespace MudBlazor.UnitTests.Components
                               .Add(p => p.InputData, isRadial ? data : null));
 
         }
+
+        [TestCase(ChartType.Line)]
+        [TestCase(ChartType.Bar)]
+        [TestCase(ChartType.StackedBar)]
+        [Test]
+        public void AxisChartOptions_LabelFontSize_ShouldApplyCorrectly(ChartType chartType)
+        {
+            var options = new AxisChartOptions { LabelFontSize = "9px" };
+            options.LabelFontSize.Should().Be("9px");
+
+            var series = new List<ChartSeries>()
+            {
+                new() { Name = "Series 1", Data = [90, 79, 72, 69, 62, 62, 55, 65, 70] },
+                new() { Name = "Series 2", Data = [10, 41, 35, 51, 49, 62, 69, 91, 148] },
+            };
+
+            double[] data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
+
+            var comp = Context.RenderComponent<MudChart>(parameters => parameters
+                              .Add(p => p.ChartType, chartType)
+                              .Add(p => p.ChartOptions, new ChartOptions { InterpolationOption = InterpolationOption.Periodic })
+                              .Add(p => p.ChartSeries, series)
+                              .Add(p => p.InputData, null));
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor
@@ -28,7 +28,7 @@
     <g @ref="_yAxisGroupElementReference" class="mud-charts-yaxis">
         @foreach (var horizontalLineValue in _horizontalValues)
         {
-            @((MarkupString)$"<text x='{horizontalLineValue.X.ToString(CultureInfo.InvariantCulture)}' y='{horizontalLineValue.Y.ToString(CultureInfo.InvariantCulture)}' font-size='12px' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{horizontalLineValue.X.ToString(CultureInfo.InvariantCulture)}' y='{horizontalLineValue.Y.ToString(CultureInfo.InvariantCulture)}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g @ref="_xAxisGroupElementReference" class="mud-charts-xaxis">
@@ -38,7 +38,7 @@
             var x = verticalLineValue.X.ToString(CultureInfo.InvariantCulture);
             var y = verticalLineValue.Y.ToString(CultureInfo.InvariantCulture);
             var rotation = (-AxisChartOptions.XAxisLabelRotation).ToString(CultureInfo.InvariantCulture);
-            @((MarkupString)$"<text x='{x}' y='{y}' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{x}' y='{y}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g class="mud-charts-bar-series">

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor
@@ -34,7 +34,7 @@
     <g @ref="_yAxisGroupElementReference" class="mud-charts-yaxis">
         @foreach (var horizontalLineValue in _horizontalValues)
         {
-            @((MarkupString)$"<text x='{horizontalLineValue.X.ToString(CultureInfo.InvariantCulture)}' y='{horizontalLineValue.Y.ToString(CultureInfo.InvariantCulture)}' font-size='12px' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{horizontalLineValue.X.ToString(CultureInfo.InvariantCulture)}' y='{horizontalLineValue.Y.ToString(CultureInfo.InvariantCulture)}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g @ref="_xAxisGroupElementReference" class="mud-charts-xaxis">
@@ -44,7 +44,7 @@
             var x = verticalLineValue.X.ToString(CultureInfo.InvariantCulture);
             var y = verticalLineValue.Y.ToString(CultureInfo.InvariantCulture);
             var rotation = (-AxisChartOptions.XAxisLabelRotation).ToString(CultureInfo.InvariantCulture);
-            @((MarkupString)$"<text x='{x}' y='{y}' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{x}' y='{y}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g class="mud-charts-line-series">

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
@@ -28,7 +28,7 @@
     <g @ref="_yAxisGroupElementReference" class="mud-charts-yaxis">
         @foreach (var horizontalLineValue in _horizontalValues)
         {
-            @((MarkupString)$"<text x='{ToS(horizontalLineValue.X)}' y='{ToS(horizontalLineValue.Y)}' font-size='12px' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{ToS(horizontalLineValue.X)}' y='{ToS(horizontalLineValue.Y)}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g @ref="_xAxisGroupElementReference" class="mud-charts-xaxis">
@@ -38,7 +38,7 @@
             var x = ToS(verticalLineValue.X);
             var y = ToS(verticalLineValue.Y);
             var rotation = ToS(-AxisChartOptions.XAxisLabelRotation);
-            @((MarkupString)$"<text x='{x}' y='{y}' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{x}' y='{y}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g class="mud-charts-bar-series">

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor
@@ -33,7 +33,7 @@
     <g @ref="_yAxisGroupElementReference" class="mud-charts-yaxis">
         @foreach (var horizontalLineValue in _horizontalValues)
         {
-            @((MarkupString)$"<text x='{horizontalLineValue.X.ToString(CultureInfo.InvariantCulture)}' y='{horizontalLineValue.Y.ToString(CultureInfo.InvariantCulture)}' font-size='12px' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{horizontalLineValue.X.ToString(CultureInfo.InvariantCulture)}' y='{horizontalLineValue.Y.ToString(CultureInfo.InvariantCulture)}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='end' dominant-baseline='auto'>{horizontalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
         @if (YAxisTitle is not null)
         {
@@ -49,7 +49,7 @@
             var x = verticalLineValue.X.ToString(CultureInfo.InvariantCulture);
             var y = verticalLineValue.Y.ToString(CultureInfo.InvariantCulture);
             var rotation = (-AxisChartOptions.XAxisLabelRotation).ToString(CultureInfo.InvariantCulture);
-            @((MarkupString)$"<text x='{x}' y='{y}' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
+            @((MarkupString)$"<text x='{x}' y='{y}' font-size='{AxisChartOptions.LabelFontSize}' text-anchor='middle' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value?.ToString(CultureInfo.InvariantCulture)}</text>")
         }
     </g>
     <g class="mud-charts-line-series">

--- a/src/MudBlazor/Components/Chart/Models/AxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/AxisChartOptions.cs
@@ -26,6 +26,11 @@ public class AxisChartOptions
     public int LabelExtraHeight { get; set; }
 
     /// <summary>
+    /// Font size of labels. Defaults to '12px'.
+    /// </summary>
+    public string LabelFontSize { get; set; } = "12px";
+
+    /// <summary>
     /// The ratio of the width of the bars to the space between them.
     /// </summary>
     public double StackedBarWidthRatio { get; set; } = 0.5;


### PR DESCRIPTION
…aults to '12px'.

In all chart types, the font size of axis labels has been programmatically fixed to '12px'. In many use cases this is too big.

I introduced a new property `string LabelFontSize` to the AxisChartOptions class which is preset to `12px`. The property value is used in all chart types. Existing code will behave unchanged.

No additional test was added, but the behaviour is shown in `Docs/Components/Charts/Stacked Bar Chart`.

This is my first PR for MudBlazor. I hope it is acceptable, since I'm very fond of the project. I use it in a volunteer species conservation project (https://biomap.itools.de).

Cheers Franz