### PR TITLE
MudFormComponent: Clear converter errors on ResetValidation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1208,19 +1208,25 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("input").First().Blur();
 
             // conversion is not possible and conversion error is set
-            comp.WaitForAssertion(() => numericField.Value.Should().Be(0));
-            comp.WaitForAssertion(() => numericField.HasErrors.Should().Be(true));
-            comp.WaitForAssertion(() => numericField.ConversionError.Should().Be(true));
-            comp.WaitForAssertion(() => numericField.ConversionErrorMessage.Should().NotBeNullOrEmpty());
+            comp.WaitForAssertion(() =>
+            {
+                numericField.Value.Should().Be(0);
+                numericField.HasErrors.Should().Be(true);
+                numericField.ConversionError.Should().Be(true);
+                numericField.ConversionErrorMessage.Should().NotBeNullOrEmpty();
+            });
 
             // reset the field
-            await comp.InvokeAsync(() => comp.Instance.ResetAsync().Wait());
+            await comp.InvokeAsync(numericField.ResetAsync);
 
             // conversion error is cleared
-            comp.WaitForAssertion(() => numericField.Value.Should().Be(0));
-            comp.WaitForAssertion(() => numericField.HasErrors.Should().Be(false));
-            comp.WaitForAssertion(() => numericField.ConversionError.Should().Be(false));
-            comp.WaitForAssertion(() => numericField.ConversionErrorMessage.Should().BeNull());
+            comp.WaitForAssertion(() =>
+            {
+                numericField.Value.Should().Be(0);
+                numericField.HasErrors.Should().Be(false); 
+                numericField.ConversionError.Should().Be(false);
+                numericField.ConversionErrorMessage.Should().BeNull();
+            });
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1223,7 +1223,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() =>
             {
                 numericField.Value.Should().Be(0);
-                numericField.HasErrors.Should().Be(false); 
+                numericField.HasErrors.Should().Be(false);
                 numericField.ConversionError.Should().Be(false);
                 numericField.ConversionErrorMessage.Should().BeNull();
             });

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1193,5 +1193,34 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(inputSelector).GetAttribute("aria-describedby").Should().Be(secondExpectedAriaDescribedBy);
         }
 #nullable disable
+
+        /// <summary>
+        /// Test that reset method clears conversion errors.
+        /// </summary>
+        [Test]
+        public async Task NumericFieldConverterErrorReset()
+        {
+            var comp = Context.RenderComponent<MudNumericField<int>>();
+            var numericField = comp.Instance;
+
+            // insert an invalid int number, greater then maximum int value
+            comp.FindAll("input").First().Change("2147483648");
+            comp.FindAll("input").First().Blur();
+
+            // conversion is not possible and conversion error is set
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(0));
+            comp.WaitForAssertion(() => numericField.HasErrors.Should().Be(true));
+            comp.WaitForAssertion(() => numericField.ConversionError.Should().Be(true));
+            comp.WaitForAssertion(() => numericField.ConversionErrorMessage.Should().NotBeNullOrEmpty());
+
+            // reset the field
+            await comp.InvokeAsync(() => comp.Instance.ResetAsync().Wait());
+
+            // conversion error is cleared
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(0));
+            comp.WaitForAssertion(() => numericField.HasErrors.Should().Be(false));
+            comp.WaitForAssertion(() => numericField.ConversionError.Should().Be(false));
+            comp.WaitForAssertion(() => numericField.ConversionErrorMessage.Should().BeNull());
+        }
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -653,8 +653,10 @@ namespace MudBlazor
         public virtual void ResetValidation()
         {
             Error = false;
+            _converter.GetError = false;
             ValidationErrors.Clear();
             ErrorText = null;
+            _converter.GetErrorMessage = default;
             StateHasChanged();
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -653,11 +653,16 @@ namespace MudBlazor
         public virtual void ResetValidation()
         {
             Error = false;
-            _converter.GetError = false;
             ValidationErrors.Clear();
             ErrorText = null;
-            _converter.GetErrorMessage = default;
+            ResetConverterErrors();
             StateHasChanged();
+        }
+
+        private void ResetConverterErrors()
+        {
+            _converter.GetError = false;
+            _converter.GetErrorMessage = null;
         }
 
         #endregion


### PR DESCRIPTION
`ResetValidation` method of `MudFormComponent` resets the `Error`, `ErrorText` and `ValidationErrors`, but does not clear `Converter` validation errors. However, `HasErrors` field checks the conversion errors and therefore its value stays true even after reset.
Conversion errors are now reset as well.

Fixes #11958 

**Checklist:**
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
