### PR TITLE
MudSnackbar: Make snackbar require interaction when action present

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/ManualMarkdown/MarkdownSnackbarConfigurationService.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/ManualMarkdown/MarkdownSnackbarConfigurationService.razor
@@ -7,7 +7,7 @@
 <span class="localVar">services</span>.<span class="function">AddMudServices</span>(<span class="localVar">config</span> =&gt;
 {
     <span class="localVar">config.SnackbarConfiguration</span>.PositionClass = <span class="class">Defaults</span>.<span class="class">Classes</span>.<span class="class">Position</span>.BottomLeft;
-
+    <span class="localVar">config.SnackbarConfiguration</span>.RequireInteraction = <span class="keyword">false</span>;
     <span class="localVar">config.SnackbarConfiguration</span>.PreventDuplicates = <span class="keyword">false</span>;
     <span class="localVar">config.SnackbarConfiguration</span>.NewestOnTop = <span class="keyword">false</span>;
     <span class="localVar">config.SnackbarConfiguration</span>.ShowCloseIcon = <span class="keyword">true</span>;

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
@@ -156,7 +156,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Require Interaction">
-                <Description>With the <CodeInline>@nameof(CommonSnackbarOptions.RequireInteraction)</CodeInline> property set to true, the <CodeInline>@nameof(MudBlazor.Snackbar)</CodeInline> will not disappear until the user interacts with it.</Description>
+                <Description>Snackbars that define an action button stay visible until the user interacts with them. Use the <CodeInline>@nameof(CommonSnackbarOptions.RequireInteraction)</CodeInline> property to enforce this behavior for all snackbars or to opt out when actions should still dismiss automatically.</Description>
             </SectionHeader>
             <SectionContent Class="pa-0" Code="@nameof(SnackbarRequireInteractionExample)" ShowCode="false">
                 <SnackbarRequireInteractionExample />

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -524,6 +524,53 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task ActionRequiresInteractionByDefault()
+        {
+            Snackbar? snackbar = null;
+
+            await _provider.InvokeAsync(() =>
+                snackbar = _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>
+                {
+                    c.ShowTransitionDuration = 0;
+                    c.HideTransitionDuration = 0;
+                    c.VisibleStateDuration = 10;
+                    c.Action = "Close";
+                    c.OnClick = _ => Task.CompletedTask;
+                })
+            );
+
+            snackbar.Should().NotBeNull();
+            _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
+
+            await Task.Delay(200);
+
+            _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
+
+            _provider.Find(".mud-snackbar-action-button").Click();
+
+            _provider.WaitForAssertion(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
+        }
+
+        [Test]
+        public async Task ActionAllowsAutoDismissWhenDisabled()
+        {
+            await _provider.InvokeAsync(() =>
+                _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>
+                {
+                    c.ShowTransitionDuration = 0;
+                    c.HideTransitionDuration = 0;
+                    c.VisibleStateDuration = 10;
+                    c.Action = "Close";
+                    c.RequireInteraction = false;
+                })
+            );
+
+            _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
+
+            _provider.WaitForAssertion(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
+        }
+
+        [Test]
         public async Task CannotStopCloseTransition()
         {
             // Set up the snackbar.

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -526,7 +526,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ActionRequiresInteractionByDefault()
         {
-            Snackbar? snackbar = null;
+            Snackbar snackbar = null;
 
             await _provider.InvokeAsync(() =>
                 snackbar = _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -54,9 +54,10 @@ public abstract class CommonSnackbarOptions
     /// Shows the snackbar until a user manually closes it.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>false</c>.
+    /// Defaults to <c>null</c>.  When <c>null</c>, snackbars that define an
+    /// <see cref="SnackbarOptions.Action"/> will require user interaction by default.
     /// </remarks>
-    public bool RequireInteraction { get; set; } = false;
+    public bool? RequireInteraction { get; set; }
 
     /// <summary>
     /// Blurs the background of the snackbar.

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -121,7 +121,7 @@ namespace MudBlazor
                     TransitionTo(SnackbarState.Visible);
                 }
             }
-            else if (state.IsVisible() && !options.RequireInteraction)
+            else if (state.IsVisible() && !options.RequiresInteraction)
             {
                 if (!animate || !StartTimer(options.VisibleStateDuration))
                 {

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -92,6 +92,8 @@ namespace MudBlazor
         /// </remarks>
         public SnackbarDuplicatesBehavior DuplicatesBehavior { get; set; } = SnackbarDuplicatesBehavior.GlobalDefault;
 
+        internal bool RequiresInteraction => RequireInteraction ?? !string.IsNullOrWhiteSpace(Action);
+
         /// <summary>
         /// Creates new options for a snackbar.
         /// </summary>


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

It's suggested in MD3 that snackbars that contain actions shouldn't fade out by themselves. https://m3.material.io/components/snackbar/guidelines#e90db9ca-e080-470f-b6c6-91afabc4ee26

This changes the default but you can still explicitly set RequireInteraction in order to control it.

Closes #11634

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
