### PR TITLE
Material design V3 switch proposal

### DIFF
--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -82,6 +82,7 @@ public class LayoutService
             {
                 RightToLeft = false,
                 DarkLightTheme = DarkLightMode.System,
+                DesignLanguage = DesignLanguage.MaterialV2
             };
             await _userPreferencesService.SaveUserPreferences(_userPreferences);
         }
@@ -89,6 +90,7 @@ public class LayoutService
         {
             IsRTL = _userPreferences.RightToLeft;
             CurrentDarkLightMode = _userPreferences.DarkLightTheme;
+            CurrentTheme.DesignLanguage = _userPreferences.DesignLanguage;
             UpdateDarkModeState();
         }
     }
@@ -122,6 +124,23 @@ public class LayoutService
         UpdateDarkModeState();
 
         _userPreferences.DarkLightTheme = CurrentDarkLightMode;
+        await _userPreferencesService.SaveUserPreferences(_userPreferences);
+        OnMajorUpdateOccurred();
+    }
+
+    /// <summary>
+    /// Cycles through the available design languages and saves the new preference.
+    /// </summary>
+    public async Task CycleDesignLanguageAsync()
+    {
+        CurrentTheme.DesignLanguage = CurrentTheme.DesignLanguage switch
+        {
+            DesignLanguage.MaterialV2 => DesignLanguage.MaterialV3,
+            DesignLanguage.MaterialV3 => DesignLanguage.MaterialV2,
+            _ => DesignLanguage.MaterialV2,
+        };
+        
+        _userPreferences.DesignLanguage = CurrentTheme.DesignLanguage;
         await _userPreferencesService.SaveUserPreferences(_userPreferences);
         OnMajorUpdateOccurred();
     }

--- a/src/MudBlazor.Docs/Services/UserPreferences/UserPreferences.cs
+++ b/src/MudBlazor.Docs/Services/UserPreferences/UserPreferences.cs
@@ -17,5 +17,10 @@ namespace MudBlazor.Docs.Services.UserPreferences
         /// The preferred dark mode configuration.
         /// </summary>
         public DarkLightMode DarkLightTheme { get; set; }
+
+        /// <summary>
+        /// The preferred design language.
+        /// </summary>
+        public DesignLanguage DesignLanguage { get; set; }
     }
 }

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -36,3 +36,7 @@
 <MudTooltip Text="@DarkLightModeButtonText">
     <MudIconButton OnClick="@LayoutService.CycleDarkLightModeAsync" Icon="@DarkLightModeButtonIcon" Color="Color.Inherit" aria-label="@DarkLightModeButtonText" />
 </MudTooltip>
+
+<MudTooltip Text="@DesignLanguageButtonText">
+    <MudIconButton OnClick="@LayoutService.CycleDesignLanguageAsync" Icon="@DesignLanguageButtonIcon" Color="Color.Inherit" aria-label="@DesignLanguageButtonText" />
+</MudTooltip>

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -42,6 +42,16 @@ public partial class AppbarButtons
     };
 
     /// <summary>
+    /// Gets the text for the design language mode toggle button, indicating the next language.
+    /// </summary>
+    public string DesignLanguageButtonText => LayoutService.CurrentTheme.DesignLanguage switch
+    {
+        DesignLanguage.MaterialV2 => "Material V2",
+        DesignLanguage.MaterialV3 => "Material V3",
+        _ => "Material V2"
+    };
+
+    /// <summary>
     /// Gets the icon for the dark/light mode toggle button.
     /// </summary>
     public string DarkLightModeButtonIcon => LayoutService.CurrentDarkLightMode switch
@@ -49,6 +59,16 @@ public partial class AppbarButtons
         DarkLightMode.Dark => Icons.Material.Rounded.AutoMode,
         DarkLightMode.Light => Icons.Material.Outlined.DarkMode,
         _ => Icons.Material.Filled.LightMode
+    };
+
+    /// <summary>
+    /// Gets the icon for the design language toggle button.
+    /// </summary>
+    public string DesignLanguageButtonIcon => LayoutService.CurrentTheme.DesignLanguage switch
+    {
+        DesignLanguage.MaterialV2 => Icons.Material.Filled.LooksTwo,
+        DesignLanguage.MaterialV3 => Icons.Material.Filled.Looks3,
+        _ => Icons.Material.Filled.LooksTwo
     };
 
     private async Task MarkNotificationAsReadAsync()

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -19,6 +19,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
     // private const string Breakpoint = "mud-breakpoint";
     private bool _disposed;
     private bool _observing;
+    private bool _isJSRuntimeAvailable;
     private const string Palette = "mud-palette";
     private const string Ripple = "mud-ripple";
     private const string Elevation = "mud-elevation";
@@ -138,6 +139,8 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
     {
         if (firstRender)
         {
+            _isJSRuntimeAvailable = true;
+            
             if (_observeSystemDarkModeChangeState.Value && !_observing)
             {
                 _observing = true;
@@ -156,7 +159,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
     }
 
     // <inheritdoc />
-    protected override void OnParametersSet()
+    protected override async Task OnParametersSetAsync()
     {
         if (Theme is not null)
         {
@@ -164,9 +167,14 @@ partial class MudThemeProvider : ComponentBaseWithState, IDisposable
             {
                 _theme = Theme;
             }
+            
+            if (_isJSRuntimeAvailable)
+            {
+                await JsRuntime.InvokeVoidAsync("setDesignLanguage", Theme.DesignLanguage.ToString().ToKebabCase());
+            }
         }
-
-        base.OnParametersSet();
+        
+        await base.OnParametersSetAsync();
     }
 
     /// <summary>

--- a/src/MudBlazor/Extensions/StringExtensions.cs
+++ b/src/MudBlazor/Extensions/StringExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 // ReSharper disable once CheckNamespace
 namespace MudBlazor;
@@ -11,8 +12,11 @@ namespace MudBlazor;
 /// <summary>
 /// Provides extension methods for string manipulation and formatting.
 /// </summary>
-internal static class StringExtensions
+internal static partial class StringExtensions
 {
+    [GeneratedRegex("(?<!^)([A-Z][a-z]|(?<=[a-z])[A-Z0-9])", RegexOptions.Compiled)]
+    private static partial Regex KebabCaseRegex();
+    
     /// <summary>
     /// Determines whether the specified string is null, empty, or consists only of white-space characters.
     /// </summary>
@@ -41,4 +45,20 @@ internal static class StringExtensions
     /// A string representation of the decimal value formatted as a percentage with up to two decimal places.
     /// </returns>
     public static string ToPercentage(this decimal value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Converts a string to kebab case.
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static string ToKebabCase(this string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        return KebabCaseRegex()
+            .Replace(value, "-$1")
+            .Trim()
+            .ToLower();
+    }
 }

--- a/src/MudBlazor/Styles/components/_fab.scss
+++ b/src/MudBlazor/Styles/components/_fab.scss
@@ -115,17 +115,11 @@
     .mud-fab-label {
       gap: 8px;
     }
-  }
 
-  &.mud-fab-size-small {
-    width: auto;
-    height: 34px;
-    padding: 0 12px;
-    min-width: 34px;
-    border-radius: 17px;
-
-    .mud-fab-label {
-      gap: 4px;
+    html[data-mud-design-language="material-v3"] & {
+      width: auto;
+      height: 96px;
+      border-radius: 28px;
     }
   }
 
@@ -139,6 +133,30 @@
     .mud-fab-label {
       gap: 8px;
     }
+
+    html[data-mud-design-language="material-v3"] & {
+      width: auto;
+      height: 80px;
+      border-radius: 20px;
+    }
+  }
+
+  &.mud-fab-size-small {
+    width: auto;
+    height: 34px;
+    padding: 0 12px;
+    min-width: 34px;
+    border-radius: 17px;
+
+    .mud-fab-label {
+      gap: 4px;
+    }
+
+    html[data-mud-design-language="material-v3"] & {
+      width: auto;
+      height: 56px;
+      border-radius: 16px;
+    }
   }
 }
 
@@ -149,14 +167,32 @@
 .mud-fab-size-small {
   width: 40px;
   height: 40px;
+
+  html[data-mud-design-language="material-v3"] & {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+  }
 }
 
 .mud-fab-size-medium {
   width: 48px;
   height: 48px;
+
+  html[data-mud-design-language="material-v3"] & {
+    width: 80px;
+    height: 80px;
+    border-radius: 28px;
+  }
 }
 
 .mud-fab-size-large {
   width: 56px;
   height: 56px;
+
+  html[data-mud-design-language="material-v3"] & {
+    width: 96px;
+    height: 96px;
+    border-radius: 20px;
+  }
 }

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -4,6 +4,10 @@ window.darkModeChange = () => {
     return darkThemeMediaQuery.matches;
 };
 
+window.setDesignLanguage = function(designLanguage) {
+    document.documentElement.setAttribute("data-mud-design-language", designLanguage);
+}
+
 function darkModeChangeListener(e) {
     dotNetHelperTheme.invokeMethodAsync('SystemDarkModeChangedAsync', e.matches);
 }

--- a/src/MudBlazor/Themes/DesignLanguage.cs
+++ b/src/MudBlazor/Themes/DesignLanguage.cs
@@ -1,0 +1,20 @@
+﻿namespace MudBlazor;
+
+/// <summary>
+/// The design language of the MudBlazor components.
+/// </summary>
+public enum DesignLanguage
+{
+    /// <summary>
+    /// Displays the components based on the <a href="https://m2.material.io">Material Design 2 guidelines</a>.
+    /// </summary>
+    MaterialV2 = 0,
+
+    /// <summary>
+    /// Displays the components based on the <a href="https://m3.material.io">Material Design 3 guidelines</a>.
+    /// </summary>
+    /// <remarks>
+    /// This design language is still under development, and not all components support it yet; These components will be displayed using <see cref="MaterialV2"/>.
+    /// </remarks>
+    MaterialV3 = 1
+}

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -1,58 +1,66 @@
-﻿namespace MudBlazor
-{
+﻿namespace MudBlazor;
+
 #nullable enable
+
+/// <summary>
+/// Represents the theme settings for the MudBlazor user interface.
+/// </summary>
+public class MudTheme
+{
     /// <summary>
-    /// Represents the theme settings for the MudBlazor user interface.
+    /// The palette for the light theme.
     /// </summary>
-    public class MudTheme
+    public Palette PaletteLight { get; set; }
+
+    /// <summary>
+    /// The palette for the dark theme.
+    /// </summary>
+    public Palette PaletteDark { get; set; }
+
+    /// <summary>
+    /// The shadow settings.
+    /// </summary>
+    public Shadow Shadows { get; set; }
+
+    /// <summary>
+    /// The typography settings.
+    /// </summary>
+    public Typography Typography { get; set; }
+
+    /// <summary>
+    /// The layout properties.
+    /// </summary>
+    public LayoutProperties LayoutProperties { get; set; }
+
+    /// <summary>
+    /// The z-index values.
+    /// </summary>
+    public ZIndex ZIndex { get; set; }
+
+    /// <summary>
+    /// The pseudo CSS styles.
+    /// </summary>
+    public PseudoCss PseudoCss { get; set; }
+    
+    /// <summary>
+    /// The overall design language of this theme.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="DesignLanguage.MaterialV2"/>.
+    /// </remarks>
+    public DesignLanguage DesignLanguage { get; set; } = DesignLanguage.MaterialV2;
+
+    /// <summary>
+    /// Initializes the <see cref="MudTheme"/> class.
+    /// </summary>
+    public MudTheme()
     {
-        /// <summary>
-        /// The palette for the light theme.
-        /// </summary>
-        public Palette PaletteLight { get; set; }
-
-        /// <summary>
-        /// The palette for the dark theme.
-        /// </summary>
-        public Palette PaletteDark { get; set; }
-
-        /// <summary>
-        /// The shadow settings.
-        /// </summary>
-        public Shadow Shadows { get; set; }
-
-        /// <summary>
-        /// The typography settings.
-        /// </summary>
-        public Typography Typography { get; set; }
-
-        /// <summary>
-        /// The layout properties.
-        /// </summary>
-        public LayoutProperties LayoutProperties { get; set; }
-
-        /// <summary>
-        /// The z-index values.
-        /// </summary>
-        public ZIndex ZIndex { get; set; }
-
-        /// <summary>
-        /// The pseudo CSS styles.
-        /// </summary>
-        public PseudoCss PseudoCss { get; set; }
-
-        /// <summary>
-        /// Initializes the <see cref="MudTheme"/> class.
-        /// </summary>
-        public MudTheme()
-        {
-            PaletteLight = new PaletteLight();
-            PaletteDark = new PaletteDark();
-            Shadows = new Shadow();
-            Typography = new Typography();
-            LayoutProperties = new LayoutProperties();
-            ZIndex = new ZIndex();
-            PseudoCss = new PseudoCss();
-        }
+        PaletteLight = new PaletteLight();
+        PaletteDark = new PaletteDark();
+        Shadows = new Shadow();
+        Typography = new Typography();
+        LayoutProperties = new LayoutProperties();
+        ZIndex = new ZIndex();
+        PseudoCss = new PseudoCss();
     }
 }


### PR DESCRIPTION
This PR implements a proposed design language switch in reference to https://github.com/MudBlazor/MudBlazor/issues/12053.

This adds a `DesignLanguage` property to the `MudTheme` class. This property is then read within the `MudThemeProvider` which sets a data attribute on the document: `<html lang="en" data-mud-design-language="material-v3">`. This attribute can then be used to adjust component appearance (exemplary for the `MudFab`):

```css
.mud-fab-size-small {
  width: 40px;
  height: 40px;

  html[data-mud-design-language="material-v3"] & {
    width: 56px;
    height: 56px;
    border-radius: 16px;
  }
}
```

![DesignLanguageSwitch](https://github.com/user-attachments/assets/a3d43f0c-c836-4a66-b508-ffb36da53404)

This whole setup would then allow to gradually implement M3 (or other design languages) without resulting in any breaking changes for existing implementations.
Please provide feedback if this is acceptable or if you have any other ideas in regard of an design language switch.

PS: Please note that the implementation in the docs is just a show and tell and not polished by any means.