### PR TITLE
MudDataGrid: Add parameters for filter icons

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
@@ -1,5 +1,5 @@
-﻿<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="DataGridFilterMode.Simple"
-             FilterIconEmpty="@Icons.Material.Filled.Battery0Bar" FilterIconFilled="@Icons.Material.Filled.BatteryFull">
+﻿<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="FilterMode"
+             FilterIconEmpty="@Icons.Material.Filled.Battery0Bar" FilterIconFilled="@Icons.Material.Filled.BatteryFull" FilterIconClear="@Icons.Material.Filled.BatteryAlert">
     <Columns>
         <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
@@ -8,6 +8,9 @@
 
 @code {
     public record Model(string Name, int Age);
+
+    [Parameter]
+    public DataGridFilterMode FilterMode { get; set; } = DataGridFilterMode.Simple;
 
     private readonly IEnumerable<Model> _items = new List<Model>()
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
@@ -1,0 +1,19 @@
+﻿<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="DataGridFilterMode.Simple"
+             FilterIconEmpty="@Icons.Material.Filled.Battery0Bar" FilterIconFilled="@Icons.Material.Filled.BatteryFull">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public record Model(string Name, int Age);
+
+    private readonly IEnumerable<Model> _items = new List<Model>()
+    {
+        new("Sam", 56),
+        new("Alicia", 54),
+        new("Ira", 27),
+        new("John", 32)
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5524,28 +5524,28 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<DataGridFilterIconsTest>();
             MudIconButton FirstFilterButton() =>
                 comp.FindComponents<MudIconButton>().FirstOrDefault(x => x.Markup.Contains("filter-button"))?.Instance;
-            
+
             // Check filter buttons when no filter applied
             var mudIconButton = FirstFilterButton();
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.Battery0Bar);
-            
+
             comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
-            
+
             mudIconButton = FirstFilterButton();
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.Battery0Bar);
-            
+
             // Check filter buttons when filter applied
             comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.Simple));
             comp.Find("button.filter-button").Click();
 
             mudIconButton = FirstFilterButton();
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
-            
+
             comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
 
             mudIconButton = FirstFilterButton();
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
-            
+
             // Check filter buttons when FilterMode is ColumnFilterRow
             comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterRow));
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5522,29 +5522,38 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridFilterIconsTest()
         {
             var comp = Context.RenderComponent<DataGridFilterIconsTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterIconsTest.Model>>();
+            MudIconButton FirstFilterButton() =>
+                comp.FindComponents<MudIconButton>().FirstOrDefault(x => x.Markup.Contains("filter-button"))?.Instance;
+            
+            // Check filter buttons when no filter applied
+            var mudIconButton = FirstFilterButton();
+            mudIconButton.Icon.Should().Be(Icons.Material.Filled.Battery0Bar);
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
+            
+            mudIconButton = FirstFilterButton();
+            mudIconButton.Icon.Should().Be(Icons.Material.Filled.Battery0Bar);
+            
+            // Check filter buttons when filter applied
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.Simple));
+            comp.Find("button.filter-button").Click();
 
-            // Note: svg are formatted differently in the icon and in the button html, so we check with svg path
+            mudIconButton = FirstFilterButton();
+            mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
+            
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
 
-            var filterEmptyButton = dataGrid.FindAll(".filter-button")[0];
-            string expectedFilterEmptyIconPath =
-                XDocument.Parse($"<svg>{Icons.Material.Filled.Battery0Bar}</svg>")
-                    .Descendants("path")
-                    .Select(p => p.Attribute("d")?.Value)
-                    .Where(d => !string.IsNullOrEmpty(d))
-                    .ToList().First();
-            filterEmptyButton.Html().Should().Contain(expectedFilterEmptyIconPath);
+            mudIconButton = FirstFilterButton();
+            mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
+            
+            // Check filter buttons when FilterMode is ColumnFilterRow
+            comp.SetParametersAndRender(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterRow));
 
-            filterEmptyButton.Click();
+            var mudMenu = comp.FindComponents<MudMenu>().FirstOrDefault(x => x.Markup.Contains("column-filter-menu"))?.Instance;
+            mudMenu.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
 
-            var filterFilledButton = dataGrid.FindAll(".filter-button.filtered")[0];
-            string expectedFilterFilledIconPath =
-                XDocument.Parse($"<svg>{Icons.Material.Filled.BatteryFull}</svg>")
-                    .Descendants("path")
-                    .Select(p => p.Attribute("d")?.Value)
-                    .Where(d => !string.IsNullOrEmpty(d))
-                    .ToList().First();
-            filterFilledButton.Html().Should().Contain(expectedFilterFilledIconPath);
+            mudIconButton = FirstFilterButton();
+            mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryAlert);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6,6 +6,7 @@
 
 using System.Globalization;
 using System.Reflection;
+using System.Xml.Linq;
 using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -5515,6 +5516,35 @@ namespace MudBlazor.UnitTests.Components
             testComponent.ToggledEvents.Should().HaveCount(3);
             testComponent.ToggledEvents.Should().OnlyContain(x => x.Expanded == true);
             testComponent.ToggledEvents.Select(x => x.Item.Name).Should().BeEquivalentTo(["John", "Jane", "Bob"]);
+        }
+
+        [Test]
+        public void DataGridFilterIconsTest()
+        {
+            var comp = Context.RenderComponent<DataGridFilterIconsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterIconsTest.Model>>();
+
+            // Note: svg are formatted differently in the icon and in the button html, so we check with svg path
+
+            var filterEmptyButton = dataGrid.FindAll(".filter-button")[0];
+            string expectedFilterEmptyIconPath =
+                XDocument.Parse($"<svg>{Icons.Material.Filled.Battery0Bar}</svg>")
+                    .Descendants("path")
+                    .Select(p => p.Attribute("d")?.Value)
+                    .Where(d => !string.IsNullOrEmpty(d))
+                    .ToList().First();
+            filterEmptyButton.Html().Should().Contain(expectedFilterEmptyIconPath);
+
+            filterEmptyButton.Click();
+
+            var filterFilledButton = dataGrid.FindAll(".filter-button.filtered")[0];
+            string expectedFilterFilledIconPath =
+                XDocument.Parse($"<svg>{Icons.Material.Filled.BatteryFull}</svg>")
+                    .Descendants("path")
+                    .Select(p => p.Attribute("d")?.Value)
+                    .Where(d => !string.IsNullOrEmpty(d))
+                    .ToList().First();
+            filterFilledButton.Html().Should().Contain(expectedFilterFilledIconPath);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6,7 +6,6 @@
 
 using System.Globalization;
 using System.Reflection;
-using System.Xml.Linq;
 using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -306,48 +306,6 @@ namespace MudBlazor
         public string SortIcon { get; set; } = Icons.Material.Filled.ArrowUpward;
 
         /// <summary>
-        /// The color of the sort icon.
-        /// </summary>
-        [Parameter]
-        public Color SortIconColor { get; set; }
-
-        /// <summary>
-        /// The empty filter icon shown when <see cref="Filterable"/> is <c>true</c>.
-        /// </summary>
-        [Parameter]
-        public string FilterIconEmpty { get; set; } = Icons.Material.Outlined.FilterAlt;
-
-        /// <summary>
-        /// The filled filter icon shown when <see cref="Filterable"/> is <c>true</c>.
-        /// </summary>
-        [Parameter]
-        public string FilterIconFilled { get; set; } = Icons.Material.Filled.FilterAlt;
-
-        /// <summary>
-        /// The clear filter icon shown when <see cref="Filterable"/> is <c>true</c>.
-        /// </summary>
-        [Parameter]
-        public string FilterIconClear { get; set; } = Icons.Material.Filled.FilterAltOff;
-
-        /// <summary>
-        /// The color of the empty filter icon.
-        /// </summary>
-        [Parameter]
-        public Color FilterIconEmptyColor { get; set; }
-
-        /// <summary>
-        /// The color of the filled filter icon.
-        /// </summary>
-        [Parameter]
-        public Color FilterIconFilledColor { get; set; }
-
-        /// <summary>
-        /// The color of the clear filter icon.
-        /// </summary>
-        [Parameter]
-        public Color FilterIconClearColor { get; set; }
-
-        /// <summary>
         /// Allows values in this column to be grouped.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -309,7 +309,7 @@ namespace MudBlazor
         /// The color of the sort icon.
         /// </summary>
         [Parameter]
-        public Color SortIconColor { get; set; } = Color.Default;
+        public Color SortIconColor { get; set; }
 
         /// <summary>
         /// The empty filter icon shown when <see cref="Filterable"/> is <c>true</c>.
@@ -333,19 +333,19 @@ namespace MudBlazor
         /// The color of the empty filter icon.
         /// </summary>
         [Parameter]
-        public Color FilterIconEmptyColor { get; set; } = Color.Default;
+        public Color FilterIconEmptyColor { get; set; }
 
         /// <summary>
         /// The color of the filled filter icon.
         /// </summary>
         [Parameter]
-        public Color FilterIconFilledColor { get; set; } = Color.Default;
+        public Color FilterIconFilledColor { get; set; }
 
         /// <summary>
         /// The color of the clear filter icon.
         /// </summary>
         [Parameter]
-        public Color FilterIconClearColor { get; set; } = Color.Default;
+        public Color FilterIconClearColor { get; set; }
 
         /// <summary>
         /// Allows values in this column to be grouped.

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -306,6 +306,48 @@ namespace MudBlazor
         public string SortIcon { get; set; } = Icons.Material.Filled.ArrowUpward;
 
         /// <summary>
+        /// The color of the sort icon.
+        /// </summary>
+        [Parameter]
+        public Color SortIconColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The empty filter icon shown when <see cref="Filterable"/> is <c>true</c>.
+        /// </summary>
+        [Parameter]
+        public string FilterIconEmpty { get; set; } = Icons.Material.Outlined.FilterAlt;
+
+        /// <summary>
+        /// The filled filter icon shown when <see cref="Filterable"/> is <c>true</c>.
+        /// </summary>
+        [Parameter]
+        public string FilterIconFilled { get; set; } = Icons.Material.Filled.FilterAlt;
+
+        /// <summary>
+        /// The clear filter icon shown when <see cref="Filterable"/> is <c>true</c>.
+        /// </summary>
+        [Parameter]
+        public string FilterIconClear { get; set; } = Icons.Material.Filled.FilterAltOff;
+
+        /// <summary>
+        /// The color of the empty filter icon.
+        /// </summary>
+        [Parameter]
+        public Color FilterIconEmptyColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the filled filter icon.
+        /// </summary>
+        [Parameter]
+        public Color FilterIconFilledColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the clear filter icon.
+        /// </summary>
+        [Parameter]
+        public Color FilterIconClearColor { get; set; } = Color.Default;
+
+        /// <summary>
         /// Allows values in this column to be grouped.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -59,7 +59,7 @@
                 }
                 @if (!Column.ShowFilterIcon.HasValue || Column.ShowFilterIcon.Value)
                 {
-                    <MudMenu Class="column-filter-menu" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" Dense="true">
+                    <MudMenu Class="column-filter-menu" Icon="@Column.FilterIconFilled" Size="@Size.Small" Color="@Column.FilterIconFilledColor" Dense="true">
                         @foreach (var o in operators)
                         {
                             if (!string.IsNullOrWhiteSpace(o))
@@ -68,7 +68,7 @@
                             }
                         }
                     </MudMenu>
-                    <MudIconButton Class="align-self-center" Icon="@Icons.Material.Filled.FilterAltOff" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
+                    <MudIconButton Class="align-self-center" Icon="@Column.FilterIconClear" Size="@Size.Small" Color="@Column.FilterIconClearColor" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
                 }
             </MudStack>
         }

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -59,7 +59,7 @@
                 }
                 @if (!Column.ShowFilterIcon.HasValue || Column.ShowFilterIcon.Value)
                 {
-                    <MudMenu Class="column-filter-menu" Icon="@Column.FilterIconFilled" Size="@Size.Small" Color="@Column.FilterIconFilledColor" Dense="true">
+                    <MudMenu Class="column-filter-menu" Icon="@DataGrid.FilterIconFilled" Size="@Size.Small" Dense="true">
                         @foreach (var o in operators)
                         {
                             if (!string.IsNullOrWhiteSpace(o))
@@ -68,7 +68,7 @@
                             }
                         }
                     </MudMenu>
-                    <MudIconButton Class="align-self-center" Icon="@Column.FilterIconClear" Size="@Size.Small" Color="@Column.FilterIconClearColor" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
+                    <MudIconButton Class="align-self-center" Icon="@DataGrid.FilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
                 }
             </MudStack>
         }

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -68,7 +68,7 @@
                             }
                         }
                     </MudMenu>
-                    <MudIconButton Class="align-self-center" Icon="@DataGrid.FilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
+                    <MudIconButton Class="align-self-center filter-button clear" Icon="@DataGrid.FilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
                 }
             </MudStack>
         }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -76,11 +76,11 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (SortDirection == SortDirection.None)
                     {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
+                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" Color="@Column.SortIconColor" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
                     else
                     {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
+                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" Color="@Column.SortIconColor" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
 
                     if (DataGrid.SortMode == SortMode.Multiple)
@@ -100,11 +100,11 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (hasFilter)
                     {
-                        <MudIconButton Class="filter-button filtered" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
+                        <MudIconButton Class="filter-button filtered" Icon="@Column.FilterIconFilled" Size="@Size.Small" Color="@Column.FilterIconFilledColor" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
                     }
                     else if (showFilterIcon)
                     {
-                        <MudIconButton Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
+                        <MudIconButton Class="filter-button" Icon="@Column.FilterIconEmpty" Size="@Size.Small" Color="@Column.FilterIconEmptyColor" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
                     }
                 }
 

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -76,11 +76,11 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (SortDirection == SortDirection.None)
                     {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" Color="@Column.SortIconColor" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
+                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
                     else
                     {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" Color="@Column.SortIconColor" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
+                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
                     }
 
                     if (DataGrid.SortMode == SortMode.Multiple)
@@ -100,11 +100,11 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (hasFilter)
                     {
-                        <MudIconButton Class="filter-button filtered" Icon="@Column.FilterIconFilled" Size="@Size.Small" Color="@Column.FilterIconFilledColor" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
+                        <MudIconButton Class="filter-button filtered" Icon="@DataGrid.FilterIconFilled" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
                     }
                     else if (showFilterIcon)
                     {
-                        <MudIconButton Class="filter-button" Icon="@Column.FilterIconEmpty" Size="@Size.Small" Color="@Column.FilterIconEmptyColor" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
+                        <MudIconButton Class="filter-button" Icon="@DataGrid.FilterIconEmpty" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
                     }
                 }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -138,7 +138,7 @@
                                                                 <MudSpacer />
 
                                                                 <div>
-                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" Color="@context.SortIconColor" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context?.HeaderCell.SortChangedAsync(e))"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context?.HeaderCell.SortChangedAsync(e))"></MudIconButton>
                                                                     @if (context.DataGrid.SortMode == SortMode.Multiple)
                                                                     {
                                                                         if (context.SortIndex < 0)
@@ -154,11 +154,11 @@
 
                                                                 @if (context.HeaderCell.hasFilter)
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.FilterIconFilled" Size="@Size.Small" Color="@context.FilterIconFilledColor" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.DataGrid.FilterIconFilled" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
                                                                 }
                                                                 else
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.FilterIconEmpty" Size="@Size.Small" Color="@context.FilterIconEmptyColor" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.DataGrid.FilterIconEmpty" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
                                                                 }
 
                                                                 @if (ColumnsPanelReordering)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -138,7 +138,7 @@
                                                                 <MudSpacer />
 
                                                                 <div>
-                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context?.HeaderCell.SortChangedAsync(e))"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" Color="@context.SortIconColor" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context?.HeaderCell.SortChangedAsync(e))"></MudIconButton>
                                                                     @if (context.DataGrid.SortMode == SortMode.Multiple)
                                                                     {
                                                                         if (context.SortIndex < 0)
@@ -154,11 +154,11 @@
 
                                                                 @if (context.HeaderCell.hasFilter)
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@Icons.Material.Filled.FilterAlt" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.FilterIconFilled" Size="@Size.Small" Color="@context.FilterIconFilledColor" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
                                                                 }
                                                                 else
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@Icons.Material.Outlined.FilterAlt" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.FilterIconEmpty" Size="@Size.Small" Color="@context.FilterIconEmptyColor" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
                                                                 }
 
                                                                 @if (ColumnsPanelReordering)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -570,6 +570,24 @@ namespace MudBlazor
         public bool ShowFilterIcons { get; set; } = true;
 
         /// <summary>
+        /// The empty filter icon shown on a column when <see cref="Filterable"/> is <c>true</c> and no filters are applied to this column.
+        /// </summary>
+        [Parameter]
+        public string FilterIconEmpty { get; set; } = Icons.Material.Outlined.FilterAlt;
+
+        /// <summary>
+        /// The filled filter icon shown on a column when <see cref="Filterable"/> is <c>true</c> and filters are applied to this column.
+        /// </summary>
+        [Parameter]
+        public string FilterIconFilled { get; set; } = Icons.Material.Filled.FilterAlt;
+
+        /// <summary>
+        /// The clear filter icon shown on a column when <see cref="Filterable"/> is <c>true</c> to remove filters applied to this column.
+        /// </summary>
+        [Parameter]
+        public string FilterIconClear { get; set; } = Icons.Material.Filled.FilterAltOff;
+
+        /// <summary>
         /// The way that this grid filters data.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This PR addresses the the issue [#7478](https://github.com/MudBlazor/MudBlazor/issues/7478) by giving the possibility to customize the icons used in the filter feature of the MudDataGrid, as well as a possibility to change the color of the sort and filter icons of the MudDataGrid.

The intended use-case is to have more feedback when the filter feature is used for a better user experience.
(For example, having the filter icon of a column become yellow when filters are applied on this column.)

I made the changes as light as possible, by just creating new parameters to replace hard coded values and not adding any logic.
Feel free to suggest better names for those parameters if you have ideas.

Checklist:
- The PR is submitted to the correct branch (dev).
- My code follows the style of this project.
- I've added relevant tests or tested on existing ones.