### PR TITLE
ResizeObserver: Resizes observer and bounding client rect cleanup

### DIFF
--- a/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
@@ -2,122 +2,122 @@
 using MudBlazor.Interop;
 using NUnit.Framework;
 
-namespace MudBlazor.UnitTests.Components
+namespace MudBlazor.UnitTests.Components;
+
+[TestFixture]
+public class BoundingClientRectTests
 {
-    [TestFixture]
-    public class BoundingClientRectTests
+    private Bunit.TestContext _ctx;
+
+    [SetUp]
+    public void Setup()
     {
-        private Bunit.TestContext ctx;
+        _ctx = new Bunit.TestContext();
+        _ctx.AddTestServices();
+    }
 
-        [SetUp]
-        public void Setup()
+    [TearDown]
+    public void TearDown() => _ctx.Dispose();
+
+    [Test]
+    public void Detect_Boundaries()
+    {
+        var client = new BoundingClientRect 
+        { 
+            Top = -10,
+            Left = -10, 
+            Height = 100, 
+            Width = 100,
+            ScrollX = 100,
+            ScrollY = 100,
+            WindowHeight = 1000,
+            WindowWidth = 1000
+        };
+
+        client.IsOutsideBottom.Should().BeFalse();
+        client.IsOutsideTop.Should().BeTrue();
+        client.IsOutsideLeft.Should().BeTrue();
+        client.IsOutsideRight.Should().BeFalse();
+    }
+
+    [Test]
+    public void BoundingClientRectProperties_ShouldBeSetAndComputedCorrectly()
+    {
+        // Arrange
+        var rect = new BoundingClientRect
         {
-            ctx = new Bunit.TestContext();
-            ctx.AddTestServices();
-        }
+            Top = 10,
+            Left = 20,
+            Width = 100,
+            Height = 200,
+            WindowHeight = 1080,
+            WindowWidth = 1920,
+            ScrollX = 5,
+            ScrollY = 10
+        };
 
-        [TearDown]
-        public void TearDown() => ctx.Dispose();
+        // Act
+        var clone = rect.Clone();
 
-        [Test]
-        public void Detect_Boundaries()
-        {
-            var client = new BoundingClientRect();
-            client.Top = -10;
-            client.Left = -10;
+        // Assert
+        clone.Top.Should().Be(rect.Top);
+        clone.Left.Should().Be(rect.Left);
+        clone.Width.Should().Be(rect.Width);
+        clone.Height.Should().Be(rect.Height);
+        clone.WindowHeight.Should().Be(rect.WindowHeight);
+        clone.WindowWidth.Should().Be(rect.WindowWidth);
+        clone.ScrollX.Should().Be(rect.ScrollX);
+        clone.ScrollY.Should().Be(rect.ScrollY);
 
-            client.Height = 100;
-            client.Width = 100;
+        // Check computed properties
+        #pragma warning disable CS0618 // Type or member is obsolete
+        clone.X.Should().Be(rect.Left);
+        clone.Y.Should().Be(rect.Top);
+        #pragma warning restore CS0618 // Type or member is obsolete
+        clone.Bottom.Should().Be(rect.Top + rect.Height);
+        clone.Right.Should().Be(rect.Left + rect.Width);
+        clone.AbsoluteLeft.Should().Be(rect.Left + rect.ScrollX);
+        clone.AbsoluteTop.Should().Be(rect.Top + rect.ScrollY);
+        clone.AbsoluteRight.Should().Be(rect.Right + rect.ScrollX);
+        clone.AbsoluteBottom.Should().Be(rect.Bottom + rect.ScrollY);
 
-            client.ScrollX = 100;
-            client.ScrollY = 100;
+        // Check if the rect is outside the viewport
+        clone.IsOutsideBottom.Should().BeFalse();
+        clone.IsOutsideLeft.Should().BeFalse();
+        clone.IsOutsideTop.Should().BeFalse();
+        clone.IsOutsideRight.Should().BeFalse();
+    }
 
-            client.WindowHeight = 1000;
-            client.WindowWidth = 1000;
+    [Test]
+    public void BoundingClientRectIsEqualTo_ShouldReturnTrueForEqualRects()
+    {
+        // Arrange
+        var rect1 = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
+        var rect2 = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
 
-            client.IsOutsideBottom.Should().BeFalse();
-            client.IsOutsideTop.Should().BeTrue();
-            client.IsOutsideLeft.Should().BeTrue();
-            client.IsOutsideRight.Should().BeFalse();
-        }
+        // Act & Assert
+        rect1.IsEqualTo(rect2).Should().BeTrue();
+    }
 
-        [Test]
-        public void BoundingClientRectProperties_ShouldBeSetAndComputedCorrectly()
-        {
-            // Arrange
-            var rect = new BoundingClientRect
-            {
-                Top = 10,
-                Left = 20,
-                Width = 100,
-                Height = 200,
-                WindowHeight = 1080,
-                WindowWidth = 1920,
-                ScrollX = 5,
-                ScrollY = 10
-            };
+    [Test]
+    public void BoundingClientRectIsEqualTo_ShouldReturnFalseForDifferentRects()
+    {
+        // Arrange
+        var rect1 = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
+        var rect2 = new BoundingClientRect { Top = 10, Left = 30, Width = 100, Height = 200 };
 
-            // Act
-            var clone = rect.Clone();
+        // Act & Assert
+        rect1.IsEqualTo(rect2).Should().BeFalse();
+    }
 
-            // Assert
-            clone.Top.Should().Be(rect.Top);
-            clone.Left.Should().Be(rect.Left);
-            clone.Width.Should().Be(rect.Width);
-            clone.Height.Should().Be(rect.Height);
-            clone.WindowHeight.Should().Be(rect.WindowHeight);
-            clone.WindowWidth.Should().Be(rect.WindowWidth);
-            clone.ScrollX.Should().Be(rect.ScrollX);
-            clone.ScrollY.Should().Be(rect.ScrollY);
+    [Test]
+    public void BoundingClientRectIsEqualTo_ShouldReturnFalseWhenEitherIsNull()
+    {
+        // Arrange
+        var rect = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
 
-            // Check computed properties
-            clone.X.Should().Be(rect.Left);
-            clone.Y.Should().Be(rect.Top);
-            clone.Bottom.Should().Be(rect.Top + rect.Height);
-            clone.Right.Should().Be(rect.Left + rect.Width);
-            clone.AbsoluteLeft.Should().Be(rect.Left + rect.ScrollX);
-            clone.AbsoluteTop.Should().Be(rect.Top + rect.ScrollY);
-            clone.AbsoluteRight.Should().Be(rect.Right + rect.ScrollX);
-            clone.AbsoluteBottom.Should().Be(rect.Bottom + rect.ScrollY);
-
-            // Check if the rect is outside of the viewport
-            clone.IsOutsideBottom.Should().BeFalse();
-            clone.IsOutsideLeft.Should().BeFalse();
-            clone.IsOutsideTop.Should().BeFalse();
-            clone.IsOutsideRight.Should().BeFalse();
-        }
-
-        [Test]
-        public void BoundingClientRectIsEqualTo_ShouldReturnTrueForEqualRects()
-        {
-            // Arrange
-            var rect1 = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
-            var rect2 = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
-
-            // Act & Assert
-            rect1.IsEqualTo(rect2).Should().BeTrue();
-        }
-
-        [Test]
-        public void BoundingClientRectIsEqualTo_ShouldReturnFalseForDifferentRects()
-        {
-            // Arrange
-            var rect1 = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
-            var rect2 = new BoundingClientRect { Top = 10, Left = 30, Width = 100, Height = 200 };
-
-            // Act & Assert
-            rect1.IsEqualTo(rect2).Should().BeFalse();
-        }
-
-        [Test]
-        public void BoundingClientRectIsEqualTo_ShouldReturnFalseWhenEitherIsNull()
-        {
-            // Arrange
-            var rect = new BoundingClientRect { Top = 10, Left = 20, Width = 100, Height = 200 };
-
-            // Act & Assert
-            rect.IsEqualTo(null).Should().BeFalse();
-            ((BoundingClientRect)null).IsEqualTo(rect).Should().BeFalse();
-        }
+        // Act & Assert
+        rect.IsEqualTo(null).Should().BeFalse();
+        ((BoundingClientRect)null).IsEqualTo(rect).Should().BeFalse();
     }
 }

--- a/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
@@ -22,11 +22,11 @@ public class BoundingClientRectTests
     [Test]
     public void Detect_Boundaries()
     {
-        var client = new BoundingClientRect 
-        { 
+        var client = new BoundingClientRect
+        {
             Top = -10,
-            Left = -10, 
-            Height = 100, 
+            Left = -10,
+            Height = 100,
             Width = 100,
             ScrollX = 100,
             ScrollY = 100,

--- a/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using MudBlazor.Extensions;
 using MudBlazor.Interop;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
@@ -70,10 +70,10 @@ public class BoundingClientRectTests
         clone.ScrollY.Should().Be(rect.ScrollY);
 
         // Check computed properties
-        #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
         clone.X.Should().Be(rect.Left);
         clone.Y.Should().Be(rect.Top);
-        #pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
         clone.Bottom.Should().Be(rect.Top + rect.Height);
         clone.Right.Should().Be(rect.Left + rect.Width);
         clone.AbsoluteLeft.Should().Be(rect.Left + rect.ScrollX);

--- a/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
@@ -70,10 +70,6 @@ public class BoundingClientRectTests
         clone.ScrollY.Should().Be(rect.ScrollY);
 
         // Check computed properties
-#pragma warning disable CS0618 // Type or member is obsolete
-        clone.X.Should().Be(rect.Left);
-        clone.Y.Should().Be(rect.Top);
-#pragma warning restore CS0618 // Type or member is obsolete
         clone.Bottom.Should().Be(rect.Top + rect.Height);
         clone.Right.Should().Be(rect.Left + rect.Width);
         clone.AbsoluteLeft.Should().Be(rect.Left + rect.ScrollX);

--- a/src/MudBlazor/Extensions/BoundingClientRectExtensions.cs
+++ b/src/MudBlazor/Extensions/BoundingClientRectExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using MudBlazor.Interop;
+
+namespace MudBlazor.Extensions;
+
+#nullable enable
+public static class BoundingClientRectExtensions
+{
+    public static bool IsEqualTo(this BoundingClientRect? sourceRect, BoundingClientRect? targetRect, double tolerance = 0.00001)
+    {
+        if (sourceRect is null || targetRect is null) return false;
+        return Math.Abs(sourceRect.Top - targetRect.Top) < tolerance
+               && Math.Abs(sourceRect.Left - targetRect.Left) < tolerance
+               && Math.Abs(sourceRect.Width - targetRect.Width) < tolerance
+               && Math.Abs(sourceRect.Height - targetRect.Height) < tolerance
+               && Math.Abs(sourceRect.WindowHeight - targetRect.WindowHeight) < tolerance
+               && Math.Abs(sourceRect.WindowWidth - targetRect.WindowWidth) < tolerance
+               && Math.Abs(sourceRect.ScrollX - targetRect.ScrollX) < tolerance
+               && Math.Abs(sourceRect.ScrollY - targetRect.ScrollY) < tolerance;
+    }
+}

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -63,24 +63,6 @@ public class BoundingClientRect
     public double ScrollY { get; set; }
 
     /// <summary>
-    /// The horizontal offset.
-    /// </summary>
-    /// <returns>
-    /// <see cref="Left"/>
-    /// </returns>
-    [Obsolete("Use Left instead")]
-    public double X => Left;
-
-    /// <summary>
-    /// The vertical offset.
-    /// </summary>
-    /// <returns>
-    /// <see cref="Top"/>
-    /// </returns>
-    [Obsolete("Use Top instead")]
-    public double Y => Top;
-
-    /// <summary>
     /// The horizontal offset including the horizontal scroll.
     /// </summary>
     /// <returns>

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -145,19 +145,3 @@ public class BoundingClientRect
         };
     }
 }
-
-public static class BoundingClientRectExtensions
-{
-    public static bool IsEqualTo(this BoundingClientRect? sourceRect, BoundingClientRect? targetRect, double tolerance = 0.00001)
-    {
-        if (sourceRect is null || targetRect is null) return false;
-        return Math.Abs(sourceRect.Top - targetRect.Top) < tolerance
-               && Math.Abs(sourceRect.Left - targetRect.Left) < tolerance
-               && Math.Abs(sourceRect.Width - targetRect.Width) < tolerance
-               && Math.Abs(sourceRect.Height - targetRect.Height) < tolerance
-               && Math.Abs(sourceRect.WindowHeight - targetRect.WindowHeight) < tolerance
-               && Math.Abs(sourceRect.WindowWidth - targetRect.WindowWidth) < tolerance
-               && Math.Abs(sourceRect.ScrollX - targetRect.ScrollX) < tolerance
-               && Math.Abs(sourceRect.ScrollY - targetRect.ScrollY) < tolerance;
-    }
-}

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -1,85 +1,177 @@
-﻿namespace MudBlazor.Interop
-{
+﻿namespace MudBlazor.Interop;
 #nullable enable
-    public class BoundingClientRect
+
+/// <summary>
+/// Represents the bounding rectangle of an element.
+/// </summary>
+public class BoundingClientRect
+{
+    /// <summary>
+    /// The vertical offset to the top edge.
+    /// </summary>
+    public double Top { get; set; }
+
+    /// <summary>
+    /// The horizontal offset relative to the left edge.
+    /// </summary>
+    public double Left { get; set; }
+
+    /// <summary>
+    /// The horizontal offset relative to the bottom edge.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Top"/> + <see cref="Height"/>
+    /// </returns>
+    public double Bottom => Top + Height;
+
+    /// <summary>
+    /// The vertical offset to the right edge.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Left"/> + <see cref="Width"/>
+    /// </returns>
+    public double Right => Left + Width;
+
+    /// <summary>
+    /// The width of this rectangle.
+    /// </summary>
+    public double Width { get; set; }
+
+    /// <summary>
+    /// The height of this rectangle.
+    /// </summary>
+    public double Height { get; set; }
+
+    /// <summary>
+    /// Height of the viewport.
+    /// </summary>
+    public double WindowHeight { get; set; }
+
+    /// <summary>
+    /// Width of the viewport.
+    /// </summary>
+    public double WindowWidth { get; set; }
+
+    /// <summary>
+    /// The horizontal scrolled offset.
+    /// </summary>
+    public double ScrollX { get; set; }
+
+    /// <summary>
+    /// The vertical scrolled offset.
+    /// </summary>
+    public double ScrollY { get; set; }
+
+    /// <summary>
+    /// The vertical offset.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Left"/>
+    /// </returns>
+    [Obsolete("Use Left instead")]
+    public double X => Left;
+
+    /// <summary>
+    /// The horizontal offset.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Top"/>
+    /// </returns>
+    [Obsolete("Use Top instead")]
+    public double Y => Top;
+
+    /// <summary>
+    /// The horizontal offset including the horizontal scroll.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Left"/> + <see cref="ScrollX"/>
+    /// </returns>
+    public double AbsoluteLeft => Left + ScrollX;
+
+    /// <summary>
+    /// The vertical offset including the vertical scroll.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Top"/> + <see cref="ScrollY"/>
+    /// </returns>
+    public double AbsoluteTop => Top + ScrollY;
+
+    /// <summary>
+    /// The horizontal offset from the right edge including the vertical scroll.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Right"/> + <see cref="ScrollX"/>
+    /// </returns>
+    public double AbsoluteRight => Right + ScrollX;
+
+    /// <summary>
+    /// The vertical offset from the bottom edge including the vertical scroll.
+    /// </summary>
+    /// <returns>
+    /// <see cref="Bottom"/> + <see cref="ScrollY"/>
+    /// </returns>
+    public double AbsoluteBottom => Bottom + ScrollY;
+
+    /// <summary>
+    /// Whether the rect is outside the viewport on the bottom side.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if <see cref="Bottom"/> &gt; <see cref="WindowHeight"/>
+    /// </returns>
+    public bool IsOutsideBottom => Bottom > WindowHeight;
+
+    /// <summary>
+    /// Whether the rect is outside the viewport on the left side.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if <see cref="Left"/> &lt; <c>0</c>
+    /// </returns>
+    public bool IsOutsideLeft => Left < 0;
+
+    /// <summary>
+    /// Whether the rect is outside the viewport on the top side.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if <see cref="Top"/> &lt; <c>0</c>
+    /// </returns>
+    public bool IsOutsideTop => Top < 0;
+
+    /// <summary>
+    /// Whether the rect is outside the viewport on the right side.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if <see cref="Right"/> &gt; <see cref="WindowWidth"/>
+    /// </returns>
+    public bool IsOutsideRight => Right > WindowWidth;
+
+    public BoundingClientRect Clone()
     {
-        public double Top { get; set; }
-        public double Left { get; set; }
-
-        public double Width { get; set; }
-        public double Height { get; set; }
-
-        /// <summary>
-        /// height of the viewport
-        /// </summary>
-        public double WindowHeight { get; set; }
-
-        /// <summary>
-        /// width of the viewport
-        /// </summary>
-        public double WindowWidth { get; set; }
-
-        /// <summary>
-        /// the horizontal offset since the left of the page
-        /// </summary>
-        public double ScrollX { get; set; }
-
-        /// <summary>
-        /// the vertical offset since the top of the page
-        /// </summary>
-        public double ScrollY { get; set; }
-
-        // computed properties, read only
-        public double X => Left;
-        public double Y => Top;
-        public double Bottom => Top + Height;
-        public double Right => Left + Width;
-
-        public double AbsoluteLeft => Left + ScrollX;
-
-        public double AbsoluteTop => Top + ScrollY;
-
-        public double AbsoluteRight => Right + ScrollX;
-
-        public double AbsoluteBottom => Bottom + ScrollY;
-
-        //check if the rect is outside of the viewport
-        public bool IsOutsideBottom => Bottom > WindowHeight;
-
-        public bool IsOutsideLeft => Left < 0;
-
-        public bool IsOutsideTop => Top < 0;
-
-        public bool IsOutsideRight => Right > WindowWidth;
-
-        public BoundingClientRect Clone()
+        return new BoundingClientRect
         {
-            return new BoundingClientRect
-            {
-                Left = Left,
-                Top = Top,
-                Width = Width,
-                Height = Height,
-                WindowHeight = WindowHeight,
-                WindowWidth = WindowWidth,
-                ScrollX = ScrollX,
-                ScrollY = ScrollY
-            };
-        }
+            Left = Left,
+            Top = Top,
+            Width = Width,
+            Height = Height,
+            WindowHeight = WindowHeight,
+            WindowWidth = WindowWidth,
+            ScrollX = ScrollX,
+            ScrollY = ScrollY
+        };
     }
-    public static class BoundingClientRectExtensions
+}
+
+public static class BoundingClientRectExtensions
+{
+    public static bool IsEqualTo(this BoundingClientRect? sourceRect, BoundingClientRect? targetRect, double tolerance = 0.00001)
     {
-        public static bool IsEqualTo(this BoundingClientRect? sourceRect, BoundingClientRect? targetRect)
-        {
-            if (sourceRect is null || targetRect is null) return false;
-            return sourceRect.Top == targetRect.Top
-                && sourceRect.Left == targetRect.Left
-                && sourceRect.Width == targetRect.Width
-                && sourceRect.Height == targetRect.Height
-                && sourceRect.WindowHeight == targetRect.WindowHeight
-                && sourceRect.WindowWidth == targetRect.WindowWidth
-                && sourceRect.ScrollX == targetRect.ScrollX
-                && sourceRect.ScrollY == targetRect.ScrollY;
-        }
+        if (sourceRect is null || targetRect is null) return false;
+        return Math.Abs(sourceRect.Top - targetRect.Top) < tolerance
+               && Math.Abs(sourceRect.Left - targetRect.Left) < tolerance
+               && Math.Abs(sourceRect.Width - targetRect.Width) < tolerance
+               && Math.Abs(sourceRect.Height - targetRect.Height) < tolerance
+               && Math.Abs(sourceRect.WindowHeight - targetRect.WindowHeight) < tolerance
+               && Math.Abs(sourceRect.WindowWidth - targetRect.WindowWidth) < tolerance
+               && Math.Abs(sourceRect.ScrollX - targetRect.ScrollX) < tolerance
+               && Math.Abs(sourceRect.ScrollY - targetRect.ScrollY) < tolerance;
     }
 }

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -17,7 +17,7 @@ public class BoundingClientRect
     public double Left { get; set; }
 
     /// <summary>
-    /// The horizontal offset relative to the bottom edge.
+    /// The vertical offset relative to the bottom edge.
     /// </summary>
     /// <returns>
     /// <see cref="Top"/> + <see cref="Height"/>
@@ -25,7 +25,7 @@ public class BoundingClientRect
     public double Bottom => Top + Height;
 
     /// <summary>
-    /// The vertical offset to the right edge.
+    /// The horizontal offset to the right edge.
     /// </summary>
     /// <returns>
     /// <see cref="Left"/> + <see cref="Width"/>
@@ -43,14 +43,14 @@ public class BoundingClientRect
     public double Height { get; set; }
 
     /// <summary>
-    /// Height of the viewport.
-    /// </summary>
-    public double WindowHeight { get; set; }
-
-    /// <summary>
     /// Width of the viewport.
     /// </summary>
     public double WindowWidth { get; set; }
+
+    /// <summary>
+    /// Height of the viewport.
+    /// </summary>
+    public double WindowHeight { get; set; }
 
     /// <summary>
     /// The horizontal scrolled offset.
@@ -63,7 +63,7 @@ public class BoundingClientRect
     public double ScrollY { get; set; }
 
     /// <summary>
-    /// The vertical offset.
+    /// The horizontal offset.
     /// </summary>
     /// <returns>
     /// <see cref="Left"/>
@@ -72,7 +72,7 @@ public class BoundingClientRect
     public double X => Left;
 
     /// <summary>
-    /// The horizontal offset.
+    /// The vertical offset.
     /// </summary>
     /// <returns>
     /// <see cref="Top"/>
@@ -97,7 +97,7 @@ public class BoundingClientRect
     public double AbsoluteTop => Top + ScrollY;
 
     /// <summary>
-    /// The horizontal offset from the right edge including the vertical scroll.
+    /// The horizontal offset from the right edge including the horizontal scroll.
     /// </summary>
     /// <returns>
     /// <see cref="Right"/> + <see cref="ScrollX"/>
@@ -144,16 +144,20 @@ public class BoundingClientRect
     /// </returns>
     public bool IsOutsideRight => Right > WindowWidth;
 
+    /// <summary>
+    /// Creates a shallow copy of the current <see cref="BoundingClientRect"/> instance.
+    /// </summary>
+    /// <returns>A new <see cref="BoundingClientRect"/> instance</returns>
     public BoundingClientRect Clone()
     {
         return new BoundingClientRect
         {
-            Left = Left,
             Top = Top,
+            Left = Left,
             Width = Width,
             Height = Height,
-            WindowHeight = WindowHeight,
             WindowWidth = WindowWidth,
+            WindowHeight = WindowHeight,
             ScrollX = ScrollX,
             ScrollY = ScrollY
         };

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
@@ -4,167 +4,166 @@ using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using MudBlazor.Interop;
 
-namespace MudBlazor.Services
-{
+namespace MudBlazor.Services;
 #nullable enable
+
+/// <summary>
+/// Observes resize events on elements and provides size information.
+/// </summary>
+internal sealed class ResizeObserver : IResizeObserver
+{
+    private bool _disposed;
+    private readonly IJSRuntime _jsRuntime;
+    private readonly Guid _id = Guid.NewGuid();
+    private readonly ResizeObserverOptions _options;
+    private readonly DotNetObjectReference<ResizeObserver> _dotNetRef;
+    private readonly Dictionary<Guid, ElementReference> _cachedValueIds = new();
+    private readonly Dictionary<ElementReference, BoundingClientRect> _cachedValues = new(ElementReferenceComparer.Default);
+
+    /// <inheritdoc />
+    public event SizeChanged? OnResized;
+
     /// <summary>
-    /// Observes resize events on elements and provides size information.
+    /// Initializes a new instance of the <see cref="ResizeObserver"/> class.
     /// </summary>
-    internal sealed class ResizeObserver : IResizeObserver
+    /// <param name="jsRuntime">The JavaScript runtime.</param>
+    /// <param name="options">The options to configure the resize observer.</param>
+    [DynamicDependency(nameof(OnSizeChanged))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SizeChangeUpdateInfo))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BoundingClientRect))]
+    public ResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions>? options = null)
     {
-        private bool _disposed;
-        private readonly IJSRuntime _jsRuntime;
-        private readonly Guid _id = Guid.NewGuid();
-        private readonly ResizeObserverOptions _options;
-        private readonly DotNetObjectReference<ResizeObserver> _dotNetRef;
-        private readonly Dictionary<Guid, ElementReference> _cachedValueIds = new();
-        private readonly Dictionary<ElementReference, BoundingClientRect> _cachedValues = new(ElementReferenceComparer.Default);
+        _dotNetRef = DotNetObjectReference.Create(this);
+        _jsRuntime = jsRuntime;
+        _options = options?.Value ?? new ResizeObserverOptions();
+    }
+
+    /// <inheritdoc />
+    public async Task<BoundingClientRect?> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
+    {
+        var filteredElements = elements.Where(x => x.Context is not null && !_cachedValues.ContainsKey(x)).ToList();
+        if (filteredElements.Count == 0)
+        {
+            return Array.Empty<BoundingClientRect>();
+        }
+
+        var elementIds = new List<Guid>();
+
+        foreach (var item in filteredElements)
+        {
+            var id = Guid.NewGuid();
+            elementIds.Add(id);
+            _cachedValueIds.Add(id, item);
+        }
+
+        var boundingRect = await _jsRuntime.InvokeAsyncWithErrorHandling<BoundingClientRect[]?>([], "mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options);
+        var result = boundingRect.value ?? [];
+        var counter = 0;
+        foreach (var item in result)
+        {
+            _cachedValues.Add(filteredElements.ElementAt(counter), item);
+            counter++;
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task Unobserve(ElementReference element)
+    {
+        var elementId = _cachedValueIds.FirstOrDefault(x => x.Value.Id == element.Id).Key;
+        if (elementId == Guid.Empty)
+        {
+            return;
+        }
+
+        await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeObserver.disconnect", _id, elementId);
+
+        _cachedValueIds.Remove(elementId);
+        _cachedValues.Remove(element);
+    }
+
+    /// <inheritdoc />
+    public bool IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
+
+    /// <inheritdoc />
+    public BoundingClientRect? GetSizeInfo(ElementReference reference) => _cachedValues.GetValueOrDefault(reference);
+
+    /// <inheritdoc />
+    public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
+
+    /// <inheritdoc />
+    public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
+
+    /// <summary>
+    /// Invoked by JavaScript when the size of an observed element changes.
+    /// </summary>
+    /// <param name="changes">The changes in size.</param>
+    [JSInvokable]
+    public void OnSizeChanged(IEnumerable<SizeChangeUpdateInfo> changes)
+    {
+        var parsedChanges = new Dictionary<ElementReference, BoundingClientRect>(ElementReferenceComparer.Default);
+        foreach (var item in changes)
+        {
+            if (_cachedValueIds.TryGetValue(item.Id, out var elementRef))
+            {
+                _cachedValues[elementRef] = item.Size;
+                parsedChanges.Add(elementRef, item.Size);
+            }
+        }
+
+        OnResized?.Invoke(parsedChanges);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (!_disposed)
+        {
+            _disposed = true;
+
+            await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeObserver.cancelListener", _id);
+
+            _dotNetRef.Dispose();
+            _cachedValueIds.Clear();
+            _cachedValues.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Represents the size change update information.
+    /// </summary>
+    /// <param name="Id">The identifier of the element.</param>
+    /// <param name="Size">The new size of the element.</param>
+    public record SizeChangeUpdateInfo(Guid Id, BoundingClientRect Size);
+
+    /// <summary>
+    /// Comparer for <see cref="ElementReference"/> to improve performance.
+    /// </summary>
+    /// <remarks>
+    /// This is needed because runtime provided implementation is not efficient for struct.
+    /// </remarks>
+    internal class ElementReferenceComparer : IEqualityComparer<ElementReference>
+    {
+        /// <inheritdoc />
+        public bool Equals(ElementReference x, ElementReference y) => x.Id == y.Id;
 
         /// <inheritdoc />
-        public event SizeChanged? OnResized;
+        public int GetHashCode(ElementReference obj)
+        {
+            // Do not modify this null workaround, as the Id can be null when ElementReference is initialized as default(ElementReference).
+            // Although the nullable annotation suggests otherwise, we use this unconventional object pattern instead of an if-else statement 
+            // to suppress the nullable annotation.
+            // https://github.com/dotnet/aspnetcore/issues/58523
+            return obj is { Id: null } ? 0 : obj.Id.GetHashCode();
+        }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ResizeObserver"/> class.
+        /// Gets the default instance of the comparer.
         /// </summary>
-        /// <param name="jsRuntime">The JavaScript runtime.</param>
-        /// <param name="options">The options to configure the resize observer.</param>
-        [DynamicDependency(nameof(OnSizeChanged))]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SizeChangeUpdateInfo))]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BoundingClientRect))]
-        public ResizeObserver(IJSRuntime jsRuntime, IOptions<ResizeObserverOptions>? options = null)
-        {
-            _dotNetRef = DotNetObjectReference.Create(this);
-            _jsRuntime = jsRuntime;
-            _options = options?.Value ?? new ResizeObserverOptions();
-        }
-
-        /// <inheritdoc />
-        public async Task<BoundingClientRect?> Observe(ElementReference element) => (await Observe(new[] { element })).FirstOrDefault();
-
-        /// <inheritdoc />
-        public async Task<IEnumerable<BoundingClientRect>> Observe(IEnumerable<ElementReference> elements)
-        {
-            var filteredElements = elements.Where(x => x.Context is not null && !_cachedValues.ContainsKey(x)).ToList();
-            if (!filteredElements.Any())
-            {
-                return Array.Empty<BoundingClientRect>();
-            }
-
-            var elementIds = new List<Guid>();
-
-            foreach (var item in filteredElements)
-            {
-                var id = Guid.NewGuid();
-                elementIds.Add(id);
-                _cachedValueIds.Add(id, item);
-            }
-
-            var result = (await _jsRuntime.InvokeAsyncWithErrorHandling<BoundingClientRect[]?>(Array.Empty<BoundingClientRect>(),
-                "mudResizeObserver.connect", _id, _dotNetRef, filteredElements, elementIds, _options)).value ?? Array.Empty<BoundingClientRect>();
-            var counter = 0;
-            foreach (var item in result)
-            {
-                _cachedValues.Add(filteredElements.ElementAt(counter), item);
-                counter++;
-            }
-
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task Unobserve(ElementReference element)
-        {
-            var elementId = _cachedValueIds.FirstOrDefault(x => x.Value.Id == element.Id).Key;
-            if (elementId == default)
-            {
-                return;
-            }
-
-            await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeObserver.disconnect", _id, elementId);
-
-            _cachedValueIds.Remove(elementId);
-            _cachedValues.Remove(element);
-        }
-
-        /// <inheritdoc />
-        public bool IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
-
-        /// <inheritdoc />
-        public BoundingClientRect? GetSizeInfo(ElementReference reference) => _cachedValues.GetValueOrDefault(reference);
-
-        /// <inheritdoc />
-        public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
-
-        /// <inheritdoc />
-        public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
-
-        /// <summary>
-        /// Invoked by JavaScript when the size of an observed element changes.
-        /// </summary>
-        /// <param name="changes">The changes in size.</param>
-        [JSInvokable]
-        public void OnSizeChanged(IEnumerable<SizeChangeUpdateInfo> changes)
-        {
-            var parsedChanges = new Dictionary<ElementReference, BoundingClientRect>(ElementReferenceComparer.Default);
-            foreach (var item in changes)
-            {
-                if (_cachedValueIds.TryGetValue(item.Id, out var elementRef))
-                {
-                    _cachedValues[elementRef] = item.Size;
-                    parsedChanges.Add(elementRef, item.Size);
-                }
-            }
-
-            OnResized?.Invoke(parsedChanges);
-        }
-
-        /// <inheritdoc />
-        public async ValueTask DisposeAsync()
-        {
-            if (!_disposed)
-            {
-                _disposed = true;
-
-                await _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudResizeObserver.cancelListener", _id);
-
-                _dotNetRef.Dispose();
-                _cachedValueIds.Clear();
-                _cachedValues.Clear();
-            }
-        }
-
-        /// <summary>
-        /// Represents the size change update information.
-        /// </summary>
-        /// <param name="Id">The identifier of the element.</param>
-        /// <param name="Size">The new size of the element.</param>
-        public record SizeChangeUpdateInfo(Guid Id, BoundingClientRect Size);
-
-        /// <summary>
-        /// Comparer for <see cref="ElementReference"/> to improve performance.
-        /// </summary>
-        /// <remarks>
-        /// This is needed because runtime provided implementation is not efficient for struct.
-        /// </remarks>
-        internal class ElementReferenceComparer : IEqualityComparer<ElementReference>
-        {
-            /// <inheritdoc />
-            public bool Equals(ElementReference x, ElementReference y) => x.Id == y.Id;
-
-            /// <inheritdoc />
-            public int GetHashCode(ElementReference obj)
-            {
-                // Do not modify this null workaround, as the Id can be null when ElementReference is initialized as default(ElementReference).
-                // Although the nullable annotation suggests otherwise, we use this unconventional object pattern instead of an if-else statement 
-                // to suppress the nullable annotation.
-                // https://github.com/dotnet/aspnetcore/issues/58523
-                return obj is { Id: null } ? 0 : obj.Id.GetHashCode();
-            }
-
-            /// <summary>
-            /// Gets the default instance of the comparer.
-            /// </summary>
-            public static ElementReferenceComparer Default { get; } = new();
-        }
+        public static ElementReferenceComparer Default { get; } = new();
     }
 }


### PR DESCRIPTION
This PR affects the `ResizeObserver` and the `BoundingClientRect`:
- Fix formatting
- Modernize a view bits
- Fix floating point comparison
- Add missing documentation for public properties
