### PR TITLE
MudTextField: Fix Focus by ElementReference

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -788,13 +788,5 @@ namespace MudBlazor
 
             await _inputIdState.SetValueAsync(_componentId);
         }
-
-        protected async Task HandleContainerClick()
-        {
-            if (!_isFocused && IsJSRuntimeAvailable)
-            {
-                await JsRuntime.InvokeVoidAsync("mudInput.focusInput", InputElementId);
-            }
-        }
     }
 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -18,7 +18,7 @@
                      Margin="@Margin"
                      Required="@Required"
                      ForId="@InputElementId"
-                     @onclick="HandleContainerClick">
+                     @onclick="@HandleContainerClick">
         <InputContent>
             <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
                 @if (_mask == null)

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -232,5 +232,13 @@ namespace MudBlazor
             0 => (string.IsNullOrEmpty(Text) ? "0" : $"{Text.Length}"),
             _ => (string.IsNullOrEmpty(Text) ? "0" : $"{Text.Length}") + $" / {Counter}"
         };
+
+        protected async Task HandleContainerClick(MouseEventArgs args)
+        {
+            if (!_isFocused && IsJSRuntimeAvailable && InputReference != null)
+            {
+                await InputReference.FocusAsync();
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -233,7 +233,7 @@ namespace MudBlazor
             _ => (string.IsNullOrEmpty(Text) ? "0" : $"{Text.Length}") + $" / {Counter}"
         };
 
-        protected async Task HandleContainerClick(MouseEventArgs _)
+        protected async Task HandleContainerClick()
         {
             if (!_isFocused && IsJSRuntimeAvailable && InputReference != null)
             {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -233,7 +233,7 @@ namespace MudBlazor
             _ => (string.IsNullOrEmpty(Text) ? "0" : $"{Text.Length}") + $" / {Counter}"
         };
 
-        protected async Task HandleContainerClick(MouseEventArgs args)
+        protected async Task HandleContainerClick(MouseEventArgs _)
         {
             if (!_isFocused && IsJSRuntimeAvailable && InputReference != null)
             {

--- a/src/MudBlazor/TScripts/mudInput.js
+++ b/src/MudBlazor/TScripts/mudInput.js
@@ -9,14 +9,6 @@ class MudInput {
             input.value = '';
         }
     }
-
-    focusInput(elementId) {
-        const input = document.getElementById(elementId);
-        if (input && document.activeElement !== input) {
-            input.focus();
-            input.click();
-        }
-    }
 }
 
 window.mudInput = new MudInput();


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #11690 and #11698 
Removed `HandleContainerClick` method calling JavaScript focusInput with InputElementId from `MudBaseInput.cs`.
Deleted `focusInput` function from javascript to streamline focus handling.
Replaced `HandleContainerClick` method in `MudTextField.razor.cs` to manage focus using the built in textarea/input override of ElementReference.FocusAsync() requiring no external javascript.


**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
