### PR TITLE
MudDatePicker: Add keyboard navigation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1251,6 +1251,48 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DatePickerTest_KeyboardNavigation_SelectDate()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var startDate = new DateTime(2022, 12, 31, CultureInfo.InvariantCulture.Calendar);
+            var expectedDate = new DateTime(2021, 1, 1, CultureInfo.InvariantCulture.Calendar);
+
+            comp.SetParam(parameter => parameter.Date, startDate);
+            comp.SetParam(parameter => parameter.OpenTo, OpenTo.Year);
+            var datePickerComponent = comp.FindComponent<MudDatePicker>();
+            var datePicker = datePickerComponent.Instance;
+
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(expectedDate);
+
+
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(startDate);
+
+
+        }
+
+        [Test]
         public async Task DatePickerTest_GoToDate()
         {
             var comp = Context.RenderComponent<SimpleMudDatePickerTest>();

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1254,8 +1254,9 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePickerTest_KeyboardNavigation_SelectDate()
         {
             var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
-            var startDate = new DateTime(2022, 12, 31, CultureInfo.InvariantCulture.Calendar);
-            var expectedDate = new DateTime(2021, 1, 1, CultureInfo.InvariantCulture.Calendar);
+            var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
+            var expectedDate1 = new DateTime(2021, 1, 23, new CultureInfo("en-US").Calendar);
+            var expectedDate2 = new DateTime(2023, 11, 22, new CultureInfo("en-US").Calendar);
 
             comp.SetParam(parameter => parameter.Date, startDate);
             comp.SetParam(parameter => parameter.OpenTo, OpenTo.Year);
@@ -1266,29 +1267,164 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
+            //year
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            //month
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            //date
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
-            datePicker.Date.Should().Be(expectedDate);
+            datePicker.Date.Should().Be(expectedDate1);
 
 
 
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
+            //year
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            //month
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            //date
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            // select month with shift key
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
+            // select year with shift key
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
             await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(expectedDate2);
+        }
+
+        [Test]
+        public async Task DatePickerTest_KeyboardNavigation_SelectMonth()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
+            var expectedDate1 = new DateTime(2022, 1, 28, new CultureInfo("en-US").Calendar);
+            var expectedDate2 = new DateTime(2023, 1, 28, new CultureInfo("en-US").Calendar);
+
+            comp.SetParam(parameter => parameter.Date, startDate);
+            comp.SetParam(parameter => parameter.OpenTo, OpenTo.Month);
+            var datePickerComponent = comp.FindComponent<MudDatePicker>();
+            var datePicker = datePickerComponent.Instance;
+
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown" }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown" }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown" }));
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(expectedDate1);
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            // select year with shift key
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(expectedDate2);
+
+        }
+
+        [Test]
+        public async Task DatePickerTest_KeyboardNavigation_BackspacePreviousView()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
+            comp.SetParam(parameter => parameter.Date, startDate);
+            comp.SetParam(parameter => parameter.OpenTo, OpenTo.Year);
+            var datePickerComponent = comp.FindComponent<MudDatePicker>();
+            var datePicker = datePickerComponent.Instance;
+
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+
+            //year
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            //month
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            //date
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
+
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            // no change to date should happen
             datePicker.Date.Should().Be(startDate);
 
+        }
+
+        [Test]
+        public async Task DatePickerTest_KeyboardNavigation_MinMaxYearLimits()
+        {
+            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
+            comp.SetParam(parameter => parameter.Date, startDate);
+            comp.SetParam(parameter => parameter.OpenTo, OpenTo.Year);
+            var maxDate = new DateTime(2023, 12, 31);
+            comp.SetParam(parameter => parameter.MaxDate, maxDate);
+            var minDate = new DateTime(2021, 12, 31);
+            comp.SetParam(parameter => parameter.MinDate, minDate);
+            var datePickerComponent = comp.FindComponent<MudDatePicker>();
+            var datePicker = datePickerComponent.Instance;
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            //try to select year below min
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(minDate);
+
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            //try to select year above max
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            datePicker.Date.Should().Be(maxDate);
 
         }
 

--- a/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
@@ -121,4 +121,32 @@ public class DateTimeExtensionTests
         // Assert
         result.Should().Be(new DateTime(1, 1, 1)); // Monday
     }
+
+    [Test]
+    public void LastWeekDayOfMonth_ShouldReturnLastWeekDayOfMonth()
+    {
+        // Arrange
+        var dateTime = new DateTime(2023, 9, 15); // September 15, 2023
+        var culture = CultureInfo.InvariantCulture;
+
+        // Act
+        var result = dateTime.LastWeekDayOfMonth(DayOfWeek.Friday, culture);
+
+        // Assert
+        result.Should().Be(new DateTime(2023, 9, 29)); // September 29, 2023 (Friday)
+    }
+
+    [Test]
+    public void FirstWeekDayOfMonth_ShouldReturnFirstWeekDayOfMonth()
+    {
+        // Arrange
+        var dateTime = new DateTime(2023, 9, 15); // September 15, 2023
+        var culture = CultureInfo.InvariantCulture;
+
+        // Act
+        var result = dateTime.FirstWeekDayOfMonth(DayOfWeek.Monday, culture);
+
+        // Assert
+        result.Should().Be(new DateTime(2023, 9, 4)); // September 4, 2023 (Monday)
+    }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -10,12 +10,12 @@
 
     protected override RenderFragment PickerContent =>
     @<CascadingValue Value="@this" IsFixed="true">
-        <MudPickerToolbar Class="mud-picker-datepicker-toolbar" ShowToolbar="@ShowToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color">
+        <MudPickerToolbar Class="mud-picker-datepicker-toolbar" ShowToolbar="@ShowToolbar" Orientation="@Orientation" PickerVariant="@PickerVariant" Color="@Color" @onmousedown:preventDefault="true">
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-year" OnClick="GoToSelectedYear">@GetFormattedYearString()</MudButton>
             <MudButton Variant="Variant.Text" Color="Color.Inherit" Class="mud-button-date" OnClick="OnFormattedDateClick">@GetTitleDateString()</MudButton>
         </MudPickerToolbar>
         <MudPickerContent>
-            <div id="@_mudPickerCalendarContentElementId" class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")">
+            <div id="@_mudPickerCalendarContentElementId" class="mud-picker-calendar-content @($"mud-picker-calendar-content-{MaxMonthColumns ?? DisplayMonths}")" @onmousedown:preventDefault="true">
                 @{
                     int dayId = 0;
                     @if (_picker_month.HasValue && Culture.Calendar.GetYear(_picker_month.Value) == 1 && Culture.Calendar.GetMonth(_picker_month.Value) == 1)
@@ -34,7 +34,7 @@
                                 @for (int i = GetMinYear(); i <= GetMaxYear(); i++)
                                 {
                                     var year = i;
-                                    <div class="mud-picker-year" id="@(_componentId + year)" @onclick="(async () => await OnYearClickedAsync(year))" @onclick:stopPropagation="true">
+                                    <div class="mud-picker-year" id="@(_componentId + year)" @onclick="@(async () => await OnYearClickedAsync(year))" @onclick:stopPropagation="true">
                                         <MudText Typo="@GetYearTypo(year)" Class="@GetYearClasses(year)">@year</MudText>
                                     </div>
                                 }
@@ -64,7 +64,7 @@
                                 @foreach (var month in GetAllMonths())
                                 {
                                     <button type="button" aria-label="@GetMonthName(month)" disabled="@IsMonthDisabled(month)"
-                                    class="mud-picker-month mud-button-root" @onclick="(async () => await OnMonthSelectedAsync(month))" @onclick:stopPropagation="true">
+                                    class="mud-picker-month mud-button-root" @onclick="@(async () => await OnMonthSelectedAsync(month))" @onclick:stopPropagation="true">
                                         <MudText Typo="@GetMonthTypo(month)" Class="@GetMonthClasses(month)">@GetAbbreviatedMonthName(month)</MudText>
                                     </button>
                                 }
@@ -123,7 +123,7 @@
                                                 var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
                                                 <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId : tempId + 1);"
                                                         class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
-                                                        @onclick="(async () => { var d = selectedDay; await OnDayClickedAsync(d); })"
+                                                        @onclick="@(async () => { var d = selectedDay; await OnDayClickedAsync(d); })"
                                                         @onclick:stopPropagation="true"
                                                         onpointerover="@(async () => await HandleMouseoverOnPickerCalendarDayButton(!firstMonthFirstYear ? tempId : tempId + 1))"
                                                         disabled="@IsDayDisabled(selectedDay)">

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -76,11 +76,11 @@
                                 <div class="mud-picker-calendar-header-switch">
                                     @if (!FixMonth.HasValue)
                                     {
-                                        <MudIconButton aria-label="@Localizer[LanguageResource.MudBaseDatePicker_PrevMonth, $"({GetMonthName((tempMonth - 1) % 12)})"]" Class="mud-picker-nav-button-prev mud-flip-x-rtl" Icon="@PreviousIcon" OnClick="OnPreviousMonthClick" />
+                                        <MudIconButton aria-label="@Localizer[LanguageResource.MudBaseDatePicker_PrevMonth, $"({GetMonthName((tempMonth - 1) % 12)})"]" Class="mud-picker-nav-button-prev mud-flip-x-rtl" Icon="@PreviousIcon" OnClick="@OnPreviousMonthClick" />
                                         <button type="button" class="mud-picker-slide-transition mud-picker-calendar-header-transition mud-button-month" @onclick="(() => OnMonthClicked(tempMonth))" @onclick:stopPropagation="true">
                                             <MudText Typo="Typo.body1" Align="Align.Center">@GetMonthName(tempMonth)</MudText>
                                         </button>
-                                        <MudIconButton aria-label="@Localizer[LanguageResource.MudBaseDatePicker_NextMonth, $"({GetMonthName((tempMonth + 1) % 12)})"]" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="OnNextMonthClick" />
+                                        <MudIconButton aria-label="@Localizer[LanguageResource.MudBaseDatePicker_NextMonth, $"({GetMonthName((tempMonth + 1) % 12)})"]" Class="mud-picker-nav-button-next mud-flip-x-rtl" Icon="@NextIcon" OnClick="@OnNextMonthClick" />
                                     }
                                     else
                                     {

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -181,7 +181,7 @@ namespace MudBlazor
         public int? MaxMonthColumns { get; set; }
 
         /// <summary>
-        /// The start month when opening the picker. 
+        /// The start month when opening the picker.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -271,7 +271,7 @@ namespace MudBlazor
         /// The year to use, which cannot be changed.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>null</c>.  
+        /// Defaults to <c>null</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
@@ -368,7 +368,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Gets the n-th week of the currently displayed month. 
+        /// Gets the n-th week of the currently displayed month.
         /// </summary>
         /// <param name="month">offset from _picker_month</param>
         /// <param name="index">between 0 and 4</param>
@@ -594,32 +594,33 @@ namespace MudBlazor
         /// <summary>
         /// We need a random id for the year items in the year list so we can scroll to the item safely in every DatePicker.
         /// </summary>
-        private readonly string _componentId = Identifier.Create();
+        protected readonly string _componentId = Identifier.Create();
 
         /// <summary>
         /// Is set to true to scroll to the actual year after the next render
         /// </summary>
-        private bool _scrollToYearAfterRender = false;
+        protected bool _scrollToYearAfterRender = false;
 
         /// <summary>
         /// Scrolls to the current year.
         /// </summary>
-        public async void ScrollToYear()
+        public async void ScrollToYear(DateTime? date = null)
         {
             _scrollToYearAfterRender = false;
-            var id = $"{_componentId}{Culture.Calendar.GetYear(GetMonthStart(0))}";
+            var dateTime = date ?? GetMonthStart(0);
+            var id = $"{_componentId}{Culture.Calendar.GetYear(dateTime)}";
             await ScrollManager.ScrollToYearAsync(id);
             StateHasChanged();
         }
 
-        private int GetMinYear()
+        protected int GetMinYear()
         {
             if (MinDate.HasValue)
                 return Culture.Calendar.GetYear(MinDate.Value);
             return Culture.Calendar.GetYear(DateTime.Today) - 100;
         }
 
-        private int GetMaxYear()
+        protected int GetMaxYear()
         {
             if (MaxDate.HasValue)
                 return Culture.Calendar.GetYear(MaxDate.Value);

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -615,7 +615,7 @@ namespace MudBlazor
         /// <summary>
         /// Scrolls to the current year.
         /// </summary>
-        public async Task ScrollToYear(DateTime? date = null)
+        public async Task ScrollToYearAsync(DateTime? date = null)
         {
             _scrollToYearAfterRender = false;
             var dateTime = date ?? GetMonthStart(0);
@@ -748,12 +748,12 @@ namespace MudBlazor
 
             if (firstRender && CurrentView == OpenTo.Year)
             {
-                ScrollToYear().CatchAndLog();
+                ScrollToYearAsync().CatchAndLog();
                 return;
             }
 
             if (_scrollToYearAfterRender)
-                ScrollToYear().CatchAndLog();
+                ScrollToYearAsync().CatchAndLog();
         }
 
         protected abstract DateTime GetCalendarStartOfMonth();

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -420,6 +420,17 @@ namespace MudBlazor
             return nextView;
         }
 
+        protected virtual OpenTo? GetPreviousView()
+        {
+            OpenTo? previousView = CurrentView switch
+            {
+                OpenTo.Date => !FixMonth.HasValue ? OpenTo.Month : !FixYear.HasValue ? OpenTo.Year : null,
+                OpenTo.Month => !FixYear.HasValue ? OpenTo.Year : null,
+                _ => null,
+            };
+            return previousView;
+        }
+
         protected virtual async Task SubmitAndCloseAsync()
         {
             if (PickerActions == null)

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -594,7 +594,7 @@ namespace MudBlazor
         /// <summary>
         /// We need a random id for the year items in the year list so we can scroll to the item safely in every DatePicker.
         /// </summary>
-        protected readonly string _componentId = Identifier.Create();
+        private readonly string _componentId = Identifier.Create();
 
         /// <summary>
         /// Is set to true to scroll to the actual year after the next render
@@ -604,7 +604,7 @@ namespace MudBlazor
         /// <summary>
         /// Scrolls to the current year.
         /// </summary>
-        public async void ScrollToYear(DateTime? date = null)
+        public async Task ScrollToYear(DateTime? date = null)
         {
             _scrollToYearAfterRender = false;
             var dateTime = date ?? GetMonthStart(0);
@@ -737,12 +737,12 @@ namespace MudBlazor
 
             if (firstRender && CurrentView == OpenTo.Year)
             {
-                ScrollToYear();
+                ScrollToYear().CatchAndLog();
                 return;
             }
 
             if (_scrollToYearAfterRender)
-                ScrollToYear();
+                ScrollToYear().CatchAndLog();
         }
 
         protected abstract DateTime GetCalendarStartOfMonth();

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -274,66 +274,52 @@ namespace MudBlazor
             switch (args.Key)
             {
                 case "ArrowRight":
-                    if (Open)
+                    if (!Open)
+                        break;
+                    if (args.ShiftKey && CurrentView is OpenTo.Date or OpenTo.Month)
                     {
-                        if (args.ShiftKey)
-                        {
-                            switch (CurrentView)
-                            {
-                                case OpenTo.Date or OpenTo.Month:
-                                    MoveToNextMonth();
-                                    PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
-                                    break;
-                            }
-                        }
-                        else
-                            switch (CurrentView)
-                            {
-                                case OpenTo.Date:
-                                    var currentDay = HighlightedDate ?? GetMonthStart(0);
-                                    var newDay = currentDay.AddDays(1);
-                                    // move to first day of current month when we overflow to next month
-                                    if (newDay.Month != currentDay.Month || _selectedDate == null)
-                                        newDay = currentDay.StartOfMonth(Culture);
-                                    HighlightedDate = _selectedDate = newDay;
-                                    break;
-                                case OpenTo.Month:
-                                    MoveToNextMonth();
-                                    break;
-                            }
+                        MoveToNextMonth();
+                        PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
                     }
-
+                    else
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Date:
+                                var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                var newDay = currentDay.AddDays(1);
+                                // move to first day of current month when we overflow to next month
+                                if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                    newDay = currentDay.StartOfMonth(Culture);
+                                HighlightedDate = _selectedDate = newDay;
+                                break;
+                            case OpenTo.Month:
+                                MoveToNextMonth();
+                                break;
+                        }
                     break;
                 case "ArrowLeft":
-                    if (Open)
+                    if (!Open)
+                        break;
+                    if (args.ShiftKey && CurrentView is OpenTo.Date or OpenTo.Month)
                     {
-                        if (args.ShiftKey)
-                        {
-                            switch (CurrentView)
-                            {
-                                case OpenTo.Date or OpenTo.Month:
-                                    MoveToPreviousMonth();
-                                    PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
-                                    break;
-                            }
-                        }
-                        else
-                            switch (CurrentView)
-                            {
-                                case OpenTo.Date:
-                                    var currentDay = HighlightedDate ?? GetMonthStart(0);
-                                    var newDay = currentDay.AddDays(-1);
-                                    // move to last day of current month when we overflow to previous month
-                                    if (newDay.Month != currentDay.Month || _selectedDate == null)
-                                        newDay = currentDay.EndOfMonth(Culture);
-                                    HighlightedDate = _selectedDate = newDay;
-                                    break;
-                                case OpenTo.Month:
-                                    MoveToPreviousMonth();
-                                    break;
-                            }
+                        MoveToPreviousMonth();
+                        PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
                     }
-
+                    else
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Date:
+                                var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                var newDay = currentDay.AddDays(-1);
+                                // move to last day of current month when we overflow to previous month
+                                if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                    newDay = currentDay.EndOfMonth(Culture);
+                                HighlightedDate = _selectedDate = newDay;
+                                break;
+                            case OpenTo.Month:
+                                MoveToPreviousMonth();
+                                break;
+                        }
                     break;
                 case "ArrowUp":
                     if (!Open && !Editable)
@@ -344,15 +330,10 @@ namespace MudBlazor
                     {
                         Open = false;
                     }
-                    else if (args.ShiftKey)
+                    else if (args.ShiftKey && CurrentView is OpenTo.Month or OpenTo.Date)
                     {
-                        switch (CurrentView)
-                        {
-                            case OpenTo.Month or OpenTo.Date:
-                                MoveToPreviousYear();
-                                PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
-                                break;
-                        }
+                        MoveToPreviousYear();
+                        PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
                     }
                     else
                     {
@@ -398,15 +379,10 @@ namespace MudBlazor
                     {
                         Open = true;
                     }
-                    else if (args.ShiftKey)
+                    else if (args.ShiftKey && CurrentView is OpenTo.Month or OpenTo.Date)
                     {
-                        switch (CurrentView)
-                        {
-                            case OpenTo.Month or OpenTo.Date:
-                                MoveToNextYear();
-                                PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
-                                break;
-                        }
+                        MoveToNextYear();
+                        PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
                     }
                     else
                     {
@@ -568,7 +544,7 @@ namespace MudBlazor
             if (Culture.Calendar.GetYear(newYear) > GetMaxYear())
                 return;
             HighlightedDate = _selectedDate = newYear;
-            ScrollToYear(HighlightedDate).CatchAndLog();
+            ScrollToYearAsync(HighlightedDate).CatchAndLog();
         }
 
         private void MoveToPreviousYear()
@@ -577,7 +553,7 @@ namespace MudBlazor
             if (Culture.Calendar.GetYear(newYear) < GetMinYear())
                 return;
             HighlightedDate = _selectedDate = newYear;
-            ScrollToYear(HighlightedDate).CatchAndLog();
+            ScrollToYearAsync(HighlightedDate).CatchAndLog();
         }
 
         private Task ReturnDateBackUpAsync() => CloseAsync(false);
@@ -593,7 +569,7 @@ namespace MudBlazor
                     Culture.Calendar.GetMonth(Date.Value),
                     1,
                     Culture.Calendar);
-                ScrollToYear().CatchAndLog();
+                ScrollToYearAsync().CatchAndLog();
             }
         }
 
@@ -609,7 +585,7 @@ namespace MudBlazor
             if (submitDate)
             {
                 await SetDateAsync(date, true);
-                ScrollToYear().CatchAndLog();
+                ScrollToYearAsync().CatchAndLog();
             }
         }
     }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -111,6 +111,7 @@ namespace MudBlazor
 
         protected override async Task OnDayClickedAsync(DateTime dateTime)
         {
+            await FocusAsync();
             _selectedDate = dateTime;
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
@@ -130,6 +131,7 @@ namespace MudBlazor
         /// <param name="month"></param>
         protected override async Task OnMonthSelectedAsync(DateTime month)
         {
+            await FocusAsync();
             PickerMonth = month;
             var nextView = GetNextView();
             if (nextView == null)
@@ -161,6 +163,7 @@ namespace MudBlazor
         /// <param name="year"></param>
         protected override async Task OnYearClickedAsync(int year)
         {
+            await FocusAsync();
             var current = GetMonthStart(0);
             PickerMonth = new DateTime(year, Culture.Calendar.GetMonth(current), 1, Culture.Calendar);
             var nextView = GetNextView();
@@ -259,13 +262,60 @@ namespace MudBlazor
                 case "ArrowRight":
                     if (Open)
                     {
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Date:
+                                var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                var newDay = currentDay.AddDays(1);
+                                if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                    newDay = new DateTime(currentDay.Year, currentDay.Month, 1, Culture.Calendar);
+                                HighlightedDate = _selectedDate = newDay;
+                                break;
+                            case OpenTo.Month:
+                                var currentMonth = HighlightedDate ?? GetMonthStart(0);
+                                var newMonth = currentMonth.AddMonths(1);
+                                if (newMonth.Year != currentMonth.Year)
+                                {
+                                    var daysInMonth =
+                                        Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                                    newMonth = new DateTime(currentMonth.Year,
+                                        1,
+                                        Math.Min(currentMonth.Day, daysInMonth),
+                                        Culture.Calendar);
+                                }
 
+                                HighlightedDate = _selectedDate = newMonth;
+                                break;
+                        }
                     }
                     break;
                 case "ArrowLeft":
                     if (Open)
                     {
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Date:
+                                var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                var newDay = currentDay.AddDays(-1);
+                                if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                    newDay = new DateTime(currentDay.Year, currentDay.Month, Culture.Calendar.GetDaysInMonth(currentDay.Year, currentDay.Month), Culture.Calendar);
+                                HighlightedDate = _selectedDate = newDay;
+                                break;
+                            case OpenTo.Month:
+                                var currentMonth = HighlightedDate ?? GetMonthStart(0);
+                                var newMonth = currentMonth.AddMonths(-1);
+                                if (currentMonth.Year != newMonth.Year)
+                                {
+                                    var daysInMonth = Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                                    newMonth = new DateTime(currentMonth.Year,
+                                        Culture.Calendar.GetMonthsInYear(currentMonth.Year),
+                                        Math.Min(currentMonth.Day, daysInMonth),
+                                        Culture.Calendar);
+                                }
 
+                                HighlightedDate = _selectedDate = newMonth;
+                                break;
+                        }
                     }
                     break;
                 case "ArrowUp":
@@ -283,7 +333,16 @@ namespace MudBlazor
                     }
                     else
                     {
-
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Year:
+                                var newYear = (HighlightedDate ?? GetMonthStart(0)).AddYears(-1);
+                                if (Culture.Calendar.GetYear(newYear) < GetMinYear())
+                                    break;
+                                HighlightedDate = _selectedDate = newYear;
+                                ScrollToYear(HighlightedDate);
+                                break;
+                        }
                     }
                     break;
                 case "ArrowDown":
@@ -297,7 +356,16 @@ namespace MudBlazor
                     }
                     else
                     {
-
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Year:
+                                var newYear = (HighlightedDate ?? GetMonthStart(0)).AddYears(1);
+                                if (Culture.Calendar.GetYear(newYear) > GetMaxYear())
+                                    break;
+                                HighlightedDate = _selectedDate = newYear;
+                                ScrollToYear(HighlightedDate);
+                                break;
+                        }
                     }
                     break;
                 case "Escape":
@@ -308,12 +376,31 @@ namespace MudBlazor
                     if (!Open)
                     {
                         await OpenAsync();
+                        if (CurrentView == OpenTo.Year)
+                            _scrollToYearAfterRender = true;
                     }
                     else
                     {
-                        await SubmitAsync();
-                        await CloseAsync();
-                        _inputReference?.SetText(Text);
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Date:
+                                if (HighlightedDate != null)
+                                    await OnDayClickedAsync(HighlightedDate.Value);
+                                break;
+                            case OpenTo.Year:
+                                if (HighlightedDate != null)
+                                    await OnYearClickedAsync(Culture.Calendar.GetYear(HighlightedDate.Value));
+                                break;
+                            case OpenTo.Month:
+                                if (HighlightedDate != null)
+                                    await OnMonthSelectedAsync(new DateTime(HighlightedDate.Value.Year, Culture.Calendar.GetMonth(HighlightedDate.Value), 1, Culture.Calendar));
+                                break;
+                            default:
+                                await SubmitAsync();
+                                _inputReference?.SetText(Text);
+                                await CloseAsync();
+                                break;
+                        }
                     }
                     break;
                 case " ":
@@ -322,6 +409,8 @@ namespace MudBlazor
                         if (!Open)
                         {
                             await OpenAsync();
+                            if (CurrentView == OpenTo.Year)
+                                _scrollToYearAfterRender = true;
                         }
                         else
                         {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -16,7 +16,8 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when the <see cref="Date"/> has changed.
         /// </summary>
-        [Parameter] public EventCallback<DateTime?> DateChanged { get; set; }
+        [Parameter]
+        public EventCallback<DateTime?> DateChanged { get; set; }
 
         /// <summary>
         /// The currently selected date.
@@ -68,7 +69,10 @@ namespace MudBlazor
                 }
 
                 if (date is not null)
-                    PickerMonth = new DateTime(Culture.Calendar.GetYear(date.Value), Culture.Calendar.GetMonth(date.Value), 1, Culture.Calendar);
+                    PickerMonth = new DateTime(Culture.Calendar.GetYear(date.Value),
+                        Culture.Calendar.GetMonth(date.Value),
+                        1,
+                        Culture.Calendar);
 
                 _value = date;
 
@@ -77,6 +81,7 @@ namespace MudBlazor
                     Converter.GetError = false;
                     await SetTextAsync(Converter.Set(_value), false);
                 }
+
                 await DateChanged.InvokeAsync(_value);
                 await BeginValidateAsync();
                 FieldChanged(_value);
@@ -105,7 +110,10 @@ namespace MudBlazor
             if ((Date?.Date == day && _selectedDate == null) || _selectedDate?.Date == day)
                 return b.AddClass("mud-selected").AddClass($"mud-theme-{Color.ToDescriptionString()}").Build();
             if (day == TimeProvider.GetLocalNow().Date)
-                return b.AddClass("mud-current mud-button-outlined").AddClass($"mud-button-outlined-{Color.ToDescriptionString()} mud-{Color.ToDescriptionString()}-text").Build();
+                return b.AddClass("mud-current mud-button-outlined")
+                        .AddClass(
+                            $"mud-button-outlined-{Color.ToDescriptionString()} mud-{Color.ToDescriptionString()}-text")
+                        .Build();
             return b.Build();
         }
 
@@ -136,7 +144,8 @@ namespace MudBlazor
             var nextView = GetNextView();
             if (nextView == null)
             {
-                _selectedDate = _selectedDate.HasValue ?
+                _selectedDate = _selectedDate.HasValue
+                    ?
                     //everything has to be set because a value could already defined -> fix values can be ignored as they are set in submit anyway
                     new DateTime(
                         Culture.Calendar.GetYear(month),
@@ -146,9 +155,13 @@ namespace MudBlazor
                         Culture.Calendar.GetMinute(_selectedDate.Value),
                         Culture.Calendar.GetSecond(_selectedDate.Value),
                         (int)Culture.Calendar.GetMilliseconds(_selectedDate.Value),
-                        Culture.Calendar, _selectedDate.Value.Kind)
+                        Culture.Calendar,
+                        _selectedDate.Value.Kind)
                     //We can assume day here, as it was not set yet. If a fix value is set, it will be overridden in Submit
-                    : new DateTime(Culture.Calendar.GetYear(month), Culture.Calendar.GetMonth(month), 1, Culture.Calendar);
+                    : new DateTime(Culture.Calendar.GetYear(month),
+                        Culture.Calendar.GetMonth(month),
+                        1,
+                        Culture.Calendar);
                 await SubmitAndCloseAsync();
             }
             else
@@ -169,7 +182,8 @@ namespace MudBlazor
             var nextView = GetNextView();
             if (nextView == null)
             {
-                _selectedDate = _selectedDate.HasValue ?
+                _selectedDate = _selectedDate.HasValue
+                    ?
                     //everything has to be set because a value could already defined -> fix values can be ignored as they are set in submit anyway
                     new DateTime(
                         year,
@@ -288,6 +302,7 @@ namespace MudBlazor
                                     break;
                             }
                     }
+
                     break;
                 case "ArrowLeft":
                     if (Open)
@@ -318,9 +333,10 @@ namespace MudBlazor
                                     break;
                             }
                     }
+
                     break;
                 case "ArrowUp":
-                    if (Open == false && Editable == false)
+                    if (!Open && !Editable)
                     {
                         Open = true;
                     }
@@ -351,7 +367,8 @@ namespace MudBlazor
                                 // move to last row months of current year when we overflow to previous year
                                 if (currentMonth.Year != newMonth.Year)
                                 {
-                                    var daysInMonth = Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                                    var daysInMonth =
+                                        Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
                                     var monthsInYear = Culture.Calendar.GetMonthsInYear(currentMonth.Year);
                                     newMonth = new DateTime(currentMonth.Year,
                                         monthsInYear - (3 - currentMonth.Month),
@@ -369,10 +386,12 @@ namespace MudBlazor
                                 {
                                     newDay = currentDay.LastWeekDayOfMonth(currentDay.DayOfWeek, Culture);
                                 }
+
                                 HighlightedDate = _selectedDate = newDay;
                                 break;
                         }
                     }
+
                     break;
                 case "ArrowDown":
                     if (Open == false && Editable == false)
@@ -402,13 +421,15 @@ namespace MudBlazor
                                 // move to first row of months of current year when we overflow to previous year
                                 if (currentMonth.Year != newMonth.Year)
                                 {
-                                    var daysInMonth = Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                                    var daysInMonth =
+                                        Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
                                     var monthsInYear = Culture.Calendar.GetMonthsInYear(currentMonth.Year);
                                     newMonth = new DateTime(currentMonth.Year,
                                         3 - (monthsInYear - currentMonth.Month),
                                         Math.Min(currentMonth.Day, daysInMonth), // handle different month lengths
                                         Culture.Calendar);
                                 }
+
                                 HighlightedDate = _selectedDate = newMonth;
                                 break;
                             case OpenTo.Date:
@@ -421,6 +442,7 @@ namespace MudBlazor
                                 break;
                         }
                     }
+
                     break;
                 case "Escape":
                     await ReturnDateBackUpAsync();
@@ -437,6 +459,7 @@ namespace MudBlazor
                     }
                     else
                         await ReturnDateBackUpAsync();
+
                     break;
                 case "Enter":
                 case "NumpadEnter":
@@ -452,6 +475,7 @@ namespace MudBlazor
                     {
                         await CommitView();
                     }
+
                     break;
                 case " ":
                     if (!Editable)
@@ -471,6 +495,7 @@ namespace MudBlazor
                             _inputReference?.SetText(Text);
                         }
                     }
+
                     break;
             }
 
@@ -564,8 +589,10 @@ namespace MudBlazor
         {
             if (Date.HasValue)
             {
-                PickerMonth = new DateTime(Culture.Calendar.GetYear(Date.Value), Culture.Calendar.GetMonth(Date.Value),
-                    1, Culture.Calendar);
+                PickerMonth = new DateTime(Culture.Calendar.GetYear(Date.Value),
+                    Culture.Calendar.GetMonth(Date.Value),
+                    1,
+                    Culture.Calendar);
                 ScrollToYear().CatchAndLog();
             }
         }
@@ -575,7 +602,9 @@ namespace MudBlazor
         /// </summary>
         public async Task GoToDate(DateTime date, bool submitDate = true)
         {
-            PickerMonth = new DateTime(Culture.Calendar.GetYear(date), Culture.Calendar.GetMonth(date), 1,
+            PickerMonth = new DateTime(Culture.Calendar.GetYear(date),
+                Culture.Calendar.GetMonth(date),
+                1,
                 Culture.Calendar);
             if (submitDate)
             {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -262,60 +262,61 @@ namespace MudBlazor
                 case "ArrowRight":
                     if (Open)
                     {
-                        switch (CurrentView)
+                        if (args.ShiftKey)
                         {
-                            case OpenTo.Date:
-                                var currentDay = HighlightedDate ?? GetMonthStart(0);
-                                var newDay = currentDay.AddDays(1);
-                                if (newDay.Month != currentDay.Month || _selectedDate == null)
-                                    newDay = new DateTime(currentDay.Year, currentDay.Month, 1, Culture.Calendar);
-                                HighlightedDate = _selectedDate = newDay;
-                                break;
-                            case OpenTo.Month:
-                                var currentMonth = HighlightedDate ?? GetMonthStart(0);
-                                var newMonth = currentMonth.AddMonths(1);
-                                if (newMonth.Year != currentMonth.Year)
-                                {
-                                    var daysInMonth =
-                                        Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
-                                    newMonth = new DateTime(currentMonth.Year,
-                                        1,
-                                        Math.Min(currentMonth.Day, daysInMonth),
-                                        Culture.Calendar);
-                                }
-
-                                HighlightedDate = _selectedDate = newMonth;
-                                break;
+                            switch (CurrentView)
+                            {
+                                case OpenTo.Date or OpenTo.Month:
+                                    MoveToNextMonth();
+                                    PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
+                                    break;
+                            }
                         }
+                        else
+                            switch (CurrentView)
+                            {
+                                case OpenTo.Date:
+                                    var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                    var newDay = currentDay.AddDays(1);
+                                    // move to first day of current month when we overflow to next month
+                                    if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                        newDay = currentDay.StartOfMonth(Culture);
+                                    HighlightedDate = _selectedDate = newDay;
+                                    break;
+                                case OpenTo.Month:
+                                    MoveToNextMonth();
+                                    break;
+                            }
                     }
                     break;
                 case "ArrowLeft":
                     if (Open)
                     {
-                        switch (CurrentView)
+                        if (args.ShiftKey)
                         {
-                            case OpenTo.Date:
-                                var currentDay = HighlightedDate ?? GetMonthStart(0);
-                                var newDay = currentDay.AddDays(-1);
-                                if (newDay.Month != currentDay.Month || _selectedDate == null)
-                                    newDay = new DateTime(currentDay.Year, currentDay.Month, Culture.Calendar.GetDaysInMonth(currentDay.Year, currentDay.Month), Culture.Calendar);
-                                HighlightedDate = _selectedDate = newDay;
-                                break;
-                            case OpenTo.Month:
-                                var currentMonth = HighlightedDate ?? GetMonthStart(0);
-                                var newMonth = currentMonth.AddMonths(-1);
-                                if (currentMonth.Year != newMonth.Year)
-                                {
-                                    var daysInMonth = Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
-                                    newMonth = new DateTime(currentMonth.Year,
-                                        Culture.Calendar.GetMonthsInYear(currentMonth.Year),
-                                        Math.Min(currentMonth.Day, daysInMonth),
-                                        Culture.Calendar);
-                                }
-
-                                HighlightedDate = _selectedDate = newMonth;
-                                break;
+                            switch (CurrentView)
+                            {
+                                case OpenTo.Date or OpenTo.Month:
+                                    MoveToPreviousMonth();
+                                    PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
+                                    break;
+                            }
                         }
+                        else
+                            switch (CurrentView)
+                            {
+                                case OpenTo.Date:
+                                    var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                    var newDay = currentDay.AddDays(-1);
+                                    // move to last day of current month when we overflow to previous month
+                                    if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                        newDay = currentDay.EndOfMonth(Culture);
+                                    HighlightedDate = _selectedDate = newDay;
+                                    break;
+                                case OpenTo.Month:
+                                    MoveToPreviousMonth();
+                                    break;
+                            }
                     }
                     break;
                 case "ArrowUp":
@@ -329,18 +330,46 @@ namespace MudBlazor
                     }
                     else if (args.ShiftKey)
                     {
-
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Month or OpenTo.Date:
+                                MoveToPreviousYear();
+                                PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
+                                break;
+                        }
                     }
                     else
                     {
                         switch (CurrentView)
                         {
                             case OpenTo.Year:
-                                var newYear = (HighlightedDate ?? GetMonthStart(0)).AddYears(-1);
-                                if (Culture.Calendar.GetYear(newYear) < GetMinYear())
-                                    break;
-                                HighlightedDate = _selectedDate = newYear;
-                                ScrollToYear(HighlightedDate).CatchAndLog();
+                                MoveToPreviousYear();
+                                break;
+                            case OpenTo.Month:
+                                var currentMonth = HighlightedDate ?? GetMonthStart(0);
+                                var newMonth = currentMonth.AddMonths(-3);
+                                // move to last row months of current year when we overflow to previous year
+                                if (currentMonth.Year != newMonth.Year)
+                                {
+                                    var daysInMonth = Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                                    var monthsInYear = Culture.Calendar.GetMonthsInYear(currentMonth.Year);
+                                    newMonth = new DateTime(currentMonth.Year,
+                                        monthsInYear - (3 - currentMonth.Month),
+                                        Math.Min(currentMonth.Day, daysInMonth), // handle different month lengths
+                                        Culture.Calendar);
+                                }
+
+                                HighlightedDate = _selectedDate = newMonth;
+                                break;
+                            case OpenTo.Date:
+                                var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                var newDay = currentDay.AddDays(-7);
+                                // move to last same week day of current month when we overflow to previous month
+                                if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                {
+                                    newDay = currentDay.LastWeekDayOfMonth(currentDay.DayOfWeek, Culture);
+                                }
+                                HighlightedDate = _selectedDate = newDay;
                                 break;
                         }
                     }
@@ -352,18 +381,43 @@ namespace MudBlazor
                     }
                     else if (args.ShiftKey)
                     {
-
+                        switch (CurrentView)
+                        {
+                            case OpenTo.Month or OpenTo.Date:
+                                MoveToNextYear();
+                                PickerMonth = HighlightedDate!.Value.StartOfMonth(Culture);
+                                break;
+                        }
                     }
                     else
                     {
                         switch (CurrentView)
                         {
                             case OpenTo.Year:
-                                var newYear = (HighlightedDate ?? GetMonthStart(0)).AddYears(1);
-                                if (Culture.Calendar.GetYear(newYear) > GetMaxYear())
-                                    break;
-                                HighlightedDate = _selectedDate = newYear;
-                                ScrollToYear(HighlightedDate).CatchAndLog();
+                                MoveToNextYear();
+                                break;
+                            case OpenTo.Month:
+                                var currentMonth = HighlightedDate ?? GetMonthStart(0);
+                                var newMonth = currentMonth.AddMonths(3);
+                                // move to first row of months of current year when we overflow to previous year
+                                if (currentMonth.Year != newMonth.Year)
+                                {
+                                    var daysInMonth = Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                                    var monthsInYear = Culture.Calendar.GetMonthsInYear(currentMonth.Year);
+                                    newMonth = new DateTime(currentMonth.Year,
+                                        3 - (monthsInYear - currentMonth.Month),
+                                        Math.Min(currentMonth.Day, daysInMonth), // handle different month lengths
+                                        Culture.Calendar);
+                                }
+                                HighlightedDate = _selectedDate = newMonth;
+                                break;
+                            case OpenTo.Date:
+                                var currentDay = HighlightedDate ?? GetMonthStart(0);
+                                var newDay = currentDay.AddDays(7);
+                                // move to same week day of beginning of current month when we overflow to next month
+                                if (newDay.Month != currentDay.Month || _selectedDate == null)
+                                    newDay = currentDay.FirstWeekDayOfMonth(currentDay.DayOfWeek, Culture);
+                                HighlightedDate = _selectedDate = newDay;
                                 break;
                         }
                     }
@@ -371,36 +425,32 @@ namespace MudBlazor
                 case "Escape":
                     await ReturnDateBackUpAsync();
                     break;
+                case "Backspace":
+                    var previousView = GetPreviousView();
+                    if (previousView != null)
+                    {
+                        CurrentView = (OpenTo)previousView;
+                        if (CurrentView == OpenTo.Year)
+                            // there is second render when opening with enter unlike with mouse click, which resets scroll to
+                            // beginning of list, so reset the flag again
+                            _scrollToYearAfterRender = true;
+                    }
+                    else
+                        await ReturnDateBackUpAsync();
+                    break;
                 case "Enter":
                 case "NumpadEnter":
                     if (!Open)
                     {
                         await OpenAsync();
                         if (CurrentView == OpenTo.Year)
+                            // there is second render when opening with enter unlike with mouse click, which resets scroll to
+                            // beginning of list, so reset the flag again
                             _scrollToYearAfterRender = true;
                     }
                     else
                     {
-                        switch (CurrentView)
-                        {
-                            case OpenTo.Date:
-                                if (HighlightedDate != null)
-                                    await OnDayClickedAsync(HighlightedDate.Value);
-                                break;
-                            case OpenTo.Year:
-                                if (HighlightedDate != null)
-                                    await OnYearClickedAsync(Culture.Calendar.GetYear(HighlightedDate.Value));
-                                break;
-                            case OpenTo.Month:
-                                if (HighlightedDate != null)
-                                    await OnMonthSelectedAsync(new DateTime(HighlightedDate.Value.Year, Culture.Calendar.GetMonth(HighlightedDate.Value), 1, Culture.Calendar));
-                                break;
-                            default:
-                                await SubmitAsync();
-                                _inputReference?.SetText(Text);
-                                await CloseAsync();
-                                break;
-                        }
+                        await CommitView();
                     }
                     break;
                 case " ":
@@ -410,6 +460,8 @@ namespace MudBlazor
                         {
                             await OpenAsync();
                             if (CurrentView == OpenTo.Year)
+                                // there is second render when opening with enter unlike with mouse click, which resets scroll to
+                                // beginning of list, so reset the flag again
                                 _scrollToYearAfterRender = true;
                         }
                         else
@@ -425,7 +477,85 @@ namespace MudBlazor
             StateHasChanged();
         }
 
-        private Task ReturnDateBackUpAsync() => CloseAsync();
+        private async Task CommitView()
+        {
+            switch (CurrentView)
+            {
+                case OpenTo.Date:
+                    if (HighlightedDate != null)
+                        await OnDayClickedAsync(HighlightedDate.Value);
+                    break;
+                case OpenTo.Year:
+                    if (HighlightedDate != null)
+                        await OnYearClickedAsync(Culture.Calendar.GetYear(HighlightedDate.Value));
+                    break;
+                case OpenTo.Month:
+                    if (HighlightedDate != null)
+                        await OnMonthSelectedAsync(HighlightedDate.Value.StartOfMonth(Culture));
+                    break;
+                default:
+                    await SubmitAsync();
+                    _inputReference?.SetText(Text);
+                    await CloseAsync();
+                    break;
+            }
+        }
+
+        private void MoveToNextMonth()
+        {
+            var currentMonth = HighlightedDate ?? GetMonthStart(0);
+            var newMonth = currentMonth.AddMonths(1);
+            // move to first month of current year when we overflow to next year
+            if (newMonth.Year != currentMonth.Year)
+            {
+                var daysInMonth =
+                    Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                newMonth = new DateTime(currentMonth.Year,
+                    1,
+                    Math.Min(currentMonth.Day, daysInMonth), // handle different month lengths
+                    Culture.Calendar);
+            }
+
+            HighlightedDate = _selectedDate = newMonth;
+        }
+
+        private void MoveToPreviousMonth()
+        {
+            var currentMonth = HighlightedDate ?? GetMonthStart(0);
+            var newMonth = currentMonth.AddMonths(-1);
+            // move to last month of current year when we overflow to previous year
+            if (currentMonth.Year != newMonth.Year)
+            {
+                var daysInMonth =
+                    Culture.Calendar.GetDaysInMonth(currentMonth.Year, currentMonth.Month);
+                newMonth = new DateTime(currentMonth.Year,
+                    Culture.Calendar.GetMonthsInYear(currentMonth.Year),
+                    Math.Min(currentMonth.Day, daysInMonth), // handle different month lengths
+                    Culture.Calendar);
+            }
+
+            HighlightedDate = _selectedDate = newMonth;
+        }
+
+        private void MoveToNextYear()
+        {
+            var newYear = (HighlightedDate ?? GetMonthStart(0)).AddYears(1);
+            if (Culture.Calendar.GetYear(newYear) > GetMaxYear())
+                return;
+            HighlightedDate = _selectedDate = newYear;
+            ScrollToYear(HighlightedDate).CatchAndLog();
+        }
+
+        private void MoveToPreviousYear()
+        {
+            var newYear = (HighlightedDate ?? GetMonthStart(0)).AddYears(-1);
+            if (Culture.Calendar.GetYear(newYear) < GetMinYear())
+                return;
+            HighlightedDate = _selectedDate = newYear;
+            ScrollToYear(HighlightedDate).CatchAndLog();
+        }
+
+        private Task ReturnDateBackUpAsync() => CloseAsync(false);
 
         /// <summary>
         /// Scrolls to the date.

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -340,7 +340,7 @@ namespace MudBlazor
                                 if (Culture.Calendar.GetYear(newYear) < GetMinYear())
                                     break;
                                 HighlightedDate = _selectedDate = newYear;
-                                ScrollToYear(HighlightedDate);
+                                ScrollToYear(HighlightedDate).CatchAndLog();
                                 break;
                         }
                     }
@@ -363,7 +363,7 @@ namespace MudBlazor
                                 if (Culture.Calendar.GetYear(newYear) > GetMaxYear())
                                     break;
                                 HighlightedDate = _selectedDate = newYear;
-                                ScrollToYear(HighlightedDate);
+                                ScrollToYear(HighlightedDate).CatchAndLog();
                                 break;
                         }
                     }
@@ -436,7 +436,7 @@ namespace MudBlazor
             {
                 PickerMonth = new DateTime(Culture.Calendar.GetYear(Date.Value), Culture.Calendar.GetMonth(Date.Value),
                     1, Culture.Calendar);
-                ScrollToYear();
+                ScrollToYear().CatchAndLog();
             }
         }
 
@@ -450,7 +450,7 @@ namespace MudBlazor
             if (submitDate)
             {
                 await SetDateAsync(date, true);
-                ScrollToYear();
+                ScrollToYear().CatchAndLog();
             }
         }
     }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -37,6 +37,7 @@
                        OnClearButtonClick="@(async () => await ClearAsync())"
                        TextUpdateSuppression="@(Editable && !GetReadOnlyState())"
                        ShrinkLabel="@ShrinkLabel"
+                       KeyDownPreventDefault="Open"
                        InputId="@InputId"
                        @onclick="OnClickAsync" />;
 

--- a/src/MudBlazor/Extensions/DateTimeExtensions.cs
+++ b/src/MudBlazor/Extensions/DateTimeExtensions.cs
@@ -80,4 +80,38 @@ public static class DateTimeExtensions
 
         return self.AddDays(-1 * diff).Date;
     }
+
+    /// <summary>
+    /// Gets the last occurrence of a specific day of the week in the month for this date
+    /// </summary>
+    /// <param name="self">The date to use as month for calculation.</param>
+    /// <param name="dayOfWeek">The day of the week to find.</param>
+    /// <param name="culture">The culture to use for formatting the date.</param>
+    public static DateTime LastWeekDayOfMonth(this DateTime self, DayOfWeek dayOfWeek, CultureInfo culture)
+    {
+        var lastDay = self.EndOfMonth(culture);
+        while (lastDay.DayOfWeek != dayOfWeek)
+        {
+            lastDay = lastDay.AddDays(-1);
+        }
+
+        return lastDay;
+    }
+
+    /// <summary>
+    /// Gets the first occurrence of a specific day of the week in the month for this date
+    /// </summary>
+    /// <param name="self">The date to use as month for calculation.</param>
+    /// <param name="dayOfWeek">The day of the week to find.</param>
+    /// <param name="culture">The culture to use for formatting the date.</param>
+    public static DateTime FirstWeekDayOfMonth(this DateTime self, DayOfWeek dayOfWeek, CultureInfo culture)
+    {
+        var firstDay = self.StartOfMonth(culture);
+        while (firstDay.DayOfWeek != dayOfWeek)
+        {
+            firstDay = firstDay.AddDays(1);
+        }
+
+        return firstDay;
+    }
 }


### PR DESCRIPTION
Features:
When popup is opened it can be navigated with keys:

- **Arrows keys:** 
Navigates years/months/days in respective views

- **Shift + arrows keys:**
Navigates years in month view
Navigates years and months in date view

- **Enter:**
Selects value in current view and moves to next view or commits value to input and closes popup on last view

- **Backspace**
Closes popup when first view and doesnt commit value to input
Moves to previous view if not first view

Fixes:
Datepicker now retains focus when value is selected

https://github.com/user-attachments/assets/12d89763-77e4-420e-9a49-e762edebbd16


