### PR TITLE
MudNavGroup: Fix Background Color After Click

### DIFF
--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -157,7 +157,11 @@
     }
   }
 
-  &:focus:not(.mud-nav-link-disabled) {
+  &:focus:not(:focus-visible) {
+    background-color: transparent !important;
+  }
+
+  &:focus-visible:not(.mud-nav-link-disabled) {
     background-color: var(--mud-palette-action-default-hover);
   }
 

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -157,10 +157,6 @@
     }
   }
 
-  &:focus:not(:focus-visible) {
-    background-color: transparent !important;
-  }
-
   &:focus-visible:not(.mud-nav-link-disabled) {
     background-color: var(--mud-palette-action-default-hover);
   }


### PR DESCRIPTION
MudNavGroup has grayed background after click. That causes a confusing visual: Active navlink and last clicked navgroup has same background color.

We changed the behavior. The background color only changes when navigated with keyboard, not click with mouse.

Before:

https://github.com/user-attachments/assets/02f07df4-35bf-48ff-bb53-5f1acb440a13

After:

https://github.com/user-attachments/assets/cd47c246-b4c9-4cbe-80c5-d44d9596f91f


