### PR TITLE
MudTextField: Fix incorrect label position in RTL mode

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldWithLongLabelRtlTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldWithLongLabelRtlTest.razor
@@ -1,0 +1,11 @@
+<div style="width: 50%">
+    <MudRTLProvider RightToLeft="true">
+        <MudTextField @bind-Value="TextValue"
+                      Label="ThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActiveThisLabelIsVeryLongAndWillDestroyTheTextfieldIfItsActive"
+                      Variant="Variant.Outlined" />
+    </MudRTLProvider>
+</div>
+
+@code {
+    public string TextValue { get; set; } = string.Empty;
+}

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -102,6 +102,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
   .mud-input-label-filled {
     transform: translate(-12px, 20px) scale(1);
+    max-width: calc(100% - 12px);
 
     &.mud-input-label-margin-dense {
       transform: translate(-12px, 17px) scale(1);
@@ -110,6 +111,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
   .mud-input-label-outlined {
     transform: translate(-14px, 20px) scale(1);
+    max-width: calc(100% - 14px);
 
     &.mud-input-label-margin-dense {
       transform: translate(-14px, 12px) scale(1);
@@ -122,6 +124,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
       &.mud-input-label-filled {
         transform: translate(-12px, 10px) scale(0.75);
+        max-width: calc((100% - 12px) / 0.75);
 
         &.mud-input-label-margin-dense {
           transform: translate(-12px, 7px) scale(0.75);
@@ -130,6 +133,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
 
       &.mud-input-label-outlined {
         transform: translate(-14px, -6px) scale(0.75);
+        max-width: calc((100% - 14px) / 0.75);
       }
     }
   }


### PR DESCRIPTION
Closes #12126 

<img width="1908" height="881" alt="image" src="https://github.com/user-attachments/assets/57960987-9b37-45cd-ab56-2a5fe9ec5316" />

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

Contribution by Gittensor, learn more at https://gittensor.io/