### PR TITLE
MudStepper: Add Skipped State (#11739)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -659,6 +659,49 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void ResetButton_ShouldTriggerResetStepActionForSkippedSteps()
+        {
+            var cancel = false;
+            var actions = new List<StepAction>();
+            var index = -1;
+            Task OnPreviewInteraction(StepperInteractionEventArgs args)
+            {
+                actions.Add(args.Action);
+                index = args.StepIndex;
+                args.Cancel = cancel;
+                return Task.CompletedTask;
+            }
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
+                self.Add(x => x.ShowResetButton, true);
+                self.Add(x => x.NonLinear, true);
+                self.AddChildContent<MudStep>(step => { step.Add(s => s.Skippable, true); });
+                self.AddChildContent<MudStep>(step => { step.Add(s => s.Skippable, true); });
+                self.AddChildContent<MudStep>(step => { step.Add(s => s.Skippable, true); });
+            });
+
+            // clicking skip sends Skip action requests to get us in a state that reset is a valid click
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+            stepper.Find(".mud-stepper-button-skip").Click();
+            index.Should().Be(0);
+            actions[0].Should().Be(StepAction.Skip);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
+            stepper.Find(".mud-stepper-button-skip").Click();
+            index.Should().Be(1);
+            actions[1].Should().Be(StepAction.Skip);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(2);
+
+            // check that clicking reset sends Reset StepAction
+            stepper.Find(".mud-stepper-button-reset").Click();
+            actions[2].Should().Be(StepAction.Reset);
+            actions[3].Should().Be(StepAction.Reset);
+            actions[4].Should().Be(StepAction.Reset);
+            actions[5].Should().Be(StepAction.Activate);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+        }
+
+        [Test]
         public void NextButton_ShouldTriggerCompleteStepAction()
         {
             var cancel = false;
@@ -689,6 +732,38 @@ namespace MudBlazor.UnitTests.Components
             action.Should().Be(StepAction.Complete);
             stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
         }
+
+        [Test]
+        public void SkipButton_ShouldTriggerSkipStepAction()
+        {
+            var cancel = false;
+            var action = StepAction.Reset;
+            var index = -1;
+            Task OnPreviewInteraction(StepperInteractionEventArgs args)
+            {
+                action = args.Action;
+                index = args.StepIndex;
+                args.Cancel = cancel;
+                return Task.CompletedTask;
+            }
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
+                self.Add(x => x.ShowResetButton, true);
+                self.Add(x => x.NonLinear, true);
+                self.AddChildContent<MudStep>(step => { step.Add(s => s.Skippable, true); });
+                self.AddChildContent<MudStep>(step => { step.Add(s => s.Skippable, true); });
+                self.AddChildContent<MudStep>(step => { step.Add(s => s.Skippable, true); });
+            });
+
+            // clicking skip sends Skipped action requests
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(0);
+            stepper.Find(".mud-stepper-button-skip").Click();
+            index.Should().Be(0);
+            action.Should().Be(StepAction.Skip);
+            stepper.Instance.GetState<int>(nameof(MudStepper.ActiveIndex)).Should().Be(1);
+        }
+
 
         [Test]
         public void BackButton_ShouldTriggerActivateStepAction()

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -27,12 +27,17 @@ public class MudStep : MudComponentBase, IAsyncDisposable
             .WithParameter(() => HasError)
             .WithEventCallback(() => HasErrorChanged)
             .WithChangeHandler(OnParameterChanged);
+        SkippedState = registerScope.RegisterParameter<bool>(nameof(Skipped))
+            .WithParameter(() => Skipped)
+            .WithEventCallback(() => SkippedChanged)
+            .WithChangeHandler(OnParameterChanged);
     }
 
     private bool _disposed;
     internal ParameterState<bool> CompletedState { get; private set; }
     internal ParameterState<bool> DisabledState { get; private set; }
     internal ParameterState<bool> HasErrorState { get; private set; }
+    internal ParameterState<bool> SkippedState { get; private set; }
 
     internal string Styles => new StyleBuilder()
         .AddStyle(Style)
@@ -47,6 +52,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
         new CssBuilder("mud-step-label-icon")
             .AddClass($"mud-{(CompletedStepColor.HasValue ? CompletedStepColor.Value.ToDescriptionString() : Parent?.CompletedStepColor.ToDescriptionString())}", CompletedState && !HasErrorState && Parent?.CompletedStepColor != Color.Default && (Parent?.ActiveStep != this || (Parent?.IsCompleted == true && Parent?.NonLinear == false)))
             .AddClass($"mud-{(ErrorStepColor.HasValue ? ErrorStepColor.Value.ToDescriptionString() : Parent?.ErrorStepColor.ToDescriptionString())}", HasErrorState)
+            .AddClass($"mud-{(SkippedStepColor.HasValue ? SkippedStepColor.Value.ToDescriptionString() : Parent?.SkippedStepColor.ToDescriptionString())}", SkippedState)
             .AddClass($"mud-{Parent?.CurrentStepColor.ToDescriptionString()}", Parent?.ActiveStep == this && !(Parent?.IsCompleted == true && Parent?.NonLinear == false))
             .Build();
 
@@ -118,14 +124,14 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     public Color? ErrorStepColor { get; set; }
 
     /// <summary>
-    /// Whether the user can skip this step.
+    /// The color used when this step is skipped.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>false</c>.
+    /// Defaults to <c>null</c>.
     /// </remarks>
     [Parameter]
-    [Category(CategoryTypes.List.Behavior)]
-    public bool Skippable { get; set; }
+    [Category(CategoryTypes.List.Appearance)]
+    public Color? SkippedStepColor { get; set; }
 
     /// <summary>
     /// Whether this step is completed.
@@ -182,6 +188,31 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     [Category(CategoryTypes.List.Behavior)]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
 
+    /// <summary>
+    /// Whether the user can skip this step.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Behavior)]
+    public bool Skippable { get; set; }
+    /// <summary>
+    /// Whether this step has been skipped.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Behavior)]
+    public bool Skipped { get; set; }
+    /// <summary>
+    /// Occurs when <see cref="Skipped"/> has changed.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.List.Behavior)]
+    public EventCallback<bool> SkippedChanged { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         base.OnInitialized();
@@ -218,6 +249,16 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     public async Task SetDisabledAsync(bool value, bool refreshParent = true)
     {
         await DisabledState.SetValueAsync(value);
+        if (refreshParent)
+            RefreshParent();
+    }
+
+    /// <summary>
+    /// Sets the <see cref="Skipped"/> parameter, and optionally refreshes the parent <see cref="MudStepper"/>.
+    /// </summary>
+    public async Task SetSkippedAsync(bool value, bool refreshParent = true)
+    {
+        await SkippedState.SetValueAsync(value);
         if (refreshParent)
             RefreshParent();
     }

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -17,6 +17,7 @@
                 .AddClass("mud-clickable", NonLinear && !step.DisabledState.Value)
                 .AddClass("mud-step-error", step.HasErrorState.Value)
                 .AddClass("mud-step-completed", step.CompletedState.Value)
+                .AddClass("mud-step-skipped", step.SkippedState.Value)
                 .Build();
 
             <button class="@stepClassname" role="tab" type="button" aria-controls="@step.Title" aria-selected="@(isActive.ToString().ToLower())"
@@ -125,6 +126,10 @@
                     @if(step.HasErrorState.Value)
                     {
                         <MudIcon Size="Size.Small" Icon="@StepErrorIcon" />
+                    }
+                    else if(step.SkippedState.Value && ShowSkip)
+                    {
+                        <MudIcon Size="Size.Small" Icon="@StepSkippedIcon" />
                     }
                     else if (step.CompletedState.Value)
                     {

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -102,6 +102,16 @@ public partial class MudStepper : MudComponentBase
     public Color ErrorStepColor { get; set; } = Color.Error;
 
     /// <summary>
+    /// The color of skipped steps.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public Color SkippedStepColor { get; set; } = Color.Default;
+
+    /// <summary>
     /// The icon shown for completed steps.
     /// </summary>
     /// <remarks>
@@ -120,6 +130,16 @@ public partial class MudStepper : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string StepErrorIcon { get; set; } = Icons.Material.Outlined.PriorityHigh;
+
+    /// <summary>
+    /// The icon shown for skipped steps.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Icons.Material.Outlined.SkipNext"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public string StepSkippedIcon { get; set; } = Icons.Material.Outlined.SkipNext;
 
     /// <summary>
     /// The icon shown for the reset button.
@@ -239,6 +259,16 @@ public partial class MudStepper : MudComponentBase
     public bool Ripple { get; set; } = true;
 
     /// <summary>
+    /// Displays if a step has been skipped in the label.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public bool ShowSkip { get; set; } = false;
+
+    /// <summary>
     /// Shows a scroll bar for steps if needed.
     /// </summary>
     /// <remarks>
@@ -284,15 +314,15 @@ public partial class MudStepper : MudComponentBase
     /// <summary>
     /// Whether all steps have been completed.
     /// </summary>
-    public bool IsCompleted => _steps.Any() && _steps.Where(x => !x.Skippable).All(x => x.CompletedState.Value);
+    public bool IsCompleted => _steps.Any() && _steps.Where(x => !x.SkippedState.Value).All(x => x.CompletedState.Value);
 
     /// <summary>
     /// Whether the <c>Complete</c> or <c>Next</c> button is displayed.
     /// </summary>
     public bool ShowCompleteInsteadOfNext => _steps.Any() &&
-                                             _steps.Count(x => !x.Skippable && !x.CompletedState.Value) == 1 &&
+                                             _steps.Count(x => !x.SkippedState.Value && !x.CompletedState.Value) == 1 &&
                                              ActiveStep != null &&
-                                             _steps.First(x => !x.Skippable && !x.CompletedState.Value) == ActiveStep;
+                                             _steps.First(x => !x.SkippedState.Value && !x.CompletedState.Value) == ActiveStep;
 
     /// <summary>
     /// The steps in this component.
@@ -426,12 +456,14 @@ public partial class MudStepper : MudComponentBase
                 }
             case StepAction.Skip:
                 {
+                    await step.SetSkippedAsync(true);
+
                     var nextStep = GetNextStep(index);
                     if (nextStep is not null)
                         index = _steps.IndexOf(nextStep);
                     await SetActiveIndexAsync(index);
+                    break;
                 }
-                break;
             case StepAction.Reset:
                 break;
             default:
@@ -549,6 +581,8 @@ public partial class MudStepper : MudComponentBase
         foreach (var step in _steps)
         {
             await step.SetCompletedAsync(false, refreshParent: false);
+            await step.SetSkippedAsync(false, refreshParent: false);
+
             if (resetErrors)
             {
                 await step.SetHasErrorAsync(false, refreshParent: false);


### PR DESCRIPTION
Fixes: #11739
This PR fixes and issue where if the last step in a stepper is skippable, or a chain of last steps are skippable. The stepper would be completed when any non skippable step was completed. This would lead to cases where the last step would not be shown or, if all steps were skippable, would complete the stepper without any step being "visited".

I went about fixing this by adding a `Skipped` state similar to `Completed`. This state is set to true when a step is skipped and for some basic functionality I added an icon and color to it. (To not conflict with the current implementation the color is set to `Color.Default`  and the Icon and be toggled on with `ShowSkip`)

![20250730-2031-48 4074930](https://github.com/user-attachments/assets/ff23f8b1-054f-49cb-96a3-c9095779d10b)
![20250730-2047-11 8544905](https://github.com/user-attachments/assets/7db3a7f3-613a-42aa-a6b5-ec868e164503)


**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the style of this project.
- [x] I've tested on existing ones, but was unsure if I should make a unit test for this.
