### PR TITLE
MudDialog: Fix when a dialog is canceled, it can be reopened

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethodTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethodTest.razor
@@ -1,0 +1,18 @@
+﻿<MudButton OnClick="OpenDialogAsync" Class="open-dialog-button">
+    Open Dialog
+</MudButton>
+
+<MudDialog @ref="_dialog">
+    <DialogContent>
+        <p>The dialog's content is displayed.</p>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    private MudDialog _dialog = null!;
+
+    private async Task OpenDialogAsync()
+    {
+        await _dialog.ShowAsync();
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -155,6 +155,49 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Check where a dialog is opened, canceled and reopened.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/MudBlazor/MudBlazor/issues/11789
+        /// </remarks>
+        [Test]
+        public void InlineDialog_OpenCancelOpen()
+        {
+            // Arrange
+
+            var comp = Context.RenderComponent<MudDialogProvider>();
+            var sup = Context.RenderComponent<InlineDialogShowMethodTest>();
+
+            // Assert : Initial state, dialog should be closed
+
+            comp.FindAll(".mud-dialog-content").Should().BeEmpty();
+
+            // Act : Open the dialog
+
+            sup.Find(".open-dialog-button").Click();
+
+            // Assert : Dialog should be open
+
+            comp.Find(".mud-dialog-content").InnerHtml.Trim().Should().NotBeEmpty();
+
+            // Act : Cancel by click outside
+
+            comp.Find("div.mud-overlay-dialog").Click();
+
+            // Assert : Dialog should be closed
+
+            comp.FindAll(".mud-dialog-content").Should().BeEmpty();
+
+            // Act : Reopen the dialog
+
+            sup.Find(".open-dialog-button").Click();
+
+            // Assert : Dialog should be open
+
+            comp.Find(".mud-dialog-content").InnerHtml.Trim().Should().NotBeEmpty();
+        }
+
+        /// <summary>
         /// Nested dialogs should not appear unless manually shown
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -205,7 +205,7 @@ namespace MudBlazor
                     throw new InvalidOperationException("You can only show an inlined dialog.");
                 }
 
-                if (_reference is not null)
+                if (_reference is not null && !_reference.Result.IsCompleted)
                     return _reference;
 
                 var parameters = new DialogParameters

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -181,7 +181,7 @@ namespace MudBlazor
         /// The element which will receive focus when this dialog is shown.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="DefaultFocus.Element"/> in <see cref="MudGlobal.DialogDefaults.DefaultFocus"/>.        
+        /// Defaults to <see cref="DefaultFocus.Element"/> in <see cref="MudGlobal.DialogDefaults.DefaultFocus"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Dialog.Behavior)]


### PR DESCRIPTION
Fixes #11789

This PR fixes the bug, where a dialog is canceled, it can't be reopened (need to be open two times to be displayed).

**Checklist:**
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.