### PR TITLE
ParameterState: Add ParameterStateAttribute

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/ParameterState/Examples/ParameterStateUsageExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/ParameterState/Examples/ParameterStateUsageExample.razor
@@ -5,7 +5,7 @@
 @code {
     private readonly ParameterState<bool> _expandedState; //separate field for storing parameter state
 
-    [Parameter]
+    [Parameter, ParameterState]
     public bool Expanded { get; set; }
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor.cs
@@ -16,7 +16,7 @@ public partial class ParameterStateChildBindingTestComp : MudComponentBase
     [Parameter]
     public string? Id { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public bool Expanded { get; set; }
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildComp1.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildComp1.razor.cs
@@ -21,7 +21,7 @@ public partial class ParameterStateChildComp1 : MudComponentBase
             .WithChangeHandler(OnParameterChanged);
     }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int Counter { get; set; } = 0;
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildComp2.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildComp2.razor.cs
@@ -21,7 +21,7 @@ public partial class ParameterStateChildComp2 : MudComponentBase
             .WithChangeHandler(OnParameterChanged);
     }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int Counter { get; set; } = 0;
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateMultipleScopeTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateMultipleScopeTestComp.razor.cs
@@ -30,12 +30,12 @@ public partial class ParameterStateMultipleScopeTestComp : MudComponentBase
     private readonly ParameterState<int> _b;
     private readonly ParameterState<int> _c;
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int A { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int B { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int C { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateTestComp.razor.cs
@@ -22,7 +22,7 @@ public partial class ParameterStateTestComp : MudComponentBase
         _parameterChanges.Add($"IntParam: {args.LastValue}=>{args.Value}");
     }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int IntParam { get; set; }
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/SharedStateHandlerTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/SharedStateHandlerTestComp.razor.cs
@@ -60,27 +60,27 @@ public partial class SharedStateHandlerTestComp : MudComponentBase
     public int OpHandlerCallCount { get; private set; }
     public int XyzHandlerCallCount { get; private set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int A { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int B { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int C { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int O { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int P { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int X { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int Y { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int Z { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/SharedStateInheritanceTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/SharedStateInheritanceTestComp.razor.cs
@@ -50,16 +50,16 @@ public abstract class AnotherComponentBase : MudComponentBase
 
     public int XyzHandlerCallCount { get; private set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int A { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int C { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int O { get; set; }
 
-    [Parameter]
+    [Parameter, ParameterState]
     public int Z { get; set; }
 }
 

--- a/src/MudBlazor/Attributes/ParameterStateAttribute.cs
+++ b/src/MudBlazor/Attributes/ParameterStateAttribute.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.State;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class ParameterStateAttribute : Attribute;

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -425,7 +425,7 @@ namespace MudBlazor
         /// <remarks>
         /// This property is passed into the <c>ToString()</c> method of the <see cref="Value"/> property, such as formatting <c>int</c>, <c>float</c>, <c>DateTime</c> and <c>TimeSpan</c> values.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string? Format { get; set; }
 
@@ -435,7 +435,7 @@ namespace MudBlazor
         /// <remarks>
         /// When set takes precedence over any internally generated IDs.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string? InputId { get; set; }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -94,7 +94,7 @@ namespace MudBlazor
         /// <summary>
         /// The text displayed if the <see cref="Error"/> property is <c>true</c>.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Validation)]
         public string? ErrorText { get; set; }
 
@@ -115,7 +115,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the text in <see cref="ErrorText"/> is displayed.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool Error { get; set; }
 
@@ -136,7 +136,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>.  When set and the <see cref="Error"/> property is <c>true</c>, an <c>aria-describedby</c> attribute is rendered to improve accessibility for users.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Validation)]
         public string? ErrorId { get; set; }
 
@@ -157,7 +157,7 @@ namespace MudBlazor
         /// <remarks>
         /// This property provides a way to customize conversions between <typeparamref name="T"/> objects and <typeparamref name="U"/> values.  If no converter is specified, a default will be chosen based on the kind of input.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public IConverter<T?, U?> Converter { get; set; } = null!;
 
@@ -167,7 +167,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="CultureInfo.InvariantCulture"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public CultureInfo Culture { get; set; } = CultureInfo.CurrentUICulture;
 

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -81,7 +81,7 @@ public partial class MudFabMenu : MudFab
     /// <remarks>
     /// When this property changes, <see cref="OpenChanged"/> occurs.
     /// </remarks>
-    [Parameter, Category(CategoryTypes.Menu.PopupBehavior)]
+    [Parameter, ParameterState, Category(CategoryTypes.Menu.PopupBehavior)]
     public bool Open { get; set; }
 
     /// <summary>

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -92,7 +92,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, the <see cref="MudCarouselItem"/> items will be rotated after the delay specified in <see cref="AutoCycleTime" />.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Carousel.Behavior)]
         public bool AutoCycle { get; set; } = true;
 
@@ -102,7 +102,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="TimeSpan.Zero"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Carousel.Behavior)]
         public TimeSpan AutoCycleTime { get; set; } = TimeSpan.FromSeconds(5);
 

--- a/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
@@ -143,7 +143,7 @@ public abstract class MudChartBase<T, TOptions> : MudComponentBase, IMudChart<T>
     /// <remarks>
     /// When this property changes, the <see cref="SelectedIndexChanged"/> event occurs.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.Chart.Behavior)]
     public int SelectedIndex { get; set; }
 

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -382,7 +382,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     /// <remarks>
     /// When <c>true</c>, the chip is displayed in a selected state.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.Chip.Behavior)]
     public bool Selected { get; set; }
 

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -211,7 +211,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     /// <remarks>
     /// This property is used when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection" /> or <see cref="SelectionMode.ToggleSelection"/>.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public T? SelectedValue { get; set; }
 
@@ -230,7 +230,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     /// <remarks>
     /// This event occurs when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection" />.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.ChipSet.Behavior)]
     public IReadOnlyCollection<T>? SelectedValues { get; set; }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -141,7 +141,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>true</c>.  When <c>true</c>, alpha options will be displayed and color output will be <c>RGBA</c>, <c>HSLA</c> or <c>HEXA</c> instead of <c>RGB</c>, <c>HSL</c> or <c>HEX</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public bool ShowAlpha { get; set; } = true;
 
@@ -211,7 +211,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="ColorPickerView.Spectrum"/>.   The view can be changed if <c>ShowToolbar</c> is <c>true</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public ColorPickerView ColorPickerView { get; set; } = ColorPickerView.Spectrum;
 
@@ -231,14 +231,14 @@ namespace MudBlazor
         /// <remarks>
         /// You can use properties in <see cref="MudColor"/> to get color channel values such as <c>RGB</c>, <c>HSL</c>, <c>HEX</c> and more.  When this value changes, the <see cref="ValueChanged"/> event occurs.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Data)]
         public MudColor? Value { get; set; } = "#594ae2";
 
         /// <summary>
         /// The currently selected value, as a string.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Data)]
         public override string? Text { get; set; }
 
@@ -332,7 +332,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>50</c> milliseconds between updates.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
         public int ThrottleInterval { get; set; } = 50;
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -123,7 +123,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to 0.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         public int GroupByOrder { get; set; }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         public bool GroupExpanded { get; set; }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         public bool Hidden { get; set; }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace MudBlazor
         /// <summary>
         /// Indicates whether this column is currently grouped.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         public bool Grouping { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1060,7 +1060,7 @@ namespace MudBlazor
         /// <remarks>
         /// This property can be bound (<c>@bind-SelectedItems</c>) to initially select rows.  Use <see cref="SelectedItem"/> when <see cref="MultiSelection"/> is <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         public HashSet<T> SelectedItems { get; set; }
 
         /// <summary>
@@ -1069,7 +1069,7 @@ namespace MudBlazor
         /// <remarks>
         /// This property can be bound (<c>@bind-SelectedItem</c>) to initially select a row.  Use <see cref="SelectedItems"/> when <see cref="MultiSelection"/> is <c>true</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         public T SelectedItem { get; set; }
 
         /// <summary>
@@ -1157,7 +1157,7 @@ namespace MudBlazor
         /// Ensures the user can only expand one Hierarchy row at a time. This only has an effect if you are using a Hierarchy column.
         /// </summary>
         /// <remarks>Defaults to <c>false</c>.</remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         public bool ExpandSingleRow { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -70,7 +70,7 @@ namespace MudBlazor
         /// <summary>
         /// The format for selected dates.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string DateFormat { get; set; }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -58,7 +58,7 @@ namespace MudBlazor
         /// Defaults to <c>true</c>. Disabled days will be included in the min/max count. 
         /// This parameter will take effect when <see cref="MinDays"/> or <see cref="MaxDays"/> is set.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool AllowDisabledDatesInCount { get; set; } = true;
 

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -168,7 +168,7 @@ namespace MudBlazor
         /// Defaults to <c>false</c>.<br />
         /// This can be bound via <c>@bind-Visible</c> to show or hide inline dialogs.  For regular dialogs, use the <see cref="DialogService.ShowAsync(Type)"/> and <see cref="IMudDialogInstance.Close()"/> methods.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Dialog.Behavior)]
         public bool Visible { get; set; }
 

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -58,14 +58,14 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to the options in the <see cref="MudDialog"/> or options passed during <see cref="DialogService.ShowAsync(Type)"/> methods.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Dialog.Misc)] // Behavior and Appearance
         public DialogOptions Options { get; set; } = DialogOptions.Default;
 
         /// <summary>
         /// The text displayed at the top of this dialog if <see cref="TitleContent" /> is not set.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Dialog.Behavior)]
         public string? Title { get; set; }
 

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -214,7 +214,7 @@ namespace MudBlazor
         /// Applies when <see cref="Variant" /> is set to <see cref="DrawerVariant.Responsive"/> or <see cref="DrawerVariant.Mini" />.
         /// </para>
         /// </remarks> 
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Drawer.Behavior)]
         public Breakpoint Breakpoint { get; set; } = Breakpoint.Md;
 
@@ -224,7 +224,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.  Raises the <see cref="OpenChanged"/> event upon change.  When bound via <c>@bind-Open</c>, this property is updated when this drawer closes itself.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Drawer.Behavior)]
         public bool Open { get; set; }
 
@@ -267,7 +267,7 @@ namespace MudBlazor
         /// <summary>
         /// The position of this drawer when opened, relative to a <see cref="MudAppBar"/> when inside a <see cref="MudLayout"/>.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Drawer.Behavior)]
         public DrawerClipMode ClipMode { get; set; }
 

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -62,7 +62,7 @@ namespace MudBlazor
         /// When <c>T</c> is <see cref="IBrowserFile" />, a single file is returned.<br />
         /// When <c>T</c> is <see cref="IReadOnlyList{IBrowserFile}">IReadOnlyList&lt;IBrowserFile&gt;</see>, multiple files are returned.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FileUpload.Behavior)]
         public T? Files { get; set; }
 

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -55,7 +55,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>true</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Hidden.Behavior)]
         public bool Hidden { get; set; } = true;
 

--- a/src/MudBlazor/Components/Image/MudImage.razor.cs
+++ b/src/MudBlazor/Components/Image/MudImage.razor.cs
@@ -49,7 +49,7 @@ public partial class MudImage : MudComponentBase
     /// <summary>
     /// The path to the image.
     /// </summary>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.Image.Behavior)]
     public string? Src { get; set; }
 

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -28,7 +28,7 @@ namespace MudBlazor
         /// <summary>
         /// The number of milliseconds to wait before updating the <see cref="MudBaseInput{T}.Text"/> value.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public double DebounceInterval { get; set; }
 

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -165,7 +165,7 @@ namespace MudBlazor
         /// <remarks>
         /// This value is updated when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Selecting)]
         public T? SelectedValue { get; set; }
 
@@ -184,7 +184,7 @@ namespace MudBlazor
         /// <remarks>
         /// This value is updated when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Selecting)]
         public IReadOnlyCollection<T>? SelectedValues { get; set; }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -364,7 +364,7 @@ namespace MudBlazor
         /// <remarks>
         /// When this property changes, <see cref="OpenChanged"/> occurs.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Menu.PopupBehavior)]
         public bool Open { get; set; }
 

--- a/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
+++ b/src/MudBlazor/Components/MessageBox/MudMessageBox.razor.cs
@@ -173,7 +173,7 @@ namespace MudBlazor
         /// <remarks>
         /// Can be bound via <c>@bind-Visible</c> to show and hide an inlined MessageBox.  Has no effect on previously opened message boxes.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.MessageBox.Behavior)]
         public bool Visible { get; set; }
 

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -125,7 +125,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.NavMenu.Behavior)]
         public bool Disabled { get; set; }
 
@@ -145,7 +145,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.  When this value changes, <see cref="ExpandedChanged"/> occurs.  Can be bound via <c>@bind-Expanded</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.NavMenu.Behavior)]
         public bool Expanded { get; set; }
 

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -69,7 +69,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.Overlay.Behavior)]
     public bool Visible { get; set; }
 

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -68,7 +68,7 @@ namespace MudBlazor
         /// <summary>
         /// The total number of pages.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Behavior)]
         public int Count { get; set; } = 1;
 
@@ -80,7 +80,7 @@ namespace MudBlazor
         /// A value of <c>1</c> would show one-page number at the edge: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c> <br />
         /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c> 
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Appearance)]
         public int BoundaryCount { get; set; } = 2;
 
@@ -92,14 +92,14 @@ namespace MudBlazor
         /// A value of <c>1</c> would show one-page number in the middle: <c>&lt; 1 ... 5 ... 9 &gt;</c> <br />
         /// A value of <c>3</c> would show three-page numbers in the middle: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c>
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Appearance)]
         public int MiddleCount { get; set; } = 3;
 
         /// <summary>
         /// The selected page number.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Behavior)]
         public int Selected { get; set; } = 1;
 

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -106,7 +106,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0</c>.  Only applies when <see cref="Indeterminate"/> is <c>False</c>.  Should be between <see cref="Min"/> and <see cref="Max"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.ProgressCircular.Behavior)]
         public double Value { get; set; }
 

--- a/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressLinear.razor.cs
@@ -119,7 +119,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0.0</c>.  Usually a percentage.  Should be lower than <see cref="Max"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double Min { get; set; } = 0.0;
 
@@ -129,7 +129,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>100.0</c>.  Usually a percentage.  Should be higher than <see cref="Min"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double Max { get; set; } = 100.0;
 
@@ -139,7 +139,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0</c>.  Only applies when <see cref="Indeterminate"/> is <c>false</c>.  Should be between <see cref="Min"/> and <see cref="Max"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double Value { get; set; }
 
@@ -149,7 +149,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0</c>.  Only shows when <see cref="Buffer"/> is <c>true</c> and <see cref="Indeterminate"/> is <c>false</c>.  Typically a value greater than <see cref="Value"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.ProgressLinear.Behavior)]
         public double BufferValue { get; set; }
 

--- a/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor.cs
+++ b/src/MudBlazor/Components/RTLProvider/MudRTLProvider.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>true</c>, text will display properly for RTL languages such as Arabic, Hebrew, and Persian.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.RTLProvider.Behavior)]
         public bool RightToLeft { get; set; }
 

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -176,7 +176,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0</c>.  Must be equal or less than <see cref="MaxValue"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Rating.Data)]
         public int SelectedValue { get; set; } = 0;
 

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -107,7 +107,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0</c>.  When this value changes, <see cref="ValueChanged"/> occurs.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Slider.Data)]
         public T Value { get; set; } = T.Zero;
 
@@ -117,7 +117,7 @@ namespace MudBlazor
         /// <remarks>
         /// When this value changes, <see cref="NullableValueChanged"/> occurs.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Slider.Data)]
         public T? NullableValue { get; set; } = default;
 

--- a/src/MudBlazor/Components/Stepper/MudStep.cs
+++ b/src/MudBlazor/Components/Stepper/MudStep.cs
@@ -34,10 +34,10 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     }
 
     private bool _disposed;
-    internal ParameterState<bool> CompletedState { get; private set; }
-    internal ParameterState<bool> DisabledState { get; private set; }
-    internal ParameterState<bool> HasErrorState { get; private set; }
-    internal ParameterState<bool> SkippedState { get; private set; }
+    internal readonly ParameterState<bool> CompletedState;
+    internal readonly ParameterState<bool> DisabledState;
+    internal readonly ParameterState<bool> HasErrorState;
+    internal readonly ParameterState<bool> SkippedState;
 
     internal string Styles => new StyleBuilder()
         .AddStyle(Style)
@@ -140,7 +140,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.List.Behavior)]
     public bool Completed { get; set; }
 
@@ -154,7 +154,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     /// <summary>
     /// Prevents this step from being selected.
     /// </summary>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.List.Behavior)]
     public bool Disabled { get; set; }
 
@@ -171,7 +171,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.List.Behavior)]
     public bool HasError { get; set; }
 
@@ -204,7 +204,7 @@ public class MudStep : MudComponentBase, IAsyncDisposable
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.List.Behavior)]
     public bool Skipped { get; set; }
     /// <summary>

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -60,7 +60,7 @@ public partial class MudStepper : MudComponentBase
     /// <summary>
     /// The index of the currently active step.
     /// </summary>
-    [Parameter]
+    [Parameter, ParameterState]
     [Category(CategoryTypes.List.Behavior)]
     public int ActiveIndex { get; set; } = -1;
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -358,7 +358,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>0</c> (the first tab). When this value changes, <see cref="ActivePanelIndexChanged"/> occurs.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.Tabs.Behavior)]
         public int ActivePanelIndex { get; set; }
 

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -59,7 +59,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// Defaults to <c>true</c>.
     /// When <c>true</c>, the theme will automatically change to Light Mode or Dark Mode as the system theme changes.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     public bool ObserveSystemDarkModeChange { get; set; } = true;
 
     /// <summary>
@@ -69,7 +69,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// Defaults to <c>false</c>.
     /// When this value changes, <see cref="IsDarkModeChanged"/> occurs.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     public bool IsDarkMode { get; set; }
 
     /// <summary>
@@ -85,7 +85,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// Returns <see cref="MudTheme.PaletteDark"/> when <see cref="IsDarkMode"/> is <c>true</c>; otherwise, returns <see cref="MudTheme.PaletteLight"/>.
     /// When this value changes, <see cref="CurrentPaletteChanged"/> occurs.
     /// </remarks>
-    [Parameter]
+    [Parameter, ParameterState]
     public Palette? CurrentPalette { get; set; }
 
     /// <summary>
@@ -101,8 +101,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
         _isDarkModeState = registerScope.RegisterParameter<bool>(nameof(IsDarkMode))
             .WithParameter(() => IsDarkMode)
             .WithEventCallback(() => IsDarkModeChanged);
-        _observeSystemDarkModeChangeState = registerScope
-            .RegisterParameter<bool>(nameof(ObserveSystemDarkModeChange))
+        _observeSystemDarkModeChangeState = registerScope.RegisterParameter<bool>(nameof(ObserveSystemDarkModeChange))
             .WithParameter(() => ObserveSystemDarkModeChange)
             .WithChangeHandler(OnObserveSystemDarkModeChangeChanged);
         _currentPaletteState = registerScope.RegisterParameter<Palette?>(nameof(CurrentPalette))

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -94,7 +94,7 @@ namespace MudBlazor
         /// <summary>
         /// Prevents the user from interacting with this toggle group.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Behavior)]
         public bool Disabled { get; set; }
 
@@ -104,7 +104,7 @@ namespace MudBlazor
         /// <remarks>
         /// Applies when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection"/> or <see cref="SelectionMode.ToggleSelection"/>.<br />
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Behavior)]
         public T? Value { get; set; }
 
@@ -124,7 +124,7 @@ namespace MudBlazor
         /// <remarks>
         /// Applies when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection"/>.<br />
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Behavior)]
         public IEnumerable<T?>? Values { get; set; }
 
@@ -144,7 +144,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>null</c>. Multiple classes must be separated by spaces.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Appearance)]
         public string? SelectedClass { get; set; }
 
@@ -179,7 +179,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>true</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Appearance)]
         public bool Outlined { get; set; } = true;
 
@@ -189,7 +189,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>true</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Appearance)]
         public bool Delimiters { get; set; } = true;
 
@@ -209,7 +209,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="Size.Medium"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Appearance)]
         public Size Size { get; set; } = Size.Medium;
 
@@ -232,7 +232,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="Color.Primary"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Appearance)]
         public Color Color { get; set; } = Color.Primary;
 
@@ -242,7 +242,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>. When <c>true</c>, the checkmark icons can be customized via <c>SelectedIcon</c> and <c>UnselectedIcon</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Behavior)]
         public bool CheckMark { get; set; }
 
@@ -252,7 +252,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.List.Behavior)]
         public bool FixedContent { get; set; }
 

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -183,7 +183,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool Visible { get; set; }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -250,7 +250,7 @@ namespace MudBlazor
         /// <remarks>
         /// Applies when <see cref="SelectionMode"/> is <see cref="SelectionMode.SingleSelection"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.TreeView.Selecting)]
         public T? SelectedValue { get; set; }
 
@@ -266,7 +266,7 @@ namespace MudBlazor
         /// <remarks>
         /// Applies when <see cref="SelectionMode"/> is <see cref="SelectionMode.MultiSelection"/> or <see cref="SelectionMode.ToggleSelection"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.TreeView.Selecting)]
         public IReadOnlyCollection<T>? SelectedValues { get; set; }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -213,7 +213,7 @@ namespace MudBlazor
         /// <summary>
         /// The child items underneath this item.
         /// </summary>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.TreeView.Data)]
         public IReadOnlyCollection<ITreeItemData<T?>>? Items { get; set; }
 
@@ -229,7 +229,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.TreeView.Expanding)]
         public bool Expanded { get; set; }
 
@@ -245,7 +245,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>. Can be set alongside other items if <see cref="MudTreeView{T}.SelectionMode"/> is <see cref="SelectionMode.MultiSelection"/> or <see cref="SelectionMode.ToggleSelection"/>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.TreeView.Selecting)]
         public bool Selected { get; set; }
 


### PR DESCRIPTION
In the future, it would be helpful to create an analyzer that warns you not to read a parameter the classic way or write to it directly. It would also help to show in docs and that `GetState` can be used when needed.

A few rules:
* For now, we don’t apply `ParameterStateAttribute` if the parameter is a `[CascadingParameter]`.
* We also don’t apply it if there’s no backing field for `registerScope.RegisterParameter`, for example:

```csharp
_ = registerScope.RegisterParameter<int>(nameof(A))
    .WithParameter(() => A)
    .WithChangeHandler(OnAbcChanged);
```

There’s no point, since there’s nowhere to read from or write to.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
