### PR TITLE
MudTable : Fix bug where CurrentPage is reset at the initialization

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterIntialized.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterIntialized.razor
@@ -1,0 +1,17 @@
+﻿<MudTable Items="@_items" CurrentPage="@_currentPage">
+    <HeaderContent>
+        <MudTh>Item</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Item">@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+
+@code {
+    private int _currentPage = 2;
+    private int[] _items = Enumerable.Range(0, 100).ToArray();
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -5,6 +5,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.UnitTests.TestComponents.DataGrid;
 using MudBlazor.UnitTests.TestComponents.Table;
 using NUnit.Framework;
 
@@ -2544,6 +2545,30 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-table-pagination-actions .mud-button-root")[2].Click();
             comp.WaitForAssertion(() => table.CurrentPage.Should().Be(2));
             comp.WaitForAssertion(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("3"));
+        }
+
+        /// <summary>
+        /// Table initialized to display the third page
+        /// </summary>
+        /// <remarks>
+        /// Table.CurrentPage start at 0, so 2 is the second page
+        /// https://github.com/MudBlazor/MudBlazor/issues/11727
+        /// </remarks>
+        [Test]
+        public void Table_WithCurrentPage_ShouldFirstRenderThisPage()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<TableCurrentPageParameterIntialized>();
+            var table = comp.FindComponent<MudTable<int>>().Instance;
+
+            // Assert : DataGrid is initialized with CurrentPage at 2
+
+            table.CurrentPage.Should().Be(2);
+
+            // Assert : The first item in the third page is 20
+
+            comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("20");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -681,6 +681,9 @@ namespace MudBlazor
 
 
             var currentPageHasChanged = false;
+
+            // On intialization, don't reset CurrentPage
+            // https://github.com/MudBlazor/MudBlazor/issues/11727
             if (_rowsPerPage.HasValue)
             {
                 currentPageHasChanged = _currentPage != 0;

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -679,10 +679,15 @@ namespace MudBlazor
                 return;
             }
 
-            var currentPageHasChanged = _currentPage != 0;
+
+            var currentPageHasChanged = false;
+            if (_rowsPerPage.HasValue)
+            {
+                currentPageHasChanged = _currentPage != 0;
+                _currentPage = 0;
+            }
+
             _rowsPerPage = size;
-            _currentPage = 0;
-            StateHasChanged();
             RowsPerPageChanged.InvokeAsync(_rowsPerPage.Value);
 
             if (currentPageHasChanged)
@@ -694,6 +699,8 @@ namespace MudBlazor
             {
                 InvokeServerLoadFunc();
             }
+
+            StateHasChanged();
         }
 
         protected abstract int NumPages { get; }


### PR DESCRIPTION
Fixes #11727

When `MudTable` is initialized with `CurrentPage` parameter, this parameter is reset at 0.

`MudTable` is correctly initialized with the expected `CurrentPage`, but next the inner `MudTablePager` is initialized and set `MudTable.RowsPerPage` what reset `MudTable.CurrentPage`.

---

The solution would be to rework the parameters `RowsPerPage` and `CurrentPage` to manage the new value in `OnParameterSet`, but the risk of breaking change is high. So maybe for a next major version.

The other solution (I implemented in this PR) is to not reset `MudTable.CurrentPage` when `RowsPerPage` is set for the first time.

**Checklist:**
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.