### PR TITLE
PopoverOptions: Fix missing property assignment

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -522,6 +522,7 @@ public class ServiceCollectionExtensionsTests
             options.PopoverOptions.QueueDelay = TimeSpan.FromSeconds(5);
             options.PopoverOptions.ContainerClass = "container_class";
             options.PopoverOptions.FlipMargin = 100;
+            options.PopoverOptions.OverflowPadding = 12;
             options.PopoverOptions.ThrowOnDuplicateProvider = false;
             options.PopoverOptions.Mode = PopoverMode.Default;
 
@@ -585,6 +586,7 @@ public class ServiceCollectionExtensionsTests
         actualPopoverOptions.QueueDelay.Should().Be(expectedOptions!.PopoverOptions.QueueDelay);
         actualPopoverOptions.ContainerClass.Should().Be(expectedOptions.PopoverOptions.ContainerClass);
         actualPopoverOptions.FlipMargin.Should().Be(expectedOptions.PopoverOptions.FlipMargin);
+        actualPopoverOptions.OverflowPadding.Should().Be(expectedOptions.PopoverOptions.OverflowPadding);
         actualPopoverOptions.ThrowOnDuplicateProvider.Should().Be(expectedOptions.PopoverOptions.ThrowOnDuplicateProvider);
         actualPopoverOptions.Mode.Should().Be(expectedOptions.PopoverOptions.Mode);
 

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -292,6 +292,7 @@ public class ServiceCollectionExtensionsTests
             options.QueueDelay = TimeSpan.FromSeconds(5);
             options.ContainerClass = "container_class";
             options.FlipMargin = 100;
+            options.OverflowPadding = 0;
             options.ThrowOnDuplicateProvider = false;
             options.Mode = PopoverMode.Default;
             expectedOptions = options;

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -410,6 +410,7 @@ namespace MudBlazor.Services
                     popoverOptions.QueueDelay = options.PopoverOptions.QueueDelay;
                     popoverOptions.ThrowOnDuplicateProvider = options.PopoverOptions.ThrowOnDuplicateProvider;
                     popoverOptions.Mode = options.PopoverOptions.Mode;
+                    popoverOptions.OverflowPadding = options.PopoverOptions.OverflowPadding;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

This PR makes the workaround described in https://github.com/MudBlazor/MudBlazor/issues/11894 work as intended by allowing developers to set the `popoverOptions.OverflowPadding` as expected when using `builder.Services.AddMudServices()`

It also adjusts the unittest testing if the options are there after DI.