### PR TITLE
MudSelect: Display selected value when null

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectNullValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectNullValueTest.razor
@@ -10,5 +10,5 @@
     public static string __description__ =
         "When the select has a null value, the text should be displayed, and the mud-shrink class should be applied.";
 
-    private int? _value = null;
+    private int? _value;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectNullValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectNullValueTest.razor
@@ -1,0 +1,14 @@
+﻿<MudPopoverProvider />
+
+<MudSelect @bind-Value="_value" Label="Select">
+    <MudSelectItem T="@(int?)" Value="@(null)">None</MudSelectItem>
+    <MudSelectItem T="@(int?)" Value="@(1)">One</MudSelectItem>
+    <MudSelectItem T="@(int?)" Value="@(2)">Two</MudSelectItem>
+</MudSelect>
+
+@code {
+    public static string __description__ =
+        "When the select has a null value, the text should be displayed, and the mud-shrink class should be applied.";
+
+    private int? _value = null;
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -319,6 +319,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Test that RegisterShadowItem handles null items gracefully.
+        /// </summary>
+        [Test]
+        public void SelectRegisterShadowItemNullTest()
+        {
+            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var select = comp.FindComponent<MudSelect<int?>>();
+
+            select.Instance.RegisterShadowItem(null);
+
+            select.Instance.Value.Should().Be(null);
+        }
+
+        /// <summary>
+        /// Test that UnregisterShadowItem handles null items gracefully.
+        /// </summary>
+        [Test]
+        public void SelectUnregisterShadowItemNullTest()
+        {
+            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var select = comp.FindComponent<MudSelect<int?>>();
+
+            select.Instance.UnregisterShadowItem(null);
+
+            select.Instance.Value.Should().Be(null);
+        }
+
+        /// <summary>
         /// The items have no render fragments, so instead of RF the select must display the converted string value
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -319,7 +319,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Test that RegisterShadowItem handles null items gracefully.
+        /// RegisterShadowItem should not throw when the item parameter is null.
         /// </summary>
         [Test]
         public void SelectRegisterShadowItemNullTest()
@@ -327,13 +327,30 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
 
-            select.Instance.RegisterShadowItem(null);
+            var registerAction = () => select.Instance.RegisterShadowItem(null);
 
-            select.Instance.Value.Should().Be(null);
+            registerAction.Should().NotThrow();
         }
 
         /// <summary>
-        /// Test that UnregisterShadowItem handles null items gracefully.
+        /// RegisterShadowItem should not throw when the item's Value property is null.
+        /// </summary>
+        [Test]
+        public void SelectRegisterShadowItemWithNullValueTest()
+        {
+            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var select = comp.FindComponent<MudSelect<int?>>();
+#pragma warning disable BL0005 // Component parameter should not be set outside of its component.
+            var itemWithNullValue = new MudSelectItem<int?> { Value = null };
+#pragma warning restore BL0005 // Component parameter should not be set outside of its component.
+
+            var registerAction = () => select.Instance.RegisterShadowItem(itemWithNullValue);
+
+            registerAction.Should().NotThrow();
+        }
+
+        /// <summary>
+        /// UnregisterShadowItem should not throw when the item parameter is null.
         /// </summary>
         [Test]
         public void SelectUnregisterShadowItemNullTest()
@@ -341,9 +358,27 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
 
-            select.Instance.UnregisterShadowItem(null);
+            var unregisterAction = () => select.Instance.UnregisterShadowItem(null);
 
-            select.Instance.Value.Should().Be(null);
+            unregisterAction.Should().NotThrow();
+        }
+
+        /// <summary>
+        /// UnregisterShadowItem should not throw when the item's Value property is null.
+        /// </summary>
+        [Test]
+        public void SelectUnregisterShadowItemWithNullValueTest()
+        {
+            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var select = comp.FindComponent<MudSelect<int?>>();
+#pragma warning disable BL0005 // Component parameter should not be set outside of its component.
+            var itemWithNullValue = new MudSelectItem<int?> { Value = null };
+#pragma warning restore BL0005 // Component parameter should not be set outside of its component.
+
+            select.Instance.RegisterShadowItem(itemWithNullValue);
+            var unregisterAction = () => select.Instance.UnregisterShadowItem(itemWithNullValue);
+
+            unregisterAction.Should().NotThrow();
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -291,9 +291,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.RenderComponent<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
-            
+
             select.Instance.Value.Should().Be(null);
-            select.Instance.Text.Should().Be("None");
+            select.Find("div.mud-input-slot").TextContent.Should().Be("None");
             select.Markup.Should().Contain("mud-shrink");
         }
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -284,6 +284,20 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// When the select has a null value, the text should be displayed, and the mud-shrink class should be applied.
+        /// </summary>
+        [Test]
+        public void SelectNullValueTest()
+        {
+            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var select = comp.FindComponent<MudSelect<int?>>();
+            
+            select.Instance.Value.Should().Be(null);
+            select.Instance.Text.Should().Be("None");
+            select.Markup.Should().Contain("mud-shrink");
+        }
+
+        /// <summary>
         /// The items have no render fragments, so instead of RF the select must display the converted string value
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -292,7 +292,28 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
 
+            // Initial state: null value
             select.Instance.Value.Should().Be(null);
+            select.Find("div.mud-input-slot").TextContent.Should().Be("None");
+            select.Markup.Should().Contain("mud-shrink");
+
+            // Open menu and select a non-null value
+            comp.Find("div.mud-input-control").MouseDown();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            comp.FindAll("div.mud-list-item").ToArray()[1].Click(); // Select "One" (value = 1)
+
+            // Verify non-null value
+            comp.WaitForAssertion(() => select.Instance.Value.Should().Be(1));
+            select.Find("div.mud-input-slot").TextContent.Should().Be("One");
+            select.Markup.Should().Contain("mud-shrink");
+
+            // Open menu again and select null value
+            comp.Find("div.mud-input-control").MouseDown();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            comp.FindAll("div.mud-list-item").ToArray()[0].Click(); // Select "None" (value = null)
+
+            // Verify back to null value
+            comp.WaitForAssertion(() => select.Instance.Value.Should().Be(null));
             select.Find("div.mud-input-slot").TextContent.Should().Be("None");
             select.Markup.Should().Contain("mud-shrink");
         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -50,7 +50,7 @@
                           OnClearButtonClick="@(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="UserAttributes"
                           OnBlur="@OnBlurAsync"
-                          ShrinkLabel="@ShrinkLabel"
+                          ShrinkLabel="@(ShrinkLabel || CanRenderValue)"
                           InputId="@InputElementId"
                           Required="@Required">
                     @if (CanRenderValue)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -499,7 +499,7 @@ namespace MudBlazor
         protected override void OnAfterRender(bool firstRender)
         {
             base.OnAfterRender(firstRender);
-            if (firstRender && Value != null)
+            if (firstRender)
             {
                 // we need to render the initial Value which is not possible without the items
                 // which supply the RenderFragment. So in this case, a second render is necessary
@@ -540,7 +540,7 @@ namespace MudBlazor
         {
             get
             {
-                if (MultiSelection || Value == null)
+                if (MultiSelection)
                     return false;
                 if (!_shadowLookup.TryGetValue(Value, out var item))
                     return false;
@@ -552,16 +552,12 @@ namespace MudBlazor
         {
             get
             {
-                if (Value == null)
-                    return false;
                 return _shadowLookup.TryGetValue(Value, out _);
             }
         }
 
         protected RenderFragment? GetSelectedValuePresenter()
         {
-            if (Value == null)
-                return null;
             if (!_shadowLookup.TryGetValue(Value, out var item))
                 return null; //<-- for now. we'll add a custom template to present values (set from outside) which are not on the list?
             return item.ChildContent;
@@ -638,12 +634,9 @@ namespace MudBlazor
             {
                 _items.Add(item);
 
-                if (item.Value is not null)
-                {
-                    _valueLookup[item.Value] = item;
-                    if (item.Value.Equals(Value) && !MultiSelection)
-                        result = true;
-                }
+                _valueLookup[item.Value] = item;
+                if (EqualityComparer<T?>.Default.Equals(item.Value, Value) && !MultiSelection)
+                    result = true;
             }
             UpdateSelectAllChecked();
             if (result.HasValue == false)
@@ -656,10 +649,7 @@ namespace MudBlazor
         internal void Remove(MudSelectItem<T> item)
         {
             _items.Remove(item);
-            if (item.Value is not null)
-            {
-                _valueLookup.Remove(item.Value);
-            }
+            _valueLookup.Remove(item.Value);
         }
 
         /// <summary>
@@ -821,11 +811,6 @@ namespace MudBlazor
 
         private async void HighlightItemForValueAsync(T? value)
         {
-            if (value == null)
-            {
-                HighlightItem(null);
-                return;
-            }
             await WaitForRender();
             _valueLookup.TryGetValue(value, out var item);
             HighlightItem(item);
@@ -1319,7 +1304,7 @@ namespace MudBlazor
         /// <param name="item">The item to add.</param>
         public void RegisterShadowItem(MudSelectItem<T>? item)
         {
-            if (item == null || item.Value == null)
+            if (item == null)
                 return;
 
             _shadowLookup[item.Value] = item;
@@ -1343,7 +1328,7 @@ namespace MudBlazor
         /// <param name="item">The item to remove.</param>
         public void UnregisterShadowItem(MudSelectItem<T>? item)
         {
-            if (item == null || item.Value == null)
+            if (item == null)
                 return;
             _shadowLookup.Remove(item.Value);
         }


### PR DESCRIPTION
# MudSelect: Display selected value when null
Fixes #9172
Fixes #4720.

This PR fixes an issue where MudSelect did not properly display the selected item's text when the value is null. Previously, selecting an item with a null value would not show the item's text.

Reproduced here: https://try.mudblazor.com/snippet/GEQzYDaTolXlHAye

Thanks to @rmotta01 for getting this started in #11645. That PR had been waiting for tests for some time, and I found that there was an issue with floating labels.
