### PR TITLE
Docs: Change table style, Add white background to sponsors, Refactor

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsClassTable.razor
+++ b/src/MudBlazor.Docs/Components/DocsClassTable.razor
@@ -1,4 +1,4 @@
-﻿<MudSimpleTable Class="docs-class-table utility-table" Dense="true" Elevation="0" FixedHeader="true">
+﻿<MudSimpleTable Class="docs-class-table utility-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
     <thead>
         <tr>
             <th>Class</th>

--- a/src/MudBlazor.Docs/Components/DocsClassTable.razor
+++ b/src/MudBlazor.Docs/Components/DocsClassTable.razor
@@ -1,4 +1,4 @@
-﻿<MudSimpleTable Class="docs-class-table utility-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+﻿<MudSimpleTable Class="docs-class-table utility-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
     <thead>
         <tr>
             <th>Class</th>

--- a/src/MudBlazor.Docs/Components/Sponsor.razor
+++ b/src/MudBlazor.Docs/Components/Sponsor.razor
@@ -15,6 +15,6 @@
     {
         return LandingPage 
             ? "lp-sponsor d-flex justify-center align-center pa-4 relative mud-transparent" 
-            : "d-flex justify-center align-center rounded-lg relative white-background";
+            : "d-flex justify-center align-center rounded-lg relative white";
     }
 }

--- a/src/MudBlazor.Docs/Components/Sponsor.razor
+++ b/src/MudBlazor.Docs/Components/Sponsor.razor
@@ -1,4 +1,11 @@
-﻿<a href="@Website" target="@Target" rel="nofollow">
+﻿<!--suppress CssUnresolvedCustomProperty, CssUnusedSymbol -->
+<style>
+    .white-background {
+        background-color: var(--mud-palette-white);
+    }
+</style>
+
+<a href="@Website" target="@Target" rel="nofollow">
     <MudPaper Elevation="@(LandingPage? 0 : 25)" Class="@GetClassnames()" Height="100%">
         <MudImage Src="@($"_content/MudBlazor.Docs/images/sponsors/{Image}")" Alt="@Name" ObjectFit="ObjectFit.Cover" ObjectPosition="ObjectPosition.Center" />
     </MudPaper>
@@ -9,18 +16,12 @@
     [Parameter] public string Name { get; set; }
     [Parameter] public string Image { get; set; }
     [Parameter] public bool LandingPage { get; set; }
-
     [Parameter] public string Target { get; set; } = "_blank";
     
     private string GetClassnames()
     {
-        if (LandingPage)
-        {
-            return "lp-sponsor d-flex justify-center align-center mud-transparent pa-4 relative";
-        }
-        else
-        {
-            return "d-flex justify-center align-center mud-transparent rounded-lg relative";
-        }
+        return LandingPage 
+            ? "lp-sponsor d-flex justify-center align-center pa-4 relative mud-transparent" 
+            : "d-flex justify-center align-center rounded-lg relative white-background";
     }
 }

--- a/src/MudBlazor.Docs/Components/Sponsor.razor
+++ b/src/MudBlazor.Docs/Components/Sponsor.razor
@@ -1,11 +1,4 @@
-﻿<!--suppress CssUnresolvedCustomProperty, CssUnusedSymbol -->
-<style>
-    .white-background {
-        background-color: var(--mud-palette-white);
-    }
-</style>
-
-<a href="@Website" target="@Target" rel="nofollow">
+﻿<a href="@Website" target="@Target" rel="nofollow">
     <MudPaper Elevation="@(LandingPage? 0 : 25)" Class="@GetClassnames()" Height="100%">
         <MudImage Src="@($"_content/MudBlazor.Docs/images/sponsors/{Image}")" Alt="@Name" ObjectFit="ObjectFit.Cover" ObjectPosition="ObjectPosition.Center" />
     </MudPaper>

--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -220,7 +220,7 @@
     {
         foreach (var value in typeof(Palette).GetProperties())
         {
-            var newProp = new ApiDefaultTheme()
+            var newProp = new ApiDefaultTheme
             {
                 Name = value.Name,
                 Type = value.PropertyType.ConvertToCSharpSource(),
@@ -234,7 +234,7 @@
 
     private void LoadShadows()
     {
-        _apiShadow.Add(new ApiDefaultTheme()
+        _apiShadow.Add(new ApiDefaultTheme
         {
             Name = "Elevation",
             Type = "String[]",
@@ -242,7 +242,7 @@
         });
         for (var i = 0; i < _mudTheme.Shadows.Elevation.Length; i++)
         {
-            _apiShadow.Add(new ApiDefaultTheme()
+            _apiShadow.Add(new ApiDefaultTheme
             {
                 Name = $"Elevation[{i}]",
                 Type = "String",
@@ -257,7 +257,7 @@
     {
         foreach (var value in typeof(LayoutProperties).GetProperties())
         {
-            _apiLayout.Add(new ApiDefaultTheme()
+            _apiLayout.Add(new ApiDefaultTheme
             {
                 Name = value.Name,
                 Type = value.PropertyType.ConvertToCSharpSource(),
@@ -271,7 +271,7 @@
     {
         foreach (var _typography in typeof(Typography).GetProperties())
         {
-            _apiTypography.Add(new ApiDefaultTheme()
+            _apiTypography.Add(new ApiDefaultTheme
             {
                 Name = _typography.Name,
                 Type = _typography.PropertyType.ConvertToCSharpSource(),
@@ -279,7 +279,7 @@
             });
             foreach (var item in _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperties() ?? [])
             {
-                _apiTypography.Add(new ApiDefaultTheme()
+                _apiTypography.Add(new ApiDefaultTheme
                 {
                     Name = _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperty(item.Name)?.Name,
                     Type = _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperty(item.Name)?.PropertyType.ConvertToCSharpSource(),
@@ -294,7 +294,7 @@
     {
         foreach (var value in typeof(ZIndex).GetProperties())
         {
-            _apiZindex.Add(new ApiDefaultTheme()
+            _apiZindex.Add(new ApiDefaultTheme
             {
                 Name = value.Name,
                 Type = value.PropertyType.ConvertToCSharpSource(),

--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -10,7 +10,7 @@
             <SectionSubGroups>
                 <DocsPageSection>
                     <SectionHeader Title="Palette"/>
-                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table" Dense="true" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -49,7 +49,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Shadows"/>
-                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -75,7 +75,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="LayoutProperties"/>
-                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -101,7 +101,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Typography"/>
-                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -163,7 +163,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="ZIndex"/>
-                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>

--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -10,7 +10,7 @@
             <SectionSubGroups>
                 <DocsPageSection>
                     <SectionHeader Title="Palette"/>
-                    <MudSimpleTable Class="docs-class-table" Dense="true" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -49,7 +49,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Shadows"/>
-                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -75,7 +75,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="LayoutProperties"/>
-                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -101,7 +101,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Typography"/>
-                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -163,7 +163,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="ZIndex"/>
-                    <MudSimpleTable Class="docs-class-table" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>

--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -1,58 +1,62 @@
 @page "/customization/default-theme"
-
-@using System.Reflection
 @using System.Text.RegularExpressions
 @using MudBlazor.Docs.Extensions
 
+<!--suppress CssUnusedSymbol -->
+<style>
+    .mud-table {
+        height: 400px;
+    }
+</style>
+
 <DocsPage>
-    <DocsPageHeader Title="Default Theme" SubTitle="Here's the default theme class with the default values." />
+    <DocsPageHeader Title="Default Theme" SubTitle="Here's the default theme class with the default values."/>
     <DocsPageContent>
         <DocsPageSection>
-            <SectionHeader Title="MudTheme" />
+            <SectionHeader Title="MudTheme"/>
             <SectionSubGroups>
                 <DocsPageSection>
                     <SectionHeader Title="Palette"/>
-                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true">
+                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" FixedHeader="true" Outlined="true">
                         <thead>
-                            <tr>
-                                <th>Name</th>
-                                <th>Type</th>
-                                <th>Default Light</th>
-                                <th>Default Dark</th>
-                                <th>CSS Variable</th>
-                            </tr>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Default Light</th>
+                            <th>Default Dark</th>
+                            <th>CSS Variable</th>
+                        </tr>
                         </thead>
                         <tbody>
-                            @foreach (var Row in ApiPalette)
-                            {
-                                <tr>
-                                    <td>@Row.Name</td>
-                                    <td>@Row.Type</td>
-                                    <td>
+                        @foreach (var Row in _apiPalette)
+                        {
+                            <tr>
+                                <td>@Row.Name</td>
+                                <td>@Row.Type</td>
+                                <td>
+                                    <div class="d-inline-flex align-center">
+                                        <MudPaper Outlined="true" Height="16px" Width="16px" Class="mr-2" Style="@($"background-color:{Row.Default}")"/>
+                                        @Row.Default
+                                    </div>
+                                </td>
+                                <td>
+                                    @if (!Row.Default.Equals(Row.Dark))
+                                    {
                                         <div class="d-inline-flex align-center">
-                                            <MudPaper Outlined="true" Height="16px" Width="16px" Class="mr-2" Style="@($"background-color:{Row.Default}")"/>
-                                            @Row.Default
+                                            <MudPaper Outlined="true" Height="16px" Width="16px" Class="mr-2" Style="@($"background-color:{Row.Dark}")"/>
+                                            @Row.Dark
                                         </div>
-                                        
-                                    </td>
-                                    <td>
-                                        @if (!Row.Default.Equals(Row.Dark))
-                                        {
-                                            <div class="d-inline-flex align-center">
-                                                <MudPaper Outlined="true" Height="16px" Width="16px" Class="mr-2" Style="@($"background-color:{Row.Dark}")"/>
-                                                @Row.Dark
-                                            </div>
-                                        }
-                                    </td>
-                                    <td>@Row.CSSVariable</td>
-                                </tr>
-                            }
+                                    }
+                                </td>
+                                <td>@Row.CSSVariable</td>
+                            </tr>
+                        }
                         </tbody>
                     </MudSimpleTable>
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Shadows"/>
-                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true">
+                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -63,7 +67,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                        @foreach (var Row in ApiShadow)
+                        @foreach (var Row in _apiShadow)
                         {
                             <tr>
                                 <td>@Row.Name</td>
@@ -78,7 +82,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="LayoutProperties"/>
-                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true">
+                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -89,7 +93,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                        @foreach (var Row in ApiLayout)
+                        @foreach (var Row in _apiLayout)
                         {
                             <tr>
                                 <td>@Row.Name</td>
@@ -104,7 +108,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Typography"/>
-                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true">
+                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -115,7 +119,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                        @foreach (var Row in ApiTypography)
+                        @foreach (var Row in _apiTypography)
                         {
                             <tr>
                                 @if (Row.IsHeader)
@@ -133,10 +137,10 @@
                                     <td>
                                         @if (Row.CSSVariable.Contains("default-family"))
                                         {
-                                            string fontFamily = "";
-                                            if (mudTheme.Typography.Default.FontFamily is not null)
+                                            var fontFamily = "";
+                                            if (_mudTheme.Typography.Default.FontFamily is not null)
                                             {
-                                                foreach (string font in mudTheme.Typography.Default.FontFamily)
+                                                foreach (var font in _mudTheme.Typography.Default.FontFamily)
                                                 {
                                                     if (fontFamily == "")
                                                     {
@@ -148,13 +152,13 @@
                                                     }
                                                 }
                                             }
+
                                             @fontFamily
                                         }
                                         else
                                         {
                                             @Row.Default
                                         }
-                                        
                                     </td>
                                     <td>@Row.CSSVariable</td>
                                     <td>@Row.CSSClass</td>
@@ -166,7 +170,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="ZIndex"/>
-                    <MudSimpleTable Class="docs-class-table default-theme" Dense="true" Elevation="0" FixedHeader="true">
+                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -177,7 +181,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                        @foreach (var Row in ApiZindex)
+                        @foreach (var Row in _apiZindex)
                         {
                             <tr>
                                 <td>@Row.Name</td>
@@ -190,21 +194,18 @@
                         </tbody>
                     </MudSimpleTable>
                 </DocsPageSection>
-                
             </SectionSubGroups>
         </DocsPageSection>
-
     </DocsPageContent>
 </DocsPage>
 
 @code {
-    MudTheme mudTheme = new MudTheme();
-
-    private List<ApiDefaultTheme> ApiPalette = new List<ApiDefaultTheme>();
-    private List<ApiDefaultTheme> ApiShadow = new List<ApiDefaultTheme>();
-    private List<ApiDefaultTheme> ApiLayout = new List<ApiDefaultTheme>();
-    private List<ApiDefaultTheme> ApiTypography= new List<ApiDefaultTheme>();
-    private List<ApiDefaultTheme> ApiZindex= new List<ApiDefaultTheme>();
+    private readonly MudTheme _mudTheme = new();
+    private readonly List<ApiDefaultTheme> _apiPalette = [];
+    private readonly List<ApiDefaultTheme> _apiShadow = [];
+    private readonly List<ApiDefaultTheme> _apiLayout = [];
+    private readonly List<ApiDefaultTheme> _apiTypography = [];
+    private readonly List<ApiDefaultTheme> _apiZindex = [];
 
     protected override void OnInitialized()
     {
@@ -217,129 +218,130 @@
 
     private void LoadPalette()
     {
-#pragma warning disable CS0618
         foreach (var value in typeof(Palette).GetProperties())
-#pragma warning restore CS0618
         {
-            var newprop = new ApiDefaultTheme()
+            var newProp = new ApiDefaultTheme()
             {
                 Name = value.Name,
                 Type = value.PropertyType.ConvertToCSharpSource(),
-                Default = value.GetValue(mudTheme.PaletteLight, null),
-                Dark = value.GetValue(mudTheme.PaletteDark, null),
+                Default = value.GetValue(_mudTheme.PaletteLight, null),
+                Dark = value.GetValue(_mudTheme.PaletteDark, null),
                 CSSVariable = $"--mud-palette-{GetCssVar(value.Name)}"
             };
-            ApiPalette.Add(newprop);
+            _apiPalette.Add(newProp);
         }
     }
 
     private void LoadShadows()
     {
-        ApiShadow.Add(new ApiDefaultTheme()
+        _apiShadow.Add(new ApiDefaultTheme()
         {
             Name = "Elevation",
             Type = "String[]",
             Default = "System.String[]"
         });
-        for (int i = 0; i < mudTheme.Shadows.Elevation.Length; i++)
+        for (var i = 0; i < _mudTheme.Shadows.Elevation.Length; i++)
         {
-            int a = i;
-            ApiShadow.Add(new ApiDefaultTheme()
+            _apiShadow.Add(new ApiDefaultTheme()
             {
-                Name = $"Elevation[{a}]",
+                Name = $"Elevation[{i}]",
                 Type = "String",
-                Default = mudTheme.Shadows.Elevation.GetValue(a),
-                CSSVariable = $"--mud-elevation-{a}",
-                CSSClass = $"mud-elevation-{a}"
+                Default = _mudTheme.Shadows.Elevation.GetValue(i),
+                CSSVariable = $"--mud-elevation-{i}",
+                CSSClass = $"mud-elevation-{i}"
             });
         }
     }
-    
+
     private void LoadLayout()
     {
         foreach (var value in typeof(LayoutProperties).GetProperties())
         {
-            ApiLayout.Add(new ApiDefaultTheme()
+            _apiLayout.Add(new ApiDefaultTheme()
             {
                 Name = value.Name,
                 Type = value.PropertyType.ConvertToCSharpSource(),
-                Default = value.GetValue(mudTheme.LayoutProperties, null),
+                Default = value.GetValue(_mudTheme.LayoutProperties, null),
                 CSSVariable = $"--mud-{GetCssVar(value.Name)}"
             });
         }
     }
-    
+
     private void LoadTypography()
     {
         foreach (var _typography in typeof(Typography).GetProperties())
         {
-            ApiTypography.Add(new ApiDefaultTheme()
+            _apiTypography.Add(new ApiDefaultTheme()
             {
                 Name = _typography.Name,
                 Type = _typography.PropertyType.ConvertToCSharpSource(),
                 IsHeader = true
             });
-            foreach (var item in _typography.GetValue(mudTheme.Typography, null).GetType().GetProperties())
+            foreach (var item in _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperties() ?? [])
             {
-                ApiTypography.Add(new ApiDefaultTheme()
+                _apiTypography.Add(new ApiDefaultTheme()
                 {
-                    Name = _typography.GetValue(mudTheme.Typography, null).GetType().GetProperty(item.Name).Name,
-                    Type = _typography.GetValue(mudTheme.Typography, null).GetType().GetProperty(item.Name).PropertyType.ConvertToCSharpSource(),
-                    Default = _typography.GetValue(mudTheme.Typography, null).GetType().GetProperty(item.Name).GetValue(_typography.GetValue(mudTheme.Typography, null), null),
-                    CSSVariable = $"--mud-typography-{_typography.Name.ToLower()}{GetCssVar(_typography.GetValue(mudTheme.Typography, null).GetType().GetProperty(item.Name).Name)}"
+                    Name = _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperty(item.Name)?.Name,
+                    Type = _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperty(item.Name)?.PropertyType.ConvertToCSharpSource(),
+                    Default = _typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperty(item.Name)?.GetValue(_typography.GetValue(_mudTheme.Typography, null), null),
+                    CSSVariable = $"--mud-typography-{_typography.Name.ToLower()}{GetCssVar(_typography.GetValue(_mudTheme.Typography, null)?.GetType().GetProperty(item.Name)?.Name)}"
                 });
             }
         }
     }
-    
+
     private void LoadZIndexes()
     {
         foreach (var value in typeof(ZIndex).GetProperties())
         {
-            ApiZindex.Add(new ApiDefaultTheme()
+            _apiZindex.Add(new ApiDefaultTheme()
             {
                 Name = value.Name,
                 Type = value.PropertyType.ConvertToCSharpSource(),
-                Default = value.GetValue(mudTheme.ZIndex, null),
+                Default = value.GetValue(_mudTheme.ZIndex, null),
                 CSSVariable = $"--mud-zindex-{GetCssVar(value.Name)}"
             });
         }
     }
 
-    private string GetCssVar(string value)
+    private static string GetCssVar(string value)
     {
         if (value == "AppBar")
         {
             return value.ToLowerInvariant();
         }
-        else if (value.Contains("ContrastText"))
+
+        if (value.Contains("ContrastText"))
         {
             return value.Replace("ContrastText", "-Text").ToLowerInvariant();
         }
-        else if (value.Contains("Font"))
+
+        if (value.Contains("Font"))
         {
             return value.Replace("Font", "-").ToLowerInvariant();
         }
-        else if (value.Contains("LineHeight"))
+
+        if (value.Contains("LineHeight"))
         {
             return value.Replace("LineHeight", "-LineHeight").ToLowerInvariant();
         }
-        else if (value.Contains("LetterSpacing"))
+
+        if (value.Contains("LetterSpacing"))
         {
             return value.Replace("LetterSpacing", "-LetterSpacing").ToLowerInvariant();
         }
-        else if (value.Contains("TextTransform"))
+
+        if (value.Contains("TextTransform"))
         {
             return value.Replace("TextTransform", "-Text-Transform").ToLowerInvariant();
         }
-        else if (value.Contains("BorderRadius"))
+
+        if (value.Contains("BorderRadius"))
         {
             return value.Replace("BorderRadius", "-BorderRadius").ToLowerInvariant();
         }
-        else
-        {
-            return Regex.Replace(value, @"\B[A-Z]", "-$&").ToLowerInvariant();
-        }
+
+        return Regex.Replace(value, @"\B[A-Z]", "-$&").ToLowerInvariant();
     }
 
     private class ApiDefaultTheme
@@ -352,4 +354,5 @@
         public string CSSVariable { get; set; }
         public bool IsHeader { get; set; }
     }
+
 }

--- a/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/DefaultTheme.razor
@@ -2,13 +2,6 @@
 @using System.Text.RegularExpressions
 @using MudBlazor.Docs.Extensions
 
-<!--suppress CssUnusedSymbol -->
-<style>
-    .mud-table {
-        height: 400px;
-    }
-</style>
-
 <DocsPage>
     <DocsPageHeader Title="Default Theme" SubTitle="Here's the default theme class with the default values."/>
     <DocsPageContent>
@@ -17,7 +10,7 @@
             <SectionSubGroups>
                 <DocsPageSection>
                     <SectionHeader Title="Palette"/>
-                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -56,7 +49,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Shadows"/>
-                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -82,7 +75,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="LayoutProperties"/>
-                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -108,7 +101,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="Typography"/>
-                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>
@@ -170,7 +163,7 @@
                 </DocsPageSection>
                 <DocsPageSection>
                     <SectionHeader Title="ZIndex"/>
-                    <MudSimpleTable Class="docs-class-table pa-4" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
+                    <MudSimpleTable Class="docs-class-table height-400" Dense="true" Elevation="0" FixedHeader="true" Outlined="true">
                         <thead>
                         <tr>
                             <th>Name</th>

--- a/src/MudBlazor.Docs/Pages/Features/Analyzers/Analyzers.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Analyzers/Analyzers.razor
@@ -1,6 +1,4 @@
 ﻿@page "/features/analyzers"
-@using System.Reflection
-@using System.Text.RegularExpressions
 
 <DocsPage>
     <DocsPageHeader Title="Analyzers">
@@ -9,25 +7,32 @@
         </Description>
     </DocsPageHeader>
     <DocsPageContent>
-        
         <DocsPageSection>
             <SectionHeader Title="MUD0002">
                 <Description>
-                    Identifies attributes set on MudBlazor components that don't match a defined pattern. This helps prevent component parameter errors due to typos or changes in MudBlazor.
-                    The warning will only indicate the correct .razor file, not the exact location. 
-                    Configure the analyzer by adding the code below to your <CodeInline>.csproj</CodeInline> file.
+                    Identifies attributes set on MudBlazor components that don't match a defined pattern.
+                    This helps prevent component parameter errors due to typos or changes in MudBlazor.
+                    The warning will only indicate the correct .razor file, not the exact location.
+                    Configure the analyzer by adding the code below to your
+                    <CodeInline>.csproj</CodeInline>
+                    file.
                 </Description>
             </SectionHeader>
-            <MUD0002ConfigurationTable />
+            <MUD0002Configuration/>
+            <br/>
+            <MUD0002ConfigurationTable/>
             <SectionSubGroups>
                 <DocsPageSection>
                     <SectionHeader Title="Custom Attribute List">
                         <Description>
-                            The HTMLAttributes option can use a custom list of attributes. Configure this by adding the code below to your <CodeInline>.csproj</CodeInline> file.
+                            The HTMLAttributes option can use a custom list of attributes.
+                            Configure this by adding the code below to your
+                            <CodeInline>.csproj</CodeInline>
+                            file.
                         </Description>
                     </SectionHeader>
                 </DocsPageSection>
-                <MUD0002CustomAttributeList />
+                <MUD0002CustomAttributeList/>
             </SectionSubGroups>
         </DocsPageSection>
     </DocsPageContent>

--- a/src/MudBlazor.Docs/Pages/Features/Analyzers/MUD0002Configuration.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Analyzers/MUD0002Configuration.razor
@@ -4,7 +4,7 @@
             <div class="html">
                 <pre>
 <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">PropertyGroup Condition="'$(Configuration)' == 'Debug'"</span><span class="htmlTagDelimiter">&gt;</span>
-    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudAllowedAttributeList</span><span class="htmlTagDelimiter">&gt;</span>attribute1,attribute2<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudAllowedAttributeList</span><span class="htmlTagDelimiter">&gt;</span>
+    <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudAllowedAttributePattern</span><span class="htmlTagDelimiter">&gt;</span>LowerCase<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudAllowedAttributePattern</span><span class="htmlTagDelimiter">&gt;</span>
 <span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">PropertyGroup</span><span class="htmlTagDelimiter">&gt;</span>
                 </pre>
             </div>

--- a/src/MudBlazor.Docs/Pages/Features/Analyzers/MUD0002ConfigurationTable.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Analyzers/MUD0002ConfigurationTable.razor
@@ -1,53 +1,54 @@
-﻿<div class="mud-codeblock">
-    <div class="html">
-<pre>
-<span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">PropertyGroup Condition=" '$(Configuration)' == 'Debug' "</span><span class="htmlTagDelimiter">&gt;</span>
-        <span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudAllowedAttributePattern</span><span class="htmlTagDelimiter">&gt;</span>LowerCase<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">MudAllowedAttributePattern</span><span class="htmlTagDelimiter">&gt;</span>
-<span class="htmlTagDelimiter">&lt;/</span><span class="htmlElementName">PropertyGroup</span><span class="htmlTagDelimiter">&gt;</span>
-</pre>
-    </div>
-</div>
-
-
-<MudSimpleTable Elevation="0" Hover="true">
+﻿<MudSimpleTable Elevation="0" Hover="true">
     <thead>
     <tr>
-            <th>Option</th>
+        <th>Option</th>
         <th>Description</th>
         <th>Default</th>
     </tr>
     </thead>
     <tbody>
     <tr>
-        <td><CodeInline>LowerCase</CodeInline></td>
+        <td>
+            <CodeInline>LowerCase</CodeInline>
+        </td>
         <td>Only allow lower case attributes</td>
-        <td><CodeInline>true</CodeInline></td>
+        <td>
+            <CodeInline>true</CodeInline>
+        </td>
     </tr>
-        <tr>
-            <td><CodeInline>HTMLAttributes</CodeInline></td>
-            <td>
-                Only allow a list of valid case sensitive HTML attributes and events including data-*, aria-* and role.
-                The default list of attributes were mainly obtained from
-                <MudLink Href="https://www.w3schools.com/tags/ref_attributes.asp">https://www.w3schools.com/tags/ref_attributes.asp</MudLink> 
-                and <MudLink Href="https://www.w3schools.com/jsref/dom_obj_event.asp">https://www.w3schools.com/jsref/dom_obj_event.asp</MudLink> 
-            </td>
-            <td></td>
-        </tr>
     <tr>
-        <td><CodeInline>DataAndAria</CodeInline></td>
-            <td>Only allow case sensitive data-*, aria-* and role attributes</td>
+        <td>
+            <CodeInline>HTMLAttributes</CodeInline>
+        </td>
+        <td>
+            Only allow a list of valid case sensitive HTML attributes and events including data-*, aria-* and role.
+            The default list of attributes were mainly obtained from
+            <MudLink Href="https://www.w3schools.com/tags/ref_attributes.asp">https://www.w3schools.com/tags/ref_attributes.asp</MudLink>
+            and
+            <MudLink Href="https://www.w3schools.com/jsref/dom_obj_event.asp">https://www.w3schools.com/jsref/dom_obj_event.asp</MudLink>
+        </td>
         <td></td>
     </tr>
     <tr>
-        <td><CodeInline>None</CodeInline></td>
+        <td>
+            <CodeInline>DataAndAria</CodeInline>
+        </td>
+        <td>Only allow case sensitive data-*, aria-* and role attributes</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>
+            <CodeInline>None</CodeInline>
+        </td>
         <td>Don't allow any additional attributes</td>
         <td></td>
     </tr>
     <tr>
-        <td><CodeInline>Any</CodeInline></td>
+        <td>
+            <CodeInline>Any</CodeInline>
+        </td>
         <td>Allows any extra attributes in any case</td>
         <td></td>
     </tr>
-    
     </tbody>
 </MudSimpleTable>

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnoucementPage.razor.cs
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnoucementPage.razor.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Services.Notifications;
 
@@ -13,18 +12,12 @@ public partial class AnnoucementPage
     [Parameter] public string Id { get; set; }
     [Inject] public INotificationService NotificationService { get; set; }
 
-    private NotificationMessage _message = null;
+    private NotificationMessage _message;
 
     protected override async Task OnParametersSetAsync()
     {
         await base.OnParametersSetAsync();
-        _message = null;
-
         _message = await NotificationService.GetMessageById(Id);
-        if (_message == null)
-        {
-
-        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor
@@ -8,13 +8,13 @@
         </SpecialHeaderContent>
     </DocsPageHeader>
     <DocsPageContent>
-        @if (_messages?.Count == 0)
-        {
-            <MudText Typo="Typo.h6">No announcements yet.</MudText>
-        }
         @if (_messages == null)
         {
             <MudProgressCircular Color="Color.Default" Indeterminate="true"/>
+        }
+        else if (_messages.Count == 0)
+        {
+            <MudText Typo="Typo.h6">No announcements yet.</MudText>
         }
         else
         {

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor
@@ -8,16 +8,10 @@
         </SpecialHeaderContent>
     </DocsPageHeader>
     <DocsPageContent>
-        <DocsPageSection>
-            <MudGrid Spacing="0" Class="my-16">
-                <MudItem xs="12" md="6">
-                    
-                </MudItem>
-            </MudGrid>
-        </DocsPageSection>
-        <DocsPageSection>
-
-        </DocsPageSection>
+        @if (_messages?.Count == 0)
+        {
+            <MudText Typo="Typo.h6">No announcements yet.</MudText>
+        }
         @if (_messages == null)
         {
             <MudProgressCircular Color="Color.Default" Indeterminate="true"/>
@@ -25,7 +19,7 @@
         else
         {
             <MudGrid>
-                @foreach (var (message, isRead) in _messages)
+                @foreach (var (message, _) in _messages)
                 {
                     <MudItem xs="12" sm="6" md="4">
                         <a href="@($"/mud/announcements/{message.Id}")">
@@ -41,7 +35,7 @@
                                         @foreach (var author in message.Authors)
                                         {
                                             <MudAvatar>
-                                                <MudImage Src="@author.AvatarUrl" />
+                                                <MudImage Src="@author.AvatarUrl"/>
                                             </MudAvatar>
                                         }
                                     </MudAvatarGroup>
@@ -53,7 +47,7 @@
                                         }
                                         else
                                         {
-                                            <MudText Typo="Typo.subtitle2">@message.Authors.FirstOrDefault().DisplayName</MudText>
+                                            <MudText Typo="Typo.subtitle2">@message.Authors.FirstOrDefault()?.DisplayName</MudText>
                                             <MudText Typo="Typo.subtitle2" Class="mud-text-secondary">@message.PublishDate.ToString("MMM dd, yyyy")</MudText>
                                         }
                                     </div>

--- a/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor.cs
+++ b/src/MudBlazor.Docs/Pages/Mud/Announcements/AnnouncementOverviewPage.razor.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Services.Notifications;
 
@@ -11,21 +9,17 @@ namespace MudBlazor.Docs.Pages.Mud.Announcements;
 
 public partial class AnnouncementOverviewPage
 {
-    private IDictionary<NotificationMessage, bool> _messages = null;
+    private IDictionary<NotificationMessage, bool> _messages;
 
     [Inject] public INotificationService NotificationService { get; set; }
-
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-        _messages = await NotificationService.GetNotifications();
-    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            _messages = await NotificationService.GetNotifications();
             await NotificationService.MarkNotificationsAsRead();
+            StateHasChanged();
         }
 
         await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
@@ -29,7 +29,6 @@
     {
         var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md");
         _roadMap = await response.Content.ReadAsStringAsync();
-        if (_roadMap.StartsWith("# Roadmap")) _roadMap = _roadMap["# Roadmap".Length..].Trim();
     }
 
     private static string GetBody(string value)

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
@@ -29,6 +29,7 @@
     {
         var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md");
         _roadMap = await response.Content.ReadAsStringAsync();
+        if (_roadMap.StartsWith("# Roadmap")) _roadMap = _roadMap["# Roadmap".Length..].Trim();
     }
 
     private static string GetBody(string value)

--- a/src/MudBlazor.Docs/Styles/core/_base.scss
+++ b/src/MudBlazor.Docs/Styles/core/_base.scss
@@ -172,11 +172,3 @@ ol,
 ul {
   list-style: none;
 }
-
-.white-background {
-  background-color: var(--mud-palette-white);
-}
-
-.height-400 {
-  height: 400px;
-}

--- a/src/MudBlazor.Docs/Styles/core/_base.scss
+++ b/src/MudBlazor.Docs/Styles/core/_base.scss
@@ -87,6 +87,8 @@
 }
 
 .docs-class-table {
+  padding: 8px;
+
   table {
     table-layout: fixed;
     position: relative;
@@ -169,4 +171,12 @@
 ol,
 ul {
   list-style: none;
+}
+
+.white-background {
+  background-color: var(--mud-palette-white);
+}
+
+.height-400 {
+  height: 400px;
 }


### PR DESCRIPTION
This pr does some small touch ups on some parts of the docs up which I noticed while browsing them:
* Modernize docs class table look
<img width="408" height="484" alt="image" src="https://github.com/user-attachments/assets/1383a321-0d63-4052-a95e-e0a2659114a4" />

* Enhance sponsor logo visibility in dark mode
<img width="476" height="200" alt="image" src="https://github.com/user-attachments/assets/d6dab7a3-0830-4592-90f7-b6979e8b1a52" />

* Wrap analyzers code examples in a code box
<img width="383" height="139" alt="image" src="https://github.com/user-attachments/assets/3fc48b15-efa9-4f0b-ab30-d1ebf7155daa" />

* Fix announcement page crashing when directly loading it
* Fix Roadmap title being displayed twice