### PR TITLE
MudFabMenu: Add new component

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleBasic.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleBasic.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudStack Row="true" Style="width: 300px;" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+    <MudStack Spacing="0">
+        <MudSwitch @bind-Value="_open" Label="@(_open ? "Opened" : "Closed")" Color="Color.Primary"/>
+        <MudSwitch @bind-Value="_fixed" Label="@(_fixed ? "Fixed" : "Relative")" Color="Color.Primary"/>
+    </MudStack>
+    <MudFabMenu StartIcon="@Icons.Material.Outlined.Send" Color="Color.Primary" @bind-Open="@_open" Fixed="@_fixed">
+        <MudFabMenuItem StartIcon="@Icons.Custom.Brands.Slack"/>
+        <MudFabMenuItem StartIcon="@Icons.Custom.Brands.Discord"/>
+        <MudFabMenuItem StartIcon="@Icons.Custom.Brands.Gmail"/>
+    </MudFabMenu>
+</MudStack>
+
+@code
+{
+    private bool _open;
+    private bool _fixed;
+}

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
@@ -1,0 +1,19 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" DampenItemColors="false" UseCloseIcon="false" Size="Size.Small">
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Color="Color.Primary" Size="Size.Small"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Color="Color.Primary" Size="Size.Small"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Color="Color.Primary" Size="Size.Small"/>
+</MudFabMenu>
+
+<MudFabMenu StartIcon="@Icons.Material.Outlined.Send" Color="Color.Secondary" AlignItems="AlignItems.End">
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Label="One" Color="Color.Secondary"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Label="Two" Color="Color.Secondary"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Label="Three" Color="Color.Secondary"/>
+</MudFabMenu>
+
+<MudFabMenu Label="Menu" Color="Color.Tertiary" AlignItems="AlignItems.End" OpenOnMouseHover="false">
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Label="One" Color="Color.Tertiary" Style="color: rgb(33, 33, 33);"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Label="Two" Color="Color.Tertiary" Style="color: rgb(33, 33, 33);"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Label="Three" Color="Color.Tertiary" Style="color: rgb(33, 33, 33);"/>
+</MudFabMenu>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
@@ -1,5 +1,4 @@
 ﻿@namespace MudBlazor.Docs.Examples
-@inject ISnackbar Snackbar
 
 <MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" DampenItemColors="false" UseCloseIcon="false" Size="Size.Small">
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Color="Color.Primary" Size="Size.Small"/>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
@@ -1,9 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
+@inject ISnackbar Snackbar
 
 <MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" DampenItemColors="false" UseCloseIcon="false" Size="Size.Small">
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Color="Color.Primary" Size="Size.Small"/>
-    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Color="Color.Primary" Size="Size.Small"/>
-    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Color="Color.Primary" Size="Size.Small"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Color="Color.Primary" Size="Size.Small" />
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Color="Color.Primary" Size="Size.Small" />
 </MudFabMenu>
 
 <MudFabMenu StartIcon="@Icons.Material.Outlined.Send" Color="Color.Secondary" AlignItems="AlignItems.End">

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
@@ -12,7 +12,7 @@
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Label="Three" Color="Color.Secondary"/>
 </MudFabMenu>
 
-<MudFabMenu Label="Menu" Color="Color.Tertiary" AlignItems="AlignItems.End" OpenOnMouseHover="false">
+<MudFabMenu Label="Menu" Color="Color.Tertiary" AlignItems="AlignItems.End" OpenOnMouseHover="false" CloseOnMenuItemClicked="false">
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Label="One" Color="Color.Tertiary" Style="color: rgb(33, 33, 33);"/>
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Label="Two" Color="Color.Tertiary" Style="color: rgb(33, 33, 33);"/>
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Label="Three" Color="Color.Tertiary" Style="color: rgb(33, 33, 33);"/>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/Examples/FabMenuExampleStyling.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" DampenItemColors="false" UseCloseIcon="false" Size="Size.Small">
+<MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" DampenItemsBackgroundColor="false" UseCloseIcon="false" Size="Size.Small">
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Color="Color.Primary" Size="Size.Small"/>
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Color="Color.Primary" Size="Size.Small" />
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Color="Color.Primary" Size="Size.Small" />

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/FabMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabMenu/FabMenuPage.razor
@@ -1,0 +1,19 @@
+﻿@page "/components/buttonfabmenu"
+
+<DocsPage>
+    <DocsPageHeader Title="Floating Action Button Menu" Component="@nameof(MudFabMenu)" />
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader Title="Basic usage" />
+            <SectionContent Code="@nameof(FabMenuExampleBasic)">
+                <FabMenuExampleBasic />
+            </SectionContent>
+        </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Styling" />
+            <SectionContent Code="@nameof(FabMenuExampleStyling)">
+                <FabMenuExampleStyling />
+            </SectionContent>
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Services/Menu/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/Menu/MenuService.cs
@@ -114,6 +114,7 @@ namespace MudBlazor.Docs.Services
                 .AddItem("Icon Button", typeof(MudIconButton))
                 .AddItem("Toggle Icon Button", typeof(MudToggleIconButton))
                 .AddItem("Button FAB", typeof(MudFab))
+                .AddItem("Button FAB Menu", typeof(MudFabMenu))
             )
 
             //Charts

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/FabMenuTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/FabMenuTest.razor
@@ -1,0 +1,5 @@
+﻿<MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" OpenOnMouseHover="false">
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Color="Color.Primary"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Color="Color.Primary"/>
+    <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Color="Color.Primary"/>
+</MudFabMenu>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/FabMenuTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/FabMenuTest.razor
@@ -1,5 +1,9 @@
-﻿<MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" OpenOnMouseHover="false">
+﻿<MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" Color="Color.Primary" OpenOnMouseHover="@OpenOnMouseHover">
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne" Color="Color.Primary"/>
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksTwo" Color="Color.Primary"/>
     <MudFabMenuItem EndIcon="@Icons.Material.Outlined.Looks3" Color="Color.Primary"/>
 </MudFabMenu>
+
+@code {
+    [Parameter] public bool OpenOnMouseHover { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Button;
 using NUnit.Framework;
 
@@ -15,11 +16,59 @@ public class FabMenuTests : BunitTest
         comp.FindAll(".mud-fab-menu").Count.Should().Be(1);
         comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0);
         comp.FindAll(".mud-fab-menu-item").Count.Should().Be(3);
+    }
+
+    [Test]
+    public void RendersCorrectlyOnClick()
+    {
+        var comp = Context.RenderComponent<FabMenuTest>();
 
         comp.FindAll(".mud-fab-menu-button")[0].Click();
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
 
         comp.FindAll(".mud-fab-menu-item")[0].Click();
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+    }
+
+    [Test]
+    public void RendersCorrectlyOnTouch()
+    {
+        var compNoHover = Context.RenderComponent<FabMenuTest>();
+
+        compNoHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
+        compNoHover.FindAll(".mud-fab-menu-button")[0].Click();
+        compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+
+        compNoHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
+        compNoHover.FindAll(".mud-fab-menu-item")[0].Click();
+        compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        
+        var compHover = Context.RenderComponent<FabMenuTest>(ComponentParameter.CreateParameter("OpenOnMouseHover", true));
+
+        compHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
+        compHover.FindAll(".mud-fab-menu-button")[0].Click();
+        compHover.WaitForAssertion(() => { compHover.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+
+        compHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
+        compHover.FindAll(".mud-fab-menu-item")[0].Click();
+        compHover.WaitForAssertion(() => { compHover.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+    }
+
+    [Test]
+    public void RendersCorrectlyOnHover()
+    {
+        var comp = Context.RenderComponent<FabMenuTest>(ComponentParameter.CreateParameter("OpenOnMouseHover", true));
+
+        comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseenter", new MouseEventArgs());
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+
+        comp.FindAll(".mud-fab-menu-item")[0].Click();
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        
+        comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseenter", new MouseEventArgs());
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        
+        comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseleave", new MouseEventArgs());
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -1,0 +1,25 @@
+﻿using Bunit;
+using FluentAssertions;
+using MudBlazor.UnitTests.TestComponents.Button;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components;
+
+[TestFixture]
+public class FabMenuTests : BunitTest
+{
+    [Test]
+    public void RendersCorrectly()
+    {
+        var comp = Context.RenderComponent<FabMenuTest>();
+        comp.FindAll(".mud-fab-menu").Count.Should().Be(1);
+        comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0);
+        comp.FindAll(".mud-fab-menu-item").Count.Should().Be(3);
+        
+        comp.FindAll(".mud-fab-menu-button")[0].Click();
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        
+        comp.FindAll(".mud-fab-menu-item")[0].Click();
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -14,7 +14,7 @@ public class FabMenuTests : BunitTest
     {
         var comp = Context.RenderComponent<FabMenuTest>();
         comp.FindAll(".mud-fab-menu").Count.Should().Be(1);
-        comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0);
+        comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0);
         comp.FindAll(".mud-fab-menu-item").Count.Should().Be(3);
     }
 
@@ -24,10 +24,10 @@ public class FabMenuTests : BunitTest
         var comp = Context.RenderComponent<FabMenuTest>();
 
         comp.FindAll(".mud-fab-menu-button")[0].Click();
-        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
         comp.FindAll(".mud-fab-menu-item")[0].Click();
-        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
     }
 
     [Test]
@@ -37,21 +37,21 @@ public class FabMenuTests : BunitTest
 
         compNoHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compNoHover.FindAll(".mud-fab-menu-button")[0].Click();
-        compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
         compNoHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compNoHover.FindAll(".mud-fab-menu-item")[0].Click();
-        compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
 
         var compHover = Context.RenderComponent<FabMenuTest>(ComponentParameter.CreateParameter("OpenOnMouseHover", true));
 
         compHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compHover.FindAll(".mud-fab-menu-button")[0].Click();
-        compHover.WaitForAssertion(() => { compHover.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        compHover.WaitForAssertion(() => { compHover.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
         compHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compHover.FindAll(".mud-fab-menu-item")[0].Click();
-        compHover.WaitForAssertion(() => { compHover.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        compHover.WaitForAssertion(() => { compHover.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
     }
 
     [Test]
@@ -60,15 +60,15 @@ public class FabMenuTests : BunitTest
         var comp = Context.RenderComponent<FabMenuTest>(ComponentParameter.CreateParameter("OpenOnMouseHover", true));
 
         comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseenter", new MouseEventArgs());
-        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
         comp.FindAll(".mud-fab-menu-item")[0].Click();
-        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
 
         comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseenter", new MouseEventArgs());
-        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
 
         comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseleave", new MouseEventArgs());
-        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
+        comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -42,7 +42,7 @@ public class FabMenuTests : BunitTest
         compNoHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compNoHover.FindAll(".mud-fab-menu-item")[0].Click();
         compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
-        
+
         var compHover = Context.RenderComponent<FabMenuTest>(ComponentParameter.CreateParameter("OpenOnMouseHover", true));
 
         compHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
@@ -64,10 +64,10 @@ public class FabMenuTests : BunitTest
 
         comp.FindAll(".mud-fab-menu-item")[0].Click();
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
-        
+
         comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseenter", new MouseEventArgs());
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
-        
+
         comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseleave", new MouseEventArgs());
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
     }

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -15,10 +15,10 @@ public class FabMenuTests : BunitTest
         comp.FindAll(".mud-fab-menu").Count.Should().Be(1);
         comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0);
         comp.FindAll(".mud-fab-menu-item").Count.Should().Be(3);
-        
+
         comp.FindAll(".mud-fab-menu-button")[0].Click();
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(1); });
-        
+
         comp.FindAll(".mud-fab-menu-item")[0].Click();
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.open").Count.Should().Be(0); });
     }

--- a/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
@@ -48,7 +48,7 @@ namespace MudBlazor.UnitTests.UserAttributes
             // these components do not need to have user attributes
             var excludedComponents = new HashSet<string>()
             {
-                nameof(MudPopover), nameof(MudStep), nameof(MudContextualActionBar), nameof(MudHeatMapCell), nameof(MudFabMenu),
+                nameof(MudPopover), nameof(MudStep), nameof(MudContextualActionBar), nameof(MudHeatMapCell),
                 "Column`1", "FooterCell`1", "HeaderCell`1", "FilterHeaderCell`1", "SelectColumn`1",
                 "HierarchyColumn`1", "PropertyColumn`2", "TemplateColumn`1", "MudToggleItem`1",
             };

--- a/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
@@ -48,7 +48,7 @@ namespace MudBlazor.UnitTests.UserAttributes
             // these components do not need to have user attributes
             var excludedComponents = new HashSet<string>()
             {
-                nameof(MudPopover), nameof(MudStep), nameof(MudContextualActionBar), nameof(MudHeatMapCell),
+                nameof(MudPopover), nameof(MudStep), nameof(MudContextualActionBar), nameof(MudHeatMapCell), nameof(MudFabMenu),
                 "Column`1", "FooterCell`1", "HeaderCell`1", "FilterHeaderCell`1", "SelectColumn`1",
                 "HierarchyColumn`1", "PropertyColumn`2", "TemplateColumn`1", "MudToggleItem`1",
             };

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -132,6 +132,7 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
+            base.OnInitialized();
             SetDefaultValues();
         }
 

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -44,7 +44,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Button.Appearance)]
-        public Size Size { get; set; } = Size.Large;
+        public virtual Size Size { get; set; } = Size.Large;
 
         /// <summary>
         /// The icon shown before any text.

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor
@@ -1,13 +1,14 @@
 ﻿@namespace MudBlazor
 @inherits MudFab
 
-<div class="@Classname" 
-     style="@Style" 
-     @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))" 
-     @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))" 
+<div class="@Classname"
+     style="@Style"
+     @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))"
+     @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))"
      @ontouchstart="@OnTouchStart"
-     @attributes="UserAttributes">
-    <div class="@ClassnameMenu" style="@StylenameMenu" @onclick="@OnMenuClickAsync">
+     @attributes="UserAttributes"
+     role="menu">
+    <div class="@ClassnameMenu" style="@MenuStyle" @onclick="@OnMenuClickAsync">
         <CascadingValue Value="@this">
             @ChildContent
         </CascadingValue>

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudFab
 
-<div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeave(true))" @onmouseleave="@(() => OnMouseEnterLeave(false))">
-    <div class="@ClassnameMenu" style="@StylenameMenu" @onclick="@OnMenuClick">
+<div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))" @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))">
+    <div class="@ClassnameMenu" style="@StylenameMenu" @onclick="@OnMenuClickAsync">
         <CascadingValue Value="@this">
             @ChildContent
         </CascadingValue>
@@ -16,7 +16,7 @@
             IconColor="@IconColor"
             IconSize="@IconSize"
             Label="@Label"
-            OnClick="@OnMenuButtonClick"
+            OnClick="@OnMenuButtonClickAsync"
             ButtonType="@ButtonType"
             Href="@Href"
             Target="@Target"

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor
@@ -1,0 +1,29 @@
+﻿@namespace MudBlazor
+@inherits MudFab
+
+<div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeave(true))" @onmouseleave="@(() => OnMouseEnterLeave(false))">
+    <div class="@ClassnameMenu" style="@StylenameMenu">
+        <CascadingValue Value="@this">
+            @ChildContent
+        </CascadingValue>
+    </div>
+    <MudFab Class="@ClassnameFab"
+            Style="@ButtonStyle"
+            Color="@Color"
+            Size="@Size"
+            StartIcon="@_startIcon"
+            EndIcon="@_endIcon"
+            IconColor="@IconColor"
+            IconSize="@IconSize"
+            Label="@Label"
+            OnClick="@OnMenuButtonClick"
+            ButtonType="@ButtonType"
+            Href="@Href"
+            Target="@Target"
+            Disabled="@Disabled"
+            HtmlTag="@HtmlTag"
+            Rel="@Rel"
+            ClickPropagation="@ClickPropagation"
+            DropShadow="@DropShadow"
+            Ripple="@Ripple"/>
+</div>

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudFab
 
-<div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))" @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))">
+<div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))" @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))" @ontouchstart="@OnTouchStart">
     <div class="@ClassnameMenu" style="@StylenameMenu" @onclick="@OnMenuClickAsync">
         <CascadingValue Value="@this">
             @ChildContent

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor
@@ -1,7 +1,12 @@
 ﻿@namespace MudBlazor
 @inherits MudFab
 
-<div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))" @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))" @ontouchstart="@OnTouchStart">
+<div class="@Classname" 
+     style="@Style" 
+     @onmouseenter="@(() => OnMouseEnterLeaveAsync(true))" 
+     @onmouseleave="@(() => OnMouseEnterLeaveAsync(false))" 
+     @ontouchstart="@OnTouchStart"
+     @attributes="UserAttributes">
     <div class="@ClassnameMenu" style="@StylenameMenu" @onclick="@OnMenuClickAsync">
         <CascadingValue Value="@this">
             @ChildContent

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor
@@ -2,7 +2,7 @@
 @inherits MudFab
 
 <div class="@Classname" style="@Stylename" @onmouseenter="@(() => OnMouseEnterLeave(true))" @onmouseleave="@(() => OnMouseEnterLeave(false))">
-    <div class="@ClassnameMenu" style="@StylenameMenu">
+    <div class="@ClassnameMenu" style="@StylenameMenu" @onclick="@OnMenuClick">
         <CascadingValue Value="@this">
             @ChildContent
         </CascadingValue>

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -1,0 +1,195 @@
+﻿#nullable enable
+using Microsoft.AspNetCore.Components;
+using MudBlazor.State;
+using MudBlazor.Utilities;
+
+namespace MudBlazor;
+
+public partial class MudFabMenu : MudFab
+{
+    private new string Classname => new CssBuilder("mud-fab-menu-container")
+        .AddClass("fixed", Fixed)
+        .AddClass($"align-{AlignItems.ToDescriptionString()}")
+        .AddClass(Class)
+        .Build();
+
+    private string ClassnameMenu => new CssBuilder("mud-fab-menu")
+        .AddClass("open", Open)
+        .AddClass("dampen", DampenItemColors)
+        .AddClass($"align-{AlignItems.ToDescriptionString()}")
+        .AddClass(MenuClass)
+        .Build();
+
+    private string ClassnameFab => new CssBuilder("mud-fab-menu-button")
+        .AddClass("open", Open && string.IsNullOrEmpty(Label))
+        .AddClass(ButtonClass)
+        .Build();
+
+    private string Stylename => new StyleBuilder()
+        .AddStyle("right: 16px;", Fixed)
+        .AddStyle("bottom: 16px;", Fixed)
+        .AddStyle("z-index: 2000;", Fixed)
+        .AddStyle(Style)
+        .Build();
+    
+    private string StylenameMenu => new StyleBuilder()
+        .AddStyle($"padding-bottom: {_menuPaddingBottomCorrection}px;", _menuPaddingBottomCorrection != 0)
+        .AddStyle(MenuStyle)
+        .Build();
+
+    private string? _startIcon;
+    private string? _endIcon;
+    private int _menuPaddingBottomCorrection;
+
+    /// <summary>
+    /// The CSS classes applied to the menu button.
+    /// </summary>
+    /// <remarks>
+    /// Multiple classes must be separated by spaces.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? ButtonClass { get; set; }
+
+    /// <summary>
+    /// The CSS style applied to the menu button.
+    /// </summary>
+    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? ButtonStyle { get; set; }
+
+    /// <summary>
+    /// The CSS classes applied to the item list.
+    /// </summary>
+    /// <remarks>
+    /// Multiple classes must be separated by spaces.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? MenuClass { get; set; }
+
+    /// <summary>
+    /// The CSS style applied to the  item list.
+    /// </summary>
+    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? MenuStyle { get; set; }
+
+    /// <summary>
+    /// The <see cref="MudFabMenuItem" /> components within this menu.
+    /// </summary>
+    /// <remarks>
+    /// Note that you can add any component you like as long as it has the <c>mud-fab-menu-item</c> class.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Whether this menu is open and the menu items are visible.
+    /// </summary>
+    /// <remarks>
+    /// When this property changes, <see cref="OpenChanged"/> occurs.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] public bool Open { get; set; }
+
+    /// <summary>
+    /// Occurs when <see cref="Open"/> has changed.
+    /// </summary>
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] public EventCallback<bool> OpenChanged { get; set; }
+
+    /// <summary>
+    /// Sets the menu to a fixed position in the bottom right corner of the screen with padding of 16 px towards each screen edge.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Behavior)] public bool Fixed { get; set; }
+
+    /// <summary>
+    /// Whether to replace the set icon with a close icon when the menu is open.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Behavior)] public bool UseCloseIcon { get; set; } = true;
+
+    /// <summary>
+    /// Dampens the background color of the menu items when set to true.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Behavior)] public bool DampenItemColors { get; set; } = true;
+
+    /// <summary>
+    /// The alignment of the menu items in respect to the menu button.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>AlignItems.Center</c>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Behavior)] public AlignItems AlignItems { get; set; } = AlignItems.Center;
+
+    /// <summary>
+    /// Whether to open the menu on mouse hover.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Menu.Behavior)] public bool OpenOnMouseHover { get; set; } = true;
+
+    public MudFabMenu()
+    {
+        using var registerScope = CreateRegisterScope();
+        registerScope.RegisterParameter<bool>(nameof(Open))
+            .WithParameter(() => Open)
+            .WithEventCallback(() => OpenChanged)
+            .WithChangeHandler(OnOpenChanged);
+    }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        if (!Open || !UseCloseIcon)
+        {
+            _startIcon = StartIcon;
+            _endIcon = EndIcon;
+        }
+
+        if (!string.IsNullOrEmpty(Label))
+        {
+            _menuPaddingBottomCorrection = Size switch
+            {
+                Size.Large => 60,
+                Size.Medium => 52,
+                Size.Small => 48,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+    }
+
+    private void OnOpenChanged(ParameterChangedEventArgs<bool> args)
+    {
+        if (args.Value && UseCloseIcon)
+        {
+            if (StartIcon != null) _startIcon = Icons.Material.Outlined.Add;
+            if (EndIcon != null) _endIcon = Icons.Material.Outlined.Add;
+        }
+
+        if (!args.Value)
+        {
+            _startIcon = StartIcon;
+            _endIcon = EndIcon;
+        }
+    }
+
+    private void ToggleOpen(bool? open = null)
+    {
+        Open = open ?? !Open;
+        OpenChanged.InvokeAsync(Open);
+        OnClick.InvokeAsync();
+
+        OnOpenChanged(new ParameterChangedEventArgs<bool>(nameof(Open), !Open, Open));
+    }
+
+    private void OnMenuButtonClick()
+    {
+        if (!OpenOnMouseHover) ToggleOpen();
+    }
+
+    private void OnMouseEnterLeave(bool enter)
+    {
+        if (OpenOnMouseHover) ToggleOpen(enter);
+    }
+}

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -193,21 +193,24 @@ public partial class MudFabMenu : MudFab
 
     private async Task OnMenuButtonClickAsync(MouseEventArgs args)
     {
-        if (!OpenOnMouseHover)
-        {
-            await ToggleOpenAsync();
-        }
-
+        await ToggleOpenAsync();
         await OnClickHandler(args);
     }
 
     private async Task OnMouseEnterLeaveAsync(bool enter)
     {
-        if (OpenOnMouseHover) await ToggleOpenAsync(enter);
+        if (OpenOnMouseHover && !_lastInteractionWasTouch) await ToggleOpenAsync(enter);
+        _lastInteractionWasTouch = false;
     }
 
     private async Task OnMenuClickAsync()
     {
         if (CloseOnMenuItemClicked) await ToggleOpenAsync(false);
+    }
+
+    private bool _lastInteractionWasTouch;
+    private void OnTouchStart()
+    {
+        _lastInteractionWasTouch = true;
     }
 }

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -19,22 +19,15 @@ public partial class MudFabMenu : MudFab
         .Build();
 
     private string ClassnameMenu => new CssBuilder("mud-fab-menu")
-        .AddClass("open", Open)
+        .AddClass("open", _openState.Value)
         .AddClass("dampen", DampenItemColors)
         .AddClass($"align-{AlignItems.ToDescriptionString()}")
         .AddClass(MenuClass)
         .Build();
 
     private string ClassnameFab => new CssBuilder("mud-fab-menu-button")
-        .AddClass("open", Open && string.IsNullOrEmpty(Label))
+        .AddClass("open", _openState.Value && string.IsNullOrEmpty(Label))
         .AddClass(ButtonClass)
-        .Build();
-
-    private string Stylename => new StyleBuilder()
-        .AddStyle("right: 16px;", Fixed)
-        .AddStyle("bottom: 16px;", Fixed)
-        .AddStyle("z-index: 2000;", Fixed)
-        .AddStyle(Style)
         .Build();
 
     private string StylenameMenu => new StyleBuilder()
@@ -42,6 +35,7 @@ public partial class MudFabMenu : MudFab
         .AddStyle(MenuStyle)
         .Build();
 
+    private readonly ParameterState<bool> _openState;
     private string? _startIcon;
     private string? _endIcon;
     private int _menuPaddingBottomCorrection;
@@ -53,12 +47,14 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Multiple classes must be separated by spaces.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? ButtonClass { get; set; }
+    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    public string? ButtonClass { get; set; }
 
     /// <summary>
     /// The CSS style applied to the menu button.
     /// </summary>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? ButtonStyle { get; set; }
+    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    public string? ButtonStyle { get; set; }
 
     /// <summary>
     /// The CSS classes applied to the item list.
@@ -66,12 +62,14 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Multiple classes must be separated by spaces.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? MenuClass { get; set; }
+    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    public string? MenuClass { get; set; }
 
     /// <summary>
     /// The CSS style applied to the  item list.
     /// </summary>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] public string? MenuStyle { get; set; }
+    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    public string? MenuStyle { get; set; }
 
     /// <summary>
     /// The <see cref="MudFabMenuItem" /> components within this menu.
@@ -79,7 +77,8 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Note that you can add any component you like as long as it has the <c>mud-fab-menu-item</c> class.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] public RenderFragment? ChildContent { get; set; }
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] 
+    public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
     /// Whether this menu is open and the menu items are visible.
@@ -87,12 +86,14 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// When this property changes, <see cref="OpenChanged"/> occurs.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] public bool Open { get; set; }
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] 
+    public bool Open { get; set; }
 
     /// <summary>
     /// Occurs when <see cref="Open"/> has changed.
     /// </summary>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] public EventCallback<bool> OpenChanged { get; set; }
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] 
+    public EventCallback<bool> OpenChanged { get; set; }
 
     /// <summary>
     /// Sets the menu to a fixed position in the bottom right corner of the screen with padding of 16 px towards each screen edge.
@@ -100,7 +101,8 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] public bool Fixed { get; set; }
+    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    public bool Fixed { get; set; }
 
     /// <summary>
     /// Whether to replace the set icon with a close icon when the menu is open.
@@ -108,7 +110,8 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] public bool UseCloseIcon { get; set; } = true;
+    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    public bool UseCloseIcon { get; set; } = true;
 
     /// <summary>
     /// Dampens the background color of the menu items when set to true.
@@ -116,7 +119,8 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] public bool DampenItemColors { get; set; } = true;
+    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    public bool DampenItemColors { get; set; } = true;
 
     /// <summary>
     /// The alignment of the menu items in respect to the menu button.
@@ -124,7 +128,8 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>AlignItems.Center</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] public AlignItems AlignItems { get; set; } = AlignItems.Center;
+    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    public AlignItems AlignItems { get; set; } = AlignItems.Center;
 
     /// <summary>
     /// Whether to open the menu on mouse hover.
@@ -132,7 +137,8 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.Behavior)] public bool OpenOnMouseHover { get; set; } = true;
+    [Parameter, Category(CategoryTypes.Menu.Behavior)] 
+    public bool OpenOnMouseHover { get; set; } = true;
 
     /// <summary>
     /// Whether to close the menu when a menu item is clicked.
@@ -140,12 +146,13 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.Behavior)] public bool CloseOnMenuItemClicked { get; set; } = true;
-
+    [Parameter, Category(CategoryTypes.Menu.Behavior)] 
+    public bool CloseOnMenuItemClicked { get; set; } = true;
+    
     public MudFabMenu()
     {
         using var registerScope = CreateRegisterScope();
-        registerScope.RegisterParameter<bool>(nameof(Open))
+        _openState = registerScope.RegisterParameter<bool>(nameof(Open))
             .WithParameter(() => Open)
             .WithEventCallback(() => OpenChanged)
             .WithChangeHandler(OnOpenChanged);
@@ -155,7 +162,7 @@ public partial class MudFabMenu : MudFab
     {
         base.OnParametersSet();
 
-        if (!Open || !UseCloseIcon)
+        if (!_openState.Value || !UseCloseIcon)
         {
             _startIcon = StartIcon;
             _endIcon = EndIcon;
@@ -190,10 +197,7 @@ public partial class MudFabMenu : MudFab
 
     private async Task ToggleOpenAsync(bool? open = null)
     {
-        Open = open ?? !Open;
-        await OpenChanged.InvokeAsync(Open);
-
-        OnOpenChanged(new ParameterChangedEventArgs<bool>(nameof(Open), !Open, Open));
+        await _openState.SetValueAsync(open ?? !_openState.Value);
     }
 
     private async Task OnMenuButtonClickAsync(MouseEventArgs args)

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -22,6 +22,7 @@ public partial class MudFabMenu : MudFab
         .AddClass("open", _openState.Value)
         .AddClass("dampen", DampenItemColors)
         .AddClass($"align-{AlignItems.ToDescriptionString()}")
+        .AddClass($"padding-bottom-{Size.ToString().ToLower()}", !string.IsNullOrEmpty(Label))
         .AddClass(MenuClass)
         .Build();
 
@@ -30,15 +31,9 @@ public partial class MudFabMenu : MudFab
         .AddClass(ButtonClass)
         .Build();
 
-    private string StylenameMenu => new StyleBuilder()
-        .AddStyle($"padding-bottom: {_menuPaddingBottomCorrection}px;", _menuPaddingBottomCorrection != 0)
-        .AddStyle(MenuStyle)
-        .Build();
-
     private readonly ParameterState<bool> _openState;
     private string? _startIcon;
     private string? _endIcon;
-    private int _menuPaddingBottomCorrection;
     private bool _lastInteractionWasTouch;
 
     /// <summary>
@@ -155,7 +150,7 @@ public partial class MudFabMenu : MudFab
         _openState = registerScope.RegisterParameter<bool>(nameof(Open))
             .WithParameter(() => Open)
             .WithEventCallback(() => OpenChanged)
-            .WithChangeHandler(OnOpenChanged);
+            .WithChangeHandler(HandleOpenChanged);
     }
 
     protected override void OnParametersSet()
@@ -167,22 +162,11 @@ public partial class MudFabMenu : MudFab
             _startIcon = StartIcon;
             _endIcon = EndIcon;
         }
-
-        if (!string.IsNullOrEmpty(Label))
-        {
-            _menuPaddingBottomCorrection = Size switch
-            {
-                Size.Large => 60,
-                Size.Medium => 52,
-                Size.Small => 48,
-                _ => throw new ArgumentOutOfRangeException()
-            };
-        }
     }
 
-    private void OnOpenChanged(ParameterChangedEventArgs<bool> args) => OnOpenChanged(args.Value);
+    private void HandleOpenChanged(ParameterChangedEventArgs<bool> args) => HandleOpenChanged(args.Value);
 
-    private void OnOpenChanged(bool open)
+    private void HandleOpenChanged(bool open)
     {
         if (open && UseCloseIcon)
         {
@@ -197,28 +181,28 @@ public partial class MudFabMenu : MudFab
         }
     }
 
-    private async Task ToggleOpenAsync(bool? open = null)
+    private async Task ToggleMenuAsync(bool? open = null)
     {
         var isOpen = open ?? !_openState.Value;
         await _openState.SetValueAsync(isOpen);
-        OnOpenChanged(isOpen);
+        HandleOpenChanged(isOpen);
     }
 
     private async Task OnMenuButtonClickAsync(MouseEventArgs args)
     {
-        await ToggleOpenAsync();
+        await ToggleMenuAsync();
         await OnClickHandler(args);
     }
 
     private async Task OnMouseEnterLeaveAsync(bool enter)
     {
-        if (OpenOnMouseHover && !_lastInteractionWasTouch) await ToggleOpenAsync(enter);
+        if (OpenOnMouseHover && !_lastInteractionWasTouch) await ToggleMenuAsync(enter);
         _lastInteractionWasTouch = false;
     }
 
     private async Task OnMenuClickAsync()
     {
-        if (CloseOnMenuItemClicked) await ToggleOpenAsync(false);
+        if (CloseOnMenuItemClicked) await ToggleMenuAsync(false);
     }
 
     private void OnTouchStart()

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -31,7 +32,7 @@ public partial class MudFabMenu : MudFab
         .AddStyle("z-index: 2000;", Fixed)
         .AddStyle(Style)
         .Build();
-    
+
     private string StylenameMenu => new StyleBuilder()
         .AddStyle($"padding-bottom: {_menuPaddingBottomCorrection}px;", _menuPaddingBottomCorrection != 0)
         .AddStyle(MenuStyle)
@@ -182,27 +183,31 @@ public partial class MudFabMenu : MudFab
         }
     }
 
-    private void ToggleOpen(bool? open = null)
+    private async Task ToggleOpenAsync(bool? open = null)
     {
         Open = open ?? !Open;
-        OpenChanged.InvokeAsync(Open);
-        OnClick.InvokeAsync();
+        await OpenChanged.InvokeAsync(Open);
 
         OnOpenChanged(new ParameterChangedEventArgs<bool>(nameof(Open), !Open, Open));
     }
 
-    private void OnMenuButtonClick()
+    private async Task OnMenuButtonClickAsync(MouseEventArgs args)
     {
-        if (!OpenOnMouseHover) ToggleOpen();
+        if (!OpenOnMouseHover)
+        {
+            await ToggleOpenAsync();
+        }
+
+        await OnClickHandler(args);
     }
 
-    private void OnMouseEnterLeave(bool enter)
+    private async Task OnMouseEnterLeaveAsync(bool enter)
     {
-        if (OpenOnMouseHover) ToggleOpen(enter);
+        if (OpenOnMouseHover) await ToggleOpenAsync(enter);
     }
 
-    private void OnMenuClick()
+    private async Task OnMenuClickAsync()
     {
-        if (CloseOnMenuItemClicked) ToggleOpen(false);
+        if (CloseOnMenuItemClicked) await ToggleOpenAsync(false);
     }
 }

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -128,6 +128,14 @@ public partial class MudFabMenu : MudFab
     /// </remarks>
     [Parameter, Category(CategoryTypes.Menu.Behavior)] public bool OpenOnMouseHover { get; set; } = true;
 
+    /// <summary>
+    /// Whether to close the menu when a menu item is clicked.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Menu.Behavior)] public bool CloseOnMenuItemClicked { get; set; } = true;
+
     public MudFabMenu()
     {
         using var registerScope = CreateRegisterScope();
@@ -191,5 +199,10 @@ public partial class MudFabMenu : MudFab
     private void OnMouseEnterLeave(bool enter)
     {
         if (OpenOnMouseHover) ToggleOpen(enter);
+    }
+
+    private void OnMenuClick()
+    {
+        if (CloseOnMenuItemClicked) ToggleOpen(false);
     }
 }

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -6,6 +6,10 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
+/// <summary>
+/// A menu appearing from a <see cref="MudFab"/> that displays a list of items.
+/// </summary>
+/// <seealso cref="MudFabMenuItem" />
 public partial class MudFabMenu : MudFab
 {
     private new string Classname => new CssBuilder("mud-fab-menu-container")
@@ -41,6 +45,7 @@ public partial class MudFabMenu : MudFab
     private string? _startIcon;
     private string? _endIcon;
     private int _menuPaddingBottomCorrection;
+    private bool _lastInteractionWasTouch;
 
     /// <summary>
     /// The CSS classes applied to the menu button.
@@ -208,7 +213,6 @@ public partial class MudFabMenu : MudFab
         if (CloseOnMenuItemClicked) await ToggleOpenAsync(false);
     }
 
-    private bool _lastInteractionWasTouch;
     private void OnTouchStart()
     {
         _lastInteractionWasTouch = true;

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -19,10 +19,10 @@ public partial class MudFabMenu : MudFab
         .Build();
 
     private string ClassnameMenu => new CssBuilder("mud-fab-menu")
-        .AddClass("open", _openState.Value)
-        .AddClass("dampen", DampenItemColors)
+        .AddClass("mud-fab-menu-open", _openState.Value)
+        .AddClass("mud-fab-menu-dampen", DampenItemColors)
         .AddClass($"align-{AlignItems.ToDescriptionString()}")
-        .AddClass($"padding-bottom-{Size.ToString().ToLower()}", !string.IsNullOrEmpty(Label))
+        .AddClass($"mud-fab-menu-{Size.ToString().ToLower()}", !string.IsNullOrEmpty(Label))
         .AddClass(MenuClass)
         .Build();
 
@@ -100,7 +100,7 @@ public partial class MudFabMenu : MudFab
     public bool Fixed { get; set; }
 
     /// <summary>
-    /// Whether to replace the set icon with a close icon when the menu is open.
+    /// Replaces the set icon with a close icon when the menu is open.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>true</c>.
@@ -127,7 +127,7 @@ public partial class MudFabMenu : MudFab
     public AlignItems AlignItems { get; set; } = AlignItems.Center;
 
     /// <summary>
-    /// Whether to open the menu on mouse hover.
+    /// Opens the menu on mouse hover.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>true</c>.
@@ -136,7 +136,7 @@ public partial class MudFabMenu : MudFab
     public bool OpenOnMouseHover { get; set; } = true;
 
     /// <summary>
-    /// Whether to close the menu when a menu item is clicked.
+    /// Closes the menu when a menu item is clicked.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>true</c>.
@@ -170,8 +170,15 @@ public partial class MudFabMenu : MudFab
     {
         if (open && UseCloseIcon)
         {
-            if (StartIcon != null) _startIcon = Icons.Material.Outlined.Add;
-            if (EndIcon != null) _endIcon = Icons.Material.Outlined.Add;
+            if (StartIcon != null)
+            {
+                _startIcon = Icons.Material.Outlined.Add;
+            }
+
+            if (EndIcon != null)
+            {
+                _endIcon = Icons.Material.Outlined.Add;
+            }
         }
 
         if (!open)
@@ -196,13 +203,20 @@ public partial class MudFabMenu : MudFab
 
     private async Task OnMouseEnterLeaveAsync(bool enter)
     {
-        if (OpenOnMouseHover && !_lastInteractionWasTouch) await ToggleMenuAsync(enter);
+        if (OpenOnMouseHover && !_lastInteractionWasTouch)
+        {
+            await ToggleMenuAsync(enter);
+        }
+
         _lastInteractionWasTouch = false;
     }
 
     private async Task OnMenuClickAsync()
     {
-        if (CloseOnMenuItemClicked) await ToggleMenuAsync(false);
+        if (CloseOnMenuItemClicked)
+        {
+            await ToggleMenuAsync(false);
+        }
     }
 
     private void OnTouchStart()

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -180,15 +180,17 @@ public partial class MudFabMenu : MudFab
         }
     }
 
-    private void OnOpenChanged(ParameterChangedEventArgs<bool> args)
+    private void OnOpenChanged(ParameterChangedEventArgs<bool> args) => OnOpenChanged(args.Value);
+
+    private void OnOpenChanged(bool open)
     {
-        if (args.Value && UseCloseIcon)
+        if (open && UseCloseIcon)
         {
             if (StartIcon != null) _startIcon = Icons.Material.Outlined.Add;
             if (EndIcon != null) _endIcon = Icons.Material.Outlined.Add;
         }
 
-        if (!args.Value)
+        if (!open)
         {
             _startIcon = StartIcon;
             _endIcon = EndIcon;
@@ -197,7 +199,9 @@ public partial class MudFabMenu : MudFab
 
     private async Task ToggleOpenAsync(bool? open = null)
     {
-        await _openState.SetValueAsync(open ?? !_openState.Value);
+        var isOpen = open ?? !_openState.Value;
+        await _openState.SetValueAsync(isOpen);
+        OnOpenChanged(isOpen);
     }
 
     private async Task OnMenuButtonClickAsync(MouseEventArgs args)

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -20,7 +20,7 @@ public partial class MudFabMenu : MudFab
 
     private string ClassnameMenu => new CssBuilder("mud-fab-menu")
         .AddClass("mud-fab-menu-open", _openState.Value)
-        .AddClass("mud-fab-menu-dampen", DampenItemColors)
+        .AddClass("mud-fab-menu-dampen", DampenItemsBackgroundColor)
         .AddClass($"align-{AlignItems.ToDescriptionString()}")
         .AddClass($"mud-fab-menu-{Size.ToString().ToLower()}", !string.IsNullOrEmpty(Label))
         .AddClass(MenuClass)
@@ -109,13 +109,14 @@ public partial class MudFabMenu : MudFab
     public bool UseCloseIcon { get; set; } = true;
 
     /// <summary>
-    /// Dampens the background color of the menu items when set to true.
+    /// Dampens the background color of the menu items when set to true to increase the contrast between the menu FAB and the menu items
+    /// to archive a similar effect as described in the <a href="https://m3.material.io/components/fab-menu/overview">Material Design guidelines</a>.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
     [Parameter, Category(CategoryTypes.Button.Behavior)]
-    public bool DampenItemColors { get; set; } = true;
+    public bool DampenItemsBackgroundColor { get; set; } = true;
 
     /// <summary>
     /// The alignment of the menu items in respect to the menu button.

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -47,13 +47,13 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Multiple classes must be separated by spaces.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    [Parameter, Category(CategoryTypes.Button.Appearance)]
     public string? ButtonClass { get; set; }
 
     /// <summary>
     /// The CSS style applied to the menu button.
     /// </summary>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    [Parameter, Category(CategoryTypes.Button.Appearance)]
     public string? ButtonStyle { get; set; }
 
     /// <summary>
@@ -62,13 +62,13 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Multiple classes must be separated by spaces.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    [Parameter, Category(CategoryTypes.Button.Appearance)]
     public string? MenuClass { get; set; }
 
     /// <summary>
     /// The CSS style applied to the  item list.
     /// </summary>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    [Parameter, Category(CategoryTypes.Button.Appearance)]
     public string? MenuStyle { get; set; }
 
     /// <summary>
@@ -77,7 +77,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Note that you can add any component you like as long as it has the <c>mud-fab-menu-item</c> class.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] 
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
@@ -86,13 +86,13 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// When this property changes, <see cref="OpenChanged"/> occurs.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] 
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)]
     public bool Open { get; set; }
 
     /// <summary>
     /// Occurs when <see cref="Open"/> has changed.
     /// </summary>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)] 
+    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)]
     public EventCallback<bool> OpenChanged { get; set; }
 
     /// <summary>
@@ -101,7 +101,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    [Parameter, Category(CategoryTypes.Button.Behavior)]
     public bool Fixed { get; set; }
 
     /// <summary>
@@ -110,7 +110,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    [Parameter, Category(CategoryTypes.Button.Behavior)]
     public bool UseCloseIcon { get; set; } = true;
 
     /// <summary>
@@ -119,7 +119,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    [Parameter, Category(CategoryTypes.Button.Behavior)]
     public bool DampenItemColors { get; set; } = true;
 
     /// <summary>
@@ -128,7 +128,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>AlignItems.Center</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Behavior)] 
+    [Parameter, Category(CategoryTypes.Button.Behavior)]
     public AlignItems AlignItems { get; set; } = AlignItems.Center;
 
     /// <summary>
@@ -137,7 +137,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.Behavior)] 
+    [Parameter, Category(CategoryTypes.Menu.Behavior)]
     public bool OpenOnMouseHover { get; set; } = true;
 
     /// <summary>
@@ -146,9 +146,9 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// Defaults to <c>true</c>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.Behavior)] 
+    [Parameter, Category(CategoryTypes.Menu.Behavior)]
     public bool CloseOnMenuItemClicked { get; set; } = true;
-    
+
     public MudFabMenu()
     {
         using var registerScope = CreateRegisterScope();

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor
@@ -11,5 +11,5 @@
         IconSize="@IconSize"
         Label="@Label"
         ClickPropagation="true"
-        @attributes="UserAttributes"
+        @attributes="@UserAttributes"
         @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"/>

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor
@@ -10,4 +10,6 @@
         IconColor="@IconColor"
         IconSize="@IconSize"
         Label="@Label"
-        ClickPropagation="true"/>
+        ClickPropagation="true"
+        @attributes="UserAttributes"
+        @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"/>

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor
@@ -1,0 +1,12 @@
+﻿@namespace MudBlazor
+@inherits MudFab
+
+<MudFab Class="@Classname"
+        Style="@Style"
+        Color="@Color"
+        Size="@Size"
+        StartIcon="@StartIcon"
+        EndIcon="@EndIcon"
+        IconColor="@IconColor"
+        IconSize="@IconSize"
+        Label="@Label"/>

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor
@@ -12,4 +12,5 @@
         Label="@Label"
         ClickPropagation="true"
         @attributes="@UserAttributes"
-        @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"/>
+        @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
+        role="menuitem"/>

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor
@@ -9,4 +9,5 @@
         EndIcon="@EndIcon"
         IconColor="@IconColor"
         IconSize="@IconSize"
-        Label="@Label"/>
+        Label="@Label"
+        ClickPropagation="true"/>

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -4,6 +4,9 @@ using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
+/// <summary>
+/// Represents an item for the <see cref="MudFabMenu"/>.
+/// </summary>
 public partial class MudFabMenuItem : MudFab
 {
     private new string Classname => new CssBuilder(base.Classname)

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -20,5 +20,6 @@ public partial class MudFabMenuItem : MudFab
     /// <remarks>
     /// Defaults to <see cref="Size.Medium"/>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] public override Size Size { get; set; } = Size.Medium;
+    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    public override Size Size { get; set; } = Size.Medium;
 }

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -20,6 +20,7 @@ public partial class MudFabMenuItem : MudFab
     /// <remarks>
     /// Defaults to <see cref="Size.Medium"/>.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Button.Appearance)] 
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
     public override Size Size { get; set; } = Size.Medium;
 }

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -20,7 +20,6 @@ public partial class MudFabMenuItem : MudFab
     /// <remarks>
     /// Defaults to <see cref="Size.Medium"/>.
     /// </remarks>
-    [Parameter]
-    [Category(CategoryTypes.Button.Appearance)]
+    [Parameter, Category(CategoryTypes.Button.Appearance)]
     public override Size Size { get; set; } = Size.Medium;
 }

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor;
+
+public partial class MudFabMenuItem : MudFab
+{
+    private new string Classname => new CssBuilder(base.Classname)
+        .AddClass("mud-fab-menu-item")
+        .AddClass(Class)
+        .Build();
+
+    /// <summary>
+    /// The size of the menu item.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Size.Medium"/>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Appearance)] public override Size Size { get; set; } = Size.Medium;
+}

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -41,6 +41,7 @@
 @import 'components/_dropzone';
 @import 'components/_expansionpanel';
 @import 'components/_fab';
+@import 'components/_fabmenu';
 @import 'components/_form';
 @import 'components/_list';
 @import 'components/_layout';

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -1,0 +1,71 @@
+.mud-fab-menu-container {
+  position: relative;
+
+  .mud-fab-menu {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    padding-bottom: calc(100% + 12px);
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: center;
+    gap: 12px;
+    z-index: calc(var(--mud-zindex-appbar) - 2);
+    width: 100%;
+    pointer-events: none;
+
+    &.dampen {
+      .mud-fab-menu-item {
+        position: relative;
+        z-index: 1;
+      }
+
+      .mud-fab-menu-item::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: inherit;
+        filter: saturate(0.5) brightness(1.25);
+        z-index: -1;
+      }
+    }
+
+    .mud-fab-menu-item {
+      opacity: 0;
+      transform: translateY(20px);
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+
+    &.open {
+      pointer-events: auto;
+
+      .mud-fab-menu-item {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @for $i from 1 through 10 {
+      .mud-fab-menu-item:nth-child(#{$i}) {
+        transition-delay: (10 - $i) * 0.05s;
+      }
+    }
+  }
+
+  &:not(.open) {
+    @for $i from 1 through 10 {
+      .mud-fab-menu-item:nth-child(#{$i}) {
+        transition-delay: $i * 0.05s;
+      }
+    }
+  }
+
+  .mud-fab-menu-button {
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    z-index: calc(var(--mud-zindex-appbar) - 1);
+
+    &.open {
+      transform: rotate(45deg);
+    }
+  }
+}

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -18,23 +18,23 @@
     flex-direction: column-reverse;
     align-items: center;
     gap: 12px;
-    z-index: calc(var(--mud-zindex-appbar) - 2);
+    z-index: calc(var(--mud-zindex-popover) - 2);
     width: 100%;
     pointer-events: none;
 
-    &.padding-bottom-small {
+    &.mud-fab-menu-small {
       padding-bottom: 48px;
     }
 
-    &.padding-bottom-medium {
+    &.mud-fab-menu-medium {
       padding-bottom: 52px;
     }
 
-    &.padding-bottom-large {
+    &.mud-fab-menu-large {
       padding-bottom: 60px;
     }
 
-    &.dampen {
+    &.mud-fab-menu-dampen {
       .mud-fab-menu-item {
         position: relative;
         z-index: 1;
@@ -56,7 +56,7 @@
       transition: transform 0.3s ease, opacity 0.3s ease;
     }
 
-    &.open {
+    &.mud-fab-menu-open {
       pointer-events: auto;
 
       .mud-fab-menu-item {
@@ -82,7 +82,7 @@
 
   .mud-fab-menu-button {
     transition: transform 0.3s ease, opacity 0.3s ease;
-    z-index: calc(var(--mud-zindex-appbar) - 1);
+    z-index: calc(var(--mud-zindex-popover) - 1);
 
     &.open {
       transform: rotate(45deg);

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -5,7 +5,7 @@
     position: fixed;
     right: 16px;
     bottom: 16px;
-    z-index: 2000;
+    z-index: calc(var(--mud-zindex-appbar) + 1);
   }
 
   .mud-fab-menu {
@@ -20,6 +20,18 @@
     z-index: calc(var(--mud-zindex-appbar) - 2);
     width: 100%;
     pointer-events: none;
+
+    &.padding-bottom-small {
+      padding-bottom: 48px;
+    }
+
+    &.padding-bottom-medium {
+      padding-bottom: 52px;
+    }
+
+    &.padding-bottom-large {
+      padding-bottom: 60px;
+    }
 
     &.dampen {
       .mud-fab-menu-item {

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -1,6 +1,13 @@
 .mud-fab-menu-container {
   position: relative;
 
+  &.fixed {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    z-index: 2000;
+  }
+
   .mud-fab-menu {
     position: absolute;
     bottom: 0;

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -1,5 +1,6 @@
 .mud-fab-menu-container {
   position: relative;
+  display: inline-flex;
 
   &.fixed {
     position: fixed;


### PR DESCRIPTION
This pr adds the material component [FabMenu](https://m3.material.io/components/fab-menu/overview) (note that this component should be compatible with M2 and M3).


![FabMenu](https://github.com/user-attachments/assets/cce374fb-d381-4788-ad29-b8cf93bcfa1a)
