### PR TITLE
MudStepper, MudPagination: Apply color parameters to all buttons

### DIFF
--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -30,7 +30,7 @@
             else if (currentPage == _selectedState.Value)
             {
                 <li class="@SelectedItemClassname">
-                    <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@SelectedPageButtonColor" aria-current="page" aria-label="@Localizer[LanguageResource.MudPagination_CurrentPage, $"{currentPage}"]">@currentPage</MudButton>
+                    <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@Color" aria-current="page" aria-label="@Localizer[LanguageResource.MudPagination_CurrentPage, $"{currentPage}"]">@currentPage</MudButton>
                 </li>
             }
             else

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -7,13 +7,13 @@
     @if (ShowFirstButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@FirstIcon" Size="@Size" Variant="@Variant" Disabled="@(_selectedState.Value == 1 || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.First))" aria-label="@Localizer[LanguageResource.MudPagination_FirstPage]"></MudIconButton>
+            <MudIconButton Icon="@FirstIcon" Size="@Size" Variant="@Variant" Disabled="@(_selectedState.Value == 1 || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.First))" Color="@FirstButtonColor" aria-label="@Localizer[LanguageResource.MudPagination_FirstPage]"></MudIconButton>
         </li>
     }
     @if (ShowPreviousButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@BeforeIcon" Size="@Size" Variant="@Variant" Disabled="@(_selectedState.Value == 1 || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.Previous))" aria-label="@Localizer[LanguageResource.MudPagination_PreviousPage]"></MudIconButton>
+            <MudIconButton Icon="@BeforeIcon" Size="@Size" Variant="@Variant" Disabled="@(_selectedState.Value == 1 || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.Previous))" Color="@PreviousButtonColor" aria-label="@Localizer[LanguageResource.MudPagination_PreviousPage]"></MudIconButton>
         </li>
     }
     @if (ShowPageButtons)
@@ -30,13 +30,13 @@
             else if (currentPage == _selectedState.Value)
             {
                 <li class="@SelectedItemClassname">
-                    <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@Color" aria-current="page" aria-label="@Localizer[LanguageResource.MudPagination_CurrentPage, $"{currentPage}"]">@currentPage</MudButton>
+                    <MudButton Variant="@(Variant == Variant.Outlined ? Variant.Outlined : Variant.Filled)" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@SelectedPageButtonColor" aria-current="page" aria-label="@Localizer[LanguageResource.MudPagination_CurrentPage, $"{currentPage}"]">@currentPage</MudButton>
                 </li>
             }
             else
             {
                 <li class="@ItemClassname">
-                    <MudButton OnClick="@(() => SetSelectedAsync(currentPage))" Variant="@Variant" Size="@Size" Ripple="false" Disabled="@Disabled" aria-label="@Localizer[LanguageResource.MudPagination_PageIndex, $"{currentPage}"]">@currentPage</MudButton>
+                    <MudButton OnClick="@(() => SetSelectedAsync(currentPage))" Variant="@Variant" Size="@Size" Ripple="false" Disabled="@Disabled" Color="@PageButtonColor" aria-label="@Localizer[LanguageResource.MudPagination_PageIndex, $"{currentPage}"]">@currentPage</MudButton>
                 </li>
             }
         }
@@ -44,13 +44,13 @@
     @if (ShowNextButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@NextIcon" Variant="@Variant" Size="@Size" Disabled="@(_selectedState.Value == _countState.Value || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.Next))" aria-label="@Localizer[LanguageResource.MudPagination_NextPage]"></MudIconButton>
+            <MudIconButton Icon="@NextIcon" Variant="@Variant" Size="@Size" Disabled="@(_selectedState.Value == _countState.Value || Disabled)" Color="@NextButtonColor" OnClick="@(() => OnClickControlButtonAsync(Page.Next))" aria-label="@Localizer[LanguageResource.MudPagination_NextPage]"></MudIconButton>
         </li>
     }
     @if (ShowLastButton)
     {
         <li class="@ItemClassname">
-            <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(_selectedState.Value == _countState.Value || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.Last))" aria-label="@Localizer[LanguageResource.MudPagination_LastPage]"></MudIconButton>
+            <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(_selectedState.Value == _countState.Value || Disabled)" Color="@LastButtonColor" OnClick="@(() => OnClickControlButtonAsync(Page.Last))" aria-label="@Localizer[LanguageResource.MudPagination_LastPage]"></MudIconButton>
         </li>
     }
 </MudElement>

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -161,7 +161,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color? SelectedPageButtonColor { get; set; };
+        public Color SelectedPageButtonColor { get; set; } = Color.Primary;
 
         /// <summary>
         /// The color of the next page button.

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -161,7 +161,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color SelectedPageButtonColor { get; set; } = Color.Primary;
+        public Color SelectedPageButtonColor { get; set; } = Color.Secondary;
 
         /// <summary>
         /// The color of the next page button.

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -127,7 +127,7 @@ namespace MudBlazor
         /// The color of the first page button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default" />.
+        /// Defaults to <see cref="Color.Secondary" />.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
@@ -137,7 +137,7 @@ namespace MudBlazor
         /// The color of the previous page button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default" />.
+        /// Defaults to <see cref="Color.Secondary" />.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
@@ -147,7 +147,7 @@ namespace MudBlazor
         /// The color of the page button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default" />.
+        /// Defaults to <see cref="Color.Secondary" />.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
@@ -157,17 +157,17 @@ namespace MudBlazor
         /// The color of the selected page button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default" />.
+        /// Defaults to <see cref="Color.Primary" />.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color SelectedPageButtonColor { get; set; } = Color.Primary;
+        public Color? SelectedPageButtonColor { get; set; };
 
         /// <summary>
         /// The color of the next page button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default" />.
+        /// Defaults to <see cref="Color.Secondary" />.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -124,6 +124,66 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Primary;
 
         /// <summary>
+        /// The color of the first page button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default" />.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Pagination.Appearance)]
+        public Color FirstButtonColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the previous page button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default" />.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Pagination.Appearance)]
+        public Color PreviousButtonColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the page button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default" />.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Pagination.Appearance)]
+        public Color PageButtonColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the selected page button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default" />.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Pagination.Appearance)]
+        public Color SelectedPageButtonColor { get; set; } = Color.Primary;
+
+        /// <summary>
+        /// The color of the next page button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default" />.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Pagination.Appearance)]
+        public Color NextButtonColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The color of the last page button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Color.Default" />.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Pagination.Appearance)]
+        public Color LastButtonColor { get; set; } = Color.Default;
+
+        /// <summary>
         /// Shows rectangular-shaped page buttons.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -131,7 +131,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color FirstButtonColor { get; set; } = Color.Default;
+        public Color FirstButtonColor { get; set; } = Color.Secondary;
 
         /// <summary>
         /// The color of the previous page button.
@@ -141,7 +141,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color PreviousButtonColor { get; set; } = Color.Default;
+        public Color PreviousButtonColor { get; set; } = Color.Secondary;
 
         /// <summary>
         /// The color of the page button.
@@ -151,7 +151,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color PageButtonColor { get; set; } = Color.Default;
+        public Color PageButtonColor { get; set; } = Color.Secondary;
 
         /// <summary>
         /// The color of the selected page button.
@@ -171,7 +171,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color NextButtonColor { get; set; } = Color.Default;
+        public Color NextButtonColor { get; set; } = Color.Secondary;
 
         /// <summary>
         /// The color of the last page button.
@@ -181,7 +181,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Pagination.Appearance)]
-        public Color LastButtonColor { get; set; } = Color.Default;
+        public Color LastButtonColor { get; set; } = Color.Secondary;
 
         /// <summary>
         /// Shows rectangular-shaped page buttons.

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -66,7 +66,7 @@
             @if (ShowResetButton)
             {
                 @* Reset Button *@
-                <MudButton StartIcon="@ResetButtonIcon" Class="mud-stepper-button-reset" Disabled="@(!CanReset)" OnClick="@(async () => await ResetAsync())">
+                <MudButton StartIcon="@ResetButtonIcon" Class="mud-stepper-button-reset" Color="@ResetButtonColor" Disabled="@(!CanReset)" OnClick="@(async () => await ResetAsync())">
                     @Localizer[LanguageResource.MudStepper_Reset]
                 </MudButton>
             }
@@ -74,7 +74,7 @@
             @if (!IsCompleted)
             {
                 @* Previous Button *@
-                <MudButton StartIcon="@PreviousButtonIcon" Class="mud-stepper-button-previous" OnClick="PreviousStepAsync" Disabled="@(!PreviousStepEnabled)">
+                <MudButton StartIcon="@PreviousButtonIcon" Class="mud-stepper-button-previous" Color="@PreviousButtonColor" OnClick="PreviousStepAsync" Disabled="@(!PreviousStepEnabled)">
                     @Localizer[LanguageResource.MudStepper_Previous]
                 </MudButton>
             }
@@ -86,21 +86,21 @@
                 @if (IsCurrentStepSkippable)
                 {
                     @* Skip Button *@
-                    <MudButton StartIcon="@SkipButtonIcon" Class="mud-stepper-button-skip" OnClick="SkipCurrentStepAsync">
+                    <MudButton StartIcon="@SkipButtonIcon" Class="mud-stepper-button-skip" Color="@SkipButtonColor" OnClick="SkipCurrentStepAsync">
                         @Localizer[LanguageResource.MudStepper_Skip]
                     </MudButton>
                 }
                 @if (ShowCompleteInsteadOfNext)
                 {
                     @* Complete Button *@
-                    <MudButton StartIcon="@CompleteButtonIcon" Class="mud-stepper-button-complete" OnClick="NextStepAsync" Color="Color.Primary">
+                    <MudButton StartIcon="@CompleteButtonIcon" Class="mud-stepper-button-complete" Color="@CompleteButtonColor" OnClick="NextStepAsync">
                         @Localizer[LanguageResource.MudStepper_Complete]
                     </MudButton>
                 }
                 else 
                 {
                     @* Next Button *@
-                    <MudButton StartIcon="@NextButtonIcon" Class="mud-stepper-button-next" OnClick="NextStepAsync" Color="Color.Primary" Disabled="@(!CanGoToNextStep)">
+                    <MudButton StartIcon="@NextButtonIcon" Class="mud-stepper-button-next" OnClick="NextStepAsync" Color="@NextButtonColor" Disabled="@(!CanGoToNextStep)">
                         @Localizer[LanguageResource.MudStepper_Next]
                     </MudButton>
                 }

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -112,6 +112,56 @@ public partial class MudStepper : MudComponentBase
     public Color SkippedStepColor { get; set; } = Color.Default;
 
     /// <summary>
+    /// The color of reset button color.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public Color ResetButtonColor { get; set; } = Color.Default;
+
+    /// <summary>
+    /// The color of previous button color.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public Color PreviousButtonColor { get; set; } = Color.Default;
+
+    /// <summary>
+    /// The color of skip button color.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public Color SkipButtonColor { get; set; } = Color.Default;
+
+    /// <summary>
+    /// The color of complete button color.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public Color CompleteButtonColor { get; set; } = Color.Primary;
+
+    /// <summary>
+    /// The color of next button color.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Color.Default"/>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public Color NextButtonColor { get; set; } = Color.Primary;
+
+    /// <summary>
     /// The icon shown for completed steps.
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -145,7 +145,7 @@ public partial class MudStepper : MudComponentBase
     /// The color of complete button color.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="Color.Default"/>.
+    /// Defaults to <see cref="Color.Primary"/>.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
@@ -155,7 +155,7 @@ public partial class MudStepper : MudComponentBase
     /// The color of next button color.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="Color.Default"/>.
+    /// Defaults to <see cref="Color.Primary"/>.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]


### PR DESCRIPTION
**Description**
This PR ensures the Color parameter consistently applies to all internal buttons in both `MudPagination` and `MudStepper`.

- Added color parameter for each button in `MudPagination.razor.cs`.
- Applied color parameter to Reset, Previous and Skip buttons in `MudStepper.razor`.

Resolves #11983
**Checklist:**
- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the style of this project.
- [x]  I've added relevant tests or confirmed existing ones.
