### PR TITLE
Tests: Cleanup, remove unused extensions

### DIFF
--- a/src/MudBlazor.UnitTests/Comparer/DoubleArrayEpsilonEqualityComparer.cs
+++ b/src/MudBlazor.UnitTests/Comparer/DoubleArrayEpsilonEqualityComparer.cs
@@ -2,9 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-
 namespace MudBlazor.UnitTests.Comparer;
 
 #nullable enable

--- a/src/MudBlazor.UnitTests/Components/AlertTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AlertTests.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents.Alert;
@@ -21,23 +19,6 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => comp.Instance.OnCloseIconClickAsync());
             comp.WaitForAssertion(() => comp.Instance.Icon.Should().Be("<path d=\"M7.38,4.24c-.84,.11-2.17-.89-2.3-1.86s1-1.53,1.83-1.65,1.82,.19,1.94,1.16-.64,2.23-1.48,2.35Z\"/><path d=\"M22.61,8.61c-.47-1.24-1.13-2.41-1.96-3.45-.56-.7-1.2-1.34-1.91-1.88-.82-.63-1.73-1.2-2.73-1.44-4.54-1.12-4.18,2.13-6.51,3.12-2.33,.99-5.1,.07-6.59,2.11-.62,.85-1.24,1.76-1.63,2.75-.36,.91-.5,1.91-.43,2.88,.13,1.9,1.04,3.96,2.62,5.08,.56,.39,1.48,.89,2.12,.42,.31-.23,.5-.6,.64-.95,.41-1.02,.51-2.17,.58-3.25s-.14-4.6,.07-5.22c.16-.48,.56-.83,1.05-.96,.6-.17,1.37,.02,1.81,.47,.19,.19,.35,.43,.47,.7,.12,.27,.26,.61,.41,1.03l.9,2.52c.08,.21,.16,.43,.25,.65,.09,.22,.18,.43,.28,.61,.1,.18,.21,.33,.32,.45,.11,.12,.23,.17,.34,.17,.1,0,.19-.05,.29-.15,.1-.1,.19-.24,.28-.41,.09-.17,.18-.36,.28-.59s.18-.46,.27-.71l.97-2.62c.14-.37,.26-.69,.38-.96,.12-.27,.26-.49,.42-.67,.16-.17,.35-.3,.57-.39,.22-.09,.51-.13,.86-.13,.27,0,.5,.03,.7,.08s.36,.16,.49,.31c.23,.29,.28,.74,.33,1.1,.11,.76,.03,1.55,.03,2.31v4.39c0,.38,.02,.76,0,1.13-.02,.32-.01,.65-.17,.95-.14,.27-.41,.48-.71,.52-.39,.05-.7-.25-.85-.59-.07-.16-.11-.32-.14-.48-.02-.16-.04-.29-.04-.38,0,0,.16-4.3-.54-4.21-.14,.02-.47,.8-.56,.99-.49,.97-1.73,3.71-1.97,4.06-.19,.28-.46,.58-.81,.64-.24,.05-.48-.04-.67-.2-.47-.38-.68-1.08-.9-1.63-.18-.45-1.36-5-2.23-5.12-.12-.02-.2,.2-.25,.59-.05,.4-.25,7.35,1.72,9.31,2.81,2.79,7.86,2.55,11.62-3.17,1.83-2.79,1.66-6.81,.54-9.77Z\"/>"));
-        }
-
-        [Test]
-        public async Task AlertTest2()
-        {
-            var comp = Context.RenderComponent<MudAlert>();
-            var exceptionMessage = "";
-            try
-            {
-                await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Severity, (object)"abc"));
-            }
-            catch (Exception ex)
-            {
-                exceptionMessage = ex.Message;
-            }
-            // The error message is different when using the new SetParametersAndRenderAsync API vs SetParamAsync
-            exceptionMessage.Should().Contain("parameter selector");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
@@ -1,7 +1,4 @@
-﻿
-using System;
-using System.Linq;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents.AvatarGroup;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/BadgeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BadgeTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Badge;

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using Bunit.Rendering;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Button;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;

--- a/src/MudBlazor.UnitTests/Components/CardTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CardTests.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents.Card;

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -5,7 +5,6 @@ using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.Charts;
-using MudBlazor.UnitTests.Components;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Charts

--- a/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
@@ -5,7 +5,6 @@ using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using MudBlazor.Charts;
-using MudBlazor.UnitTests.Components;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Charts

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.ChipSet;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using AngleSharp.Dom;
-using AngleSharp.Html.Dom;
 using Bunit;
-using Bunit.Web.AngleSharp;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents.Collapse;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1,15 +1,12 @@
 ﻿#pragma warning disable IDE1006 // leading underscore
 
 using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
-using MudBlazor;
 using MudBlazor.Extensions;
 using MudBlazor.Resources;
 using MudBlazor.UnitTests.TestComponents.ColorPicker;

--- a/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
@@ -2,10 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.Components;
 using MudBlazor.UnitTests.Dummy;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/DataGrid/AggregateDefinitionTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGrid/AggregateDefinitionTests.cs
@@ -2,10 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/DataGrid/Mocks/CustomFilterDefinitionMock.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGrid/Mocks/CustomFilterDefinitionMock.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace MudBlazor.UnitTests.Components;
 
 #nullable enable

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.Serialization;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;

--- a/src/MudBlazor.UnitTests/Components/Dialog/DialogParametersTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Dialog/DialogParametersTests.cs
@@ -2,10 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Dialog;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.JSInterop;
 using Moq;
 using MudBlazor.Services;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Drawer;
 using NUnit.Framework;
 using static Bunit.ComponentParameterFactory;

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.DropZone;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/ElementTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ElementTests.cs
@@ -1,7 +1,5 @@
-﻿
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Element;
 using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components

--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -6,7 +6,6 @@ using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.Services;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Hidden;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/IconTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bunit;
 using FluentAssertions;
 using NUnit.Framework;
+
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -21,5 +21,4 @@ public class InputTests : BunitTest
         await comp.SetParametersAndRenderAsync(p => p.Add(x => x.ReadOnly, true)); //no clear button when readonly
         comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
     }
-#nullable disable
 }

--- a/src/MudBlazor.UnitTests/Components/LinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/LinkTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.List;

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;

--- a/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
@@ -1,7 +1,5 @@
-﻿using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.NavMenu;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -1,6 +1,5 @@
 ﻿using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.NavMenu;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/NavigationAccessibilityTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavigationAccessibilityTests.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System.Linq;
+
 using Bunit;
 using FluentAssertions;
 using MudBlazor.Extensions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Navigation;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/ProgressLinearTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressLinearTests.cs
@@ -1,6 +1,4 @@
-﻿
-using System;
-using System.Globalization;
+﻿using System.Globalization;
 using Bunit;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Docs.Examples;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.RadioGroup;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;

--- a/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Scroll;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.Dummy;

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Globalization;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Slider;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -1,13 +1,8 @@
-﻿
-using System;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Snackbar;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/StackTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StackTests.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
-using AngleSharp.Html.Dom;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
-using Microsoft.AspNetCore.Components;
-using MudBlazor.UnitTests.TestComponents;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components

--- a/src/MudBlazor.UnitTests/Components/StepperContextTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperContextTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
 {

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -1,15 +1,13 @@
-﻿#nullable enable
-using System;
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
-using MudBlazor;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.Stepper;
 using NUnit.Framework;
 
+#nullable enable
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/SwipeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwipeTests.cs
@@ -1,8 +1,6 @@
-﻿using System.Threading.Tasks;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.SwipeArea;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -1,7 +1,6 @@
 ﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents.Switch;
 using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Globalization;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.ThemeProvider;
 using MudBlazor.Utilities;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Components/TimelineTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimelineTests.cs
@@ -2,13 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading.Tasks;
 using AngleSharp.Css.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Timeline;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -1,6 +1,5 @@
 ﻿using Bunit;
 using FluentAssertions;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.ToggleIconButton;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
@@ -30,6 +30,5 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudToolBar>();
             comp.Instance.WrapContent.Should().Be(false);
         }
-
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Bunit;
+﻿using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;

--- a/src/MudBlazor.UnitTests/Converters/DeferredConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DeferredConverterTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using FluentAssertions;
-using MudBlazor.Utilities.Converter;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Converters;

--- a/src/MudBlazor.UnitTests/Dummy/DummyBrowserFile.cs
+++ b/src/MudBlazor.UnitTests/Dummy/DummyBrowserFile.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System;
-using System.IO;
-using System.Threading;
+
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace MudBlazor.UnitTests.Dummy;

--- a/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using FluentAssertions;
-using MudBlazor;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Extensions

--- a/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IBrowserFileExtensions.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System.IO;
+
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace MudBlazor.UnitTests

--- a/src/MudBlazor.UnitTests/Extensions/IReadOnlyCollectionExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IReadOnlyCollectionExtensions.cs
@@ -2,10 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace MudBlazor.UnitTests;
 
 #nullable enable

--- a/src/MudBlazor.UnitTests/Extensions/IRenderedComponentExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IRenderedComponentExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using Bunit;
 using Bunit.Rendering;
@@ -90,28 +89,5 @@ public static class IRenderedComponentExtensions
         }
 
         return parameterView;
-    }
-
-    public static Task SetParamAsync<T>(this IRenderedComponentBase<T> self, Expression<Func<T, object?>> exp, object? value) where T : IComponent
-    {
-        var name = (exp.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)exp.Body).Operand).Member.Name;
-        return self.SetParametersAndRenderAsync(ComponentParameter.CreateParameter(name, value));
-    }
-
-    public static Task SetCascadingValueAsync<T>(this IRenderedComponentBase<T> self, Expression<Func<T, object?>> exp, object value) where T : IComponent
-    {
-        var name = (exp.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)exp.Body).Operand).Member.Name;
-        return self.SetParametersAndRenderAsync(ComponentParameter.CreateCascadingValue(name, value));
-    }
-
-    public static Task SetCallbackAsync<T, U>(this IRenderedComponentBase<T> self, string name, Action<U> callback) where T : IComponent
-    {
-        return self.SetParametersAndRenderAsync(ComponentParameter.CreateParameter(name, new EventCallback<U>(null, callback)));
-    }
-
-    public static Task SetCallbackAsync<T, U>(this IRenderedComponentBase<T> self, Expression<Func<T, EventCallback<U>>> exp, Action<U> callback) where T : IComponent
-    {
-        var name = (exp.Body as MemberExpression ?? (MemberExpression)((UnaryExpression)exp.Body).Operand).Member.Name;
-        return self.SetParametersAndRenderAsync(ComponentParameter.CreateParameter(name, new EventCallback<U>(null, callback)));
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/InputFileExtensions.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-using System;
-using System.Threading.Tasks;
+
 using Bunit;
 using Microsoft.AspNetCore.Components.Forms;
 

--- a/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Extensions/ResizeOptionsExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ResizeOptionsExtensionsTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Extensions;
 using MudBlazor.Services;

--- a/src/MudBlazor.UnitTests/Mocks/MockIntEqualityComparer.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockIntEqualityComparer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace MudBlazor.UnitTests.Mocks
+﻿namespace MudBlazor.UnitTests.Mocks
 {
 #nullable enable
     public class MockIntEqualityComparer : IEqualityComparer<int>

--- a/src/MudBlazor.UnitTests/Mocks/MockJsRuntime.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockJsRuntime.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
 namespace MudBlazor.UnitTests.Mocks;

--- a/src/MudBlazor.UnitTests/Mocks/MockLoggerProvider.cs
+++ b/src/MudBlazor.UnitTests/Mocks/MockLoggerProvider.cs
@@ -2,11 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace MudBlazor.UnitTests.Mocks

--- a/src/MudBlazor.UnitTests/Other/TypeIdentifierTests.cs
+++ b/src/MudBlazor.UnitTests/Other/TypeIdentifierTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Numerics;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportSubscriptionTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportSubscriptionTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Services/Browser/Mocks/BrowserViewportObserverMock.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/Mocks/BrowserViewportObserverMock.cs
@@ -2,9 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using MudBlazor.Services;
 
 namespace MudBlazor.UnitTests.Services.Browser.Mocks;

--- a/src/MudBlazor.UnitTests/Services/Browser/ResizeOptionsTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/ResizeOptionsTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Services;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Services/Localization/InternalMudLocalizerTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Localization/InternalMudLocalizerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;

--- a/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverMock.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverMock.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.UnitTests.Services.Popover.Mocks;

--- a/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverObserverMock.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverObserverMock.cs
@@ -2,11 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace MudBlazor.UnitTests.Services.Popover.Mocks;
 
 #nullable enable

--- a/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverServiceMock.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/Mocks/PopoverServiceMock.cs
@@ -2,9 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;

--- a/src/MudBlazor.UnitTests/Services/SnackbarServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/SnackbarServiceTests.cs
@@ -6,7 +6,6 @@ using Bunit.TestDoubles;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MudBlazor.UnitTests.Components;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Services;

--- a/src/MudBlazor.UnitTests/SourceGenerator/FastEnumDescriptionGeneratorTest.cs
+++ b/src/MudBlazor.UnitTests/SourceGenerator/FastEnumDescriptionGeneratorTest.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/MudBlazor.UnitTests/TestComponents/Stepper/StepContextRecorder.cs
+++ b/src/MudBlazor.UnitTests/TestComponents/Stepper/StepContextRecorder.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-using System;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -18,6 +17,7 @@ public class StepContextRecorder : ComponentBase
 
     protected override void OnParametersSet()
     {
+        base.OnParametersSet();
         Capture?.Invoke(Context);
     }
 

--- a/src/MudBlazor.UnitTests/TestData/BreakpointWithinReferenceSizeTestCase.cs
+++ b/src/MudBlazor.UnitTests/TestData/BreakpointWithinReferenceSizeTestCase.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Castle.Components.DictionaryAdapter.Xml;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.TestData

--- a/src/MudBlazor.UnitTests/Utilities/Background/BackgroundWorkerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Background/BackgroundWorkerTests.cs
@@ -2,9 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using MudBlazor.UnitTests.Utilities.Background.Mocks;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Utilities/Background/BatchPeriodicQueueTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Background/BatchPeriodicQueueTests.cs
@@ -2,10 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using MudBlazor.Utilities.Background.Batch;

--- a/src/MudBlazor.UnitTests/Utilities/Comparer/CollectionComparerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Comparer/CollectionComparerTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Utilities.Comparer;

--- a/src/MudBlazor.UnitTests/Utilities/Comparer/DoubleEpsilonEqualityComparerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Comparer/DoubleEpsilonEqualityComparerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Utilities.Comparer;

--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -2,8 +2,6 @@
 // License: MIT
 // See https://github.com/EdCharbeneau
 
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading.Tasks;
 using FluentAssertions;
 using MudBlazor.Utilities.Debounce;
 using NUnit.Framework;

--- a/src/MudBlazor.UnitTests/Utilities/DisplayNameLabelClass.cs
+++ b/src/MudBlazor.UnitTests/Utilities/DisplayNameLabelClass.cs
@@ -2,13 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace MudBlazor.UnitTests.Utilities
 {
     public class DisplayNameLabelClass

--- a/src/MudBlazor.UnitTests/Utilities/EventUtilTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/EventUtilTests.cs
@@ -2,15 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.UnitTests.Components;
 using MudBlazor.UnitTests.TestComponents.Utilities;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Expressions/ExpressionHasherTests.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using FluentAssertions;
 using MudBlazor.Utilities.Expressions;

--- a/src/MudBlazor.UnitTests/Utilities/Expressions/PropertyPathTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Expressions/PropertyPathTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Linq.Expressions;
 using FluentAssertions;
 using MudBlazor.Utilities.Expressions;

--- a/src/MudBlazor.UnitTests/Utilities/LoggerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/LoggerTests.cs
@@ -2,18 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using MudBlazor.UnitTests.Components;
 using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.Logger;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/Mask/BlockMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/BlockMaskTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/Mask/DateMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/DateMaskTests.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Globalization;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/Mask/MultiMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/MultiMaskTests.cs
@@ -2,12 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/Mask/PatternMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/PatternMaskTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentAssertions;
+﻿using FluentAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
@@ -2,10 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using MudBlazor.Utilities.Throttle;
 using NUnit.Framework;


### PR DESCRIPTION
Clearing usings.
Removing non used `IRenderedComponentExtensions`, we don't want to have different API to set parameter.
`AlertTest2` was removed because the test was useless. It did not verify any component behavior; it only checked whether `SetParam{Async}` could cast an object to an enum. However, the API has since been migrated to a strongly typed approach: https://github.com/MudBlazor/MudBlazor/pull/12228
Testing non-component behavior, like enum casting, using bUnit is unnecessary and inappropriate.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
