### PR TITLE
MudColorPicker: Add opt-out tooltips for icon buttons

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ColorPicker/SimpleColorPickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ColorPicker/SimpleColorPickerTest.razor
@@ -7,6 +7,7 @@
                 TextChanged="@((x) => { TextValue = x; ValueChangeCallbackCounter++;  })"
                 Palette="@Palette"
                 ShowToolbar="@ShowToolbar"
+                ShowTooltips="@ShowTooltips"
                 ShowColorField="@ShowColorField"
                 ShowPreview="@ShowPreview"
                 ShowSliders="@ShowSliders"
@@ -53,6 +54,9 @@
 
     [Parameter]
     public bool ShowModeSwitch { get; set; } = true;
+
+    [Parameter]
+    public bool ShowTooltips { get; set; } = true;
 
     [Parameter]
     public bool ShowAlpha { get; set; } = true;

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1,11 +1,16 @@
 ﻿#pragma warning disable IDE1006 // leading underscore
 
 using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Resources;
 using MudBlazor.UnitTests.TestComponents.ColorPicker;
 using MudBlazor.Utilities;
 using NUnit.Framework;
@@ -590,6 +595,52 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Tooltips_Disabled_ShouldSuppressTooltipContent()
+        {
+            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            {
+                p.Add(x => x.ShowToolbar, true);
+                p.Add(x => x.ShowTooltips, false);
+            });
+
+            var tooltipRoots = comp.FindAll(".mud-tooltip-root");
+            tooltipRoots.Should().HaveCount(4);
+
+            foreach (var root in tooltipRoots)
+            {
+                root.Children.Length.Should().Be(1);
+            }
+
+            var tooltips = comp.FindComponents<MudTooltip>();
+            tooltips.Should().HaveCount(4);
+            tooltips.Should().OnlyContain(t => string.IsNullOrEmpty(t.Instance.Text));
+            comp.FindAll(".mud-tooltip").Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task Tooltips_Enabled_ShouldDisplayLocalizedContent()
+        {
+            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            {
+                p.Add(x => x.ShowToolbar, true);
+                p.Add(x => x.ShowTooltips, true);
+            });
+
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
+            var expectedTexts = new[]
+            {
+                localizer[LanguageResource.MudColorPicker_SpectrumView].Value,
+                localizer[LanguageResource.MudColorPicker_GridView].Value,
+                localizer[LanguageResource.MudColorPicker_PaletteView].Value,
+                localizer[LanguageResource.MudColorPicker_ModeSwitch].Value,
+            };
+
+            var tooltips = comp.FindComponents<MudTooltip>();
+            tooltips.Should().HaveCount(4);
+            tooltips.Select(t => t.Instance.Text).Should().Equal(expectedTexts);
+        }
+
+        [Test]
         [TestCase(ColorPickerMode.HSL)]
         [TestCase(ColorPickerMode.RGB)]
         public void Toggle_Alpha(ColorPickerMode mode)
@@ -1133,11 +1184,14 @@ namespace MudBlazor.UnitTests.Components
             await comp.Instance.OpenPicker();
 
             var providerNode = comp.Find(".mud-popover-provider");
-            providerNode.Children.Count().Should().Be(2);
+            providerNode.Children.Length.Should().BeGreaterThanOrEqualTo(2);
 
-            var popoverNode = providerNode.Children[1];
+            var popoverNode = providerNode.Children
+                .FirstOrDefault(child => child.ClassList.Contains("mud-picker-popover"));
 
-            popoverNode.ClassList.Should().BeEquivalentTo(
+            popoverNode.Should().NotBeNull();
+
+            popoverNode!.ClassList.Should().BeEquivalentTo(
             [
                 "mud-popover",
                 "mud-popover-fixed",

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -618,7 +618,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Tooltips_Enabled_ShouldDisplayLocalizedContent()
+        public void Tooltips_Enabled_ShouldDisplayLocalizedContent()
         {
             var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
             {

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -21,24 +21,33 @@
                                aria-label="@Localizer[LanguageResource.MudColorPicker_Close]" />
             }
             <MudSpacer />
+
+        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_SpectrumView] : null))">
             <MudIconButton Class="pa-1"
                            Size="Size.Small"
                            Color="GetButtonColor(ColorPickerView.Spectrum)"
                            Icon="@SpectrumIcon"
                            OnClick="() => ChangeView(ColorPickerView.Spectrum)"
                            aria-label="@Localizer[LanguageResource.MudColorPicker_SpectrumView]" />
+        </MudTooltip>
+
+        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_GridView] : null))">
             <MudIconButton Class="pa-1 mx-1"
                            Size="Size.Small"
                            Color="GetButtonColor(ColorPickerView.Grid)"
                            Icon="@GridIcon"
                            OnClick="() => ChangeView(ColorPickerView.Grid)"
                            aria-label="@Localizer[LanguageResource.MudColorPicker_GridView]" />
+        </MudTooltip>
+
+        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_PaletteView] : null))">
             <MudIconButton Class="pa-1"
                            Size="Size.Small"
                            Color="GetButtonColor(ColorPickerView.Palette)"
                            Icon="@PaletteIcon"
                            OnClick="() => ChangeView(ColorPickerView.Palette)"
                            aria-label="@Localizer[LanguageResource.MudColorPicker_PaletteView]" />
+        </MudTooltip>
         </MudPickerToolbar>
         <MudPickerContent Class="mud-picker-color-content">
             @if (ShowColorField)
@@ -253,10 +262,12 @@
                                 @if (ShowModeSwitch)
                                 {
                                     <div class="mud-picker-control-switch">
-                                        <MudIconButton OnClick="ChangeMode"
-                                                       Icon="@ImportExportIcon"
-                                                       Class="pa-1 me-n1"
-                                                       aria-label="@Localizer[LanguageResource.MudColorPicker_ModeSwitch]"></MudIconButton>
+                                        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_ModeSwitch] : null))">
+                                            <MudIconButton OnClick="ChangeMode"
+                                                           Icon="@ImportExportIcon"
+                                                           Class="pa-1 me-n1"
+                                                           aria-label="@Localizer[LanguageResource.MudColorPicker_ModeSwitch]" />
+                                        </MudTooltip>
                                     </div>
                                 }
                             </div>

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -301,6 +301,11 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int ThrottleInterval { get; set; } = 50;
 
+        /// <summary>
+        /// Enables tooltips for icon buttons.
+        /// </summary>
+        public bool ShowTooltips { get; set; } = true;
+
         /// <inheritdoc />
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -304,6 +304,8 @@ namespace MudBlazor
         /// <summary>
         /// Enables tooltips for icon buttons.
         /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public bool ShowTooltips { get; set; } = true;
 
         /// <inheritdoc />


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

This adds tooltips to the icon buttons in the Color Picker to help overall accessibility. They use the same localization strings as the ARIA labels (no extra setup) and can be disabled if wanted. They are opt-out instead of opt-in as the risk should be low while the benefit in usability is noticeable.

<img alt="image" src="https://github.com/user-attachments/assets/e77df08f-e26d-41c3-b9db-a535f08ed9f3" />


<img alt="image" src="https://github.com/user-attachments/assets/406ce1c7-aeed-4379-90d4-fe3d28fa21ab" />


These icons (and this component) were specifically picked because the purpose may not be immediately understandable for most users, unlike standard icons like a pencil for edit, a gear for settings, a palette for the adornment, etc.

They use the default tooltip timings (instantly appears) which can be changed in MudGlobal.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
