### PR TITLE
MudDataGrid : Refresh on collection changed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridObservabilityTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridObservabilityTest.razor
@@ -21,22 +21,22 @@
 
     ObservableCollection<Model> _items = new ObservableCollection<Model>()
     {
-        new Model("Sam", 56, Severity.Normal, 50_000.00M, new DateTime(2005, 3, 5), false), 
-        new Model("Alicia", 54, Severity.Info, 75_000.00M, new DateTime(2010, 1, 17), false), 
+        new Model("Sam", 56, Severity.Normal, 50_000.00M, new DateTime(2005, 3, 5), false),
+        new Model("Alicia", 54, Severity.Info, 75_000.00M, new DateTime(2010, 1, 17), false),
         new Model("Ira", 27, Severity.Success, 102_000.00M, new DateTime(2017, 6, 15), true),
         new Model("John", 32, Severity.Warning, 132_000.00M, new DateTime(2021, 12, 23), true),
-        new Model("Fred", 65, Severity.Warning, 87_000.00M, new DateTime(2003, 7, 3), false), 
-        new Model("Tabitha", 33, Severity.Info, 157_000.00M, new DateTime(2015, 2, 12), true), 
+        new Model("Fred", 65, Severity.Warning, 87_000.00M, new DateTime(2003, 7, 3), false),
+        new Model("Tabitha", 33, Severity.Info, 157_000.00M, new DateTime(2015, 2, 12), true),
         new Model("Hunter", 22, Severity.Success, 43_000.00M, new DateTime(2017, 9, 20), false),
         new Model("Esme", 55, Severity.Warning, 149_000.00M, new DateTime(2017, 8, 1), true)
     };
 
-    void AddItem()
+    public void AddItem()
     {
         _items.Add(new Model("New Person", 44, Severity.Warning, 85_000.00M, new DateTime(2022, 1, 1), true));
     }
 
-    void RemoveItem()
+    public void RemoveItem()
     {
         if (_items.Any())
         {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4112,6 +4112,45 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(8);
         }
 
+        /// <summary>
+        /// Checks that when the collection is modified, the change is applied in the rendering.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/MudBlazor/MudBlazor/issues/11758
+        /// </remarks>
+        [Test]
+        public void DataGridObservabilityTest2()
+        {
+            // Arrange
+
+            var sup = Context.RenderComponent<DataGridObservabilityTest>();
+            var comp = sup.Instance;
+            var dataGrid = sup.FindComponent<MudDataGrid<DataGridObservabilityTest.Model>>();
+
+            // Assert : Initial state with 8 rows
+
+            dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(8);
+
+            // Act : Add 2 items
+
+            comp.AddItem();
+            comp.AddItem();
+
+            // Arrange : DataGrid should display 10 rows
+
+            dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(10);
+
+            // Act : Remove 3 items
+
+            comp.RemoveItem();
+            comp.RemoveItem();
+            comp.RemoveItem();
+
+            // Arrange : DataGrid should display 7 rows
+
+            dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(7);
+        }
+
         public void TableFilterGuid()
         {
             var comp = Context.RenderComponent<DataGridFilterGuid<Guid>>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -621,7 +621,7 @@ namespace MudBlazor
 
         /// <summary>
         /// A RenderFragment that will be used as a placeholder when the Virtualize component is asynchronously loading data.
-        /// This placeholder is displayed for each item in the data source that is yet to be loaded. Useful for presenting a loading indicator 
+        /// This placeholder is displayed for each item in the data source that is yet to be loaded. Useful for presenting a loading indicator
         /// in a data grid row while the actual data is being fetched from the server.
         /// </summary>
         [Parameter]
@@ -771,12 +771,16 @@ namespace MudBlazor
             {
                 changed.CollectionChanged += (s, e) =>
                 {
-                    _currentRenderFilteredItemsCache = null;
+                    InvokeAsync(() =>
+                    {
+                        _currentRenderFilteredItemsCache = null;
 
-                    if (Groupable)
-                        GroupItems();
+                        if (Groupable)
+                            GroupItems();
 
-                    ApplyInitialExpansionForNewItems(e);
+                        ApplyInitialExpansionForNewItems(e);
+                        StateHasChanged();
+                    });
                 };
             }
         }
@@ -960,7 +964,7 @@ namespace MudBlazor
         /// <remarks>
         /// The function accepts a <see cref="GridStateVirtualize{T}"/> with current sorting, filtering, and pagination parameters.
         /// Then, return a <see cref="GridData{T}"/> with a list of values, and the total (unpaginated) items count in <see cref="GridData{T}.TotalItems"/>.
-        /// This property is used when you need to display a list without a paginator, 
+        /// This property is used when you need to display a list without a paginator,
         /// but with loading data from the server as the scroll position changes.
         /// </remarks>
         [Parameter]
@@ -1144,7 +1148,7 @@ namespace MudBlazor
 
 #nullable enable
         /// <summary>
-        /// The default template used to display column grouping for any column that is grouped. 
+        /// The default template used to display column grouping for any column that is grouped.
         /// </summary>
         /// <remarks>Can be overridden by using the column level GroupTemplate, defaults to <c>null</c>.</remarks>
         [Parameter]
@@ -1157,7 +1161,7 @@ namespace MudBlazor
         /// Determines whether an unsorted state (<see cref="SortDirection.None"/>) is allowed when toggling sort directions.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>. When <c>false</c>, the sort direction toggles only between 
+        /// Defaults to <c>false</c>. When <c>false</c>, the sort direction toggles only between
         /// <see cref="SortDirection.Ascending"/> and <see cref="SortDirection.Descending"/>.
         /// When <c>true</c>, a third toggle state, <see cref="SortDirection.None"/>, is included.
         /// </remarks>
@@ -2287,7 +2291,7 @@ namespace MudBlazor
                 var newOrder = groupedColumns.Any() ? groupedColumns.Max(x => x._groupByOrderState.Value) + 1 : 0;
                 await column._groupByOrderState.SetValueAsync(newOrder);
             }
-            // if removed then reset _groupByOrderState.Value 
+            // if removed then reset _groupByOrderState.Value
             else
             {
                 await column._groupByOrderState.SetValueAsync(default);


### PR DESCRIPTION
Fix #11758

Currently, when `MudDataGrid.Items` is set with a observable collection and the collection is modified, the change isn't rendered.

This PR fix it. When the collection is modified, `StateHasChanged` is called to refresh the UI.

Moreover, I move the callback of `INotifyCollectionChanged.CollectionChanged` in `InvokeAsync`, because the collection can be changed in a other thread (like in bug issue #11758 where the collection is modified in a trigger).

**Checklist:**

- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
