### PR TITLE
MudFormComponent: Make ErrorText property two-way bindable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithErrorTextTwoWayBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithErrorTextTwoWayBindingTest.razor
@@ -1,0 +1,17 @@
+﻿<MudForm>
+    <MudTextField T="string" @bind-Value="Text" Validation="((Func<string, IEnumerable<string>>)(v => ValidateText(v)))" @bind-ErrorText="BoundErrorText"/>
+</MudForm>
+
+@code {
+    public string Text { get; set; } = "Lorem Ipsum.";
+    public string BoundErrorText { get; set; } = "Default value not changed by binding";
+
+    public IEnumerable<string> ValidateText(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ["EmptyOrWhitespace!"];
+        }
+        return [];
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -178,7 +178,7 @@ namespace MudBlazor.UnitTests.Components
             checkbox.Find("input").Change(true);
             form.IsValid.Should().BeTrue();
             checkbox.Instance.Error.Should().BeFalse();
-            checkbox.Instance.ErrorText.Should().Be(null);
+            checkbox.Instance.GetState(x => x.ErrorText).Should().Be(null);
         }
 
         /// <summary>
@@ -207,14 +207,14 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.Validate());
             form.IsValid.Should().BeTrue();
             checkbox.Instance.Error.Should().BeFalse();
-            checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
+            checkbox.Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // state: false, form should be valid
             checkbox.Find("input").Change(false);
             await comp.InvokeAsync(() => form.Validate());
             form.IsValid.Should().BeTrue();
             checkbox.Instance.Error.Should().BeFalse();
-            checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
+            checkbox.Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // state: null, form should be invalid again
             checkbox.Find("input").Change(null);

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -170,7 +170,7 @@ namespace MudBlazor.UnitTests.Components
             checkbox.Find("input").Change(false);
             checkbox.Instance.Error.Should().BeTrue();
             checkbox.Markup.Should().Contain("You must agree");
-            checkbox.Instance.GetState(x=> x.ErrorText).Should().Be("You must agree");
+            checkbox.Instance.GetState(x => x.ErrorText).Should().Be("You must agree");
             form.IsValid.Should().BeFalse();
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("You must agree");

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -169,7 +169,7 @@ namespace MudBlazor.UnitTests.Components
             // click the checkbox to make the form invalid again because the checkbox is required
             checkbox.Find("input").Change(false);
             checkbox.Instance.Error.Should().BeTrue();
-            checkbox.Find(".mud-input-helper-text.mud-input-error").TextContent.Should().Be("You must agree");
+            checkbox.Markup.Should().Contain("You must agree");
             checkbox.Instance.GetState(x=> x.ErrorText).Should().Be("You must agree");
             form.IsValid.Should().BeFalse();
             form.Errors.Length.Should().Be(1);
@@ -199,7 +199,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.Validate());
             form.IsValid.Should().BeFalse();
             checkbox.Instance.Error.Should().BeTrue();
-            checkbox.Instance.ErrorText.Should().Be("You must select a value");
+            checkbox.Markup.Should().Contain("You must select a value");
+            checkbox.Instance.GetState(x => x.ErrorText).Should().Be("You must select a value");
 
             // state: true, form should be valid
             checkbox.Find("input").Change(true);
@@ -220,7 +221,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.Validate());
             form.IsValid.Should().BeFalse();
             checkbox.Instance.Error.Should().BeTrue();
-            checkbox.Instance.ErrorText.Should().Be("You must select a value");
+            checkbox.Markup.Should().Contain("You must select a value");
+            checkbox.Instance.GetState(x => x.ErrorText).Should().Be("You must select a value");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.CheckBox;
 using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;
@@ -168,7 +169,8 @@ namespace MudBlazor.UnitTests.Components
             // click the checkbox to make the form invalid again because the checkbox is required
             checkbox.Find("input").Change(false);
             checkbox.Instance.Error.Should().BeTrue();
-            checkbox.Instance.ErrorText.Should().Be("You must agree");
+            checkbox.Find(".mud-input-helper-text.mud-input-error").TextContent.Should().Be("You must agree");
+            checkbox.Instance.GetState(x=> x.ErrorText).Should().Be("You must agree");
             form.IsValid.Should().BeFalse();
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("You must agree");

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -8,6 +8,7 @@ using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;
@@ -614,7 +615,9 @@ namespace MudBlazor.UnitTests.Components
             // validated the picker
             await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Validate());
             dateRangePickerInstance.Error.Should().BeTrue("Value is required and should be handled as invalid");
-            dateRangePickerInstance.ErrorText.Should().Be(errorMessage);
+            dateRangePickerComponent.Markup.Should().Contain(errorMessage);
+            dateRangePickerInstance.GetState(x => x.ErrorText).Should().Be(errorMessage);
+
 
             // set a value
             await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Text = RangeConverter<DateTime>.Join(startDate.ToShortDateString(), endDate.ToShortDateString()));
@@ -623,16 +626,18 @@ namespace MudBlazor.UnitTests.Components
             dateRangePickerInstance.DateRange.Start.Should().Be(startDate);
             dateRangePickerInstance.DateRange.End.Should().Be(endDate);
             dateRangePickerInstance.Error.Should().BeFalse("Value has been set and should be handled as valid");
-            dateRangePickerInstance.ErrorText.Should().BeNullOrWhiteSpace();
+            dateRangePickerComponent.Markup.Should().NotContain(errorMessage);
+            dateRangePickerInstance.GetState(x => x.ErrorText).Should().BeNull();
 
             // reset value
             await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.ClearAsync());
 
-            // assert values have benn nulled
+            // assert values have been nulled
             dateRangePickerInstance.Text.Should().BeNullOrEmpty();
             dateRangePickerInstance.DateRange.Should().Be(null);
             dateRangePickerInstance.Error.Should().BeTrue("Value has been cleared and should be handled as invalid");
-            dateRangePickerInstance.ErrorText.Should().Be(errorMessage);
+            dateRangePickerComponent.Markup.Should().Contain(errorMessage);
+            dateRangePickerInstance.GetState(x => x.ErrorText).Should().Be(errorMessage);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.Mocks;
 using MudBlazor.UnitTests.TestComponents.FileUpload;
@@ -232,11 +233,11 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse(); //form is invalid to start
 
             var single = comp.FindComponent<MudFileUpload<IBrowserFile>>();
-            single.Instance.ErrorText.Should().Be("'File' must not be empty.");
+            single.Instance.GetState(x => x.ErrorText).Should().Be("'File' must not be empty.");
             single.Markup.Should().Contain("'File' must not be empty.");
 
             var multiple = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
-            multiple.Instance.ErrorText.Should().Be("'Files' must not be empty.");
+            multiple.Instance.GetState(x => x.ErrorText).Should().Be("'Files' must not be empty.");
             multiple.Markup.Should().Contain("'Files' must not be empty.");
 
             var singleInput = single.FindComponent<InputFile>();
@@ -244,7 +245,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => form.Validate());
 
-            single.Instance.ErrorText.Should().Be(null); //first input is now valid
+            single.Instance.GetState(x => x.ErrorText).Should().BeNull();
             single.Markup.Should().NotContain("'File' must not be empty.");
 
             form.IsValid.Should().BeFalse(); //form is still invalid
@@ -254,7 +255,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => form.Validate());
 
-            single.Instance.ErrorText.Should().Be(null); //second input is now valid
+            single.Instance.GetState(x => x.ErrorText).Should().BeNull();
             single.Markup.Should().NotContain("'Files' must not be empty.");
 
             form.IsValid.Should().BeTrue(); //form is now valid
@@ -457,7 +458,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.File.Should().BeNull(); // File should be rejected
             fileUpload.Error.Should().BeTrue();
-            fileUpload.ErrorText.Should().Be("File 'test.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.GetState(x => x.ErrorText).Should().Be("File 'test.txt' exceeds the maximum allowed size of 100 bytes.");
         }
 
         [Test]
@@ -519,7 +520,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Files.Should().Contain(f => f.Name == "test1.txt");
             comp.Instance.Files.Should().Contain(f => f.Name == "test3.txt");
             fileUpload.Error.Should().BeTrue();
-            fileUpload.ErrorText.Should().Be("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.GetState(x => x.ErrorText).Should().Be("File 'test2.txt' exceeds the maximum allowed size of 100 bytes.");
         }
 
         [Test]
@@ -584,14 +585,14 @@ namespace MudBlazor.UnitTests.Components
             var fileUpload = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>().Instance;
 
             fileUpload.Error.Should().BeTrue();
-            fileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.GetState(x => x.ErrorText).Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
 
             await comp.InvokeAsync(fileUpload.ClearAsync);
 
             // Assert cleared state
             comp.Instance.Files.Should().BeNull();
             fileUpload.Error.Should().BeFalse(); // Errors should be cleared
-            fileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
+            fileUpload.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             fileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
         }
 
@@ -610,7 +611,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert initial error state
             comp.Instance.File.Should().BeNull();
             fileUpload.Error.Should().BeTrue();
-            fileUpload.ErrorText.Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
+            fileUpload.GetState(x => x.ErrorText).Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
 
             await comp.InvokeAsync(fileUpload.ResetValidation);
 

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -476,7 +476,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.File.Name.Should().Be("test.txt");
             comp.Instance.File.Size.Should().Be(200);
             fileUpload.Error.Should().BeFalse();
-            fileUpload.ErrorText.Should().BeNullOrEmpty();
+            fileUpload.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         [Test]
@@ -497,7 +497,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Files[0].Name.Should().Be("test1.txt");
             comp.Instance.Files[1].Name.Should().Be("test2.txt");
             fileUpload.Error.Should().BeFalse();
-            fileUpload.ErrorText.Should().BeNullOrEmpty();
+            fileUpload.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         [Test]
@@ -564,7 +564,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Files[0].Name.Should().Be("test1.txt");
             comp.Instance.Files[1].Name.Should().Be("test2.txt");
             fileUpload.Error.Should().BeFalse();
-            fileUpload.ErrorText.Should().BeNullOrEmpty();
+            fileUpload.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         [Test]
@@ -618,7 +618,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert cleared state
             comp.Instance.File.Should().BeNull();
             fileUpload.Error.Should().BeFalse(); // Errors should be cleared
-            fileUpload.ErrorText.Should().BeNullOrEmpty(); // ErrorText should be cleared
+            fileUpload.GetState(x => x.ErrorText).Should().BeNullOrEmpty(); // ErrorText should be cleared
             fileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
         }
     }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
@@ -1862,6 +1863,34 @@ namespace MudBlazor.UnitTests.Components
             await validator.InvokeAsync(() => validator.Instance.ClearErrors());
 
             tf.Instance.ValidationErrors.Should().HaveCount(0);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public void FormComponentTest_ErrorTextTwoWayBinding()
+        {
+            var comp = Context.RenderComponent<FormWithErrorTextTwoWayBindingTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textInput = comp.Find("input");
+
+            // check initial state: ErrorText and bound Property should be the default value defined inside the component property.
+            comp.Instance.BoundErrorText.Should().Be("Default value not changed by binding");
+            textField.GetState(x => x.ErrorText).Should().Be("Default value not changed by binding");
+
+            // call validation on the textfield: now the error text should be null and the bound property aswell
+            textField.Validate();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
+            comp.Instance.BoundErrorText.Should().BeNullOrEmpty();
+
+            // empty the input text and call validation: now the error text and the bound property should be the validation error message.
+            textInput.Change("");
+            textField.Validate();
+            textField.GetState(x => x.ErrorText).Should().Be("EmptyOrWhitespace!");
+            comp.Instance.BoundErrorText.Should().Be("EmptyOrWhitespace!");
+            comp.Markup.Should().Contain("EmptyOrWhitespace!");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid, but text field does not display an error initially!
             form.IsValid.Should().Be(false);
             textField.Error.Should().BeFalse();
-            textField.ErrorText.Should().BeNullOrEmpty();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textFieldcomp.Find("input").Change("Marilyn Manson");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
@@ -266,7 +266,7 @@ namespace MudBlazor.UnitTests.Components
             //form.IsValid.Should().Be(true);
             //form.Errors.Length.Should().Be(0);
             //textField.Error.Should().BeFalse();
-            //textField.ErrorText.Should().BeNullOrEmpty();
+            //textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // ok, not a rock star, but a star nonetheless
             textFieldcomp.Find("input").Change("Marilyn Monroe");
@@ -1233,28 +1233,28 @@ namespace MudBlazor.UnitTests.Components
             var numericFields = comp.FindComponents<MudNumericField<decimal>>();
 
             textfields[0].Instance.HasErrors.Should().BeFalse();
-            textfields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[1].Instance.HasErrors.Should().BeFalse();
-            textfields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[2].Instance.HasErrors.Should().BeFalse();
-            textfields[2].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[3].Instance.HasErrors.Should().BeFalse();
-            textfields[3].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[3].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[4].Instance.HasErrors.Should().BeFalse();
-            textfields[4].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[4].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[5].Instance.HasErrors.Should().BeFalse();
-            textfields[5].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[5].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             //Nested Forms
             textfields[6].Instance.HasErrors.Should().BeFalse();
-            textfields[6].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[6].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             numericFields[0].Instance.HasErrors.Should().BeFalse();
-            numericFields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            numericFields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             textfields[7].Instance.HasErrors.Should().BeFalse();
-            textfields[7].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[7].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             numericFields[1].Instance.HasErrors.Should().BeFalse();
-            numericFields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            numericFields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -1826,12 +1826,12 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid, but text field does not display an error initially!
             parentForm.IsValid.Should().Be(false);
             parentTextField.Error.Should().BeFalse();
-            parentTextField.ErrorText.Should().BeNullOrEmpty();
+            parentTextField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             parentTextFieldCmp.Find("input").Change("Marilyn Manson");
             parentForm.IsValid.Should().Be(true);
             parentForm.Errors.Length.Should().Be(0);
             parentTextField.Error.Should().BeFalse();
-            parentTextField.ErrorText.Should().BeNullOrEmpty();
+            parentTextField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // display the child form
             childFormSwitch.Change(true);
             var forms = comp.FindComponents<MudForm>();

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -4,6 +4,7 @@ using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.Utilities;
@@ -33,27 +34,27 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
-            textField.ErrorText.Should().BeNullOrEmpty();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // clear value to null
             textFieldcomp.Find("input").Change(null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Enter a rock star");
             textField.Error.Should().BeTrue();
-            textField.ErrorText.Should().Be("Enter a rock star");
+            textField.GetState(x => x.ErrorText).Should().Be("Enter a rock star");
             // set value to "" -> should also be an error
             textFieldcomp.Find("input").Change("");
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Enter a rock star");
             textField.Error.Should().BeTrue();
-            textField.ErrorText.Should().Be("Enter a rock star");
+            textField.GetState(x => x.ErrorText).Should().Be("Enter a rock star");
             //
             textFieldcomp.Find("input").Change("Kurt Cobain");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
-            textField.ErrorText.Should().BeNullOrEmpty();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -243,19 +244,19 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid, but text field does not display an error initially!
             form.IsValid.Should().Be(false);
             textField.Error.Should().BeFalse();
-            textField.ErrorText.Should().BeNullOrEmpty();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // this rock star starts with Marilyn
             textFieldcomp.Find("input").Change("Marilyn Manson");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
-            textField.ErrorText.Should().BeNullOrEmpty();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // this rock star doesn't start with Marilyn
             textFieldcomp.Find("input").Change("Kurt Cobain");
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             textField.Error.Should().BeTrue();
-            textField.ErrorText.Should().Be("Invalid");
+            textField.GetState(x => x.ErrorText).Should().Be("Invalid");
 
             // note: this logic is invalid, so it was removed. Validation funcs are always called
             // the validation func must validate non-required empty fields as valid.
@@ -272,7 +273,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             textField.Error.Should().BeFalse();
-            textField.ErrorText.Should().BeNullOrEmpty();
+            textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -516,26 +517,26 @@ namespace MudBlazor.UnitTests.Components
             validateButton.Find("button").Click();
             var textfields = comp.FindComponents<MudTextField<string>>();
             comp.WaitForAssertion(() => textfields[0].Instance.HasErrors.Should().BeTrue());
-            textfields[0].Instance.ErrorText.Should().Be("User name is required!");
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().Be("User name is required!");
             comp.WaitForAssertion(() => textfields[1].Instance.HasErrors.Should().BeTrue());
-            textfields[1].Instance.ErrorText.Should().Be("Email is required!");
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().Be("Email is required!");
             comp.WaitForAssertion(() => textfields[2].Instance.HasErrors.Should().BeTrue());
-            textfields[2].Instance.ErrorText.Should().Be("Password is required!");
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().Be("Password is required!");
             var checkbox = comp.FindComponent<MudCheckBox<bool>>();
             comp.WaitForAssertion(() => checkbox.Instance.HasErrors.Should().BeTrue());
-            checkbox.Instance.ErrorText.Should().Be("You must agree");
+            checkbox.Instance.GetState(x => x.ErrorText).Should().Be("You must agree");
             // click reset validation
             var resetValidationButton = buttons[3];
             resetValidationButton.Find("button").Click();
             comp.WaitForState(() => form.Errors.Length == 0);
             comp.WaitForAssertion(() => textfields[0].Instance.HasErrors.Should().BeFalse());
-            textfields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => textfields[1].Instance.HasErrors.Should().BeFalse());
-            textfields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => textfields[2].Instance.HasErrors.Should().BeFalse());
-            textfields[2].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => checkbox.Instance.HasErrors.Should().BeFalse());
-            checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
+            checkbox.Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // fill in the form to make it valid
             textfields[0].Find("input").Change("Rick Sanchez");
             textfields[1].Find("input").Change("rick.sanchez@citadel-of-ricks.com");
@@ -549,16 +550,16 @@ namespace MudBlazor.UnitTests.Components
             resetButton.Find("button").Click();
             comp.WaitForState(() => form.Errors.Length == 0);
             comp.WaitForAssertion(() => textfields[0].Instance.HasErrors.Should().BeFalse());
-            textfields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[0].Instance.Text.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => textfields[1].Instance.HasErrors.Should().BeFalse());
-            textfields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[1].Instance.Text.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => textfields[2].Instance.HasErrors.Should().BeFalse());
-            textfields[2].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[2].Instance.Text.Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => checkbox.Instance.HasErrors.Should().BeFalse());
-            checkbox.Instance.ErrorText.Should().BeNullOrEmpty();
+            checkbox.Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             comp.WaitForAssertion(() => checkbox.Instance.Value.Should().BeFalse());
             // TODO: fill out the form with errors, field after field, check how fields get validation errors after blur
         }
@@ -577,20 +578,20 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid
             form.IsValid.Should().Be(false);
             radioGroup.Error.Should().BeFalse();
-            radioGroup.ErrorText.Should().BeNullOrEmpty();
+            radioGroup.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // click on first radio: form should be valid now
             radioGroupcomp.Find("input").Click();
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             radioGroup.Error.Should().BeFalse();
-            radioGroup.ErrorText.Should().BeNullOrEmpty();
+            radioGroup.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // clear selection
             comp.SetParam("Selected", null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             radioGroup.Error.Should().BeTrue();
-            radioGroup.ErrorText.Should().Be("Required");
+            radioGroup.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -609,21 +610,21 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeFalse();
             form.IsValid.Should().BeFalse();
             colorPicker.Error.Should().BeFalse();
-            colorPicker.ErrorText.Should().BeNullOrEmpty();
+            colorPicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // input a valid color
             await comp.InvokeAsync(() => colorPickerComp.FindAll("input")[0].Change("#111111"));
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeTrue();
             form.Errors.Length.Should().Be(0);
             colorPicker.Error.Should().BeFalse();
-            colorPicker.ErrorText.Should().BeNullOrEmpty();
+            colorPicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // reset to forbidden color
             comp.SetParam(x => x.ColorValue, forbiddenColor);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be($"{forbiddenColor.Value} is not allowed");
             colorPicker.Error.Should().BeTrue();
-            colorPicker.ErrorText.Should().Be($"{forbiddenColor.Value} is not allowed");
+            colorPicker.GetState(x => x.ErrorText).Should().Be($"{forbiddenColor.Value} is not allowed");
         }
 
         /// <summary>
@@ -655,7 +656,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeTrue();
             form.Errors.Length.Should().Be(0);
             colorPicker.Error.Should().BeFalse();
-            colorPicker.ErrorText.Should().BeNullOrEmpty();
+            colorPicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             await comp.InvokeAsync(() => comp.Find("div.mud-picker-color-dot-current").Click());
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(1));
@@ -668,7 +669,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be($"{forbiddenColor.Value} is not allowed");
             colorPicker.Error.Should().BeTrue();
-            colorPicker.ErrorText.Should().Be($"{forbiddenColor.Value} is not allowed");
+            colorPicker.GetState(x => x.ErrorText).Should().Be($"{forbiddenColor.Value} is not allowed");
         }
 
         /// <summary>
@@ -684,20 +685,20 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid because datepicker is required
             form.IsValid.Should().Be(false);
             datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            datepicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // input a date
             dateComp.Find("input").Change(new DateTime(2001, 01, 31).ToShortDateString());
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            datepicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // clear selection
             comp.SetParam(x => x.Date, null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             datepicker.Error.Should().BeTrue();
-            datepicker.ErrorText.Should().Be("Required");
+            datepicker.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -715,14 +716,14 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             datepicker.Error.Should().BeFalse();
-            datepicker.ErrorText.Should().BeNullOrEmpty();
+            datepicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // set invalid date:
             comp.SetParam(x => x.Date, (DateTime?)new DateTime(1999, 1, 1));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Year must be >= 2000");
             datepicker.Error.Should().BeTrue();
-            datepicker.ErrorText.Should().Be("Year must be >= 2000");
+            datepicker.GetState(x => x.ErrorText).Should().Be("Year must be >= 2000");
         }
 
         /// <summary>
@@ -741,21 +742,21 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid because dateRangePicker is required
             form.IsValid.Should().Be(false);
             dateRangePicker.Error.Should().BeFalse();
-            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            dateRangePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // input a date
             await comp.InvokeAsync(() => dateRangeComp.FindAll("input")[0].Change(firstDateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern)));
             await comp.InvokeAsync(() => dateRangeComp.FindAll("input")[1].Change(secondDateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern)));
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             dateRangePicker.Error.Should().BeFalse();
-            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            dateRangePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // clear selection
             comp.SetParam(x => x.DateRange, null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             dateRangePicker.Error.Should().BeTrue();
-            dateRangePicker.ErrorText.Should().Be("Required");
+            dateRangePicker.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -771,7 +772,7 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid because dateRangePicker is required
             form.IsValid.Should().Be(false);
             dateRangePicker.Error.Should().BeFalse();
-            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            dateRangePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             comp.Find("input").Click();
             // clicking day buttons to select a date range
             await comp.InvokeAsync(() => comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).Click());
@@ -783,14 +784,14 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             dateRangePicker.Error.Should().BeFalse();
-            dateRangePicker.ErrorText.Should().BeNullOrEmpty();
+            dateRangePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // clear selection
             comp.SetParam(x => x.DateRange, null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             dateRangePicker.Error.Should().BeTrue();
-            dateRangePicker.ErrorText.Should().Be("Required");
+            dateRangePicker.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -806,20 +807,20 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid because datepicker is required
             form.IsValid.Should().Be(false);
             timePicker.Error.Should().BeFalse();
-            timePicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // input a date
             timePickerComp.Find("input").Change("09:30");
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             timePicker.Error.Should().BeFalse();
-            timePicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // clear selection
             comp.SetParam(x => x.Time, null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             timePicker.Error.Should().BeTrue();
-            timePicker.ErrorText.Should().Be("Required");
+            timePicker.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -837,14 +838,14 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             timePicker.Error.Should().BeFalse();
-            timePicker.ErrorText.Should().BeNullOrEmpty();
+            timePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // set invalid date:
             comp.SetParam(x => x.Time, (TimeSpan?)new TimeSpan(0, 17, 05, 00)); // "17:05"
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Only full hours allowed");
             timePicker.Error.Should().BeTrue();
-            timePicker.ErrorText.Should().Be("Only full hours allowed");
+            timePicker.GetState(x => x.ErrorText).Should().Be("Only full hours allowed");
         }
 
         /// <summary>
@@ -865,7 +866,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.Error.Should().BeFalse();
-            fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
+            fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // add a file
             input.UploadFiles(fileToUpload);
@@ -884,7 +885,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             fileUploadInstance.Error.Should().BeTrue();
-            fileUploadInstance.ErrorText.Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -907,7 +908,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.Error.Should().BeFalse();
-            fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
+            fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // clear files
             await input.ClearFilesAsync();
@@ -919,7 +920,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             fileUploadInstance.Error.Should().BeTrue();
-            fileUploadInstance.ErrorText.Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
@@ -927,6 +928,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(0);
             fileUploadInstance.Error.Should().BeFalse();
+            fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             fileUploadInstance.Files.Name.Should().Be(fileName);
         }
 
@@ -951,7 +953,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.Files.Should().NotBeNull();
             fileUploadInstance.Error.Should().BeFalse();
-            fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
+            fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // clear files
             await comp.InvokeAsync(async () => await fileUploadInstance.ClearAsync());
@@ -963,7 +965,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             fileUploadInstance.Error.Should().BeTrue();
-            fileUploadInstance.ErrorText.Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
@@ -993,7 +995,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.Files.Should().NotBeNull();
             fileUploadInstance.Error.Should().BeFalse();
-            fileUploadInstance.ErrorText.Should().BeNullOrEmpty();
+            fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // clear files
             await comp.InvokeAsync(() => comp.Find("button#clear-button").Click());
@@ -1005,7 +1007,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             fileUploadInstance.Error.Should().BeTrue();
-            fileUploadInstance.ErrorText.Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
@@ -1013,6 +1015,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(0);
             fileUploadInstance.Error.Should().BeFalse();
+            fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             fileUploadInstance.Files.Name.Should().Be(fileName);
         }
 
@@ -1027,13 +1030,17 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("form").Submit();
             var textfields = comp.FindComponents<MudTextField<string>>();
             textfields[0].Instance.HasErrors.Should().BeTrue();
-            textfields[0].Instance.ErrorText.Should().Be("The Username field is required.");
+            textfields[0].Markup.Should().Contain("The Username field is required.");
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().Be("The Username field is required.");
             textfields[1].Instance.HasErrors.Should().BeTrue();
-            textfields[1].Instance.ErrorText.Should().Be("The Email field is required.");
+            textfields[1].Markup.Should().Contain("The Email field is required.");
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().Be("The Email field is required.");
             textfields[2].Instance.HasErrors.Should().BeTrue();
-            textfields[2].Instance.ErrorText.Should().Be("The Password field is required.");
+            textfields[2].Markup.Should().Contain("The Password field is required.");
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().Be("The Password field is required.");
             textfields[3].Instance.HasErrors.Should().BeTrue();
-            textfields[3].Instance.ErrorText.Should().Be("The Password2 field is required.");
+            textfields[3].Markup.Should().Contain("The Password2 field is required.");
+            textfields[3].Instance.GetState(x => x.ErrorText).Should().Be("The Password2 field is required.");
         }
 
         /// <summary>
@@ -1054,14 +1061,15 @@ namespace MudBlazor.UnitTests.Components
             // same effect as clicking the validate button
             comp.Find("form").Submit();
             var textfields = comp.FindComponents<MudTextField<string>>();
-            textfields[0].Instance.ErrorText.Should().Be("Name length can't be more than 8.");
+            textfields[0].Markup.Should().Contain("Name length can't be more than 8.");
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().Be("Name length can't be more than 8.");
             textfields[0].Instance.HasErrors.Should().BeTrue();
             textfields[1].Instance.HasErrors.Should().BeFalse();
-            textfields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[2].Instance.HasErrors.Should().BeFalse();
-            textfields[2].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[3].Instance.HasErrors.Should().BeFalse();
-            textfields[3].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[3].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -1125,28 +1133,28 @@ namespace MudBlazor.UnitTests.Components
             var numericFields = comp.FindComponents<MudNumericField<decimal>>();
 
             textfields[0].Instance.HasErrors.Should().BeFalse();
-            textfields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[1].Instance.HasErrors.Should().BeFalse();
-            textfields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[2].Instance.HasErrors.Should().BeFalse();
-            textfields[2].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[3].Instance.HasErrors.Should().BeFalse();
-            textfields[3].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[3].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[4].Instance.HasErrors.Should().BeFalse();
-            textfields[4].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[4].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[5].Instance.HasErrors.Should().BeFalse();
-            textfields[5].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[5].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             //Nested Forms
             textfields[6].Instance.HasErrors.Should().BeFalse();
-            textfields[6].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[6].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             numericFields[0].Instance.HasErrors.Should().BeFalse();
-            numericFields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            numericFields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             textfields[7].Instance.HasErrors.Should().BeTrue();
-            textfields[7].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            textfields[7].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
             numericFields[1].Instance.HasErrors.Should().BeTrue();
-            numericFields[1].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            numericFields[1].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
         }
 
         /// <summary>
@@ -1170,28 +1178,28 @@ namespace MudBlazor.UnitTests.Components
             var numericFields = comp.FindComponents<MudNumericField<decimal>>();
 
             textfields[0].Instance.HasErrors.Should().BeTrue();
-            textfields[0].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            textfields[0].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
             textfields[1].Instance.HasErrors.Should().BeTrue();
-            textfields[1].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            textfields[1].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
             textfields[2].Instance.HasErrors.Should().BeFalse();
-            textfields[2].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[2].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfields[3].Instance.HasErrors.Should().BeTrue();
-            textfields[3].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            textfields[3].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
             textfields[4].Instance.HasErrors.Should().BeTrue();
-            textfields[4].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            textfields[4].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
             textfields[5].Instance.HasErrors.Should().BeTrue();
-            textfields[5].Instance.ErrorText.Should().NotBeNullOrEmpty();
+            textfields[5].Instance.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
 
             //Nested Forms
             textfields[6].Instance.HasErrors.Should().BeFalse();
-            textfields[6].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[6].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             numericFields[0].Instance.HasErrors.Should().BeFalse();
-            numericFields[0].Instance.ErrorText.Should().BeNullOrEmpty();
+            numericFields[0].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             textfields[7].Instance.HasErrors.Should().BeFalse();
-            textfields[7].Instance.ErrorText.Should().BeNullOrEmpty();
+            textfields[7].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             numericFields[1].Instance.HasErrors.Should().BeFalse();
-            numericFields[1].Instance.ErrorText.Should().BeNullOrEmpty();
+            numericFields[1].Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -1270,7 +1278,7 @@ namespace MudBlazor.UnitTests.Components
             tf.SetParam(nameof(MudTextField<string>.For), expression);
             await comp.InvokeAsync(tf.Instance.Validate);
             tf.Instance.Error.Should().Be(true);
-            tf.Instance.ErrorText.Should().Be("Error in validation func: User error");
+            tf.Instance.GetState(x => x.ErrorText).Should().Be("Error in validation func: User error");
         }
 
         /// <summary>
@@ -1292,7 +1300,7 @@ namespace MudBlazor.UnitTests.Components
             tf.SetParam(nameof(MudTextField<string>.Validation), validationFunc);
             await comp.InvokeAsync(tf.Instance.Validate);
             tf.Instance.Error.Should().Be(true);
-            tf.Instance.ErrorText.Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
+            tf.Instance.GetState(x => x.ErrorText).Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
         }
 
         /// <summary>
@@ -1314,7 +1322,7 @@ namespace MudBlazor.UnitTests.Components
             tf.SetParam(nameof(MudTextField<string>.Validation), validationFunc);
             await comp.InvokeAsync(tf.Instance.Validate);
             tf.Instance.Error.Should().Be(true);
-            tf.Instance.ErrorText.Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
+            tf.Instance.GetState(x => x.ErrorText).Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
         }
 
         /// <summary>
@@ -1339,7 +1347,7 @@ namespace MudBlazor.UnitTests.Components
             tf.SetParam(nameof(MudTextField<string>.For), expression);
             await comp.InvokeAsync(tf.Instance.Validate);
             tf.Instance.Error.Should().Be(true);
-            tf.Instance.ErrorText.Should().Be("Error1");
+            tf.Instance.GetState(x => x.ErrorText).Should().Be("Error1");
         }
 
         /// <summary>
@@ -1869,7 +1877,7 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid because checkBox is required
             form.IsValid.Should().Be(false);
             checkBox.Error.Should().BeFalse();
-            checkBox.ErrorText.Should().BeNullOrEmpty();
+            checkBox.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // tick checkBox with an emulated mouse click
             comp.Find("input").Change(true);
@@ -1877,7 +1885,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             checkBox.Error.Should().BeFalse();
-            checkBox.ErrorText.Should().BeNullOrEmpty();
+            checkBox.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // untick checkBox with an emulated mouse click
             comp.Find("input").Change(false);
@@ -1885,7 +1893,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             checkBox.Error.Should().BeTrue();
-            checkBox.ErrorText.Should().Be("Required");
+            checkBox.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         /// <summary>
@@ -1901,7 +1909,7 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be valid because checkBox is required
             form.IsValid.Should().Be(false);
             checkBox.Error.Should().BeFalse();
-            checkBox.ErrorText.Should().BeNullOrEmpty();
+            checkBox.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // tick checkBox with a key press
             comp.Find("input").KeyDown(Key.Space);
@@ -1909,7 +1917,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
             checkBox.Error.Should().BeFalse();
-            checkBox.ErrorText.Should().BeNullOrEmpty();
+            checkBox.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // untick checkBox with a key press
             comp.Find("input").KeyDown(Key.Space);
@@ -1917,7 +1925,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
             checkBox.Error.Should().BeTrue();
-            checkBox.ErrorText.Should().Be("Required");
+            checkBox.GetState(x => x.ErrorText).Should().Be("Required");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.NumericField;
 using NUnit.Framework;
@@ -202,12 +203,12 @@ namespace MudBlazor.UnitTests.Components
             // first try a valid value
             comp.Find("input").Change(99);
             numericField.Error.Should().BeFalse(because: "The value is < 100");
-            numericField.ErrorText.Should().BeNullOrEmpty();
+            numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // now try something that's outside of range
             comp.Find("input").Change("100.1");
             numericField.Error.Should().BeFalse(because: "The value should be set to Max (100)");
             numericField.Value.Should().Be(100M);
-            numericField.ErrorText.Should().BeNullOrEmpty();
+            numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -222,12 +223,12 @@ namespace MudBlazor.UnitTests.Components
             // first try set max decimal value
             comp.Find("input").Change(decimal.MaxValue);
             numericField.Value.Should().Be(decimal.MaxValue);
-            numericField.ErrorText.Should().BeNullOrEmpty();
+            numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // next try set minimum decimal value
             comp.Find("input").Change(decimal.MinValue);
             numericField.Value.Should().Be(decimal.MinValue);
-            numericField.ErrorText.Should().BeNullOrEmpty();
+            numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
         /// <summary>
@@ -297,7 +298,7 @@ namespace MudBlazor.UnitTests.Components
         //    comp.Find("input").Blur();
         //    numericField.Value.Should().BeNull();
         //    numericField.HasErrors.Should().Be(true);
-        //    numericField.ErrorText.Should().Be("Not a valid number");
+        //    numericField.GetState(x => x.ErrorText).Should().Be("Not a valid number");
         //}
 
         /// <summary>
@@ -311,7 +312,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<NumericFieldRequiredTest>();
             var numericField = comp.FindComponent<MudNumericField<int?>>().Instance;
             numericField.Touched.Should().BeFalse();
-            numericField.ErrorText.Should().BeNullOrEmpty();
+            numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             numericField.HasErrors.Should().Be(false);
         }
 

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Field;
 using MudBlazor.UnitTests.TestComponents.Form;
@@ -226,11 +227,11 @@ namespace MudBlazor.UnitTests.Components
             // first try a valid credit card number
             comp.Find("input").Change("4012 8888 8888 1881");
             textfield.Error.Should().BeFalse(because: "The number is a valid VISA test credit card number");
-            textfield.ErrorText.Should().BeNullOrEmpty();
+            textfield.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // now try something that produces a validation error
             comp.Find("input").Change("0000 1111 2222 3333");
             textfield.Error.Should().BeTrue(because: "The credit card number is fake");
-            textfield.ErrorText.Should().NotBeNullOrEmpty();
+            textfield.GetState(x => x.ErrorText).Should().NotBeNullOrEmpty();
         }
 
 
@@ -299,7 +300,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Blur();
             textfield.Text.Should().Be("A");
             textfield.HasErrors.Should().Be(true);
-            textfield.ErrorText.Should().Be("Not a valid number");
+            textfield.GetState(x => x.ErrorText).Should().Be("Not a valid number");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -313,7 +313,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<TextFieldRequiredTest>();
             var textfield = comp.FindComponent<MudTextField<string>>().Instance;
             textfield.Touched.Should().BeFalse();
-            textfield.ErrorText.Should().BeNullOrEmpty();
+            textfield.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             textfield.HasErrors.Should().Be(false);
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -2,18 +2,14 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor.Interfaces;
+using MudBlazor.State;
 using static System.String;
 
 namespace MudBlazor
@@ -26,6 +22,8 @@ namespace MudBlazor
     /// <typeparam name="U">The value type managed by this input.</typeparam>
     public abstract class MudFormComponent<T, U> : MudComponentBase, IFormComponent, IAsyncDisposable
     {
+        protected readonly ParameterState<string?> ErrorTextState;
+
         [Inject]
         private InternalMudLocalizer Localizer { get; set; } = null!;
 
@@ -33,6 +31,10 @@ namespace MudBlazor
 
         protected MudFormComponent(Converter<T, U> converter)
         {
+            using var registerScope = CreateRegisterScope();
+            ErrorTextState = registerScope.RegisterParameter<string?>(nameof(ErrorText))
+                .WithParameter(() => ErrorText)
+                .WithEventCallback(() => ErrorTextChanged);
             _converter = converter ?? throw new ArgumentNullException(nameof(converter));
             _converter.OnError = OnConversionError;
         }
@@ -73,6 +75,13 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
         public string? ErrorText { get; set; }
+
+        /// <summary>
+        /// Occurs when <see cref="ErrorText"/> has changed.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Validation)]
+        public EventCallback<string?> ErrorTextChanged { get; set; }
 
         /// <summary>
         /// Displays an error.
@@ -205,9 +214,9 @@ namespace MudBlazor
         public string? GetErrorText()
         {
             // ErrorText is either set from outside or the first validation error
-            if (!IsNullOrWhiteSpace(ErrorText))
+            if (!IsNullOrWhiteSpace(ErrorTextState.Value))
             {
-                return ErrorText;
+                return ErrorTextState.Value;
             }
 
             if (!IsNullOrWhiteSpace(ConversionErrorMessage))
@@ -407,7 +416,7 @@ namespace MudBlazor
                     // if Error, create an error id that can be used by aria-describedby on input control
                     ValidationErrors = errors;
                     Error = errors.Count > 0;
-                    ErrorText = errors.FirstOrDefault();
+                    await ErrorTextState.SetValueAsync(errors.FirstOrDefault());
                     ErrorId = HasErrors ? Guid.NewGuid().ToString() : null;
                     Form?.Update(this);
                     StateHasChanged();
@@ -654,7 +663,8 @@ namespace MudBlazor
         {
             Error = false;
             ValidationErrors.Clear();
-            ErrorText = null;
+            //TODO: v9 make the method async
+            ErrorTextState.SetValueAsync(null).CatchAndLog();
             ResetConverterErrors();
             StateHasChanged();
         }
@@ -716,7 +726,8 @@ namespace MudBlazor
             {
                 var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
                 Error = errorMessages.Length > 0;
-                ErrorText = Error ? errorMessages[0] : null;
+                //TODO: v9 there no async API, but just make it async void (acceptable for EventHandler) 
+                ErrorTextState.SetValueAsync(Error ? errorMessages[0] : null).CatchAndLog();
 
                 ValidationErrors.Clear();
                 ValidationErrors.AddRange(errorMessages);

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -7,7 +7,7 @@
 
     protected override RenderFragment InputContent=>
         @<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" Error="@Error"
-                          ErrorText="@ErrorText" Disabled="@GetDisabledState()" Margin="@Margin" Required="@Required"
+                          ErrorText="@ErrorTextState.Value" Disabled="@GetDisabledState()" Margin="@Margin" Required="@Required"
                           @onclick="async () => { if (!Editable) await ToggleStateAsync(); }" ForId="@FieldId">
                <InputContent>
                    <MudRangeInput @ref="_rangeInput"
@@ -28,7 +28,7 @@
                                   Required="@Required"
                                   RequiredError="@RequiredError"
                                   Error="@Error"
-                                  ErrorText="@ErrorText"
+                                  ErrorText="@ErrorTextState.Value"
                                   Margin="@Margin"
                                   AdornmentAriaLabel="@AdornmentAriaLabel"
                                   PlaceholderStart="@PlaceholderStart"

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -317,7 +317,7 @@ namespace MudBlazor
 
             ValidationErrors = [.. ValidationErrors, .. _validationErrors];
             Error = ValidationErrors.Count > 0;
-            ErrorText = ValidationErrors.FirstOrDefault();
+            await ErrorTextState.SetValueAsync(ValidationErrors.FirstOrDefault());
         }
 
         public override void ResetValidation()

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -32,7 +32,7 @@
                        Required="@Required"
                        RequiredError="@RequiredError"
                        Error="@Error"
-                       ErrorText="@ErrorText"
+                       ErrorText="@ErrorTextState.Value"
                        Clearable="@(Clearable && !GetReadOnlyState())"
                        OnClearButtonClick="@(async () => await ClearAsync())"
                        TextUpdateSuppression="@(Editable && !GetReadOnlyState())"


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

Fixes #12106

This PR changes the property `ErrorText` in the component `MudFormComponent`. The EventCallback `ErrorTextChanged` is added and the property is now using `ParameterState` as described in the contribution guidelines. Since the ErrorText property is used in alot of UnitTests i had to adjust all of the usages in the tests to use `.GetState()`.

The `ErrorText` property is also used directly inside `MudPicker`, `MudFileUpload` and `MudDateRangePicker` so those components had to be adjusted in the usage of the property.

The changes in the implementation of the property was done by @ScarletKuro , thanks for helping me with this issue.
This is my first contribution to this repository so i would appreciate a thoroughly check of the changes so i dont break something by accident.