### PR TITLE
MudGrid: Support Responsive Layout via Order Parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridResponsiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/Examples/GridResponsiveExample.razor
@@ -1,0 +1,133 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudGrid Class="pa-4 demo-responsive-grid">
+
+    <!-- Item 1 -->
+    <MudItem xs="12" sm="6" md="4"
+             Order="@Order1" OrderSm="@OrderSm1" OrderMd="@OrderMd1" OrderLg="@OrderLg1">
+        <MudPaper Class="pa-4 text-center" Elevation="2">
+            <MudText Typo="Typo.h6">Item 1</MudText>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudNumericField T="int?" Label="Order" Min="0" Max="12" @bind-Value="Order1" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderSm" Min="0" Max="12" @bind-Value="OrderSm1" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderMd" Min="0" Max="12" @bind-Value="OrderMd1" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderLg" Min="0" Max="12" @bind-Value="OrderLg1" Immediate="true" />
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+
+    <!-- Item 2 -->
+    <MudItem xs="12" sm="6" md="4"
+             Order="@Order2" OrderSm="@OrderSm2" OrderMd="@OrderMd2" OrderLg="@OrderLg2">
+        <MudPaper Class="pa-4 text-center" Elevation="2">
+            <MudText Typo="Typo.h6">Item 2</MudText>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudNumericField T="int?" Label="Order" Min="0" Max="12" @bind-Value="Order2" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderSm" Min="0" Max="12" @bind-Value="OrderSm2" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderMd" Min="0" Max="12" @bind-Value="OrderMd2" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderLg" Min="0" Max="12" @bind-Value="OrderLg2" Immediate="true" />
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+
+    <!-- Item 3 -->
+    <MudItem xs="12" sm="6" md="4"
+             Order="@Order3" OrderSm="@OrderSm3" OrderMd="@OrderMd3" OrderLg="@OrderLg3">
+        <MudPaper Class="pa-4 text-center" Elevation="2">
+            <MudText Typo="Typo.h6">Item 3</MudText>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudNumericField T="int?" Label="Order" Min="0" Max="12" @bind-Value="Order3" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderSm" Min="0" Max="12" @bind-Value="OrderSm3" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderMd" Min="0" Max="12" @bind-Value="OrderMd3" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderLg" Min="0" Max="12" @bind-Value="OrderLg3" Immediate="true" />
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+
+    <!-- Item 4 -->
+    <MudItem xs="12" sm="6" md="4"
+             Order="@Order4" OrderSm="@OrderSm4" OrderMd="@OrderMd4" OrderLg="@OrderLg4">
+        <MudPaper Class="pa-4 text-center" Elevation="2">
+            <MudText Typo="Typo.h6">Item 4</MudText>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudNumericField T="int?" Label="Order" Min="0" Max="12" @bind-Value="Order4" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderSm" Min="0" Max="12" @bind-Value="OrderSm4" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderMd" Min="0" Max="12" @bind-Value="OrderMd4" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderLg" Min="0" Max="12" @bind-Value="OrderLg4" Immediate="true" />
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+
+    <!-- Item 5 -->
+    <MudItem xs="12" sm="6" md="4"
+             Order="@Order5" OrderSm="@OrderSm5" OrderMd="@OrderMd5" OrderLg="@OrderLg5">
+        <MudPaper Class="pa-4 text-center" Elevation="2">
+            <MudText Typo="Typo.h6">Item 5</MudText>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudNumericField T="int?" Label="Order" Min="0" Max="12" @bind-Value="Order5" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderSm" Min="0" Max="12" @bind-Value="OrderSm5" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderMd" Min="0" Max="12" @bind-Value="OrderMd5" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderLg" Min="0" Max="12" @bind-Value="OrderLg5" Immediate="true" />
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+
+    <!-- Item 6 -->
+    <MudItem xs="12" sm="6" md="4"
+             Order="@Order6" OrderSm="@OrderSm6" OrderMd="@OrderMd6" OrderLg="@OrderLg6">
+        <MudPaper Class="pa-4 text-center" Elevation="2">
+            <MudText Typo="Typo.h6">Item 6</MudText>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+                <MudNumericField T="int?" Label="Order" Min="0" Max="12" @bind-Value="Order6" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderSm" Min="0" Max="12" @bind-Value="OrderSm6" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderMd" Min="0" Max="12" @bind-Value="OrderMd6" Immediate="true" />
+                <MudNumericField T="int?" Label="OrderLg" Min="0" Max="12" @bind-Value="OrderLg6" Immediate="true" />
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+
+</MudGrid>
+
+@code {
+    // Item 1
+    private int? Order1 = 1;
+    private int? OrderSm1;
+    private int? OrderMd1;
+    private int? OrderLg1;
+
+    // Item 2
+    private int? Order2 = 2;
+    private int? OrderSm2;
+    private int? OrderMd2;
+    private int? OrderLg2;
+
+    // Item 3
+    private int? Order3 = 3;
+    private int? OrderSm3;
+    private int? OrderMd3;
+    private int? OrderLg3;
+
+    // Item 4
+    private int? Order4 = 4;
+    private int? OrderSm4;
+    private int? OrderMd4;
+    private int? OrderLg4;
+
+    // Item 5
+    private int? Order5 = 5;
+    private int? OrderSm5;
+    private int? OrderMd5;
+    private int? OrderLg5;
+
+    // Item 6
+    private int? Order6 = 6;
+    private int? OrderSm6;
+    private int? OrderMd6;
+    private int? OrderLg6;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
@@ -46,6 +46,23 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Responsive Grid">
+                <Description>
+                    Demonstrates how to build a responsive layout using the MudGrid and MudItem components.
+                    <br />
+                    You can use the Order, OrderSm, OrderMd, OrderLg, OrderXl, and OrderXxl parameters (max value up to 12) to control the visual order of grid items across different breakpoints.
+                    <br />
+                    This allows the same layout to adapt naturally between mobile and desktop views without duplicating markup.
+                    <br />
+                    If multiple order parameters are set, the largest active breakpoint takes precedence.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Class="demo-grid-basic" Code="@nameof(GridResponsiveExample)" ShowCode="false">
+                <GridResponsiveExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Grid Builder">
                 <Description>Calculate your breakpoints with this tool. Move the slider to add and remove items.</Description>
             </SectionHeader>

--- a/src/MudBlazor/Components/Grid/MudItem.razor.cs
+++ b/src/MudBlazor/Components/Grid/MudItem.razor.cs
@@ -23,6 +23,12 @@ public partial class MudItem : MudComponentBase
             .AddClass($"mud-grid-item-lg-{lg}", lg != 0)
             .AddClass($"mud-grid-item-xl-{xl}", xl != 0)
             .AddClass($"mud-grid-item-xxl-{xxl}", xxl != 0)
+            .AddClass($"order-{Order}", Order != null)
+            .AddClass($"order-sm-{OrderSm}", OrderSm != null)
+            .AddClass($"order-md-{OrderMd}", OrderMd != null)
+            .AddClass($"order-lg-{OrderLg}", OrderLg != null)
+            .AddClass($"order-xl-{OrderXl}", OrderXl != null)
+            .AddClass($"order-xxl-{OrderXxl}", OrderXxl != null)
             .AddClass(Class)
             .Build();
 
@@ -70,6 +76,59 @@ public partial class MudItem : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Item.Behavior)]
     public int xxl { get; set; }
+
+    /// <summary>
+    /// Controls the visual order of the grid item for all breakpoints by default.
+    /// Lower values appear before higher ones.  
+    /// If multiple order parameters are set (e.g., <see cref="OrderMd"/>),  
+    /// the largest active breakpoint takes precedence.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Item.Behavior)]
+    public int? Order { get; set; }
+
+    /// <summary>
+    /// Controls the visual order of the grid item starting from the 'small' breakpoint (≥600px).
+    /// Overrides <see cref="Order"/> when the viewport width is within this range or larger.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Item.Behavior)]
+    public int? OrderSm { get; set; }
+
+    /// <summary>
+    /// Controls the visual order of the grid item starting from the 'medium' breakpoint (≥960px).
+    /// Overrides smaller breakpoint orders (<see cref="Order"/> and <see cref="OrderSm"/>)
+    /// when the viewport width is within this range or larger.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Item.Behavior)]
+    public int? OrderMd { get; set; }
+
+    /// <summary>
+    /// Controls the visual order of the grid item starting from the 'large' breakpoint (≥1280px).
+    /// Overrides <see cref="Order"/>, <see cref="OrderSm"/>, and <see cref="OrderMd"/>  
+    /// when this breakpoint is active.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Item.Behavior)]
+    public int? OrderLg { get; set; }
+
+    /// <summary>
+    /// Controls the visual order of the grid item starting from the 'extra large' breakpoint (≥1920px).
+    /// Overrides all smaller breakpoint order values when active.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Item.Behavior)]
+    public int? OrderXl { get; set; }
+
+    /// <summary>
+    /// Controls the visual order of the grid item starting from the 'extra extra large' breakpoint (≥2560px).
+    /// Overrides all smaller breakpoint order values when active.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Item.Behavior)]
+    public int? OrderXxl { get; set; }
+
 
     // ToDo false,auto,true on all sizes.
 

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -13,6 +13,7 @@
 @import 'core/_animations';
 @import 'core/_reset';
 @import 'core/_elevation';
+@import 'core/_order.scss';
 
 @import 'components/_alert';
 @import 'components/_badge';

--- a/src/MudBlazor/Styles/core/_order.scss
+++ b/src/MudBlazor/Styles/core/_order.scss
@@ -1,0 +1,47 @@
+$orders: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12;
+
+@each $o in $orders {
+  .order-#{$o} {
+    order: $o !important;
+  }
+}
+
+@media (min-width: $breakpoint-sm) {
+  @each $o in $orders {
+    .order-sm-#{$o} {
+      order: $o !important;
+    }
+  }
+}
+
+@media (min-width: $breakpoint-md) {
+  @each $o in $orders {
+    .order-md-#{$o} {
+      order: $o !important;
+    }
+  }
+}
+
+@media (min-width: $breakpoint-lg) {
+  @each $o in $orders {
+    .order-lg-#{$o} {
+      order: $o !important;
+    }
+  }
+}
+
+@media (min-width: $breakpoint-xl) {
+  @each $o in $orders {
+    .order-xl-#{$o} {
+      order: $o !important;
+    }
+  }
+}
+
+@media (min-width: $breakpoint-xxl) {
+  @each $o in $orders {
+    .order-xxl-#{$o} {
+      order: $o !important;
+    }
+  }
+}


### PR DESCRIPTION
Currently there is no option that show MudItems with different order on different screen size like laptop, tablet or mobile. The only way was rearranging items with MudHidden.

With this PR, we announce new parameters like Order, OrderSm, OrderMd, OrderLg, OrderXl and OrderXxl. With this parameters, users can re-arrange item order on different breakpoints. The last item on desktop can be the first item on mobile view with these parameters easily.

The logic only uses CSS to achieve maximum performance.

Also added an example to show clearly how this enhancement works.

Hope you like.


https://github.com/user-attachments/assets/89dab3fa-3167-45ca-b07a-e95bea9093fd

