### PR TITLE
MudDataGrid, MudTable: Fix Mobile Loading Bar

### DIFF
--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -59,7 +59,7 @@
                         }
                         @if (Loading)
                         {
-                            <tr class="mud-table-row">
+                            <tr>
                                 <th colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
                                     <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                                 </th>

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -532,7 +532,7 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 
 @mixin table-display-smalldevices ($breakpoint) {
   .mud-#{$breakpoint}table {
-    .mud-table-root .mud-table-head,
+    .mud-table-root .mud-table-head .mud-table-row,
     .mud-table-root .mud-table-foot {
       display: none;
     }


### PR DESCRIPTION
<!-- MAKE SURE TO READ THE CONTRIBUTING GUIDE: https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md -->
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

The loading bar being in the header is hidden in smaller layouts. Adjusted the css to only hide items with .mud-table-row which the loading bar does not contain in `MudDataGrid` and removed `mud-table-row` from the surrounding row in `MudTable`. 

I checked all viewer tests in WASM and Docs in BSS, found no discrepencies and now everything works as it should. There is always the concern that someone could be targeting the loading CSS with mud-table-row as a combination class but I think that is a rather far fetched chance as it's not necessary for targetting.

Resolves #12091 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- The PR is submitted to the correct branch (`dev`).
- My code follows the style of this project.
- I've added relevant tests or confirmed existing ones.
