### PR TITLE
ParameterState: Add RenderValue and HasCallback

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateChildBindingTestComp.razor.cs
@@ -22,7 +22,7 @@ public partial class ParameterStateChildBindingTestComp : MudComponentBase
     [Parameter]
     public EventCallback<bool> ExpandedChanged { get; set; }
 
-    public bool ExpandedStateValue => _expandedState.Value;
+    public ParameterState<bool> ExpandedState => _expandedState;
 
     public IReadOnlyList<(bool lastValue, bool value)> ParameterChangedEvents => _parameterChangedEvents;
 

--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -36,9 +36,11 @@ public class ParameterStateTests
 
         // Assert
         eventFired.Should().BeTrue();
+        parameterState.HasCallback.Should().BeTrue();
         parameterState.IsInitialized.Should().BeTrue();
         parameterState.InitialValue.Should().Be(InitialValue);
         parameterState.Value.Should().Be(NewValue);
+        parameterState.RenderValue.Should().Be(InitialValue);
     }
 
     [Test]
@@ -60,6 +62,7 @@ public class ParameterStateTests
         await parameterState.SetValueAsync(InitialValue);
 
         // Assert
+        parameterState.HasCallback.Should().BeTrue();
         parameterState.IsInitialized.Should().BeTrue();
         parameterState.InitialValue.Should().Be(InitialValue);
         parameterState.Value.Should().Be(InitialValue);
@@ -81,6 +84,7 @@ public class ParameterStateTests
         parameterState.OnInitialized();
 
         // Assert
+        parameterState.HasCallback.Should().BeFalse();
         parameterState.InitialValue.Should().Be(InitialValue);
         parameterState.IsInitialized.Should().BeTrue();
         parameterState.Value.Should().Be(InitialValue);

--- a/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
@@ -207,7 +207,7 @@ public class ParameterStateUsageTests : BunitTest
         // Initial
         expanded.Should().BeFalse("Initial value is false.");
         comp.Instance.Expanded.Should().BeFalse();
-        comp.Instance.ExpandedStateValue.Should().BeFalse();
+        comp.Instance.ExpandedState.Value.Should().BeFalse();
         comp.Instance.ParameterChangedEvents.Should().BeEmpty();
 
         // Show
@@ -215,7 +215,7 @@ public class ParameterStateUsageTests : BunitTest
         alertTextFunc().InnerHtml.Should().Be("Oh my! We got secret content!");
         expanded.Should().BeTrue("Two way binding must change when inner modification happen.");
         comp.Instance.Expanded.Should().BeFalse("We do not write to parameter directly.");
-        comp.Instance.ExpandedStateValue.Should().BeTrue("We do write to state, it should change.");
+        comp.Instance.ExpandedState.Value.Should().BeTrue("We do write to state, it should change.");
         comp.Instance.ParameterChangedEvents.Should().BeEmpty();
 
         // Hide
@@ -223,7 +223,7 @@ public class ParameterStateUsageTests : BunitTest
         alertTextFunc.Should().Throw<ComponentNotFoundException>();
         expanded.Should().BeFalse("Two way binding must change when inner modification happen.");
         comp.Instance.Expanded.Should().BeFalse("We do not write to parameter directly.");
-        comp.Instance.ExpandedStateValue.Should().BeFalse("We do write to state, it should change.");
+        comp.Instance.ExpandedState.Value.Should().BeFalse("We do write to state, it should change.");
         comp.Instance.ParameterChangedEvents.Should().BeEmpty();
 
         // Outer modifications
@@ -232,7 +232,7 @@ public class ParameterStateUsageTests : BunitTest
         await comp.SetParametersAndRenderAsync(parameters => parameters.Add(parameter => parameter.Expanded, true));
         alertTextFunc().InnerHtml.Should().Be("Oh my! We got secret content!");
         comp.Instance.Expanded.Should().BeTrue("We changed the parameter directly, must change.");
-        comp.Instance.ExpandedStateValue.Should().BeTrue("We sync on OnInitialized, must be same as Expanded.");
+        comp.Instance.ExpandedState.Value.Should().BeTrue("We sync on OnInitialized, must be same as Expanded.");
         comp.Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[]
         {
             (false, true)
@@ -242,7 +242,7 @@ public class ParameterStateUsageTests : BunitTest
         await comp.SetParametersAndRenderAsync(parameters => parameters.Add(parameter => parameter.Expanded, false));
         alertTextFunc.Should().Throw<ComponentNotFoundException>();
         comp.Instance.Expanded.Should().BeFalse("We changed the parameter directly, must change.");
-        comp.Instance.ExpandedStateValue.Should().BeFalse("We sync on OnInitialized, must be same as Expanded.");
+        comp.Instance.ExpandedState.Value.Should().BeFalse("We sync on OnInitialized, must be same as Expanded.");
         comp.Instance.ParameterChangedEvents.Should().BeEquivalentTo(new[]
         {
             (false, true),
@@ -333,10 +333,25 @@ public class ParameterStateUsageTests : BunitTest
         comp.Instance.Child3Instance.Expanded.Should().BeFalse();
         comp.Instance.Child4Instance.Expanded.Should().BeFalse();
 
-        comp.Instance.Child1Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child2Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child3Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child4Instance.ExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child1Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.Value.Should().BeFalse();
+
+        comp.Instance.Child1Instance.ExpandedState.InitialValue.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.InitialValue.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.InitialValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.InitialValue.Should().BeFalse();
+
+        comp.Instance.Child1Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.RenderValue.Should().BeFalse();
+
+        comp.Instance.Child1Instance.ExpandedState.HasCallback.Should().BeTrue();
+        comp.Instance.Child2Instance.ExpandedState.HasCallback.Should().BeTrue();
+        comp.Instance.Child3Instance.ExpandedState.HasCallback.Should().BeTrue();
+        comp.Instance.Child4Instance.ExpandedState.HasCallback.Should().BeFalse();
 
         comp.Instance.ExpandedChild1BindSyntax.Should().BeFalse();
         comp.Instance.ExpandedChild2VariableAndCallback.Should().BeFalse();
@@ -364,10 +379,20 @@ public class ParameterStateUsageTests : BunitTest
         comp.Instance.Child3Instance.Expanded.Should().BeFalse();
         comp.Instance.Child4Instance.Expanded.Should().BeFalse();
 
-        comp.Instance.Child1Instance.ExpandedStateValue.Should().BeTrue();
-        comp.Instance.Child2Instance.ExpandedStateValue.Should().BeTrue();
-        comp.Instance.Child3Instance.ExpandedStateValue.Should().BeTrue();
-        comp.Instance.Child4Instance.ExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child1Instance.ExpandedState.InitialValue.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.InitialValue.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.InitialValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.InitialValue.Should().BeFalse();
+
+        comp.Instance.Child1Instance.ExpandedState.Value.Should().BeTrue();
+        comp.Instance.Child2Instance.ExpandedState.Value.Should().BeTrue();
+        comp.Instance.Child3Instance.ExpandedState.Value.Should().BeTrue();
+        comp.Instance.Child4Instance.ExpandedState.Value.Should().BeTrue();
+
+        comp.Instance.Child1Instance.ExpandedState.RenderValue.Should().BeTrue();
+        comp.Instance.Child2Instance.ExpandedState.RenderValue.Should().BeTrue();
+        comp.Instance.Child3Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.RenderValue.Should().BeFalse();
 
         comp.Instance.ExpandedChild1BindSyntax.Should().BeTrue();
         comp.Instance.ExpandedChild2VariableAndCallback.Should().BeTrue();
@@ -395,10 +420,15 @@ public class ParameterStateUsageTests : BunitTest
         comp.Instance.Child3Instance.Expanded.Should().BeFalse();
         comp.Instance.Child4Instance.Expanded.Should().BeFalse();
 
-        comp.Instance.Child1Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child2Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child3Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child4Instance.ExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child1Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.Value.Should().BeFalse();
+
+        comp.Instance.Child1Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.RenderValue.Should().BeFalse();
 
         comp.Instance.ExpandedChild1BindSyntax.Should().BeFalse();
         comp.Instance.ExpandedChild2VariableAndCallback.Should().BeFalse();
@@ -427,10 +457,15 @@ public class ParameterStateUsageTests : BunitTest
         comp.Instance.Child3Instance.Expanded.Should().BeFalse();
         comp.Instance.Child4Instance.Expanded.Should().BeTrue();
 
-        comp.Instance.Child1Instance.ExpandedStateValue.Should().BeTrue();
-        comp.Instance.Child2Instance.ExpandedStateValue.Should().BeTrue();
-        comp.Instance.Child3Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child4Instance.ExpandedStateValue.Should().BeTrue();
+        comp.Instance.Child1Instance.ExpandedState.Value.Should().BeTrue();
+        comp.Instance.Child2Instance.ExpandedState.Value.Should().BeTrue();
+        comp.Instance.Child3Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.Value.Should().BeTrue();
+
+        comp.Instance.Child1Instance.ExpandedState.RenderValue.Should().BeTrue();
+        comp.Instance.Child2Instance.ExpandedState.RenderValue.Should().BeTrue();
+        comp.Instance.Child3Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.RenderValue.Should().BeTrue();
 
         comp.Instance.ExpandedChild1BindSyntax.Should().BeTrue();
         comp.Instance.ExpandedChild2VariableAndCallback.Should().BeTrue();
@@ -457,10 +492,15 @@ public class ParameterStateUsageTests : BunitTest
         comp.Instance.Child3Instance.Expanded.Should().BeFalse();
         comp.Instance.Child4Instance.Expanded.Should().BeFalse();
 
-        comp.Instance.Child1Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child2Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child3Instance.ExpandedStateValue.Should().BeFalse();
-        comp.Instance.Child4Instance.ExpandedStateValue.Should().BeFalse();
+        comp.Instance.Child1Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.Value.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.Value.Should().BeFalse();
+
+        comp.Instance.Child1Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child2Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child3Instance.ExpandedState.RenderValue.Should().BeFalse();
+        comp.Instance.Child4Instance.ExpandedState.RenderValue.Should().BeFalse();
 
         comp.Instance.ExpandedChild1BindSyntax.Should().BeFalse();
         comp.Instance.ExpandedChild2VariableAndCallback.Should().BeFalse();

--- a/src/MudBlazor/State/ParameterState.cs
+++ b/src/MudBlazor/State/ParameterState.cs
@@ -72,9 +72,9 @@ public abstract class ParameterState<T>
     /// in that case <see cref="HasCallback"/> will be <c>true</c>.
     /// </para>
     /// <para>
-    /// <para>
     /// <b>NB!</b> Having a callback doesn't always mean the usage of Blazor's <c>@bind-</c> syntax.
     /// </para>
+    /// <para>
     /// When <see cref="HasCallback"/> is <c>true</c>, calling <see cref="SetValueAsync"/> triggers
     /// the associated <see cref="EventCallback{T}"/> so the parent can update its value and re-render — which in turn updates
     /// <see cref="RenderValue"/> when the parent supplies the new value.

--- a/src/MudBlazor/State/ParameterState.cs
+++ b/src/MudBlazor/State/ParameterState.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
+using MudBlazor.State.Builder;
 
 namespace MudBlazor.State;
 
@@ -19,9 +20,67 @@ namespace MudBlazor.State;
 public abstract class ParameterState<T>
 {
     /// <summary>
-    /// Gets the current value.
+    /// Gets the current logical value tracked by the <see cref="ParameterState{T}"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When you call <see cref="SetValueAsync"/> the <see cref="Value"/> is updated immediately in the local
+    /// <see cref="ParameterState{T}"/> instance so subsequent reads within the same render/logic will see the
+    /// new value.
+    /// </para>
+    /// <para>
+    /// The <see cref="Value"/> represents the child component's current notion of the parameter. It may differ from
+    /// <see cref="RenderValue"/> until the parent re-renders and supplies the updated value (see <see cref="HasCallback"/>).
+    /// </para>
+    /// </remarks>
     public abstract T Value { get; }
+
+    /// <summary>
+    /// Gets the value most recently received from the parent component's render.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="RenderValue"/> represents the parameter value as provided by the parent component during the
+    /// last parameter set/render. It is the value that should be shown to the user when you want to reflect
+    /// what the parent actually rendered.
+    /// </para>
+    /// <para>
+    /// Example: when you call <see cref="SetValueAsync"/> the local <see cref="Value"/> will change immediately,
+    /// but <see cref="RenderValue"/> will only update if the parent component participates in two-way binding
+    /// (see <see cref="HasCallback"/>). In two-way binding the child typically invokes the <see cref="EventCallback{T}"/>
+    /// and the parent responds by updating the parameter and re-rendering; when that happens the child will receive
+    /// the new value from the parent and <see cref="RenderValue"/> will be updated accordingly.
+    /// </para>
+    /// </remarks>
+    public abstract T RenderValue { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this parameter has an associated <see cref="EventCallback{T}"/> on the component.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>true</c> when the component defines an <see cref="EventCallback{T}"/> parameter that corresponds to the parameter
+    /// (conventionally named <c>{ParameterName}Changed</c>). For example:
+    /// <code>
+    /// [Parameter]
+    /// public int Counter { get; set; }
+    /// 
+    /// [Parameter]
+    /// public EventCallback&lt;int&gt; CounterChanged { get; set; }
+    /// </code>
+    /// If you supply the <see cref="EventCallback{T}"/> to <see cref="RegisterParameterBuilder{T}.WithEventCallback"/> then
+    /// in that case <see cref="HasCallback"/> will be <c>true</c>.
+    /// </para>
+    /// <para>
+    /// <para>
+    /// <b>NB!</b> Having a callback doesn't always mean the usage of Blazor's <c>@bind-</c> syntax.
+    /// </para>
+    /// When <see cref="HasCallback"/> is <c>true</c>, calling <see cref="SetValueAsync"/> triggers
+    /// the associated <see cref="EventCallback{T}"/> so the parent can update its value and re-render — which in turn updates
+    /// <see cref="RenderValue"/> when the parent supplies the new value.
+    /// </para>
+    /// </remarks>
+    public abstract bool HasCallback { get; }
 
     /// <summary>
     /// Gets a value indicating whether the object is initialized.
@@ -45,7 +104,18 @@ public abstract class ParameterState<T>
     /// </summary>
     /// <remarks>
     /// Note: you should never set the parameter's property directly from within the component.
-    /// Instead, use SetValueAsync on the ParameterState object.
+    /// Instead, use <see cref="SetValueAsync"/> on the <see cref="ParameterState{T}"/> object.
+    /// <para>
+    /// When the parameter has an associated callback (<see cref="HasCallback"/> is <c>true</c>), calling this method will
+    /// invoke the associated <see cref="EventCallback{T}"/> so the parent can update its state and
+    /// re-render. The child's <see cref="RenderValue"/> will then be updated when the parent supplies the new
+    /// value on the next render.
+    /// </para>
+    /// <para>
+    /// When <see cref="HasCallback"/> is <c>false</c>, invoking <see cref="SetValueAsync"/> updates the child's local
+    /// <see cref="Value"/> but does not notify the parent; therefore <see cref="RenderValue"/> will only change when
+    /// the parent explicitly supplies a different value.
+    /// </para>
     /// </remarks>
     /// <param name="value">New parameter's value.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -47,6 +47,9 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     public bool HasHandler => _parameterChangedHandler is not null;
 
     /// <inheritdoc />
+    public override bool HasCallback => _eventCallbackFunc().HasDelegate;
+
+    /// <inheritdoc />
     [MemberNotNullWhen(true, nameof(_value), nameof(_initialValue))]
     public override bool IsInitialized => _isInitialized;
 
@@ -101,6 +104,9 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
             return _value;
         }
     }
+
+    /// <inheritdoc/>
+    public override T RenderValue => _getParameterValueFunc();
 
     /// <summary>
     /// Gets the function to provide the comparer for the parameter.


### PR DESCRIPTION
I didn’t really want to do that before, I just wanted to keep two simple members, `Value` and `SetValueAsync`, so no one had to think about which one to use, especially other developers working with `ParameterState`.

That said, I still believe that most people outside of Mud don't really need `ParameterState`, so using it is entirely at their own risk, they should clearly understand what they’re doing. As for us, I just want to have more flexibility. In 95% of cases these new properties shouldn’t be used, but there *are* situations where having this kind of information is genuinely useful.

Maybe in future I will just make `ParameterStateUnsafe<T>` that inherits `ParameterState<T>`, will see how I will feel about it, probably will see depend if I will see miss-usage of the new properties in the PRs.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
