### PR TITLE
MudCard: Hide gap when MudCardActions is empty

### DIFF
--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -58,4 +58,8 @@
   display: flex;
   padding: 8px;
   align-items: center;
+
+  &:empty {
+    display: none;
+  }
 }


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Take a look at an example card:

<img width="985" height="569" alt="mudblazor com_components_card" src="https://github.com/user-attachments/assets/4185f807-8800-47c0-8590-576a69cc079a" />

There is a gap of 16px between the content and the actions:

<img width="451" height="290" alt="image" src="https://github.com/user-attachments/assets/6241011d-4407-49a0-b899-f32df187cd19" />

If you remove `<MudCardActions>` the gap will be correctly removed:

```razor
<MudCard>
    <MudCardContent>
        <MudText>Story of the day</MudText>
        <MudText Typo="Typo.body2">The quick, brown fox jumps over a lazy dog.</MudText>
    </MudCardContent>
</MudCard>
```

<img width="445" height="278" alt="image" src="https://github.com/user-attachments/assets/2eadd29f-b683-49c5-8f39-06cd465078bb" />

But if you left `<MudCardActions>` in, like when conditionally rendering, the gap will remain:

```razor
<MudCard>
    <MudCardContent>
        <MudText>Story of the day</MudText>
        <MudText Typo="Typo.body2">The quick, brown fox jumps over a lazy dog.</MudText>
    </MudCardContent>
    <MudCardActions>
        @if(conditional rendering...)
    </MudCardActions>
</MudCard>
```

<img width="456" height="256" alt="image" src="https://github.com/user-attachments/assets/a5eefd11-cd3f-43de-8618-054194e096fb" />

This PR removes `.mud-card-actions` from the display if it contains no content.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
