### PR TITLE
MudIconButton: Fix filled buttons losing background color on click

### DIFF
--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -19,8 +19,14 @@
     }
   }
 
-  &:focus-within, &:active {
+  &:focus-within {
     background-color: var(--mud-palette-action-default-hover);
+
+    @each $color in $mud-palette-colors {
+      &[class*="mud-button-filled-#{$color}"] {
+        background-color: var(--mud-palette-#{$color}-darken);
+      }
+    }
   }
 
   &:disabled {
@@ -42,7 +48,7 @@
     }
   }
 
-  &:focus-within, &:active {
+  &:focus-within {
     background-color: var(--mud-palette-action-default-hover);
   }
 }

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -19,7 +19,7 @@
     }
   }
 
-  &:focus-within {
+  &:focus-within, &:active {
     background-color: var(--mud-palette-action-default-hover);
 
     @each $color in $mud-palette-colors {
@@ -48,7 +48,7 @@
     }
   }
 
-  &:focus-within {
+  &:focus-within, &:active {
     background-color: var(--mud-palette-action-default-hover);
   }
 }

--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -23,7 +23,7 @@
     background-color: var(--mud-palette-action-default-hover);
 
     @each $color in $mud-palette-colors {
-      &[class*="mud-button-filled-#{$color}"] {
+      &.mud-button-filled-#{$color} {
         background-color: var(--mud-palette-#{$color}-darken);
       }
     }


### PR DESCRIPTION
Fixes: #11930 

Filled icon buttons didn't have the correct background color after being **clicked** because we were using `--mud-palette-action-default-hover` as color. For filled icon buttons we now use the same method as for normal buttons, which is to define the background color based on the filled color class applied to the component.

Using icon buttons via keyboard navigation didn't trigger this issue because the `hover` color would take effect instead, hence why I didn't notice it.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
