### PR TITLE
MudGlobals -> added DataGrid class with RowsPerPage.

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -980,7 +980,7 @@ namespace MudBlazor
         [Parameter]
         public int RowsPerPage
         {
-            get => _rowsPerPage ?? 10;
+            get => _rowsPerPage ?? MudGlobal.DataGridDefault.RowsPerPage;
             set
             {
                 if (_rowsPerPage == null)

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -190,6 +190,19 @@ public static class MudGlobal
     }
 
     /// <summary>
+    /// Default settings for <see cref="MudDataGrid{T}"/>.
+    /// <br/>
+    /// <b>Warning:</b> This feature is under development and breaking changes to the API <b>will occur</b> between releases.
+    /// </summary>
+    public static class DataGridDefault
+    {
+        /// <summary>
+        /// The default number of rows per page.
+        /// </summary>
+        public static int RowsPerPage { get; set; } = 10;
+    }
+
+    /// <summary>
     /// Applies regular rounding to components by default; additional rounding if set to true; or squares them if set to false for MudBlazor components.
     /// </summary>
     public static bool? Rounded { get; set; }


### PR DESCRIPTION
Added a static class DataGridDefault in MudGlobal, with only one property RowsPerPage.
The property is used in MudDataGrid.razor.cs, and replace the hardcoded 10.

Default value of 10 is moved from MudDataGrid.razor.cs to the newly created property in MudGlobal.