### PR TITLE
MudAutocomplete: Fix `Strict=false` when using a `Converter` with `CoerceValue`

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteConverterStrictTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteConverterStrictTest.razor
@@ -1,0 +1,52 @@
+@using MudBlazor.Examples.Data
+<MudPopoverProvider />
+
+<MudAutocomplete @bind-Value="_value1" SearchFunc="@Search1" CoerceValue Strict="false" Converter="_elementConverter" PopoverClass="autocomplete-popover-class" />
+
+@code {
+    public static string __description__ = "Strict = false should work when a Converter is provided and CoerceValue is true";
+
+    private ConverterElement? _value1;
+    private PeriodicTableService _service = new PeriodicTableService();
+    
+    private Converter<ConverterElement?> _elementConverter = new Converter<ConverterElement?>
+    {
+        SetFunc = value => value?.ToString(), //convert to string
+        GetFunc = text => new ConverterElement { Name = text } //convert to element
+    };
+
+    private readonly string[] _states =
+    [
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming"
+    ];
+
+    private async Task<IEnumerable<ConverterElement?>> Search1(string value, CancellationToken token)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(50, token);
+
+        value ??= string.Empty;
+        var elements = await _service.GetElements(value);
+        return elements.Select(x => new ConverterElement { Name = x.Name });
+    }
+    
+    public class ConverterElement
+    {
+        public string? Name { get; set; }
+        
+        public override string ToString() => Name ?? string.Empty;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteConverterStrictTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteConverterStrictTest.razor
@@ -15,24 +15,6 @@
         GetFunc = text => new ConverterElement { Name = text } //convert to element
     };
 
-    private readonly string[] _states =
-    [
-        "Alabama", "Alaska", "American Samoa", "Arizona",
-        "Arkansas", "California", "Colorado", "Connecticut",
-        "Delaware", "District of Columbia", "Federated States of Micronesia",
-        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
-        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
-        "Louisiana", "Maine", "Marshall Islands", "Maryland",
-        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
-        "Missouri", "Montana", "Nebraska", "Nevada",
-        "New Hampshire", "New Jersey", "New Mexico", "New York",
-        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
-        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
-        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
-        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
-        "Washington", "West Virginia", "Wisconsin", "Wyoming"
-    ];
-
     private async Task<IEnumerable<ConverterElement?>> Search1(string value, CancellationToken token)
     {
         // In real life use an asynchronous function for fetching data from an api.

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -21,15 +21,14 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class AutocompleteTests : BunitTest
     {
-        #nullable enable
+#nullable enable
         [Test]
         public void Autocomplete_Should_Handle_Converter_WithStrict()
         {
             var comp = Context.RenderComponent<AutocompleteConverterStrictTest>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<AutocompleteConverterStrictTest.ConverterElement>>();
-            var autocomplete = autocompleteComponent.Instance;
             comp.Markup.Should().NotContain("mud-popover-open");
-            
+
             autocompleteComponent.Find(".mud-button-root.mud-no-activator").Click(); // open popover
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             var items = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>().ToArray();
@@ -43,8 +42,7 @@ namespace MudBlazor.UnitTests.Components
             var filteredItems = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>().ToArray();
             filteredItems.Length.Should().Be(4, "The popover should contain 4 items.");
         }
-#nullable disable
-        
+
         /// <summary>
         /// Initial value should be shown and popup should not open.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -21,7 +21,6 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class AutocompleteTests : BunitTest
     {
-#nullable enable
         [Test]
         public void Autocomplete_Should_Handle_Converter_WithStrict()
         {

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -9,6 +9,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Examples.Data;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Autocomplete;
 using NUnit.Framework;
@@ -20,6 +21,30 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class AutocompleteTests : BunitTest
     {
+        #nullable enable
+        [Test]
+        public void Autocomplete_Should_Handle_Converter_WithStrict()
+        {
+            var comp = Context.RenderComponent<AutocompleteConverterStrictTest>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<AutocompleteConverterStrictTest.ConverterElement>>();
+            var autocomplete = autocompleteComponent.Instance;
+            comp.Markup.Should().NotContain("mud-popover-open");
+            
+            autocompleteComponent.Find(".mud-button-root.mud-no-activator").Click(); // open popover
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            var items = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>().ToArray();
+            items.Length.Should().Be(10, "The popover should contain 10 items."); // default maxitems is 10
+            comp.Find(".mud-button-root.mud-no-activator").Click(); // close popover
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+
+            // set search
+            autocompleteComponent.Find("input").Input("he");
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            var filteredItems = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>().ToArray();
+            filteredItems.Length.Should().Be(4, "The popover should contain 4 items.");
+        }
+#nullable disable
+        
         /// <summary>
         /// Initial value should be shown and popup should not open.
         /// </summary>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -25,6 +25,7 @@ namespace MudBlazor
         private int _returnedItemsCount;
         private bool _open;
         private bool _opening;
+        private bool _isValueCoerced;
         private MudInput<string> _elementReference = null!;
         private CancellationTokenSource? _cancellationTokenSrc;
         private Task? _currentSearchTask;
@@ -710,7 +711,7 @@ namespace MudBlazor
                 }
 
                 // Search while selected if enabled and the Text is equivalent to the Value.
-                searchingWhileSelected = !Strict && Value != null && (Value.ToString() == Text || (ToStringFunc != null && ToStringFunc(Value) == Text));
+                searchingWhileSelected = !_isValueCoerced && !Strict && Value != null && (Value.ToString() == Text || (ToStringFunc != null && ToStringFunc(Value) == Text));
                 _cancellationTokenSrc ??= new CancellationTokenSource();
                 var searchText = searchingWhileSelected ? string.Empty : Text;
                 var searchTask = SearchFunc?.Invoke(searchText, _cancellationTokenSrc.Token);
@@ -797,6 +798,12 @@ namespace MudBlazor
             {
                 await ScrollToListItemAsync(_selectedListItemIndex);
             }
+        }
+
+        protected override Task SetValueAsync(T? value, bool updateText = true, bool force = false)
+        {
+            _isValueCoerced = false;
+            return base.SetValueAsync(value, updateText, force);
         }
 
         /// <summary>
@@ -1133,15 +1140,17 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
-        private Task CoerceValueToTextAsync()
+        private async Task CoerceValueToTextAsync()
         {
             if (!CoerceValue)
-                return Task.CompletedTask;
+                return;
 
             _debounceTimer?.Dispose();
 
             var value = Converter.Get(Text);
-            return SetValueAsync(value, updateText: false);
+            await SetValueAsync(value, updateText: false);
+
+            _isValueCoerced = true; //we must set _isValueCoerced to true after calling SetValueAsync, as it sets it to false
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1149,8 +1149,10 @@ namespace MudBlazor
 
             var value = Converter.Get(Text);
             await SetValueAsync(value, updateText: false);
-
-            _isValueCoerced = true; //we must set _isValueCoerced to true after calling SetValueAsync, as it sets it to false
+            
+            // We must set _isValueCoerced to true after calling SetValueAsync, as it sets it to false
+            // CoerceValue is always true at this point, so we can set the value to true rather than checking the property again
+            _isValueCoerced = true;
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1149,7 +1149,7 @@ namespace MudBlazor
 
             var value = Converter.Get(Text);
             await SetValueAsync(value, updateText: false);
-            
+
             // We must set _isValueCoerced to true after calling SetValueAsync, as it sets it to false
             // CoerceValue is always true at this point, so we can set the value to true rather than checking the property again
             _isValueCoerced = true;


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high quality video. -->

Fixes #11797

When a `Converter` is provided and `CoerceValue=true`, `Strict=false` would break and always show all items. This fixes the issue by tracking whether the current value was coerced from the text, and if true, it won't return all items from the `SearchFunc`.

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.
