### PR TITLE
chore: Fix NU1510 System.Text.Json will not be pruned

### DIFF
--- a/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
+++ b/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.10" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.10" />
+    <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Include="System.Net.Http.Json" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="FluentValidation" Version="12.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.10" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.10" />
+    <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Include="System.Net.Http.Json" Version="9.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MudBlazor.Examples.Data\MudBlazor.Examples.Data.csproj" />


### PR DESCRIPTION
Annoying error, when you compile for net9.0 while having SDK 10 installed, MSBuild throws an NU1510 error.
I found the solution here: https://github.com/azure-sdk/docs/blob/adbeb05ad11e1772e4bc4afbf076444fb78869ce/docs/core/compatibility/sdk/10.0/nu1510-pruned-references.md

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
