### PR TITLE
MudDataGrid: Add Order parameter for explicit column ordering

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnDragAndDropNullsOrderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnDragAndDropNullsOrderTest.razor
@@ -1,0 +1,42 @@
+@namespace MudBlazor.UnitTests.TestComponents.DataGrid
+
+<MudDataGrid @ref="_dataGrid" Items="@_items" DragDropColumnReordering="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" @bind-Order="@NameColumnOrder" />
+        <PropertyColumn Property="x => x.Age" Title="Age" @bind-Order="@AgeColumnOrder" />
+        <PropertyColumn Property="x => x.Position" Title="Position" @bind-Order="@PositionColumnOrder" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private MudDataGrid<Model> _dataGrid = null!;
+
+    public class Model
+    {
+        public string? Name { get; set; }
+        public int Age { get; set; }
+        public string? Position { get; set; }
+    }
+
+    private IEnumerable<Model> _items = new List<Model>();
+
+    [Parameter]
+    public int? NameColumnOrder { get; set; } = 1;
+
+    [Parameter]
+    public int? AgeColumnOrder { get; set; } = 2;
+
+    [Parameter]
+    public int? PositionColumnOrder { get; set; }
+
+    public MudDataGrid<Model> DataGrid => _dataGrid;
+
+    protected override void OnInitialized()
+    {
+        _items = new[]
+        {
+            new Model { Name = "Alice", Age = 30, Position = "Engineer" },
+            new Model { Name = "Bob", Age = 25, Position = "Designer" },
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnOrderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnOrderTest.razor
@@ -1,0 +1,40 @@
+@namespace MudBlazor.UnitTests.TestComponents.DataGrid
+
+<MudDataGrid Items="@_items">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Title="Name" />
+        <PropertyColumn Property="x => x.Position" Title="Position" Order="@PositionColumnOrder" />
+        <SelectColumn T="Model" Order="@SelectColumnOrder" />
+        <HierarchyColumn T="Model" Order="@HierarchyColumnOrder" />
+        <PropertyColumn Property="x => x.Number" Title="Number" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public class Model
+    {
+        public string? Name { get; set; }
+        public int Number { get; set; }
+        public string? Position { get; set; }
+    }
+
+    private IEnumerable<Model> _items = new List<Model>();
+
+    [Parameter]
+    public int? PositionColumnOrder { get; set; }
+
+    [Parameter]
+    public int? SelectColumnOrder { get; set; }
+
+    [Parameter]
+    public int? HierarchyColumnOrder { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _items = new[]
+        {
+            new Model { Name = "A", Number = 1, Position = "First" },
+            new Model { Name = "B", Number = 2, Position = "Second" },
+        };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5581,5 +5581,97 @@ namespace MudBlazor.UnitTests.Components
             mudIconButton = FirstFilterButton();
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryAlert);
         }
+
+        [Test]
+        public async Task DataGridColumnOrderTest()
+        {
+            var comp = Context.RenderComponent<DataGridColumnOrderTest>();
+            var grid = comp.FindComponent<MudDataGrid<DataGridColumnOrderTest.Model>>().Instance;
+
+            // Test default order (no Order set)
+            var columns = grid.RenderedColumns.ToList();
+            columns[0].Tag.Should().Be("hierarchy-column");
+            columns[1].Tag.Should().Be("select-column");
+            columns[2].Title.Should().Be("Name");
+            columns[3].Title.Should().Be("Position");
+            columns[4].Title.Should().Be("Number");
+
+            // Test overriding special column order
+            await comp.InvokeAsync(() =>
+            {
+                comp.SetParametersAndRender(parameters =>
+                {
+                    parameters.Add(p => p.SelectColumnOrder, 3);
+                    parameters.Add(p => p.HierarchyColumnOrder, 4);
+                });
+            });
+            columns = grid.RenderedColumns.ToList();
+            columns[0].Title.Should().Be("Name");
+            columns[1].Title.Should().Be("Position");
+            columns[2].Title.Should().Be("Number");
+            columns[3].Tag.Should().Be("select-column");
+            columns[4].Tag.Should().Be("hierarchy-column");
+
+            // Test placing a regular column first
+            await comp.InvokeAsync(() =>
+            {
+                comp.SetParametersAndRender(parameters =>
+                {
+                    parameters.Add(p => p.PositionColumnOrder, -1);
+                    parameters.Add(p => p.SelectColumnOrder, (int?)null);
+                    parameters.Add(p => p.HierarchyColumnOrder, (int?)null);
+                });
+            });
+            columns = grid.RenderedColumns.ToList();
+            columns[0].Title.Should().Be("Position");
+            columns[1].Tag.Should().Be("hierarchy-column");
+            columns[2].Tag.Should().Be("select-column");
+            columns[3].Title.Should().Be("Name");
+            columns[4].Title.Should().Be("Number");
+        }
+
+        [Test]
+        public async Task DataGridColumnDragAndDropNullsOrderTest()
+        {
+            var comp = Context.RenderComponent<DataGridColumnDragAndDropNullsOrderTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnDragAndDropNullsOrderTest.Model>>();
+            var grid = dataGrid.Instance;
+
+            // Verify initial Order values
+            var nameColumn = grid.RenderedColumns.First(c => c.Title == "Name");
+            var ageColumn = grid.RenderedColumns.First(c => c.Title == "Age");
+            var positionColumn = grid.RenderedColumns.First(c => c.Title == "Position");
+
+            nameColumn.Order.Should().Be(1, "Name column should start with Order=1");
+            ageColumn.Order.Should().Be(2, "Age column should start with Order=2");
+            positionColumn.Order.Should().BeNull("Position column should start with no Order");
+
+            // Verify initial order in UI
+            var headerValues = dataGrid.FindAll(".sortable-column-header");
+            headerValues[0].InnerHtml.Should().Be("Name");
+            headerValues[1].InnerHtml.Should().Be("Age");
+            headerValues[2].InnerHtml.Should().Be("Position");
+
+            // Perform drag-and-drop: drag Name to Age's position
+            var dropZones = dataGrid.FindAll(".mud-drop-zone");
+            var nameDropItem = dropZones[0].Children[0];
+            var ageDropItem = dropZones[1].Children[0];
+
+            await nameDropItem.DragStartAsync(new DragEventArgs());
+            await ageDropItem.DropAsync(new DragEventArgs());
+
+            // Verify columns swapped in UI
+            var newHeaderValues = dataGrid.FindAll(".sortable-column-header");
+            newHeaderValues[0].InnerHtml.Should().Be("Age");
+            newHeaderValues[1].InnerHtml.Should().Be("Name");
+            newHeaderValues[2].InnerHtml.Should().Be("Position");
+
+            // Verify Order values were nulled for dragged columns
+            nameColumn.Order.Should().BeNull("Name column Order should be null after drag-and-drop");
+            ageColumn.Order.Should().BeNull("Age column Order should be null after drag-and-drop");
+
+            // Verify Position column (not involved) keeps its null Order
+            positionColumn.Order.Should().BeNull("Position column Order should remain null");
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -24,6 +24,7 @@ namespace MudBlazor
         internal ParameterState<bool> GroupingState { get; }
         internal ParameterState<bool> _groupExpandedState;
         internal ParameterState<int> _groupByOrderState;
+        internal ParameterState<int?> OrderState { get; }
 
         /// <summary>
         /// The data grid which owns this column.
@@ -361,6 +362,22 @@ namespace MudBlazor
         /// </summary>
         public string Identifier { get; set; }
 
+        /// <summary>
+        /// Specifies the display order of this column within the DataGrid.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. When set, determines the column's relative position during rendering.
+        /// Lower values appear earlier. Columns without this value default to priority 2; <c>SelectColumn</c> and <c>HierarchyColumn</c> default to priorities 1 and 0 respectively, unless overridden.
+        /// </remarks>
+        [Parameter]
+        public int? Order { get; set; }
+
+        /// <summary>
+        /// Occurs when the <see cref="Order"/> property has changed.
+        /// </summary>
+        [Parameter]
+        public EventCallback<int?> OrderChanged { get; set; }
+
 
         private CultureInfo _culture;
 
@@ -591,6 +608,10 @@ namespace MudBlazor
             _groupByOrderState = registerScope.RegisterParameter<int>(nameof(GroupByOrder))
                 .WithParameter(() => GroupByOrder)
                 .WithChangeHandler(OnGroupByOrderChangedAsync);
+            OrderState = registerScope.RegisterParameter<int?>(nameof(Order))
+                .WithParameter(() => Order)
+                .WithEventCallback(() => OrderChanged)
+                .WithChangeHandler(OnOrderChangedAsync);
         }
 
         private void OnGroupingParameterChangedAsync() => DataGrid?.GroupItems();
@@ -598,6 +619,13 @@ namespace MudBlazor
         private void OnGroupByOrderChangedAsync() => DataGrid?.GroupItems();
 
         private void OnGroupExpandedChangedAsync() => DataGrid?.GroupItems();
+
+        private void OnOrderChangedAsync()
+        {
+            DataGrid?.SortColumnsByOrder();
+            DataGrid?.DropContainerHasChanged();
+            ((IMudStateHasChanged)DataGrid)?.StateHasChanged();
+        }
 
         protected override void OnInitialized()
         {

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor
@@ -5,7 +5,7 @@
 <TemplateColumn T="T" Tag="@("hierarchy-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderClassFunc="@HeaderClassFunc"
     Hideable="Hideable" Hidden="Hidden" HiddenChanged="HiddenChanged" HeaderClass="@(EnableHeaderToggle ? $"mud-header-togglehierarchy {HeaderClass}" : HeaderClass)"
     Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled" HeaderTemplate="@HeaderTemplate" ButtonDisabledFunc="@ButtonDisabledFunc"
-    HeaderStyle="@HeaderStyle" HeaderStyleFunc="@HeaderStyleFunc" InitiallyExpandedFunc="@InitiallyExpandedFunc">
+    HeaderStyle="@HeaderStyle" HeaderStyleFunc="@HeaderStyleFunc" InitiallyExpandedFunc="@InitiallyExpandedFunc" Order="@Order" OrderChanged="@OrderChanged">
     <CellTemplate>
         @if (CellTemplate is not null)
         {

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -85,6 +85,22 @@ public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAcce
     public EventCallback<bool> HiddenChanged { get; set; }
 
     /// <summary>
+    /// Specifies the display order of this column within the DataGrid.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>. When set, determines the column's relative position during rendering.
+    /// Lower values appear earlier. When not set, defaults to priority 0 (appears first).
+    /// </remarks>
+    [Parameter]
+    public int? Order { get; set; }
+
+    /// <summary>
+    /// Occurs when the <see cref="Order"/> property has changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<int?> OrderChanged { get; set; }
+
+    /// <summary>
     /// Whether or not to show a button in the header to expand/collapse all columns.
     /// </summary>
     /// <remarks>Defaults to <c>false</c>.</remarks>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -234,6 +234,10 @@ namespace MudBlazor
                 dragAndDropSource.HeaderCell.Width = dest;
                 dragAndDropDestination.HeaderCell.Width = src;
 
+                // Null both Order values on drag-and-drop
+                dragAndDropSource.OrderState.SetValueAsync(null).CatchAndLog();
+                dragAndDropDestination.OrderState.SetValueAsync(null).CatchAndLog();
+
                 StateHasChanged();
             }
             return Task.CompletedTask;
@@ -243,6 +247,34 @@ namespace MudBlazor
         /// The columns currently being displayed.
         /// </summary>
         public readonly List<Column<T>> RenderedColumns = new List<Column<T>>();
+
+        /// <summary>
+        /// Sorts columns by their <see cref="Column{T}.Order"/> parameter when at least one column has an explicit Order value.
+        /// </summary>
+        /// <remarks>
+        /// Columns without an explicit Order use fallback priorities: hierarchy=0, select=1, others=2. Lower values appear earlier.
+        /// </remarks>
+        internal void SortColumnsByOrder()
+        {
+            // Only sort if any column has an explicit Order set
+            if (RenderedColumns.Any(c => c.Order.HasValue))
+            {
+                var sorted = RenderedColumns
+                    .OrderBy(x =>
+                    {
+                        if (x.Order.HasValue)
+                            return x.Order.Value;
+
+                        // Default priorities: hierarchy=0, select=1, others=2
+                        return x.Tag?.ToString() == "hierarchy-column" ? 0 :
+                            x.Tag?.ToString() == "select-column" ? 1 : 2;
+                    })
+                    .ToList();
+
+                RenderedColumns.Clear();
+                RenderedColumns.AddRange(sorted);
+            }
+        }
 
         internal T _editingItem;
 
@@ -284,6 +316,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         public EventCallback<T> SelectedItemChanged { get; set; }
+
 
         /// <summary>
         /// Occurs when the <see cref="SelectedItems"/> have changed.

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -3,7 +3,8 @@
 
 <TemplateColumn T="T" Tag="@("select-column")" Sortable="false" Resizable="false" ShowColumnOptions="false" HeaderStyle="width:0%"
                 Hideable="Hideable" Hidden="Hidden" HiddenChanged="HiddenChanged"
-                Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled" FooterTemplate="@GetFooterTemplate()">
+                Filterable="false" Editable="false" DragAndDropEnabled="@DragAndDropEnabled" FooterTemplate="@GetFooterTemplate()"
+                Order="@Order" OrderChanged="@OrderChanged">
     <HeaderTemplate>
         @if (ShowInHeader)
         {

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
@@ -73,4 +73,20 @@ public partial class SelectColumn<[DynamicallyAccessedMembers(DynamicallyAccesse
     /// </summary>
     [Parameter]
     public EventCallback<bool> HiddenChanged { get; set; }
+
+    /// <summary>
+    /// Specifies the display order of this column within the DataGrid.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>. When set, determines the column's relative position during rendering.
+    /// Lower values appear earlier. When not set, defaults to priority 1 (appears second after HierarchyColumn).
+    /// </remarks>
+    [Parameter]
+    public int? Order { get; set; }
+
+    /// <summary>
+    /// Occurs when the <see cref="Order"/> property has changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<int?> OrderChanged { get; set; }
 }


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

## Description

Closes [#10697](https://github.com/MudBlazor/MudBlazor/issues/10697)  
A revised implementation of the approach discussed in [#11918](https://github.com/MudBlazor/MudBlazor/pull/11918) at https://github.com/MudBlazor/MudBlazor/pull/11918#issuecomment-3347379575

Adds an `Order` parameter to all column types in `MudDataGrid` for controlling column display order. Enables repositioning of special columns (`Hierarchy`, `Select`) when needed.

#### Default behavior (unchanged):
- `HierarchyColumn` is inserted in `RenderedColumns` at index 0 → appears first  
- `SelectColumn` is inserted in `RenderedColumns` at index 1 if a `HierarchyColumn` is present, otherwise at index 0 → appears second, otherwise first  
- All other columns are added in markup order → appear after special columns, preserving declared markup order

#### With explicit `Order` values:
Columns are added as usual. When any column has `Order` set, a sort is applied via `SortColumnsByOrder()` where:
- Columns with `Order` → sorted by their `Order` value
- Columns without `Order` → use fallback priority (hierarchy=0, select=1, others=2)
- Lower values appear earlier

## Drag-and-Drop Interaction
Drag-and-drop nulls the `Order` parameter of both swapped columns. The rationale being that when a user drags a column, they're explicitly overriding declarative positioning. It gets tricky to infer user intent when dragging between columns with mixed Order states, e.g what value should a column get when dropped next to unordered columns? Also, rather than auto-assigning Order to all columns and then swapping on DragAndDrop, just nulling keeps Order opt-in.

## Key Changes

**Column.razor.cs:**  
- Added `Order` parameter (nullable int) with `ParameterState<int?>` pattern  
- Added `OrderChanged` event callback
- Added `OnOrderChangedAsync()` handler that triggers column re-sorting via `SortColumnsByOrder()`
- Updated constructor to register parameter state with change handler  

**MudDataGrid.razor.cs:**  
- Added `SortColumnsByOrder()` method to sort `RenderedColumns` in-place when any column has an explicit `Order` value
- Modified `ItemUpdatedAsync()` to null `Order` values of both columns involved in drag-and-drop operations

**HierarchyColumn.razor.cs / SelectColumn.razor.cs:**  
- Added `Order` parameter and `OrderChanged` event callback

**HierarchyColumn.razor / SelectColumn.razor:**  
- Pass `Order` and `OrderChanged` parameters through to internal `TemplateColumn`

**DataGridTests.cs:**  
- Added `DataGridColumnOrderTest()` - verifies `Order` parameter sorting behavior
- Added `DataGridColumnDragAndDropNullsOrderTest()` - verifies drag-and-drop nulls `Order` values

**Test Components:**  
- Created `DataGridColumnOrderTest.razor`
- Created `DataGridColumnDragAndDropNullsOrderTest.razor`

## Order Demo

The example below shows a `MudDataGrid` where columns are declared in this order:  
`Product`, `Order Date`, `Order #`, `Quantity`, `Total`, `SelectColumn`, `HierarchyColumn`.


https://github.com/user-attachments/assets/20dcb52e-0e0a-4b42-836c-e809d3d7762e

#### Initial State:  
`HierarchyColumn` appears first (`Order=0`), `SelectColumn` second (`Order=1`), and others follow (`Order=2`).

**Step 1:** Setting `Order=3` on `HierarchyColumn` moves it to the last position.  
**Step 2:** Setting `Order=0` on `Order #` moves it ahead of `SelectColumn`.  
**Step 3:** Setting `Order=-1` on `SelectColumn` moves it back to the first position.

## Order & DragAndDrop Demo
Same setup as above with DragDropColumnReordering enabled.
Set Order=3 on HierarchyColumn, then drag columns. Dragging columns overrides declared Order.

https://github.com/user-attachments/assets/3fb52212-0cdf-48d3-ae89-42fbce1600b4

## How Has This Been Tested
- [x] Added unit tests for `Order` parameter sorting behavior
- [x] Added unit tests for drag-and-drop Order nulling
- [x] Verified all existing DataGrid tests pass  
- [x] Visual testing in WASM and BSS  
- [x] Tested integration with local TryMudBlazor pointing to local MudBlazor solution  

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation (fix or improvement to the website or code docs)  

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).  
- [x] My code follows the code style of this project.  
- [x] I've added relevant tests and confirmed existing ones.
