### PR TITLE
ParameterState: Fix Value edge case, fix nullability

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -165,12 +165,12 @@ namespace MudBlazor.UnitTests.Components
         /// Tests that ExpandAll method expands all panels.
         /// </summary>
         [Test]
-        public async Task MudExpansionPanel_ExpandAllAync()
+        public async Task MudExpansionPanel_ExpandAllAsync()
         {
             var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = new MudExpansionPanel();
-            var panel2 = new MudExpansionPanel();
-            var panel3 = new MudExpansionPanel();
+            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -193,9 +193,9 @@ namespace MudBlazor.UnitTests.Components
         public async Task MudExpansionPanel_CollapseAllAsync()
         {
             var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = new MudExpansionPanel();
-            var panel2 = new MudExpansionPanel();
-            var panel3 = new MudExpansionPanel();
+            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -221,9 +221,9 @@ namespace MudBlazor.UnitTests.Components
         public async Task MudExpansionPanel_CollapseAllExceptAsync()
         {
             var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = new MudExpansionPanel();
-            var panel2 = new MudExpansionPanel();
-            var panel3 = new MudExpansionPanel();
+            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);

--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -90,26 +90,21 @@ public class ParameterStateTests
     public void OnParametersSet_UpdatesValueIfChanged()
     {
         // Arrange
-        var initialValue = 5;
-        const int NewValue = 10;
+        const int InitialValue = 5;
         // ReSharper disable once AccessToModifiedClosure
         var parameterState = ParameterAttachBuilder
             .Create<int>()
-            .WithMetadata(new ParameterMetadata(nameof(initialValue)))
-            .WithGetParameterValueFunc(() => initialValue)
+            .WithMetadata(new ParameterMetadata(nameof(InitialValue)))
+            .WithGetParameterValueFunc(() => InitialValue)
             .Attach();
 
         // Act
         parameterState.OnParametersSet();
 
         // Assert
-        parameterState.Value.Should().Be(initialValue);
-
-        // Act & Assert
-        initialValue = NewValue;
         parameterState.OnParametersSet();
-        parameterState.Value.Should().Be(NewValue);
-        parameterState.InitialValue.Should().Be(0, because: "OnInitialized wasn't called, so InitialValue remains its default for int");
+        parameterState.Value.Should().Be(InitialValue);
+        parameterState.InitialValue.Should().Be(InitialValue);
     }
 
     [Test]

--- a/src/MudBlazor/State/ParameterState.cs
+++ b/src/MudBlazor/State/ParameterState.cs
@@ -21,7 +21,7 @@ public abstract class ParameterState<T>
     /// <summary>
     /// Gets the current value.
     /// </summary>
-    public abstract T? Value { get; }
+    public abstract T Value { get; }
 
     /// <summary>
     /// Gets a value indicating whether the object is initialized.
@@ -38,7 +38,7 @@ public abstract class ParameterState<T>
     /// This value is captured once when the component is initialized and never changes thereafter,
     /// even if the <see cref="Value"/> property changes later.
     /// </remarks>
-    public abstract T? InitialValue { get; }
+    public abstract T InitialValue { get; }
 
     /// <summary>
     /// Set the parameter's value. 
@@ -56,5 +56,5 @@ public abstract class ParameterState<T>
     /// </summary>
     /// <param name="parameterState">The <see cref="ParameterState{T}"/> object to convert.</param>
     /// <returns>The underlying value of type <typeparamref name="T"/>.</returns>
-    public static implicit operator T?(ParameterState<T> parameterState) => parameterState.Value;
+    public static implicit operator T(ParameterState<T> parameterState) => parameterState.Value;
 }

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.State;
 [DebuggerDisplay("ParameterName = {Metadata.ParameterName}, Value = {_value}")]
 internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponentLifeCycle, IEquatable<ParameterStateInternal<T>>
 {
-    internal T? _value;
+    private T? _value;
     private T? _lastValue;
     private T? _initialValue;
     private bool _isInitialized;

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.State;
 [DebuggerDisplay("ParameterName = {Metadata.ParameterName}, Value = {_value}")]
 internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponentLifeCycle, IEquatable<ParameterStateInternal<T>>
 {
-    private T? _value;
+    internal T? _value;
     private T? _lastValue;
     private T? _initialValue;
     private bool _isInitialized;
@@ -47,13 +47,60 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     public bool HasHandler => _parameterChangedHandler is not null;
 
     /// <inheritdoc />
+    [MemberNotNullWhen(true, nameof(_value), nameof(_initialValue))]
     public override bool IsInitialized => _isInitialized;
 
     /// <inheritdoc />
-    public override T? InitialValue => _initialValue;
+    public override T InitialValue
+    {
+        get
+        {
+            if (!IsInitialized)
+            {
+                return _getParameterValueFunc();
+            }
+
+            return _initialValue;
+        }
+    }
 
     /// <inheritdoc/>
-    public override T? Value => _value;
+    /// <remarks>
+    /// <para>
+    /// Some (bad) components may attempt to read parameter values before OnInitialized is called
+    /// (e.g., during SetParametersAsync). In that case, the state is not yet fully initialized,
+    /// and accessing the Value will return null even when the parameter has a default value, such as:
+    /// <code>[Parameter] string MyParameter { get; set; } = "some value";</code>
+    /// <br/>
+    /// To avoid this, if initialization has not yet occurred, fall back to the delegate
+    /// that retrieves the current parameter value.
+    /// <br/>
+    /// Important: Some incorrect tests bypass the normal Blazor lifecycle, which can lead to
+    /// incorrect state being read. For example:
+    /// </para>
+    /// <code>
+    ///      var panels = Context.RenderComponent&lt;MudExpansionPanels&gt;();
+    ///      var panel = new MudExpansionPanel();
+    ///      panels.Instance.AddPanelAsync(panel);
+    /// </code>
+    /// <para>
+    /// In this scenario, MudExpansionPanel is created outside Blazor's lifecycle, so
+    /// AddPanelAsync receives an invalid _expandedState.Value.
+    /// Such test patterns should be avoided—rewrite the tests to follow normal Blazor usage.
+    /// </para>
+    /// </remarks>
+    public override T Value
+    {
+        get
+        {
+            if (!IsInitialized)
+            {
+                return _getParameterValueFunc();
+            }
+
+            return _value;
+        }
+    }
 
     /// <summary>
     /// Gets the function to provide the comparer for the parameter.
@@ -67,14 +114,14 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         _eventCallbackFunc = eventCallbackFunc;
         _parameterChangedHandler = parameterChangedHandler;
         _comparer = comparer ?? new ParameterEqualityComparerSwappable<T>(() => EqualityComparer<T>.Default);
-        _lastValue = default;
-        _value = default;
     }
 
     /// <inheritdoc/>
     public override Task SetValueAsync(T value)
     {
-        if (!_comparer.Equals(Value, value))
+        // Avoid using the Value property here because its getter includes an
+        // IsInitialized branch which may cause the SetValueAsync to be skipped.
+        if (!_comparer.Equals(_value, value))
         {
             _value = value;
             var eventCallback = _eventCallbackFunc();


### PR DESCRIPTION
### 1. Nullability Fix

Previously, the `.Value` of `ParameterState<T>` was always nullable, even when `T` itself was non-nullable. This caused unnecessary null checks and incorrectly weakened the type safety of components using the API.

Nullability **should be inherited from `T`**:

* If a consumer declares `ParameterState<string>`, then `.Value` should be **non-nullable**.
* If they declare `ParameterState<string?>`, then `.Value` should be **nullable**.

This aligns with how Blazor parameters typically behave. For example, a component may define:

```csharp
[Parameter]
public string MyParameter { get; set; } = "some value";
```

In this case, the property is guaranteed to have a value unless explicitly set to `null`, and with nullable reference types enabled the developer is expected to respect the annotation.

While it’s technically possible for someone to force a `null` into a non-nullable parameter, that’s outside the responsibility of this API. Our implementation should reflect the declared nullability of `T` rather than weakening it to nullable unconditionally.

---

### 2. Early Parameter Access Issue

Some components incorrectly attempt to read parameter values **before `OnInitialized` is called** (for example, during `SetParametersAsync`). When this happens, the internal state has not yet been fully initialized.

This leads to situations where accessing `.Value` returns `null` even though a parameter has a default value, such as:

```csharp
[Parameter]
public string MyParameter { get; set; } = "some value";
```

To prevent this, if initialization has not yet occurred, the implementation now falls back to the delegate that retrieves the current parameter value. This ensures correct behavior even when components try to access the parameter value prematurely (our `MudSelect` does this).



**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
