### PR TITLE
ParameterState: Add Middleware functionality [WIP

### DIFF
--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -79,12 +79,12 @@ public class ParameterStateTests
             .WithMiddleware(
                 onRead: value =>
                 {
-                    logs.Add($"Read middleware: input={value}, +1");
+                    logs.Add($"Read middleware: value={value}, +1");
                     return value + 1;
                 },
                 onWriteAsync: async (value, next) =>
                 {
-                    logs.Add($"Write middleware: input={value}, +4");
+                    logs.Add($"Write middleware: value={value}, +4");
                     value += 4;
                     await next(value);
                     logs.Add($"Write middleware: completed next with value={value}");
@@ -95,28 +95,27 @@ public class ParameterStateTests
         parameterState.OnInitialized();
 
         // Assert
-        parameterState.Value.Should().Be(
-            6,
-            because: "Read middleware adds 1 to the initial value (5 + 1 = 6)"
-        );
+        parameterState.Value.Should().Be(6, because: "Read middleware adds 1 to the initial value (5 + 1 = 6)");
 
-        logs.Should().ContainInOrder("Read middleware: input=5, +1");
+        logs.Should().ContainInOrder("Read middleware: value=5, +1");
 
         // Act
         await parameterState.SetValueAsync(Initial);
 
         // Assert
-        parameterState.Value.Should().Be(
-            10,
-            because: "Write middleware adds 4 to 5 (5 + 4 = 9), then read middleware adds 1 (9 + 1 = 10)"
+        logs.Should().ContainInOrder(
+            "Read middleware: value=5, +1",
+            "Write middleware: value=5, +4",
+            "Write middleware: completed next with value=9"
         );
 
+        parameterState.Value.Should().Be(10, because: "Write middleware adds 4 to 5 (5 + 4 = 9), then read middleware adds 1 (9 + 1 = 10)");
+
         logs.Should().ContainInOrder(
-            "Read middleware: input=5, +1",
-            "Write middleware: input=5, +4",
-            "Read middleware: input=5, +1",
+            "Read middleware: value=5, +1",
+            "Write middleware: value=5, +4",
             "Write middleware: completed next with value=9",
-            "Read middleware: input=9, +1"
+            "Read middleware: value=9, +1"
         );
     }
 

--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -67,6 +67,60 @@ public class ParameterStateTests
     }
 
     [Test]
+    public async Task SetValueAsync_And_Value_Middleware()
+    {
+        // Arrange
+        const int Initial = 5;
+        var logs = new List<string>();
+        var parameterState = ParameterAttachBuilder
+            .Create<int>()
+            .WithMetadata(new ParameterMetadata(nameof(Initial)))
+            .WithGetParameterValueFunc(() => Initial)
+            .WithMiddleware(
+                onRead: value =>
+                {
+                    logs.Add($"Read middleware: input={value}, +1");
+                    return value + 1;
+                },
+                onWriteAsync: async (value, next) =>
+                {
+                    logs.Add($"Write middleware: input={value}, +4");
+                    value += 4;
+                    await next(value);
+                    logs.Add($"Write middleware: completed next with value={value}");
+                })
+            .Attach();
+
+        // Act
+        parameterState.OnInitialized();
+
+        // Assert
+        parameterState.Value.Should().Be(
+            6,
+            because: "Read middleware adds 1 to the initial value (5 + 1 = 6)"
+        );
+
+        logs.Should().ContainInOrder("Read middleware: input=5, +1");
+
+        // Act
+        await parameterState.SetValueAsync(Initial);
+
+        // Assert
+        parameterState.Value.Should().Be(
+            10,
+            because: "Write middleware adds 4 to 5 (5 + 4 = 9), then read middleware adds 1 (9 + 1 = 10)"
+        );
+
+        logs.Should().ContainInOrder(
+            "Read middleware: input=5, +1",
+            "Write middleware: input=5, +4",
+            "Read middleware: input=5, +1",
+            "Write middleware: completed next with value=9",
+            "Read middleware: input=9, +1"
+        );
+    }
+
+    [Test]
     public void OnInitialized_SetsInitialValue()
     {
         // Arrange

--- a/src/MudBlazor/State/Builder/ParameterAttachBuilderOfT.cs
+++ b/src/MudBlazor/State/Builder/ParameterAttachBuilderOfT.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State.Comparer;
+using MudBlazor.State.Middleware;
 
 namespace MudBlazor.State.Builder;
 
@@ -26,6 +27,7 @@ internal class ParameterAttachBuilder<T>
     private Func<EventCallback<T>> _eventCallbackFunc = () => default;
     private IParameterChangedHandler<T>? _parameterChangedHandler;
     private IParameterEqualityComparerSwappable<T>? _comparer;
+    private IParameterMiddleware<T>[]? _middlewares;
 
     /// <summary>
     /// Sets the metadata for the parameter.
@@ -148,11 +150,63 @@ internal class ParameterAttachBuilder<T>
         return this;
     }
 
+    /// <summary>
+    /// Sets the function to provide the comparer for the parameter, converting it to a comparer of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="TFrom">The type of the original comparer.</typeparam>
+    /// <param name="comparerFromFunc">The function to provide the original comparer.</param>
+    /// <param name="comparerToFunc">The function to convert the original comparer to a comparer of type <typeparamref name="T"/>.</param>
+    /// <param name="comparerParameterName">The parameter's comparer name. Do not set this value as it's set at compile-time through <see cref="CallerArgumentExpressionAttribute"/>.</param>
+    /// <returns>The current instance of the builder.</returns>
     public ParameterAttachBuilder<T> WithComparer<TFrom>(Func<IEqualityComparer<TFrom>> comparerFromFunc, Func<IEqualityComparer<TFrom>, IEqualityComparer<T>> comparerToFunc, [CallerArgumentExpression(nameof(comparerFromFunc))] string? comparerParameterName = null)
     {
         _comparer = new ParameterEqualityComparerTransformSwappable<TFrom, T>(comparerFromFunc, comparerToFunc);
 
         return this;
+    }
+
+    /// <summary>
+    /// Sets the parameter middlewares to be applied to this parameter.
+    /// </summary>
+    /// <param name="middlewares">An array of <see cref="IParameterMiddleware{T}"/> instances that will be executed for read and write operations on the parameter.</param>
+    /// <remarks>
+    /// Middlewares are invoked when the parameter value is read or written through the <see cref="ParameterState{T}"/> pipeline.
+    /// The order of the array determines the invocation order.
+    /// </remarks>
+    /// <returns>The current instance of the builder.</returns>
+    public ParameterAttachBuilder<T> WithMiddleWare(params IParameterMiddleware<T>[] middlewares)
+    {
+        _middlewares = middlewares;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Convenience overload that registers a middleware created from inline lambda delegates.
+    /// </summary>
+    /// <param name="onRead">
+    /// Optional delegate invoked when the parameter value is read. Receives the current value (maybe <c>null</c>) and should
+    /// return the value that should be observed after middleware processing (either the same value or a transformed value).
+    /// </param>
+    /// <param name="onWriteAsync">
+    /// Optional asynchronous delegate invoked when the parameter value is written. Receives the incoming value and a <c>next</c>
+    /// delegate that invokes the next stage in the write pipeline. Call <c>await next(value)</c> to continue the pipeline and pass
+    /// the (optionally modified) value; omitting the call will short-circuit the pipeline.
+    /// </param>
+    /// <returns>The current instance of the builder.</returns>
+    /// <remarks>
+    /// This method constructs a <see cref="LambdaParameterMiddleware{T}"/> from the supplied delegates and registers it by delegating to <see cref="WithMiddleWare"/>.
+    /// Use this overload for small, inline middleware logic without creating a dedicated middleware type.
+    /// Middleware execution order is determined by registration order and can affect overall behaviour.
+    /// <para>
+    /// Note: this overload creates and registers a single middleware instance (a <see cref="LambdaParameterMiddleware{T}"/>).
+    /// To register multiple middlewares, use <see cref="WithMiddleWare(IParameterMiddleware{T}[])"/>.
+    /// </para>
+    /// </remarks>
+    public ParameterAttachBuilder<T> WithMiddleware(Func<T?, T>? onRead = null, Func<T, Func<T, Task>, Task>? onWriteAsync = null)
+    {
+        var middleware = new LambdaParameterMiddleware<T>(onRead, onWriteAsync);
+        return WithMiddleWare(middleware);
     }
 
     /// <summary>
@@ -167,6 +221,7 @@ internal class ParameterAttachBuilder<T>
             _getParameterValueFunc ?? throw new ArgumentNullException(nameof(_getParameterValueFunc)),
             _eventCallbackFunc,
             _parameterChangedHandler,
+            _middlewares,
             _comparer
         );
     }

--- a/src/MudBlazor/State/Builder/RegisterParameterBuilderOfT.cs
+++ b/src/MudBlazor/State/Builder/RegisterParameterBuilderOfT.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State.Comparer;
+using MudBlazor.State.Middleware;
 
 namespace MudBlazor.State.Builder;
 
@@ -22,6 +23,7 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
     private Func<EventCallback<T>> _eventCallbackFunc = () => default;
     private IParameterChangedHandler<T>? _parameterChangedHandler;
     private IParameterEqualityComparerSwappable<T>? _comparer;
+    private IParameterMiddleware<T>[]? _middlewares;
     private readonly Lazy<ParameterStateInternal<T>> _parameterStateLazy;
 
     /// <summary>
@@ -171,6 +173,50 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
     }
 
     /// <summary>
+    /// Sets the parameter middlewares to be applied to this parameter.
+    /// </summary>
+    /// <param name="middlewares">An array of <see cref="IParameterMiddleware{T}"/> instances that will be executed for read and write operations on the parameter.</param>
+    /// <remarks>
+    /// Middlewares are invoked when the parameter value is read or written through the <see cref="ParameterState{T}"/> pipeline.
+    /// The order of the array determines the invocation order.
+    /// </remarks>
+    /// <returns>The current instance of the builder.</returns>
+    public RegisterParameterBuilder<T> WithMiddleWare(params IParameterMiddleware<T>[] middlewares)
+    {
+        _middlewares = middlewares;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Convenience overload that registers a middleware created from inline lambda delegates.
+    /// </summary>
+    /// <param name="onRead">
+    /// Optional delegate invoked when the parameter value is read. Receives the current value (maybe <c>null</c>) and should
+    /// return the value that should be observed after middleware processing (either the same value or a transformed value).
+    /// </param>
+    /// <param name="onWriteAsync">
+    /// Optional asynchronous delegate invoked when the parameter value is written. Receives the incoming value and a <c>next</c>
+    /// delegate that invokes the next stage in the write pipeline. Call <c>await next(value)</c> to continue the pipeline and pass
+    /// the (optionally modified) value; omitting the call will short-circuit the pipeline.
+    /// </param>
+    /// <returns>The current instance of the builder.</returns>
+    /// <remarks>
+    /// This method constructs a <see cref="LambdaParameterMiddleware{T}"/> from the supplied delegates and registers it by delegating to <see cref="WithMiddleWare"/>.
+    /// Use this overload for small, inline middleware logic without creating a dedicated middleware type.
+    /// Middleware execution order is determined by registration order and can affect overall behaviour.
+    /// <para>
+    /// Note: this overload creates and registers a single middleware instance (a <see cref="LambdaParameterMiddleware{T}"/>).
+    /// To register multiple middlewares, use <see cref="WithMiddleWare(IParameterMiddleware{T}[])"/>.
+    /// </para>
+    /// </remarks>
+    public RegisterParameterBuilder<T> WithMiddleware(Func<T?, T>? onRead = null, Func<T, Func<T, Task>, Task>? onWriteAsync = null)
+    {
+        var middleware = new LambdaParameterMiddleware<T>(onRead, onWriteAsync);
+        return WithMiddleWare(middleware);
+    }
+
+    /// <summary>
     /// Builds the parameter state.
     /// </summary>
     /// <returns>The created parameter state.</returns>
@@ -185,6 +231,7 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
             _getParameterValueFunc ?? throw new ArgumentNullException(nameof(_getParameterValueFunc)),
             _eventCallbackFunc,
             _parameterChangedHandler,
+            _middlewares,
             _comparer);
 
         return parameterState;

--- a/src/MudBlazor/State/Middleware/IParameterMiddleware.cs
+++ b/src/MudBlazor/State/Middleware/IParameterMiddleware.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+namespace MudBlazor.State.Middleware;
+
+#nullable enable
+/// <summary>
+/// Middleware that can intercept and modify reads and writes performed by <see cref="ParameterState{T}"/>.
+/// </summary>
+/// <typeparam name="T">The type of the parameter value.</typeparam>
+/// <remarks>
+/// Middlewares are invoked in the order they are registered:
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <see cref="OnRead(T?)"/> is called for every read and may transform or validate the value before it is returned.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <see cref="OnWriteAsync(T, Func{T, Task})"/> participates in the write pipeline and can modify, validate or short-circuit the write operation.
+///       When participating in the write pipeline, a middleware should call the provided <c>next</c> delegate to continue processing; omitting the call short-circuits the pipeline.
+///     </description>
+///   </item>
+/// </list>
+/// Middlewares provide a stable extensibility point — you can add new behaviour (for example: transformation, logging, add <see cref="System.ComponentModel.INotifyPropertyChanged"/>, etc.)
+/// to parameter reads/writes without modifying the core <see cref="ParameterState{T}"/> implementation.
+/// The order of registration determines invocation order and therefore can affect overall behaviour.
+/// </remarks>
+public interface IParameterMiddleware<T>
+{
+    /// <summary>
+    /// Called when the parameter value is read via <see cref="ParameterState{T}.Value"/>.
+    /// </summary>
+    /// <param name="currentValue">The current value as seen by the pipeline. May be <c>null</c>.</param>
+    /// <returns>
+    /// The value that should be returned to the caller after middleware processing.
+    /// The middleware may return the same value or a transformed value.
+    /// </returns>
+    T? OnRead(T? currentValue);
+
+    /// <summary>
+    /// Called when the parameter value is being written (set) as part of the <see cref="ParameterState{T}"/> write pipeline.
+    /// </summary>
+    /// <param name="newValue">The incoming value requested to be set.</param>
+    /// <param name="next">
+    /// A delegate that invokes the next middleware (or the final setter) in the pipeline.
+    /// Call <c>await next(newValue)</c> to continue the pipeline and pass the (optionally modified) value.
+    /// </param>
+    /// <returns>A task that completes when this middleware and any downstream processing has finished.</returns>
+    /// <remarks>
+    /// The write pipeline preserves the registration order of middlewares. A middleware may short-circuit the pipeline by not calling <paramref name="next"/>.
+    /// </remarks>
+    Task OnWriteAsync(T newValue, Func<T, Task> next);
+}

--- a/src/MudBlazor/State/Middleware/LambdaParameterMiddleware.cs
+++ b/src/MudBlazor/State/Middleware/LambdaParameterMiddleware.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.State.Middleware;
+
+#nullable enable
+internal class LambdaParameterMiddleware<T> : IParameterMiddleware<T>
+{
+    private readonly Func<T?, T>? _onRead;
+    private readonly Func<T, Func<T, Task>, Task>? _onWriteAsync;
+
+    public LambdaParameterMiddleware(Func<T?, T>? onRead = null, Func<T, Func<T, Task>, Task>? onWriteAsync = null)
+    {
+        _onRead = onRead;
+        _onWriteAsync = onWriteAsync;
+    }
+
+    public T? OnRead(T? value) => _onRead is not null ? _onRead(value) : value;
+
+    public Task OnWriteAsync(T incomingValue, Func<T, Task> next)
+    {
+        return _onWriteAsync is not null
+            ? _onWriteAsync(incomingValue, next)
+            : next(incomingValue);
+    }
+}

--- a/src/MudBlazor/State/Middleware/LambdaParameterMiddleware.cs
+++ b/src/MudBlazor/State/Middleware/LambdaParameterMiddleware.cs
@@ -16,12 +16,12 @@ internal class LambdaParameterMiddleware<T> : IParameterMiddleware<T>
         _onWriteAsync = onWriteAsync;
     }
 
-    public T? OnRead(T? value) => _onRead is not null ? _onRead(value) : value;
+    public T? OnRead(T? currentValue) => _onRead is not null ? _onRead(currentValue) : currentValue;
 
-    public Task OnWriteAsync(T incomingValue, Func<T, Task> next)
+    public Task OnWriteAsync(T newValue, Func<T, Task> next)
     {
         return _onWriteAsync is not null
-            ? _onWriteAsync(incomingValue, next)
-            : next(incomingValue);
+            ? _onWriteAsync(newValue, next)
+            : next(newValue);
     }
 }

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State.Comparer;
 using MudBlazor.State.Invocation;
+using MudBlazor.State.Middleware;
 using MudBlazor.State.Rule;
 
 namespace MudBlazor.State;
@@ -35,6 +36,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     private readonly IParameterEqualityComparerSwappable<T> _comparer;
     private readonly Func<EventCallback<T>> _eventCallbackFunc;
     private readonly IParameterChangedHandler<T>? _parameterChangedHandler;
+    private readonly IReadOnlyList<IParameterMiddleware<T>> _middlewares;
 
     [MemberNotNullWhen(true, nameof(_parameterChangedEventArgs))]
     private bool HasParameterChangedEventArgs => _parameterChangedEventArgs is not null;
@@ -53,38 +55,56 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     public override T? InitialValue => _initialValue;
 
     /// <inheritdoc/>
-    public override T? Value => _value;
+    public override T? Value => OnRead(_value);
+
+    // TODO: Do we need this?
+    //public override T? RawValue => _value;
 
     /// <summary>
     /// Gets the function to provide the comparer for the parameter.
     /// </summary>
     public IParameterEqualityComparerSwappable<T> Comparer => _comparer;
 
-    private ParameterStateInternal(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, IParameterEqualityComparerSwappable<T>? comparer = null)
+    private ParameterStateInternal(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, IParameterMiddleware<T>[]? middlewares = null, IParameterEqualityComparerSwappable<T>? comparer = null)
     {
         Metadata = metadata;
         _getParameterValueFunc = getParameterValueFunc;
         _eventCallbackFunc = eventCallbackFunc;
         _parameterChangedHandler = parameterChangedHandler;
+        _middlewares = middlewares ?? [];
         _comparer = comparer ?? new ParameterEqualityComparerSwappable<T>(() => EqualityComparer<T>.Default);
         _lastValue = default;
         _value = default;
     }
 
     /// <inheritdoc/>
-    public override Task SetValueAsync(T value)
+    public override async Task SetValueAsync(T value)
     {
-        if (!_comparer.Equals(Value, value))
+        Task Final(T incomingValue)
         {
-            _value = value;
-            var eventCallback = _eventCallbackFunc();
-            if (eventCallback.HasDelegate)
+            if (!_comparer.Equals(Value, incomingValue))
             {
-                return eventCallback.InvokeAsync(value);
+                _value = incomingValue;
+                var eventCallback = _eventCallbackFunc();
+                if (eventCallback.HasDelegate)
+                {
+                    return eventCallback.InvokeAsync(incomingValue);
+                }
             }
+            return Task.CompletedTask;
         }
 
-        return Task.CompletedTask;
+        var pipeline = Final;
+
+        // Pipeline from last to first to preserve registration order
+        for (var i = _middlewares.Count - 1; i >= 0; i--)
+        {
+            var middleware = _middlewares[i];
+            var next = pipeline;
+            pipeline = incomingValue => middleware.OnWriteAsync(incomingValue, next);
+        }
+
+        await pipeline(value);
     }
 
     /// <inheritdoc />
@@ -147,6 +167,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         if (parameters.HasParameterChanged(Metadata.ParameterName, currentParameterValue, out var newValue, comparer: comparer))
         {
             changed = true;
+            // TODO: Do we need middleware OnRead here, does the change handler should receive transformed new value (and current value)?
             _parameterChangedEventArgs = new ParameterChangedEventArgs<T>(Metadata.ParameterName, currentParameterValue, newValue);
         }
 
@@ -163,16 +184,17 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     ///  <param name="getParameterValueFunc">A function that allows <see cref="ParameterState{T}"/> to read the property value.</param>
     ///  <param name="eventCallbackFunc">A function that allows <see cref="ParameterState{T}"/> to get the <see cref="EventCallback{T}"/> of the parameter.</param>
     ///  <param name="parameterChangedHandler">A change handler containing code that needs to be executed when the parameter value changes/</param>
+    ///  <param name="middlewares">An optional array of <see cref="IParameterMiddleware{T}"/> instances to apply to the parameter. Middlewares are invoked for both reads and writes of the parameter value and are executed in the order they are provided. Use middlewares to transform, validate, or short-circuit read/write operations.</param>
     ///  <param name="comparer">An optional comparer used to determine equality of parameter values.</param>
     ///  <remarks>
     ///  For details and usage please read CONTRIBUTING.md
     ///  </remarks>
     ///  <returns>The <see cref="ParameterState{T}"/> object to be stored in a field for accessing the current state value.</returns>
-    public static ParameterStateInternal<T> Attach(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, IParameterEqualityComparerSwappable<T>? comparer = null)
+    public static ParameterStateInternal<T> Attach(ParameterMetadata metadata, Func<T> getParameterValueFunc, Func<EventCallback<T>> eventCallbackFunc, IParameterChangedHandler<T>? parameterChangedHandler = null, IParameterMiddleware<T>[]? middlewares = null, IParameterEqualityComparerSwappable<T>? comparer = null)
     {
         metadata = ParameterMetadataRules.Morph(metadata);
 
-        return new ParameterStateInternal<T>(metadata, getParameterValueFunc, eventCallbackFunc, parameterChangedHandler, comparer);
+        return new ParameterStateInternal<T>(metadata, getParameterValueFunc, eventCallbackFunc, parameterChangedHandler, middlewares, comparer);
     }
 
     /// <inheritdoc />
@@ -199,4 +221,15 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
 
     /// <inheritdoc />
     public override int GetHashCode() => Metadata.ParameterName.GetHashCode();
+
+    private T? OnRead(T? currentValue)
+    {
+        // ReSharper disable once LoopCanBeConvertedToQuery
+        foreach (var middleware in _middlewares)
+        {
+            currentValue = middleware.OnRead(currentValue);
+        }
+
+        return currentValue;
+    }
 }

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -55,7 +55,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     public override T? InitialValue => _initialValue;
 
     /// <inheritdoc/>
-    public override T? Value => OnRead(_value);
+    public override T? Value => ApplyReadMiddleware(_value);
 
     // TODO: Do we need this?
     //public override T? RawValue => _value;
@@ -82,7 +82,9 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     {
         Task Final(T incomingValue)
         {
-            if (!_comparer.Equals(Value, incomingValue))
+            // TODO: Should we do middleware OnRead here too?
+            // The incoming value could be transformed (for example by converter) and we are comparing against a raw value, so it's not exactly correct?
+            if (!_comparer.Equals(_value, incomingValue))
             {
                 _value = incomingValue;
                 var eventCallback = _eventCallbackFunc();
@@ -222,7 +224,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     /// <inheritdoc />
     public override int GetHashCode() => Metadata.ParameterName.GetHashCode();
 
-    private T? OnRead(T? currentValue)
+    private T? ApplyReadMiddleware(T? currentValue)
     {
         // ReSharper disable once LoopCanBeConvertedToQuery
         foreach (var middleware in _middlewares)

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -84,7 +84,12 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         {
             // TODO: Should we do middleware OnRead here too?
             // The incoming value could be transformed (for example by converter) and we are comparing against a raw value, so it's not exactly correct?
-            if (!_comparer.Equals(_value, incomingValue))
+            // Possible Combinations and not cute clear what is the most "correct" one:
+            // - raw (_value) vs raw (value): chosen option for now
+            // - raw (_value) vs transformed (incomingValue) ??: old one
+            // - transformed (ApplyReadMiddleware(_value)) vs transformed (incomingValue) or ApplyRead(incomingValue
+            // - transformed (ApplyReadMiddleware(_value)) vs transformed ApplyReadMiddleware(value)
+            if (!_comparer.Equals(_value, value))
             {
                 _value = incomingValue;
                 var eventCallback = _eventCallbackFunc();


### PR DESCRIPTION
Something I’ve wanted to do for a long time. This could be a powerful feature.
For example, some components use:

https://github.com/MudBlazor/MudBlazor/blob/2fe8e15304342c3c58498af9103bd7af68ce161f/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs#L1156

https://github.com/MudBlazor/MudBlazor/blob/2fe8e15304342c3c58498af9103bd7af68ce161f/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs#L846

We could add a middleware that handles this behind the scenes once, so you wouldn’t need to write it manually every time. You could also expand the functionality, for example, to call `INotifyPropertyChanged.PropertyChanged` on writes.

If something more advanced is needed, you’d want a full-fledged interceptor for all `ParameterStateInternal` lifecycles: `OnInitialized`, `OnParametersSet`, `HandleAsync`, etc. However, this is not something we, or the community currently need.

There are still open questions:

* Do we need a `RawValue` that shows the original value without the middleware?
* Should `ParameterChangedEventArgs.Value` and `ParameterChangedEventArgs.LastValue` go through the middleware?
* What is the best comparison strategy for the `SetValueAsync`?
* Concerns with reference type, it's easy to modify them inside middleware which might mess `_value` in `ParameterState`. I'd say people that use reference types should clone their objects, modify and pass them next so that this doesn't affect the original value.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
