### PR TITLE
MudDataGrid: Fix generated EditTemplates not inheriting their column's culture

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -677,6 +677,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [SetCulture("en-US")]
         public async Task DataGridGroupingTemplateSetAtGridLevel()
         {
             var component = Context.RenderComponent<DataGridGroupingMultiLevelTest>();
@@ -689,7 +690,7 @@ namespace MudBlazor.UnitTests.Components
             groupingTemplateSwitch.Find("input").Change(true);
             dataGrid.Render();
 
-            //current grouping should use the defined template  
+            //current grouping should use the defined template
             var groupRow = component.FindComponent<DataGridGroupRow<DataGridGroupingMultiLevelTest.USState>>().Find(".mud-datagrid-group");
             var text = new string(groupRow.TextContent.Where(c => !Char.IsWhiteSpace(c)).ToArray());
             text.Should().Be("Manufacturing1states");

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -380,7 +380,7 @@
                                            ValueChanged="@cell.StringValueChangedAsync"
                                            Margin="@Margin.Dense" Style="margin-top:0"
                                            Required=column.Required
-                                           Variant="@Variant.Text"/>
+                                           Variant="@Variant.Text" Culture="@column.Culture"/>
                          }
                          else if (column.isNumber)
                          {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -296,12 +296,12 @@
                             if (propertyType == typeof(string))
                             {
                                 <MudTextField T="string" Label="@column.Title" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense"
-                                Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" />
+                                Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
                             }
                             else if (TypeIdentifier.IsNumber(propertyType))
                             {
                                 <MudNumericField T="double?" Label="@column.Title" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense"
-                                Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" />
+                                Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
                             }
                         }
                     }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -380,7 +380,7 @@
                                            ValueChanged="@cell.StringValueChangedAsync"
                                            Margin="@Margin.Dense" Style="margin-top:0"
                                            Required=column.Required
-                                           Variant="@Variant.Text" Culture="@column.Culture"/>
+                                           Variant="@Variant.Text" Culture="@column.Culture" />
                          }
                          else if (column.isNumber)
                          {
@@ -388,8 +388,8 @@
                                               Value="@cell._valueNumber"
                                               ValueChanged="@cell.NumberValueChangedAsync"
                                               Margin="@Margin.Dense" Style="margin-top:0"
-                                              Required=column.Required 
-                                              Variant="@Variant.Text" Culture="@column.Culture"/>
+                                              Required=column.Required
+                                              Variant="@Variant.Text" Culture="@column.Culture" />
                          }
                      }
                  }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -296,12 +296,12 @@
                             if (propertyType == typeof(string))
                             {
                                 <MudTextField T="string" Label="@column.Title" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense"
-                                Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
+                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
                             }
                             else if (TypeIdentifier.IsNumber(propertyType))
                             {
                                 <MudNumericField T="double?" Label="@column.Title" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense"
-                                Required=column.Required Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
+                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
                             }
                         }
                     }
@@ -379,7 +379,7 @@
                                            Value="@cell._valueString"
                                            ValueChanged="@cell.StringValueChangedAsync"
                                            Margin="@Margin.Dense" Style="margin-top:0"
-                                           Required=column.Required
+                                           Required="@column.Required"
                                            Variant="@Variant.Text" Culture="@column.Culture" />
                          }
                          else if (column.isNumber)
@@ -388,7 +388,7 @@
                                               Value="@cell._valueNumber"
                                               ValueChanged="@cell.NumberValueChangedAsync"
                                               Margin="@Margin.Dense" Style="margin-top:0"
-                                              Required=column.Required
+                                              Required="@column.Required"
                                               Variant="@Variant.Text" Culture="@column.Culture" />
                          }
                      }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -388,7 +388,8 @@
                                               Value="@cell._valueNumber"
                                               ValueChanged="@cell.NumberValueChangedAsync"
                                               Margin="@Margin.Dense" Style="margin-top:0"
-                                              Required=column.Required Variant="@Variant.Text" Culture="@column.Culture"/>
+                                              Required=column.Required 
+                                              Variant="@Variant.Text" Culture="@column.Culture"/>
                          }
                      }
                  }


### PR DESCRIPTION
### Description

This PR makes the automatically generated EditTemplates inherit their enclosing Columns' Culture. This behaviour would mirror the automatically generated CellTemplates as they already inherit the Culture of the columns they are defined in.

### Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (fix or improvement to the website or code docs)

### Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the style of this project.
- [x] I've added relevant tests or confirmed existing ones.
