### PR TITLE
ParameterState: Add InitialValue and expose IsInitialized

### DIFF
--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -35,8 +35,10 @@ public class ParameterStateTests
         await parameterState.SetValueAsync(NewValue);
 
         // Assert
-        parameterState.Value.Should().Be(NewValue);
         eventFired.Should().BeTrue();
+        parameterState.IsInitialized.Should().BeTrue();
+        parameterState.InitialValue.Should().Be(InitialValue);
+        parameterState.Value.Should().Be(NewValue);
     }
 
     [Test]
@@ -58,6 +60,8 @@ public class ParameterStateTests
         await parameterState.SetValueAsync(InitialValue);
 
         // Assert
+        parameterState.IsInitialized.Should().BeTrue();
+        parameterState.InitialValue.Should().Be(InitialValue);
         parameterState.Value.Should().Be(InitialValue);
         eventFired.Should().BeFalse();
     }
@@ -77,8 +81,9 @@ public class ParameterStateTests
         parameterState.OnInitialized();
 
         // Assert
-        parameterState.Value.Should().Be(InitialValue);
+        parameterState.InitialValue.Should().Be(InitialValue);
         parameterState.IsInitialized.Should().BeTrue();
+        parameterState.Value.Should().Be(InitialValue);
     }
 
     [Test]
@@ -104,6 +109,7 @@ public class ParameterStateTests
         initialValue = NewValue;
         parameterState.OnParametersSet();
         parameterState.Value.Should().Be(NewValue);
+        parameterState.InitialValue.Should().Be(0, because: "OnInitialized wasn't called, so InitialValue remains its default for int");
     }
 
     [Test]

--- a/src/MudBlazor/State/ParameterState.cs
+++ b/src/MudBlazor/State/ParameterState.cs
@@ -24,6 +24,23 @@ public abstract class ParameterState<T>
     public abstract T? Value { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the object is initialized.
+    /// </summary>
+    /// <remarks>
+    /// This property is <c>true</c> once the <see cref="ComponentBase.OnInitialized"/> method is called; otherwise, <c>false</c>.
+    /// </remarks>
+    public abstract bool IsInitialized { get; }
+
+    /// <summary>
+    /// Gets the initial value of the parameter at the time <see cref="ComponentBase.OnInitialized"/> is called.
+    /// </summary>
+    /// <remarks>
+    /// This value is captured once when the component is initialized and never changes thereafter,
+    /// even if the <see cref="Value"/> property changes later.
+    /// </remarks>
+    public abstract T? InitialValue { get; }
+
+    /// <summary>
     /// Set the parameter's value. 
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -26,6 +26,8 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
 {
     private T? _value;
     private T? _lastValue;
+    private T? _initialValue;
+    private bool _isInitialized;
     private bool _isChildOriginatedChange;
     private ParameterChangedEventArgs<T>? _parameterChangedEventArgs;
 
@@ -44,14 +46,11 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     [MemberNotNullWhen(true, nameof(_parameterChangedHandler))]
     public bool HasHandler => _parameterChangedHandler is not null;
 
-    /// <summary>
-    /// Gets a value indicating whether the object is initialized.
-    /// </summary>
-    /// <remarks>
-    /// This property is <c>true</c> once the <see cref="OnInitialized"/> method is called; otherwise, <c>false</c>.
-    /// </remarks>
-    [MemberNotNullWhen(true, nameof(_lastValue), nameof(_value), nameof(Value))]
-    public bool IsInitialized { get; private set; }
+    /// <inheritdoc />
+    public override bool IsInitialized => _isInitialized;
+
+    /// <inheritdoc />
+    public override T? InitialValue => _initialValue;
 
     /// <inheritdoc/>
     public override T? Value => _value;
@@ -91,8 +90,9 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     /// <inheritdoc />
     public void OnInitialized()
     {
-        IsInitialized = true;
+        _isInitialized = true;
         var currentParameterValue = _getParameterValueFunc();
+        _initialValue = currentParameterValue;
         _value = currentParameterValue;
         _lastValue = currentParameterValue;
     }


### PR DESCRIPTION
In some scenario it's useful to know what was the initial value of the component's parameter.
For example
```razor
  <MudColorPicker Required="true" @bind-Value="ColorValue">

@code {
    [Parameter]
    public MudColor ColorValue { get; set; } = new("#000000");
}
```
Now we know from `InitialValue` that the initial value was `#000000`.
In more complex scenarios, we need to determine whether the current value has changed from the initial value.
The `ParameterChangedEventArgs.LastValue` provided during the change handler isn’t very helpful because we can’t distinguish whether the handler is being called during initialization or in later calls when the user supplies a new value.

The `ComponentBase.OnInitialized` is called only once during blazor component lifecycle:
> This method is only executed once when the component is first created. If the parent changes the component's parameters at a later time, this method is skipped. When the component is a `@page`, and our Blazor app navigates to a new URL that renders the same page, Blazor will reuse the current object instance for that page. Because the object is the same instance, Blazor does not call `IDisposable.Dispose` on the object, nor does it execute its `OnInitialized` method again.

So, that value should not change (and be safe).

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
