### PR TITLE
MudDataGrid: Hierarchy ExpandAll/CollapseAll when one item is present

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -18,9 +18,6 @@
 <MudSwitch @bind-Value="EnableHeaderToggle" Label="Enable Header Toggle" />
 <MudSwitch @bind-Value="ExpandSingleRow" Label="Expand Single Row" />
 @code {
-
-
-
     public static string __description__ = "A general test for all things Row Detail / Hierarchy Column";
     [Parameter]
     public bool RightToLeft { get; set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyColumnTest.razor
@@ -1,5 +1,5 @@
 ﻿<CascadingValue Name="RightToLeft" Value="@RightToLeft" IsFixed="true">
-    <MudDataGrid @ref="_dataGrid" Items="@_items" Filterable="true" ExpandSingleRow="@ExpandSingleRow">
+    <MudDataGrid @ref="_dataGrid" Items="@_filteredItems" Filterable="true" ExpandSingleRow="@ExpandSingleRow">
         <Columns>
             <HierarchyColumn EnableHeaderToggle="@EnableHeaderToggle" ButtonDisabledFunc="@(x => x.Name == "Alicia")" InitiallyExpandedFunc="@(x => x.Name == "Ira" || x.Name == "Anders")" />
             <PropertyColumn Property="x => x.Name" />
@@ -18,6 +18,9 @@
 <MudSwitch @bind-Value="EnableHeaderToggle" Label="Enable Header Toggle" />
 <MudSwitch @bind-Value="ExpandSingleRow" Label="Expand Single Row" />
 @code {
+
+
+
     public static string __description__ = "A general test for all things Row Detail / Hierarchy Column";
     [Parameter]
     public bool RightToLeft { get; set; }
@@ -27,6 +30,11 @@
 
     [Parameter]
     public bool ExpandSingleRow { get; set; }
+
+    [Parameter]
+    public bool LimitRowsToOne { get; set; }
+
+    private IEnumerable<Model> _filteredItems => _items.Take(LimitRowsToOne ? 1 : _items.Count());
 
     private MudDataGrid<Model> _dataGrid = null!;
     private readonly IEnumerable<Model> _items = new List<Model>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3292,6 +3292,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DataGrid_RowDetail_ExpandCollapseAllWithOneTest()
+        {
+            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(p => p
+                .Add(x => x.LimitRowsToOne, true)
+                .Add(x => x.EnableHeaderToggle, true)
+            );
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
+
+            dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(0));
+            var headerToggle = dataGrid.Find("th button.mud-hierarchy-toggle-button");
+            headerToggle.Click();
+            dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(1));
+            headerToggle.Click();
+            dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(0));
+        }
+
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public void DataGrid_RowDetail_RTL_GroupIcon(bool rightToLeft)

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -268,7 +268,6 @@ namespace MudBlazor
             {
                 await DataGrid.ExpandAllHierarchy();
             }
-            await InvokeAsync(StateHasChanged);
         }
 
         internal string GetGroupIcon()

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -116,7 +116,7 @@ namespace MudBlazor
 
         #region Computed Properties and Functions
 
-        private bool Expanded => Column?.DataGrid._openHierarchies.Count > 1;
+        private bool Expanded => DataGrid?._openHierarchies.Count > 0;
 
         internal bool IncludeHierarchyToggle => Column?.HeaderClass?.Contains("mud-header-togglehierarchy") ?? false;
 
@@ -268,6 +268,7 @@ namespace MudBlazor
             {
                 await DataGrid.ExpandAllHierarchy();
             }
+            await InvokeAsync(StateHasChanged);
         }
 
         internal string GetGroupIcon()


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Resolves #11899 by setting the Expanded count > 0 instead of > 1

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.

Created a failing unit test
Made adjustment until it passed
