### PR TITLE
MudChart: Fix YAxisFormat regression 

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Options;
 using MudBlazor.Charts;
 using MudBlazor.UnitTests.TestComponents.Charts;
 using MudBlazor.Utilities;
@@ -82,7 +81,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void LineChartYAxisFormat()
+        [TestCase(ChartType.Bar)]
+        [TestCase(ChartType.Line)]
+        [TestCase(ChartType.StackedBar)]
+        public void ChartYAxisFormat(ChartType chartType)
         {
             var options = new ChartOptions();
             var series = new List<ChartSeries>()
@@ -95,7 +97,7 @@ namespace MudBlazor.UnitTests.Components
             var height = "350px";
 
             var comp = Context.RenderComponent<MudChart>(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartType, chartType)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.XAxisLabels, xAxis)
                 .Add(p => p.ChartOptions, options)
@@ -111,7 +113,7 @@ namespace MudBlazor.UnitTests.Components
             // now, we will apply currency format
             options.YAxisFormat = "c2";
             comp.SetParametersAndRender(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartType, chartType)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.XAxisLabels, xAxis)
                 .Add(p => p.ChartOptions, options)
@@ -125,7 +127,7 @@ namespace MudBlazor.UnitTests.Components
             //number format
             options.YAxisFormat = "n6";
             comp.SetParametersAndRender(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartType, chartType)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.XAxisLabels, xAxis)
                 .Add(p => p.ChartOptions, options)

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -40,7 +40,10 @@ namespace MudBlazor.Charts
         protected override void RebuildChart()
         {
             if (MudChartParent != null)
+            {
                 _series = MudChartParent.ChartSeries;
+                ChartOptions = MudChartParent.ChartOptions;
+            }
 
             SetBounds();
             ComputeUnitsAndNumberOfLines(out var gridXUnits, out var gridYUnits, out var numHorizontalLines, out var lowestHorizontalLine, out var numVerticalLines);

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -41,7 +41,10 @@ namespace MudBlazor.Charts
         protected override void RebuildChart()
         {
             if (MudChartParent != null)
+            {
                 _series = MudChartParent.ChartSeries;
+                ChartOptions = MudChartParent.ChartOptions;
+            }
 
             // ensure the stacked bar width ratio is within the valid range
             AxisChartOptions.StackedBarWidthRatio = AxisChartOptions.StackedBarWidthRatio.EnsureRange(0.1, 1);

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -110,7 +110,10 @@ namespace MudBlazor.Charts
         private void RebuildChart()
         {
             if (MudChartParent != null)
+            {
                 _series = MudChartParent.ChartSeries;
+                ChartOptions = MudChartParent.ChartOptions;
+            }
 
             SetBounds();
             ComputeMinAndMaxDateTimes();


### PR DESCRIPTION
Closes #11922 

PR #11674 introduced a change that stopped YAxisFormat from working with chart types other than line chart. 
The unit test for the formatting only covered line charts. I've updated it to cover both Bar & Stacked Bar as well.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
[x] The PR is submitted to the correct branch (`dev`).
[x] My code follows the style of this project.
[x] I've added relevant tests or confirmed existing ones.
