### PR TITLE
MudFormComponent: Rename methods to async, use await

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/MudFormExample.razor
@@ -29,9 +29,9 @@
             </MudForm>   
         </MudPaper>
         <MudPaper Class="pa-4 mt-4">
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="@(()=>form.Validate())">Validate</MudButton>
-            <MudButton Variant="Variant.Filled" Color="Color.Secondary" DropShadow="false" OnClick="@(()=>form.ResetAsync())" Class="mx-2">Reset</MudButton>
-            <MudButton Variant="Variant.Filled" DropShadow="false" OnClick="@(()=>form.ResetValidation())">Reset Validation</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="@(() => form.Validate())">Validate</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" DropShadow="false" OnClick="@(() => form.ResetAsync())" Class="mx-2">Reset</MudButton>
+            <MudButton Variant="Variant.Filled" DropShadow="false" OnClick="@(() => form.ResetValidationAsync())">Reset Validation</MudButton>
         </MudPaper>
     </MudItem>
     <MudItem xs="12" sm="5">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteValidationTest.razor
@@ -7,7 +7,7 @@
                              RequiredError="Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message. Very long error message." 
                              ResetValueOnEmptyText="true" />
         </MudForm>
-        <MudButton Variant="Variant.Filled" OnClick="@(()=>_form.ResetValidation())">Reset Validation</MudButton>
+        <MudButton Variant="Variant.Filled" OnClick="@(() => _form.ResetValidationAsync())">Reset Validation</MudButton>
     </MudItem>
 </MudGrid>
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormIsValidTest3.razor
@@ -6,7 +6,7 @@
     <div class="d-flex mt-5">
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => _form1.Validate())">Validate</MudButton>
         <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="@(() => _form1.ResetAsync())" Class="mx-2">Reset</MudButton>
-        <MudButton Variant="Variant.Filled" OnClick="@(() => _form1.ResetValidation())">Reset Validation</MudButton>
+        <MudButton Variant="Variant.Filled" OnClick="@(() => _form1.ResetValidationAsync())">Reset Validation</MudButton>
     </div>
     <div class="d-flex mt-3">
         <MudSwitch @bind-Value="@_valid" Label="IsValid " Color="Color.Info" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationTest4.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationTest4.razor
@@ -30,7 +30,7 @@
         <MudPaper Class="pa-4 mt-4">
             <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="@(() => _form.Validate())">Validate</MudButton>
             <MudButton Variant="Variant.Filled" Color="Color.Secondary" DropShadow="false" OnClick="@(() => _form.ResetAsync())" Class="mx-2">Reset</MudButton>
-            <MudButton Variant="Variant.Filled" DropShadow="false" OnClick="@(() => _form.ResetValidation())">Reset Validation</MudButton>
+            <MudButton Variant="Variant.Filled" DropShadow="false" OnClick="@(() => _form.ResetValidationAsync())">Reset Validation</MudButton>
         </MudPaper>
     </MudItem>
     <MudItem xs="12" sm="5">

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -705,7 +705,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Value.Should().Be("Quux");
             autocomplete.Text.Should().Be("Quux");
             // check validity
-            await comp.InvokeAsync(autocomplete.Validate);
+            await comp.InvokeAsync(autocomplete.ValidateAsync);
             autocomplete.ValidationErrors.Should().NotBeEmpty();
             autocomplete.ValidationErrors.Should().HaveCount(1);
             autocomplete.ValidationErrors[0].Should().Be("Should not be longer than 3");
@@ -724,7 +724,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.Value.Should().Be("Qux");
             autocomplete.Text.Should().Be("Qux");
             // check validity
-            await comp.InvokeAsync(autocomplete.Validate);
+            await comp.InvokeAsync(autocomplete.ValidateAsync);
             autocomplete.ValidationErrors.Should().BeEmpty();
         }
 
@@ -740,7 +740,7 @@ namespace MudBlazor.UnitTests.Components
 
             autocomplete.Required.Should().BeTrue();
 
-            await comp.InvokeAsync(autocomplete.Validate);
+            await comp.InvokeAsync(autocomplete.ValidateAsync);
 
             autocomplete.ValidationErrors.First().Should().Be("Required");
         }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -613,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
             dateRangePickerInstance.DateRange.Should().Be(null);
 
             // validated the picker
-            await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.Validate());
+            await dateRangePickerComponent.InvokeAsync(() => dateRangePickerInstance.ValidateAsync());
             dateRangePickerInstance.GetState(x => x.Error).Should().BeTrue("Value is required and should be handled as invalid");
             dateRangePickerComponent.Markup.Should().Contain(errorMessage);
             dateRangePickerInstance.GetState(x => x.ErrorText).Should().Be(errorMessage);

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -613,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
             fileUpload.GetState(x => x.Error).Should().BeTrue();
             fileUpload.GetState(x => x.ErrorText).Should().Be("File 'test1.txt' exceeds the maximum allowed size of 100 bytes.");
 
-            await comp.InvokeAsync(fileUpload.ResetValidation);
+            await comp.InvokeAsync(fileUpload.ResetValidationAsync);
 
             // Assert cleared state
             comp.Instance.File.Should().BeNull();

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -133,7 +133,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().Be(true);
 
             //reset validation should not reset touched state
-            await comp.InvokeAsync(() => form.ResetValidation());
+            await comp.InvokeAsync(() => form.ResetValidationAsync());
             form.IsTouched.Should().Be(true);
         }
 
@@ -168,7 +168,7 @@ namespace MudBlazor.UnitTests.Components
             nestedForm.IsTouched.Should().Be(false);
 
             //reset validation should not reset touched state
-            await comp.InvokeAsync(() => form.ResetValidation());
+            await comp.InvokeAsync(() => form.ResetValidationAsync());
             form.IsTouched.Should().Be(true);
             nestedForm.IsTouched.Should().Be(false);
         }
@@ -206,7 +206,7 @@ namespace MudBlazor.UnitTests.Components
             nestedForm.IsTouched.Should().Be(true);
 
             //reset validation should not reset touched state
-            await comp.InvokeAsync(() => nestedFormDateField.ResetValidation());
+            await comp.InvokeAsync(() => nestedFormDateField.ResetValidationAsync());
             form.IsTouched.Should().Be(false);
             nestedForm.IsTouched.Should().Be(true);
         }
@@ -1277,7 +1277,7 @@ namespace MudBlazor.UnitTests.Components
             await tf.SetParamAsync(x => x.Validation, validationFunc);
             Expression<Func<string>> expression = () => model.data;
             await tf.SetParamAsync(x => x.For, expression);
-            await comp.InvokeAsync(tf.Instance.Validate);
+            await comp.InvokeAsync(tf.Instance.ValidateAsync);
             tf.Instance.GetState(x => x.Error).Should().Be(true);
             tf.Instance.GetState(x => x.ErrorText).Should().Be("Error in validation func: User error");
         }
@@ -1296,7 +1296,7 @@ namespace MudBlazor.UnitTests.Components
             var tf = comp.FindComponent<MudTextField<string>>();
             var validationFunc = new Func<object, string, IEnumerable<string>>((obj, property) => throw new InvalidOperationException("User error"));
             await tf.SetParamAsync(x => x.Validation, validationFunc);
-            await comp.InvokeAsync(tf.Instance.Validate);
+            await comp.InvokeAsync(tf.Instance.ValidateAsync);
             tf.Instance.GetState(x => x.Error).Should().Be(true);
             tf.Instance.GetState(x => x.ErrorText).Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
         }
@@ -1318,7 +1318,7 @@ namespace MudBlazor.UnitTests.Components
                 throw new InvalidOperationException("User error");
             });
             await tf.SetParamAsync(x => x.Validation, validationFunc);
-            await comp.InvokeAsync(tf.Instance.Validate);
+            await comp.InvokeAsync(tf.Instance.ValidateAsync);
             tf.Instance.GetState(x => x.Error).Should().Be(true);
             tf.Instance.GetState(x => x.ErrorText).Should().Be("For is null, please set parameter For on the form input component of type MudTextField`1");
         }
@@ -1343,7 +1343,7 @@ namespace MudBlazor.UnitTests.Components
             await tf.SetParamAsync(x => x.Validation, validationFunc);
             Expression<Func<string>> expression = () => model.data;
             await tf.SetParamAsync(x => x.For, expression);
-            await comp.InvokeAsync(tf.Instance.Validate);
+            await comp.InvokeAsync(tf.Instance.ValidateAsync);
             tf.Instance.GetState(x => x.Error).Should().Be(true);
             tf.Instance.GetState(x => x.ErrorText).Should().Be("Error1");
         }
@@ -1878,13 +1878,13 @@ namespace MudBlazor.UnitTests.Components
             textField.GetState(x => x.ErrorText).Should().Be("Default value not changed by binding");
 
             // call validation on the textfield: now the error text should be null and the bound property aswell
-            textField.Validate();
+            textField.ValidateAsync();
             textField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             comp.Instance.BoundErrorText.Should().BeNullOrEmpty();
 
             // empty the input text and call validation: now the error text and the bound property should be the validation error message.
             textInput.Change("");
-            textField.Validate();
+            textField.ValidateAsync();
             textField.GetState(x => x.ErrorText).Should().Be("EmptyOrWhitespace!");
             comp.Instance.BoundErrorText.Should().Be("EmptyOrWhitespace!");
             comp.Markup.Should().Contain("EmptyOrWhitespace!");

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -600,10 +600,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParamAsync(x => x.Value, value);
             var numericField = comp.Instance;
             numericField.Value.Should().Be(value);
-            await comp.InvokeAsync(() =>
-            {
-                numericField.Validate().Wait();
-            });
+            await comp.InvokeAsync(numericField.ValidateAsync);
             numericField.Value.Should().Be(value);
         }
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -871,7 +871,7 @@ namespace MudBlazor.UnitTests.Components
             select.Value.Should().Be("Quux");
             select.Text.Should().Be("Quux");
             // check validity
-            await comp.InvokeAsync(() => select.Validate());
+            await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.Should().NotBeEmpty();
             select.ValidationErrors.Should().HaveCount(1);
             select.ValidationErrors[0].Should().Be("Should not be longer than 3");
@@ -889,7 +889,7 @@ namespace MudBlazor.UnitTests.Components
             select.Value.Should().Be("Qux");
             select.Text.Should().Be("Qux");
             // check validity
-            await comp.InvokeAsync(() => select.Validate());
+            await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.Should().BeEmpty();
         }
         #endregion
@@ -903,7 +903,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<SelectRequiredTest>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
-            await comp.InvokeAsync(() => select.Validate());
+            await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.First().Should().Be("Required");
         }
 
@@ -1283,13 +1283,13 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
-            await comp.InvokeAsync(() => select.Validate());
+            await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.First().Should().Be("Required");
 
             //1b. Check on T type - MultiSelect of T(e.g. class object)
             var selectWithT = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
             selectWithT.Required.Should().BeTrue();
-            await comp.InvokeAsync(() => selectWithT.Validate());
+            await comp.InvokeAsync(() => selectWithT.ValidateAsync());
             selectWithT.ValidationErrors.First().Should().Be("Required");
 
             //2a. Now check when SelectedItems is greater than one - Validation Should Pass
@@ -1297,7 +1297,7 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].MouseDown();//The 2nd one is the
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
-            await comp.InvokeAsync(() => select.Validate());
+            await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.Count.Should().Be(0);
 
             //2b.
@@ -1306,7 +1306,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForState(() => comp.FindAll("div.mud-list-item").Count == 5);
             items = comp.FindAll("div.mud-list-item").ToArray();
             items[3].Click();
-            await comp.InvokeAsync(() => selectWithT.Validate());
+            await comp.InvokeAsync(() => selectWithT.ValidateAsync());
             selectWithT.ValidationErrors.Count.Should().Be(0);
         }
 
@@ -1316,7 +1316,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
-            await comp.InvokeAsync(() => select.Validate());
+            await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.First().Should().Be("Required");
 
             await comp.Find("#clear-string").ClickAsync(new MouseEventArgs());
@@ -1359,7 +1359,7 @@ namespace MudBlazor.UnitTests.Components
             //test clearing object values
             var select2 = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
             select2.Required.Should().BeTrue();
-            await comp.InvokeAsync(() => select2.Validate());
+            await comp.InvokeAsync(() => select2.ValidateAsync());
             select2.ValidationErrors.First().Should().Be("Required");
 
             await comp.Find("#clear-object").ClickAsync(new MouseEventArgs());

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -476,7 +476,7 @@ namespace MudBlazor.UnitTests.Components
             textfield.Value.Should().Be("Quux");
             textfield.Text.Should().Be("Quux");
             // check validity
-            await comp.InvokeAsync(() => textfield.Validate());
+            await comp.InvokeAsync(() => textfield.ValidateAsync());
             textfield.ValidationErrors.Should().NotBeEmpty();
             textfield.ValidationErrors.Should().HaveCount(1);
             textfield.ValidationErrors[0].Should().Be("Should not be longer than 3");
@@ -495,7 +495,7 @@ namespace MudBlazor.UnitTests.Components
             textfield.Value.Should().Be("Qux");
             textfield.Text.Should().Be("Qux");
             // check validity
-            await comp.InvokeAsync(() => textfield.Validate());
+            await comp.InvokeAsync(() => textfield.ValidateAsync());
             textfield.ValidationErrors.Should().BeEmpty();
         }
 
@@ -518,7 +518,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var model = new TestFailingModel();
             var comp = Context.RenderComponent<MudTextField<string>>(ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => model.Foo)));
-            await comp.InvokeAsync(() => comp.Instance.Validate());
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
             comp.Instance.ValidationErrors[0].Should().Be("Foo");
@@ -541,7 +541,7 @@ namespace MudBlazor.UnitTests.Components
                 ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => (model as TestFailingModel2).Foo))
             //ComponentParameter.CreateParameter("ForModel", typeof(TestFailingModel2)) // Explicitly set the `For` class
             );
-            await comp.InvokeAsync(() => comp.Instance.Validate());
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
             comp.Instance.ValidationErrors[0].Should().Be("Bar");
@@ -567,7 +567,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var model = new TestThrowingModel();
             var comp = Context.RenderComponent<MudTextField<string>>(ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => model.Foo)));
-            await comp.InvokeAsync(() => comp.Instance.Validate());
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
             comp.Instance.ValidationErrors[0].Should().Be("An unhandled exception occurred: This is a test exception");
@@ -718,7 +718,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var model = new TestDataAnnotationModel();
             var comp = Context.RenderComponent<MudTextField<string>>(ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => model.Foo1)));
-            await comp.InvokeAsync(() => comp.Instance.Validate());
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
             comp.Instance.ValidationErrors[0].Should().Be($"The {nameof(TestDataAnnotationModel.Foo1)} field is required.");
@@ -726,7 +726,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() =>
             {
                 comp.Instance.Value = "Foo";
-                comp.Instance.Validate();
+                comp.Instance.ValidateAsync();
             });
             comp.Instance.GetState(x => x.Error).Should().BeFalse();
             comp.Instance.ValidationErrors.Should().HaveCount(0);
@@ -737,7 +737,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var model = new TestDataAnnotationModel();
             var comp = Context.RenderComponent<MudTextField<string>>(ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => model.Foo2)));
-            await comp.InvokeAsync(() => comp.Instance.Validate());
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
             comp.Instance.ValidationErrors[0].Should().Be($"The {TestDataAnnotationModel.FooTwoDisplayName} field is required.");
@@ -752,7 +752,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudTextField<string>>(
                 ComponentParameter.CreateParameter("For", (Expression<Func<string>>)(() => model.Foo2)),
                 ComponentParameter.CreateParameter("Value", value));
-            await comp.InvokeAsync(() => comp.Instance.Validate());
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
             comp.Instance.ValidationErrors[0].Should().Be($"'{TestDataAnnotationModel.FooTwoDisplayName}' and '{nameof(TestDataAnnotationModel.Foo1)}' do not match.");
@@ -760,7 +760,7 @@ namespace MudBlazor.UnitTests.Components
             model.Foo1 = value;
             await comp.InvokeAsync(() =>
             {
-                comp.Instance.Validate();
+                comp.Instance.ValidateAsync();
             });
             comp.Instance.GetState(x => x.Error).Should().BeFalse();
             comp.Instance.ValidationErrors.Should().HaveCount(0);

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.Logging;
 using MudBlazor.Interfaces;
 using MudBlazor.State;
 using static System.String;
@@ -351,7 +352,7 @@ namespace MudBlazor
         /// <remarks>
         /// When using a <see cref="MudForm"/>, the input is validated via the function set in the <see cref="Validation"/> property.
         /// </remarks>
-        public Task Validate()
+        public Task ValidateAsync()
         {
             // when a validation is forced, we must set Touched to true, because for untouched fields with
             // no value, validation does nothing due to the way forms are expected to work (display errors
@@ -676,7 +677,7 @@ namespace MudBlazor
         public async Task ResetAsync()
         {
             await ResetValueAsync();
-            ResetValidation();
+            await ResetValidationAsync();
         }
 
         protected virtual async Task ResetValueAsync()
@@ -684,7 +685,7 @@ namespace MudBlazor
             /* to be overridden */
             await WriteValueAsync(default);
             Touched = false;
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         /// <summary>
@@ -693,14 +694,13 @@ namespace MudBlazor
         /// <remarks>
         /// When called, the <see cref="Error"/>, <see cref="ErrorText"/>, and <see cref="ValidationErrors"/> properties are all reset.
         /// </remarks>
-        public virtual void ResetValidation()
+        public virtual async Task ResetValidationAsync()
         {
-            //TODO: v9 make the ResetValidation async
-            ErrorState.SetValueAsync(false).CatchAndLog();
+            await ErrorState.SetValueAsync(false);
             ValidationErrors.Clear();
-            ErrorTextState.SetValueAsync(null).CatchAndLog();
+            await ErrorTextState.SetValueAsync(null);
             ResetConverterErrors();
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         private void ResetConverterErrors()
@@ -720,7 +720,7 @@ namespace MudBlazor
         /// When using an <see cref="EditForm"/>, gets a context used to perform validation.
         /// </remarks>
         [CascadingParameter]
-        private EditContext? EditContext { get; set; } = default!;
+        private EditContext? EditContext { get; set; }
 
         /// <summary>
         /// Triggers field to be validated.
@@ -754,20 +754,27 @@ namespace MudBlazor
         /// </summary>
         private IEnumerable<ValidationAttribute>? _validationAttrsFor;
 
-        private void OnValidationStateChanged(object? sender, ValidationStateChangedEventArgs e)
+        private async void OnValidationStateChanged(object? sender, ValidationStateChangedEventArgs e)
         {
-            if (EditContext is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
+            try
             {
-                var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
-                var hasError = errorMessages.Length > 0;
-                //TODO: v9 there no async API, but just make it async void (acceptable for EventHandler) 
-                ErrorState.SetValueAsync(hasError).CatchAndLog();
-                ErrorTextState.SetValueAsync(hasError ? errorMessages[0] : null).CatchAndLog();
+                if (EditContext is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
+                {
+                    var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
+                    var hasError = errorMessages.Length > 0;
+                    //TODO: v9 there no async API, but just make it async void (acceptable for EventHandler) 
+                    await ErrorState.SetValueAsync(hasError);
+                    await ErrorTextState.SetValueAsync(hasError ? errorMessages[0] : null);
 
-                ValidationErrors.Clear();
-                ValidationErrors.AddRange(errorMessages);
+                    ValidationErrors.Clear();
+                    ValidationErrors.AddRange(errorMessages);
 
-                StateHasChanged();
+                    await InvokeAsync(StateHasChanged);
+                }
+            }
+            catch (Exception exception)
+            {
+                Logger.LogError(exception, "An unexpected exception occurred: {ExceptionMessage}", exception.Message);
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -76,7 +76,7 @@ namespace MudBlazor
             _errors.Clear();
             foreach (var formControl in _formControls.ToArray())
             {
-                formControl.Validate();
+                formControl.ValidateAsync();
                 foreach (var err in formControl.ValidationErrors)
                 {
                     _errors.Add(err);

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -321,11 +321,11 @@ namespace MudBlazor
             await ErrorTextState.SetValueAsync(ValidationErrors.FirstOrDefault());
         }
 
-        public override void ResetValidation()
+        public override Task ResetValidationAsync()
         {
             _validationErrors.Clear();
 
-            base.ResetValidation();
+            return base.ResetValidationAsync();
         }
     }
 }

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -291,7 +291,7 @@ namespace MudBlazor
         /// </remarks>
         public async Task Validate()
         {
-            await Task.WhenAll(_formControls.Select(x => x.Validate()));
+            await Task.WhenAll(_formControls.Select(x => x.ValidateAsync()));
 
             if (ChildForms.Count > 0)
             {
@@ -328,16 +328,16 @@ namespace MudBlazor
         /// <remarks>
         /// The values in each form input component will not be changed.
         /// </remarks>
-        public void ResetValidation()
+        public async Task ResetValidationAsync()
         {
             foreach (var control in _formControls.ToArray())
             {
-                control.ResetValidation();
+                await control.ResetValidationAsync();
             }
 
             foreach (var form in ChildForms)
             {
-                form.ResetValidation();
+                await form.ResetValidationAsync();
             }
 
             EvaluateForm(debounce: false);

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -65,7 +65,7 @@ namespace MudBlazor
             _errors.Clear();
             foreach (var formControl in _formControls.ToArray())
             {
-                formControl.Validate();
+                formControl.ValidateAsync();
                 foreach (var err in formControl.ValidationErrors)
                 {
                     _errors.Add(err);

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -2,9 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
 namespace MudBlazor.Interfaces
 {
     public interface IFormComponent
@@ -16,8 +13,8 @@ namespace MudBlazor.Interfaces
         public object Validation { get; set; }
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }
-        public Task Validate();
+        public Task ValidateAsync();
         public Task ResetAsync();
-        public void ResetValidation();
+        public Task ResetValidationAsync();
     }
 }


### PR DESCRIPTION
Breaking change.
There was TODO to replace `ResetValidation` to `ResetValidationAsync` and make it `Task`.
Also renamed couple of other methods and changed the methods that were dependent on it.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
