### PR TITLE
Docs: Use fake people data in Simple Table examples

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/SimpleTable/Examples/SimpleTableExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SimpleTable/Examples/SimpleTableExample.razor
@@ -25,11 +25,11 @@
 @code {
     string[] headings = { "ID", "Name", "Email", "Gender", "IP Address" };
     string[] rows = {
-        @"1 Krishna kpartner0@usatoday.com Male 28.25.250.202",
-        @"2 Webb wstitle1@ning.com Male 237.168.134.114",
-        @"3 Nathanil nneal2@cyberchimps.com Male 92.6.0.175",
-        @"4 Adara alockwood3@patch.com Female 182.174.217.152",
-        @"5 Cecilius cchaplin4@shinystat.com Male 195.124.144.18",
-        @"6 Cicely cemerine9@soup.io Female 138.94.191.43",
+        @"1 Ruby ruby_wood@example.org Female 192.0.2.77",
+        @"2 Elias elias.doyle+us@example.net Male 198.51.100.88",
+        @"3 Aria aria.lopez-training@example.com Female 203.0.113.99",
+        @"4 Miles miles_smith2025@example.net Male 192.0.2.110",
+        @"5 Eva eva.murphy-ops@example.org Female 198.51.100.121",
+        @"6 Leo leo.williams+dev@example.com Male 203.0.113.132",
     };
 }

--- a/src/MudBlazor.Docs/Pages/Components/SimpleTable/Examples/SimpleTableFixedHeaderExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SimpleTable/Examples/SimpleTableFixedHeaderExample.razor
@@ -27,17 +27,17 @@
     bool fixedheader = true;
     string[] headings = { "ID", "Name", "Email", "Gender", "IP Address" };
     string[] rows = {
-        @"1 Krishna kpartner0@usatoday.com Male 28.25.250.202",
-        @"2 Webb wstitle1@ning.com Male 237.168.134.114",
-        @"3 Nathanil nneal2@cyberchimps.com Male 92.6.0.175",
-        @"4 Adara alockwood3@patch.com Female 182.174.217.152",
-        @"5 Cecilius cchaplin4@shinystat.com Male 195.124.144.18",
-        @"6 Cicely cemerine9@soup.io Female 138.94.191.43",
-        @"7 Caleb cwebber0@usatoday.com Male 28.25.250.202",
-        @"8 Grayson gcarlyle@bt.com Male 173.174.94.114",
-        @"9 Lori lo@independentweek.com Female 134.16.20.191",
-        @"10 Natasha nkerensky@ilclan.com Female 217.217.18.15",
-        @"11 Andrew aredburn@shinystat.com Male 20.114.244.58",
-        @"12 Katherine ksteiner@fedsun.io Female 122.64.153.22",
+        @"1 Aiden a.reed+work@example.com Male 192.0.2.10",
+        @"2 Mason mason_gray-1@example.net Male 192.0.2.21",
+        @"3 Leo leo.hart1990@example.org Male 198.51.100.32",
+        @"4 Zara zara.armstrong.sales+eu@example.com Female 198.51.100.43",
+        @"5 Rowan rowan.phillips_team@example.net Male 198.51.100.54",
+        @"6 Iris iris_morgan@example.org Female 203.0.113.65",
+        @"7 Ethan ethan.brooks+dev@example.com Male 203.0.113.76",
+        @"8 Noah n.carter-hr@example.net Male 203.0.113.87",
+        @"9 Lily lily_green123@example.org Female 192.0.2.98",
+        @"10 Nina nina.olsen+news@example.com Female 192.0.2.109",
+        @"11 Owen owen.davis_uk@example.net Male 198.51.100.111",
+        @"12 Emma emma.klein-ops@example.org Female 203.0.113.122",
     };
 }

--- a/src/MudBlazor.Docs/Pages/Components/SimpleTable/Examples/SimpleTableHoverDenseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SimpleTable/Examples/SimpleTableHoverDenseExample.razor
@@ -36,11 +36,11 @@
 
     string[] headings = { "ID", "Name", "Email", "Gender", "IP Address" };
     string[] rows = {
-        @"1 Krishna kpartner0@usatoday.com Male 28.25.250.202",
-        @"2 Webb wstitle1@ning.com Male 237.168.134.114",
-        @"3 Nathanil nneal2@cyberchimps.com Male 92.6.0.175",
-        @"4 Adara alockwood3@patch.com Female 182.174.217.152",
-        @"5 Cecilius cchaplin4@shinystat.com Male 195.124.144.18",
-        @"6 Cicely cemerine9@soup.io Female 138.94.191.43",
+        @"1 Clara clara.jones+team@example.com Female 192.0.2.11",
+        @"2 Felix felix_martin88@example.net Male 198.51.100.22",
+        @"3 Isla isla-fernandez@example.org Female 203.0.113.33",
+        @"4 Jonah jonah.brown_dev@example.com Male 192.0.2.44",
+        @"5 Mia mia.chen-marketing@example.net Female 198.51.100.55",
+        @"6 Hugo hugo.taylor123@example.org Male 203.0.113.66",
     };
 }


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Explanation:

> In documentation and example code, it’s important to avoid using real names, email addresses, or IPs because they may belong to actual people or systems, risking privacy violations, accidental spam, or unintended network traffic. Instead, we use reserved domains like `example.com`, `example.net`, and `example.org` (set aside by IANA) and reserved IP ranges such as `192.0.2.0/24`, `198.51.100.0/24`, and `203.0.113.0/24` (defined in RFC 5737), which are guaranteed not to map to real inboxes or machines. This ensures our examples are safe, unambiguous, and professional while clearly signaling to readers that the values are placeholders meant only for demonstration.

<img width="2411" height="2438" alt="image" src="https://github.com/user-attachments/assets/210b5ad7-cfee-48bc-86ab-6c38be74e742" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
