### PR TITLE
MudTable: Add AriaLabel parameter for accessibility

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableAriaLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableAriaLabelExample.razor
@@ -1,4 +1,4 @@
-@namespace MudBlazor.Docs.Examples
+﻿@namespace MudBlazor.Docs.Examples
 
 <MudTable T="string" Items="@_items" AriaLabel="Fruits table" Hover="true" Breakpoint="Breakpoint.Sm">
     <HeaderContent>

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableAriaLabelExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableAriaLabelExample.razor
@@ -1,0 +1,14 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudTable T="string" Items="@_items" AriaLabel="Fruits table" Hover="true" Breakpoint="Breakpoint.Sm">
+    <HeaderContent>
+        <MudTh>Fruit</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Fruit">@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    private readonly string[] _items = new[] { "Apple", "Banana", "Cherry" };
+}

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -1,4 +1,4 @@
-@page "/components/table"
+﻿@page "/components/table"
 
 <DocsPage>
     <DocsPageHeader Title="Table" Component="@nameof(MudTable<T>)" />
@@ -326,5 +326,6 @@
 
     </DocsPageContent>
 </DocsPage>
+
 
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -1,4 +1,4 @@
-﻿@page "/components/table"
+@page "/components/table"
 
 <DocsPage>
     <DocsPageHeader Title="Table" Component="@nameof(MudTable<T>)" />
@@ -67,7 +67,7 @@
                     See <MudLink Href="@ApiLink.GetApiLinkFor(typeof(MudTablePager))">TablePager API</MudLink> for more informations.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         <CodeInline>@("RowsPerPage")</CodeInline> parameter of MudTable is independent of <CodeInline>@("PageSizeOptions")</CodeInline> parameter of PagerContent. Therefore, the RowsPerPage value does not have
-                        to be one of the values ​​in the PageSizeOptions list. If the table pager is shown you should make sure the value of RowsPerPage is also available in the PageSizeOptions list, otherwise the users can not go back to this RowsPerPage value once they have chosen another one.
+                        to be one of the values ??in the PageSizeOptions list. If the table pager is shown you should make sure the value of RowsPerPage is also available in the PageSizeOptions list, otherwise the users can not go back to this RowsPerPage value once they have chosen another one.
                     </MudAlert>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
                         Specifying <CodeInline>int.MaxValue</CodeInline> in the <CodeInline>@("PageSizeOptions")</CodeInline> will render as "All" in the Page Size dropdown. Use it when you want users to be able to show all items at once, but be careful, as this can lead to poor performance.
@@ -311,6 +311,16 @@
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableMultiGroupingExample)" ShowCode="false" Block="true" FullWidth="true">
                 <TableMultiGroupingExample />
+            </SectionContent>
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Accessibility">
+                <Description>
+                    Set the <CodeInline>AriaLabel</CodeInline> parameter to provide an accessible name for the HTML <CodeInline>&lt;table&gt;</CodeInline> element. This helps screen readers announce the purpose of the table.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(TableAriaLabelExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TableAriaLabelExample />
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -67,7 +67,7 @@
                     See <MudLink Href="@ApiLink.GetApiLinkFor(typeof(MudTablePager))">TablePager API</MudLink> for more informations.
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
                         <CodeInline>@("RowsPerPage")</CodeInline> parameter of MudTable is independent of <CodeInline>@("PageSizeOptions")</CodeInline> parameter of PagerContent. Therefore, the RowsPerPage value does not have
-                        to be one of the values ??in the PageSizeOptions list. If the table pager is shown you should make sure the value of RowsPerPage is also available in the PageSizeOptions list, otherwise the users can not go back to this RowsPerPage value once they have chosen another one.
+                        to be one of the values in the PageSizeOptions list. If the table pager is shown you should make sure the value of RowsPerPage is also available in the PageSizeOptions list, otherwise the users can not go back to this RowsPerPage value once they have chosen another one.
                     </MudAlert>
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
                         Specifying <CodeInline>int.MaxValue</CodeInline> in the <CodeInline>@("PageSizeOptions")</CodeInline> will render as "All" in the Page Size dropdown. Use it when you want users to be able to show all items at once, but be careful, as this can lead to poor performance.

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable BL0005 // Set parameter outside component
+#pragma warning disable BL0005 // Set parameter outside component
 
 using AngleSharp.Dom;
 using Bunit;
@@ -3039,5 +3039,20 @@ namespace MudBlazor.UnitTests.Components
             _mockScrollManager.Verify(sm => sm.ScrollToVirtualizedItemAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<ScrollBehavior>()), Times.Never);
             jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudTableCell.focusCell", It.IsAny<object[]>()), Times.Never);
         }
+
+        [Test]
+        public void TableAriaLabel_RendersOnTable()
+        {
+            var comp = Context.RenderComponent<TableRowClickTest>();
+            var tableEl = comp.Find("table");
+            tableEl.HasAttribute("aria-label").Should().BeFalse();
+
+            var table = comp.FindComponent<MudTable<int>>();
+            table.SetParametersAndRender(p => p.Add(x => x.AriaLabel, "My Accessible Table"));
+
+            tableEl = comp.Find("table");
+            tableEl.GetAttribute("aria-label").Should().Be("My Accessible Table");
+        }
+
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1,4 +1,4 @@
-#pragma warning disable BL0005 // Set parameter outside component
+﻿#pragma warning disable BL0005 // Set parameter outside component
 
 using AngleSharp.Dom;
 using Bunit;
@@ -3056,3 +3056,4 @@ namespace MudBlazor.UnitTests.Components
 
     }
 }
+

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor
+@namespace MudBlazor
 @inherits MudTableBase
 @using MudBlazor.Utilities
 @typeparam T
@@ -29,7 +29,7 @@
             </div>
         }
         <div id="@_tableId" class="mud-table-container @TableContainerClass" style="@TableContainerStyle @(GetHorizontalScrollbarStyle())">
-            <table class="@TableClassname">
+            <table class="@TableClassname" aria-label="@AriaLabel">
                 @if (ColGroup != null)
                 {
                     <colgroup>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -1,4 +1,4 @@
-@namespace MudBlazor
+﻿@namespace MudBlazor
 @inherits MudTableBase
 @using MudBlazor.Utilities
 @typeparam T
@@ -255,3 +255,4 @@
         return rootNode;
     }
 }
+

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
@@ -800,3 +800,4 @@ namespace MudBlazor
         public Interfaces.IForm Validator { get; set; } = new TableRowValidator();
     }
 }
+

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
@@ -46,6 +46,17 @@ namespace MudBlazor
         protected string FootClassname => new CssBuilder("mud-table-foot")
             .AddClass(FooterClass)
             .Build();
+
+        /// <summary>
+        /// The aria-label for the HTML table element.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to null. When set, renders as the table's <c>aria-label</c> attribute for accessibility.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Behavior)]
+        public string? AriaLabel { get; set; }
+
 
         /// <summary>
         /// Forces a row being edited to be saved or canceled before a new row can be selected.


### PR DESCRIPTION
# Summary

- Adds an AriaLabel parameter to MudTable to render an aria-label on the underlying HTML table for improved accessibility.
- Updates the Table docs with an Accessibility section and example.
- Adds a unit test to verify the attribute is rendered.

# Motivation

- Addresses accessibility gap requested in issue #11929.
- Screen readers rely on an accessible name to identify the purpose of the table. This makes MudTable more usable with assistive technologies.
- Default behavior remains unchanged; when not set, no attribute is rendered.

# Changes

- New parameter
  - Adds public string? AriaLabel { get; set; } on the base class so it’s available on all MudTable usages.
  - Path: src/MudBlazor/Components/Table/MudTableBase.cs
- Table markup
  - Binds the new parameter to the <table> element.
  - Path: src/MudBlazor/Components/Table/MudTable.razor:32
  - Change: <table class="@TableClassname" aria-label="@AriaLabel">
- Unit test
  - Verifies that aria-label is omitted by default, then appears when set.
  - Path: src/MudBlazor.UnitTests/Components/TableTests.cs (method: TableAriaLabel_RendersOnTable)
- Docs
  - Example: src/MudBlazor.Docs/Pages/Components/Table/Examples/TableAriaLabelExample.razor
  - Section: Adds “Accessibility” section to the Table page referencing the example.
  - Path: src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor

# Usage

- Example:
  - <MudTable T="Element" AriaLabel="Order list"> … </MudTable>
- Defaults to null; no markup change unless set.

# Notes

- No visual changes; purely an accessibility enhancement.
- No breaking changes.
- No performance impact; single attribute render when provided.
- Category: Table.Behavior.

# Testing

- Added unit test: TableAriaLabel_RendersOnTable.
- Ran tests locally; the new test passes.

Fixes #11929
# Checklist

- [x] The PR is submitted to the correct branch (dev).
- [x] My code follows the style of this project.
- [x] I've added relevant tests or confirmed existing ones.