### PR TITLE
MudSnackbar: Add global HideIcon option

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -814,7 +814,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task GlobalHideIcon_True_HidesIcon()
+        public async Task SnackbarShouldNotRenderIconWhenGlobalHideIconIsTrue()
         {
             // Arrange: set global via configuration
             _service.Configuration.HideIcon = true;
@@ -830,7 +830,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task PerSnackbarOverride_ShowsIcon_WhenGlobalHideIconTrue()
+        public async Task SnackbarShouldRenderIconWhenPerSnackbarOverrideIsFalse()
         {
             // Arrange: globally hide icons
             _service.Configuration.HideIcon = true;
@@ -848,7 +848,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Default_GlobalHideIcon_False_ShowsIcon()
+        public async Task SnackbarShouldRenderIconByDefault()
         {
             // Arrange: globally hide icons
             _service.Configuration.HideIcon = false;

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -812,5 +812,55 @@ namespace MudBlazor.UnitTests.Components
             // Only one click should have been successful and multiple clicks should have been attempted.
             successfulClicks.Should().Be(1).And.BeLessThan(clickAttempts);
         }
+
+        [Test]
+        public async Task GlobalHideIcon_True_HidesIcon()
+        {
+            // Arrange: set global via configuration
+            _service.Configuration.HideIcon = true;
+
+            // Act
+            await _provider.InvokeAsync(() => _service.Add("Hello world", Severity.Success));
+
+            // Assert: Snackbar is rendered, but no icon element
+            _provider.WaitForAssertion(() =>
+                _provider.FindAll(".mud-snackbar").Count.Should().Be(1)
+            );
+            _provider.FindAll(".mud-snackbar-icon").Count.Should().Be(0);
+        }
+
+        [Test]
+        public async Task PerSnackbarOverride_ShowsIcon_WhenGlobalHideIconTrue()
+        {
+            // Arrange: globally hide icons
+            _service.Configuration.HideIcon = true;
+
+            // Act: override for this one snackbar
+            await _provider.InvokeAsync(() =>
+                _service.Add("Hello world", Severity.Success, opts => opts.HideIcon = false)
+            );
+
+            // Assert: Snackbar is rendered and icon appears due to per-snackbar override
+            _provider.WaitForAssertion(() =>
+                _provider.FindAll(".mud-snackbar").Count.Should().Be(1)
+            );
+            _provider.FindAll(".mud-snackbar-icon").Count.Should().Be(1);
+        }
+
+        [Test]
+        public async Task Default_GlobalHideIcon_False_ShowsIcon()
+        {
+            // Arrange: globally hide icons
+            _service.Configuration.HideIcon = false;
+
+            // Act
+            await _provider.InvokeAsync(() => _service.Add("Hello world", Severity.Info));
+
+            // Assert: Snackbar is rendered and icon appears as default
+            _provider.WaitForAssertion(() =>
+                _provider.FindAll(".mud-snackbar").Count.Should().Be(1)
+            );
+            _provider.FindAll(".mud-snackbar-icon").Count.Should().Be(1);
+        }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -122,6 +122,14 @@ public abstract class CommonSnackbarOptions
     /// </remarks>
     public string ErrorIcon { get; set; } = Icons.Material.Filled.ErrorOutline;
 
+    /// <summary>
+    /// Hides the icon for the snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    public bool HideIcon { get; set; }
+
     protected CommonSnackbarOptions() { }
 
     protected CommonSnackbarOptions(CommonSnackbarOptions options)
@@ -140,5 +148,6 @@ public abstract class CommonSnackbarOptions
         SuccessIcon = options.SuccessIcon;
         WarningIcon = options.WarningIcon;
         ErrorIcon = options.ErrorIcon;
+        HideIcon = options.HideIcon;
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -69,14 +69,6 @@ namespace MudBlazor
         public bool CloseAfterNavigation { get; set; }
 
         /// <summary>
-        /// Hides the icon for the snackbar.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>.
-        /// </remarks>
-        public bool HideIcon { get; set; }
-
-        /// <summary>
         /// The custom icon to display for the snackbar.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -377,6 +377,7 @@ namespace MudBlazor.Services
                     snackBarConfiguration.SuccessIcon = options.SnackbarConfiguration.SuccessIcon;
                     snackBarConfiguration.WarningIcon = options.SnackbarConfiguration.WarningIcon;
                     snackBarConfiguration.ErrorIcon = options.SnackbarConfiguration.ErrorIcon;
+                    snackBarConfiguration.HideIcon = options.SnackbarConfiguration.HideIcon;
                 })
                 .AddMudBlazorResizeListener(resizeOptions =>
                 {


### PR DESCRIPTION
### Summary
Fixes: https://github.com/MudBlazor/MudBlazor/issues/11677

- Added `HideIcon` property to `CommonSnackbarOptions` so it is available in both:
  - `SnackbarConfiguration` (global config via `Program.cs`)
  - `SnackbarOptions` (per-snackbar override).
- Removed duplicate `HideIcon` property from `SnackbarOptions` since it now inherits from `CommonSnackbarOptions`.
- Updated `AddMudServices` to pass through the new option.
- Added unit tests covering:
  - Global default (`HideIcon = false`)
  - Global `HideIcon = true`
  - Per-snackbar override of global setting.

### Usage
Global configuration in `Program.cs`:
```csharp
builder.Services.AddMudServices(cfg =>
{
    cfg.SnackbarConfiguration.HideIcon = true;
});
```

Per-snackbar override:
```csharp
_snackbar.Add("Saved!", Severity.Success, o => o.HideIcon = false);
```