### PR TITLE
MudDataGrid: SCSS, Clean Up Sticky Columns

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyHeaderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridStickyHeaderTest.razor
@@ -1,0 +1,46 @@
+﻿
+<MudDataGrid Class="mygrid" 
+             Items="@_persons" T="Person" Loading="@_loading"
+             FilterMode="@_filterMode"
+             Filterable Dense="@_dense" FixedHeader ShowMenuIcon Height="350px">
+    <ToolBarContent>
+        <MudSwitch Class="ml-auto" @bind-Value="@_dense" Label="Dense" />
+        <MudSwitch Class="mr-auto" @bind-Value="@_loading" Label="Loading" /> 
+    </ToolBarContent>
+    <ColGroup>
+        <col style="width: 50px; background: var(--mud-palette-tertiary);" />
+        <col />
+    </ColGroup>
+    <Columns>
+        <PropertyColumn Property="x => x.Id" Title="Id" />
+        <PropertyColumn Property="x => x.Name" Title="Name" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Person" PageSizeOptions="new[] {10, 1000}" />
+    </PagerContent>
+</MudDataGrid>
+
+<div class="d-flex flex-wrap mt-4">
+    <MudRadioGroup T="DataGridFilterMode" @bind-Value="@_filterMode">
+        <MudRadio Dense="true" Value="@DataGridFilterMode.Simple" Color="Color.Primary">Simple</MudRadio>
+        <MudRadio Dense="true" Value="@DataGridFilterMode.ColumnFilterMenu" Color="Color.Tertiary">Column Menu</MudRadio>
+        <MudRadio Dense="true" Value="@DataGridFilterMode.ColumnFilterRow">Column Row</MudRadio>
+    </MudRadioGroup>
+</div>
+
+@code {
+    public static string __description__ = "Visual Representation of Sticky Headers";
+    private bool _dense = false;
+    private bool _loading = false;
+    private DataGridFilterMode _filterMode = DataGridFilterMode.ColumnFilterRow;
+    private readonly List<Person> _persons = Enumerable.Repeat(0, 100)
+                .Select((_, i) => new Person { Id = i, Name = $"Name{i}" })
+                .ToList();
+
+    public class Person
+    {
+        public required int Id { get; init; }
+
+        public required string Name { get; init; }
+    }
+}

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -123,6 +123,7 @@ namespace MudBlazor
         protected string HeadClassname =>
             new CssBuilder("mud-table-head")
                 .AddClass(HeaderClass)
+                .AddClass("mud-table-dense", Dense)
                 .Build();
 
         protected string FootClassname =>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
@@ -42,6 +40,7 @@ namespace MudBlazor
 
         protected string HeadClassname => new CssBuilder("mud-table-head")
             .AddClass(HeaderClass)
+            .AddClass("mud-table-dense", Dense)
             .Build();
 
         protected string FootClassname => new CssBuilder("mud-table-foot")

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -1,5 +1,10 @@
 @import '../abstracts/variables';
 
+$header-height: 59px;
+$header-height-dense: 39px;
+$header-height-with-filter: 109px; // 59px + 50px (filter row height)
+$header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
+
 .mud-table {
   color: var(--mud-palette-text-primary);
   background-color: var(--mud-palette-surface);
@@ -273,37 +278,39 @@
       & * .mud-table-cell:last-child {
         border-radius: 0px var(--mud-default-borderradius) 0px 0px;
       }
-      // Row 1 (always)
+      //Shared Sticky Header Styles
       .mud-table-cell, .mud-table-loading {
         background-color: var(--mud-palette-surface);
         position: sticky;
         z-index: 2;
+      }
+      // Row 1 (always)
+      .mud-table-cell {
         top: 0;
       }
-
       // Row 2 (filter or panel row)
       .filter-header-cell {
-        top: 59px;
+        top: $header-height;
       }
       // Row 2 (filter or panel row if table is dense)
       &.mud-table-dense .filter-header-cell {
-        top: 39px;
+        top: $header-height-dense;
       }
       // Row 2 (loading row without filter header)
       .mud-table-loading {
-        top: 59px;
+        top: $header-height;
       }
       // Row 2 (loading row without filter header if table is dense)
       &.mud-table-dense .mud-table-loading {
-        top: 39px;
+        top: $header-height-dense;
       }
       // Row 3 (loading row with filter header)
       &:has(.filter-header-cell) .mud-table-loading {
-        top: 109px;
+        top: $header-height-with-filter;
       }
       // Row 3 (loading row with filter header if table is dense)
       &.mud-table-dense:has(.filter-header-cell) .mud-table-loading {
-        top: 89px;
+        top: $header-height-with-filter-dense;
       }
 
       & * .mud-table-cell.sticky-left,

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -265,7 +265,6 @@
   }
 
   & * .mud-table-root {
-
     .mud-table-head {
       & * .mud-table-cell:first-child {
         border-radius: var(--mud-default-borderradius) 0px 0px 0px;
@@ -274,52 +273,43 @@
       & * .mud-table-cell:last-child {
         border-radius: 0px var(--mud-default-borderradius) 0px 0px;
       }
-
-      & * .mud-table-cell {
+      // Row 1 (always)
+      .mud-table-cell, .mud-table-loading {
         background-color: var(--mud-palette-surface);
         position: sticky;
         z-index: 2;
         top: 0;
       }
 
-      & * .mud-table-loading {
-        background-color: var(--mud-palette-surface);
-        position: sticky;
-        z-index: 2;
+      // Row 2 (filter or panel row)
+      .filter-header-cell {
         top: 59px;
       }
-
-      & * .mud-filter-panel-cell {
+      // Row 2 (filter or panel row if table is dense)
+      &.mud-table-dense .filter-header-cell {
+        top: 39px;
+      }
+      // Row 2 (loading row without filter header)
+      .mud-table-loading {
         top: 59px;
       }
-      // If .mud-table-loading exists, move .mud-filter-panel-cell down
-      table:has(.mud-table-loading) & * .mud-filter-panel-cell {
-        top: 63px;
+      // Row 2 (loading row without filter header if table is dense)
+      &.mud-table-dense .mud-table-loading {
+        top: 39px;
+      }
+      // Row 3 (loading row with filter header)
+      &:has(.filter-header-cell) .mud-table-loading {
+        top: 109px;
+      }
+      // Row 3 (loading row with filter header if table is dense)
+      &.mud-table-dense:has(.filter-header-cell) .mud-table-loading {
+        top: 89px;
       }
 
       & * .mud-table-cell.sticky-left,
       & * .mud-table-cell.sticky-right {
         z-index: 3;
         background-color: var(--mud-palette-background-gray);
-      }
-    }
-  }
-}
-
-.mud-table-sticky-header.mud-table-dense {
-  & * .mud-table-root {
-    .mud-table-head {
-
-      & * .mud-table-loading {
-        top: 39px;
-      }
-
-      & * .mud-filter-panel-cell {
-        top: 39px;
-      }
-
-      table:has(.mud-table-loading) & * .mud-filter-panel-cell {
-        top: 43px;
       }
     }
   }


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->
Adjusted MudDataGrid and MudTable to include the mud-table-dense css selector on the thead element as well, allowing me to reduce overall scss burden and streamline SCSS problems with Sticky Headers. 

Corrected Sticky column behavior, now filter row when ColumnFilterRow is selected sticks to the 2nd row of Sticky column and Loading sticks to the second or third row depending of ColumnFilterRow is used. Also now all 6 different modes respect the Dense property.

Resolves #11786 

Visually tested all Docs for both MudTable and MudDataGrid in Docs.Server as well as UnitTests.Viewer

https://github.com/user-attachments/assets/8544cce1-5f3f-49f6-8023-491c168edcbd

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
