### PR TITLE
Tests: Remove .Wait() usage

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -854,7 +854,7 @@ namespace MudBlazor.UnitTests.Components
 
             // ToggleMenu to open menu and Clear to close it and check the text and value
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
-            await comp.InvokeAsync(() => autocomplete.ClearAsync().Wait());
+            await comp.InvokeAsync(() => autocomplete.ClearAsync());
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be("");
@@ -867,7 +867,7 @@ namespace MudBlazor.UnitTests.Components
             items.First().Markup.Should().Contain("California");
 
             // Clearing it and check the close status text and value again
-            await comp.InvokeAsync(() => autocomplete.ClearAsync().Wait());
+            await comp.InvokeAsync(() => autocomplete.ClearAsync());
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             autocomplete.Value.Should().Be(null);
             autocomplete.Text.Should().Be("");

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -662,15 +662,15 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Min, (T)min)
                 .Add(x => x.Step, value)
                 .Add(x => x.Value, value));
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(value);
             // setting min and max to value will cover the boundary checking code
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Max, value)
                 .Add(x => x.Min, value));
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(value);
         }
 
@@ -685,15 +685,15 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Min, (T?)min)
                 .Add(x => x.Step, value)
                 .Add(x => x.Value, value));
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(value);
             // setting min and max to value will cover the boundary checking code
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Max, value)
                 .Add(x => x.Min, value));
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(value);
         }
 
@@ -703,7 +703,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.RenderComponent<MudNumericField<T?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, value));
 
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
             comp.Instance.Value.Should().Be(value);
 
             comp.Find("input").Change("");
@@ -713,7 +713,7 @@ namespace MudBlazor.UnitTests.Components
             else
                 value = (T)Convert.ChangeType(-Convert.ToDouble(value), typeof(T));
 
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(value);
         }
 
@@ -725,12 +725,12 @@ namespace MudBlazor.UnitTests.Components
 
             // test max overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Max));
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
             comp.Instance.Value.Should().Be(comp.Instance.Max);
 
             // test min overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Min));
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(comp.Instance.Min);
         }
 
@@ -742,12 +742,12 @@ namespace MudBlazor.UnitTests.Components
 
             // test max overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Max));
-            await comp.InvokeAsync(() => comp.Instance.Increment().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Increment());
             comp.Instance.Value.Should().Be(comp.Instance.Max);
 
             // test min overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Min));
-            await comp.InvokeAsync(() => comp.Instance.Decrement().Wait());
+            await comp.InvokeAsync(() => comp.Instance.Decrement());
             comp.Instance.Value.Should().Be(comp.Instance.Min);
         }
 

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -250,22 +250,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TextField_Should_FireValueChangedOnTextParameterChange()
+        public void TextField_Should_FireValueChangedOnTextParameterChange()
         {
             string changed_value = null;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
-                .Add(p => p.ValueChanged, x => changed_value = x));
-            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, "A"));
+            _ = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+                .Add(p => p.ValueChanged, x => changed_value = x)
+                .Add(p => p.Text, "A"));
             changed_value.Should().Be("A");
         }
 
         [Test]
-        public async Task TextField_Should_FireTextChangedOnValueParameterChange()
+        public void TextField_Should_FireTextChangedOnValueParameterChange()
         {
             string changed_text = null;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
-                .Add(p => p.TextChanged, x => changed_text = x));
-            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, "A"));
+            _ = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+                .Add(p => p.TextChanged, x => changed_text = x)
+                .Add(p => p.Value, "A"));
             changed_text.Should().Be("A");
         }
 

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1223,7 +1223,6 @@ namespace MudBlazor.UnitTests.Components
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
                 var comp = Context.RenderComponent<TreeViewTest8>();
-                comp.Render();
                 comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
             });
 


### PR DESCRIPTION
Remove the `.Wait()`, they are unnecessary and harmful.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
