### PR TITLE
MudAutocomplete: ProgressBar AdornmentIcon Hiding

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutoCompleteProgressTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutoCompleteProgressTest.razor
@@ -1,0 +1,129 @@
+﻿@using System.Threading
+
+<MudGrid>
+    <MudItem xs="12">
+        <MudText Typo="Typo.h6">Normal</MudText>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" Variant="Variant.Outlined" ShowProgressIndicator="true" ProgressIndicatorColor="SelectedColor" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value3" SearchFunc="@Search1" Variant="Variant.Outlined" ProgressIndicatorColor="SelectedColor">
+            <ProgressIndicatorInPopoverTemplate>
+                <MudList T="string" ReadOnly>
+                    <MudListItem>
+                        Loading...
+                    </MudListItem>
+                </MudList>
+            </ProgressIndicatorInPopoverTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search1" ShowProgressIndicator="true">
+            <ProgressIndicatorTemplate>
+                <MudProgressLinear Size="Size.Small" Indeterminate="true" Color="SelectedColor" />
+            </ProgressIndicatorTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12">
+        <MudText Typo="Typo.h6">Start Icons</MudText>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" Variant="Variant.Outlined" ShowProgressIndicator="true" ProgressIndicatorColor="SelectedColor" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Rounded.Search" AdornmentColor="Color.Inherit"/>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value3" SearchFunc="@Search1" Variant="Variant.Outlined" ProgressIndicatorColor="SelectedColor" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Rounded.Search" AdornmentColor="Color.Inherit">
+            <ProgressIndicatorInPopoverTemplate>
+                <MudList T="string" ReadOnly>
+                    <MudListItem>
+                        Loading...
+                    </MudListItem>
+                </MudList>
+            </ProgressIndicatorInPopoverTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search1" ShowProgressIndicator="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Rounded.Search" AdornmentColor="Color.Inherit">
+            <ProgressIndicatorTemplate>
+                <MudProgressLinear Size="Size.Small" Indeterminate="true" Color="SelectedColor" />
+            </ProgressIndicatorTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12">
+        <MudText Typo="Typo.h6">End Icons</MudText>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value1" SearchFunc="@Search1" Variant="Variant.Outlined" ShowProgressIndicator="true" ProgressIndicatorColor="SelectedColor" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Rounded.Search" AdornmentColor="Color.Inherit"/>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value3" SearchFunc="@Search1" Variant="Variant.Outlined" ProgressIndicatorColor="SelectedColor" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Rounded.Search" AdornmentColor="Color.Inherit">
+            <ProgressIndicatorInPopoverTemplate>
+                <MudList T="string" ReadOnly>
+                    <MudListItem>
+                        Loading...
+                    </MudListItem>
+                </MudList>
+            </ProgressIndicatorInPopoverTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="4">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="value2" SearchFunc="@Search1" ShowProgressIndicator="true" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Rounded.Search" AdornmentColor="Color.Inherit">
+            <ProgressIndicatorTemplate>
+                <MudProgressLinear Size="Size.Small" Indeterminate="true" Color="SelectedColor" />
+            </ProgressIndicatorTemplate>
+        </MudAutocomplete>
+    </MudItem>
+    <MudItem md="4">
+        <MudText Typo="Typo.h6" GutterBottom="true">Progress options</MudText>
+        <MudSelect T="Color" Label="Color" Margin="Margin.Dense" Dense="true" Value="@SelectedColor" ValueChanged="OnColorSelected">
+            <MudSelectItem T="Color" Value="@Color.Default">Default</MudSelectItem>
+            <MudSelectItem T="Color" Value="@Color.Info">Info</MudSelectItem>
+            <MudSelectItem T="Color" Value="@Color.Success">Success</MudSelectItem>
+            <MudSelectItem T="Color" Value="@Color.Warning">Warning</MudSelectItem>
+            <MudSelectItem T="Color" Value="@Color.Error">Error</MudSelectItem>
+        </MudSelect>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public static string __description__ = "Viewer Test to Display Adornment Icons with Progress Bar as well as the normal Progress Indicators from Examples";
+    public Color SelectedColor { get; set; } = Color.Default;
+
+    private string value1 = string.Empty;
+    private string value2 = string.Empty;
+    private string value3 = string.Empty;
+
+    private string[] states =
+    {
+        "Alabama", "Alaska", "American Samoa", "Arizona",
+        "Arkansas", "California", "Colorado", "Connecticut",
+        "Delaware", "District of Columbia", "Federated States of Micronesia",
+        "Florida", "Georgia", "Guam", "Hawaii", "Idaho",
+        "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky",
+        "Louisiana", "Maine", "Marshall Islands", "Maryland",
+        "Massachusetts", "Michigan", "Minnesota", "Mississippi",
+        "Missouri", "Montana", "Nebraska", "Nevada",
+        "New Hampshire", "New Jersey", "New Mexico", "New York",
+        "North Carolina", "North Dakota", "Northern Mariana Islands", "Ohio",
+        "Oklahoma", "Oregon", "Palau", "Pennsylvania", "Puerto Rico",
+        "Rhode Island", "South Carolina", "South Dakota", "Tennessee",
+        "Texas", "Utah", "Vermont", "Virgin Island", "Virginia",
+        "Washington", "West Virginia", "Wisconsin", "Wyoming",
+    };
+
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(1000, token);
+
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return states;
+        return states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    public void OnColorSelected(Color value)
+    {
+        SelectedColor = value;
+    }
+}

--- a/src/MudBlazor/Styles/components/_select.scss
+++ b/src/MudBlazor/Styles/components/_select.scss
@@ -24,8 +24,9 @@
       padding-right: 4.5rem !important;
     }
 
-    // If autocomplete has a progress indicator, the adornment should be hidden when loading
-    & .mud-select-input .mud-icon-button {
+    // hide only when the wrapper does NOT contain mud-input-adornment-start
+    // AND DOES contain .progress-indicator-circular somewhere inside
+    &:not(:has(.mud-input-adornment-start)):has(.progress-indicator-circular) .mud-select-input .mud-icon-button {
       display: none !important;
     }
 


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Previously when you set ShowProgressIndicator was true it would always hide the icon regardless of situation. This PR changes that since the progress indicator is always at the end (RTL doesn't matter here) then we only hide the adornmenticon if it's at the end. Also added logic to only hide if it contains a circular bar, so if a user does their own template it won't hide (Most use the underline method)

Resolves #11574 

Before:
![AdornmentPrevious](https://github.com/user-attachments/assets/9838b46d-3c05-4059-8daf-5708f3f22f72)

After:
![AdornmentProgress](https://github.com/user-attachments/assets/36da2658-a0aa-4bb7-8357-c0993dbcf347)

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
