### PR TITLE
SankeyChart: Add multiple convenience features

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample1.razor
@@ -1,33 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Sankey" Nodes="@_nodes" Edges="@_edges" Width="@_width" Height="@_height" ChartOptions="@_options" NodeChartOptions="_nodeChartOptions"/>
+    <MudChart ChartType="ChartType.Sankey" Nodes="@_nodes" Edges="@_edges" Width="650px" Height="350px"/>
 </MudPaper>
 
-<MudGrid>
-    <MudItem md="6" xs="12">
-        <MudTextField @bind-Value="_width" Label="Chart Width"></MudTextField>
-    </MudItem>
-    <MudItem md="6" xs="12">
-        <MudTextField @bind-Value="_height" Label="Chart Height"></MudTextField>
-    </MudItem>
-    <MudItem md="4" xs="12">
-        <MudSlider @bind-Value="_nodeChartOptions.NodeWidth" Max="50" ValueLabel="true">Node width</MudSlider>
-    </MudItem>
-    <MudItem md="4" xs="12">
-        <MudSlider @bind-Value="_nodeChartOptions.MinVerticalSpacing" Max="30" ValueLabel="true">Min. vertical spacing</MudSlider>
-    </MudItem>
-    <MudItem md="4" xs="12">
-        <MudSlider @bind-Value="_nodeChartOptions.EdgeOpacity" Step="0.01" Max="1" ValueLabel="true">Edge opacity</MudSlider>
-    </MudItem>
-</MudGrid>
-
 @code {
-    private ChartOptions _options = new();
-    private NodeChartOptions _nodeChartOptions = new();
-    private string _width = "650px";
-    private string _height = "350px";
-
     private readonly List<SankeyChartNode> _nodes =
     [
         new("Income", 0),

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -84,7 +84,8 @@
         MinVerticalSpacing = 5,
         LabelFontSize = "0.33rem",
         LabelPadding = 2,
-        OrderNodesByValue = true
+        OrderNodesByValue = true,
+        HideNodesSmallerThan = 1
     };
 
     private int _width = 650;

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -32,6 +32,9 @@
             <MudTooltip Text="Hide nodes with no edges">
                 <MudToggleIconButton Icon="@Icons.Material.Filled.DisabledVisible" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.HideNodesWithNoEdges"/>
             </MudTooltip>
+            <MudTooltip Text="Order nodes by value">
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Sort" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.OrderNodesByValue"/>
+            </MudTooltip>
         </MudButtonGroup>
     </MudItem>
     <MudItem xs="12" md="4">
@@ -74,14 +77,14 @@
 @code {
     private List<SankeyChartNode> _nodes = [];
     private List<SankeyChartEdge> _edges = [];
-    private ChartOptions _options = new();
-
-    private NodeChartOptions _nodeChartOptions = new()
+    private readonly ChartOptions _options = new();
+    private readonly NodeChartOptions _nodeChartOptions = new()
     {
         NodeWidth = 5,
         MinVerticalSpacing = 5,
         LabelFontSize = "0.33rem",
-        LabelPadding = 2
+        LabelPadding = 2,
+        OrderNodesByValue = true
     };
 
     private int _width = 650;

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -1,7 +1,17 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
+<MudStack Row="true" Justify="Justify.Center" Class="mud-width-full">
+    <MudPaper Class="pa-4">
+        <MudStack Row="true">
+            <MudNumericField @bind-Value="_nodeCount" Label="Nodes" Min="2" Max="500"/>
+            <MudNumericField @bind-Value="_columnCount" Label="Columns" Min="2" Max="5"/>
+            <MudButton OnClick="@(() => GenerateData())" StartIcon="@Icons.Material.Outlined.Refresh" Color="Color.Primary" Variant="Variant.Outlined">Generate</MudButton>
+        </MudStack>
+    </MudPaper>
+</MudStack>
+
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Sankey" Nodes="@_nodes" Edges="@_edges" Width="@_width" ChartOptions="@_options" NodeChartOptions="_nodeChartOptions"/>
+    <MudChart ChartType="ChartType.Sankey" Nodes="@_nodes" Edges="@_edges" Width="@($"{_width}px")" Height="@($"{_height}px")" ChartOptions="@_options" NodeChartOptions="_nodeChartOptions"/>
 </MudPaper>
 
 <MudGrid>
@@ -24,20 +34,20 @@
             </MudTooltip>
         </MudButtonGroup>
     </MudItem>
-    <MudItem xs="12" md="6">
-        <MudColorPicker Label="Color good" @bind-Value="@_nodes[^2].Color"/>
+    <MudItem xs="12" md="4">
+        <MudSlider @bind-Value="_nodeChartOptions.NodeWidth" Max="50" ValueLabel="true">Node width</MudSlider>
+    </MudItem>
+    <MudItem xs="12" md="4">
+        <MudSlider @bind-Value="_nodeChartOptions.MinVerticalSpacing" Max="30" ValueLabel="true">Min. vertical spacing</MudSlider>
+    </MudItem>
+    <MudItem xs="12" md="4">
+        <MudSlider @bind-Value="_nodeChartOptions.EdgeOpacity" Step="0.01" Max="1" ValueLabel="true">Edge opacity</MudSlider>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudColorPicker Label="Color evil" @bind-Value="@_nodes[^1].Color"/>
+        <MudSlider @bind-Value="_width" ValueLabel="true" Max="2000">Chart width</MudSlider>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudSelect @bind-Value="_nodeChartOptions.LabelFontSize" Label="Label font size">
-            <MudSelectItem Value="@("0.5rem")">0.5rem</MudSelectItem>
-            <MudSelectItem Value="@("0.75rem")">0.75rem</MudSelectItem>
-            <MudSelectItem Value="@("1rem")">1rem</MudSelectItem>
-            <MudSelectItem Value="@("8px")">8px</MudSelectItem>
-            <MudSelectItem Value="@("12px")">12px</MudSelectItem>
-        </MudSelect>
+        <MudSlider @bind-Value="_height" ValueLabel="true" Max="2000">Chart height</MudSlider>
     </MudItem>
     <MudItem xs="12" md="6">
         <MudColorPicker Label="Highlighting color" @bind-Text="@_nodeChartOptions.HighlightColor"/>
@@ -45,34 +55,123 @@
     <MudItem xs="12" md="6">
         <MudNumericField @bind-Value="_nodeChartOptions.HideNodesSmallerThan" Label="Hide nodes smaller than"/>
     </MudItem>
+    <MudItem xs="12" md="6">
+        <MudSelect @bind-Value="_nodeChartOptions.LabelFontSize" Label="Label font size">
+            <MudSelectItem Value="@("0.25rem")">0.25rem</MudSelectItem>
+            <MudSelectItem Value="@("0.33rem")">0.33rem</MudSelectItem>
+            <MudSelectItem Value="@("0.5rem")">0.5rem</MudSelectItem>
+            <MudSelectItem Value="@("0.66rem")">0.66rem</MudSelectItem>
+            <MudSelectItem Value="@("0.75rem")">0.75rem</MudSelectItem>
+            <MudSelectItem Value="@("1rem")">1rem</MudSelectItem>
+            <MudSelectItem Value="@("1.25rem")">1.25rem</MudSelectItem>
+        </MudSelect>
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudNumericField @bind-Value="_nodeChartOptions.LabelPadding" Label="Label padding"/>
+    </MudItem>
 </MudGrid>
 
 @code {
+    private List<SankeyChartNode> _nodes = [];
+    private List<SankeyChartEdge> _edges = [];
     private ChartOptions _options = new();
-    private NodeChartOptions _nodeChartOptions = new();
-    private string _width = "650px";
 
-    private readonly List<SankeyChartNode> _nodes =
-    [
-        new("Dogs", 0),
+    private NodeChartOptions _nodeChartOptions = new()
+    {
+        NodeWidth = 5,
+        MinVerticalSpacing = 5,
+        LabelFontSize = "0.33rem",
+        LabelPadding = 2
+    };
 
-        new("Dachshund", 1),
-        new("Bernese", 1),
-        new("Chihuahua", 1),
+    private int _width = 650;
+    private int _height = 650;
+    private int _nodeCount = 50;
+    private int _columnCount = 3;
 
-        new("Good boy", 2),
-        new("Pure evil", 2),
-    ];
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        if (firstRender) GenerateData();
+    }
 
-    private readonly List<SankeyChartEdge> _edges =
-    [
-        new("Dogs", "Dachshund", 5),
-        new("Dogs", "Bernese", 2),
-        new("Dogs", "Chihuahua", 10),
+    private void GenerateData(double minEdgePercentage = 0.15, double maxEdgePercentage = 0.7)
+    {
+        var rnd = new Random();
+        _nodes = [];
+        _edges = [];
 
-        new("Dachshund", "Good boy", 5),
-        new("Bernese", "Good boy", 2),
-        new("Chihuahua", "Pure evil", 10),
-    ];
+        var nodesPerColumn = (int)Math.Ceiling((double)_nodeCount / _columnCount);
+        for (var col = 0; col < _columnCount; col++)
+        {
+            var nodesInCurrentColumn = Math.Min(nodesPerColumn, _nodeCount - _nodes.Count);
+            for (var i = 0; i < nodesInCurrentColumn; i++)
+            {
+                var nodeName = $"Node_{col}_{i}";
+                _nodes.Add(new SankeyChartNode(nodeName, col));
+            }
+        }
 
+        var nodesByColumn = _nodes.GroupBy(n => n.Column)
+            .OrderBy(g => g.Key)
+            .Select(g => g.ToList())
+            .ToList();
+        var nodeOutputs = new Dictionary<string, double>();
+        var nodeInputs = new Dictionary<string, double>();
+        foreach (var node in _nodes)
+        {
+            nodeOutputs[node.Name] = 0;
+            nodeInputs[node.Name] = 0;
+        }
+
+        for (var colI = 0; colI < nodesByColumn.Count - 1; colI++)
+        {
+            var sourceNodes = nodesByColumn[colI];
+            var targetNodes = nodesByColumn[colI + 1];
+
+            if (colI == 0)
+            {
+                foreach (var sourceNode in sourceNodes)
+                {
+                    nodeOutputs[sourceNode.Name] = rnd.Next(1, 1000);
+                }
+            }
+
+            foreach (var sourceNode in sourceNodes)
+            {
+                var remainingEdgeValue = nodeOutputs[sourceNode.Name];
+                var edgeCount = rnd.Next(1, Math.Min(targetNodes.Count, 3) + 1);
+                var selectedTargets = targetNodes.OrderBy(_ => rnd.Next()).Take(edgeCount).ToList();
+
+                for (var i = 0; i < selectedTargets.Count; i++)
+                {
+                    var targetNode = selectedTargets[i];
+                    double edgeValue;
+
+                    if (i == selectedTargets.Count - 1)
+                    {
+                        edgeValue = remainingEdgeValue;
+                    }
+                    else
+                    {
+                        var maxEdgeValue = remainingEdgeValue - (selectedTargets.Count - i - 1) * 10;
+                        edgeValue = rnd.NextDouble() * maxEdgeValue * maxEdgePercentage + maxEdgeValue * minEdgePercentage;
+                        remainingEdgeValue -= edgeValue;
+                    }
+
+                    _edges.Add(new SankeyChartEdge(sourceNode.Name, targetNode.Name, Math.Round(edgeValue)));
+                    nodeInputs[targetNode.Name] += edgeValue;
+                }
+            }
+
+            foreach (var targetNode in targetNodes)
+            {
+                nodeOutputs[targetNode.Name] = nodeInputs[targetNode.Name];
+            }
+        }
+
+        _edges.RemoveAll(e => e.Value <= 0);
+
+        StateHasChanged();
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -6,7 +6,7 @@
 
 <MudGrid>
     <MudItem xs="12" Class="d-flex justify-center">
-        <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+        <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" Class="pt-4">
             <MudTooltip Text="Show edge values">
                 <MudToggleIconButton Icon="@Icons.Material.Filled.ShortText" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.ShowEdgeLabels"/>
             </MudTooltip>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -1,40 +1,49 @@
-﻿@using MudBlazor.Utilities
-@namespace MudBlazor.Docs.Examples
+﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Sankey" Nodes="@_nodes" Edges="@_edges" Width="@_width" Height="@_height" ChartOptions="@_options" NodeChartOptions="_nodeChartOptions"/>
+    <MudChart ChartType="ChartType.Sankey" Nodes="@_nodes" Edges="@_edges" Width="@_width" ChartOptions="@_options" NodeChartOptions="_nodeChartOptions"/>
 </MudPaper>
 
 <MudGrid>
-    <MudItem md="6" xs="12">
+    <MudItem xs="12" Class="d-flex justify-center">
+        <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
+            <MudTooltip Text="Show edge values">
+                <MudToggleIconButton Icon="@Icons.Material.Filled.ShortText" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.ShowEdgeLabels"/>
+            </MudTooltip>
+            <MudTooltip Text="Show labels">
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Textsms" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.ShowLabels"/>
+            </MudTooltip>
+            <MudTooltip Text="Show node values">
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Money" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.ShowNodeValues"/>
+            </MudTooltip>
+            <MudTooltip Text="Highlight on hover">
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Highlight" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.HighlightOnHover"/>
+            </MudTooltip>
+            <MudTooltip Text="Hide nodes with no edges">
+                <MudToggleIconButton Icon="@Icons.Material.Filled.DisabledVisible" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_nodeChartOptions.HideNodesWithNoEdges"/>
+            </MudTooltip>
+        </MudButtonGroup>
+    </MudItem>
+    <MudItem xs="12" md="6">
         <MudColorPicker Label="Color good" @bind-Value="@_nodes[^2].Color"/>
     </MudItem>
-    <MudItem md="6" xs="12">
+    <MudItem xs="12" md="6">
         <MudColorPicker Label="Color evil" @bind-Value="@_nodes[^1].Color"/>
     </MudItem>
-    <MudItem md="3" xs="12">
-        <MudCheckBox @bind-Value="_options.ShowLabels" Label="Show labels"></MudCheckBox>
-    </MudItem>
-    <MudItem sm="3" xs="12">
-        <MudCheckBox @bind-Value="_nodeChartOptions.ShowNodeValues" Label="Show node values"></MudCheckBox>
-    </MudItem>
-    <MudItem md="6" xs="12">
+    <MudItem xs="12" md="6">
         <MudSelect @bind-Value="_nodeChartOptions.LabelFontSize" Label="Label font size">
             <MudSelectItem Value="@("0.5rem")">0.5rem</MudSelectItem>
             <MudSelectItem Value="@("0.75rem")">0.75rem</MudSelectItem>
             <MudSelectItem Value="@("1rem")">1rem</MudSelectItem>
-            <MudSelectItem Value="@("1.25rem")">1.25rem</MudSelectItem>
-            <MudSelectItem Value="@("1.5rem")">1.5rem</MudSelectItem>
+            <MudSelectItem Value="@("8px")">8px</MudSelectItem>
+            <MudSelectItem Value="@("12px")">12px</MudSelectItem>
         </MudSelect>
     </MudItem>
-    <MudItem md="3" sm="6" xs="12">
-        <MudSwitch T="bool" ValueChanged="LabelSwitchValueChanged" Label="@(_options.ShowLabels ? "Show edge values" : "Show node values")"></MudSwitch>
-    </MudItem>
-    <MudItem md="3" sm="6" xs="12">
-        <MudCheckBox @bind-Value="_nodeChartOptions.HighlightOnHover" Label="Highlight on hover"></MudCheckBox>
-    </MudItem>
-    <MudItem md="6" xs="12">
+    <MudItem xs="12" md="6">
         <MudColorPicker Label="Highlighting color" @bind-Text="@_nodeChartOptions.HighlightColor"/>
+    </MudItem>
+    <MudItem xs="12" md="6">
+        <MudNumericField @bind-Value="_nodeChartOptions.HideNodesSmallerThan" Label="Hide nodes smaller than"/>
     </MudItem>
 </MudGrid>
 
@@ -42,7 +51,6 @@
     private ChartOptions _options = new();
     private NodeChartOptions _nodeChartOptions = new();
     private string _width = "650px";
-    private string _height = "350px";
 
     private readonly List<SankeyChartNode> _nodes =
     [
@@ -58,18 +66,13 @@
 
     private readonly List<SankeyChartEdge> _edges =
     [
-        new("Dogs", "Dachshund", 10),
-        new("Dogs", "Bernese", 10),
+        new("Dogs", "Dachshund", 5),
+        new("Dogs", "Bernese", 2),
         new("Dogs", "Chihuahua", 10),
 
-        new("Dachshund", "Good boy", 10),
-        new("Bernese", "Good boy", 10),
+        new("Dachshund", "Good boy", 5),
+        new("Bernese", "Good boy", 2),
         new("Chihuahua", "Pure evil", 10),
     ];
 
-    private void LabelSwitchValueChanged(bool value)
-    {
-        _options.ShowLabels = !value;
-        _nodeChartOptions.ShowEdgeLabels = value;
-    }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests.Charts
             Regex.Matches(markup, "<linearGradient").Count.Should().Be(edges.Count);
             Regex.Matches(markup, "<path").Count.Should().Be(edges.Count);
             Regex.Matches(markup, "stop-color=\"#9E9E9E\"").Count.Should().Be(0); // Ensure the parent color palette is used
-            sankey.Markup.Should().Contain("<path d=\"M19.9,227.3333 C167.5,227.3333 167.5,245.3333 315.1,245.3333 L315.1,350 C167.5,350 167.5,332 19.9,332 Z\" fill=\"url(#gradient_");
+            sankey.Markup.Should().Contain("<path d=\"M19.99,18 C167.5,18 167.5,12 315.01,12 L315.01,116.6667 C167.5,116.6667 167.5,122.6667 19.99,122.6667 Z\" fill=\"url(#gradient_");
             sankey.Markup.Should().Contain(")\" opacity=\"0.5\" filter=\"\" blazor:onmouseover=\"5\" blazor:onmouseout=\"6\">");
 
             // Nodes

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -46,7 +46,7 @@
               @onmouseout="@OnNodeMouseOut"
               @onclick="@(e => OnNodeClick(e, kv.Value))"/>
 
-        if (ChartOptions.ShowLabels)
+        if (ChartOptions.ShowLabels || kv.Key == _activeNode)
         {
             <ChartTooltip Title="@(NodeChartOptions.ShowNodeValues ? $"{kv.Key} ({_nodeValues.GetValueOrDefault(kv.Key!)})" : kv.Key!)"
                           Color="rgba(0,0,0,0.25)"
@@ -56,10 +56,11 @@
                           StrokeWidth="0"
                           FontColor="var(--mud-palette-text-primary)"
                           AnchorPositionX="@(kv.Value.X <= 10 ? ChartTooltipAnchorPositionX.Start : ChartTooltipAnchorPositionX.End)"
-                          FontSize="@NodeChartOptions.LabelFontSize"/>
+                          FontSize="@NodeChartOptions.LabelFontSize"
+                          PaddingSize="@NodeChartOptions.LabelPadding"/>
         }
     }
-    @* Draw edge labels last to have them at the top*@
+    @* Draw edge labels last to have them at the top *@
     @foreach (var edge in _edgePaths.Where(edge => NodeChartOptions.ShowEdgeLabels || edge.Name == _activeEdge))
     {
         <ChartTooltip Title="@edge.Name"
@@ -69,7 +70,8 @@
                       ShowTriangle="false"
                       StrokeWidth="0"
                       FontColor="var(--mud-palette-text-primary)"
-                      FontSize="@NodeChartOptions.LabelFontSize"/>
+                      FontSize="@NodeChartOptions.LabelFontSize"
+                      PaddingSize="@NodeChartOptions.LabelPadding"/>
     }
     @MudChartParent?.CustomGraphics
 </svg>

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -3,7 +3,7 @@
 @inherits MudCategoryChartBase
 
 @{
-    var glowName = $"glow_{NodeChartOptions.HighlightColor.Replace('(', '_').Replace(')', '_')}";
+    var glowName = $"glow_{Guid.NewGuid()}";
 }
 
 <svg @attributes="UserAttributes" class="mud-chart-sankey mud-ltr" width="@Width" height="@Height" viewBox="0 0 650 350">

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -48,7 +48,7 @@ namespace MudBlazor.Charts
             var edgeWithInvalidNode = Edges.FirstOrDefault(e => Nodes.All(n => n.Name != e.Source) || Nodes.All(n => n.Name != e.Target));
             if (edgeWithInvalidNode != null)
             {
-                throw new ArgumentException($"Edge {edgeWithInvalidNode.Source} {NodeChartOptions.EdgeLabelSymbol} {edgeWithInvalidNode.Target} specifies an non-existing node");
+                throw new ArgumentException($"Edge {edgeWithInvalidNode.Source} {NodeChartOptions.EdgeLabelSymbol} {edgeWithInvalidNode.Target} specifies a non-existing node");
             }
 
             // Draw

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -70,7 +70,7 @@ namespace MudBlazor.Charts
             _nodeValues = _nodeValues.Where(kv => nodes.Any(n => n.Name == kv.Key)).ToDictionary();
 
             if (NodeChartOptions.OrderNodesByValue) nodes = nodes.OrderByDescending(n => _nodeValues[n.Name]).ToList();
-            
+
             return nodes.ToArray();
         }
 

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -224,15 +224,15 @@ namespace MudBlazor.Charts
                         Source: rectSource,
                         Target: rectTarget,
                         D: BuildSankyEdgePath(
-                            sourceX: startX - 0.1, // -0.1 to prevent a visible edge when setting the edge opacity to 1
+                            sourceX: startX - 0.01, // -0.01 to prevent a visible edge when setting the edge opacity to 1
                             sourceY: startY,
                             sourceHeight: height,
-                            targetX: endX + 0.1, // +0.1 to prevent a visible edge when setting the edge opacity to 1
+                            targetX: endX + 0.01, // +0.01 to prevent a visible edge when setting the edge opacity to 1
                             targetY: endY,
                             targetHeight: height
                         ),
                         CenterX: startX + Math.Abs(startX - endX) / 2,
-                        CenterY: startY + Math.Abs(startY - (endY + height)) / 2
+                        CenterY: startY + (endY - startY) / 2 + height / 2
                     ));
 
                     startYOffset += height;

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -48,7 +48,7 @@ namespace MudBlazor.Charts
             var edgeWithInvalidNode = Edges.FirstOrDefault(e => Nodes.All(n => n.Name != e.Source) || Nodes.All(n => n.Name != e.Target));
             if (edgeWithInvalidNode != null)
             {
-                throw new ArgumentException($"Edge {edgeWithInvalidNode.Source} => {edgeWithInvalidNode.Target} specifies an non-existing node");
+                throw new ArgumentException($"Edge {edgeWithInvalidNode.Source} {NodeChartOptions.EdgeLabelSymbol} {edgeWithInvalidNode.Target} specifies an non-existing node");
             }
 
             // Draw
@@ -218,7 +218,7 @@ namespace MudBlazor.Charts
                     var height = edge.Value / maxColumnValue * relativeBoundHeight;
 
                     _edgePaths.Add(new EdgePath(
-                        Name: $"{rectSource.Name} => {rectTarget.Name} ({edge.Value})",
+                        Name: $"{rectSource.Name} {NodeChartOptions.EdgeLabelSymbol} {rectTarget.Name} ({edge.Value})",
                         Source: rectSource,
                         Target: rectTarget,
                         D: BuildSankyEdgePath(

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
@@ -15,13 +16,14 @@ namespace MudBlazor.Charts
         {
             public double LowestIncomingNodeY { get; set; } = Y;
         }
+
         private record EdgePath(string Name, NodeRect Source, NodeRect Target, string D, double CenterX, double CenterY);
 
         private const double BoundWidth = 650;
         private const double BoundHeight = 350;
         private const double HorizontalPadding = 10;
 
-        private Dictionary<string, NodeRect> _nodeRects { get; } = [];
+        private Dictionary<string, NodeRect> _nodeRects { get; set; } = [];
         private List<EdgePath> _edgePaths { get; } = [];
         private Dictionary<string, double> _nodeValues { get; set; } = [];
         private string? _activeNode { get; set; }
@@ -30,8 +32,7 @@ namespace MudBlazor.Charts
         /// <summary>
         /// The chart, if any, containing this component.
         /// </summary>
-        [CascadingParameter]
-        public MudChart? MudChartParent { get; set; }
+        [CascadingParameter] public MudChart? MudChartParent { get; set; }
 
         protected override void OnParametersSet()
         {
@@ -50,12 +51,39 @@ namespace MudBlazor.Charts
                 throw new ArgumentException($"Edge {edgeWithInvalidNode.Source} => {edgeWithInvalidNode.Target} specifies an non-existing node");
             }
 
-            if (Nodes.Any())
+            // Draw
+            if (Nodes.Count != 0)
             {
-                _nodeValues = GetAllNodeValues();
-                var (maxColumnValue, relativeBoundHeight) = GenerateNodeRects();
-                GenerateEdgePaths(maxColumnValue, relativeBoundHeight);
+                var nodes = GetAllNodesToDraw();
+                var edges = GetAllEdgesToDraw(nodes);
+                if (NodeChartOptions.HideNodesWithNoEdges) nodes = RemoveNodesWithNoEdges(nodes, edges);
+
+                _nodeRects = GenerateNodeRects(nodes, out var maxColumnValue, out var boundHeightRelativeToNodeHeight);
+                GenerateEdgePaths(edges, maxColumnValue, boundHeightRelativeToNodeHeight);
             }
+        }
+
+        private SankeyChartNode[] GetAllNodesToDraw()
+        {
+            _nodeValues = GetAllNodeValues();
+            var nodes = Nodes.Where(n => _nodeValues[n.Name] >= NodeChartOptions.HideNodesSmallerThan).ToList();
+            _nodeValues = _nodeValues.Where(kv => nodes.Any(n => n.Name == kv.Key)).ToDictionary();
+
+            return nodes.ToArray();
+        }
+
+        private SankeyChartEdge[] GetAllEdgesToDraw(SankeyChartNode[] nodes)
+        {
+            return Edges
+                .Where(e => nodes.Any(n => n.Name == e.Source) && nodes.Any(n => n.Name == e.Target))
+                .ToArray();
+        }
+
+        private static SankeyChartNode[] RemoveNodesWithNoEdges(SankeyChartNode[] nodes, SankeyChartEdge[] edges)
+        {
+            return nodes
+                .Where(n => edges.Any(e => e.Source == n.Name || e.Target == n.Name))
+                .ToArray();
         }
 
         private Dictionary<string, double> GetAllNodeValues()
@@ -79,27 +107,26 @@ namespace MudBlazor.Charts
             return nodeValues;
         }
 
-        private (double MaxNodeValue, double RealtiveBoundHeight) GenerateNodeRects()
+        private Dictionary<string, NodeRect> GenerateNodeRects(SankeyChartNode[] nodes, out double maxColumnValue, out double boundHeightRelativeToNodeHeight)
         {
-            _nodeRects.Clear();
-
-            var nodesPerColumn = NormaliseNodeColumnIndices()
+            var nodesPerColumn = NormaliseNodeColumnIndices(nodes)
                 .GroupBy(x => x.Column)
                 .OrderBy(grp => grp.Key)
                 .ToArray();
-            var maxColumnValue = Nodes
+            maxColumnValue = nodes
                 .GroupBy(n => n.Column)
                 .Select(grp => grp.Sum(n => _nodeValues.GetValueOrDefault(n.Name)))
                 .Max();
-            var relativeNodesValuesMapping = GetNormalisedNodeValuesMapping(maxColumnValue);
+            var relativeNodesValuesMapping = GetNormalisedNodeValuesMapping(nodes, maxColumnValue);
 
             // Calculate grid sizes
             var maxRows = nodesPerColumn.Max(n => n.Count());
             var maxColumns = nodesPerColumn.Length - 1;
-            var boundHeightRelativeToNodeHeight = BoundHeight - NodeChartOptions.MinVerticalSpacing * maxRows;
+            boundHeightRelativeToNodeHeight = BoundHeight - NodeChartOptions.MinVerticalSpacing * maxRows;
             var boundWidthRelativeToNodeWidth = BoundWidth - NodeChartOptions.NodeWidth * maxColumns - 2 * HorizontalPadding;
 
             // Draw all nodes column per column
+            var nodeRects = new Dictionary<string, NodeRect>();
             foreach (var column in nodesPerColumn)
             {
                 var x = column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth + HorizontalPadding;
@@ -113,27 +140,25 @@ namespace MudBlazor.Charts
                     var y = currentY + verticalSpacing;
                     var height = relativeNodesValuesMapping[node] * boundHeightRelativeToNodeHeight;
 
-                    _nodeRects[node.Name] = new NodeRect(
+                    nodeRects[node.Name] = new NodeRect(
                         Hash: node.GetHashCode(),
                         Name: node.Name,
                         X: x,
                         Y: y,
                         Width: NodeChartOptions.NodeWidth,
                         Height: height,
-                        Color: GetNextHexColorForNodeRect(node)
+                        Color: GetNextHexColorForNodeRect(node, nodeRects.Count)
                     );
 
                     currentY = y + height;
                 }
             }
 
-            return (maxColumnValue, boundHeightRelativeToNodeHeight);
+            return nodeRects;
         }
 
-        private SankeyChartNode[] NormaliseNodeColumnIndices()
+        private static SankeyChartNode[] NormaliseNodeColumnIndices(SankeyChartNode[] nodes)
         {
-            var nodes = Nodes.ToArray();
-
             // Normalise column indices
             var columnMap = nodes
                 .Select(n => n.Column)
@@ -146,10 +171,10 @@ namespace MudBlazor.Charts
             return nodes;
         }
 
-        private Dictionary<SankeyChartNode, double> GetNormalisedNodeValuesMapping(double maxColumnValue)
+        private Dictionary<SankeyChartNode, double> GetNormalisedNodeValuesMapping(SankeyChartNode[] nodes, double maxColumnValue)
         {
             var result = new Dictionary<SankeyChartNode, double>();
-            foreach (var node in Nodes)
+            foreach (var node in nodes)
             {
                 result[node] = _nodeValues.GetValueOrDefault(node.Name) / maxColumnValue;
             }
@@ -157,7 +182,7 @@ namespace MudBlazor.Charts
             return result;
         }
 
-        private string GetNextHexColorForNodeRect(SankeyChartNode node)
+        private string GetNextHexColorForNodeRect(SankeyChartNode node, int index)
         {
             if (node.Color != null)
             {
@@ -166,17 +191,17 @@ namespace MudBlazor.Charts
 
             if (MudChartParent?.ChartOptions.ChartPalette is { Length: > 0 } palette)
             {
-                return palette[_nodeRects.Count % palette.Length];
+                return palette[index % palette.Length];
             }
 
             return Colors.Gray.Default;
         }
 
-        private void GenerateEdgePaths(double maxColumnValue, double relativeBoundHeight)
+        private void GenerateEdgePaths(SankeyChartEdge[] edges, double maxColumnValue, double relativeBoundHeight)
         {
             _edgePaths.Clear();
 
-            var edgesPerSources = Edges.GroupBy(e => e.Source).ToList();
+            var edgesPerSources = edges.GroupBy(e => e.Source).ToList();
             foreach (var sourceGrp in edgesPerSources)
             {
                 if (!_nodeRects.TryGetValue(sourceGrp.Key, out var rectSource)) continue;
@@ -214,7 +239,8 @@ namespace MudBlazor.Charts
             }
         }
 
-        private static string BuildSankyEdgePath(double sourceX, double sourceY, double sourceHeight, double targetX, double targetY, double targetHeight)
+        [SuppressMessage("ReSharper", "InlineTemporaryVariable")]
+        private static string BuildSankyEdgePath(double sourceX, double sourceY, double sourceHeight, double targetX, double targetY, double targetHeight, double curvature = 0.5)
         {
             // Midpoints of source and target edges
             var sy0 = sourceY;
@@ -223,7 +249,6 @@ namespace MudBlazor.Charts
             var ty1 = targetY + targetHeight;
 
             // Control points for cubic Bezier curve
-            const double curvature = 0.5;
             var cx0 = sourceX + (targetX - sourceX) * curvature;
             var cx1 = targetX - (targetX - sourceX) * curvature;
 

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -69,6 +69,8 @@ namespace MudBlazor.Charts
             var nodes = Nodes.Where(n => _nodeValues[n.Name] >= NodeChartOptions.HideNodesSmallerThan).ToList();
             _nodeValues = _nodeValues.Where(kv => nodes.Any(n => n.Name == kv.Key)).ToDictionary();
 
+            if (NodeChartOptions.OrderNodesByValue) nodes = nodes.OrderByDescending(n => _nodeValues[n.Name]).ToList();
+            
             return nodes.ToArray();
         }
 

--- a/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
@@ -108,4 +108,12 @@ public class NodeChartOptions
     /// Defaults to <c>⇒</c>.
     /// </remarks>
     public string EdgeLabelSymbol { get; set; } = "⇒";
+    
+    /// <summary>
+    /// Orders the nodes in each column by their corresponding value descending.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    public bool OrderNodesByValue { get; set; } = false;
 }

--- a/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
@@ -92,4 +92,12 @@ public class NodeChartOptions
     /// Defaults to <c>false</c>.
     /// </remarks>
     public bool HideNodesWithNoEdges { get; set; }
+    
+    /// <summary>
+    /// The symbol used to represent edges in chart labels.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>⇒</c>.
+    /// </remarks>
+    public string EdgeLabelSymbol { get; set; } = "⇒";
 }

--- a/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
@@ -52,6 +52,14 @@ public class NodeChartOptions
     /// Defaults to <c>"0.75rem"</c>.
     /// </remarks>
     public string LabelFontSize { get; set; } = "0.75rem";
+    
+    /// <summary>
+    /// The padding of the label background in px.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>5</c>.
+    /// </remarks>
+    public int LabelPadding { get; set; } = 5;
 
     /// <summary>
     /// Whether to constantly show the labels of the edges.

--- a/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
@@ -52,7 +52,7 @@ public class NodeChartOptions
     /// Defaults to <c>"0.75rem"</c>.
     /// </remarks>
     public string LabelFontSize { get; set; } = "0.75rem";
-    
+
     /// <summary>
     /// The padding of the label background in px.
     /// </summary>
@@ -92,7 +92,7 @@ public class NodeChartOptions
     /// Defaults to <c>0</c>.
     /// </remarks>
     public int HideNodesSmallerThan { get; set; }
-    
+
     /// <summary>
     /// Whether to hide nodes which have no edges.
     /// </summary>
@@ -100,7 +100,7 @@ public class NodeChartOptions
     /// Defaults to <c>false</c>.
     /// </remarks>
     public bool HideNodesWithNoEdges { get; set; }
-    
+
     /// <summary>
     /// The symbol used to represent edges in chart labels.
     /// </summary>
@@ -108,7 +108,7 @@ public class NodeChartOptions
     /// Defaults to <c>⇒</c>.
     /// </remarks>
     public string EdgeLabelSymbol { get; set; } = "⇒";
-    
+
     /// <summary>
     /// Orders the nodes in each column by their corresponding value descending.
     /// </summary>

--- a/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/NodeChartOptions.cs
@@ -76,4 +76,20 @@ public class NodeChartOptions
     /// Defaults to <c>var(--mud-palette-text-primary)</c>.
     /// </remarks>
     public string HighlightColor { get; set; } = "var(--mud-palette-text-primary)";
+
+    /// <summary>
+    /// Hides all nodes and their corresponding edges which have a weight of less than the specified one. 
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>0</c>.
+    /// </remarks>
+    public int HideNodesSmallerThan { get; set; }
+    
+    /// <summary>
+    /// Whether to hide nodes which have no edges.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    public bool HideNodesWithNoEdges { get; set; }
 }

--- a/src/MudBlazor/Components/Chart/Models/SankeyChartNode.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyChartNode.cs
@@ -42,5 +42,18 @@ namespace MudBlazor
             Name = name;
             Column = column;
         }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="SankeyChartNode"/>.
+        /// </summary>
+        /// <param name="name">The name of this node.</param>
+        /// <param name="column">The column in which to display this node.</param>
+        /// <param name="color">The color in which to display this node.</param>
+        public SankeyChartNode(string name, int column, MudColor color)
+        {
+            Name = name;
+            Column = column;
+            Color = color;
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor
@@ -10,7 +10,7 @@
                  stroke-width="@TriangleStrokeWidth"/>
     }
 
-    <!-- Keep this here to prevent the triangle from having a base line -->
+    <!-- Background -->
     <rect x="@ToS(_backgroundBBox.X)"
           y="@ToS(_backgroundBBox.Y)"
           width="@ToS(_backgroundBBox.Width)"
@@ -28,6 +28,7 @@
                  fill="@Color"/>
     }
 
+    <!-- Text -->
     <text @ref="_text"
           x="@ToS(_textBbox.X)"
           y="@ToS(_textBbox.Y - (HasSubtitle ? _textBbox.Height : 0))"

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -73,7 +73,7 @@ public partial class ChartTooltip : ComponentBase
     /// The padding size of the tooltip background in px.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>"5"</c>.
+    /// Defaults to <c>5</c>.
     /// </remarks>
     [Parameter]
     public int PaddingSize { get; set; } = 5;

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -3,13 +3,13 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 
 #nullable enable
+
 namespace MudBlazor.Charts;
 
 public partial class ChartTooltip : ComponentBase
 {
     private record BBox(double X = 0, double Y = 0, double Width = 0, double Height = 0);
 
-    private const int Padding = 5;
     private const double TriangleWidth = 16;
     private const double TriangleHeight = 8;
 
@@ -68,6 +68,15 @@ public partial class ChartTooltip : ComponentBase
     /// </remarks>
     [Parameter]
     public string FontSize { get; set; } = "12px";
+
+    /// <summary>
+    /// The padding size of the tooltip background in px.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>"5"</c>.
+    /// </remarks>
+    [Parameter]
+    public int PaddingSize { get; set; } = 5;
 
     /// <summary>
     /// The color of the <see cref="Title"/> and <see cref="Subtitle"/>.
@@ -131,9 +140,9 @@ public partial class ChartTooltip : ComponentBase
 
         var xText = AnchorPositionX switch
         {
-            ChartTooltipAnchorPositionX.Start => X + textWidth / 2 + Padding,
+            ChartTooltipAnchorPositionX.Start => X + textWidth / 2 + PaddingSize,
             ChartTooltipAnchorPositionX.Center => X,
-            ChartTooltipAnchorPositionX.End => X - textWidth / 2 - Padding,
+            ChartTooltipAnchorPositionX.End => X - textWidth / 2 - PaddingSize,
             _ => throw new ArgumentException($"Unknown relative position {AnchorPositionX}")
         };
         if (ShowTriangle) textWidth = Math.Max(textWidth, TriangleWidth);
@@ -145,7 +154,7 @@ public partial class ChartTooltip : ComponentBase
             Height: textHeight
         );
 
-        var backgroundWidth = textWidth + Padding * 2;
+        var backgroundWidth = textWidth + PaddingSize * 2;
         var xBackground = AnchorPositionX switch
         {
             ChartTooltipAnchorPositionX.Start => X,
@@ -153,7 +162,7 @@ public partial class ChartTooltip : ComponentBase
             ChartTooltipAnchorPositionX.End => X - backgroundWidth,
             _ => throw new ArgumentException($"Unknown relative position {AnchorPositionX}")
         };
-        var backgroundHeight = textHeight + Padding * 2;
+        var backgroundHeight = textHeight + PaddingSize * 2;
         _backgroundBBox = new BBox(
             X: xBackground,
             Y: Y - backgroundHeight / 2 * (HasSubtitle ? 2.1 : 1) - triangleOffsetY,


### PR DESCRIPTION
This PR enhances the Sankey chart by adding multiple convenience features as well as fixing 2 small optical issues:

- `NodeChartOptions.EdgeLabelSymbol` allows for setting a custom edge label symbol to be displayed in the edge labels
- `NodeChartOptions.LabelPadding` allows for setting a custom `ChartTooltip` padding, which may be required for very large Sankey charts
- `NodeChartOptions.HideNodesSmallerThan` automatically hides nodes below a certain threshold (again for large charts)
- `NodeChartOptions.HideNodesWithNoEdges` automatically hides nodes with no connections
- `NodeChartOptions.OrderNodesByValue` orders the nodes in each column by their corresponding value descending
- Changed `ChartTooltip.PaddingSize` to a parameter
- Edge label position calculation resulted in a wrong y in certain cases
- Always show node labels on hover (same behaviour as edges)
- Expanded and enhanced the docs section with a data generator:
<img width="1232" height="1237" alt="image" src="https://github.com/user-attachments/assets/f0f37533-2e46-40de-a7ac-e33e13775d4f" />