### PR TITLE
MudTabs: Guard for ScrollPrev

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/DynamicTabsSimpleExample.razor
@@ -1,45 +1,26 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudDynamicTabs @ref="@DynamicTabs" @bind-ActivePanelIndex="@UserIndex"
-                AddTab="@AddTabCallback" CloseTab="@CloseTabCallback"
+<MudDynamicTabs @ref="@_dynamicTabs" @bind-ActivePanelIndex="@_userIndex"
+                AddTab="@OnAddTab" CloseTab="@OnCloseTab"
                 AddIconToolTip="Click to add a new tab" CloseIconToolTip="Close tab. All data will be lost"
                 PanelClass="px-4 py-6" Elevation="4" Rounded ApplyEffectsToContainer>
-    @foreach (var tab in UserTabs)
+    @foreach (var tab in _userTabs)
     {
         <MudTabPanel ID="@tab.Id" Text="@tab.Label" ShowCloseIcon="@tab.ShowCloseIcon">@tab.Content</MudTabPanel>
     }
 </MudDynamicTabs>
 <MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
-<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {_closeToggableTab}'s close icon")</MudSwitch>
-<MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
-<MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
+<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {TabWithToggableCloseIcon}'s close icon")</MudSwitch>
+<MudText>UserTabs index: @_userIndex / DynamicTabs ActivePanelIndex: @_userIndex</MudText>
+<MudText>UserTabs.Count: @_userTabs.Count / DynamicTabs Panels.Count: @_dynamicTabs.Panels.Count</MudText>
 
-    @code {
-
-    public class TabView
-    {
-        public string Label { get; set; }
-        public string Content { get; set; }
-        public Guid Id { get; set; }
-        public bool ShowCloseIcon { get; set; } = true;
-    }
-
-    public MudDynamicTabs DynamicTabs;
-    public List<TabView> UserTabs = new();
-    public int UserIndex;
-    bool _stateHasChanged;
-    bool _showCloseIcon = false;
-    string _closeToggableTab = "Tab B";
-
-    void RestoreUserTabs()
-    {
-        UserTabs.Clear();
-        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content"});
-        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = _closeToggableTab, Content = $"{_closeToggableTab} content", ShowCloseIcon = _showCloseIcon });
-        UserTabs.Add(new TabView {Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content"});
-        UserIndex = 1; // Start on 2nd tab: "Tab B"
-        _stateHasChanged = true;
-    }
+@code {
+    private int _userIndex;
+    private bool _showCloseIcon;
+    private bool _stateHasChanged;
+    private List<TabView> _userTabs = [];
+    private MudDynamicTabs _dynamicTabs = null!;
+    private const string TabWithToggableCloseIcon = "Tab B";
 
     protected override void OnInitialized()
     {
@@ -57,30 +38,66 @@
         }
     }
 
-    private void ToggleShowCloseIcon(bool show)
+    private void RestoreUserTabs()
     {
-        var tab = UserTabs?.SingleOrDefault(t => t.Label.Equals(_closeToggableTab));
-        if (tab is not null) tab.ShowCloseIcon = show;
-        _showCloseIcon = show;
-    }
-
-    public void AddTab(Guid id)
-    {
-        UserTabs.Add(new TabView {Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}"});
-        UserIndex = UserTabs.Count - 1; // Automatically switch to the new tab.
+        _userTabs =
+        [
+            new TabView { Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content" },
+            new TabView { Id = Guid.NewGuid(), Label = TabWithToggableCloseIcon, Content = $"{TabWithToggableCloseIcon} content", ShowCloseIcon = _showCloseIcon },
+            new TabView { Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content" }
+        ];
+        // Start on 2nd tab: "Tab B"
+        _userIndex = 1;
         _stateHasChanged = true;
     }
 
-    public void RemoveTab(Guid id)
+    private void ToggleShowCloseIcon(bool show)
     {
-        var tabView = UserTabs.SingleOrDefault((t) => Equals(t.Id, id));
+        var tab = _userTabs.FirstOrDefault(t => t.Label == TabWithToggableCloseIcon);
+        if (tab is not null)
+        {
+            tab.ShowCloseIcon = show;
+        }
+
+        _showCloseIcon = show;
+    }
+
+    private void AddTab(Guid id)
+    {
+        _userTabs.Add(new TabView { Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}" });
+        // Automatically switch to the new tab.
+        _userIndex = _userTabs.Count - 1;
+        _stateHasChanged = true;
+    }
+
+    private void OnAddTab() => AddTab(Guid.NewGuid());
+
+    private void RemoveTab(Guid id)
+    {
+        var tabView = _userTabs.FirstOrDefault(t => t.Id == id);
         if (tabView is not null)
         {
-            UserTabs.Remove(tabView);
+            _userTabs.Remove(tabView);
             _stateHasChanged = true;
         }
     }
 
-    void AddTabCallback() => AddTab(Guid.NewGuid());
-    void CloseTabCallback(MudTabPanel panel) => RemoveTab((Guid)panel.ID);
+    private void OnCloseTab(MudTabPanel panel)
+    {
+        if (panel.ID is Guid id)
+        {
+            RemoveTab(id);
+        }
+    }
+
+    public class TabView
+    {
+        public required Guid Id { get; init; }
+
+        public required string Label { get; init; }
+
+        public required string Content { get; init; }
+
+        public bool ShowCloseIcon { get; set; } = true;
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActiveIndexVisibleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActiveIndexVisibleTest.razor
@@ -1,44 +1,26 @@
-﻿<MudDynamicTabs @ref="@DynamicTabs" @bind-ActivePanelIndex="@UserIndex"
-                AddTab="@AddTabCallback" CloseTab="@CloseTabCallback"
+﻿<MudDynamicTabs @ref="@_dynamicTabs" @bind-ActivePanelIndex="@_userIndex"
+                AddTab="@OnAddTab" CloseTab="@OnCloseTab"
                 AddIconToolTip="Click to add a new tab" CloseIconToolTip="Close tab. All data will be lost"
                 PanelClass="px-4 py-6" Elevation="4" Rounded ApplyEffectsToContainer>
-    @foreach (var tab in UserTabs)
+    @foreach (var tab in _userTabs)
     {
         <MudTabPanel ID="@tab.Id" Text="@tab.Label" ShowCloseIcon="@tab.ShowCloseIcon">@tab.Content</MudTabPanel>
     }
 </MudDynamicTabs>
 <MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
-<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {_closeToggableTab}'s close icon")</MudSwitch>
-<MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
-<MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
+<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {TabWithToggableCloseIcon}'s close icon")</MudSwitch>
+<MudText>UserTabs index: @_userIndex / DynamicTabs ActivePanelIndex: @_userIndex</MudText>
+<MudText>UserTabs.Count: @_userTabs.Count / DynamicTabs Panels.Count: @_dynamicTabs.Panels.Count</MudText>
 
 @code {
     public static string __description__ = "A test to ensure setting ActivePanelIndex when out of viewable range causes scroll.";
 
-    public class TabView
-    {
-        public string Label { get; set; } = default!;
-        public string Content { get; set; } = default!;
-        public Guid Id { get; set; }
-        public bool ShowCloseIcon { get; set; } = true;
-    }
-
-    public MudDynamicTabs DynamicTabs = default!;
-    public List<TabView> UserTabs = new();
-    public int UserIndex;
-    bool _stateHasChanged;
-    bool _showCloseIcon = false;
-    string _closeToggableTab = "Tab B";
-
-    void RestoreUserTabs()
-    {
-        UserTabs.Clear();
-        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content" });
-        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = _closeToggableTab, Content = $"{_closeToggableTab} content", ShowCloseIcon = _showCloseIcon });
-        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content" });
-        UserIndex = 1; // Start on 2nd tab: "Tab B"
-        _stateHasChanged = true;
-    }
+    private int _userIndex;
+    private bool _showCloseIcon;
+    private bool _stateHasChanged;
+    private List<TabView> _userTabs = [];
+    private MudDynamicTabs _dynamicTabs = null!;
+    private const string TabWithToggableCloseIcon = "Tab B";
 
     protected override void OnInitialized()
     {
@@ -56,34 +38,66 @@
         }
     }
 
-    private void ToggleShowCloseIcon(bool show)
+    private void RestoreUserTabs()
     {
-        var tab = UserTabs?.SingleOrDefault(t => t.Label.Equals(_closeToggableTab));
-        if (tab is not null) tab.ShowCloseIcon = show;
-        _showCloseIcon = show;
-    }
-
-    public void AddTab(Guid id)
-    {
-        UserTabs.Add(new TabView { Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}" });
-        UserIndex = UserTabs.Count - 1; // Automatically switch to the new tab.
+        _userTabs =
+        [
+            new TabView { Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content" },
+            new TabView { Id = Guid.NewGuid(), Label = TabWithToggableCloseIcon, Content = $"{TabWithToggableCloseIcon} content", ShowCloseIcon = _showCloseIcon },
+            new TabView { Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content" }
+        ];
+        // Start on 2nd tab: "Tab B"
+        _userIndex = 1;
         _stateHasChanged = true;
     }
 
-    public void RemoveTab(Guid id)
+    private void ToggleShowCloseIcon(bool show)
     {
-        var tabView = UserTabs.SingleOrDefault((t) => Equals(t.Id, id));
+        var tab = _userTabs.FirstOrDefault(t => t.Label == TabWithToggableCloseIcon);
+        if (tab is not null)
+        {
+            tab.ShowCloseIcon = show;
+        }
+
+        _showCloseIcon = show;
+    }
+
+    private void AddTab(Guid id)
+    {
+        _userTabs.Add(new TabView { Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}" });
+        // Automatically switch to the new tab.
+        _userIndex = _userTabs.Count - 1;
+        _stateHasChanged = true;
+    }
+
+    private void OnAddTab() => AddTab(Guid.NewGuid());
+
+    private void RemoveTab(Guid id)
+    {
+        var tabView = _userTabs.FirstOrDefault(t => t.Id == id);
         if (tabView is not null)
         {
-            UserTabs.Remove(tabView);
+            _userTabs.Remove(tabView);
             _stateHasChanged = true;
         }
     }
 
-    void AddTabCallback() => AddTab(Guid.NewGuid());
-    void CloseTabCallback(MudTabPanel panel)
+    private void OnCloseTab(MudTabPanel panel)
     {
         if (panel.ID is Guid id)
+        {
             RemoveTab(id);
+        }
+    }
+
+    public class TabView
+    {
+        public required Guid Id { get; init; }
+
+        public required string Label { get; init; }
+
+        public required string Content { get; init; }
+
+        public bool ShowCloseIcon { get; set; } = true;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActiveIndexVisibleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/ActiveIndexVisibleTest.razor
@@ -1,0 +1,89 @@
+﻿<MudDynamicTabs @ref="@DynamicTabs" @bind-ActivePanelIndex="@UserIndex"
+                AddTab="@AddTabCallback" CloseTab="@CloseTabCallback"
+                AddIconToolTip="Click to add a new tab" CloseIconToolTip="Close tab. All data will be lost"
+                PanelClass="px-4 py-6" Elevation="4" Rounded ApplyEffectsToContainer>
+    @foreach (var tab in UserTabs)
+    {
+        <MudTabPanel ID="@tab.Id" Text="@tab.Label" ShowCloseIcon="@tab.ShowCloseIcon">@tab.Content</MudTabPanel>
+    }
+</MudDynamicTabs>
+<MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
+<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {_closeToggableTab}'s close icon")</MudSwitch>
+<MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
+<MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
+
+@code {
+    public static string __description__ = "A test to ensure setting ActivePanelIndex when out of viewable range causes scroll.";
+
+    public class TabView
+    {
+        public string Label { get; set; } = default!;
+        public string Content { get; set; } = default!;
+        public Guid Id { get; set; }
+        public bool ShowCloseIcon { get; set; } = true;
+    }
+
+    public MudDynamicTabs DynamicTabs = default!;
+    public List<TabView> UserTabs = new();
+    public int UserIndex;
+    bool _stateHasChanged;
+    bool _showCloseIcon = false;
+    string _closeToggableTab = "Tab B";
+
+    void RestoreUserTabs()
+    {
+        UserTabs.Clear();
+        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content" });
+        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = _closeToggableTab, Content = $"{_closeToggableTab} content", ShowCloseIcon = _showCloseIcon });
+        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content" });
+        UserIndex = 1; // Start on 2nd tab: "Tab B"
+        _stateHasChanged = true;
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        RestoreUserTabs();
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        if (_stateHasChanged)
+        {
+            _stateHasChanged = false;
+            StateHasChanged();
+        }
+    }
+
+    private void ToggleShowCloseIcon(bool show)
+    {
+        var tab = UserTabs?.SingleOrDefault(t => t.Label.Equals(_closeToggableTab));
+        if (tab is not null) tab.ShowCloseIcon = show;
+        _showCloseIcon = show;
+    }
+
+    public void AddTab(Guid id)
+    {
+        UserTabs.Add(new TabView { Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}" });
+        UserIndex = UserTabs.Count - 1; // Automatically switch to the new tab.
+        _stateHasChanged = true;
+    }
+
+    public void RemoveTab(Guid id)
+    {
+        var tabView = UserTabs.SingleOrDefault((t) => Equals(t.Id, id));
+        if (tabView is not null)
+        {
+            UserTabs.Remove(tabView);
+            _stateHasChanged = true;
+        }
+    }
+
+    void AddTabCallback() => AddTab(Guid.NewGuid());
+    void CloseTabCallback(MudTabPanel panel)
+    {
+        if (panel.ID is Guid id)
+            RemoveTab(id);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/DynamicTabsSimpleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/DynamicTabsSimpleTest.razor
@@ -1,5 +1,5 @@
-﻿<MudDynamicTabs @ref="@DynamicTabs" @bind-ActivePanelIndex="@UserIndex"
-                AddTab="@AddTabCallback" CloseTab="@CloseTabCallback"
+﻿<MudDynamicTabs @ref="@_dynamicTabs" @bind-ActivePanelIndex="@UserIndex"
+                AddTab="@OnAddTab" CloseTab="@OnCloseTab"
                 AddIconToolTip="Click to add a new tab" CloseIconToolTip="Close tab. All data will be lost"
                 PanelClass="px-4 py-6" Elevation="4" Rounded ApplyEffectsToContainer>
     @foreach (var tab in UserTabs)
@@ -8,30 +8,19 @@
     }
 </MudDynamicTabs>
 <MudButton OnClick="@RestoreUserTabs">Restore</MudButton>
-<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {_closeToggableTab}'s close icon")</MudSwitch>
-<MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @DynamicTabs.ActivePanelIndex</MudText>
-<MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @DynamicTabs.Panels.Count</MudText>
+<MudSwitch T="bool" Color="Color.Primary" Value="@_showCloseIcon" ValueChanged="@ToggleShowCloseIcon">@($"Show {TabWithToggableCloseIcon}'s close icon")</MudSwitch>
+<MudText>UserTabs index: @UserIndex / DynamicTabs ActivePanelIndex: @UserIndex</MudText>
+<MudText>UserTabs.Count: @UserTabs.Count / DynamicTabs Panels.Count: @_dynamicTabs.Panels.Count</MudText>
 
 @code {
     private bool _showCloseIcon;
     private bool _stateHasChanged;
-    private readonly string _closeToggableTab = "Tab B";
+    private MudDynamicTabs _dynamicTabs = null!;
+    private const string TabWithToggableCloseIcon = "Tab B";
 
-    public MudDynamicTabs DynamicTabs { get; private set; } = null!;
-
-    public List<TabView> UserTabs { get; } = [];
+    public List<TabView> UserTabs { get; private set; } = [];
 
     public int UserIndex { get; private set; }
-
-    private void RestoreUserTabs()
-    {
-        UserTabs.Clear();
-        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content" });
-        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = _closeToggableTab, Content = $"{_closeToggableTab} content", ShowCloseIcon = _showCloseIcon });
-        UserTabs.Add(new TabView { Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content" });
-        UserIndex = 1; // Start on 2nd tab: "Tab B"
-        _stateHasChanged = true;
-    }
 
     protected override void OnInitialized()
     {
@@ -49,23 +38,43 @@
         }
     }
 
+    private void RestoreUserTabs()
+    {
+        UserTabs =
+        [
+            new TabView { Id = Guid.NewGuid(), Label = "Tab A", Content = "Tab A content" },
+            new TabView { Id = Guid.NewGuid(), Label = TabWithToggableCloseIcon, Content = $"{TabWithToggableCloseIcon} content", ShowCloseIcon = _showCloseIcon },
+            new TabView { Id = Guid.NewGuid(), Label = "Tab C", Content = "Tab C content" }
+        ];
+        // Start on 2nd tab: "Tab B"
+        UserIndex = 1;
+        _stateHasChanged = true;
+    }
+
     private void ToggleShowCloseIcon(bool show)
     {
-        var tab = UserTabs?.SingleOrDefault(t => t.Label.Equals(_closeToggableTab));
-        if (tab is not null) tab.ShowCloseIcon = show;
+        var tab = UserTabs.FirstOrDefault(t => t.Label == TabWithToggableCloseIcon);
+        if (tab is not null)
+        {
+            tab.ShowCloseIcon = show;
+        }
+
         _showCloseIcon = show;
     }
 
     public void AddTab(Guid id)
     {
         UserTabs.Add(new TabView { Id = id, Label = "dynamic tab", Content = $"Tab ID: {id}" });
-        UserIndex = UserTabs.Count - 1; // Automatically switch to the new tab.
+        // Automatically switch to the new tab.
+        UserIndex = UserTabs.Count - 1;
         _stateHasChanged = true;
     }
 
+    private void OnAddTab() => AddTab(Guid.NewGuid());
+
     public void RemoveTab(Guid id)
     {
-        var tabView = UserTabs.SingleOrDefault((t) => Equals(t.Id, id));
+        var tabView = UserTabs.FirstOrDefault(t => t.Id == id);
         if (tabView is not null)
         {
             UserTabs.Remove(tabView);
@@ -73,23 +82,21 @@
         }
     }
 
-    private void AddTabCallback() => AddTab(Guid.NewGuid());
-
-    private void CloseTabCallback(MudTabPanel panel)
+    private void OnCloseTab(MudTabPanel panel)
     {
-        if (panel.ID is Guid guid)
+        if (panel.ID is Guid id)
         {
-            RemoveTab(guid);
+            RemoveTab(id);
         }
     }
 
     public class TabView
     {
+        public required Guid Id { get; init; }
+
         public required string Label { get; init; }
 
         public required string Content { get; init; }
-
-        public required Guid Id { get; init; }
 
         public bool ShowCloseIcon { get; set; } = true;
     }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1259,30 +1259,29 @@ namespace MudBlazor.UnitTests.Components
 
         #endregion
 
-
         [Test]
         public void DynamicTabs_CollectionRenderSyncTest()
         {
             var comp = Context.RenderComponent<DynamicTabsSimpleTest>();
 
             var userTabs = comp.Instance.UserTabs;
-            var mudTabs = comp.Instance.DynamicTabs;
+            var mudTabs = comp.FindComponent<MudDynamicTabs>();
 
             // Initial
             userTabs.Count.Should().Be(3);
-            mudTabs.Panels.Count.Should().Be(3);
+            mudTabs.Instance.Panels.Count.Should().Be(3);
 
             // Remove
             comp.Instance.RemoveTab(userTabs.Last().Id);
             userTabs.Count.Should().Be(2);
             comp.Render(); // Render to refresh MudTabs
-            mudTabs.Panels.Count.Should().Be(2);
+            mudTabs.Instance.Panels.Count.Should().Be(2);
 
             // Add
             comp.Instance.AddTab(Guid.NewGuid());
             userTabs.Count.Should().Be(3);
             comp.Render(); // Render to refresh MudTabs
-            mudTabs.Panels.Count.Should().Be(3);
+            mudTabs.Instance.Panels.Count.Should().Be(3);
 
             // Remove all, no ArgumentOutOfRangeException should be thrown.
             comp.Instance.RemoveTab(userTabs.Last().Id);
@@ -1290,16 +1289,15 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.RemoveTab(userTabs.Last().Id);
             userTabs.Count.Should().Be(0);
             comp.Render(); // Render to refresh MudTabs.
-            mudTabs.Panels.Count.Should().Be(0);
+            mudTabs.Instance.Panels.Count.Should().Be(0);
 
             // No active panel.
-            mudTabs.ActivePanel.Should().BeNull();
+            mudTabs.Instance.ActivePanel.Should().BeNull();
 
             // No active panel means no active panel index.
             comp.Instance.UserIndex.Should().Be(-1);
-            mudTabs.ActivePanelIndex.Should().Be(-1);
+            mudTabs.Instance.ActivePanelIndex.Should().Be(-1);
         }
-
 
         [Test]
         public void TabPanel_ShowCloseIconTest()

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -953,19 +953,22 @@ namespace MudBlazor
 
         private void ScrollPrev()
         {
-            // guard against an empty _panels list
             if (_panels.Count == 0)
                 return;
 
             var scrollAmount = Math.Max(GetVisiblePanels(), 1);
-            // this guards for negative index
             _scrollIndex = Math.Max(_scrollIndex - scrollAmount, 0);
-            // this guards for index out of bounds
-            _scrollIndex = Math.Min(_scrollIndex, _panels.Count - 1);
-            ScrollToItem(_panels[_scrollIndex]);
+
+            if (_scrollIndex >= 0 && _scrollIndex < _panels.Count)
+            {
+                ScrollToItem(_panels[_scrollIndex]);
+            }
+
             SetScrollButtonVisibility();
             SetScrollabilityStates();
         }
+
+
 
         private void ScrollNext()
         {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -954,7 +954,10 @@ namespace MudBlazor
         private void ScrollPrev()
         {
             var scrollAmount = Math.Max(GetVisiblePanels(), 1);
+            // this guards for negative index
             _scrollIndex = Math.Max(_scrollIndex - scrollAmount, 0);
+            // this guards for index out of bounds
+            _scrollIndex = Math.Min(_scrollIndex, _panels.Count - 1);
             ScrollToItem(_panels[_scrollIndex]);
             SetScrollButtonVisibility();
             SetScrollabilityStates();

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -958,17 +958,13 @@ namespace MudBlazor
 
             var scrollAmount = Math.Max(GetVisiblePanels(), 1);
             _scrollIndex = Math.Max(_scrollIndex - scrollAmount, 0);
-
-            if (_scrollIndex >= 0 && _scrollIndex < _panels.Count)
-            {
-                ScrollToItem(_panels[_scrollIndex]);
-            }
-
+            // when _scrollIndex is set incorrectly this corrects it to the last panel
+            if (_scrollIndex > _panels.Count - 1)
+                _scrollIndex = _panels.Count - 1;
+            ScrollToItem(_panels[_scrollIndex]);
             SetScrollButtonVisibility();
             SetScrollabilityStates();
         }
-
-
 
         private void ScrollNext()
         {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -953,6 +953,10 @@ namespace MudBlazor
 
         private void ScrollPrev()
         {
+            // guard against an empty _panels list
+            if (_panels.Count == 0)
+                return;
+
             var scrollAmount = Math.Max(GetVisiblePanels(), 1);
             // this guards for negative index
             _scrollIndex = Math.Max(_scrollIndex - scrollAmount, 0);


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

ScrollNext() method contains a guard to ensure it's not scrolling beyond _panels.Count - 1, ScrollPrev() has no such guard to prevent scrolling to an invalid index when there were no visible panels. Added an if statement to prevent an invalid scroll left, but still update the scroll panels. 

Resolves #11906 

The deeper root of the problem lies in AddPanel and RemovePanel not updating the view to ensure a panel is in view if one exists. I may get back to that when I get time again. Also RemovePanel was acting odd when I looked at it.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
