### PR TITLE
MudOverlay: Fix scrollable background with visible dialog

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Overlay/OverlayScrollLockedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Overlay/OverlayScrollLockedTest.razor
@@ -1,0 +1,42 @@
+﻿<MudButton OnClick="(() => _dialogOpen = true)" Variant="Variant.Filled" Color="Color.Primary">
+    Open simple dialog
+</MudButton>
+
+<p>
+
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sit amet posuere quam. Praesent a risus efficitur, vestibulum velit et, tincidunt eros. Nunc ac tempor ligula. Nunc ac vehicula quam. Cras a volutpat nisl. Aenean egestas porttitor dui ut lobortis. Nulla in imperdiet erat, vitae pharetra elit. Sed a lectus quam. Vestibulum posuere sed enim at tincidunt. Mauris ut viverra quam. Proin mattis varius egestas. Aenean cursus arcu massa, non consequat felis cursus nec. Praesent blandit ligula vitae purus laoreet eleifend. Vivamus aliquam tortor vitae odio dignissim porta. Vestibulum ac velit metus. Aliquam ut orci auctor, scelerisque odio suscipit, efficitur ipsum.
+
+    Cras id posuere justo. Praesent tristique, libero a cursus mattis, lacus dui interdum urna, et tristique enim erat sed velit. Integer a laoreet quam. Proin purus arcu, suscipit id luctus at, commodo a risus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed ornare dolor in pellentesque consequat. Sed convallis porta ultrices. Fusce sed orci et ante pharetra porta eget ac neque. Praesent quis viverra ex, et mollis nulla. Aliquam metus diam, venenatis nec arcu aliquet, fringilla blandit massa.
+
+    Proin in sem eget augue consequat porta in eget risus. Phasellus ut turpis id nunc placerat mattis. Nam cursus iaculis cursus. Nunc ullamcorper euismod libero at semper. Aenean ac tempus ligula. Nam ultrices risus sed sollicitudin tincidunt. Nulla auctor neque bibendum eros elementum, ut interdum dui dapibus. Aliquam lacinia erat sem, id fringilla massa condimentum eu.
+
+    Quisque mattis bibendum commodo. Nunc laoreet dui in lectus tincidunt, quis vestibulum tortor ullamcorper. Proin laoreet vulputate accumsan. Sed bibendum ipsum id ligula ullamcorper tristique eu eleifend velit. Donec et eros nec magna mattis cursus non porttitor justo. Nulla eu mauris enim. Mauris semper ut magna nec venenatis.
+
+    Morbi eleifend velit id convallis viverra. Sed dapibus ornare eros vitae venenatis. Suspendisse potenti. Morbi gravida bibendum neque, et lacinia justo pharetra non. Aenean scelerisque, enim varius vestibulum auctor, metus ex bibendum magna, vel ullamcorper ligula nisl eu lacus. In pellentesque, nibh sit amet egestas euismod, tortor nisi aliquam augue, ullamcorper rhoncus lectus magna in massa. Duis nec dolor vel massa lacinia ullamcorper ut nec metus. Sed eu ligula vitae sapien convallis suscipit at at leo. Mauris justo mauris, accumsan nec sapien sed, tristique lobortis ante. Praesent malesuada dictum vestibulum. Integer ac sem vestibulum, tempor massa eget, condimentum nibh.
+</p>
+
+<style>
+    p {
+        font-size: 10rem;
+    }
+</style>
+
+<MudDialog Options="_options" @bind-Visible="_dialogOpen">
+    <TitleContent>
+        Dialog Title
+    </TitleContent>
+    <DialogContent>
+        Dialog Content
+        <MudOverlay Visible="false" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="(() => _dialogOpen = false)">Cancel</MudButton>
+        <MudButton Color="Color.Primary" OnClick="(() => _dialogOpen = false)">OK</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private bool _dialogOpen = false;
+    private DialogOptions _options = new DialogOptions { CloseOnEscapeKey = true };
+}

--- a/src/MudBlazor.UnitTests/Components/OverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/OverlayTests.cs
@@ -2,6 +2,8 @@
 using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.UnitTests.TestComponents.Overlay;
 using NUnit.Framework;
@@ -387,5 +389,47 @@ public class OverlayTests : BunitTest
         {
             scrollManagerMock.Verify(s => s.UnlockScrollAsync(It.IsAny<string>(), It.IsAny<string>()), Times.AtMostOnce());
         }
+    }
+
+    [Test]
+    public void Overlay_StartClosedTest()
+    {
+        var jsRuntimeMock = new Mock<IJSRuntime>(MockBehavior.Loose);
+
+        Context.Services.AddSingleton(typeof(IJSRuntime), jsRuntimeMock.Object);
+        // verifies lockScroll was called once and 2 arguments were supplied
+        jsRuntimeMock
+            .Setup(x => x.InvokeAsync<IJSVoidResult>("mudScrollManager.lockScroll", It.Is<object[]>(y => y.Length == 2)))
+            .ReturnsAsync(Mock.Of<IJSVoidResult>())
+            .Verifiable();
+
+        // Expect unlockScroll to NOT be called
+        jsRuntimeMock
+            .Setup(x => x.InvokeAsync<IJSVoidResult>(
+                "mudScrollManager.unlockScroll",
+                It.IsAny<object[]>()))
+            .Throws(new Exception("unlockScroll should not be called!"));
+
+        var dialog = Context.RenderComponent<MudDialogProvider>();
+        var comp = Context.RenderComponent<OverlayScrollLockedTest>();
+        // click the button opening dialog
+        var button = comp.Find("button");
+        button.Click();
+        // verify dialog is open
+        comp.WaitForAssertion(() => dialog.FindComponent<MudOverlay>().Should().NotBeNull());
+
+        // verify lockScroll was called
+        jsRuntimeMock.Verify(
+            x => x.InvokeAsync<IJSVoidResult>(
+                "mudScrollManager.lockScroll",
+                It.IsAny<object[]>()),
+            Times.Once);
+
+        // verify unlockScroll was NOT called
+        jsRuntimeMock.Verify(
+            x => x.InvokeAsync<IJSVoidResult>(
+                "mudScrollManager.unlockScroll",
+                It.IsAny<object[]>()),
+            Times.Never);
     }
 }

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -218,11 +218,17 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
         {
             _previousLockScroll = LockScroll;
             _previousAbsolute = Absolute;
-            await HandleLockScrollChange();
+
+            // Calling HandleLockScrollChange when the overlay isn't intially set to
+            // visible will incorrectly decrement the lock count
+            if (_visibleState.Value)
+            {
+                await HandleLockScrollChange();
+            }
 
             // If the overlay is initially visible and modeless auto-close is enabled,
             // then start tracking pointer down events.
-            if (Visible && !Modal && AutoClose)
+            if (_visibleState.Value && !Modal && AutoClose)
             {
                 await StartModelessAutoCloseTrackingAsync();
             }
@@ -244,7 +250,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
             return;
         }
 
-        if (Visible)
+        if (_visibleState.Value)
         {
             await StartModelessAutoCloseTrackingAsync();
         }


### PR DESCRIPTION
Fixes #12078 

Added a visibility check on MudOverlay first render to avoid incorrectly decrementing the overlay lock count.

- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
