### PR TITLE
MudPopover: Maintain Scroll Position

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -328,7 +328,8 @@ window.mudpopoverHelper = {
                 if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
                     popoverContentNode.style.maxHeight = null;
                     if (isList) {
-                        popoverContentNode.firstElementChild.style.maxHeight = null;
+                        popoverContentNode.mudScrollTop = firstChild.scrollTop;
+                        firstChild.style.maxHeight = null;
                     }
                     popoverContentNode.mudHeight = null;
                 }
@@ -584,6 +585,10 @@ window.mudpopoverHelper = {
                             popoverContentNode.style.maxHeight = `${newMaxHeight}px`;
                             firstChild.style.maxHeight = `${newMaxHeight}px`;
                             popoverContentNode.mudHeight = "setmaxheight";
+                            if (popoverContentNode.mudScrollTop) {
+                                firstChild.scrollTop = popoverContentNode.mudScrollTop;
+                                popoverContentNode.mudScrollTop = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Resolves #11667 (2nd attempt)

During a flip operation there is code to handle the height of lists. In order to respect "FlipAlways" that code needs to be evaluated each time a movement happens. By resetting the heights if they were modified prior to flip checks scroll position can be lost. I added simple code to save the scroll position of the list and restore it after the height calculation. 

Before:
![flip-maxheight-badscroll](https://github.com/user-attachments/assets/b639db60-d2a2-4914-99a3-5dbed6a3b3dd)

After:
![flip-maxheight-fixedscroll](https://github.com/user-attachments/assets/e1e2efcb-d948-4b20-9bc9-34adb04de3a0)

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
