### PR TITLE
MudNumericField: Reset input text on blur if value is null

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1193,5 +1193,46 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(inputSelector).GetAttribute("aria-describedby").Should().Be(secondExpectedAriaDescribedBy);
         }
 #nullable disable
+
+        [Test]
+        public void Should_resolve_the_expected_underlying_input_id_and_label_id()
+        {
+            // using InputId
+            var inputIdComp = Context.RenderComponent<MudNumericField<int>>(p => p
+                .Add(x => x.Label, "A label")
+                .Add(x => x.InputId, "my-input-id"));
+            inputIdComp.Find("input").Id.Should().Be("my-input-id");
+            inputIdComp.Find("label").GetAttribute("for").Should().Be("my-input-id");
+
+            // using UserAttributes
+            var userAttributesComp = Context.RenderComponent<MudNumericField<int>>(p => p
+                .Add(x => x.Label, "A label")
+                .Add(x => x.UserAttributes, new Dictionary<string, object> { { "id", "my-user-attributes-input-id" } }));
+            userAttributesComp.Find("input").Id.Should().Be("my-user-attributes-input-id");
+            userAttributesComp.Find("label").GetAttribute("for").Should().Be("my-user-attributes-input-id");
+
+            // using neither InputId nor UserAttributes
+            var defaultComp = Context.RenderComponent<MudNumericField<int>>(p => p
+                .Add(x => x.Label, "A label"));
+            defaultComp.Find("input").Id.Should().StartWith("mudinput");
+            defaultComp.Find("label").GetAttribute("for").Should().Be(defaultComp.Find("input").Id);
+
+            // using both InputId and UserAttributes, InputId should take precedence
+            var bothComp = Context.RenderComponent<MudNumericField<int>>(p => p
+                .Add(x => x.Label, "A label")
+                .Add(x => x.InputId, "my-input-id")
+                .Add(x => x.UserAttributes, new Dictionary<string, object> { { "id", "my-user-attributes-input-id" } }));
+            bothComp.Find("input").Id.Should().Be("my-input-id");
+            bothComp.Find("label").GetAttribute("for").Should().Be("my-input-id");
+
+            // InputId is initially null, then set to a value
+            var dynamicComp = Context.RenderComponent<MudNumericField<int>>(p => p
+                .Add(x => x.Label, "A label"));
+            dynamicComp.Find("input").Id.Should().StartWith("mudinput");
+            dynamicComp.Find("label").GetAttribute("for").Should().Be(dynamicComp.Find("input").Id);
+            dynamicComp.SetParametersAndRender(p => p.Add(x => x.InputId, "my-input-id"));
+            dynamicComp.Find("input").Id.Should().Be("my-input-id");
+            dynamicComp.Find("label").GetAttribute("for").Should().Be("my-input-id");
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -777,6 +777,7 @@ namespace MudBlazor
         {
             if (InputId is not null)
             {
+                await _inputIdState.SetValueAsync(InputId);
                 return;
             }
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor.Services;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -15,7 +16,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A field for numeric values from users. 
+    /// A field for numeric values from users.
     /// </summary>
     /// <typeparam name="T">The type of number being collected.</typeparam>
     public partial class MudNumericField<T> : MudDebouncedInput<T>
@@ -38,6 +39,9 @@ namespace MudBlazor
 
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
+
+        [Inject]
+        private IJSRuntime JsRuntime { get; set; } = null!;
 
         public MudNumericField()
         {
@@ -152,7 +156,7 @@ namespace MudBlazor
             }
 
             // Overrides the browser's culture since <input type="number"> does not consider culture.
-            // If a specific Culture, Pattern, or Format is defined, <input type="text"> will be used 
+            // If a specific Culture, Pattern, or Format is defined, <input type="text"> will be used
             // with the corresponding attributes applied.
             if (!IsFormatted)
             {
@@ -193,6 +197,20 @@ namespace MudBlazor
         {
             (value, var valueChanged) = ConstrainBoundaries(value);
             return base.SetValueAsync(value, valueChanged || updateText, force);
+        }
+
+        /// <inheritdoc />
+        protected override async Task UpdateTextPropertyAsync(bool updateValue)
+        {
+            // workaround for #11196, in firefox if letters are typed into a number input,
+            // firefox sends a null value but retains the invalid letters in the input field
+            // the only way to remove those, is by explicitly resetting the value
+            if (Text is null)
+            {
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudInput.resetValue", InputElementId);
+            }
+
+            await base.UpdateTextPropertyAsync(updateValue);
         }
 
         /// <inheritdoc />
@@ -381,7 +399,7 @@ namespace MudBlazor
         /// Reverses the mouse wheel direction.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  
+        /// Defaults to <c>false</c>.
         /// When <c>true</c>, moving the mouse wheel up will decrease the value, and down will increase the value.
         /// </remarks>
         [Parameter]
@@ -428,7 +446,7 @@ namespace MudBlazor
         /// The amount added or subtracted when changing values.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>1</c>.  
+        /// Defaults to <c>1</c>.
         /// This affects changing values via spin buttons or the keyboard.
         /// </remarks>
         [Parameter]


### PR DESCRIPTION
Fixes: #11196

Firefox allows any characters to be entered into an `input` of type `number`. However, the value stored in the HTML input remains null/empty if it doesn't match a number, so our input components never see those characters (unless we handle all key presses).

In order to clear that text on blur as suggested in the issue, we have to manually reset the value in HTML when the `Text` property is `null` as that's the only condition that matches from what I can tell.

I also changed a line in the base input because I was seeing locally that the `MudNumericField`'s `input` and `label`s had mismatched `id`s. On the production and dev site I don't see that issue. I assume it's some timing/re-rendering issue. The test I added consistently fails on the last example without the changed line in the base input.

This covers the original issue, but a better solution would be to use an `input` of type `text` and to handle keys manually / with a pattern / format / others (which seems to be what most other component libraries do), but of course much more work than this workaround.

**Checklist:**
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
