### PR TITLE
MudScrollListener: Fix document scroll

### DIFF
--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -49,22 +49,14 @@ class MudScrollListener {
 
             // determine if the target is the document
             const isDocument = element === document;
+            const scrollSource = isDocument ? (document.scrollingElement || document.documentElement || document.body) : element;
 
             //data to pass
-            let scrollTop = element.scrollTop;
-            let scrollHeight = element.scrollHeight;
-            let scrollWidth = element.scrollWidth;
-            let scrollLeft = element.scrollLeft;
+            let scrollTop = scrollSource.scrollTop || 0;
+            let scrollHeight = scrollSource.scrollHeight || 0;
+            let scrollWidth = scrollSource.scrollWidth || 0;
+            let scrollLeft = scrollSource.scrollLeft || 0;
             let nodeName = element.nodeName;
-
-            if (isDocument) {
-                // prefer document.scrollingElement for page-level scroll values
-                const scrollingEl = document.scrollingElement || document.documentElement || document.body;
-                scrollTop = scrollingEl.scrollTop || 0;
-                scrollHeight = scrollingEl.scrollHeight || 0;
-                scrollWidth = scrollingEl.scrollWidth || 0;
-                scrollLeft = scrollingEl.scrollLeft || 0;
-            }
 
             //data to pass
             let firstChild = element.firstElementChild;

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -47,12 +47,24 @@ class MudScrollListener {
         try {
             let element = event.target;
 
+            // determine if the target is the document
+            const isDocument = element === document;
+
             //data to pass
             let scrollTop = element.scrollTop;
             let scrollHeight = element.scrollHeight;
             let scrollWidth = element.scrollWidth;
             let scrollLeft = element.scrollLeft;
             let nodeName = element.nodeName;
+
+            if (isDocument) {
+                // prefer document.scrollingElement for page-level scroll values
+                const scrollingEl = document.scrollingElement || document.documentElement || document.body;
+                scrollTop = scrollingEl.scrollTop || 0;
+                scrollHeight = scrollingEl.scrollHeight || 0;
+                scrollWidth = scrollingEl.scrollWidth || 0;
+                scrollLeft = scrollingEl.scrollLeft || 0;
+            }
 
             //data to pass
             let firstChild = element.firstElementChild;
@@ -67,7 +79,7 @@ class MudScrollListener {
                 nodeName,
             });
         } catch (error) {
-            console.log('[MudBlazor] Error in scrollHandler:', { error });
+            console.error('[MudBlazor] Error in scrollHandler:', { error });
         }
     }
 


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

While I can't speak to the intentions when this was built it seems like it was created to capture page scroll in addition to Selector scroll. This change just adds in a check when the element is "document" and grabs the scroll position. Tested with the new Service docs before porting to it's own PR. It has literal 0 effect if someone was calculating it manually via firstChild (possible) but instead returns the proper scroll positions for the first scrollable element of a document.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
