### PR TITLE
MudDataGrid: add UseDeclaredColumnOrder option (Closes #10697)

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridUseDeclaredColumnOrderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridUseDeclaredColumnOrderTest.razor
@@ -1,0 +1,29 @@
+﻿<MudDataGrid Items="_data"
+             Dense="true"
+             Hover="true"
+             UseDeclaredColumnOrder="@UseDeclaredColumnOrder">
+    <Columns>
+        <PropertyColumn Property="e => e.Name" Title="Name" />
+        <PropertyColumn Property="e => e.Number" Title="Number" />
+        <PropertyColumn Property="e => e.Group" Title="Group" />
+        <SelectColumn />
+        <HierarchyColumn />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    [Parameter] public bool UseDeclaredColumnOrder { get; set; }
+
+    private readonly List<Element> _data = new()
+    {
+        new() { Name = "Hydrogen", Number = 1, Group = "Nonmetal" },
+        new() { Name = "Helium", Number = 2, Group = "Noble gas" }
+    };
+
+    public class Element
+    {
+        public string Name { get; set; } = "";
+        public int Number { get; set; }
+        public string Group { get; set; } = "";
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5482,6 +5482,35 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DataGridRespectDeclaredColumnOrderWhenEnabled()
+        {
+            var comp = Context.RenderComponent<DataGridUseDeclaredColumnOrderTest>(
+                parameters => parameters.Add(p => p.UseDeclaredColumnOrder, false));
+            var grid = comp.FindComponent<MudDataGrid<DataGridUseDeclaredColumnOrderTest.Element>>();
+            var columns = grid.Instance.RenderedColumns;
+
+            columns.Should().HaveCount(5);
+            columns[0].Tag?.ToString().Should().Be("hierarchy-column");
+            columns[1].Tag?.ToString().Should().Be("select-column");
+            columns.Skip(2).Select(c => c.Title).Should().ContainInOrder("Name", "Number", "Group");
+
+            comp = Context.RenderComponent<DataGridUseDeclaredColumnOrderTest>(
+                parameters => parameters.Add(p => p.UseDeclaredColumnOrder, true));
+            grid = comp.FindComponent<MudDataGrid<DataGridUseDeclaredColumnOrderTest.Element>>();
+
+            columns = grid.Instance.RenderedColumns;
+
+            columns.Should().HaveCount(5);
+
+            columns[0].Title.Should().Be("Name");
+            columns[1].Title.Should().Be("Number");
+            columns[2].Title.Should().Be("Group");
+            columns[3].Tag?.ToString().Should().Be("select-column");
+            columns[4].Tag?.ToString().Should().Be("hierarchy-column");
+
+        }
+
+        [Test]
         public async Task DataGrid_HierarchyVisibilityToggled_SingleRowToggle()
         {
             var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1187,6 +1187,16 @@ namespace MudBlazor
         [Parameter]
         public bool AllowUnsorted { get; set; } = false;
 
+        /// <summary>
+        /// Use the order in which columns are declared in the markup when rendering the grid.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>. When <c>true</c>, columns are displayed in the order they are declared in the markup.
+        /// When <c>false</c>, hierarchy and select columns are positioned first.
+        /// </remarks>
+        [Parameter]
+        public bool UseDeclaredColumnOrder { get; set; } = false;
+
         #region Properties
 
         internal IEnumerable<T> CurrentPageItems
@@ -1518,9 +1528,13 @@ namespace MudBlazor
 
         internal void AddColumn(Column<T> column)
         {
-            if (column.Tag?.ToString() == "hierarchy-column")
+            if (UseDeclaredColumnOrder)
             {
-                if (column is TemplateColumn<T> templateColumn)
+                // When using declared order, always append to maintain markup order
+                RenderedColumns.Add(column);
+
+                // Handle special column initialization logic regardless of ordering mode
+                if (column.Tag?.ToString() == "hierarchy-column" && column is TemplateColumn<T> templateColumn)
                 {
                     _initialExpandedFunc = templateColumn.InitiallyExpandedFunc;
                     _buttonDisabledFunc = templateColumn.ButtonDisabledFunc;
@@ -1534,23 +1548,45 @@ namespace MudBlazor
                         ApplyInitialExpansionForItems(_serverData.Items);
                     }
                 }
-                RenderedColumns.Insert(0, column);
-            }
-            else if (column.Tag?.ToString() == "select-column")
-            {
-                // Position SelectColumn after HierarchyColumn if present
-                if (RenderedColumns.Select(x => x.Tag).Contains("hierarchy-column"))
-                {
-                    RenderedColumns.Insert(1, column);
-                }
-                else
-                {
-                    RenderedColumns.Insert(0, column);
-                }
             }
             else
             {
-                RenderedColumns.Add(column);
+                // Legacy behavior: special columns first
+                if (column.Tag?.ToString() == "hierarchy-column")
+                {
+                    if (column is TemplateColumn<T> templateColumn)
+                    {
+                        _initialExpandedFunc = templateColumn.InitiallyExpandedFunc;
+                        _buttonDisabledFunc = templateColumn.ButtonDisabledFunc;
+                        // Apply expansion now if items or _serverData.Items is already set
+                        if (_items is not null)
+                        {
+                            ApplyInitialExpansionForItems(_items);
+                        }
+                        else if (_serverData?.Items?.Any() == true)
+                        {
+                            ApplyInitialExpansionForItems(_serverData.Items);
+                        }
+                    }
+
+                    RenderedColumns.Insert(0, column);
+                }
+                else if (column.Tag?.ToString() == "select-column")
+                {
+                    // Position SelectColumn after HierarchyColumn if present
+                    if (RenderedColumns.Select(x => x.Tag).Contains("hierarchy-column"))
+                    {
+                        RenderedColumns.Insert(1, column);
+                    }
+                    else
+                    {
+                        RenderedColumns.Insert(0, column);
+                    }
+                }
+                else
+                {
+                    RenderedColumns.Add(column);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->
## Description

Adds `UseDeclaredColumnOrder` parameter to `MudDataGrid` that allows `HierarchyColumn` and `SelectColumn` to respect their declared position in markup instead of being automatically repositioned at the beginning.

- **Default behavior (unchanged):** `HierarchyColumn` always positioned first (index 0). `SelectColumn` positioned first unless `HierarchyColumn` is present, then positioned second (index 1).

- **With `UseDeclaredColumnOrder="true"`:** Columns appear in the exact order declared in markup.

Added the parameter (defaults to `false` for backward compatibility) and modified the `AddColumn` method to append columns in declaration order when enabled. Applied to both `HierarchyColumn` and `SelectColumn` since users may want flexible positioning for both special column types.

The demo shows a data grid where columns are declared in this order: Date, Name, Price, SelectColumn, HierarchyColumn. After adding `UseDeclaredColumnOrder="true"`, the `SelectColumn` appears before the `HierarchyColumn`, exactly where they were declared in the markup:

https://github.com/user-attachments/assets/06f93cb6-3c88-442c-b088-e50a0044f62d

Here's the same feature demonstrated in the MudBlazor documentation server using the existing Row Detail View example. By adding `UseDeclaredColumnOrder="true"` and moving the `HierarchyColumn` to the last position while adding a `SelectColumn` above it, you can see how both special columns now respect their declared order instead of being automatically positioned first and second:

<img width="1557" height="903" alt="image" src="https://github.com/user-attachments/assets/5c50e393-65f8-47b0-a56f-9764e8059b32" />

Closes #10697

## How Has This Been Tested

Testing has covered select and hierarchy columns with both true and false flags and default behavior.

- [x] Added unit test component `DataGridUseDeclaredColumnOrderTest.razor`
- [x] Added unit test `DataGridRespectDeclaredColumnOrderWhenEnabled()` 
- [x] Verified all existing DataGrid tests pass
- [x] Tested visually using local MudBlazor documentation server
- [x] Tested integration with TryMudBlazor pointing to local solution

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

## Checklist

- [x] The PR is submitted to the correct branch ( `dev` ).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests and confirmed existing ones.

Co-authored-by: Justin Saminathen <justinsaminathen12@gmail.com>
@justin2186
