### PR TITLE
ParameterState: Add Snapshot to avoid race condition

### DIFF
--- a/src/MudBlazor.UnitTests/State/ParameterContainerTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterContainerTests.cs
@@ -188,6 +188,57 @@ public class ParameterContainerTests
         parameter2ChangedEventArgs!.Value.Should().Be(Parameter2NewValue);
     }
 
+    [Test(Description = "https://github.com/MudBlazor/MudBlazor/pull/12023")]
+    public async Task ParameterState_Snapshot_Test()
+    {
+        var tcs1 = new TaskCompletionSource();
+        var tcs2 = new TaskCompletionSource();
+        var handlerFireCount = 0;
+        var parameter = 1;
+        const string ParameterName = nameof(parameter);
+        var parameter1State = ParameterAttachBuilder
+            .Create<int>()
+            .WithMetadata(new ParameterMetadata(ParameterName))
+            .WithGetParameterValueFunc(() => parameter)
+            .WithParameterChangedHandler(OnParameter1Change)
+            .Attach();
+        var parameterView1 = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { ParameterName, 2 }
+        });
+        var parameterView2 = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { ParameterName, 2 }
+        });
+        var parameterContainer = new ParameterContainer { new ParameterScopeContainer(parameter1State) };
+        void OnParameter1Change()
+        {
+            handlerFireCount++;
+        }
+
+        // Act
+        var task1 = parameterContainer.SetParametersAsync(async _ =>
+        {
+            // Update the parameter value so that the second SetParametersAsync sees that
+            // and does not trigger the parameter handler by resetting _parameterChangedEventArgs to null.
+            parameter = 2;
+            await tcs1.Task;
+        }, parameterView1);
+        var task2 = parameterContainer.SetParametersAsync(_ => tcs2.Task, parameterView2);
+
+        tcs2.SetResult();
+        // Small delay to simulate scheduling
+        await Task.Delay(100);
+        tcs1.SetResult();
+
+        await Task.WhenAll(task1, task2);
+
+        handlerFireCount.Should().Be(1, because: "each SetParametersAsync should fire its handler independently; " +
+                                                 "if 0, the second call overwrote the first call's ParameterChangedEventArgs; " +
+                                                 "if 1, the snapshot mechanism works correctly; " +
+                                                 "if more than 1, something is wrong with the test setup");
+    }
+
     [Test]
     public void GetEnumeratorNonGeneric_ReturnsAllParameterSets()
     {

--- a/src/MudBlazor.UnitTests/State/ParameterHandlerUniquenessComparerTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterHandlerUniquenessComparerTests.cs
@@ -50,13 +50,12 @@ public class ParameterHandlerUniquenessComparerTests
             .WithGetParameterValueFunc(() => 0)
             .Attach();
         var snapshot = parameterState.CreateInvocationSnapshot();
-        IParameterComponentLifeCycle parameterStateLifeCycle = parameterState;
 
         // Act
         var result1 = comparer.Equals(parameterMetadata, null);
         var result2 = comparer.Equals(null, parameterMetadata);
-        var result3 = comparer.Equals(parameterStateLifeCycle, null);
-        var result4 = comparer.Equals(null, parameterStateLifeCycle);
+        var result3 = comparer.Equals(parameterState, null);
+        var result4 = comparer.Equals(null, parameterState);
         var result5 = comparer.Equals(snapshot, null);
         var result6 = comparer.Equals(null, snapshot);
 
@@ -88,13 +87,10 @@ public class ParameterHandlerUniquenessComparerTests
             .Attach();
         var snapshot1 = parameterState1.CreateInvocationSnapshot();
         var snapshot2 = parameterState2.CreateInvocationSnapshot();
-        IParameterComponentLifeCycle parameterStateLifeCycle1 = parameterState1;
-        IParameterComponentLifeCycle parameterStateLifeCycle2 = parameterState2;
-
 
         // Act
         var result1 = comparer.Equals(handler1, handler2);
-        var result2 = comparer.Equals(parameterStateLifeCycle1, parameterStateLifeCycle2);
+        var result2 = comparer.Equals(parameterState1, parameterState2);
         var result3 = comparer.Equals(snapshot1, snapshot2);
 
         // Assert
@@ -110,24 +106,28 @@ public class ParameterHandlerUniquenessComparerTests
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var handler1 = new ParameterMetadata("Parameter1", "Handler1");
         var handler2 = new ParameterMetadata("Parameter2", "Handler2");
-        IParameterComponentLifeCycle parameterState1 = ParameterAttachBuilder
+        var parameterState1 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler1)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
-        IParameterComponentLifeCycle parameterState2 = ParameterAttachBuilder
+        var parameterState2 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler2)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot1 = parameterState1.CreateInvocationSnapshot();
+        var snapshot2 = parameterState2.CreateInvocationSnapshot();
 
         // Act
         var result1 = comparer.Equals(handler1, handler2);
         var result2 = comparer.Equals(parameterState1, parameterState2);
+        var result3 = comparer.Equals(snapshot1, snapshot2);
 
         // Assert
         result1.Should().BeFalse();
         result2.Should().BeFalse();
+        result3.Should().BeFalse();
     }
 
     [Test]
@@ -137,24 +137,28 @@ public class ParameterHandlerUniquenessComparerTests
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var handler1 = new ParameterMetadata("Parameter1", null);
         var handler2 = new ParameterMetadata("Parameter2", null);
-        IParameterComponentLifeCycle parameterState1 = ParameterAttachBuilder
+        var parameterState1 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler1)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
-        IParameterComponentLifeCycle parameterState2 = ParameterAttachBuilder
+        var parameterState2 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler2)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot1 = parameterState1.CreateInvocationSnapshot();
+        var snapshot2 = parameterState2.CreateInvocationSnapshot();
 
         // Act
         var result1 = comparer.Equals(handler1, handler2);
         var result2 = comparer.Equals(parameterState1, parameterState2);
+        var result3 = comparer.Equals(snapshot1, snapshot2);
 
         // Assert
         result1.Should().BeFalse("If there is no handler name we consider them to be unique.");
         result2.Should().BeFalse("If there is no handler name we consider them to be unique.");
+        result3.Should().BeFalse("If there is no handler name we consider them to be unique.");
     }
 
     [Test]
@@ -164,28 +168,35 @@ public class ParameterHandlerUniquenessComparerTests
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var handler1 = new ParameterMetadata("Parameter1", "Handler1");
         var handler2 = new ParameterMetadata("Parameter2", "Handler1");
-        IParameterComponentLifeCycle parameterState1 = ParameterAttachBuilder
+        var parameterState1 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler1)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
-        IParameterComponentLifeCycle parameterState2 = ParameterAttachBuilder
+        var parameterState2 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler2)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot1 = parameterState1.CreateInvocationSnapshot();
+        var snapshot2 = parameterState2.CreateInvocationSnapshot();
 
         // Act
         var handler1HashCode = comparer.GetHashCode(handler1);
         var handler2HashCode = comparer.GetHashCode(handler2);
         var parameterState1HashCode = comparer.GetHashCode(parameterState1);
         var parameterState2HashCode = comparer.GetHashCode(parameterState2);
+        var snapshot11HashCode = comparer.GetHashCode(snapshot1);
+        var snapshot2HashCode = comparer.GetHashCode(snapshot2);
+
         var result1 = handler1HashCode == handler2HashCode;
         var result2 = parameterState1HashCode == parameterState2HashCode;
+        var result3 = snapshot11HashCode == snapshot2HashCode;
 
         // Assert
         result1.Should().BeTrue();
         result2.Should().BeTrue();
+        result3.Should().BeTrue();
     }
 
     [Test]
@@ -195,28 +206,34 @@ public class ParameterHandlerUniquenessComparerTests
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var handler1 = new ParameterMetadata("Parameter1", "Handler1");
         var handler2 = new ParameterMetadata("Parameter2", "Handler2");
-        IParameterComponentLifeCycle parameterState1 = ParameterAttachBuilder
+        var parameterState1 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler1)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
-        IParameterComponentLifeCycle parameterState2 = ParameterAttachBuilder
+        var parameterState2 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler2)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot1 = parameterState1.CreateInvocationSnapshot();
+        var snapshot2 = parameterState2.CreateInvocationSnapshot();
 
         // Act
         var handler1HashCode = comparer.GetHashCode(handler1);
         var handler2HashCode = comparer.GetHashCode(handler2);
         var parameterState1HashCode = comparer.GetHashCode(parameterState1);
         var parameterState2HashCode = comparer.GetHashCode(parameterState2);
+        var snapshot11HashCode = comparer.GetHashCode(snapshot1);
+        var snapshot2HashCode = comparer.GetHashCode(snapshot2);
         var result1 = handler1HashCode == handler2HashCode;
         var result2 = parameterState1HashCode == parameterState2HashCode;
+        var result3 = snapshot11HashCode == snapshot2HashCode;
 
         // Assert
         result1.Should().BeFalse();
         result2.Should().BeFalse();
+        result3.Should().BeFalse();
     }
 
     [Test]
@@ -226,27 +243,33 @@ public class ParameterHandlerUniquenessComparerTests
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var handler1 = new ParameterMetadata("Parameter1", null);
         var handler2 = new ParameterMetadata("Parameter2", null);
-        IParameterComponentLifeCycle parameterState1 = ParameterAttachBuilder
+        var parameterState1 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler1)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
-        IParameterComponentLifeCycle parameterState2 = ParameterAttachBuilder
+        var parameterState2 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler2)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot1 = parameterState1.CreateInvocationSnapshot();
+        var snapshot2 = parameterState2.CreateInvocationSnapshot();
 
         // Act
         var handler1HashCode = comparer.GetHashCode(handler1);
         var handler2HashCode = comparer.GetHashCode(handler2);
         var parameterState1HashCode = comparer.GetHashCode(parameterState1);
         var parameterState2HashCode = comparer.GetHashCode(parameterState2);
+        var snapshot11HashCode = comparer.GetHashCode(snapshot1);
+        var snapshot2HashCode = comparer.GetHashCode(snapshot2);
         var result1 = handler1HashCode == handler2HashCode;
         var result2 = parameterState1HashCode == parameterState2HashCode;
+        var result3 = snapshot11HashCode == snapshot2HashCode;
 
         // Assert
         result1.Should().BeFalse("If there is no handler name we consider them to be unique.");
         result2.Should().BeFalse("If there is no handler name we consider them to be unique.");
+        result3.Should().BeFalse("If there is no handler name we consider them to be unique.");
     }
 }

--- a/src/MudBlazor.UnitTests/State/ParameterHandlerUniquenessComparerTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterHandlerUniquenessComparerTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using MudBlazor.State;
 using MudBlazor.State.Builder;
 using MudBlazor.State.Comparer;
+using MudBlazor.State.Invocation;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.State;
@@ -23,14 +24,18 @@ public class ParameterHandlerUniquenessComparerTests
         ParameterMetadata? parameterMetadata2 = null;
         IParameterComponentLifeCycle? parameterComponentLifeCycle1 = null;
         IParameterComponentLifeCycle? parameterComponentLifeCycle2 = null;
+        IParameterStateInvocationSnapshot? snapshot1 = null;
+        IParameterStateInvocationSnapshot? snapshot2 = null;
 
         // Act
         var result1 = comparer.Equals(parameterMetadata1, parameterMetadata2);
         var result2 = comparer.Equals(parameterComponentLifeCycle1, parameterComponentLifeCycle2);
+        var result3 = comparer.Equals(snapshot1, snapshot2);
 
         // Assert
         result1.Should().BeTrue();
         result2.Should().BeTrue();
+        result3.Should().BeTrue();
     }
 
     [Test]
@@ -39,23 +44,29 @@ public class ParameterHandlerUniquenessComparerTests
         // Arrange
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var parameterMetadata = new ParameterMetadata("Parameter1", "Handler1");
-        IParameterComponentLifeCycle parameterState = ParameterAttachBuilder
+        var parameterState = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(parameterMetadata)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot = parameterState.CreateInvocationSnapshot();
+        IParameterComponentLifeCycle parameterStateLifeCycle = parameterState;
 
         // Act
         var result1 = comparer.Equals(parameterMetadata, null);
         var result2 = comparer.Equals(null, parameterMetadata);
-        var result3 = comparer.Equals(parameterState, null);
-        var result4 = comparer.Equals(null, parameterState);
+        var result3 = comparer.Equals(parameterStateLifeCycle, null);
+        var result4 = comparer.Equals(null, parameterStateLifeCycle);
+        var result5 = comparer.Equals(snapshot, null);
+        var result6 = comparer.Equals(null, snapshot);
 
         // Assert
         result1.Should().BeFalse();
         result2.Should().BeFalse();
         result3.Should().BeFalse();
         result4.Should().BeFalse();
+        result5.Should().BeFalse();
+        result6.Should().BeFalse();
     }
 
     [Test]
@@ -65,24 +76,31 @@ public class ParameterHandlerUniquenessComparerTests
         var comparer = ParameterHandlerUniquenessComparer.Default;
         var handler1 = new ParameterMetadata("Parameter1", "Handler1");
         var handler2 = new ParameterMetadata("Parameter2", "Handler1");
-        IParameterComponentLifeCycle parameterState1 = ParameterAttachBuilder
+        var parameterState1 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler1)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
-        IParameterComponentLifeCycle parameterState2 = ParameterAttachBuilder
+        var parameterState2 = ParameterAttachBuilder
             .Create<int>()
             .WithMetadata(handler2)
             .WithGetParameterValueFunc(() => 0)
             .Attach();
+        var snapshot1 = parameterState1.CreateInvocationSnapshot();
+        var snapshot2 = parameterState2.CreateInvocationSnapshot();
+        IParameterComponentLifeCycle parameterStateLifeCycle1 = parameterState1;
+        IParameterComponentLifeCycle parameterStateLifeCycle2 = parameterState2;
+
 
         // Act
         var result1 = comparer.Equals(handler1, handler2);
-        var result2 = comparer.Equals(parameterState1, parameterState2);
+        var result2 = comparer.Equals(parameterStateLifeCycle1, parameterStateLifeCycle2);
+        var result3 = comparer.Equals(snapshot1, snapshot2);
 
         // Assert
         result1.Should().BeTrue();
         result2.Should().BeTrue();
+        result3.Should().BeTrue();
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -128,7 +128,7 @@ public class ParameterStateTests
 
         // Act
         var changed = parameterState.HasParameterChanged(parameters);
-        await parameterState.ParameterChangeHandleAsync();
+        await parameterState.CreateInvocationSnapshot().ParameterChangeHandleAsync();
 
         // Assert
         changed.Should().BeTrue();
@@ -160,7 +160,7 @@ public class ParameterStateTests
 
         // Act
         var changed = parameterState.HasParameterChanged(parameters);
-        await parameterState.ParameterChangeHandleAsync();
+        await parameterState.CreateInvocationSnapshot().ParameterChangeHandleAsync();
 
         // Assert
         changed.Should().BeFalse();
@@ -183,7 +183,7 @@ public class ParameterStateTests
             .Attach();
 
         // Act
-        await parameterState.ParameterChangeHandleAsync();
+        await parameterState.CreateInvocationSnapshot().ParameterChangeHandleAsync();
 
         // Assert
         parameterState.HasHandler.Should().BeTrue();
@@ -202,7 +202,7 @@ public class ParameterStateTests
             .Attach();
 
         // Act & Assert
-        await parameterState.ParameterChangeHandleAsync(); //Does nothing, we are making coverage happy
+        await parameterState.CreateInvocationSnapshot().ParameterChangeHandleAsync(); //Does nothing, we are making coverage happy
         parameterState.HasHandler.Should().BeFalse();
     }
 

--- a/src/MudBlazor/State/Comparer/ParameterHandlerUniquenessComparer.cs
+++ b/src/MudBlazor/State/Comparer/ParameterHandlerUniquenessComparer.cs
@@ -1,4 +1,6 @@
-﻿namespace MudBlazor.State.Comparer;
+﻿using MudBlazor.State.Invocation;
+
+namespace MudBlazor.State.Comparer;
 
 #nullable enable
 /// <summary>
@@ -7,7 +9,7 @@
 /// <remarks>
 /// This checks only uniqueness of <see cref="ParameterMetadata.HandlerName"/>.
 /// </remarks>
-internal class ParameterHandlerUniquenessComparer : IEqualityComparer<ParameterMetadata>, IEqualityComparer<IParameterComponentLifeCycle>
+internal class ParameterHandlerUniquenessComparer : IEqualityComparer<ParameterMetadata>, IEqualityComparer<IParameterComponentLifeCycle>, IEqualityComparer<IParameterStateInvocationSnapshot>
 {
     /// <inheritdoc />
     public bool Equals(ParameterMetadata? x, ParameterMetadata? y)
@@ -57,6 +59,27 @@ internal class ParameterHandlerUniquenessComparer : IEqualityComparer<ParameterM
     }
 
     /// <inheritdoc />
+    public bool Equals(IParameterStateInvocationSnapshot? x, IParameterStateInvocationSnapshot? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(x, null))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(y, null))
+        {
+            return false;
+        }
+
+        return Equals(x.Metadata, y.Metadata);
+    }
+
+    /// <inheritdoc />
     public int GetHashCode(ParameterMetadata parameterMetadata)
     {
         return parameterMetadata.HandlerName is not null
@@ -66,6 +89,9 @@ internal class ParameterHandlerUniquenessComparer : IEqualityComparer<ParameterM
 
     /// <inheritdoc />
     public int GetHashCode(IParameterComponentLifeCycle parameterComponentLifeCycle) => GetHashCode(parameterComponentLifeCycle.Metadata);
+
+    /// <inheritdoc />
+    public int GetHashCode(IParameterStateInvocationSnapshot snapshot) => GetHashCode(snapshot.Metadata);
 
     /// <summary>
     /// Gets the default instance of <see cref="ParameterHandlerUniquenessComparer"/>.

--- a/src/MudBlazor/State/IParameterComponentLifeCycle.cs
+++ b/src/MudBlazor/State/IParameterComponentLifeCycle.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
+using MudBlazor.State.Invocation;
 
 namespace MudBlazor.State;
 
@@ -30,15 +31,17 @@ internal interface IParameterComponentLifeCycle
     bool HasParameterChanged(ParameterView parameters);
 
     /// <summary>
-    /// Called by the <see cref="ParameterState{T}"/> framework when <see cref="IParameterChangedHandler{T}"/> is supplied.
+    /// Creates a snapshot of the current parameter invocation state.
     /// </summary>
     /// <remarks>
-    /// This method is intended for internal use and is controlled by the <see cref="MudComponentBase"/> and <see cref="ParameterScopeContainer"/>.
-    /// It should only be invoked after <see cref="HasParameterChanged"/> has been called.
-    /// Direct invocation of this method by external code is discouraged.
+    /// This method is used by the parameter lifecycle system to prepare safe, immutable handler invocation snapshots.
+    /// The returned object contains cloned event arguments and current handler bindings, ensuring that
+    /// asynchronous invocations or concurrent renders cannot mutate live state.
     /// </remarks>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task ParameterChangeHandleAsync();
+    /// <returns>
+    /// An <see cref="IParameterStateInvocationSnapshot"/> representing the current state of the parameter.
+    /// </returns>
+    IParameterStateInvocationSnapshot CreateInvocationSnapshot();
 
     /// <summary>
     /// Invoked when <see cref="ComponentBase.OnInitialized"/> is called, used to set the initial parameter value.

--- a/src/MudBlazor/State/Invocation/IParameterStateInvocationSnapshot.cs
+++ b/src/MudBlazor/State/Invocation/IParameterStateInvocationSnapshot.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+namespace MudBlazor.State.Invocation;
+
+/// <summary>
+/// Represents a read-only, immutable snapshot of a parameter's invocation state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface exists to decouple parameter change invocation logic from the live parameter state.
+/// Instead of directly invoking <see cref="IParameterChangedHandler{T}"/> during a render or lifecycle update,
+/// a snapshot is created containing all necessary data to safely execute the handler later.
+/// </para>
+/// <para>
+/// This ensures that concurrent lifecycle operations, reentrant parameter updates,
+/// or asynchronous component updates cannot interfere with a live state mutation.
+/// </para>
+/// </remarks>
+internal interface IParameterStateInvocationSnapshot
+{
+    /// <summary>
+    /// Gets metadata associated with the parameter, including its name, handler name etc.
+    /// </summary>
+    ParameterMetadata Metadata { get; }
+
+    /// <summary>
+    /// Called by the <see cref="ParameterState{T}"/> framework when <see cref="IParameterChangedHandler{T}"/> is supplied.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method is intended for internal use and is controlled by the <see cref="MudComponentBase"/> and <see cref="ParameterScopeContainer"/>.
+    /// It should only be invoked after <see cref="IParameterComponentLifeCycle.HasParameterChanged"/> has been called.
+    /// </para>
+    /// <para>
+    /// Direct invocation of this method from external code is discouraged,
+    /// as it may bypass lifecycle consistency guarantees.
+    /// </para>
+    /// </remarks>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task ParameterChangeHandleAsync();
+}

--- a/src/MudBlazor/State/Invocation/ParameterStateInvocationSnapshot.cs
+++ b/src/MudBlazor/State/Invocation/ParameterStateInvocationSnapshot.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace MudBlazor.State.Invocation;
+
+#nullable enable
+
+/// <summary>
+/// Implements <see cref="IParameterStateInvocationSnapshot"/>.
+/// </summary>
+/// <typeparam name="T">The type of the component's property value.</typeparam>
+internal class ParameterStateInvocationSnapshot<T> : IParameterStateInvocationSnapshot
+{
+    private readonly Func<bool> _isChildOriginatedChangeFunc;
+    private readonly ParameterChangedEventArgs<T>? _parameterChangedEventArgs;
+    private readonly IParameterChangedHandler<T>? _parameterChangedHandler;
+
+    /// <inheritdoc />
+    public ParameterMetadata Metadata { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParameterStateInvocationSnapshot{T}"/> class.
+    /// </summary>
+    /// <param name="parameterMetadata">Metadata describing the parameter.</param>
+    /// <param name="parameterChangedEventArgs">A cloned instance of the last parameter change event arguments, if any.</param>
+    /// <param name="parameterChangedHandler">The registered handler responsible for processing parameter changes.</param>
+    /// <param name="isChildOriginatedChangeFunc">Indicates whether the change originated from a child component.</param>
+    /// <remarks>
+    /// This constructor is intentionally internal. Snapshots are created exclusively through
+    /// <see cref="ParameterStateInternal{T}.CreateInvocationSnapshot"/> to ensure lifecycle consistency.
+    /// </remarks>
+    public ParameterStateInvocationSnapshot(ParameterMetadata parameterMetadata, ParameterChangedEventArgs<T>? parameterChangedEventArgs, IParameterChangedHandler<T>? parameterChangedHandler, Func<bool> isChildOriginatedChangeFunc)
+    {
+        Metadata = parameterMetadata;
+        _parameterChangedEventArgs = parameterChangedEventArgs;
+        _parameterChangedHandler = parameterChangedHandler;
+        _isChildOriginatedChangeFunc = isChildOriginatedChangeFunc;
+    }
+
+    [MemberNotNullWhen(true, nameof(_parameterChangedEventArgs))]
+    private bool HasParameterChangedEventArgs => _parameterChangedEventArgs is not null;
+
+    [MemberNotNullWhen(true, nameof(_parameterChangedHandler))]
+    private bool HasHandler => _parameterChangedHandler is not null;
+
+    /// <inheritdoc />
+    public Task ParameterChangeHandleAsync()
+    {
+        if (HasHandler)
+        {
+            if (HasParameterChangedEventArgs)
+            {
+                // Since the ParameterSet lifecycles control all operations, it is acceptable to trigger the handler only when
+                // HasParameterChanged has been invoked and stored the ParameterChangedEventArgs.
+                // Direct invocation of this method by external callers is discouraged, so we shouldn't worry about it.
+                return _parameterChangedHandler.HandleAsync(_parameterChangedEventArgs.ChildOriginated(_isChildOriginatedChangeFunc()));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor/State/Invocation/ParameterStateInvocationSnapshot.cs
+++ b/src/MudBlazor/State/Invocation/ParameterStateInvocationSnapshot.cs
@@ -49,15 +49,12 @@ internal class ParameterStateInvocationSnapshot<T> : IParameterStateInvocationSn
     /// <inheritdoc />
     public Task ParameterChangeHandleAsync()
     {
-        if (HasHandler)
+        if (HasHandler && HasParameterChangedEventArgs)
         {
-            if (HasParameterChangedEventArgs)
-            {
-                // Since the ParameterSet lifecycles control all operations, it is acceptable to trigger the handler only when
-                // HasParameterChanged has been invoked and stored the ParameterChangedEventArgs.
-                // Direct invocation of this method by external callers is discouraged, so we shouldn't worry about it.
-                return _parameterChangedHandler.HandleAsync(_parameterChangedEventArgs.ChildOriginated(_isChildOriginatedChangeFunc()));
-            }
+            // Since the ParameterSet lifecycles control all operations, it is acceptable to trigger the handler only when
+            // HasParameterChanged has been invoked and stored the ParameterChangedEventArgs.
+            // Direct invocation of this method by external callers is discouraged, so we shouldn't worry about it.
+            return _parameterChangedHandler.HandleAsync(_parameterChangedEventArgs.ChildOriginated(_isChildOriginatedChangeFunc()));
         }
 
         return Task.CompletedTask;

--- a/src/MudBlazor/State/ParameterChangedEventArgs.cs
+++ b/src/MudBlazor/State/ParameterChangedEventArgs.cs
@@ -51,4 +51,12 @@ public class ParameterChangedEventArgs<T> : EventArgs
 
         return this;
     }
+
+    internal ParameterChangedEventArgs<T> Clone()
+    {
+        return new ParameterChangedEventArgs<T>(ParameterName, LastValue, Value)
+        {
+            IsChildOriginatedChange = IsChildOriginatedChange
+        };
+    }
 }

--- a/src/MudBlazor/State/ParameterContainer.cs
+++ b/src/MudBlazor/State/ParameterContainer.cs
@@ -89,7 +89,7 @@ internal class ParameterContainer : IParameterContainer
 
         var parametersHandlerShouldFire = _parameterScopeContainers.SelectMany(parameter => parameter)
             .Where(parameter => parameter.HasHandler && parameter.HasParameterChanged(parameters))
-            .Select(x=> x.CreateInvocationSnapshot())
+            .Select(x => x.CreateInvocationSnapshot())
             .ToFrozenSet(ParameterHandlerUniquenessComparer.Default);
 
         await baseSetParametersAsync(parameters);

--- a/src/MudBlazor/State/ParameterContainer.cs
+++ b/src/MudBlazor/State/ParameterContainer.cs
@@ -89,6 +89,7 @@ internal class ParameterContainer : IParameterContainer
 
         var parametersHandlerShouldFire = _parameterScopeContainers.SelectMany(parameter => parameter)
             .Where(parameter => parameter.HasHandler && parameter.HasParameterChanged(parameters))
+            .Select(x=> x.CreateInvocationSnapshot())
             .ToFrozenSet(ParameterHandlerUniquenessComparer.Default);
 
         await baseSetParametersAsync(parameters);

--- a/src/MudBlazor/State/ParameterScopeContainer.cs
+++ b/src/MudBlazor/State/ParameterScopeContainer.cs
@@ -113,7 +113,8 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     {
         var parametersHandlerShouldFire = _parameters.Value.Values
             .Where(parameter => parameter.HasHandler && parameter.HasParameterChanged(parameters))
-            .ToHashSet(ParameterHandlerUniquenessComparer.Default);
+            .Select(x => x.CreateInvocationSnapshot())
+            .ToFrozenSet(ParameterHandlerUniquenessComparer.Default);
 
         await baseSetParametersAsync(parameters);
 

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -114,7 +114,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     {
         return new ParameterStateInvocationSnapshot<T>(
             Metadata,
-            _parameterChangedEventArgs?.Clone(),
+            HasParameterChangedEventArgs ? _parameterChangedEventArgs.Clone() : null,
             _parameterChangedHandler,
             // We should not cache this value because it may be modified by OnParametersSet.
             // In theory, this could also lead to race conditions if multiple OnParametersSet calls occur with different _lastValue, currentParameterValue values.

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -116,7 +116,9 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
             Metadata,
             _parameterChangedEventArgs?.Clone(),
             _parameterChangedHandler,
-            // We should not cache it changed by OnParametersSet.
+            // We should not cache this value because it may be modified by OnParametersSet.
+            // In theory, this could also lead to race conditions if multiple OnParametersSet calls occur with different _lastValue, currentParameterValue values.
+            // For now, we'll leave it as-is since properly fixing this would be complex, it should be fixed only if it happens in practise.
             () => _isChildOriginatedChange);
     }
 

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State.Comparer;
+using MudBlazor.State.Invocation;
 using MudBlazor.State.Rule;
 
 namespace MudBlazor.State;
@@ -108,21 +109,15 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         }
     }
 
-    /// <inheritdoc />
-    public Task ParameterChangeHandleAsync()
+    /// <inheritdoc/>
+    public IParameterStateInvocationSnapshot CreateInvocationSnapshot()
     {
-        if (HasHandler)
-        {
-            if (HasParameterChangedEventArgs)
-            {
-                // Since the ParameterSet lifecycles control all operations, it is acceptable to trigger the handler only when
-                // HasParameterChanged has been invoked and stored the ParameterChangedEventArgs.
-                // Direct invocation of this method by external callers is discouraged, so we shouldn't worry about it.
-                return _parameterChangedHandler.HandleAsync(_parameterChangedEventArgs.ChildOriginated(_isChildOriginatedChange));
-            }
-        }
-
-        return Task.CompletedTask;
+        return new ParameterStateInvocationSnapshot<T>(
+            Metadata,
+            _parameterChangedEventArgs?.Clone(),
+            _parameterChangedHandler,
+            // We should not cache it changed by OnParametersSet.
+            () => _isChildOriginatedChange);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
From discord:
> It seems to be linked to some code I did to track a selected item id by updating the url with NavigateTo when it changes, but I'm confused about what it actually happening. I can't get it to work on TryMudBlazor, so here is an archive of a basic project that display this behavior: [BugProject.zip](https://github.com/user-attachments/files/23242631/BugProject.zip)

Explanation:
It looks like this is caused by `Navigation.NavigateTo`.
What I’m seeing is that when the page initializes, it calls Blazor’s `SetParametersAsync`, which tells us the parameters changed and queues that info up. But then, because of the `NavigateTo`, another `SetParametersAsync` fires almost right away, before the first one even finishes. At that point, it sees that the parameter was already set to the same value, since it reuses same `ParameterStateInternal` reference and removes the info that parameter changed:
https://github.com/MudBlazor/MudBlazor/blob/3c678ef7066499bf6aa63b74dd3fca0a3bd90b35/src/MudBlazor/State/ParameterStateInternalOfT.cs#L131
Then, when the first `SetParametersAsync` gets to finish to call the change handler it sees no changes (since it was already cleared earlier by second `SetParametersAsync`), and doesn’t trigger `ParameterChangeHandleAsync`.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
