### PR TITLE
MudCheckbox: Fix Tri-State required validation 

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxFormTest2.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/CheckBox/CheckBoxFormTest2.razor
@@ -1,0 +1,9 @@
+﻿<MudForm ValidationDelay="0">
+    <MudCheckBox T="bool?" Required="true" RequiredError="You must select a value" TriState="true">
+        Do you agree that MudBlazor is awesome
+    </MudCheckBox>
+</MudForm>
+
+@code {
+    public static string __description__ = "A required tristate checkbox must have a value of true or false, but not null.";
+}

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -179,6 +179,49 @@ namespace MudBlazor.UnitTests.Components
             checkbox.Instance.ErrorText.Should().Be(null);
         }
 
+
+        /// <summary>
+        /// A required tristate checkbox must have a value of true or false, but not null.
+        /// </summary>
+        [Test]
+        public async Task TriStateCheckBoxFormTest()
+        {
+            var comp = Context.RenderComponent<CheckBoxFormTest2>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var checkbox = comp.FindComponent<MudCheckBox<bool?>>();
+
+            // initial state: null, form should be invalid without errors
+            form.IsValid.Should().BeFalse();
+            form.Errors.Length.Should().Be(0);
+
+            // after validating, the form should be invalid with errors
+            await comp.InvokeAsync(() => form.Validate());
+            form.IsValid.Should().BeFalse();
+            checkbox.Instance.Error.Should().BeTrue();
+            checkbox.Instance.ErrorText.Should().Be("You must select a value");
+
+            // state: true, form should be valid
+            checkbox.Find("input").Change(true);
+            await comp.InvokeAsync(() => form.Validate());
+            form.IsValid.Should().BeTrue();
+            checkbox.Instance.Error.Should().BeFalse();
+            checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
+
+            // state: false, form should be valid
+            checkbox.Find("input").Change(false);
+            await comp.InvokeAsync(() => form.Validate());
+            form.IsValid.Should().BeTrue();
+            checkbox.Instance.Error.Should().BeFalse();
+            checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
+
+            // state: null, form should be invalid again
+            checkbox.Find("input").Change(null);
+            await comp.InvokeAsync(() => form.Validate());
+            form.IsValid.Should().BeFalse();
+            checkbox.Instance.Error.Should().BeTrue();
+            checkbox.Instance.ErrorText.Should().Be("You must select a value");
+        }
+
         /// <summary>
         /// Binding checkboxes two-way against an array of bools
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -179,7 +179,6 @@ namespace MudBlazor.UnitTests.Components
             checkbox.Instance.ErrorText.Should().Be(null);
         }
 
-
         /// <summary>
         /// A required tristate checkbox must have a value of true or false, but not null.
         /// </summary>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -215,6 +215,26 @@ namespace MudBlazor
             await base.OnAfterRenderAsync(firstRender);
         }
 
+        /// <summary>
+        /// Determines whether the checkbox is considered to have a value.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if a value is considered present; otherwise, <c>false</c>.<br/>
+        /// When <see cref="TriState"/> is <c>true</c>, this returns <c>true</c> if <paramref name="value"/> is not <c>null</c>.
+        /// Otherwise, it defers to the base implementation.
+        /// </returns>
+        protected override bool HasValue(T? value)
+        {
+            if (TriState)
+            {
+                return BoolValue is not null;
+            }
+            else
+            {
+                return base.HasValue(value);
+            }
+        }
+
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE
https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md
-->

Closes: #11885 
When `TriState` is enabled and `Required` is set the `true`, validation will only fail if the checkbox is **null**. Both `true` and `false` are valid options for form validation. Maintains the original behavior of `true` being the only valid option when `TriState` is `false`.

**Checklist:**

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the style of this project.
- [x] I've added relevant tests or tested on existing ones.
