### PR TITLE
MudStepper: Provide step context to child content

### DIFF
--- a/src/MudBlazor.UnitTests/Components/StepperContextTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperContextTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class StepperContextTests
+    {
+        [Test]
+        public void StepContext_NullStepper_Throws()
+        {
+            Assert.That(() => _ = new MudStepContext(null!, new MudStep()),
+                Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("stepper"));
+        }
+
+        [Test]
+        public void StepContext_NullStep_Throws()
+        {
+            Assert.That(() => _ = new MudStepContext(new MudStepper(), null!),
+                Throws.TypeOf<ArgumentNullException>().With.Property("ParamName").EqualTo("step"));
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -1,6 +1,11 @@
-﻿using AngleSharp.Dom;
+﻿#nullable enable
+using System;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using MudBlazor;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.Stepper;
 using NUnit.Framework;
@@ -22,13 +27,13 @@ namespace MudBlazor.UnitTests.Components
                     step.Add(x => x.SecondaryText, "a");
                     step.Add(x => x.Class, "step-a");
                     step.Add(x => x.Style, "fontsize:11px");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step 1"));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
                     step.Add(x => x.SecondaryText, "b");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step 2"));
                     step.Add(x => x.Class, "step-b");
                     step.Add(x => x.Style, "fontsize:12px");
                 });
@@ -53,6 +58,52 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void StepperStepContext_ShouldBeAvailableInsideChildContent()
+        {
+            MudStepContext? firstStepContext = null;
+            MudStepContext? secondStepContext = null;
+
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Title, "A");
+                    step.Add(x => x.ChildContent, builder =>
+                    {
+                        builder.OpenComponent<StepContextRecorder>(0);
+                        builder.AddAttribute(1, nameof(StepContextRecorder.ActiveMarkup), "step-1-active");
+                        builder.AddAttribute(2, nameof(StepContextRecorder.Capture), (Action<MudStepContext?>)(context => firstStepContext = context));
+                        builder.CloseComponent();
+                    });
+                });
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Title, "B");
+                    step.Add(x => x.ChildContent, builder =>
+                    {
+                        builder.OpenComponent<StepContextRecorder>(0);
+                        builder.AddAttribute(1, nameof(StepContextRecorder.ActiveMarkup), "step-2-active");
+                        builder.AddAttribute(2, nameof(StepContextRecorder.Capture), (Action<MudStepContext?>)(context => secondStepContext = context));
+                        builder.CloseComponent();
+                    });
+                });
+            });
+
+            firstStepContext.Should().NotBeNull();
+            firstStepContext!.Step.Should().Be(stepper.Instance.Steps[0]);
+            firstStepContext.IsActive.Should().BeTrue();
+            secondStepContext.Should().BeNull();
+            stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Be("step-1-active");
+
+            stepper.FindAll(".mud-step")[1].Click();
+
+            secondStepContext.Should().NotBeNull();
+            secondStepContext!.Step.Should().Be(stepper.Instance.Steps[1]);
+            secondStepContext.IsActive.Should().BeTrue();
+            stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Be("step-2-active");
+        }
+
+        [Test]
         public void Stepper_ShouldDisplayContentOfActiveStep()
         {
             var stepper = Context.RenderComponent<MudStepper>(self =>
@@ -64,13 +115,13 @@ namespace MudBlazor.UnitTests.Components
                     step.Add(x => x.SecondaryText, "a");
                     step.Add(x => x.Class, "step-a");
                     step.Add(x => x.Style, "fontsize:11px");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step 1"));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
                     step.Add(x => x.SecondaryText, "b");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step 2"));
                     step.Add(x => x.Class, "step-b");
                     step.Add(x => x.Style, "fontsize:12px");
                 });
@@ -98,12 +149,12 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step 1"));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step 2"));
                 });
             });
             // check the stepper content
@@ -190,12 +241,12 @@ namespace MudBlazor.UnitTests.Components
                 {
                     step.Add(x => x.Title, "A");
                     step.Add(x => x.Skippable, true);
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
             });
             // check the stepper content
@@ -256,17 +307,17 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "C");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 3"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 3")));
                 });
             });
 
@@ -384,12 +435,12 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
             });
             // check the stepper content
@@ -432,12 +483,12 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
             });
             // check the stepper content
@@ -461,12 +512,12 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
             });
             // check the stepper content
@@ -486,17 +537,17 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "C");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 3"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 3")));
                 });
             });
 
@@ -556,7 +607,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 self.Add(x => x.Tag, "je ne sais pas");
                 // this replaces the action buttons prev, skip and next with just text
-                self.Add(x => x.ActionContent, stepperRef => (string)stepperRef.Tag); // <-- here we simulate using the passed in stepper context
+                self.Add(x => x.ActionContent, stepperRef => (string)stepperRef.Tag!); // <-- here we simulate using the passed in stepper context
             });
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(0, "because the action content replaces them");
             stepper.Find(".mud-card-actions").InnerHtml?.Trim().Should().Be("je ne sais pas");
@@ -588,17 +639,17 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "B");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 2"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 2")));
                 });
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "C");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 3"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 3")));
                 });
             });
             stepper.Instance.GetState(x => x.ActiveIndex).Should().Be(0);
@@ -911,7 +962,7 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
             });
 
@@ -938,7 +989,7 @@ namespace MudBlazor.UnitTests.Components
                 self.AddChildContent<MudStep>(step =>
                 {
                     step.Add(x => x.Title, "A");
-                    step.AddChildContent(text => text.AddMarkupContent(0, "step 1"));
+                    step.Add(x => x.ChildContent, StepContent(text => text.AddMarkupContent(0, "step 1")));
                 });
             });
 
@@ -953,5 +1004,8 @@ namespace MudBlazor.UnitTests.Components
                 stepButton.ClassList.Should().NotContain("mud-clickable");
             }
         }
+
+        private static RenderFragment StepContent(Action<RenderTreeBuilder> content)
+            => builder => content(builder);
     }
 }

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -1007,5 +1007,26 @@ namespace MudBlazor.UnitTests.Components
 
         private static RenderFragment StepContent(Action<RenderTreeBuilder> content)
             => builder => content(builder);
+
+        [Test]
+        public void Stepper_ShouldHandleNullChildContent()
+        {
+            var stepper = Context.RenderComponent<MudStepper>(self =>
+            {
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Title, "A");
+                });
+                self.AddChildContent<MudStep>(step =>
+                {
+                    step.Add(x => x.Title, "B");
+                    step.Add(x => x.ChildContent, builder => builder.AddMarkupContent(0, "step-b"));
+                });
+            });
+
+            stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().BeEmpty();
+            stepper.FindAll(".mud-step")[1].Click();
+            stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Be("step-b");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -1028,5 +1028,20 @@ namespace MudBlazor.UnitTests.Components
             stepper.FindAll(".mud-step")[1].Click();
             stepper.Find(".mud-stepper-content").TextContent.Trimmed().Should().Be("step-b");
         }
+
+        [Test]
+        public void StepContext_NullStepper_Throws()
+        {
+            Action act = () => _ = new MudStepContext(null!, new MudStep());
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("stepper");
+        }
+
+        [Test]
+        public void StepContext_NullStep_Throws()
+        {
+            Action act = () => _ = new MudStepContext(new MudStepper(), null!);
+            act.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("step");
+        }
+
     }
 }

--- a/src/MudBlazor.UnitTests/TestComponents/Stepper/StepContextRecorder.cs
+++ b/src/MudBlazor.UnitTests/TestComponents/Stepper/StepContextRecorder.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace MudBlazor.UnitTests.TestComponents.Stepper;
+
+public class StepContextRecorder : ComponentBase
+{
+    [Parameter]
+    public string? ActiveMarkup { get; set; }
+
+    [Parameter]
+    public Action<MudStepContext?>? Capture { get; set; }
+
+    [CascadingParameter]
+    public MudStepContext? Context { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        Capture?.Invoke(Context);
+    }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        if (Context?.IsActive == true && !string.IsNullOrEmpty(ActiveMarkup))
+        {
+            builder.AddMarkupContent(0, ActiveMarkup);
+        }
+    }
+}

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -73,6 +73,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// Defaults to <c>null</c>.  Only shown when this step is active.
+    /// Use the <see cref="MudStepContext"/> cascading parameter to access information about the current step inside the template.
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]

--- a/src/MudBlazor/Components/Stepper/MudStepContext.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepContext.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 #nullable enable
 

--- a/src/MudBlazor/Components/Stepper/MudStepContext.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepContext.cs
@@ -10,17 +10,6 @@ namespace MudBlazor;
 public sealed class MudStepContext
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="MudStepContext"/> class.
-    /// </summary>
-    /// <param name="stepper">The owning stepper.</param>
-    /// <param name="step">The step associated with the context.</param>
-    public MudStepContext(MudStepper stepper, MudStep step)
-    {
-        Stepper = stepper ?? throw new ArgumentNullException(nameof(stepper));
-        Step = step ?? throw new ArgumentNullException(nameof(step));
-    }
-
-    /// <summary>
     /// Gets the owning <see cref="MudStepper"/>.
     /// </summary>
     public MudStepper Stepper { get; }
@@ -34,4 +23,15 @@ public sealed class MudStepContext
     /// Gets a value indicating whether the associated step is currently active.
     /// </summary>
     public bool IsActive => Stepper.ActiveStep == Step;
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MudStepContext"/> class.
+    /// </summary>
+    /// <param name="stepper">The owning stepper.</param>
+    /// <param name="step">The step associated with the context.</param>
+    public MudStepContext(MudStepper stepper, MudStep step)
+    {
+        Stepper = stepper ?? throw new ArgumentNullException(nameof(stepper));
+        Step = step ?? throw new ArgumentNullException(nameof(step));
+    }
 }

--- a/src/MudBlazor/Components/Stepper/MudStepContext.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepContext.cs
@@ -1,0 +1,37 @@
+using System;
+
+#nullable enable
+
+namespace MudBlazor;
+
+/// <summary>
+/// Provides contextual information about a <see cref="MudStep"/> within a <see cref="MudStepper"/>.
+/// </summary>
+public sealed class MudStepContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MudStepContext"/> class.
+    /// </summary>
+    /// <param name="stepper">The owning stepper.</param>
+    /// <param name="step">The step associated with the context.</param>
+    public MudStepContext(MudStepper stepper, MudStep step)
+    {
+        Stepper = stepper ?? throw new ArgumentNullException(nameof(stepper));
+        Step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    /// <summary>
+    /// Gets the owning <see cref="MudStepper"/>.
+    /// </summary>
+    public MudStepper Stepper { get; }
+
+    /// <summary>
+    /// Gets the <see cref="MudStep"/> associated with the context.
+    /// </summary>
+    public MudStep Step { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the associated step is currently active.
+    /// </summary>
+    public bool IsActive => Stepper.ActiveStep == Step;
+}

--- a/src/MudBlazor/Components/Stepper/MudStepContext.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepContext.cs
@@ -23,7 +23,7 @@ public sealed class MudStepContext
     /// Gets a value indicating whether the associated step is currently active.
     /// </summary>
     public bool IsActive => Stepper.ActiveStep == Step;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MudStepContext"/> class.
     /// </summary>

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -162,16 +162,23 @@
         </div>;
 
     RenderFragment StepContent(MudStep step) =>
-        @<div @attributes="@step.UserAttributes" class="@step.Classname" style="@step.Styles" role="tabpanel" aria-labelledby="@step.Title" tabindex="0">
-            @if (Vertical)
-            {
-                <MudCollapse Expanded="step == ActiveStep">
-                    @step.ChildContent
-                </MudCollapse>
-            }
-            else
-            {
-                @step.ChildContent
-            }
-        </div>;
+        @<CascadingValue Value="@CreateStepContext(step)">
+            <div @attributes="@step.UserAttributes" class="@step.Classname" style="@step.Styles" role="tabpanel" aria-labelledby="@step.Title" tabindex="0">
+                @if (step.ChildContent is not null)
+                {
+                    if (Vertical)
+                    {
+                        <MudCollapse Expanded="step == ActiveStep">
+                            @step.ChildContent
+                        </MudCollapse>
+                    }
+                    else
+                    {
+                        @step.ChildContent
+                    }
+                }
+            </div>
+        </CascadingValue>;
+
+    private MudStepContext CreateStepContext(MudStep step) => new(this, step);
 }


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

## Summary

- Adds a step context for MudStepper children so nested components can know whether a step is active (and access other stepper/step info).
- Implements this via a new MudStepContext type provided as a CascadingValue around each step’s content.
- Keeps existing step markup intact; no breaking changes to current consumers.

## Motivation

- Addresses feature request to access step context within a step (issue #11686).
- Enables patterns like rendering expensive/dependent content only when the step is active, improving UX and performance for multi-step forms.

## Changes

- New context type
  - Adds MudStepContext with:
  - Properties: Stepper, Step, IsActive
  - Path: src/MudBlazor/Components/Stepper/MudStepContext.cs
- Provide context to step content
  - Wraps each step’s content in a CascadingValue providing the MudStepContext
  - Path: src/MudBlazor/Components/Stepper/MudStepper.razor
  - Adds helper method CreateStepContext(MudStep step)
- Documentation hint
  - Notes in MudStep XML docs that step context is available via CascadingParameter
  - Path: src/MudBlazor/Components/Stepper/MudStep.cs

## Tests
- Adds StepContextRecorder test component (consumes [CascadingParameter] MudStepContext)
- Adds a unit test to assert context availability and IsActive behavior
- Paths:
  - src/MudBlazor.UnitTests/TestComponents/Stepper/StepContextRecorder.cs
  - src/MudBlazor.UnitTests/Components/StepperTests.cs (adds StepperStepContext_ShouldBeAvailableInsideChildContent and adjusts ChildContent assignment where needed)

## Usage

- Consume the step context in any nested component using a CascadingParameter:
```
public class MyStepAwareChild : ComponentBase
[CascadingParameter] public MudStepContext? Context { get; set; }
protected override void BuildRenderTree(RenderTreeBuilder builder)
if (Context?.IsActive == true) { /* render active-only content */ }
```
- Example:
```
<MudStepper> <MudStep Title="Step 1"> <MyStepAwareChild /> </MudStep> <MudStep Title="Step 2"> <MyStepAwareChild /> </MudStep> </MudStepper>
```

## Backward compatibility

- No breaking changes to existing MudStepper or MudStep parameters or markup.
- Existing step content continues to render as before when not consuming the context.