### PR TITLE
MudPopover: MudList MaxHeight Adjustments

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverListMaxHeightTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverListMaxHeightTest.razor
@@ -3,7 +3,7 @@
 
 <MudLayout>
     <MudAppBar Dense Elevation="1">
-        <MudIconButton id="NI_NaviagtionMenu_ID" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />        
+        <MudIconButton id="NI_NavigationMenu_ID" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />        
         <MudText Typo="Typo.h5" Class="ml-3">Demo</MudText>
         <MudSpacer />
         <MudMenu Variant="Variant.Outlined" Icon="@Icons.Material.Filled.MoreVert" Color="Color.Secondary" 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverListMaxHeightTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverListMaxHeightTest.razor
@@ -1,0 +1,38 @@
+﻿
+<MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/11730" Target="_blank">MudBlazor/Issues/11730</MudLink>
+
+<MudLayout>
+    <MudAppBar Dense Elevation="1">
+        <MudIconButton id="NI_NaviagtionMenu_ID" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />        
+        <MudText Typo="Typo.h5" Class="ml-3">Demo</MudText>
+        <MudSpacer />
+        <MudMenu Variant="Variant.Outlined" Icon="@Icons.Material.Filled.MoreVert" Color="Color.Secondary" 
+            AnchorOrigin="Origin.TopLeft" TransformOrigin="Origin.TopLeft" Dense Class="mt-1 ml-4">
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                One
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                Two
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                Three
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                Four
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                Five
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                Six
+            </MudMenuItem>
+            <MudMenuItem Icon="@Icons.Material.Filled.ModeEditOutline">
+                Seven
+            </MudMenuItem>
+        </MudMenu>
+    </MudAppBar>
+</MudLayout>
+
+@code {
+    public static string __description__ = "Test Popover Lists Max Height Functionality";
+}

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -320,7 +320,10 @@ window.mudpopoverHelper = {
                 // Adjust .mud-list children if they would run off screen even after flipping
                 const firstChild = popoverContentNode.firstElementChild;
                 // Check if firstChild exists, has a classList, and is a mud-list
-                const isList = firstChild?.classList?.contains("mud-list");
+                const isList =
+                    firstChild &&
+                    firstChild.classList &&
+                    firstChild.classList.contains("mud-list");
                 // we do it here to ensure it flips properly if more space becomes available on the other side.
                 if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
                     popoverContentNode.style.maxHeight = null;

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -313,14 +313,24 @@ window.mudpopoverHelper = {
                 popoverContentNode.style['min-width'] = (boundingRect.width) + 'px';
             }
 
-            // Reset max-height if it was previously set and anchor is in bounds
-            if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
-                popoverContentNode.style.maxHeight = null;
-                popoverContentNode.mudHeight = null;
-            }
-
             // flipping logic
             if (isFlipOnOpen || isFlipAlways) {
+
+                // Reset max-height if it was previously set and anchor is in bounds
+                // Adjust .mud-list children if they would run off screen even after flipping
+                const firstChild = popoverContentNode.firstElementChild;
+                // Check if firstChild exists, has a classList, and is a mud-list
+                var isList = firstChild &&
+                    firstChild.classList &&
+                    firstChild.classList.contains("mud-list");
+                // we do it here to ensure it flips properly if more space becomes available on the other side.
+                if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
+                    popoverContentNode.style.maxHeight = null;
+                    if (isList) {
+                        popoverContentNode.firstElementChild.style.maxHeight = null;
+                    }
+                    popoverContentNode.mudHeight = null;
+                }
 
                 const appBarElements = document.getElementsByClassName("mud-appbar mud-appbar-fixed-top");
                 let appBarOffset = 0;
@@ -525,54 +535,55 @@ window.mudpopoverHelper = {
                     this.updatePopoverZIndex(popoverContentNode, appBarElements[0]);
                 }
 
-                const firstChild = popoverContentNode.firstElementChild;
+                // height adjustment logic for mud lists
+                if (isList) {
+                    const popoverStyle = popoverContentNode.style;
+                    const listStyle = firstChild.style;
 
-                // adjust the popover position/maxheight if it or firstChild does not have a max-height set (even if set to 'none')
-                // exceeds the bounds and doesn't have a max-height set by the user
-                // maxHeight adjustments stop the minute popoverNode is no longer inside the window
-                // Check if max-height is set on popover or firstChild
-                const hasMaxHeight = popoverContentNode.style.maxHeight != '' || (firstChild && firstChild.style.maxHeight != '');
-                const isList = firstChild && firstChild.classList && firstChild.classList.contains("mud-list");
+                    // If there is no max height set we need to check the height
+                    // we reset previously flipped at the start of flipping logic
+                    const checkHeight = true && !(
+                        (popoverStyle.maxHeight && popoverStyle.maxHeight !== '') ||
+                        (listStyle.maxHeight && listStyle.maxHeight !== '')
+                    );
 
-                if (!hasMaxHeight && isList) {
-                    // in case of a reflow check it should show from top properly
-                    let shouldShowFromTop = false;
-                    // calculate new max height if it exceeds bounds
-                    let newMaxHeight = window.innerHeight - top - offsetY - window.mudpopoverHelper.overflowPadding; // downwards
+                    if (checkHeight) {
+                        const overflowPadding = window.mudpopoverHelper.overflowPadding;
+                        const isCentered = Array.from(classList).some(cls =>
+                            cls.includes('mud-popover-anchor-center')
+                        );
 
-                    // Check if this is a flipped popover showing upward
-                    // Convert classList to an array and check if any class contains the substring
-                    const isCentered = Array.from(classList).some(className => className.includes('mud-popover-anchor-center'));
-                    const isFlippedUpward = !isCentered && ( // center anchors don't flip
-                                            popoverContentNode.getAttribute('data-mudpopover-flip') === 'top' ||
-                                            popoverContentNode.getAttribute('data-mudpopover-flip') === 'top-and-left' ||
-                                            popoverContentNode.getAttribute('data-mudpopover-flip') === 'top-and-right');
+                        const flipAttr = popoverContentNode.getAttribute('data-mudpopover-flip');
+                        const isFlippedUpward = !isCentered && (
+                            flipAttr === 'top' ||
+                            flipAttr === 'top-and-left' ||
+                            flipAttr === 'top-and-right'
+                        );
 
-                    // moving upwards
-                    if (top + offsetY < anchorY || top + offsetY == window.mudpopoverHelper.overflowPadding) {
-                        shouldShowFromTop = true;
-                        // adjust newMaxHeight if flipped upwards
+                        let availableHeight;
+                        let shouldClamp = false;
+
                         if (isFlippedUpward) {
-                            newMaxHeight = anchorY - window.mudpopoverHelper.overflowPadding - popoverNode.offsetHeight;
+                            availableHeight = anchorY - overflowPadding;
+                            shouldClamp = availableHeight < popoverContentNode.offsetHeight;
+                            if (shouldClamp) {
+                                top = overflowPadding;
+                                offsetY = 0;
+                            }
+                        } else {
+                            // Space from popover top down to bottom of screen
+                            const popoverTopEdge = top + offsetY;
+                            availableHeight = window.innerHeight - popoverTopEdge - overflowPadding;
+                            shouldClamp = popoverContentNode.offsetHeight > availableHeight;
                         }
-                        // adjust newMaxHeight if not flipped upwards
-                        else {
-                            newMaxHeight = anchorY - window.mudpopoverHelper.overflowPadding;
-                        }
-                    }
 
-                    // if calculated height exceeds the new maxheight
-                    if (popoverContentNode.offsetHeight > newMaxHeight) {
-                        if (shouldShowFromTop) { // adjust top to show from top
-                            // also adjust newMaxHeight 
-                            top = window.mudpopoverHelper.overflowPadding;                          
-                            offsetY = 0;
+                        if (shouldClamp) {
+                            const minVisibleHeight = overflowPadding * 3;
+                            const newMaxHeight = Math.max(availableHeight, minVisibleHeight);
+                            popoverContentNode.style.maxHeight = `${newMaxHeight}px`;
+                            firstChild.style.maxHeight = `${newMaxHeight}px`;
+                            popoverContentNode.mudHeight = "setmaxheight";
                         }
-                        // set newMaxHeight to be minimum of 3x overflow padding, by default 72px (or 3 items roughly)
-                        newMaxHeight = Math.max(newMaxHeight, window.mudpopoverHelper.overflowPadding * 3);
-                        popoverContentNode.style.maxHeight = (newMaxHeight) + 'px';
-                        firstChild.style.maxHeight = (newMaxHeight) + 'px';
-                        popoverContentNode.mudHeight = "setmaxheight";
                     }
                 }
             }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -320,9 +320,7 @@ window.mudpopoverHelper = {
                 // Adjust .mud-list children if they would run off screen even after flipping
                 const firstChild = popoverContentNode.firstElementChild;
                 // Check if firstChild exists, has a classList, and is a mud-list
-                var isList = firstChild &&
-                    firstChild.classList &&
-                    firstChild.classList.contains("mud-list");
+                const isList = firstChild?.classList?.contains("mud-list");
                 // we do it here to ensure it flips properly if more space becomes available on the other side.
                 if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
                     popoverContentNode.style.maxHeight = null;
@@ -542,10 +540,10 @@ window.mudpopoverHelper = {
 
                     // If there is no max height set we need to check the height
                     // we reset previously flipped at the start of flipping logic
-                    const checkHeight = true && !(
-                        (popoverStyle.maxHeight && popoverStyle.maxHeight !== '') ||
-                        (listStyle.maxHeight && listStyle.maxHeight !== '')
-                    );
+                    // a Style setting of max-height: unset; will bypass this check
+                    const isUnset = (val) =>
+                        val == null || val === '' || val === 'none';
+                    const checkHeight = isUnset(popoverStyle.maxHeight) && isUnset(listStyle.maxHeight);
 
                     if (checkHeight) {
                         const overflowPadding = window.mudpopoverHelper.overflowPadding;
@@ -564,7 +562,7 @@ window.mudpopoverHelper = {
                         let shouldClamp = false;
 
                         if (isFlippedUpward) {
-                            availableHeight = anchorY - overflowPadding;
+                            availableHeight = anchorY - overflowPadding - popoverNode.offsetHeight;
                             shouldClamp = availableHeight < popoverContentNode.offsetHeight;
                             if (shouldClamp) {
                                 top = overflowPadding;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #11730 

There is a section of code that triggers when a popover has `FlipAlways` or `FlipOnOpen` that is supposed to determine if 
1) The popover is a MudList -> Typically a MudSelect, MudMenu, or MudAutocomplete.
2) The list or popover does not already have a max height set 
3) The popover would exceed all of the available space even after it flips. (minus padding on top/bottom)

Then if it would exceed the available space it would assign a max height to both the popover and the mud list that would force a recalculation and repositioning resulting in a *best fit* scenario. 

Found and Fixed 3 bugs in the calculation and reworked it to be easier to follow.
Bug 1) I was not resetting the list maxheight if I altered it during a reflow.
Bug 2) I was doing the reset outside of flip logic. Unnecessary
Bug 3) [and the one related to attached issue] If a popover started at exactly the the top position that matches the overflow it tried to set maxheight. Previously it was getting overwritten in a reflow but a previous fix brought this edge case bug out.

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
