### PR TITLE
Tests: Migrate to bUnit 2.x

### DIFF
--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -251,7 +251,7 @@ public partial class TestsForApiPages
             cb.IndentLevel++;
             // Create Api.razor with a type
             cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{type.Name}""));");
-            cb.AddLine(@$"var comp = ctx.RenderComponent<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
+            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
             cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
             // Make sure docs for the type were actually found
             cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {type.Name} was not found"");");
@@ -282,7 +282,7 @@ public partial class TestsForApiPages
             cb.IndentLevel++;
             // Create Api.razor with a type
             cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{url}""));");
-            cb.AddLine(@$"var comp = ctx.RenderComponent<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
+            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
             cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
             // Make sure docs for the type were actually found
             cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {component} was not found"");");

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -48,7 +48,7 @@ public class TestsForExamples
                 cb.AddLine($"public void {componentName}_Test()");
                 cb.AddLine("{");
                 cb.IndentLevel++;
-                cb.AddLine($"ctx.RenderComponent<{componentName}>();");
+                cb.AddLine($"ctx.Render<{componentName}>();");
                 cb.IndentLevel--;
                 cb.AddLine("}");
             }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
@@ -21,7 +21,7 @@ public sealed class ApiMemberTableTests : BunitTest
     [Test]
     public void ApiMemberTable_RenderMissingType()
     {
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters.Add(x => x.Type, null));
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters.Add(x => x.Type, null));
         // There should be a message saying no members are found
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
     }
@@ -33,7 +33,7 @@ public sealed class ApiMemberTableTests : BunitTest
     public void ApiMemberTable_RenderNoneMode()
     {
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.None));
         // There should be a message saying no members are found
@@ -48,7 +48,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type with protected properties
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Properties)
             .Add(x => x.ShowProtected, true));
@@ -68,7 +68,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type without protected properties
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Properties)
             .Add(x => x.ShowProtected, false));
@@ -88,7 +88,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type without protected methods
         var mudAutocomplete = ApiDocumentation.GetType("MudBlazor.MudAutocomplete`1");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAutocomplete)
             .Add(x => x.Mode, ApiMemberTableMode.Methods)
             .Add(x => x.ShowProtected, true));
@@ -108,7 +108,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type without protected methods
         var mudAutocomplete = ApiDocumentation.GetType("MudBlazor.MudAutocomplete`1");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAutocomplete)
             .Add(x => x.Mode, ApiMemberTableMode.Methods)
             .Add(x => x.ShowProtected, false));
@@ -128,7 +128,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type with protected fields
         var mudBaseDatePicker = ApiDocumentation.GetType("MudBlazor.MudBaseDatePicker");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudBaseDatePicker)
             .Add(x => x.Mode, ApiMemberTableMode.Fields)
             .Add(x => x.ShowProtected, true));
@@ -148,7 +148,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type without protected fields
         var mudBaseDatePicker = ApiDocumentation.GetType("MudBlazor.MudBaseDatePicker");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudBaseDatePicker)
             .Add(x => x.Mode, ApiMemberTableMode.Fields)
             .Add(x => x.ShowProtected, false));
@@ -171,7 +171,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type with events
         var mudDataGrid = ApiDocumentation.GetType("MudBlazor.MudDataGrid`1");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudDataGrid)
             .Add(x => x.Mode, ApiMemberTableMode.Events));
         // There should NOT be a message saying no members are found  
@@ -189,7 +189,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type with globals
         var mudDialog = ApiDocumentation.GetType("MudBlazor.MudDialog");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudDialog)
             .Add(x => x.Mode, ApiMemberTableMode.Globals));
         // There should NOT be a message saying no members are found  
@@ -207,7 +207,7 @@ public sealed class ApiMemberTableTests : BunitTest
     {
         // Get a type with no globals
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
-        using var comp = Context.RenderComponent<ApiMemberTable>(parameters => parameters
+        using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Globals));
         // There should be a message saying no members are found  

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
@@ -26,7 +26,7 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
     {
         // Get a type with see-also links
         var mudButton = ApiDocumentation.GetType("MudBlazor.MudButton");
-        using var comp = Context.RenderComponent<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudButton));
+        using var comp = Context.Render<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudButton));
         // There should be a see-also link to MudButtonGroup
         comp.Markup.Should().Contain("<a href=\"/api/MudButtonGroup\"");
         comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudButtonGroup</a>");
@@ -45,7 +45,7 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
     {
         // Get a type with no see-also links
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
-        using var comp = Context.RenderComponent<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudAlert));
+        using var comp = Context.Render<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudAlert));
         // There should be a message saying no members are found  
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>");
     }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
@@ -20,7 +20,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_HandleMalformedXmlDocs()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Sorry guys, I was drunk when I <see cref wrote these docs, </burp>"));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Sorry guys, I was drunk when I <see cref wrote these docs, </burp>"));
         comp.Markup.Should().Be("<span class=\"mud-typography mud-typography-caption mud-warning-text\">XML documentation error.</span>");
     }
 
@@ -30,7 +30,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderJustText()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Gets or sets the icon for this widget."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets or sets the icon for this widget."));
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets or sets the icon for this widget.</span>");
     }
 
@@ -40,7 +40,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderNullText()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, null));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, null));
         comp.Markup.Should().Be("");
     }
 
@@ -50,7 +50,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderEmptyText()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, ""));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, ""));
         comp.Markup.Should().Be("");
     }
 
@@ -60,7 +60,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeHref_SelfClosing()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\" /> right now."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\" /> right now."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>");
         // Then a link to https://www.mudblazor.com with the same text
@@ -75,7 +75,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeHref_WithText()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\">MudBlazor</see> right now."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\">MudBlazor</see> right now."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>");
         // Then a link to "MudBlazor" (text)
@@ -90,7 +90,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeHref_EmptyUrl()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "For another Blazor library, go to <see href=\"\" />."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For another Blazor library, go to <see href=\"\" />."));
         // The link should be skipped completely
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For another Blazor library, go to </span><span class=\"mud-typography mud-typography-caption\">.</span>");
     }
@@ -101,7 +101,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_ExistingProperty()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.MudComponentBase.Class\" /> has changed."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.MudComponentBase.Class\" /> has changed."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>");
         // Then a link to /api/MudComponentBase#Class
@@ -116,7 +116,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_NonExistantProperty()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.NotExistingType.NotExistingProperty\" /> has changed."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.NotExistingType.NotExistingProperty\" /> has changed."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>");
         // There's no valid link, just a span for the non-existant property
@@ -131,7 +131,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_ExistingMethod()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.AggregateDefinition`1.SimpleAvg\" /> to receive viewport changes."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.AggregateDefinition`1.SimpleAvg\" /> to receive viewport changes."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>");
         // Then a link to /api/AggregateDefinition`1#SimpleAvg
@@ -146,7 +146,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_NonExistantMethod()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.NotExistingType.NotExistingMethod\" /> to do stuff."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.NotExistingType.NotExistingMethod\" /> to do stuff."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>");
         // There's no valid link, just a span for the non-existant method
@@ -161,7 +161,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_ExistingField()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.End\" />."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.End\" />."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>");
         // There should be a link to /api/Adornment
@@ -176,7 +176,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_NonExistantField()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.EndOfTheUniverse\" />."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.EndOfTheUniverse\" />."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>");
         // There should be a text span
@@ -191,7 +191,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_ExistingEvent()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnClick\" /> event occurs."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnClick\" /> event occurs."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>");
         // There should be a link to /api/MudAlert#OnClick
@@ -206,7 +206,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_NonExistantEvent()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnSmokeAlarmInYourHouse\" /> event occurs."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnSmokeAlarmInYourHouse\" /> event occurs."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>");
         // There should be a text span
@@ -221,7 +221,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_External_MicrosoftType()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "The button can contain a <see cref=\"T:Microsoft.AspNetCore.Components.RenderFragment\" />."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "The button can contain a <see cref=\"T:Microsoft.AspNetCore.Components.RenderFragment\" />."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The button can contain a </span>");
         // There should be a link to Microsoft docs
@@ -238,7 +238,7 @@ public sealed class ApiTextTests : BunitTest
     [Test]
     public void ApiText_RenderSeeCref_External_SystemType()
     {
-        var comp = Context.RenderComponent<ApiText>(parameters => parameters.Add(x => x.Text, "The popover unique ID is a <see cref=\"T:System.Guid\" />."));
+        var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "The popover unique ID is a <see cref=\"T:System.Guid\" />."));
         // There should be a text span
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The popover unique ID is a </span>");
         // There should be a link to Microsoft docs

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
@@ -20,7 +20,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Boolean()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Boolean"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Boolean"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">bool</code>");
     }
 
@@ -30,7 +30,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_BooleanArray()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Boolean[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Boolean[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">bool[]</code>");
     }
 
@@ -40,7 +40,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Int32()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int32"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int32"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">int</code>");
     }
 
@@ -50,7 +50,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Int32Array()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int32[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int32[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">int[]</code>");
     }
 
@@ -60,7 +60,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Int64()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int64"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int64"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">long</code>");
     }
 
@@ -70,7 +70,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Int64Array()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int64[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int64[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">long[]</code>");
     }
 
@@ -80,7 +80,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_String()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.String"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.String"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">string</code>");
     }
 
@@ -90,7 +90,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_StringArray()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.String[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.String[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">string[]</code>");
     }
 
@@ -100,7 +100,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Double()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Double"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Double"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">double</code>");
     }
 
@@ -110,7 +110,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_DoubleArray()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Double[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Double[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">double[]</code>");
     }
 
@@ -120,7 +120,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Single()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Single"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Single"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">float</code>");
     }
 
@@ -130,7 +130,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_SingleArray()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Single[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Single[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">float[]</code>");
     }
 
@@ -140,7 +140,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Object()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Object"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Object"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">object</code>");
     }
 
@@ -150,7 +150,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_ObjectArray()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Object[]"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Object[]"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">object[]</code>");
     }
 
@@ -160,7 +160,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_Void()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Void"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Void"));
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">void</code>");
     }
 
@@ -170,7 +170,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_MudBlazor_Component()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
         // There should be a link to MudAlert
         comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>");
     }
@@ -181,7 +181,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_MudBlazor_Enums()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.Adornment"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.Adornment"));
         // There should be a link to Adornment
         comp.Markup.Should().Contain("<a href=\"/api/Adornment\"");
         comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">Adornment</a>");
@@ -193,7 +193,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_External_MicrosoftType()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "Microsoft.AspNetCore.Components.RenderFragment"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "Microsoft.AspNetCore.Components.RenderFragment"));
         // There should be a link to Microsoft docs
         comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/Microsoft.AspNetCore.Components.RenderFragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">");
         // There should be a Link icon
@@ -206,7 +206,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     [Test]
     public void ApiTypeLink_External_SystemType()
     {
-        var comp = Context.RenderComponent<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Guid"));
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Guid"));
         // There should be a link to Microsoft docs
         comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/System.Guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">");
         // There should be a Link icon

--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -13,12 +13,12 @@ namespace MudBlazor.UnitTests.Docs.Generated
     [TestFixture]
     public partial class ApiDocsTests
     {
-        private Bunit.TestContext ctx;
+        private Bunit.BunitContext ctx;
 
         [SetUp]
         public void Setup()
         {
-            ctx = new Bunit.TestContext();
+            ctx = new Bunit.BunitContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton(TimeProvider.System);
             ctx.Services.AddSingleton<IDialogService>(new DialogService());
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
         public async Task AlertPage_Test()
         {
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/alert"));
-            var comp = ctx.RenderComponent<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
+            var comp = ctx.Render<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
             await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
         }
 
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
         public async Task MudAlert_API_Test_Example()
         {
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/MudAlert"));
-            var comp = ctx.RenderComponent<Api>(parameters => parameters.Add(x => x.TypeName, "MudAlert"));
+            var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, "MudAlert"));
             await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
             comp.Markup.Should().NotContain("Sorry, the type").And.NotContain("could not be found");
             var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href.StartsWith("/component"));
@@ -70,6 +70,6 @@ namespace MudBlazor.UnitTests.Docs.Generated
         }
 
         [TearDown]
-        public void TearDown() => ctx.Dispose();
+        public async Task TearDown() => await ctx.DisposeAsync();
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -12,12 +12,12 @@ namespace MudBlazor.UnitTests.Docs.Generated
     [TestFixture]
     public partial class ExampleDocsTests
     {
-        private Bunit.TestContext ctx;
+        private BunitContext ctx;
 
         [SetUp]
         public void Setup()
         {
-            ctx = new Bunit.TestContext();
+            ctx = new BunitContext();
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton(TimeProvider.System);
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());

--- a/src/MudBlazor.UnitTests.Shared/BunitTest.cs
+++ b/src/MudBlazor.UnitTests.Shared/BunitTest.cs
@@ -9,7 +9,7 @@ namespace MudBlazor.UnitTests.Shared
 {
     public abstract class BunitTest
     {
-        protected Bunit.TestContext Context { get; private set; } = null!;
+        protected Bunit.BunitContext Context { get; private set; } = null!;
 
         [SetUp]
         public virtual void Setup()

--- a/src/MudBlazor.UnitTests.Shared/Extensions/TestContextExtensions.cs
+++ b/src/MudBlazor.UnitTests.Shared/Extensions/TestContextExtensions.cs
@@ -8,7 +8,7 @@ namespace MudBlazor.UnitTests.Shared.Extensions
 {
     public static class TestContextExtensions
     {
-        public static void AddTestServices(this TestContext ctx)
+        public static void AddTestServices(this BunitContext ctx)
         {
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());

--- a/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
+++ b/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.40.0" />
+    <PackageReference Include="bunit" Version="2.2.2" />
     <PackageReference Include="nunit" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/MudBlazor.UnitTests/Components/AlertTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AlertTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AlertTest()
         {
-            var comp = Context.RenderComponent<MudAlert>(parameters => parameters.Add(x => x.Icon, Icons.Custom.Brands.MudBlazor));
+            var comp = Context.Render<MudAlert>(parameters => parameters.Add(x => x.Icon, Icons.Custom.Brands.MudBlazor));
 
             await comp.InvokeAsync(() => comp.Instance.OnCloseIconClickAsync());
             comp.WaitForAssertion(() => comp.Instance.Icon.Should().Be("<path d=\"M7.38,4.24c-.84,.11-2.17-.89-2.3-1.86s1-1.53,1.83-1.65,1.82,.19,1.94,1.16-.64,2.23-1.48,2.35Z\"/><path d=\"M22.61,8.61c-.47-1.24-1.13-2.41-1.96-3.45-.56-.7-1.2-1.34-1.91-1.88-.82-.63-1.73-1.2-2.73-1.44-4.54-1.12-4.18,2.13-6.51,3.12-2.33,.99-5.1,.07-6.59,2.11-.62,.85-1.24,1.76-1.63,2.75-.36,.91-.5,1.91-.43,2.88,.13,1.9,1.04,3.96,2.62,5.08,.56,.39,1.48,.89,2.12,.42,.31-.23,.5-.6,.64-.95,.41-1.02,.51-2.17,.58-3.25s-.14-4.6,.07-5.22c.16-.48,.56-.83,1.05-.96,.6-.17,1.37,.02,1.81,.47,.19,.19,.35,.43,.47,.7,.12,.27,.26,.61,.41,1.03l.9,2.52c.08,.21,.16,.43,.25,.65,.09,.22,.18,.43,.28,.61,.1,.18,.21,.33,.32,.45,.11,.12,.23,.17,.34,.17,.1,0,.19-.05,.29-.15,.1-.1,.19-.24,.28-.41,.09-.17,.18-.36,.28-.59s.18-.46,.27-.71l.97-2.62c.14-.37,.26-.69,.38-.96,.12-.27,.26-.49,.42-.67,.16-.17,.35-.3,.57-.39,.22-.09,.51-.13,.86-.13,.27,0,.5,.03,.7,.08s.36,.16,.49,.31c.23,.29,.28,.74,.33,1.1,.11,.76,.03,1.55,.03,2.31v4.39c0,.38,.02,.76,0,1.13-.02,.32-.01,.65-.17,.95-.14,.27-.41,.48-.71,.52-.39,.05-.7-.25-.85-.59-.07-.16-.11-.32-.14-.48-.02-.16-.04-.29-.04-.38,0,0,.16-4.3-.54-4.21-.14,.02-.47,.8-.56,.99-.49,.97-1.73,3.71-1.97,4.06-.19,.28-.46,.58-.81,.64-.24,.05-.48-.04-.67-.2-.47-.38-.68-1.08-.9-1.63-.18-.45-1.36-5-2.23-5.12-.12-.02-.2,.2-.25,.59-.05,.4-.25,7.35,1.72,9.31,2.81,2.79,7.86,2.55,11.62-3.17,1.83-2.79,1.66-6.81,.54-9.77Z\"/>"));
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AlertTest_Click()
         {
-            var comp = Context.RenderComponent<AlertClickTest>();
+            var comp = Context.Render<AlertClickTest>();
             var alert = comp.FindComponent<MudAlert>();
             var numeric = comp.FindComponent<MudNumericField<int>>();
             comp.WaitForAssertion(() => numeric.Instance.Value.Should().Be(0));

--- a/src/MudBlazor.UnitTests/Components/AppBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AppBarTests.cs
@@ -18,7 +18,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AppBarWithModifiedToolBarClass()
         {
-            var comp = Context.RenderComponent<MudAppBar>(parameters => parameters.Add(x => x.ToolBarClass, "test-class"));
+            var comp = Context.Render<MudAppBar>(parameters => parameters.Add(x => x.ToolBarClass, "test-class"));
 
             // Find the Toolbar inside the AppBar
             comp.Find("div").ToMarkup()
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AppBarWithBottomUnset()
         {
-            var bar = Context.RenderComponent<MudAppBar>();
+            var bar = Context.Render<MudAppBar>();
             bar.Markup
                .Should()
                .StartWith("<header")
@@ -46,7 +46,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AppBarWithBottomSetFalse()
         {
-            var bar = Context.RenderComponent<MudAppBar>(parameters => parameters.Add(x => x.Bottom, false));
+            var bar = Context.Render<MudAppBar>(parameters => parameters.Add(x => x.Bottom, false));
             bar.Markup
                .Should()
                .StartWith("<header")
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AppBarWithBottomSetTrue()
         {
-            var bar = Context.RenderComponent<MudAppBar>(parameters => parameters.Add(x => x.Bottom, true));
+            var bar = Context.Render<MudAppBar>(parameters => parameters.Add(x => x.Bottom, true));
             bar.Markup
                .Should()
                .StartWith("<footer")
@@ -74,14 +74,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AppBar_WrapContent_ShouldBeFalseByDefault()
         {
-            var comp = Context.RenderComponent<MudAppBar>();
+            var comp = Context.Render<MudAppBar>();
             comp.FindComponent<MudToolBar>().Instance.WrapContent.Should().Be(false);
         }
 
         [Test]
         public void AppBarWithContextualSetTrue()
         {
-            var comp = Context.RenderComponent<ContextualAppBarTest>();
+            var comp = Context.Render<ContextualAppBarTest>();
             var bar = comp.FindComponent<MudAppBar>();
 
             bar.Markup.Should().Contain("regular-app-bar").And.Contain("mud-theme-primary");
@@ -94,7 +94,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AppBarWithContextualSetFalse()
         {
-            var comp = Context.RenderComponent<ContextualAppBarTest>(parameters => parameters.Add(x => x.IsContextual, false));
+            var comp = Context.Render<ContextualAppBarTest>(parameters => parameters.Add(x => x.IsContextual, false));
             var bar = comp.FindComponent<MudAppBar>();
 
             bar.Markup.Should().Contain("regular-app-bar").And.Contain("mud-theme-primary");

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -24,15 +24,18 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_Handle_Converter_WithStrict()
         {
-            var comp = Context.RenderComponent<AutocompleteConverterStrictTest>();
+            var comp = Context.Render<AutocompleteConverterStrictTest>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<AutocompleteConverterStrictTest.ConverterElement>>();
             comp.Markup.Should().NotContain("mud-popover-open");
 
-            autocompleteComponent.Find(".mud-button-root.mud-no-activator").Click(); // open popover
+            // Don't replace autocompleteComponent with comp, as then the test will be flaky (problem after migrating to bUnit 2.x)
+            IElement ButtonActivator() => autocompleteComponent.Find(".mud-button-root.mud-no-activator");
+
+            ButtonActivator().Click(); // open popover
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
-            var items = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>().ToArray();
-            items.Length.Should().Be(10, "The popover should contain 10 items."); // default maxitems is 10
-            comp.Find(".mud-button-root.mud-no-activator").Click(); // close popover
+            var items = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>();
+            items.Count.Should().Be(10, "The popover should contain 10 items."); // default maxitems is 10
+            ButtonActivator().Click(); // close popover
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             // set search
@@ -48,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteTest1()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
@@ -81,7 +84,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteTest2()
         {
-            var comp = Context.RenderComponent<AutocompleteTest2>();
+            var comp = Context.Render<AutocompleteTest2>();
             // select elements needed for the test
             var select = comp.FindComponent<MudAutocomplete<string>>();
 
@@ -107,7 +110,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteTest3()
         {
-            var comp = Context.RenderComponent<AutocompleteTest3>();
+            var comp = Context.Render<AutocompleteTest3>();
             var autocomplete = comp.FindComponent<MudAutocomplete<AutocompleteTest3.State>>().Instance;
             autocomplete.Text.Should().Be("Assam");
         }
@@ -118,7 +121,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteCancelDisposeTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTest8>();
+            var comp = Context.Render<AutocompleteTest8>();
             var autocompleteContainerComp = comp.FindComponent<AutoCompleteContainer>();
             var autocompleteComp = autocompleteContainerComp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComp.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Text, "Alabama"));
@@ -136,7 +139,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteLabelFor()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var label = comp.FindAll(".mud-input-label");
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("autocompleteLabelTest");
         }
@@ -147,7 +150,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteTest4()
         {
-            var comp = Context.RenderComponent<AutocompleteTest4>();
+            var comp = Context.Render<AutocompleteTest4>();
             var autocomplete = comp.FindComponent<MudAutocomplete<AutocompleteTest4.State>>().Instance;
             autocomplete.Text.Should().Be("Assam");
         }
@@ -159,7 +162,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteCoercionTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
@@ -183,7 +186,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteCoerceValueTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
@@ -207,7 +210,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteImmediateCoerceValueTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
@@ -231,7 +234,7 @@ namespace MudBlazor.UnitTests.Components
             // Arrange
 
             var valueChangedCount = 0;
-            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            var comp = Context.Render<AutocompleteStates>(parameters =>
             {
                 parameters.Add(p => p.DebounceInterval, 0);
                 parameters.Add(p => p.CoerceText, false);
@@ -273,7 +276,7 @@ namespace MudBlazor.UnitTests.Components
             // Arrange
 
             var valueChangedCount = 0;
-            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            var comp = Context.Render<AutocompleteStates>(parameters =>
             {
                 parameters.Add(p => p.DebounceInterval, 500);
                 parameters.Add(p => p.CoerceText, false);
@@ -325,7 +328,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            var comp = Context.Render<MudAutocomplete<string>>(parameters =>
             {
                 parameters.Add(a => a.CoerceValue, true);
                 parameters.Add(a => a.CoerceText, false);
@@ -363,7 +366,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            var comp = Context.Render<MudAutocomplete<string>>(parameters =>
             {
                 parameters.Add(a => a.CoerceValue, false);
                 parameters.Add(a => a.CoerceText, false);
@@ -401,7 +404,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            var comp = Context.Render<MudAutocomplete<string>>(parameters =>
             {
                 parameters.Add(a => a.CoerceValue, true);
                 parameters.Add(a => a.CoerceText, false);
@@ -438,7 +441,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters =>
+            var comp = Context.Render<MudAutocomplete<string>>(parameters =>
             {
                 parameters.Add(a => a.CoerceValue, false);
                 parameters.Add(a => a.CoerceText, false);
@@ -473,7 +476,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteCoercionOffTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
+            var comp = Context.Render<AutocompleteTestCoersionAndBlur>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CoerceText, false));
@@ -492,7 +495,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteTextCoercionOnTabKeyTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
+            var comp = Context.Render<AutocompleteTestCoersionAndBlur>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CoerceText, true));
@@ -514,7 +517,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteTextCoercionAndResetIfEmptyTextTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTestCoersionAndBlur>();
+            var comp = Context.Render<AutocompleteTestCoersionAndBlur>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
@@ -538,7 +541,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_TolerateNullFromSearchFunc()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>((a) =>
+            var comp = Context.Render<MudAutocomplete<string>>((a) =>
             {
                 a.Add(x => x.DebounceInterval, 0);
                 a.Add(x => x.SearchFunc, (_, _) => Task.FromResult<IEnumerable<string>>(null)); // <--- searchfunc returns null instead of sequence
@@ -556,7 +559,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_ReadOnly_Should_Not_Open()
         {
-            var comp = Context.RenderComponent<AutocompleteTest5>();
+            var comp = Context.Render<AutocompleteTest5>();
             comp.FindAll(".mud-input-control")[0].MouseDown();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
         }
@@ -564,7 +567,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteReadOnlyShouldNotHaveClearButton()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(p => p
+            var comp = Context.Render<MudAutocomplete<string>>(p => p
                 .Add(x => x.Text, "some value")
                 .Add(x => x.Clearable, true)
                 .Add(x => x.ReadOnly, false));
@@ -581,7 +584,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteTest6()
         {
-            var comp = Context.RenderComponent<AutocompleteTest6>();
+            var comp = Context.Render<AutocompleteTest6>();
 
             comp.Find("div.mud-input-control").Focus();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -598,7 +601,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteTest7()
         {
-            var comp = Context.RenderComponent<AutocompleteTest7>();
+            var comp = Context.Render<AutocompleteTest7>();
 
             comp.Find("div.mud-input-control").Focus();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -615,7 +618,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_after_Enter_Should_show_Selected_Value()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
@@ -642,7 +645,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Initialize_Value_on_SetParametersAsync()
         {
-            var comp = Context.RenderComponent<AutocompleteSetParametersInitialization>();
+            var comp = Context.Render<AutocompleteSetParametersInitialization>();
             // select elements needed for the test
             await Task.Delay(100);
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<ExternalList>>();
@@ -657,7 +660,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var calls = 0;
             void Fn(FocusEventArgs args) => calls++;
-            var comp = Context.RenderComponent<MudAutocomplete<string>>((a) =>
+            var comp = Context.Render<MudAutocomplete<string>>((a) =>
             {
                 a.Add(x => x.OnBlur, Fn);
             });
@@ -671,7 +674,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutoCompleteClearableTest()
         {
-            var comp = Context.RenderComponent<AutocompleteTestClearable>();
+            var comp = Context.Render<AutocompleteTestClearable>();
 
             // No button when initialized empty
             comp.WaitForAssertion(() => comp.FindAll(".mud-input-clear-button").Should().BeEmpty());
@@ -694,7 +697,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_Validate_Data_Attribute_Fail()
         {
-            var comp = Context.RenderComponent<AutocompleteValidationDataAttrTest>();
+            var comp = Context.Render<AutocompleteValidationDataAttrTest>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
@@ -713,7 +716,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_Validate_Data_Attribute_Success()
         {
-            var comp = Context.RenderComponent<AutocompleteValidationDataAttrTest>();
+            var comp = Context.Render<AutocompleteValidationDataAttrTest>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
@@ -733,7 +736,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_SetRequiredTrue()
         {
-            var comp = Context.RenderComponent<AutocompleteRequiredTest>();
+            var comp = Context.Render<AutocompleteRequiredTest>();
 
             var autocomplete = comp.FindComponent<MudAutocomplete<string>>().Instance;
 
@@ -750,7 +753,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_Close_OnTab()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
@@ -774,7 +777,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_SelectValue_On_Tab_With_SelectValueOnTab()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.SelectValueOnTab, true));
@@ -809,7 +812,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_NotCloseDropdownOnInputBlur()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
@@ -839,7 +842,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_CheckTextValueandOpenState_OnClear()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CoerceValue, true));
@@ -886,7 +889,7 @@ namespace MudBlazor.UnitTests.Components
             var selectedItemIndexPropertyInfo = typeof(MudAutocomplete<string>).GetField("_selectedListItemIndex", BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new ArgumentException("Cannot find field named '_selectedListItemIndex' on type 'MudAutocomplete<T>'");
 
             // create the component
-            var component = Context.RenderComponent<AutocompleteDisabledItemsTest>();
+            var component = Context.Render<AutocompleteDisabledItemsTest>();
 
             // get the elements needed for the test
             var autocompleteComponent = component.FindComponent<MudAutocomplete<string>>();
@@ -917,7 +920,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_CheckTextAndValue_OnReset()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             // select elements needed for the test
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CoerceValue, true));
@@ -978,7 +981,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            var comp = Context.Render<AutocompleteStates>(parameters =>
             {
                 parameters.Add(a => a.DebounceInterval, 0);
             });
@@ -1014,7 +1017,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<AutocompleteStates>(parameters =>
+            var comp = Context.Render<AutocompleteStates>(parameters =>
             {
                 parameters.Add(a => a.Value, "Idaho");
                 parameters.Add(a => a.ResetValueOnEmptyText, resetValueOnEmptyText);
@@ -1060,7 +1063,7 @@ namespace MudBlazor.UnitTests.Components
             var selectedItemIndexPropertyInfo = typeof(MudAutocomplete<string>).GetField("_selectedListItemIndex", BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new ArgumentException("Cannot find field named '_selectedListItemIndex' on type 'MudAutocomplete<T>'");
 
             // create the component
-            var component = Context.RenderComponent<AutocompleteDisabledItemsTest>();
+            var component = Context.Render<AutocompleteDisabledItemsTest>();
 
             // get the elements needed for the test
             var autocompleteComponent = component.FindComponent<MudAutocomplete<string>>();
@@ -1122,7 +1125,7 @@ namespace MudBlazor.UnitTests.Components
         {
             await ImproveChanceOfSuccess(async () =>
             {
-                var comp = Context.RenderComponent<AutocompleteChangeBoundObjectTest>();
+                var comp = Context.Render<AutocompleteChangeBoundObjectTest>();
                 var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
                 var autocomplete = autocompleteComponent.Instance;
                 await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DebounceInterval, 0));
@@ -1237,7 +1240,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_Support_Sync_Search()
         {
-            var root = Context.RenderComponent<AutocompleteSyncTest>();
+            var root = Context.Render<AutocompleteSyncTest>();
 
             var popoverProvider = root.FindComponent<MudPopoverProvider>();
             var autocomplete = root.FindComponent<MudAutocomplete<string>>();
@@ -1267,7 +1270,7 @@ namespace MudBlazor.UnitTests.Components
             jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("Blazor._internal.domWrapper.focus", It.IsAny<object[]>()));
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<AutocompleteStates>();
+            var comp = Context.Render<AutocompleteStates>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             var adornment = comp.Find(".mud-input-adornment-icon-button");
@@ -1296,7 +1299,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_ChangeAdornmentIcon()
         {
-            var comp = Context.RenderComponent<AutocompleteAdornmentChange>(parameters => parameters.Add(x => x.Icon, Icons.Material.Filled.Abc));
+            var comp = Context.Render<AutocompleteAdornmentChange>(parameters => parameters.Add(x => x.Icon, Icons.Material.Filled.Abc));
             var instance = comp.Instance;
 
             var markupBefore = comp.Find("svg.mud-icon-root").Children.ToMarkup().Trim();
@@ -1315,7 +1318,7 @@ namespace MudBlazor.UnitTests.Components
         public void Autocomplete_Should_NotIndicateLoadingByDefault()
         {
             // Arrange
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
@@ -1334,7 +1337,7 @@ namespace MudBlazor.UnitTests.Components
             // Currently, we increase the load time to 50mms to catch the progress UI
 
             // Arrange
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ShowProgressIndicator, true));
 
@@ -1355,7 +1358,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_IndicateLoadingWithCircularProgressIndicatorAndAdornmentAdjustment()
         {
             // Arrange
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.ShowProgressIndicator, true)
@@ -1386,7 +1389,7 @@ namespace MudBlazor.UnitTests.Components
                 builder.AddContent(0, "Loading...");
             };
 
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
 
             await autocompletecomp.SetParametersAndRenderAsync(parameters => parameters
@@ -1414,7 +1417,7 @@ namespace MudBlazor.UnitTests.Components
                 builder.AddContent(0, "Loading...");
             };
 
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
@@ -1436,7 +1439,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_Cancel_Search()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             // Arrange first call
@@ -1487,7 +1490,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_FullWidth()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComp = comp.FindComponent<MudAutocomplete<string>>();
 
             autocompleteComp.Find("div.mud-select").ClassList.Should().Contain("mud-autocomplete");
@@ -1503,7 +1506,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_HaveValueWithTextChangedEvent()
         {
             // Arrange
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             const string testText = "testText";
@@ -1528,7 +1531,7 @@ namespace MudBlazor.UnitTests.Components
             var californiaString = "California";
             var virginiaString = "Virginia";
 
-            var comp = Context.RenderComponent<AutocompleteStrictFalseTest>();
+            var comp = Context.Render<AutocompleteStrictFalseTest>();
             var autocompleteComponent = comp.FindComponents<MudAutocomplete<AutocompleteStrictFalseTest.State>>()[index];
             var autocomplete = autocompleteComponent.Instance;
 
@@ -1573,7 +1576,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_Not_Throw_When_SearchFunc_Is_Null()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SearchFunc, null));
@@ -1589,7 +1592,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_Raise_KeyDown_KeyUp_Event()
         {
             //Create comp
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var result = new List<string>();
             //create eventCallback
@@ -1623,7 +1626,7 @@ namespace MudBlazor.UnitTests.Components
             var selectedItemString = "peach";
             var disabledItemString = "carrot";
 
-            var comp = Context.RenderComponent<AutocompleteStrictFalseSelectedHighlight>();
+            var comp = Context.Render<AutocompleteStrictFalseSelectedHighlight>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
 
@@ -1654,7 +1657,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Reset_Value_ShouldBe_Empty()
         {
-            var component = Context.RenderComponent<AutocompleteResetTest>();
+            var component = Context.Render<AutocompleteResetTest>();
             var autocompleteComponent = component.FindComponent<MudAutocomplete<string>>();
 
             // get the instance
@@ -1680,7 +1683,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_LoadListStartWhenSetAndThereAreItems()
         {
-            var comp = Context.RenderComponent<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
+            var comp = Context.Render<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
 
             comp.Find("div.mud-input-control").Focus();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1697,7 +1700,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_LoadListEndWhenSetAndThereAreItems()
         {
-            var comp = Context.RenderComponent<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
+            var comp = Context.Render<AutocompleteListBeforeAndAfterRendersWithItemsTest>();
 
             comp.Find("div.mud-input-control").Focus();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1714,7 +1717,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_Not_LoadListStartWhenSet()
         {
-            var comp = Context.RenderComponent<AutocompleteListStartRendersTest>();
+            var comp = Context.Render<AutocompleteListStartRendersTest>();
 
             comp.Find("div.mud-input-control").Focus();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1728,7 +1731,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Should_Not_LoadListEndWhenSet()
         {
-            var comp = Context.RenderComponent<AutocompleteListEndRendersTest>();
+            var comp = Context.Render<AutocompleteListEndRendersTest>();
 
             comp.Find("div.mud-input-control").Focus();
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1739,7 +1742,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_ApplyListItemClass()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var listItemClassTest = "list-item-class-test";
 
@@ -1754,7 +1757,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task Autocomplete_Should_OpenMenuOnFocus(bool openOnFocus)
         {
-            var comp = Context.RenderComponent<AutocompleteFocusTest>();
+            var comp = Context.Render<AutocompleteFocusTest>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.OpenOnFocus, openOnFocus));
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -1774,7 +1777,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_OpenMenuOnFocus_AlwaysOnClick()
         {
-            var comp = Context.RenderComponent<AutocompleteFocusTest>();
+            var comp = Context.Render<AutocompleteFocusTest>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.OpenOnFocus, false));
 
             comp.Find("div.mud-input-control").Focus(); // Browser would focus first.
@@ -1795,7 +1798,7 @@ namespace MudBlazor.UnitTests.Components
                 return Task.FromResult(values.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
             }
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>();
+            var comp = Context.Render<MudAutocomplete<string>>();
             await comp.SetParametersAndRenderAsync(p => p
                 .Add(x => x.Value, "nothing will ever match this")
                 .Add(x => x.SearchFunc, Search)
@@ -1820,7 +1823,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters
                 => parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -1835,7 +1838,7 @@ namespace MudBlazor.UnitTests.Components
         public void AutocompleteWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattribute-id";
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label").Add(p => p.UserAttributes, new Dictionary<string, object>
                     {
@@ -1854,7 +1857,7 @@ namespace MudBlazor.UnitTests.Components
         public void AutocompleteWithLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1874,7 +1877,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalAutocomplete_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>();
+            var comp = Context.Render<MudAutocomplete<string>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1886,7 +1889,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredAutocomplete_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -1899,7 +1902,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredAutocompleteAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>();
+            var comp = Context.Render<MudAutocomplete<string>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1917,7 +1920,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_SelectingOption_ShouldNot_ReopenList()
         {
-            var comp = Context.RenderComponent<AutocompleteTest1>();
+            var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
 
@@ -1938,7 +1941,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_User_ShouldNot_OpenMenu_InReadOnlyMode()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.ReadOnly, true)
                 .Add(p => p.OpenOnFocus, true));
             var autocomplete = comp.Instance;
@@ -1962,7 +1965,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_User_ShouldNot_OpenMenu_InDisabledMode()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.Disabled, true)
                 .Add(p => p.OpenOnFocus, true));
             var autocomplete = comp.Instance;
@@ -1986,7 +1989,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AutocompleteItemTemplateDisplayTest()
         {
-            var comp = Context.RenderComponent<AutocompleteItemTemplateDisplayTest>();
+            var comp = Context.Render<AutocompleteItemTemplateDisplayTest>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
             // Search for a to get Alabama, Alaska, American Samoa,...
@@ -2004,7 +2007,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Should_render_conversion_error_message()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<int>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<int>>(parameters => parameters
                 .Add(p => p.ErrorId, "error-id")
                 .Add(p => p.CoerceValue, true)
                 .Add(p => p.Converter, new DummyErrorConverter())
@@ -2019,7 +2022,7 @@ namespace MudBlazor.UnitTests.Components
         public void Should_render_aria_label_for_adornment_if_provided(Adornment adornment)
         {
             var ariaLabel = "the aria label";
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.Adornment, adornment)
                 .Add(p => p.AdornmentIcon, Icons.Material.Filled.Accessibility)
                 .Add(p => p.AdornmentAriaLabel, ariaLabel));
@@ -2055,7 +2058,7 @@ namespace MudBlazor.UnitTests.Components
                     ? $"{inputId}-helper-text"
                     : null;
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.InputId, inputId)
                 .Add(p => p.HelperId, helperId)
                 .Add(p => p.HelperText, helperText)
@@ -2094,7 +2097,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_Attribute_Should_Exist()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>();
+            var comp = Context.Render<MudAutocomplete<string>>();
 
             comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("off");
         }
@@ -2102,7 +2105,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Should_Override_Autocomplete_Attribute_With_UserAttributes()
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.UserAttributes, new() { ["autocomplete"] = "on" }));
 
             comp.Find("input.mud-input-root").GetAttribute("autocomplete").Should().Be("on");
@@ -2119,7 +2122,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<AutocompleteResetValueOnEmptyText>();
+            var comp = Context.Render<AutocompleteResetValueOnEmptyText>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             var autocomplete = autocompleteComponent.Instance;
 
@@ -2140,7 +2143,7 @@ namespace MudBlazor.UnitTests.Components
             var inputClass = "custom-input-class";
 
             // Act
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.InputClass, inputClass)
             );
 
@@ -2153,7 +2156,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var selectedItemIndexPropertyInfo = typeof(MudAutocomplete<string>).GetField("_selectedListItemIndex", BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new ArgumentException("Cannot find field named '_selectedListItemIndex' on type 'MudAutocomplete<T>'");
 
-            var component = Context.RenderComponent<AutocompleteTest1>();
+            var component = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = component.FindComponent<MudAutocomplete<string>>();
             var autocompleteInstance = autocompleteComponent.Instance;
 
@@ -2211,7 +2214,7 @@ namespace MudBlazor.UnitTests.Components
             var _delegate = attachDelegate ?
                 eventCallbackFactory.Create<MouseEventArgs>(this, (e) => { }) : default;
 
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.OnAdornmentClick, _delegate));
 
             var autocompleteInstance = comp.Instance;
@@ -2225,7 +2228,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void Autocomplete_OpenOnFocusShouldWork(bool openOnFocus)
         {
-            var comp = Context.RenderComponent<MudAutocomplete<string>>(parameters => parameters
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
                 .Add(p => p.OpenOnFocus, openOnFocus));
             comp.Find("input").Focus();
 
@@ -2235,7 +2238,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Autocomplete_OpenTwiceInMenu()
         {
-            var comp = Context.RenderComponent<AutocompleteMenuCloseTest>();
+            var comp = Context.Render<AutocompleteMenuCloseTest>();
             // Open the menu
             comp.Find("#menu-open").Click();
             comp.WaitForAssertion(() =>
@@ -2268,7 +2271,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_OpenChanged_OpenMenuAsync()
         {
-            var comp = Context.RenderComponent<AutocompleteOpenChangedTest>();
+            var comp = Context.Render<AutocompleteOpenChangedTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.OpenMenuAsync());
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.OpenMenuAsync());
             comp.Instance.OpenedCount.Should().Be(1);
@@ -2277,7 +2280,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_OpenChanged_CloseMenuAsync()
         {
-            var comp = Context.RenderComponent<AutocompleteOpenChangedTest>();
+            var comp = Context.Render<AutocompleteOpenChangedTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.CloseMenuAsync());
             comp.Instance.ClosedCount.Should().Be(0);
         }
@@ -2285,7 +2288,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_OpenChanged_OpenClose()
         {
-            var comp = Context.RenderComponent<AutocompleteOpenChangedTest>();
+            var comp = Context.Render<AutocompleteOpenChangedTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.OpenMenuAsync());
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.CloseMenuAsync());
             comp.Instance.OpenedCount.Should().Be(1);
@@ -2295,7 +2298,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_OpenChanged_SelectOptionAsync()
         {
-            var comp = Context.RenderComponent<AutocompleteOpenChangedTest>();
+            var comp = Context.Render<AutocompleteOpenChangedTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.SelectOptionAsync("Alabama"));
             comp.Instance.OpenedCount.Should().Be(0);
             comp.Instance.ClosedCount.Should().Be(1);
@@ -2304,7 +2307,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_OpenChanged_HandleClearButtonAsync()
         {
-            var comp = Context.RenderComponent<AutocompleteHandleClearButtonAsyncTest>();
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.HandleClearButtonAsync(new()));
             comp.Instance.OpenedCount.Should().Be(0);
             comp.Instance.ClosedCount.Should().Be(0);
@@ -2314,7 +2317,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PopoverSettings_SetsDefaultValues()
         {
-            var auto = Context.RenderComponent<MudAutocomplete<string>>();
+            var auto = Context.Render<MudAutocomplete<string>>();
 
             auto.Instance.PopoverFixed.Should().BeFalse();
             auto.Instance.OverflowBehavior.Should().Be(MudGlobal.PopoverDefaults.OverflowBehavior);
@@ -2327,7 +2330,7 @@ namespace MudBlazor.UnitTests.Components
             try
             {
                 MudGlobal.PopoverDefaults.OverflowBehavior = OverflowBehavior.FlipNever;
-                var auto = Context.RenderComponent<MudAutocomplete<string>>(p =>
+                var auto = Context.Render<MudAutocomplete<string>>(p =>
                 {
                     p.Add(p => p.PopoverFixed, true);
                 });

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -32,17 +32,18 @@ namespace MudBlazor.UnitTests.Components
             IElement ButtonActivator() => autocompleteComponent.Find(".mud-button-root.mud-no-activator");
 
             ButtonActivator().Click(); // open popover
-            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            var pop = comp.WaitForElement("div.mud-popover"); // doesn't return until popover exists
+            comp.WaitForAssertion(() => pop.ClassList.Should().Contain("mud-popover-open")); // wait for popover to open
             var items = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>();
             items.Count.Should().Be(10, "The popover should contain 10 items."); // default maxitems is 10
             ButtonActivator().Click(); // close popover
-            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+            comp.WaitForAssertion(() => pop.ClassList.Should().NotContain("mud-popover-open"));
 
             // set search
             autocompleteComponent.Find("input").Input("he");
-            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
-            var filteredItems = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>().ToArray();
-            filteredItems.Length.Should().Be(4, "The popover should contain 4 items.");
+            comp.WaitForAssertion(() => pop.ClassList.Should().Contain("mud-popover-open"));
+            var filteredItems = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>();
+            filteredItems.Count.Should().Be(4, "The popover should contain 4 items.");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarGroupTests.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AvatarGroupTest()
         {
-            var comp = Context.RenderComponent<AvatarGroupTest>();
+            var comp = Context.Render<AvatarGroupTest>();
             // select elements needed for the test
             var group = comp.FindComponent<MudAvatarGroup>();
             var avatars = comp.FindAll(".mud-avatar").ToArray();
@@ -33,7 +33,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AvatarGroupMaxDefaultTest()
         {
-            var comp = Context.RenderComponent<AvatarGroupMaxDefaultTest>();
+            var comp = Context.Render<AvatarGroupMaxDefaultTest>();
             // select elements needed for the test
             var group = comp.FindComponent<MudAvatarGroup>();
             var avatars = group.FindAll(".mud-avatar").ToArray();
@@ -63,7 +63,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AvatarGroupChangeMaxTest()
         {
-            var comp = Context.RenderComponent<AvatarGroupChangeMaxTest>();
+            var comp = Context.Render<AvatarGroupChangeMaxTest>();
             // select elements needed for the test
             var group = comp.FindComponent<MudAvatarGroup>();
             var avatars = comp.FindAll(".mud-avatar").ToArray();
@@ -141,7 +141,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AvatarGroupRemoveTest()
         {
-            var comp = Context.RenderComponent<AvatarGroupRemoveTest>();
+            var comp = Context.Render<AvatarGroupRemoveTest>();
 
             comp.Find("#empty-button").Click();
 
@@ -151,7 +151,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AvatarGroupMaxAvatarsTemplateTest()
         {
-            var comp = Context.RenderComponent<AvatarGroupMaxAvatarsTemplateTest>();
+            var comp = Context.Render<AvatarGroupMaxAvatarsTemplateTest>();
 
             comp.FindComponent<MudButton>().Should().NotBeNull();
 

--- a/src/MudBlazor.UnitTests/Components/BadgeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BadgeTests.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Badge_Renders_Using_Default_Values()
         {
-            var comp = Context.RenderComponent<MudBadge>();
+            var comp = Context.Render<MudBadge>();
             comp.FindAll("span").Should().HaveCount(3, "Default behavior of badge is to render 3 spans");
 
             await comp.InvokeAsync(() => comp.Instance.HandleBadgeClick(new MouseEventArgs()));
@@ -21,7 +21,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Badge_Renders_When_VisibleIsTrue()
         {
-            var comp = Context.RenderComponent<MudBadge>();
+            var comp = Context.Render<MudBadge>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Visible, true));
             comp.FindAll("span").Should().HaveCount(3, "Visible badge renders 3 spans");
         }
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Badge_Does_Not_Render_When_VisibleIsFalse()
         {
-            var comp = Context.RenderComponent<MudBadge>();
+            var comp = Context.Render<MudBadge>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Visible, false));
             comp.FindAll("span").Should().HaveCount(1, "Hidden badge renders 1 span");
         }
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task BadgeTest_Click()
         {
-            var comp = Context.RenderComponent<BadgeClickTest>();
+            var comp = Context.Render<BadgeClickTest>();
             var badge = comp.FindComponent<MudBadge>();
             var numeric = comp.FindComponent<MudNumericField<int>>();
             comp.WaitForAssertion(() => numeric.Instance.Value.Should().Be(0));
@@ -52,7 +52,7 @@ namespace MudBlazor.UnitTests.Components
             const string BadgeAriaLabel = "New notifications";
 
             // Act
-            var cut = Context.RenderComponent<MudBadge>(parameters => parameters
+            var cut = Context.Render<MudBadge>(parameters => parameters
                 .Add(p => p.BadgeAriaLabel, BadgeAriaLabel)
                 .Add(p => p.Visible, true)
                 .AddChildContent("Test Content")

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudBreadcrumbs_ShouldRenderItemsWithSeparators()
         {
-            var comp = Context.RenderComponent<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
             {
                 new("Link 1", "link1"),
                 new("Link 2", "link2"),
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudBreadcrumbs_ShouldRenderItemsWithIcons()
         {
-            var comp = Context.RenderComponent<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
             {
                 new("Link 1", "link1", icon: Icons.Material.Filled.Home),
                 new("Link 2", "link2", icon: Icons.Material.Filled.List),
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudBreadcrumbs_ShouldCollapseWhenMaxItemsIsReached()
         {
-            var comp = Context.RenderComponent<MudBreadcrumbs>(parameters => parameters
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters
                 .Add(x => x.MaxItems, (byte)4)
                 .Add(x => x.Items, new List<BreadcrumbItem>
                 {
@@ -56,7 +56,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudBreadcrumbs_Other()
         {
-            var comp = Context.RenderComponent<MudBreadcrumbs>(parameters => parameters
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters
                 .Add(x => x.MaxItems, (byte)4)
                 .Add(x => x.Items, new List<BreadcrumbItem>
                 {

--- a/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonGroupTests.cs
@@ -13,7 +13,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
+            var comp = Context.Render<ButtonGroupWithThreeButtons>(
                 parameters => parameters
                     .Add(c => c.ButtonGroupFullWidth, true)
                     .Add(c => c.Button1FullWidth, false)
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
+            var comp = Context.Render<ButtonGroupWithThreeButtons>(
                 parameters => parameters
                     .Add(c => c.ButtonGroupFullWidth, true)
                     .Add(c => c.Button1FullWidth, true)
@@ -54,7 +54,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<ButtonGroupWithThreeButtons>(
+            var comp = Context.Render<ButtonGroupWithThreeButtons>(
                 parameters => parameters
                     .Add(c => c.ButtonGroupFullWidth, true)
                     .Add(c => c.Button1FullWidth, true)

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -19,7 +19,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonShouldRenderAButtonByDefault()
         {
-            var comp = Context.RenderComponent<MudButton>();
+            var comp = Context.Render<MudButton>();
             //no HtmlTag nor Link properties are set, so HtmlTag is button by default
             comp.Instance
                 .HtmlTag
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonShouldRenderAnAnchorIfLinkIsSetAndIsNotDisabled()
         {
-            var comp = Context.RenderComponent<MudButton>(parameters => parameters
+            var comp = Context.Render<MudButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank"));
             //Link property is set, so it has to render an anchor element
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
                 .And
                 .NotContain("__internal_stopPropagation_onclick");
 
-            comp = Context.RenderComponent<MudButton>(parameters => parameters
+            comp = Context.Render<MudButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank")
                 .Add(p => p.Disabled, true));
@@ -74,7 +74,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonShouldRenderRelIfSet()
         {
-            var comp = Context.RenderComponent<MudButton>(parameters => parameters
+            var comp = Context.Render<MudButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, "nofollow"));
             comp
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonShouldHaveNoopenerOverridenByRel()
         {
-            var comp = Context.RenderComponent<MudButton>(parameters => parameters
+            var comp = Context.Render<MudButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank")
                 .Add(p => p.Rel, "nofollow"));
@@ -107,7 +107,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonShouldHaveHaveNoRelWhenSetToEmpty()
         {
-            var comp = Context.RenderComponent<MudButton>(parameters => parameters
+            var comp = Context.Render<MudButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, "")
                 .Add(p => p.Target, "_blank"));
@@ -124,7 +124,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonShouldNotRenderRelIfNullAndTargetNotBlank()
         {
-            var comp = Context.RenderComponent<MudButton>(parameters => parameters
+            var comp = Context.Render<MudButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, null)
                 .Add(p => p.Target, "_notblank"));
@@ -141,7 +141,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudIconButtonShouldRenderAButtonByDefault()
         {
-            var comp = Context.RenderComponent<MudIconButton>();
+            var comp = Context.Render<MudIconButton>();
             //no HtmlTag nor Link properties are set, so HtmlTag is button by default
             comp.Instance
                 .HtmlTag
@@ -160,8 +160,8 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudIconButtonShouldRenderAnAnchorIfLinkIsSet()
         {
-            using var ctx = new Bunit.TestContext();
-            var comp = ctx.RenderComponent<MudIconButton>(parameters => parameters
+            using var ctx = new Bunit.BunitContext();
+            var comp = ctx.Render<MudIconButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank"));
             //Link property is set, so it has to render an anchor element
@@ -186,7 +186,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudIconButtonShouldRenderRelIfSet()
         {
-            var comp = Context.RenderComponent<MudIconButton>(parameters => parameters
+            var comp = Context.Render<MudIconButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, "nofollow"));
             comp
@@ -202,7 +202,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudIconButtonShouldHaveNoopenerOverridenByRel()
         {
-            var comp = Context.RenderComponent<MudIconButton>(parameters => parameters
+            var comp = Context.Render<MudIconButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank")
                 .Add(p => p.Rel, "nofollow"));
@@ -219,7 +219,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudIconButtonShouldHaveHaveNoRelWhenSetToEmpty()
         {
-            var comp = Context.RenderComponent<MudIconButton>(parameters => parameters
+            var comp = Context.Render<MudIconButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank")
                 .Add(p => p.Rel, ""));
@@ -236,7 +236,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudIconButtonShouldNotRenderRelIfNullAndTargetNotBlank()
         {
-            var comp = Context.RenderComponent<MudIconButton>(parameters => parameters
+            var comp = Context.Render<MudIconButton>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, null)
                 .Add(p => p.Target, "_notblank"));
@@ -253,7 +253,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldRenderAButtonByDefault()
         {
-            var comp = Context.RenderComponent<MudFab>();
+            var comp = Context.Render<MudFab>();
             //no HtmlTag nor Link properties are set, so HtmlTag is button by default
             comp.Instance
                 .HtmlTag
@@ -272,7 +272,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldRenderAnAnchorIfLinkIsSet()
         {
-            var comp = Context.RenderComponent<MudFab>(parameters => parameters
+            var comp = Context.Render<MudFab>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank"));
             //Link property is set, so it has to render an anchor element
@@ -297,7 +297,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldNotRenderIconIfNoneSpecified()
         {
-            var comp = Context.RenderComponent<MudFab>();
+            var comp = Context.Render<MudFab>();
             comp.Markup
                 .Should()
                 .NotContainAny("mud-icon-root");
@@ -309,7 +309,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldRenderRelIfSet()
         {
-            var comp = Context.RenderComponent<MudFab>(parameters => parameters
+            var comp = Context.Render<MudFab>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, "nofollow"));
             comp
@@ -325,7 +325,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldHaveNoopenerOverridenByRel()
         {
-            var comp = Context.RenderComponent<MudFab>(parameters => parameters
+            var comp = Context.Render<MudFab>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank")
                 .Add(p => p.Rel, "nofollow"));
@@ -342,7 +342,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldHaveHaveNoRelWhenSetToEmpty()
         {
-            var comp = Context.RenderComponent<MudFab>(parameters => parameters
+            var comp = Context.Render<MudFab>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Target, "_blank")
                 .Add(p => p.Rel, ""));
@@ -359,7 +359,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFabShouldNotRenderRelIfNullAndTargetNotBlank()
         {
-            var comp = Context.RenderComponent<MudFab>(parameters => parameters
+            var comp = Context.Render<MudFab>(parameters => parameters
                 .Add(p => p.Href, "https://www.google.com")
                 .Add(p => p.Rel, null)
                 .Add(p => p.Target, "_notblank"));
@@ -373,7 +373,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudToggleIconTest()
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>();
+            var comp = Context.Render<MudToggleIconButton>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             await comp.InvokeAsync(() => comp.Instance.SetToggledAsync(true));
             comp.WaitForAssertion(() => comp.Instance.Toggled.Should().BeFalse());
@@ -382,7 +382,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonSizesTest()
         {
-            var comp = Context.RenderComponent<ButtonSizeIconSizeTest>();
+            var comp = Context.Render<ButtonSizeIconSizeTest>();
 
             var buttons = comp.Nodes.Where(n => n.NodeName.Equals("BUTTON")).ToArray();
             buttons.Length.Should().Be(6);
@@ -396,7 +396,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudButtonIconSizesTest()
         {
-            var comp = Context.RenderComponent<ButtonSizeIconSizeTest>();
+            var comp = Context.Render<ButtonSizeIconSizeTest>();
 
             var buttons = comp.Nodes.Where(n => n.NodeName.Equals("BUTTON")).ToArray();
 
@@ -428,7 +428,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ButtonsNestedDisabledTest()
         {
-            var comp = Context.RenderComponent<ButtonsNestedDisabledTest>();
+            var comp = Context.Render<ButtonsNestedDisabledTest>();
 
             comp.FindComponent<MudButton>().Find("button").HasAttribute("disabled").Should().BeFalse();
             comp.FindComponent<MudFab>().Find("button").HasAttribute("disabled").Should().BeFalse();
@@ -444,10 +444,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ButtonsOnClickErrorContentCaughtException()
         {
-            var comp = Context.RenderComponent<ButtonErrorContenCaughtException>();
+            var comp = Context.Render<ButtonErrorContenCaughtException>();
             var alertTextFunc = () => MudAlert().Find("div.mud-alert-message");
             IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
-            IRefreshableElementCollection<IElement> Buttons() => comp.FindAll("button.mud-button-root");
+            IReadOnlyList<IElement> Buttons() => comp.FindAll("button.mud-button-root");
             IElement MudButton() => Buttons()[0];
             IElement MudFab() => Buttons()[1];
             IElement MudIconButton() => Buttons()[2];

--- a/src/MudBlazor.UnitTests/Components/CardTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CardTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CardChildContent()
         {
             //Card header with child content should be render successfully
-            var comp = Context.RenderComponent<CardChildContentTest>();
+            var comp = Context.Render<CardChildContentTest>();
             var button = comp.FindComponent<MudButton>();
             var numeric = comp.FindComponent<MudNumericField<int>>();
             comp.WaitForAssertion(() => numeric.Instance.Value.Should().Be(0));

--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CarouselTest1()
         {
-            var comp = Context.RenderComponent<CarouselTest>();
+            var comp = Context.Render<CarouselTest>();
             // print the generated html
             // select elements needed for the test
             var carouselComponent = comp.FindComponent<MudCarousel<object>>();
@@ -134,13 +134,13 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CarouselTest_RenderingOptions()
         {
-            var comp = Context.RenderComponent<MudCarousel<object>>();
+            var comp = Context.Render<MudCarousel<object>>();
             // print the generated html
             comp.FindAll("button.mud-icon-button").Count.Should().Be(2); //left + right
             // adding some pages
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
             comp.Render();
             // playing with params
             comp.FindAll("button.mud-icon-button").Count.Should().Be(5); //left + right + 3 items
@@ -171,12 +171,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CarouselTest_AutoCycle()
         {
-            var comp = Context.RenderComponent<MudCarousel<object>>();
+            var comp = Context.Render<MudCarousel<object>>();
             // print the generated html
             // adding some pages
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.AutoCycle, true));
             await comp.InvokeAsync(() => comp.Instance.MoveTo(0));
@@ -203,7 +203,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CarouselTest_SelectedIndexTransition()
         {
-            var comp = Context.RenderComponent<CarouselTest>();
+            var comp = Context.Render<CarouselTest>();
 
             // No change
             comp.Instance.SelectedIndex = 0;
@@ -231,12 +231,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CarouselTest_DisableSwipeGesture()
         {
-            var comp = Context.RenderComponent<MudCarousel<object>>();
+            var comp = Context.Render<MudCarousel<object>>();
 
             //Add some pages
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
-            comp.Instance.Items.Add(Context.RenderComponent<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
+            comp.Instance.Items.Add(Context.Render<MudCarouselItem>().Instance);
 
             //Move the SelectedIndex from -1 to 0
             await comp.InvokeAsync(() => comp.Instance.MoveTo(0));
@@ -260,7 +260,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CarouselTest_DataBinding()
         {
-            var comp = Context.RenderComponent<CarouselBindingTest>();
+            var comp = Context.Render<CarouselBindingTest>();
             // print the generated html
             //// select elements needed for the test
             var carousel = comp.FindComponent<MudCarousel<string>>().Instance;
@@ -292,21 +292,21 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CarouselTest_AddBullets()
         {
-            var comp = Context.RenderComponent<MudCarousel<object>>();
+            var comp = Context.Render<MudCarousel<object>>();
 
             // check for the default buttons
             comp.FindAll("button.mud-icon-button").Count.Should().Be(2); //left + right
 
             // adding one page
-            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.RenderComponent<MudCarouselItem>().Instance));
+            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.Render<MudCarouselItem>().Instance));
 
             // check the new button amount
             comp.FindAll("button.mud-icon-button").Count.Should().Be(3); //left + right + 1 item
 
             // adding 3 more pages
-            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.RenderComponent<MudCarouselItem>().Instance));
-            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.RenderComponent<MudCarouselItem>().Instance));
-            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.RenderComponent<MudCarouselItem>().Instance));
+            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.Render<MudCarouselItem>().Instance));
+            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.Render<MudCarouselItem>().Instance));
+            await comp.InvokeAsync(() => comp.Instance.AddItem(Context.Render<MudCarouselItem>().Instance));
 
             // check the final button amount
             comp.FindAll("button.mud-icon-button").Count.Should().Be(6); //left + right + 4 items

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PieChartSelectionTest()
         {
-            var comp = Context.RenderComponent<PieChartSelectionTest>();
+            var comp = Context.Render<PieChartSelectionTest>();
             // print the generated html
             comp.Find("h6").InnerHtml.Trim().Should().Be("Selected portion of the chart: -1");
             // now click something and see that the selected index changes:
@@ -36,7 +36,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DonutChartSelectionTest()
         {
-            var comp = Context.RenderComponent<DonutChartSelectionTest>();
+            var comp = Context.Render<DonutChartSelectionTest>();
             // print the generated html
             comp.Find("h6").InnerHtml.Trim().Should().Be("Selected portion of the chart: -1");
             // now click something and see that the selected index changes:
@@ -49,7 +49,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void LineChartSelectionTest()
         {
-            var comp = Context.RenderComponent<LineChartSelectionTest>();
+            var comp = Context.Render<LineChartSelectionTest>();
             // print the generated html
             comp.Find("h6").InnerHtml.Trim().Should().Be("Selected portion of the chart: -1");
             // now click something and see that the selected index changes:
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void BarChartSelectionTest()
         {
-            var comp = Context.RenderComponent<BarChartSelectionTest>();
+            var comp = Context.Render<BarChartSelectionTest>();
             // print the generated html
             comp.Find("h6").InnerHtml.Trim().Should().Be("Selected portion of the chart: -1");
 
@@ -104,7 +104,7 @@ namespace MudBlazor.UnitTests.Components
             var width = "100%";
             var height = "350px";
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, chartType)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartLabels, xAxis)
@@ -154,7 +154,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void BarChartWithSingleXAxisValue()
         {
-            var comp = Context.RenderComponent<BarChartWithSingleXAxisTest>();
+            var comp = Context.Render<BarChartWithSingleXAxisTest>();
 
             comp.Markup.Should().NotContain("NaN");
         }
@@ -169,7 +169,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // the test should run through instantly (max 5s for a slow build server). 
             // without the fix it took minutes on a fast computer
-            var comp = Context.RenderComponent<LineChartWithBigValuesTest>();
+            var comp = Context.Render<LineChartWithBigValuesTest>();
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void LineChartWithZeroValues()
         {
-            var comp = Context.RenderComponent<LineChartWithZeroValuesTest>();
+            var comp = Context.Render<LineChartWithZeroValuesTest>();
 
             comp.Markup.Should().NotContain("NaN");
         }
@@ -194,7 +194,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(ChartType.Pie, "henon")]
         public void ChartCustomGraphics(ChartType chartType, string text)
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
               .Add(p => p.ChartType, chartType)
               .Add(p => p.Width, "100%")
               .Add(p => p.Height, "300px")
@@ -215,7 +215,7 @@ namespace MudBlazor.UnitTests.Components
             };
             var options = new HeatMapChartOptions { ShowLegend = true, ShowLegendLabels = true };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -236,7 +236,7 @@ namespace MudBlazor.UnitTests.Components
             };
             var options = new ChartOptions() { ShowLegend = true };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -257,7 +257,7 @@ namespace MudBlazor.UnitTests.Components
 
             var options = new HeatMapChartOptions() { ValueFormatString = "F2" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -283,7 +283,7 @@ namespace MudBlazor.UnitTests.Components
                 new() { Name = "Valid Series", Data = new([1.0, 2.0]) }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
             );
@@ -302,7 +302,7 @@ namespace MudBlazor.UnitTests.Components
                 new() { Name = "Series 2", Data = new([3, 4]), Visible = true }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
             );
@@ -329,7 +329,7 @@ namespace MudBlazor.UnitTests.Components
                 ShowLegendLabels = true
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -356,7 +356,7 @@ namespace MudBlazor.UnitTests.Components
 
             var options = new HeatMapChartOptions { EnableSmoothGradient = true };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -389,7 +389,7 @@ namespace MudBlazor.UnitTests.Components
             else if (position is YAxisLabelPosition yPos)
                 options.YAxisLabelPosition = yPos;
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -411,7 +411,7 @@ namespace MudBlazor.UnitTests.Components
 
             var options = new ChartOptions { ShowToolTips = true };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -430,7 +430,7 @@ namespace MudBlazor.UnitTests.Components
             };
 
             // Test with different dimensions
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.Width, "200px") // Smaller width to test font size adaptation
@@ -450,7 +450,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Single color palette
             var singleColorOptions = new ChartOptions { ChartPalette = ["#587934"] };
-            var singleColorComp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var singleColorComp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartOptions, singleColorOptions)
                 .Add(p => p.ChartSeries, [
@@ -464,7 +464,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Multi-color palette
             var multiColorOptions = new ChartOptions { ChartPalette = ["#587934", "#FF0000", "#00FF00"] };
-            var multiColorComp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var multiColorComp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartOptions, multiColorOptions)
                 .Add(p => p.ChartSeries, [
@@ -491,7 +491,7 @@ namespace MudBlazor.UnitTests.Components
 
             var options = new HeatMapChartOptions { ValueFormatString = "G" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, options)
@@ -534,7 +534,7 @@ namespace MudBlazor.UnitTests.Components
                 new() { Name = "Series 2", Data = new([4, 5, 6]) }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, new ChartOptions() { ShowToolTips = true })
@@ -559,7 +559,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Attempt to render MudHeatMapCell outside of MudChart
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                Context.RenderComponent<MudHeatMapCell<double>>(parameters => parameters
+                Context.Render<MudHeatMapCell<double>>(parameters => parameters
                     .Add(p => p.Row, 0)
                     .Add(p => p.Column, 0)
                 )
@@ -579,7 +579,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void HeatMap_ShouldCorrectBadPositions(Position pos)
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.LegendPosition, pos)
                 .Add(p => p.ChartSeries, [
@@ -596,7 +596,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(0, .95)]
         public void HeatMap_Override_Min_Max(double? min, double? max)
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.ChartSeries, new List<ChartSeries<double>>
                 {
@@ -640,7 +640,7 @@ namespace MudBlazor.UnitTests.Components
             else if (chart == ChartType.Timeseries)
                 options = new TimeSeriesChartOptions() { InterpolationOption = InterpolationOption.Periodic };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                               .Add(p => p.ChartType, chart)
                               .Add(p => p.ChartOptions, options)
                               .Add(p => p.ChartSeries, series));
@@ -658,7 +658,7 @@ namespace MudBlazor.UnitTests.Components
             };
             string[] xAxisLabels = { "Time 1", "Time 2", "Time 3", "Time 4" }; // Columns
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.HeatMap)
                 .Add(p => p.Height, "300px")
                 .Add(p => p.Width, "400px")
@@ -723,7 +723,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public void YAxisToStringFuncTest(YAxisTestCase testCase)
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Line)
                 .Add(p => p.ChartLabels, [""])
                 .Add(p => p.ChartOptions, new LineChartOptions() { YAxisToStringFunc = testCase.YAxisToStringFunc })

--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -42,7 +42,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void BarChartEmptyData()
         {
-            var comp = Context.RenderComponent<Bar<double>>();
+            var comp = Context.Render<Bar<double>>();
             comp.Markup.Should().Contain("mud-chart");
         }
 
@@ -57,7 +57,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Bar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -121,7 +121,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Jan" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Bar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -196,7 +196,7 @@ namespace MudBlazor.UnitTests.Charts
                 new ChartSeries<double>() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Bar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -239,7 +239,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Bar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartToolTipTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void BarChartEmptyData()
         {
-            var comp = Context.RenderComponent<ChartTooltip>(parameters => parameters
+            var comp = Context.Render<ChartTooltip>(parameters => parameters
                     .Add(p => p.Title, "Some Title")
                     .Add(p => p.Subtitle, "Some Subtitle")
                     .Add(p => p.X, 10.05)

--- a/src/MudBlazor.UnitTests/Components/Charts/DonutChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/DonutChartTests.cs
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void DonutChartEmptyData()
         {
-            var comp = Context.RenderComponent<Donut<double>>();
+            var comp = Context.Render<Donut<double>>();
             comp.Markup.Should().Contain("mud-chart-donut");
         }
 
@@ -54,7 +54,7 @@ namespace MudBlazor.UnitTests.Charts
                 "Hydro", "Geothermal", "Fossil", "Nuclear", "Solar", "Wind", "Oil",
                 "Coal", "Gas", "Biomass", "Hydro", "Geothermal" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Donut)
                 .Add(p => p.Height, "300px")
                 .Add(p => p.Width, "300px")
@@ -105,7 +105,7 @@ namespace MudBlazor.UnitTests.Charts
                 "Hydro", "Geothermal", "Fossil", "Nuclear", "Solar", "Wind", "Oil",
                 "Coal", "Gas", "Biomass", "Hydro", "Geothermal" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Donut)
                 .Add(p => p.Height, "300px")
                 .Add(p => p.Width, "300px")
@@ -134,7 +134,7 @@ namespace MudBlazor.UnitTests.Charts
         {
             double[] data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Donut)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -171,7 +171,7 @@ namespace MudBlazor.UnitTests.Charts
         {
             double[] data = { 50, 0, 0 };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Donut)
                 .Add(p => p.ChartSeries, [data]));
 
@@ -185,7 +185,7 @@ namespace MudBlazor.UnitTests.Charts
             string[] chartLabels = { "Area A", "Area B", "Area C", "Area D" };
             var chartSeries = new List<ChartSeries<double>>() { new() { Data = chartData } };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Donut)
                 .Add(p => p.Height, "300px")
                 .Add(p => p.Width, "300px")

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -44,7 +44,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void LineChartEmptyData()
         {
-            var comp = Context.RenderComponent<Bar<double>>();
+            var comp = Context.Render<Bar<double>>();
             comp.Markup.Should().Contain("mud-chart");
         }
 
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Line)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -194,7 +194,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Line)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -265,7 +265,7 @@ namespace MudBlazor.UnitTests.Charts
                 new ChartSeries<double>() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Line)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")

--- a/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
@@ -39,7 +39,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void PieChartEmptyData()
         {
-            var comp = Context.RenderComponent<Pie<double>>(parameters => parameters
+            var comp = Context.Render<Pie<double>>(parameters => parameters
                 .Add(p => p.ChartSeries, null));
 
             comp.Markup.Should().Contain("mud-chart-pie");
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Charts
                 "Polonium", "Astatine", "Radon", "Francium", "Radium", "Actinium", "Protactinium",
                 "Neptunium", "Americium", "Curium", "Berkelium", "Californium", "Einsteinium", "Mudblaznium" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Pie)
                 .Add(p => p.ChartOptions, new ChartOptions { ChartPalette = _baseChartPalette })
                 .Add(p => p.Height, "300px")
@@ -101,7 +101,7 @@ namespace MudBlazor.UnitTests.Charts
         {
             double[] data = { 50, 25, 20, 5, 16, 14, 8, 4, 2, 8, 10, 19, 8, 17, 6, 11, 19, 24, 35, 13, 20, 12 };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Pie)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -138,7 +138,7 @@ namespace MudBlazor.UnitTests.Charts
         {
             double[] data = { 50, 0, 0 };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Pie)
                 .Add(p => p.ChartSeries, [data]));
 
@@ -155,7 +155,7 @@ namespace MudBlazor.UnitTests.Charts
             // The `ChartSeries.Visible` property might not apply here in the same way as for other charts if we want to hide slices.
             // Instead, the legend interaction directly controls visibility of slices.
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Pie)
                 .Add(p => p.Height, "300px")
                 .Add(p => p.Width, "300px")

--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
@@ -19,7 +19,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_BasicRendering_NoData()
     {
-        var comp = Context.RenderComponent<Radar<double>>();
+        var comp = Context.Render<Radar<double>>();
         comp.Markup.Should().Contain("<svg");
         comp.FindAll("path.mud-chart-serie").Count.Should().Be(0);
         comp.FindAll("path.mud-chart-axis-line").Count.Should().Be(0); // No labels, no data, so no axes.
@@ -32,7 +32,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "A", "B", "C" };
         var options = new RadarChartOptions { ShowDataMarkers = true, AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> {
                 new() { Name = "Series", Data = seriesData },
                 new() { Name = "Other Series", Data = new double[] { 5,15,25 } } // Add another series
@@ -62,7 +62,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_BasicRendering_WithData_InferAxesFromData()
     {
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartOptions, new RadarChartOptions() { AggregationOption = AggregationOption.GroupByLabel })
             .Add(p => p.Width, "300px")
@@ -75,7 +75,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_BasicRendering_WithData_AndLabels()
     {
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30, 40 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C", "D" })
             .Add(p => p.ChartOptions, new RadarChartOptions() { AggregationOption = AggregationOption.GroupByLabel })
@@ -91,7 +91,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Option_ShowGridLines_And_GridLevels()
     {
         var options = new RadarChartOptions { ShowGridLines = true, GridLevels = 3, AggregationOption = AggregationOption.GroupByLabel };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -105,7 +105,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Option_ShowGridLines_False()
     {
         var options = new RadarChartOptions { ShowGridLines = false };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -119,7 +119,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Option_ShowAxisLabels_True()
     {
         var options = new RadarChartOptions { ShowAxisLabels = true, AggregationOption = AggregationOption.GroupByDataSet };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "Axis1", "Axis2", "Axis3" })
             .Add(p => p.ChartOptions, options)
@@ -134,7 +134,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Option_ShowAxisLabels_False()
     {
         var options = new RadarChartOptions { ShowAxisLabels = false };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "Axis1", "Axis2", "Axis3" })
             .Add(p => p.ChartOptions, options)
@@ -149,7 +149,7 @@ public class RadarChartTests : BunitTest
     {
         var options = new RadarChartOptions { ShowDataMarkers = true, DataPointRadius = 4 };
         var seriesData = new double[] { 10, 20, 30, 40 };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = seriesData } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C", "D" })
             .Add(p => p.ChartOptions, options)
@@ -163,7 +163,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Option_ShowDataPoints_False()
     {
         var options = new RadarChartOptions { ShowDataMarkers = false };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30, 40 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C", "D" })
             .Add(p => p.ChartOptions, options)
@@ -181,7 +181,7 @@ public class RadarChartTests : BunitTest
             new() { Name = "Series1", Data = new double[] { 10, 20, 30 } },
             new() { Name = "Series2", Data = new double[] { 15, 25, 35 } }
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, series)
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, new RadarChartOptions() { AggregationOption = AggregationOption.GroupByDataSet })
@@ -195,7 +195,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Interaction_SelectedIndex()
     {
         var selectedIndex = -1;
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> {
                 new() { Name = "Series1", Data = new double[] { 10, 20, 30 } },
                 new() { Name = "Series2", Data = new double[] { 15, 25, 35 } }
@@ -221,7 +221,7 @@ public class RadarChartTests : BunitTest
     public void RadarChart_Option_AngleOffset()
     {
         var options = new RadarChartOptions { AngleOffset = 45, AggregationOption = AggregationOption.GroupByLabel };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -243,7 +243,7 @@ public class RadarChartTests : BunitTest
         };
         string[] xAxisLabels = { "Cat A", "Cat B", "Cat C", "Cat D" };
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Radar)
             .Add(p => p.Height, "400px")
             .Add(p => p.Width, "400px")
@@ -303,7 +303,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_Should_ApplyWidthAndHeight()
     {
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.Width, "500px")
@@ -332,7 +332,7 @@ public class RadarChartTests : BunitTest
             AggregationOption = AggregationOption.GroupByDataSet
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, series)
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -364,7 +364,7 @@ public class RadarChartTests : BunitTest
             ShowLegend = true,
             AggregationOption = AggregationOption.GroupByDataSet
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -390,7 +390,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_Should_RenderGracefully_WhenChartOptionsIsNull()
     {
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, null) // Set ChartOptions to null
@@ -418,7 +418,7 @@ public class RadarChartTests : BunitTest
             new() { Name = "Series2", Data = new double[] { 15, 25, 35 } }
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, series)
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -446,7 +446,7 @@ public class RadarChartTests : BunitTest
             GridLineWidth = 3,
             AggregationOption = AggregationOption.GroupByLabel // Ensures grid lines are typically generated
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -473,7 +473,7 @@ public class RadarChartTests : BunitTest
             AxisLineWidth = 2,
             AggregationOption = AggregationOption.GroupByLabel // Ensures axis lines are rendered
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" }) // Labels are needed for axes to be drawn
             .Add(p => p.ChartOptions, options)
@@ -502,7 +502,7 @@ public class RadarChartTests : BunitTest
             AggregationOption = AggregationOption.GroupByLabel
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = seriesData } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C", "D" })
             .Add(p => p.ChartOptions, options)
@@ -532,7 +532,7 @@ public class RadarChartTests : BunitTest
             AngleOffset = angleOffset,
             AggregationOption = AggregationOption.GroupByDataSet
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -554,7 +554,7 @@ public class RadarChartTests : BunitTest
             GridLevels = 2,
             AggregationOption = AggregationOption.GroupByLabel
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -574,7 +574,7 @@ public class RadarChartTests : BunitTest
             GridLevels = 2,
             AggregationOption = AggregationOption.GroupByLabel
         };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -588,7 +588,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_Should_RenderEmpty_WhenChartSeriesIsNull()
     {
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, null)
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" }) // Provide labels to define axes
             .Add(p => p.Width, "300px")
@@ -602,7 +602,7 @@ public class RadarChartTests : BunitTest
     [Test]
     public void RadarChart_Should_RenderEmpty_WhenChartSeriesIsEmpty()
     {
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>>())
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" }) // Provide labels to define axes
             .Add(p => p.Width, "300px")
@@ -624,7 +624,7 @@ public class RadarChartTests : BunitTest
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -648,7 +648,7 @@ public class RadarChartTests : BunitTest
         };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.ChartOptions, options)
@@ -673,7 +673,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new string[] { "Label1", "Label2", "Label3" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByLabel };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -703,7 +703,7 @@ public class RadarChartTests : BunitTest
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -729,7 +729,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new string[] { "A", "B", "C", "D" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -755,7 +755,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new string[] { "A", "B", "C", "D" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -779,7 +779,7 @@ public class RadarChartTests : BunitTest
     {
         var chartLabels = new[] { "Axis One", "Axis Two", "Axis Three" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet, ShowAxisLabels = true };
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -802,7 +802,7 @@ public class RadarChartTests : BunitTest
             new() { Name = "Series2", Data = new double[] { 15, 25, 35, 45 } }
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -820,7 +820,7 @@ public class RadarChartTests : BunitTest
     {
         var chartLabels = new[] { "Very Long Axis Label Name That Might Cause Wrapping or Truncation Issues", "Axis with !@#$%^&*()_+[]{};:'\",.<>/?\\|`~", "Short" };
         var options = new RadarChartOptions { ShowAxisLabels = true, AggregationOption = AggregationOption.GroupByDataSet }; // GroupByDataSet for simpler label mapping
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -844,7 +844,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "A", "B" }; // Fewer labels than data points
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet, ShowAxisLabels = true };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = seriesData } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -869,7 +869,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "A", "B", "C", "D", "E" }; // More labels than data points
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet, ShowAxisLabels = true };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = seriesData } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -896,7 +896,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "Cost", "Performance", "Usability" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = seriesName, Data = seriesData } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -932,7 +932,7 @@ public class RadarChartTests : BunitTest
             builder.CloseElement();
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = seriesName, Data = seriesData } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -960,7 +960,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "Alpha", "Beta", "Gamma" };
         var options = new RadarChartOptions { ShowDataMarkers = true, DataPointRadius = 3, AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = seriesName, Data = seriesData } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -1019,7 +1019,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "P1", "P2", "P3" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = seriesName, Data = seriesData } })
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -1047,7 +1047,7 @@ public class RadarChartTests : BunitTest
         var chartLabels = new[] { "A", "B", "C" };
         var options = new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, initialSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -1088,7 +1088,7 @@ public class RadarChartTests : BunitTest
         var seriesData = new List<ChartSeries<double>> { new() { Name = "ProductX", Data = new double[] { 10, 20, 30 } } };
         var options = new RadarChartOptions { ShowAxisLabels = true, AggregationOption = AggregationOption.GroupByDataSet };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, seriesData)
             .Add(p => p.ChartLabels, initialLabels)
             .Add(p => p.ChartOptions, options)
@@ -1127,7 +1127,7 @@ public class RadarChartTests : BunitTest
         var series = new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } };
         var labels = new[] { "A", "B", "C" };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, series)
             .Add(p => p.ChartLabels, labels)
             .Add(p => p.ChartOptions, initialOptions)
@@ -1185,7 +1185,7 @@ public class RadarChartTests : BunitTest
             ShowAxisLabels = true // To verify axis labels
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, options)
@@ -1225,7 +1225,7 @@ public class RadarChartTests : BunitTest
             ShowAxisLabels = true
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, originalChartSeries)
             .Add(p => p.ChartLabels, originalChartLabels)
             .Add(p => p.ChartOptions, options)
@@ -1263,7 +1263,7 @@ public class RadarChartTests : BunitTest
             builder.CloseElement();
         };
 
-        var comp = Context.RenderComponent<Radar<double>>(parameters => parameters
+        var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new string[] { "A", "B", "C" })
             .Add(p => p.CustomGraphics, customGraphicsFragment)

--- a/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
@@ -25,7 +25,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_BasicRendering_NoData()
     {
-        var comp = Context.RenderComponent<Rose<double>>();
+        var comp = Context.Render<Rose<double>>();
         comp.Markup.Should().Contain("<svg");
         comp.FindAll("path.mud-chart-series").Count.Should().Be(0); // No data, no series paths
     }
@@ -33,7 +33,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_BasicRendering_WithData()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions())
             .Add(p => p.Width, "300px")
@@ -46,7 +46,7 @@ public class RoseChartTests : BunitTest
     public void RoseChart_Option_AngleOffset()
     {
         var options = new RoseChartOptions { AngleOffset = 90 };
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10 } } })
             .Add(p => p.ChartOptions, options)
             .Add(p => p.Width, "300px")
@@ -65,7 +65,7 @@ public class RoseChartTests : BunitTest
         var optionsSmall = new RoseChartOptions { ScaleFactor = 0.5 };
         var optionsLarge = new RoseChartOptions { ScaleFactor = 1.0 };
 
-        var compSmall = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var compSmall = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, series)
             .Add(p => p.ChartOptions, optionsSmall)
             .Add(p => p.Width, "300px")
@@ -73,7 +73,7 @@ public class RoseChartTests : BunitTest
         );
         var pathDataSmall = compSmall.Find("path.mud-chart-serie").GetAttribute("d");
 
-        var compLarge = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var compLarge = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, series)
             .Add(p => p.ChartOptions, optionsLarge)
             .Add(p => p.Width, "300px")
@@ -87,7 +87,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_Option_ShowChartLabels_True()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions { ShowValues = true })
             .Add(p => p.ChartLabels, new string[] { "LabelA", "LabelB" })
@@ -101,7 +101,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_Option_ShowChartLabels_False()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions { ShowValues = false }) // Default
             .Add(p => p.ChartLabels, new string[] { "LabelA", "LabelB" })
@@ -114,7 +114,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_Option_ShowAsPercentage()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 30 } } }) // Total 40
             .Add(p => p.ChartOptions, new RoseChartOptions { ShowValues = true, ShowAsPercentage = true })
             .Add(p => p.ChartLabels, new string[] { "A", "B" })
@@ -129,7 +129,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_Data_EmptySeries()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>>()) // Empty list of series
             .Add(p => p.ChartOptions, new RoseChartOptions())
             .Add(p => p.Width, "300px")
@@ -141,7 +141,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_Data_SeriesWithEmptyData()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { } } })
             .Add(p => p.ChartOptions, new RoseChartOptions())
             .Add(p => p.Width, "300px")
@@ -154,7 +154,7 @@ public class RoseChartTests : BunitTest
     public void RoseChart_Interaction_SelectedIndex()
     {
         var selectedIndex = -1;
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions())
             .Add(p => p.Width, "300px")
@@ -179,7 +179,7 @@ public class RoseChartTests : BunitTest
         string[] chartLabels = { "Petal 1", "Petal 2", "Petal 3", "Petal 4" };
         var chartSeriesList = new List<ChartSeries<double>>() { new() { Data = chartData } };
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.Height, "300px")
             .Add(p => p.Width, "300px")
@@ -238,7 +238,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_ChartLabels_NotSet()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions { ShowValues = true, ShowLegend = true })
             .Add(p => p.Width, "300px")
@@ -258,7 +258,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_ChartLabels_MoreLabelsThanData()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions { ShowValues = true, ShowLegend = true })
             .Add(p => p.ChartLabels, new string[] { "LabelA", "LabelB", "LabelC" })
@@ -302,7 +302,7 @@ public class RoseChartTests : BunitTest
             builder.CloseElement();
         };
 
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartOptions, new RoseChartOptions())
             .Add(p => p.CustomGraphics, customSvg)
@@ -326,7 +326,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_Dimensions_ShouldRenderWithDefaults()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20 } } })
         );
 
@@ -348,7 +348,7 @@ public class RoseChartTests : BunitTest
     [Test]
     public void RoseChart_MatchBoundsToSize_False_ShouldRespectExplicitDimensions()
     {
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.MatchBoundsToSize, false)
             .Add(p => p.Width, "250px")
@@ -368,7 +368,7 @@ public class RoseChartTests : BunitTest
 
     private IRenderedComponent<MudChart<double>> RenderRoseChartWithLegend(Position legendPosition, bool rtl = false)
     {
-        return Context.RenderComponent<MudChart<double>>(parameters => parameters
+        return Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series1", Data = new double[] { 10, 20, 30 } } })
             .Add(p => p.ChartLabels, new[] { "LabelA", "LabelB", "LabelC" })
@@ -444,7 +444,7 @@ public class RoseChartTests : BunitTest
             new() { Name = "Set B", Data = new double[] { 30 } }      // Sum = 30
         };
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartOptions, new RoseChartOptions { AggregationOption = AggregationOption.GroupByDataSet, ChartPalette = _baseChartPalette })
@@ -510,7 +510,7 @@ public class RoseChartTests : BunitTest
             new() { Name = "Gamma", Data = new double[] { 5 } }       // Sum = 5
         };
 
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartOptions, new RoseChartOptions { AggregationOption = AggregationOption.GroupByDataSet, ShowValues = true, ShowLegend = true })
             .Add(p => p.Width, "400px")
@@ -569,7 +569,7 @@ public class RoseChartTests : BunitTest
             new() { Name = "s2", Data = new double[] { 5,  15 } }  // X=5,  Y=15
         };
 
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, new RoseChartOptions { AggregationOption = AggregationOption.GroupByLabel, ShowValues = true, ShowLegend = true })
@@ -597,7 +597,7 @@ public class RoseChartTests : BunitTest
         var chartSeries = new List<ChartSeries<double>> { new() { Data = new[] { 10.0, 20.0 } } };
         var chartLabels = new[] { "A", "B" };
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
@@ -627,7 +627,7 @@ public class RoseChartTests : BunitTest
         var chartSeries = new List<ChartSeries<double>> { new() { Data = new[] { 10.0, 20.0 } } };
         var chartLabels = new[] { "A", "B" };
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
@@ -660,7 +660,7 @@ public class RoseChartTests : BunitTest
             builder.CloseElement();
         };
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
@@ -688,7 +688,7 @@ public class RoseChartTests : BunitTest
 
         Func<SvgPath, (double X, double Y)> customPositionFunc = _ => (123.0, 456.0);
 
-        var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Rose)
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
@@ -715,7 +715,7 @@ public class RoseChartTests : BunitTest
         var chartSeries = new List<ChartSeries<double>> { new() { Data = new[] { 10.5, 20.77, 30.0 } } };
         var chartLabels = new[] { "A", "B", "C" };
 
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartLabels, chartLabels)
             .Add(p => p.ChartOptions, new RoseChartOptions { ShowValues = true, ShowAsPercentage = false })
@@ -748,7 +748,7 @@ public class RoseChartTests : BunitTest
         var chartSeries = new List<ChartSeries<double>> { new() { Data = new[] { 10.0, 20.0, 30.0 } } };
         var customPalette = new[] { "rgb(255, 0, 0)", "rgb(0, 255, 0)", "rgb(0, 0, 255)" }; // Red, Green, Blue
 
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartOptions, new RoseChartOptions { ChartPalette = customPalette })
             .Add(p => p.Width, "300px")
@@ -773,7 +773,7 @@ public class RoseChartTests : BunitTest
         var chartSeries = new List<ChartSeries<double>> { new() { Data = new[] { 10.0, 20.0, 30.0, 40.0 } } };
         var customPalette = new[] { "rgb(255, 0, 0)", "rgb(0, 255, 0)" };
 
-        var comp = Context.RenderComponent<Rose<double>>(parameters => parameters
+        var comp = Context.Render<Rose<double>>(parameters => parameters
             .Add(p => p.ChartSeries, chartSeries)
             .Add(p => p.ChartOptions, new RoseChartOptions { ChartPalette = customPalette })
             .Add(p => p.Width, "300px")

--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void EmptyData()
         {
-            var sankey = Context.RenderComponent<Sankey<double>>();
+            var sankey = Context.Render<Sankey<double>>();
             sankey.Markup.Should().Contain("mud-chart");
         }
 
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Charts
 
         private IRenderedComponent<MudChart<double>> RenderSankey(List<SankeyEdge<double>> edges, SankeyChartOptions options = null)
         {
-            var result = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var result = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Sankey)
                 .Add(p => p.ChartSeries, [new() { Name = "Sankey Test", Data = edges }])
                 .Add(p => p.ChartOptions, options ?? new SankeyChartOptions()));

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -43,7 +43,7 @@ namespace MudBlazor.UnitTests.Charts
         public void StackedBarChart_DefaultRender_ShouldNotThrow()
         {
             // Test basic rendering with default parameters to ensure no exceptions.
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar));
             comp.Should().NotBeNull();
             comp.Markup.Should().Contain("mud-chart");
@@ -53,7 +53,7 @@ namespace MudBlazor.UnitTests.Charts
         public void StackedBarChart_EmptyData_ShouldRenderAxesAndLegend()
         {
             // Test rendering with empty ChartSeries and ChartLabels.
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, new List<ChartSeries<double>>())
                 .Add(p => p.ChartLabels, System.Array.Empty<string>()));
@@ -68,7 +68,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void BarChartEmptyData()
         {
-            var comp = Context.RenderComponent<StackedBar<double>>();
+            var comp = Context.Render<StackedBar<double>>();
             comp.Markup.Should().Contain("mud-chart");
         }
 
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B", "C" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -105,7 +105,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -128,7 +128,7 @@ namespace MudBlazor.UnitTests.Charts
             // Labels should ideally match the series with the most data points
             string[] xAxisLabels = { "A", "B", "C" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -150,7 +150,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, initialSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -180,7 +180,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, initialSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -210,7 +210,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -236,7 +236,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] initialXAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, initialXAxisLabels));
@@ -258,7 +258,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "Series 1", Data = new double[] { 10 } } };
             string[] xAxisLabels = { "A" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -275,7 +275,7 @@ namespace MudBlazor.UnitTests.Charts
         [TestCase(Position.Right)]
         public void StackedBarChart_LegendPosition_ShouldApplyCorrectClass(Position position)
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.LegendPosition, position)
                 .Add(p => p.ChartSeries, new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 1.0 } } })
@@ -298,7 +298,7 @@ namespace MudBlazor.UnitTests.Charts
             string[] xAxisLabels = { "A" };
             var customPalette = new string[] { "#FF0000", "#00FF00" }; // Red, Green
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -323,7 +323,7 @@ namespace MudBlazor.UnitTests.Charts
             string[] xAxisLabels = { "A" };
             var customPalette = new string[] { "#111111", "#222222" }; // Only two colors
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -341,7 +341,7 @@ namespace MudBlazor.UnitTests.Charts
         [TestCase("50%", "75%")]
         public void StackedBarChart_WidthAndHeight_ShouldApplyToSvg(string width, string height)
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.Width, width)
                 .Add(p => p.Height, height));
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public async Task StackedBarChart_RightToLeft_True_ShouldAdjustLegendPositionStartEnd()
         {
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.RightToLeft, true)
                 .Add(p => p.LegendPosition, Position.Start) // Should become Right in RTL
@@ -380,7 +380,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B", "C" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -413,7 +413,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -448,7 +448,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Q1", "Q2", "Q3", "Q4" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -473,7 +473,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -498,7 +498,7 @@ namespace MudBlazor.UnitTests.Charts
             // Only one X-axis label for the single data point category
             string[] xAxisLabels = { "Category A" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -519,7 +519,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Solo Point" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels));
@@ -538,7 +538,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 10.0 } } };
             string[] xAxisLabels = { "A" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -554,7 +554,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 10.0 } } };
             string[] xAxisLabels = { "A" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -581,7 +581,7 @@ namespace MudBlazor.UnitTests.Charts
             var selectedIndex = -1; // Initial value, should be different from what we click
             var eventFiredCount = 0;
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -622,7 +622,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "X" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -654,7 +654,7 @@ namespace MudBlazor.UnitTests.Charts
                 builder.CloseElement();
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -684,7 +684,7 @@ namespace MudBlazor.UnitTests.Charts
                 builder.CloseElement();
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -713,7 +713,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "PosFuncSeries", Data = new[] { 55.0 } } };
             string[] xAxisLabels = { "PFX" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -736,7 +736,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 1000.0, 2000.0 } } };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -754,7 +754,7 @@ namespace MudBlazor.UnitTests.Charts
             string[] xAxisLabels = { "A" };
 
             // Test with specific YAxisTicks
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -781,7 +781,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 10.0, 50.0 } } };
             string[] xAxisLabels = { "A", "B" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -805,7 +805,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 10.0 } } };
             string[] xAxisLabels = { "A" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -825,7 +825,7 @@ namespace MudBlazor.UnitTests.Charts
             var chartSeries = new List<ChartSeries<double>>() { new() { Name = "S1", Data = new[] { 10.0 } } };
             string[] xAxisLabels = { "A" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.ChartLabels, xAxisLabels)
@@ -851,7 +851,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "650px")
@@ -928,7 +928,7 @@ namespace MudBlazor.UnitTests.Charts
                 new() { Name = "Deep Sea Blue", Data = new double[] { 1, 11, 4, 18, 1 } }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")
@@ -971,7 +971,7 @@ namespace MudBlazor.UnitTests.Charts
             };
             string[] xAxisLabels = { "Label A", "Label B", "Label C" };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.StackedBar)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")

--- a/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
@@ -58,7 +58,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var time = new DateTime(2000, 1, 1);
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Timeseries)
                 .Add(p => p.ChartSeries, [
                     new ()
@@ -119,7 +119,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var time = new DateTime(2000, 1, 1);
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Timeseries)
                 .Add(p => p.ChartSeries, [
                     new ()
@@ -143,7 +143,7 @@ namespace MudBlazor.UnitTests.Charts
         {
             var time = new DateTime(2000, 1, 1);
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Timeseries)
                 .Add(p => p.ChartSeries, [
                     new ()
@@ -170,7 +170,7 @@ namespace MudBlazor.UnitTests.Charts
         {
             var time = new DateTime(2000, 1, 1);
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Timeseries)
                 .Add(p => p.ChartSeries, [
                     new ()
@@ -199,7 +199,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void TimeSeriesChartEmptyData()
         {
-            var comp = Context.RenderComponent<TimeSeries<double>>();
+            var comp = Context.Render<TimeSeries<double>>();
             comp.Markup.Should().Contain("mud-chart-line mud-ltr");
         }
 
@@ -209,7 +209,7 @@ namespace MudBlazor.UnitTests.Charts
             var time = new DateTime(2000, 1, 1);
             var format = "dd/MM HH:mm";
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Timeseries)
                 .Add(p => p.ChartSeries, new() {
                     new ChartSeries<double>()
@@ -286,7 +286,7 @@ namespace MudBlazor.UnitTests.Charts
                 }
             };
 
-            var comp = Context.RenderComponent<MudChart<double>>(parameters => parameters
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
                 .Add(p => p.ChartType, ChartType.Timeseries)
                 .Add(p => p.Height, "350px")
                 .Add(p => p.Width, "100%")

--- a/src/MudBlazor.UnitTests/Components/ChatTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChatTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChat_DefaultValues()
         {
-            var comp = Context.RenderComponent<MudChat>();
+            var comp = Context.Render<MudChat>();
             comp.Instance.Color.Should().Be(Color.Default);
             comp.Instance.ChatPosition.Should().Be(ChatBubblePosition.Start);
             comp.Instance.Elevation.Should().Be(0);
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChat_CssClasses()
         {
-            var comp = Context.RenderComponent<MudChat>(parameters => parameters
+            var comp = Context.Render<MudChat>(parameters => parameters
                 .Add(p => p.ChatPosition, ChatBubblePosition.End)
                 .Add(p => p.ArrowPosition, ChatArrowPosition.Middle)
                 .Add(p => p.Square, true)
@@ -46,7 +46,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatBubble_CssClasses()
         {
-            var comp = Context.RenderComponent<MudChatBubble>(parameters => parameters
+            var comp = Context.Render<MudChatBubble>(parameters => parameters
                  .Add(p => p.Color, Color.Success)
                  .Add(p => p.Variant, Variant.Outlined));
 
@@ -58,7 +58,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatBubble_InheritsParentValues()
         {
-            var comp = Context.RenderComponent<MudChat>(parameters => parameters
+            var comp = Context.Render<MudChat>(parameters => parameters
                 .Add(p => p.Color, Color.Primary)
                 .Add(p => p.Variant, Variant.Filled)
                 .Add(p => p.ArrowPosition, ChatArrowPosition.Middle)
@@ -78,7 +78,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatBubble_HasElementReference()
         {
-            var comp = Context.RenderComponent<MudChatBubble>();
+            var comp = Context.Render<MudChatBubble>();
             var elementRef = comp.Instance.ElementReference;
             elementRef.Should().NotBeNull();
         }
@@ -86,7 +86,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatBubble_OverridesParentValues()
         {
-            var comp = Context.RenderComponent<MudChat>(parameters => parameters
+            var comp = Context.Render<MudChat>(parameters => parameters
                 .Add(p => p.Color, Color.Primary)
                 .Add(p => p.Variant, Variant.Filled)
                 .Add(p => p.ChildContent, builder =>
@@ -107,7 +107,7 @@ namespace MudBlazor.UnitTests.Components
             var clicked = false;
             var rightClicked = false;
 
-            var comp = Context.RenderComponent<MudChatBubble>(parameters => parameters
+            var comp = Context.Render<MudChatBubble>(parameters => parameters
                 .Add(p => p.OnClick, (MouseEventArgs e) => { clicked = true; })
                 .Add(p => p.OnContextClick, (MouseEventArgs e) => { rightClicked = true; }));
 
@@ -121,7 +121,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChat_RightToLeft()
         {
-            var comp = Context.RenderComponent<MudChat>(parameters => parameters
+            var comp = Context.Render<MudChat>(parameters => parameters
                 .Add(p => p.RightToLeft, true));
 
             comp.Markup.Should().Contain("mud-chat-rtl");
@@ -130,7 +130,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChat_CustomStyles()
         {
-            var comp = Context.RenderComponent<MudChat>(parameters => parameters
+            var comp = Context.Render<MudChat>(parameters => parameters
                 .Add(p => p.Style, "background-color: red;")
                 .Add(p => p.Class, "custom-class"));
 
@@ -141,7 +141,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatHeader_Parameters()
         {
-            var comp = Context.RenderComponent<MudChatHeader>(parameters => parameters
+            var comp = Context.Render<MudChatHeader>(parameters => parameters
                 .Add(p => p.Name, "John Doe")
                 .Add(p => p.Time, "12:00 PM")
                 .Add(p => p.Class, "custom-header-class"));
@@ -155,7 +155,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatHeader_ChildContent()
         {
-            var comp = Context.RenderComponent<MudChatHeader>(parameters => parameters
+            var comp = Context.Render<MudChatHeader>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, "Custom Header Content");
@@ -167,7 +167,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatFooter_Parameters()
         {
-            var comp = Context.RenderComponent<MudChatFooter>(parameters => parameters
+            var comp = Context.Render<MudChatFooter>(parameters => parameters
                 .Add(p => p.Text, "Typing...")
                 .Add(p => p.Class, "custom-footer-class"));
 
@@ -179,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudChatFooter_ChildContent()
         {
-            var comp = Context.RenderComponent<MudChatFooter>(parameters => parameters
+            var comp = Context.Render<MudChatFooter>(parameters => parameters
                 .Add(p => p.ChildContent, builder =>
                 {
                     builder.AddContent(0, "Custom Footer Content");

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -17,15 +17,15 @@ namespace MudBlazor.UnitTests.Components
         {
             // the state of the checkbox should manifest itself in the classes
             // mud-checkbox-true, mud-checkbox-false, mud-checkbox-null applied to the span
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, false))
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Value, false))
                 .Find(".mud-checkbox .mud-checkbox-false").Should().NotBe(null);
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
                 .Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-true");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
                 .Find(".mud-checkbox span").ClassList.Should().NotContain("mud-checkbox-false");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Value, true))
                 .Find(".mud-checkbox span").ClassList.Should().NotContain("mud-checkbox-null");
-            var comp = Context.RenderComponent<MudCheckBox<bool?>>(self => self
+            var comp = Context.Render<MudCheckBox<bool?>>(self => self
                 .Add(x => x.Value, null)
                 .Add(x => x.TriState, true));
             comp.Find(".mud-checkbox span").ClassList.Should().Contain("mud-checkbox-null");
@@ -43,7 +43,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxTest1()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>();
+            var comp = Context.Render<MudCheckBox<bool>>();
             // print the generated html
             // select elements needed for the test
             var box = comp.Instance;
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxTest2()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>(parameters => parameters.Add(x => x.Value, true));
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters.Add(x => x.Value, true));
             // select elements needed for the test
             var box = comp.Instance;
             // check initial state
@@ -80,7 +80,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxTest3()
         {
-            var comp = Context.RenderComponent<CheckBoxTest3>();
+            var comp = Context.Render<CheckBoxTest3>();
             // select elements needed for the test
             var boxes = comp.FindComponents<MudCheckBox<bool>>();
             // check initial state
@@ -111,7 +111,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxTest4()
         {
-            var comp = Context.RenderComponent<CheckBoxTest4>();
+            var comp = Context.Render<CheckBoxTest4>();
 
             // check dense
             comp.FindAll("span").ToArray()[0].ClassList.Should().Contain("mud-checkbox-dense");
@@ -131,7 +131,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxTriStateTest()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool?>>(parameters => parameters.Add(x => x.TriState, true));
+            var comp = Context.Render<MudCheckBox<bool?>>(parameters => parameters.Add(x => x.TriState, true));
             // print the generated html
             // select elements needed for the test
             var box = comp.Instance;
@@ -156,7 +156,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxFormTest1()
         {
-            var comp = Context.RenderComponent<CheckBoxFormTest1>();
+            var comp = Context.Render<CheckBoxFormTest1>();
             var form = comp.FindComponent<MudForm>().Instance;
             form.IsValid.Should().BeFalse();
             form.Errors.Length.Should().Be(0);
@@ -185,7 +185,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TriStateCheckBoxFormTest()
         {
-            var comp = Context.RenderComponent<CheckBoxFormTest2>();
+            var comp = Context.Render<CheckBoxFormTest2>();
             var form = comp.FindComponent<MudForm>().Instance;
             var checkbox = comp.FindComponent<MudCheckBox<bool?>>();
 
@@ -229,7 +229,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxesBindAgainstArrayTest()
         {
-            var comp = Context.RenderComponent<CheckBoxesBindAgainstArrayTest>();
+            var comp = Context.Render<CheckBoxesBindAgainstArrayTest>();
             comp.FindAll("p")[^1].TrimmedText().Should().Be("A=True, B=False, C=True, D=False, E=True");
             comp.FindAll("input")[0].Change(false);
             comp.FindAll("p")[^1].TrimmedText().Should().Be("A=False, B=False, C=True, D=False, E=True");
@@ -240,7 +240,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBox_StopClickPropagation_Default_Is_True()
         {
-            using var comp = Context.RenderComponent<MudCheckBox<bool>>();
+            using var comp = Context.Render<MudCheckBox<bool>>();
             comp.Instance.StopClickPropagation.Should().BeTrue();
             comp.Markup.Contains("blazor:onclick:stopPropagation").Should().BeTrue();
         }
@@ -251,7 +251,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CheckBoxTest_KeyboardInput()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool?>>();
+            var comp = Context.Render<MudCheckBox<bool?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.TriState, true));
             // print the generated html
             // select elements needed for the test
@@ -300,7 +300,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CheckBoxTest_KeyboardDisabled()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool?>>();
+            var comp = Context.Render<MudCheckBox<bool?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.TriState, true)
                 .Add(x => x.KeyboardEnabled, false));
@@ -358,7 +358,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Dark, Color.Primary)]
         public void CheckBoxColorTest(Color color, Color uncheckedcolor)
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>(x => x.Add(c => c.Color, color).Add(b => b.UncheckedColor, uncheckedcolor));
+            var comp = Context.Render<MudCheckBox<bool>>(x => x.Add(c => c.Color, color).Add(b => b.UncheckedColor, uncheckedcolor));
 
             var box = comp.Instance;
 
@@ -375,14 +375,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckBoxDisabledTest()
         {
-            var comp = Context.RenderComponent<CheckboxLabelTest>();
+            var comp = Context.Render<CheckboxLabelTest>();
             comp.FindAll("label.mud-checkbox")[3].ClassList.Should().Contain("mud-disabled"); // 4rd checkbox
         }
 
         [Test]
         public void CheckBoxLabelPlacementTest()
         {
-            var comp = Context.RenderComponent<CheckboxLabelTest>();
+            var comp = Context.Render<CheckboxLabelTest>();
 
             comp.FindAll("label.mud-checkbox")[2].ClassList.Should().Contain("mud-input-content-placement-start"); // 3rd checkbox: Placement.Start
         }
@@ -392,10 +392,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var value = new DisplayNameLabelClass();
 
-            var comp = Context.RenderComponent<MudCheckBox<bool>>(x => x.Add(f => f.For, () => value.Boolean));
+            var comp = Context.Render<MudCheckBox<bool>>(x => x.Add(f => f.For, () => value.Boolean));
             comp.Instance.Label.Should().Be("Boolean LabelAttribute"); //label should be set by the attribute
 
-            var comp2 = Context.RenderComponent<MudCheckBox<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
+            var comp2 = Context.Render<MudCheckBox<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
 
@@ -405,7 +405,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalCheckBox_Should_NotHaveRequiredAttribute()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>();
+            var comp = Context.Render<MudCheckBox<bool>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
         }
@@ -416,7 +416,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredCheckBox_Should_HaveRequiredAttribute()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>(parameters => parameters
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters
                 .Add(p => p.Required, true));
             comp.Find("input").HasAttribute("required").Should().BeTrue();
         }
@@ -427,7 +427,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredCheckBoxAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudCheckBox<bool>>();
+            var comp = Context.Render<MudCheckBox<bool>>();
 
             var input = () => comp.Find("input");
             input().HasAttribute("required").Should().BeFalse();
@@ -441,18 +441,18 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span").ClassList.Should().Contain("hover:mud-default-hover");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, true)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, true).Add(x => x.Disabled, false)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Disabled, false)).Find("span").ClassList.Should().Contain("hover:mud-default-hover");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, false)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
-            Context.RenderComponent<MudCheckBox<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, true)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span").ClassList.Should().Contain("hover:mud-default-hover");
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, true)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, true).Add(x => x.Disabled, false)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Disabled, false)).Find("span").ClassList.Should().Contain("hover:mud-default-hover");
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, false)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, true)).Find("span").ClassList.Should().NotContain("hover:mud-default-hover");
         }
 
         [Test]
         public void CheckBox_AriaLabel_OverRides()
         {
-            var comp = Context.RenderComponent<CheckBoxAriaLabelTest>();
+            var comp = Context.Render<CheckBoxAriaLabelTest>();
             var checkboxes = comp.FindAll(".mud-input-control.mud-input-control-boolean-input");
 
             // verify checkbox one maintains it's original structure, no aria class used, label with a p element

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_SingleSelection()
         {
-            var comp = Context.RenderComponent<ChipSetSingleSelectionTest>();
+            var comp = Context.Render<ChipSetSingleSelectionTest>();
             // initially nothing is selected
             comp.FindAll(".mud-chip").Count.Should().Be(7);
             comp.Find("div.selected-value").TrimmedText().Should().Be("");
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_SingleSelection_WithInitialValue()
         {
-            var comp = Context.RenderComponent<ChipSetSingleSelectionTest>(p => p.Add(x => x.InitialValue, "Milk"));
+            var comp = Context.Render<ChipSetSingleSelectionTest>(p => p.Add(x => x.InitialValue, "Milk"));
             // initial value is selected
             comp.Find("div.selected-value").TrimmedText().Should().Be("Milk");
             comp.Find("div.selected-values").TrimmedText().Should().Be("Nothing selected");
@@ -53,7 +53,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_SingleSelection_Mandatory()
         {
-            var comp = Context.RenderComponent<ChipSetSingleSelectionTest>(parameters => parameters
+            var comp = Context.Render<ChipSetSingleSelectionTest>(parameters => parameters
                 .Add(p => p.SelectionMode, SelectionMode.SingleSelection)
             );
             // initially nothing is selected
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection()
         {
-            var comp = Context.RenderComponent<ChipSetMultiSelectionTest>();
+            var comp = Context.Render<ChipSetMultiSelectionTest>();
             // select elements needed for the test
             comp.FindAll(".mud-chip").Count.Should().Be(7);
             comp.Find("div.selected-value").TrimmedText().Should().Be("");
@@ -115,7 +115,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection_WithInitialValues()
         {
-            var comp = Context.RenderComponent<ChipSetMultiSelectionTest>(parameters => parameters.Add(x => x.InitialValues, ["Corn flakes", "Milk", "Red wine"]));
+            var comp = Context.Render<ChipSetMultiSelectionTest>(parameters => parameters.Add(x => x.InitialValues, ["Corn flakes", "Milk", "Red wine"]));
             // initial values should be selected
             comp.Find("div.selected-value").TrimmedText().Should().Be("");
             comp.Find("div.selected-values").TrimmedText().Should().Be("Corn flakes, Milk, Red wine");
@@ -131,7 +131,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_SingleSelection_WithMultipleDefaultChips()
         {
-            var comp = Context.RenderComponent<ChipSetDefaultChipsTest>();
+            var comp = Context.Render<ChipSetDefaultChipsTest>();
             // select elements needed for the test
             comp.FindAll(".mud-chip").Count.Should().Be(7);
             comp.Find(".selected-value").TrimmedText().Should().Be("Corn flakes");
@@ -140,7 +140,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection_DefaultChipsShouldBeInitiallySelected()
         {
-            var comp = Context.RenderComponent<ChipSetDefaultChipsTest>(p => p.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+            var comp = Context.Render<ChipSetDefaultChipsTest>(p => p.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.FindAll(".mud-chip").Count.Should().Be(7);
             comp.Find(".selected-values").TrimmedText().Should().Be("Corn flakes, Milk");
             // de-select cornflakes
@@ -154,7 +154,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection_DefaultChipsShouldOverrideInitiallySelected()
         {
-            var comp = Context.RenderComponent<ChipSetDefaultChipsTest>(p => p
+            var comp = Context.Render<ChipSetDefaultChipsTest>(p => p
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
                 .Add(x => x.InitialValues, ["Eggs", "Soap"])
             );
@@ -171,7 +171,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection_LateDefaultChipsShouldBeInitiallySelected()
         {
-            var comp = Context.RenderComponent<ChipSetLateDefaultTest>();
+            var comp = Context.Render<ChipSetLateDefaultTest>();
             // check that only one item is present
             comp.FindAll(".mud-chip").Count.Should().Be(1);
             comp.FindAll("p")[0].TrimmedText().Should().Be("Primary");
@@ -189,7 +189,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_ReadOnly()
         {
-            var comp = Context.RenderComponent<ChipSetReadOnlyTest>();
+            var comp = Context.Render<ChipSetReadOnlyTest>();
             // print the generated html
             // no chip should have mud-clickable or mud-ripple classes
             var chipset = comp.FindComponent<MudChipSet<string>>();
@@ -212,7 +212,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_SelectedValues_TwoWayBinding()
         {
-            var comp = Context.RenderComponent<ChipSetSelectionTwoWayBindingTest>();
+            var comp = Context.Render<ChipSetSelectionTwoWayBindingTest>();
             // initial values check
             comp.Find("p.set").TrimmedText().Should().Be("Selection: 1");
             comp.FindComponents<MudChip<int>>()[0].Find(".mud-chip").ClassList.Should().Contain("mud-chip-selected");
@@ -250,7 +250,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSetComparerTest()
         {
-            var comp = Context.RenderComponent<ChipSetComparerTest>();
+            var comp = Context.Render<ChipSetComparerTest>();
             // initial values check
             comp.Find("p.sel").TrimmedText().Should().Be("Selection:");
 
@@ -274,7 +274,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection_AfterChipArraySetNull_ShouldBeAbleToSelectSameChip()
         {
-            var comp = Context.RenderComponent<ChipSetClearSelectionTest>();
+            var comp = Context.Render<ChipSetClearSelectionTest>();
             var chipSet = comp.FindComponent<MudChipSet<string>>();
 
             // Select one chip
@@ -299,7 +299,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ChipSet_MultiSelection_AfterChipArraySetEmpty_ShouldBeAbleToSelectSameChip()
         {
-            var comp = Context.RenderComponent<ChipSetClearSelectionTest>();
+            var comp = Context.Render<ChipSetClearSelectionTest>();
             var chipSet = comp.FindComponent<MudChipSet<string>>();
 
             // Select one chip
@@ -325,18 +325,18 @@ namespace MudBlazor.UnitTests.Components
         public void Chip_GetValue_ShouldReturnTextIfValueIsNullAndT_IsString()
         {
             // Backwards compatibility with non-generic chips where setting the Text without a Value treated the Text as Value
-            Context.RenderComponent<MudChip<string>>(p => p
+            Context.Render<MudChip<string>>(p => p
                 .Add(x => x.Text, "はい")
             ).Instance.GetValue().Should().Be("はい");
-            Context.RenderComponent<MudChip<string>>(p => p
+            Context.Render<MudChip<string>>(p => p
                 .Add(x => x.Text, "はい")
                 .Add(x => x.Value, "Yes")
             ).Instance.GetValue().Should().Be("Yes");
             // Not for types != string though!
-            Context.RenderComponent<MudChip<int?>>(p => p
+            Context.Render<MudChip<int?>>(p => p
                 .Add(x => x.Text, "Zero")
             ).Instance.GetValue().Should().Be(null);
-            Context.RenderComponent<MudChip<int?>>(p => p
+            Context.Render<MudChip<int?>>(p => p
                 .Add(x => x.Text, "Zero")
                 .Add(x => x.Value, 0)
             ).Instance.GetValue().Should().Be(0);
@@ -345,7 +345,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ChipSet_CheckMark_Parameter()
         {
-            var comp = Context.RenderComponent<MudChipSet<string>>(self => self
+            var comp = Context.Render<MudChipSet<string>>(self => self
                 .Add(x => x.CheckMark, true)
                 .Add(x => x.SelectedValue, "x")
                 .AddChildContent<MudChip<string>>(chip => chip.Add(x => x.Value, "x"))
@@ -363,7 +363,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.CheckMark.Should().Be(false);
             // for coverage
             new MudChip<int>().ShowCheckMark.Should().Be(false);
-            var chip = Context.RenderComponent<MudChip<string>>(chip => chip
+            var chip = Context.Render<MudChip<string>>(chip => chip
                 .Add(x => x.CheckedIcon, Icons.Material.Filled.Cake)
                 .Add(x => x.CloseIcon, Icons.Material.Filled.Plagiarism)
                 .Add(x => x.Ripple, false)
@@ -372,14 +372,14 @@ namespace MudBlazor.UnitTests.Components
             ).Instance;
             await comp.InvokeAsync(() => chip.UpdateSelectionStateAsync(true));
             chip.ShowCheckMark.Should().Be(false); // because not in a chipset
-            Context.RenderComponent<MudChip<int>>(self => self.Add(x => x.Variant, (Variant)69)).Instance.GetVariant().Should().Be(Variant.Outlined); // falls back to outlined
+            Context.Render<MudChip<int>>(self => self.Add(x => x.Variant, (Variant)69)).Instance.GetVariant().Should().Be(Variant.Outlined); // falls back to outlined
         }
 
         [Test]
         public async Task ChipSet_RemoveChip_Logic()
         {
             IReadOnlyCollection<string> selectedValues = ["x", "y", "z"];
-            var comp = Context.RenderComponent<MudChipSet<string>>(self => self
+            var comp = Context.Render<MudChipSet<string>>(self => self
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
                 .Bind(x => x.SelectedValues, selectedValues, x => selectedValues = x)
                 .AddChildContent<MudChip<string>>(chip => chip.Add(x => x.Value, "x"))
@@ -389,7 +389,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.Instance.RemoveAsync(comp.FindComponent<MudChip<string>>().Instance));
             string.Join(", ", selectedValues).Should().Be("y, z");
             // removing a foreign chip doesn't do anything
-            await comp.Instance.RemoveAsync(Context.RenderComponent<MudChip<string>>(chip => chip.Add(x => x.Value, "y")).Instance);
+            await comp.Instance.RemoveAsync(Context.Render<MudChip<string>>(chip => chip.Add(x => x.Value, "y")).Instance);
             string.Join(", ", selectedValues).Should().Be("y, z");
             // removing from a disposed chipset doesn't raise events, so in this case the selection stays the same
             var chipY = comp.FindComponent<MudChip<string>>().Instance;
@@ -405,7 +405,7 @@ namespace MudBlazor.UnitTests.Components
             var b = new object();
             var c = new object();
             IReadOnlyCollection<object> selectedValues = [a];
-            var comp = Context.RenderComponent<MudChipSet<object>>(self => self
+            var comp = Context.Render<MudChipSet<object>>(self => self
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
                 .Bind(x => x.SelectedValues, selectedValues, x => selectedValues = x)
                 .AddChildContent<MudChip<object>>(chip => chip.Add(x => x.Value, a))
@@ -421,7 +421,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Chip_TwoWayBinding_ShouldUpdateSelection()
         {
-            var comp = Context.RenderComponent<ChipSetChipBindingTest>();
+            var comp = Context.Render<ChipSetChipBindingTest>();
             comp.Find("div.selection").TrimmedText().Should().Be("Add ingredients to your cocktail.");
             // initial state
             comp.FindAll(".mud-chip")[0].ClassList.Should().NotContain("mud-chip-selected");
@@ -458,7 +458,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Should_provide_accessible_keyboard_navigation()
         {
             var onCloseCount = 0;
-            var comp = Context.RenderComponent<ChipSetKeyboardNavigationTests>(parameters => parameters
+            var comp = Context.Render<ChipSetKeyboardNavigationTests>(parameters => parameters
                 .Add(p => p.AreChipsClosable, false)
                 .Add(p => p.OnClose, () => onCloseCount++));
 
@@ -506,7 +506,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Should_not_accept_keyboard_inputs_when_disabled_or_readonly()
         {
             var onCloseCount = 0;
-            var comp = Context.RenderComponent<ChipSetKeyboardNavigationTests>(parameters => parameters
+            var comp = Context.Render<ChipSetKeyboardNavigationTests>(parameters => parameters
                 .Add(p => p.AreChipsClosable, true)
                 .Add(p => p.Disabled, true)
                 .Add(p => p.OnClose, () => onCloseCount++));

--- a/src/MudBlazor.UnitTests/Components/ChipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Chip_ShouldRenderDivByDefault()
         {
-            var comp = Context.RenderComponent<MudChip<string>>();
+            var comp = Context.Render<MudChip<string>>();
 
             var chip = comp.Find(".mud-chip");
 
@@ -35,7 +35,7 @@ namespace MudBlazor.UnitTests.Components
             [Values(null, "noopener", "nofollow")] string rel)
         {
 
-            var comp = Context.RenderComponent<MudChip<string>>(parameters => parameters
+            var comp = Context.Render<MudChip<string>>(parameters => parameters
                 .Add(p => p.Href, "https://example.com")
                 .Add(p => p.Target, target)
                 .Add(p => p.Rel, rel)
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
             [Values(null, "", "ASDF", "_blank")] string target,
             [Values(null, "", "noopener", "nofollow")] string rel)
         {
-            var comp = Context.RenderComponent<MudChip<string>>(parameters => parameters
+            var comp = Context.Render<MudChip<string>>(parameters => parameters
                 .Add(p => p.OnClick, () => { })
                 .Add(p => p.Href, href)
                 .Add(p => p.Target, target)
@@ -87,7 +87,7 @@ namespace MudBlazor.UnitTests.Components
                 { "data-test", "testValue" }
             };
 
-            var comp = Context.RenderComponent<MudChip<string>>(parameters => parameters
+            var comp = Context.Render<MudChip<string>>(parameters => parameters
                 .Add(p => p.OnClick, () => { })
                 .Add(p => p.UserAttributes, userAttributes)
             );
@@ -103,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Chip_ShouldRenderAvatar()
         {
-            var comp = Context.RenderComponent<ChipAvatarContentTest>();
+            var comp = Context.Render<ChipAvatarContentTest>();
 
             comp.Find("div.mud-chip").InnerHtml.Should().Contain("mud-avatar");
         }
@@ -114,7 +114,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Chip_OnClick()
         {
-            var comp = Context.RenderComponent<ChipOnClickTest>();
+            var comp = Context.Render<ChipOnClickTest>();
             // print the generated html
 
             // chip should have mud-clickable and mud-ripple classes
@@ -135,7 +135,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Chip_OnClose()
         {
-            var comp = Context.RenderComponent<ChipOnClickTest>();
+            var comp = Context.Render<ChipOnClickTest>();
             // print the generated html
 
             // chip should have mud-clickable and mud-ripple classes

--- a/src/MudBlazor.UnitTests/Components/CollapseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Collapse_TwoWayBinding_Test1()
         {
-            var comp = Context.RenderComponent<CollapseBindingTest>();
+            var comp = Context.Render<CollapseBindingTest>();
             var collapse = comp.FindComponent<MudCollapse>();
 
             collapse.Markup.Should().Contain("mud-collapse-entered");

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -138,7 +138,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ColorPickerOpenButtonDefaultAriaLabel()
         {
-            var comp = Context.RenderComponent<MudColorPicker>();
+            var comp = Context.Render<MudColorPicker>();
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
@@ -146,7 +146,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Default()
         {
-            var comp = Context.RenderComponent<MudColorPicker>();
+            var comp = Context.Render<MudColorPicker>();
 
             comp.Instance.ShowAlpha.Should().BeTrue();
             comp.Instance.ShowColorField.Should().BeTrue();
@@ -166,7 +166,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(40, 256.78, _defaultYForColorPanel)]
         public void SetR(byte r, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var rInput = GetColorInput(comp, 0);
 
@@ -180,7 +180,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(240, 196.3, 14.71)]
         public void SetG(byte g, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var gInput = GetColorInput(comp, 1);
 
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(90, 55.47, 161.76)]
         public void SetB(byte b, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var bInput = GetColorInput(comp, 2);
 
@@ -210,7 +210,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(0.9, _defaultXForColorPanel, _defaultYForColorPanel)]
         public void SetA_InRGBMode(double a, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var aInput = GetColorInput(comp, 3);
 
@@ -225,7 +225,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(90, 208.46, _defaultYForColorPanel)]
         public void SetH(int h, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
 
             var hInput = GetColorInput(comp, 0);
 
@@ -240,7 +240,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(0.4, 134.88, 61.76)]
         public void SetS(double s, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
 
             var sColor = GetColorInput(comp, 1);
 
@@ -255,7 +255,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(0.67, 163.43, 23.53)]
         public void SetL(double l, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
 
             var lColor = GetColorInput(comp, 2);
 
@@ -269,7 +269,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(0.5, _defaultXForColorPanel, _defaultYForColorPanel)]
         public void SetAlpha_AsHLS(double a, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
 
             var lColor = GetColorInput(comp, 3);
 
@@ -283,7 +283,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("#8cb829ff", 242.48, 69.61)]
         public void SetColorInput(string colorHexString, double selectorXPosition, double selectorYPosition)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HEX));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HEX));
 
             var inputs = comp.FindAll(".mud-picker-color-inputs input");
 
@@ -299,7 +299,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("#8qb829ff")]
         public void SetColorInput_InvalidNoChange(string colorHexString)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HEX));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HEX));
 
             var inputs = comp.FindAll(".mud-picker-color-inputs input");
 
@@ -314,7 +314,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SetAlphaSlider()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             for (var i = 256 - 1; i >= 0; i--)
             {
@@ -333,7 +333,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PointerMove()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             const double x = 117.0;
             const double y = 140.0;
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SetHueSlider()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             for (var i = 0; i <= 360; i++)
             {
@@ -373,7 +373,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Click_ColorPanel()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var overlay = comp.Find(CssSelector);
 
@@ -391,7 +391,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Click_ModeButton()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var color = comp.Instance.ColorValue;
             var modeButton = comp.Find(".mud-picker-control-switch button");
@@ -415,7 +415,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ColorPalette_Interaction()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var colorDot = comp.Find(_colorDotCssSelector);
             // no collection
@@ -445,7 +445,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var expectedColors = new MudColor[] { "#23af3daa", "#56a23dff", "#56a85dff" };
 
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.Palette, expectedColors));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.Palette, expectedColors));
 
             var colorDot = comp.Find(_colorDotCssSelector);
             colorDot.Click();
@@ -464,7 +464,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ColorPalette_SelectColor()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>();
+            var comp = Context.Render<SimpleColorPickerTest>();
 
             var colorDot = comp.Find(_colorDotCssSelector);
             // no collection
@@ -491,7 +491,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Toggle_Toolbar()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ShowToolbar, true));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ShowToolbar, true));
 
             _ = comp.Find(_toolbarCssSelector);
 
@@ -507,7 +507,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Toggle_ColorField()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ShowColorField, true));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ShowColorField, true));
 
             _ = comp.Find(_mudColorPickerCssSelector);
 
@@ -523,7 +523,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Toggle_Preview()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ShowPreview, true));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ShowPreview, true));
 
             _ = comp.Find(_colorDotCssSelector);
 
@@ -539,7 +539,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Toggle_Sliders()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ShowSliders, true));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ShowSliders, true));
 
             _ = comp.Find(_slidersControlCssSelector);
 
@@ -558,7 +558,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(ColorPickerMode.RGB)]
         public async Task Toggle_Input(ColorPickerMode mode)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ColorPickerMode, mode);
                 p.Add(x => x.DisableInput, false);
@@ -579,7 +579,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Toggle_ModeSwitch()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p => p.Add(x => x.ShowModeSwitch, true));
+            var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ShowModeSwitch, true));
 
             _ = comp.Find(_colorInputModeSwitchCssSelector);
 
@@ -595,7 +595,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Tooltips_Disabled_ShouldSuppressTooltipContent()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ShowToolbar, true);
                 p.Add(x => x.ShowTooltips, false);
@@ -618,7 +618,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Tooltips_Enabled_ShouldDisplayLocalizedContent()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ShowToolbar, true);
                 p.Add(x => x.ShowTooltips, true);
@@ -646,7 +646,7 @@ namespace MudBlazor.UnitTests.Components
             var color = new MudColor(12, 220, 124, 120);
             var expectedColor = new MudColor(12, 220, 124, 120);
 
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ColorPickerMode, mode);
                 p.Add(x => x.ShowAlpha, true);
@@ -674,7 +674,7 @@ namespace MudBlazor.UnitTests.Components
             var color = new MudColor(12, 220, 124, 120);
             var expectedColor = new MudColor(12, 220, 124, 120);
 
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ColorPickerMode, ColorPickerMode.HEX);
                 p.Add(x => x.ShowAlpha, true);
@@ -709,13 +709,13 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleViewMode()
         {
-            var comp = Context.RenderComponent<MudColorPicker>(p =>
+            var comp = Context.Render<MudColorPicker>(p =>
             {
                 p.Add(x => x.ShowToolbar, true);
                 p.Add(x => x.PickerVariant, PickerVariant.Static);
             });
 
-            IRefreshableElementCollection<IElement> Buttons() => comp.FindAll(_mudToolbarButtonsCssSelector);
+            IReadOnlyList<IElement> Buttons() => comp.FindAll(_mudToolbarButtonsCssSelector);
 
             Dictionary<int, (ColorPickerView, string)> buttonMapper = new()
             {
@@ -738,7 +738,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(PickerVariant.Dialog, true)]
         public async Task CloseButtonInToolbarVisible(PickerVariant variant, bool expectedVisibility)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.Variant, variant);
                 p.Add(x => x.ShowToolbar, true);
@@ -765,7 +765,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(ColorPickerView.Palette, 2)]
         public void ColorPickerView_Selection(ColorPickerView view, int index)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, view);
                 p.Add(x => x.ShowToolbar, true);
@@ -788,7 +788,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaletteView()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
                 p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
@@ -814,7 +814,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaletteView_ChooseColor()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
                 p.Add(x => x.Palette, _mudGridPaletteDefaultColors);
@@ -838,7 +838,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void GridView()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Grid);
             });
@@ -863,7 +863,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void GridView_ChooseColor()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Grid);
             });
@@ -888,7 +888,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void GridCompactView()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.GridCompact);
             });
@@ -916,7 +916,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void GridCompactView_ChooseColor()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.GridCompact);
             });
@@ -945,7 +945,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(PickerVariant.Dialog)]
         public async Task GridCompact_CloseOnSelect(PickerVariant variant)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.GridCompact);
                 p.Add(x => x.Variant, variant);
@@ -968,7 +968,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(PickerVariant.Dialog)]
         public async Task Palette_CloseOnSelect(PickerVariant variant)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, ColorPickerView.Palette);
                 p.Add(x => x.Variant, variant);
@@ -994,7 +994,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(PickerVariant.Dialog, ColorPickerView.Spectrum)]
         public async Task NoControls_CloseOnSelect(PickerVariant variant, ColorPickerView view)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, view);
                 p.Add(x => x.Variant, variant);
@@ -1042,7 +1042,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(ColorPickerView.GridCompact, true, "#78797a")]
         public void TextOutput_Alpha(ColorPickerView view, bool disableAlpha, string expectedOutput)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ViewMode, view);
                 p.Add(x => x.ShowAlpha, !disableAlpha);
@@ -1055,7 +1055,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SetNullColor_NothingChanged()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL);
             });
@@ -1072,7 +1072,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SetHLS_NotChangeRBG_ButCallbackFired()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL);
                 p.Add(x => x.ColorValue, new MudColor(245, 0.35, 0.95, 1.0));
@@ -1096,7 +1096,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RTL_AlphaSliderInverseStyle()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.AddCascadingValue("RightToLeft", true);
             });
@@ -1109,7 +1109,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void Spectrum_DragPointer(bool disableDragEffect)
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 //p.Add(x => x.Variant, PickerVariant.Static);
                 //p.Add(x => x.ViewMode, ColorPickerView.Spectrum);
@@ -1150,7 +1150,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void StableHue_WhenColorSpectrumClicked()
         {
-            var comp = Context.RenderComponent<MudColorPicker>(p =>
+            var comp = Context.Render<MudColorPicker>(p =>
             {
                 p.Add(x => x.PickerVariant, PickerVariant.Static);
                 p.Add(x => x.ColorPickerView, ColorPickerView.Spectrum);
@@ -1174,7 +1174,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CheckPickerPopover()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(p =>
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
             {
                 p.Add(x => x.Variant, PickerVariant.Inline);
             });
@@ -1206,7 +1206,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DistinguishBetweenInternalAndExternalView()
         {
-            var comp = Context.RenderComponent<PickerWithFixedView>();
+            var comp = Context.Render<PickerWithFixedView>();
 
             //open the color picker
             var inputField = comp.Find(".mud-input-slot");
@@ -1241,7 +1241,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ColorPickerValueShouldUpdateOnTextTest()
         {
-            var comp = Context.RenderComponent<MudColorPicker>(parameters => parameters
+            var comp = Context.Render<MudColorPicker>(parameters => parameters
                 .Add(x => x.Editable, true));
 
             comp.Find("input").Change("#180f6fff");
@@ -1255,7 +1255,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ColorPickerWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudColorPicker>(parameters
+            var comp = Context.Render<MudColorPicker>(parameters
                 => parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -1270,7 +1270,7 @@ namespace MudBlazor.UnitTests.Components
         public void ColorPickerWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudColorPicker>(parameters
+            var comp = Context.Render<MudColorPicker>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1289,7 +1289,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalRGBColorPicker_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.ColorPickerMode, ColorPickerMode.RGB));
 
             comp.FindAll("input:not(.mud-slider-input)").Should().AllSatisfy(input =>
@@ -1305,7 +1305,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredRGBColorPicker_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.ColorPickerMode, ColorPickerMode.RGB));
 
@@ -1322,7 +1322,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredRGBColorPickerAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.ColorPickerMode, ColorPickerMode.RGB));
 
             comp.FindAll("input:not(.mud-slider-input)").Should().AllSatisfy(input =>
@@ -1347,7 +1347,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalHSLColorPicker_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.ColorPickerMode, ColorPickerMode.HSL));
 
             comp.FindAll("input:not(.mud-slider-input)").Should().AllSatisfy(input =>
@@ -1363,7 +1363,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredHSLColorPicker_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.ColorPickerMode, ColorPickerMode.HSL));
 
@@ -1380,7 +1380,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredHSLColorPickerAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.ColorPickerMode, ColorPickerMode.HSL));
 
             comp.FindAll("input:not(.mud-slider-input)").Should().AllSatisfy(input =>
@@ -1405,7 +1405,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalHEXColorPicker_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.ColorPickerMode, ColorPickerMode.HEX));
 
             comp.FindAll("input:not(.mud-slider-input)").Should().AllSatisfy(input =>
@@ -1421,7 +1421,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredHEXColorPicker_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.ColorPickerMode, ColorPickerMode.HEX));
 
@@ -1438,7 +1438,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredHEXColorPickerAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(p => p.ColorPickerMode, ColorPickerMode.HEX));
 
             comp.FindAll("input:not(.mud-slider-input)").Should().AllSatisfy(input =>
@@ -1461,7 +1461,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ColorPickerInputId()
         {
-            var comp = Context.RenderComponent<SimpleColorPickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleColorPickerTest>(parameters => parameters
                 .Add(c => c.Variant, PickerVariant.Inline)
                 .Add(c => c.InputId, "primary-color"));
 

--- a/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ComponentBaseTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests
         [Test]
         public void Should_have_consistent_field_id_when_user_id_is_not_provided()
         {
-            var comp = Context.RenderComponent<DummyComponentBase>();
+            var comp = Context.Render<DummyComponentBase>();
 
             comp.Instance.FieldId.Should().Be(comp.Instance.FieldId);
         }
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests
         public void Should_prefer_user_id_over_internal_field_id()
         {
             var id = "this-is-an-id";
-            var comp = Context.RenderComponent<DummyComponentBase>(parameters =>
+            var comp = Context.Render<DummyComponentBase>(parameters =>
             {
                 parameters.Add(x => x.UserAttributes, new Dictionary<string, object>
                 {
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests
         public async Task Should_prefer_user_id_over_internal_field_id_when_set_after_initialization()
         {
             var id = "this-is-an-id";
-            var comp = Context.RenderComponent<DummyComponentBase>();
+            var comp = Context.Render<DummyComponentBase>();
 
             await comp.SetParametersAndRenderAsync(parameters =>
             {
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests
         [Test]
         public async Task Should_fallback_to_internal_field_id_if_user_id_is_invalid()
         {
-            var comp = Context.RenderComponent<DummyComponentBase>();
+            var comp = Context.Render<DummyComponentBase>();
             var internalId = comp.Instance.FieldId;
 
             await comp.SetParametersAndRenderAsync(parameters =>

--- a/src/MudBlazor.UnitTests/Components/ContainerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ContainerTests.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.UnitTests.Components
         public void GuttersProperty_AddsClass(bool gutters)
         {
             // Arrange
-            var component = Context.RenderComponent<MudContainer>(builder => builder
+            var component = Context.Render<MudContainer>(builder => builder
                 .Add(p => p.Gutters, gutters)
             );
 

--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandedTrueTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedTest>();
+            var comp = Context.Render<DataGridGroupExpandedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
             // until a change happens this bool tracks whether GroupExpanded is applied.
             dataGrid.Instance._groupInitialExpanded = true;
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandedTrueAsyncTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedAsyncTest>();
+            var comp = Context.Render<DataGridGroupExpandedAsyncTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedAsyncTest.Fruit>>();
 
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(7));
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandedTrueServerDataTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedServerDataTest>();
+            var comp = Context.Render<DataGridGroupExpandedServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedServerDataTest.Fruit>>();
 
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(7));
@@ -72,7 +72,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandedFalseTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedFalseTest>();
+            var comp = Context.Render<DataGridGroupExpandedFalseTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseTest.Fruit>>();
 
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(2);
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandedFalseAsyncTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedFalseAsyncTest>();
+            var comp = Context.Render<DataGridGroupExpandedFalseAsyncTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseAsyncTest.Fruit>>();
 
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(2));
@@ -108,7 +108,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandedFalseServerDataTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedFalseServerDataTest>();
+            var comp = Context.Render<DataGridGroupExpandedFalseServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedFalseServerDataTest.Fruit>>();
 
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(2));
@@ -125,7 +125,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupCollapseAllTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupCollapseAllTest>();
+            var comp = Context.Render<DataGridGroupCollapseAllTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupCollapseAllTest.TestObject>>();
 
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(3);
@@ -144,7 +144,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupExpandAllCollapseAllTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandAllCollapseAllTest>();
+            var comp = Context.Render<DataGridGroupExpandAllCollapseAllTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandAllCollapseAllTest.Element>>();
 
             comp.FindAll("tbody .mud-table-row").Count.Should().Be(2);
@@ -167,7 +167,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldSetIsGenderGroupedToTrueWhenGroupingIsApplied()
         {
             // Render the DataGridGroupingTest component for testing.
-            var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
+            var comp = Context.Render<DataGridColumnGroupingTest>();
 
             // Attempt to find the MudPopoverProvider component within the rendered component.
             // MudPopoverProvider is used to manage popovers in the component, including the grouping popover.
@@ -204,7 +204,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public void DataGridServerGroupUngroupingTest()
         {
-            var comp = Context.RenderComponent<DataGridServerDataColumnGroupingTest>();
+            var comp = Context.Render<DataGridServerDataColumnGroupingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<Examples.Data.Models.Element>>();
             var popoverProvider = comp.FindComponent<MudPopoverProvider>();
 
@@ -259,12 +259,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridGroupingTestBoundAndUnboundScenarios()
         {
-            var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
+            var comp = Context.Render<DataGridColumnGroupingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnGroupingTest.Model>>();
             var popoverProvider = comp.FindComponent<MudPopoverProvider>();
 
-            IRefreshableElementCollection<IElement> Rows() => dataGrid.FindAll("tr");
-            IRefreshableElementCollection<IElement> Cells() => dataGrid.FindAll("td");
+            IReadOnlyList<IElement> Rows() => dataGrid.FindAll("tr");
+            IReadOnlyList<IElement> Cells() => dataGrid.FindAll("td");
 
             // Assert that initially, before any user interaction, IsGenderGrouped and IsAgeGrouped should be false
             // The default grouping is by name
@@ -399,7 +399,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridGrouping_ManualGroupByOrderTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnGroupingTest>();
+            var comp = Context.Render<DataGridColumnGroupingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnGroupingTest.Model>>();
             var popoverProvider = comp.FindComponent<MudPopoverProvider>();
 
@@ -462,7 +462,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridGroupedWithServerDataPaginationTest()
         {
-            var comp = Context.RenderComponent<DataGridGroupableServerDataTest>();
+            var comp = Context.Render<DataGridGroupableServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupableServerDataTest.Item>>();
             var rows = dataGrid.FindAll("tr");
             rows.Count.Should().Be(12, because: "1 header row + 10 data rows + 1 footer row");
@@ -548,7 +548,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task GroupExpandClick_ShouldToggleExpandedState()
         {
             // Arrange
-            var component = Context.RenderComponent<DataGridGroupingMultiLevelTest>();
+            var component = Context.Render<DataGridGroupingMultiLevelTest>();
 
             var dataGrid = component.FindComponent<MudDataGrid<DataGridGroupingMultiLevelTest.USState>>();
             await component.InvokeAsync(() => dataGrid.Instance.ReloadServerData());
@@ -583,7 +583,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_Grouping_TestGroupableSets()
         {
-            var component = Context.RenderComponent<DataGridGroupingMultiLevelTest>();
+            var component = Context.Render<DataGridGroupingMultiLevelTest>();
 
             var dataGrid = component.FindComponent<MudDataGrid<DataGridGroupingMultiLevelTest.USState>>();
             // by default has a groupdefinition
@@ -605,7 +605,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_Grouping_GroupDefinition()
         {
-            var component = Context.RenderComponent<DataGridGroupingMultiLevelTest>();
+            var component = Context.Render<DataGridGroupingMultiLevelTest>();
 
             var dataGrid = component.FindComponent<MudDataGrid<DataGridGroupingMultiLevelTest.USState>>();
             await component.InvokeAsync(() => dataGrid.Instance.ReloadServerData());
@@ -640,8 +640,8 @@ namespace MudBlazor.UnitTests.Components
         {
             // Tests the IsGrouping property of MudDataGrid to ensure it handles a change properly
             // and ensures the correct UI is rendered for column options
-            var provider = Context.RenderComponent<MudPopoverProvider>();
-            var comp = Context.RenderComponent<DataGridGroupExpandedTest>();
+            var provider = Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<DataGridGroupExpandedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
             provider.Should().NotBeNull();
             comp.WaitForAssertion(() => comp.FindAll("tbody .mud-table-row").Count.Should().Be(7));
@@ -673,7 +673,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGrid_Grouping_ByNull()
         {
-            var comp = Context.RenderComponent<DataGridGroupByNullTest>();
+            var comp = Context.Render<DataGridGroupByNullTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupByNullTest.Fruit>>();
             // until a change happens this bool tracks whether GroupExpanded is applied.
             dataGrid.Instance._groupInitialExpanded = true;
@@ -696,7 +696,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public async Task DataGridGroupingTemplateSetAtGridLevel()
         {
-            var component = Context.RenderComponent<DataGridGroupingMultiLevelTest>();
+            var component = Context.Render<DataGridGroupingMultiLevelTest>();
 
             var dataGrid = component.FindComponent<MudDataGrid<DataGridGroupingMultiLevelTest.USState>>();
             await component.InvokeAsync(() => dataGrid.Instance.ReloadServerData());
@@ -729,7 +729,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridGroupingTemplateDefault()
         {
             await Task.Yield();
-            var component = Context.RenderComponent<DataGridColumnGroupingTest>();
+            var component = Context.Render<DataGridColumnGroupingTest>();
 
             //grouping should be the built in default
             var groupRow = component.FindComponent<DataGridGroupRow<DataGridColumnGroupingTest.Model>>().Find(".mud-datagrid-group");
@@ -741,7 +741,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_MultilevelGrouping_ExpandSpecificNestedGroup()
         {
-            var comp = Context.RenderComponent<DataGridMultilevelGroupingNestedGroupExpansionTest>();
+            var comp = Context.Render<DataGridMultilevelGroupingNestedGroupExpansionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridMultilevelGroupingNestedGroupExpansionTest.Model>>();
             var subGroupColName = nameof(DataGridMultilevelGroupingNestedGroupExpansionTest.Model.SubGroup);
             var groupKey = new GroupKeyPath(["A", "X"]);

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -34,7 +34,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("")]
         public void DataGridPropertyNullCheck()
         {
-            var comp = Context.RenderComponent<DataGridPropertyColumnNullCheckTest>();
+            var comp = Context.Render<DataGridPropertyColumnNullCheckTest>();
             var cells = comp.FindAll("td").ToArray();
 
             // First Row
@@ -57,7 +57,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSortableTest()
         {
-            var comp = Context.RenderComponent<DataGridSortableTest>();
+            var comp = Context.Render<DataGridSortableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTest.Item>>();
 
             // Count the number of rows including header.
@@ -154,7 +154,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGirdWithServerDataAndVirtualize()
         {
-            var comp = Context.RenderComponent<DataGridServerDataWithVirtualizeTest>();
+            var comp = Context.Render<DataGridServerDataWithVirtualizeTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataWithVirtualizeTest.Item>>();
 
             // Count the number of rows including header.
@@ -174,7 +174,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSortableVirtualizeServerDataTest()
         {
-            var comp = Context.RenderComponent<DataGridSortableVirtualizeServerDataTest>();
+            var comp = Context.Render<DataGridSortableVirtualizeServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableVirtualizeServerDataTest.Item>>();
 
             // Count the number of rows including header.
@@ -270,7 +270,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSortableHeaderRowTest()
         {
-            var comp = Context.RenderComponent<DataGridSortableHeaderRowTest>();
+            var comp = Context.Render<DataGridSortableHeaderRowTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableHeaderRowTest.Item>>();
 
             // Count the number of rows including header.
@@ -296,7 +296,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSortableTemplateColumnTest()
         {
-            var comp = Context.RenderComponent<DataGridSortableTemplateColumnTest>();
+            var comp = Context.Render<DataGridSortableTemplateColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTemplateColumnTest.Item>>();
 
             // Count the number of rows including header.
@@ -370,7 +370,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFilterableVirtualizeServerDataTest()
         {
-            var comp = Context.RenderComponent<DataGridFilterableVirtualizeServerDataTest>();
+            var comp = Context.Render<DataGridFilterableVirtualizeServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterableVirtualizeServerDataTest.Item>>();
 
             // Count the number of rows including header.
@@ -400,7 +400,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFilterableTest()
         {
-            var comp = Context.RenderComponent<DataGridFilterableTest>();
+            var comp = Context.Render<DataGridFilterableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterableTest.Item>>();
 
             // Count the number of rows including header.
@@ -433,7 +433,7 @@ namespace MudBlazor.UnitTests.Components
             var serverDataFunc =
                 new Func<GridState<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                Context.RenderComponent<MudDataGrid<TestModel1>>(parameters => parameters
+                Context.Render<MudDataGrid<TestModel1>>(parameters => parameters
                     .Add(p => p.ServerData, serverDataFunc)
                     .Add(p => p.Items, Array.Empty<TestModel1>())
                 )
@@ -451,7 +451,7 @@ namespace MudBlazor.UnitTests.Components
             var serverDataFunc =
                 new Func<GridState<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                Context.RenderComponent<MudDataGrid<TestModel1>>(parameters => parameters
+                Context.Render<MudDataGrid<TestModel1>>(parameters => parameters
                     .Add(p => p.ServerData, serverDataFunc)
                     .Add(p => p.QuickFilter, (TestModel1 x) => true)
                 )
@@ -465,7 +465,7 @@ namespace MudBlazor.UnitTests.Components
             var virtualizeServerDataFunc =
                 new Func<GridStateVirtualize<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                Context.RenderComponent<MudDataGrid<TestModel1>>(parameters => parameters
+                Context.Render<MudDataGrid<TestModel1>>(parameters => parameters
                     .Add(p => p.VirtualizeServerData, virtualizeServerDataFunc)
                     .Add(p => p.QuickFilter, (TestModel1 x) => true)
                 )
@@ -481,7 +481,7 @@ namespace MudBlazor.UnitTests.Components
             var virtualizeServerDataFunc =
                 new Func<GridStateVirtualize<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                Context.RenderComponent<MudDataGrid<TestModel1>>(parameters => parameters
+                Context.Render<MudDataGrid<TestModel1>>(parameters => parameters
                     .Add(p => p.ServerData, serverDataFunc)
                     .Add(p => p.VirtualizeServerData, virtualizeServerDataFunc)
                 )
@@ -500,7 +500,7 @@ namespace MudBlazor.UnitTests.Components
             var virtualizeServerDataFunc =
                 new Func<GridStateVirtualize<TestModel1>, CancellationToken, Task<GridData<TestModel1>>>((x, c) => throw new NotImplementedException());
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                Context.RenderComponent<MudDataGrid<TestModel1>>(parameters => parameters
+                Context.Render<MudDataGrid<TestModel1>>(parameters => parameters
                     .Add(p => p.Items, Array.Empty<TestModel1>())
                     .Add(p => p.VirtualizeServerData, virtualizeServerDataFunc)
                 )
@@ -516,7 +516,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFilterableServerDataTest()
         {
-            var comp = Context.RenderComponent<DataGridFilterableServerDataTest>();
+            var comp = Context.Render<DataGridFilterableServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterableServerDataTest.Item>>();
 
             // Count the number of rows including header.
@@ -549,7 +549,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCustomComparerTest()
         {
-            var comp = Context.RenderComponent<DataGridSelectionComparerTest>();
+            var comp = Context.Render<DataGridSelectionComparerTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionComparerTest.Person>>();
 
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
@@ -571,7 +571,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSingleSelectionTest()
         {
-            var comp = Context.RenderComponent<DataGridSingleSelectionTest>();
+            var comp = Context.Render<DataGridSingleSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSingleSelectionTest.Item>>();
 
             dataGrid.Instance.GetState(x => x.SelectedItems).Count.Should().Be(0);
@@ -601,7 +601,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridMultiSelectionTest()
         {
-            var comp = Context.RenderComponent<DataGridMultiSelectionTest>();
+            var comp = Context.Render<DataGridMultiSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridMultiSelectionTest.Item>>();
 
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
@@ -632,7 +632,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridMultiSelectionTest_Should_Not_Render_Footer_If_ShowInFooter_Is_False()
         {
-            var comp = Context.RenderComponent<DataGridMultiSelectionTest>(parameters => parameters
+            var comp = Context.Render<DataGridMultiSelectionTest>(parameters => parameters
                 .Add(p => p.ShowInFooter, false));
             comp.FindAll("td.footer-cell").Should().BeEmpty();
         }
@@ -640,7 +640,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSelectAllWithFilterTest()
         {
-            var comp = Context.RenderComponent<DataGridMultiSelectionTest>();
+            var comp = Context.Render<DataGridMultiSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridMultiSelectionTest.Item>>();
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4, because: "all four rows shown by default");
@@ -680,7 +680,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridServerMultiSelectionTest()
         {
-            var comp = Context.RenderComponent<DataGridServerMultiSelectionTest>();
+            var comp = Context.Render<DataGridServerMultiSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerMultiSelectionTest.Item>>();
 
             dataGrid.Instance.SelectedItems.Count.Should().Be(0);
@@ -711,7 +711,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridEditableSelectionTest()
         {
-            var comp = Context.RenderComponent<DataGridEditableWithSelectColumnTest>();
+            var comp = Context.Render<DataGridEditableWithSelectColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditableWithSelectColumnTest.Item>>();
 
             // test that all rows, header and footer have cell with a checkbox
@@ -736,7 +736,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridInlineEditVirtualizeServerDataTest()
         {
-            var comp = Context.RenderComponent<DataGridCellEditVirtualizeServerDataTest>();
+            var comp = Context.Render<DataGridCellEditVirtualizeServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditVirtualizeServerDataTest.Item>>();
 
             dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
@@ -758,7 +758,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridVirtualizeServerDataLoadingWithCancelTest()
         {
-            var comp = Context.RenderComponent<DataGridVirtualizeServerDataLoadingWithCancelTest>();
+            var comp = Context.Render<DataGridVirtualizeServerDataLoadingWithCancelTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<int>>();
 
             // Make a cancellation token we can monitor
@@ -801,7 +801,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridPaginationTest()
         {
-            var comp = Context.RenderComponent<DataGridPaginationTest>();
+            var comp = Context.Render<DataGridPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
             // check that the page size dropdown is shown
             comp.FindComponents<MudSelect<int>>().Count.Should().Be(1);
@@ -838,7 +838,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridPaginationPageSizeDropDownTest()
         {
-            var comp = Context.RenderComponent<DataGridPaginationTest>(self => self.Add(x => x.PageSizeDropDown, false));
+            var comp = Context.Render<DataGridPaginationTest>(self => self.Add(x => x.PageSizeDropDown, false));
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
             dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
 
@@ -855,7 +855,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridPagingAllTest()
         {
-            var comp = Context.RenderComponent<DataGridPaginationAllItemsTest>();
+            var comp = Context.Render<DataGridPaginationAllItemsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationAllItemsTest.Item>>();
             var pager = comp.FindComponent<MudSelect<int>>().Instance;
 
@@ -877,7 +877,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridPaginationNoItemsTest()
         {
-            var comp = Context.RenderComponent<DataGridPaginationNoItemsTest>();
+            var comp = Context.Render<DataGridPaginationNoItemsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationNoItemsTest.Item>>();
             // check that the page size dropdown is shown
             comp.FindComponents<MudSelect<int>>().Count.Should().Be(1);
@@ -888,7 +888,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridHideNavigationTest()
         {
-            var comp = Context.RenderComponent<DataGridPaginationTest>();
+            var comp = Context.Render<DataGridPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
             var pagerContent = comp.FindComponent<MudDataGridPager<DataGridPaginationTest.Item>>();
 
@@ -904,7 +904,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridRowsPerPageTwoWayBindingTest()
         {
-            var comp = Context.RenderComponent<DataGridRowsPerPageBindingTest>();
+            var comp = Context.Render<DataGridRowsPerPageBindingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridRowsPerPageBindingTest.Item>>();
 
             // confirm that BoundRowsPerPage is equal to the initial value of 5 (See DataGridRowsPerPageBindingTest)
@@ -920,7 +920,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridInlineEditTest()
         {
-            var comp = Context.RenderComponent<DataGridCellEditTest>();
+            var comp = Context.Render<DataGridCellEditTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditTest.Model>>();
 
             dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
@@ -943,7 +943,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridInlineEditWithNullableChangeTest()
         {
-            var comp = Context.RenderComponent<DataGridCellEditWithNullableTest>();
+            var comp = Context.Render<DataGridCellEditWithNullableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithNullableTest.Model>>();
 
             // try setting a value to null
@@ -958,7 +958,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridInlineEditWithNullableTest()
         {
-            var comp = Context.RenderComponent<DataGridCellEditWithNullableTest>();
+            var comp = Context.Render<DataGridCellEditWithNullableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithNullableTest.Model>>();
 
             dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
@@ -981,7 +981,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridInlineEditWithTemplateTest()
         {
-            var comp = Context.RenderComponent<DataGridCellEditWithTemplateTest>();
+            var comp = Context.Render<DataGridCellEditWithTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellEditWithTemplateTest.Model>>();
 
             dataGrid.FindAll("td input")[0].GetAttribute("value").Trim().Should().Be("John");
@@ -1011,7 +1011,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridDialogEditTest()
         {
-            var comp = Context.RenderComponent<DataGridFormEditTest>();
+            var comp = Context.Render<DataGridFormEditTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditTest.Model>>();
 
             //verify values before opening dialog
@@ -1052,7 +1052,7 @@ namespace MudBlazor.UnitTests.Components
         [Test(Description = "Checks if there is no NRE exception when nested property has a null value somewhere in the middle.")]
         public void DataGridNoNullExceptionWhenNestedPropertyNullValue()
         {
-            var comp = Context.RenderComponent<DataGridNestedNullPropertyTest>();
+            var comp = Context.Render<DataGridNestedNullPropertyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridNestedNullPropertyTest.Model>>();
             dataGrid.FindAll("td")[0].Html().Trim().Should().Be("Class A");
             dataGrid.FindAll("td")[1].Html().Trim().Should().Be(string.Empty);
@@ -1065,7 +1065,7 @@ namespace MudBlazor.UnitTests.Components
         [Test(Description = "Checks if clone strategy is working, if we used default one it would fail as STJ doesn't support abstract classes without additional configuration.")]
         public void DataGridDialogEditCloneStrategyTest1()
         {
-            var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>();
+            var comp = Context.Render<DataGridFormEditCloneStrategyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
 
             dataGrid.FindAll("td")[0].Html().Trim().Should().Be("James");
@@ -1101,7 +1101,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridDialogEditCloneStrategyTest2()
         {
-            var comp = Context.RenderComponent<DataGridFormEditCloneStrategyTest>(parameters => parameters
+            var comp = Context.Render<DataGridFormEditCloneStrategyTest>(parameters => parameters
                 .Add(p => p.CloneStrategy, SystemTextJsonDeepCloneStrategy<DataGridFormEditCloneStrategyTest.Movement>.Instance));
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormEditCloneStrategyTest.Movement>>();
 
@@ -1126,7 +1126,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridFormFieldChangedTest()
         {
-            var comp = Context.RenderComponent<DataGridFormFieldChangedTest>();
+            var comp = Context.Render<DataGridFormFieldChangedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormFieldChangedTest.Item>>();
             //open edit dialog
             dataGrid.FindAll("tbody tr")[0].Click();
@@ -1142,7 +1142,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridFormValidationErrorsPreventUpdateTest()
         {
-            var comp = Context.RenderComponent<DataGridFormValidationErrorsPreventUpdateTest>();
+            var comp = Context.Render<DataGridFormValidationErrorsPreventUpdateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormValidationErrorsPreventUpdateTest.Model>>();
 
             // open form dialog
@@ -1173,7 +1173,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridVisualStylingTest()
         {
-            var comp = Context.RenderComponent<DataGridVisualStylingTest>();
+            var comp = Context.Render<DataGridVisualStylingTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridVisualStylingTest.Item>>();
 
             dataGrid.FindAll("td")[1].GetAttribute("style").Should().Contain("background-color:#E5BDE5");
@@ -1190,7 +1190,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridEventCallbacksTest()
         {
-            var comp = Context.RenderComponent<DataGridEventCallbacksTest>();
+            var comp = Context.Render<DataGridEventCallbacksTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEventCallbacksTest.Item>>();
 
             // Include callbacks in test coverage.
@@ -1251,7 +1251,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridEditComplexPropertyExpressionTest()
         {
-            var comp = Context.RenderComponent<DataGridEditComplexPropertyExpressionTest>();
+            var comp = Context.Render<DataGridEditComplexPropertyExpressionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditComplexPropertyExpressionTest.Item>>();
 
 
@@ -1278,7 +1278,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridOnContextMenuClickWhenIsGrouped()
         {
-            var comp = Context.RenderComponent<DataGridGroupExpandedTest>();
+            var comp = Context.Render<DataGridGroupExpandedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
 
             // Include callbacks in test coverage.
@@ -1300,7 +1300,7 @@ namespace MudBlazor.UnitTests.Components
             // Disable simulated load on server side:
             TestComponents.DataGrid.DataGridServerSideSortableTest.DisableServerTimeoutForTests = true;
 
-            var comp = Context.RenderComponent<DataGridServerSideSortableTest>();
+            var comp = Context.Render<DataGridServerSideSortableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerSideSortableTest.Item>>();
 
             var cells = dataGrid.FindAll("td");
@@ -1360,7 +1360,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FilterDefinitionStringTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             var nameColumn = dataGrid.Instance.GetColumnByPropertyName("Name");
 
@@ -1809,7 +1809,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FilterDefinitionBoolTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             var hiredColumn = dataGrid.Instance.GetColumnByPropertyName("Hired");
 
@@ -1865,7 +1865,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FilterDefinitionEnumTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             var statusColumn = dataGrid.Instance.GetColumnByPropertyName("Status");
 
@@ -1954,7 +1954,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FilterDefinitionDateTimeTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             var dateColumn = dataGrid.Instance.GetColumnByPropertyName("HiredOn");
             var utcnow = DateTime.UtcNow;
@@ -2225,7 +2225,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FilterDefinitionDateOnlyTest()
         {
-            var comp = Context.RenderComponent<DataGridDateOnlyFilterTest>();
+            var comp = Context.Render<DataGridDateOnlyFilterTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridDateOnlyFilterTest.Model>>();
             var dateColumn = dataGrid.Instance.GetColumnByPropertyName("HiredOn");
             var testDate = new DateOnly(2020, 3, 10);
@@ -2504,7 +2504,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FilterDefinitionNumberTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             var ageColumn = dataGrid.Instance.GetColumnByPropertyName("Age");
 
@@ -2726,7 +2726,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FilterDefinitionReplaceWithCustom()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             dataGrid.Instance.SetDefaultFilterDefinition<CustomFilterDefinitionMock<DataGridFiltersTest.Model>>();
 
@@ -2747,7 +2747,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridClickFilterButtonTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             IElement FilterButton() => dataGrid.FindAll(".filter-button")[0];
 
@@ -2767,7 +2767,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridCloseFiltersTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
             IElement FilterButton() => dataGrid.FindAll(".filter-button")[0];
 
@@ -2822,7 +2822,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFiltersTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
 
             // test filter definition on the Name property (string contains)
@@ -3013,7 +3013,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFilterRemoveAsyncTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
 
             var filterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
@@ -3035,7 +3035,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridFilterFieldChangedTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
 
             var filterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
@@ -3057,7 +3057,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridFilterPerColumnTest()
         {
-            var comp = Context.RenderComponent<DataGridFilterPerColumnTest>();
+            var comp = Context.Render<DataGridFilterPerColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterPerColumnTest.Model>>();
 
             IElement FirstnameFilterButton() => dataGrid.FindAll(".filter-button")[0];
@@ -3089,7 +3089,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridInvalidFilterPerColumnTest()
         {
-            var exception = Assert.Throws<ArgumentException>(() => Context.RenderComponent<DataGridFilterPerColumnTest>(parameters => parameters.Add(x => x.AddInvalid, true)));
+            var exception = Assert.Throws<ArgumentException>(() => Context.Render<DataGridFilterPerColumnTest>(parameters => parameters.Add(x => x.AddInvalid, true)));
 
             exception.Message.Should().Be("Invalid filter operators for Severity: <");
         }
@@ -3097,7 +3097,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridIDictionaryFiltersTest()
         {
-            var comp = Context.RenderComponent<DataGridIDictionaryFiltersTest>();
+            var comp = Context.Render<DataGridIDictionaryFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<IDictionary<string, object>>>();
 
             // test filter definition on the Name property (string contains)
@@ -3157,7 +3157,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridColGroupTest()
         {
-            var comp = Context.RenderComponent<DataGridColGroupTest>();
+            var comp = Context.Render<DataGridColGroupTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColGroupTest.Model>>();
 
             dataGrid.FindAll("col").Count.Should().Be(3);
@@ -3166,7 +3166,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColReorderRowFiltersTest()
         {
-            var comp = Context.RenderComponent<DataGridColReorderRowFiltersTest>();
+            var comp = Context.Render<DataGridColReorderRowFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColReorderRowFiltersTest.Model>>();
 
             await comp.InvokeAsync(() =>
@@ -3195,7 +3195,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColReorderRowModifiedFiltersTest()
         {
-            var comp = Context.RenderComponent<DataGridColReorderRowFiltersTest>();
+            var comp = Context.Render<DataGridColReorderRowFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColReorderRowFiltersTest.Model>>();
 
             await comp.InvokeAsync(async () =>
@@ -3234,7 +3234,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridHeaderTemplateTest()
         {
-            var comp = Context.RenderComponent<DataGridHeaderTemplateTest>();
+            var comp = Context.Render<DataGridHeaderTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHeaderTemplateTest.Model>>();
 
             dataGrid.Find("thead th").TextContent.Trim().Should().Be("test");
@@ -3246,7 +3246,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridRowDetailOpenTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance
@@ -3258,7 +3258,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridRowDetailClosedTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             dataGrid.FindAll("td").SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Sam|56|Normal|")).Should().BeNull();
@@ -3267,7 +3267,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_RowDetail_ExpandCollapseAllTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             dataGrid.WaitForAssertion(() => dataGrid.Instance._openHierarchies.Count.Should().Be(2));
@@ -3281,7 +3281,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGrid_RowDetail_ExpandCollapseAllWithOneTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(p => p
+            var comp = Context.Render<DataGridHierarchyColumnTest>(p => p
                 .Add(x => x.LimitRowsToOne, true)
                 .Add(x => x.EnableHeaderToggle, true)
             );
@@ -3300,7 +3300,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void DataGrid_RowDetail_RTL_GroupIcon(bool rightToLeft)
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(param => param
+            var comp = Context.Render<DataGridHierarchyColumnTest>(param => param
                 .Add(p => p.RightToLeft, rightToLeft)
             );
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
@@ -3323,7 +3323,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridRowDetailButtonDisabledTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             dataGrid.FindAll("button")[10].OuterHtml.Contains("disabled")
@@ -3333,7 +3333,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridRowDetailButtonDisabledClickTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             await comp.InvokeAsync(() =>
@@ -3349,7 +3349,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridChildRowContentTest()
         {
-            var comp = Context.RenderComponent<DataGridChildRowContentTest>();
+            var comp = Context.Render<DataGridChildRowContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridChildRowContentTest.Model>>();
 
             dataGrid.FindAll("td").SingleOrDefault(x => x.TextContent.Trim().StartsWith("uid = Sam|56|Normal|")).Should().NotBeNull();
@@ -3358,7 +3358,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridLoadingContentTest()
         {
-            var comp = Context.RenderComponent<DataGridLoadingContentTest>();
+            var comp = Context.Render<DataGridLoadingContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridLoadingContentTest.Model>>();
 
             dataGrid.Find("th.mud-table-empty-row div").TextContent.Trim().Should().Be("Data loading, please wait...");
@@ -3371,7 +3371,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridLoadingProgressTest()
         {
             // Render the component
-            var comp = Context.RenderComponent<DataGridLoadingProgressTest>();
+            var comp = Context.Render<DataGridLoadingProgressTest>();
 
             // Initial count of header and body rows
             var initialHeaderRows = comp.FindAll("thead tr");
@@ -3398,7 +3398,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridNoRecordsContentTest()
         {
-            var comp = Context.RenderComponent<DataGridNoRecordsContentTest>();
+            var comp = Context.Render<DataGridNoRecordsContentTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridNoRecordsContentTest.Model>>();
 
             dataGrid.Find("th.mud-table-empty-row div").TextContent.Trim().Should().Be("There are no records to view.");
@@ -3407,7 +3407,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridNoRecordsContentVirtualizeTest()
         {
-            var comp = Context.RenderComponent<DataGridNoRecordsContentVirtualizeTest>();
+            var comp = Context.Render<DataGridNoRecordsContentVirtualizeTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridNoRecordsContentVirtualizeTest.Model>>();
 
             dataGrid.Find("th.mud-table-empty-row div").TextContent.Trim().Should().Be("There are no records to view.");
@@ -3416,7 +3416,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridFooterTemplateTest()
         {
-            var comp = Context.RenderComponent<DataGridFooterTemplateTest>();
+            var comp = Context.Render<DataGridFooterTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFooterTemplateTest.Model>>();
 
             dataGrid.FindAll("tfoot td").First().TextContent.Trim().Should().Be("Names: Sam, Alicia, Ira, John");
@@ -3426,7 +3426,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridServerPaginationTest()
         {
-            var comp = Context.RenderComponent<DataGridServerPaginationTest>();
+            var comp = Context.Render<DataGridServerPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerPaginationTest.Model>>();
 
             // test that we are on the first page of results
@@ -3450,7 +3450,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<DataGridServerPaginationTest>();
+            var comp = Context.Render<DataGridServerPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerPaginationTest.Model>>();
             await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CurrentPage, 2));
             var serverDataCallCount = 0;
@@ -3473,7 +3473,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCellTemplateTest()
         {
-            var comp = Context.RenderComponent<DataGridCellTemplateTest>();
+            var comp = Context.Render<DataGridCellTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellTemplateTest.Model>>();
 
             dataGrid.FindAll("td")[0].TextContent.Trim().Should().Be("John");
@@ -3483,7 +3483,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColumnChooserTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnChooserTest>();
+            var comp = Context.Render<DataGridColumnChooserTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnChooserTest.Model>>();
             var popoverProvider = comp.FindComponent<MudPopoverProvider>();
 
@@ -3555,7 +3555,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColumnHiddenTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnHiddenTest>();
+            var comp = Context.Render<DataGridColumnHiddenTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnHiddenTest.Model>>();
 
             var popoverProvider = comp.FindComponent<MudPopoverProvider>();
@@ -3639,7 +3639,7 @@ namespace MudBlazor.UnitTests.Components
         //[Test]
         //public async Task DataGridFilterRowHiddenTest()
         //{
-        //    var comp = Context.RenderComponent<DataGridFilterRowHiddenTest>();
+        //    var comp = Context.Render<DataGridFilterRowHiddenTest>();
         //    var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterRowHiddenTest.Model>>();
 
         //    //there should be only one filter cell visible
@@ -3690,7 +3690,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridShowMenuIconTest()
         {
-            var comp = Context.RenderComponent<DataGridShowMenuIconTest>();
+            var comp = Context.Render<DataGridShowMenuIconTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridShowMenuIconTest.Item>>();
             dataGrid.FindAll(".mud-table-toolbar .mud-menu").Should().BeEmpty();
             await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ShowMenuIcon, true));
@@ -3700,7 +3700,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColumnPopupFilteringTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnPopupFilteringTest>();
+            var comp = Context.Render<DataGridColumnPopupFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnPopupFilteringTest.Model>>();
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
@@ -3727,7 +3727,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridColumnShowFilterIconsTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnShowFilterIconsTest>();
+            var comp = Context.Render<DataGridColumnShowFilterIconsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnShowFilterIconsTest.Model>>();
 
             // Should have 5 columns, but only two with filter icons
@@ -3738,7 +3738,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColumnPopupFilteringEmptyTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnPopupFilteringTest>();
+            var comp = Context.Render<DataGridColumnPopupFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnPopupFilteringTest.Model>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilter());
@@ -3751,7 +3751,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColumnPopupFilteringIntentionalEmptyTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnPopupFilteringTest>();
+            var comp = Context.Render<DataGridColumnPopupFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnPopupFilteringTest.Model>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilter());
@@ -3765,7 +3765,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridFilterableFalseTest()
         {
-            var comp = Context.RenderComponent<DataGridFilterableFalseTest>();
+            var comp = Context.Render<DataGridFilterableFalseTest>();
 
             comp.Find(".filter-button").Click();
             comp.FindAll(".filters-panel").Count.Should().Be(1);
@@ -3777,7 +3777,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridColumnPopupCustomFilteringTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnPopupCustomFilteringTest>();
+            var comp = Context.Render<DataGridColumnPopupCustomFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnPopupCustomFilteringTest.Model>>();
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
@@ -3795,7 +3795,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridCustomFilteringTest()
         {
-            var comp = Context.RenderComponent<DataGridCustomFilteringTest>();
+            var comp = Context.Render<DataGridCustomFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomFilteringTest.Model>>();
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
@@ -3812,7 +3812,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridCustomPropertyFilterTemplateTest()
         {
-            var comp = Context.RenderComponent<DataGridCustomPropertyFilterTemplateTest>();
+            var comp = Context.Render<DataGridCustomPropertyFilterTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomPropertyFilterTemplateTest.Model>>();
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
@@ -3833,7 +3833,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridCustomPropertyFilterTemplateApplyFilterTwiceTest()
         {
-            var comp = Context.RenderComponent<DataGridCustomPropertyFilterTemplateTest>();
+            var comp = Context.Render<DataGridCustomPropertyFilterTemplateTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomPropertyFilterTemplateTest.Model>>();
 
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
@@ -3859,7 +3859,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridShowFilterIconTest()
         {
-            var comp = Context.RenderComponent<DataGridCustomFilteringTest>();
+            var comp = Context.Render<DataGridCustomFilteringTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomFilteringTest.Model>>();
             await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Filterable, false));
             dataGrid.Instance.DropContainerHasChanged();
@@ -3875,7 +3875,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridServerDataColumnFilterMenuTest()
         {
-            var comp = Context.RenderComponent<DataGridServerDataColumnFilterMenuTest>();
+            var comp = Context.Render<DataGridServerDataColumnFilterMenuTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataColumnFilterMenuTest.Model>>();
             var callCountText = comp.FindComponent<MudText>();
             dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(4);
@@ -3898,7 +3898,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGrid_ColumnFilterMenu_OpensAtCursorPosition()
         {
             // https://github.com/MudBlazor/MudBlazor/issues/11518
-            var comp = Context.RenderComponent<DataGridServerDataColumnFilterMenuTest>();
+            var comp = Context.Render<DataGridServerDataColumnFilterMenuTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataColumnFilterMenuTest.Model>>();
 
             dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(4);
@@ -3916,7 +3916,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridServerDataColumnFilterMenuApplyTwiceTest()
         {
-            var comp = Context.RenderComponent<DataGridServerDataColumnFilterMenuTest>();
+            var comp = Context.Render<DataGridServerDataColumnFilterMenuTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataColumnFilterMenuTest.Model>>();
 
             dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(4);
@@ -3942,7 +3942,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridServerDataColumnFilterRowTest()
         {
-            var comp = Context.RenderComponent<DataGridServerDataColumnFilterRowTest>();
+            var comp = Context.Render<DataGridServerDataColumnFilterRowTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridServerDataColumnFilterRowTest.Model>>();
             var callCountText = comp.FindComponent<MudText>();
             dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(4);
@@ -3962,7 +3962,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridColumnFilterRowPropertyTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
+            var comp = Context.Render<DataGridColumnFilterRowPropertyTest>();
 
             Assert.DoesNotThrow(() => comp.FindComponent<MudTextField<string>>());
             Assert.DoesNotThrow(() => comp.FindComponent<MudNumericField<double?>>());
@@ -3974,14 +3974,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridColumnFilterRowPropertyClearTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
+            var comp = Context.Render<DataGridColumnFilterRowPropertyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterRowPropertyTest.Model>>();
 
             var inputsBefore = dataGrid.FindAll("input").OfType<IHtmlInputElement>().Select(e => e.Value).ToList();
             var hireDate = new DateTime(2011, 1, 2).ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern, CultureInfo.CurrentCulture);
             inputsBefore.Should().BeEquivalentTo("Ira", "27", "Success", "True", hireDate, "00:00");
 
-            IRefreshableElementCollection<IElement> ClearButtons() => dataGrid.FindAll(".align-self-center");
+            IReadOnlyList<IElement> ClearButtons() => dataGrid.FindAll(".align-self-center");
             ClearButtons().Should().HaveCount(5);
             ClearAllFiltersOneByOne();
 
@@ -4006,7 +4006,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridColumnFilterRowPropertyClearAllTest()
         {
-            var comp = Context.RenderComponent<DataGridColumnFilterRowPropertyTest>();
+            var comp = Context.Render<DataGridColumnFilterRowPropertyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterRowPropertyTest.Model>>();
 
             var inputsBefore = dataGrid.FindAll("input").OfType<IHtmlInputElement>().Select(e => e.Value).ToList();
@@ -4022,7 +4022,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridStickyColumnsTest()
         {
-            var comp = Context.RenderComponent<DataGridStickyColumnsTest>();
+            var comp = Context.Render<DataGridStickyColumnsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridStickyColumnsTest.Model>>();
 
             dataGrid.Find("th").ClassList.Should().Contain("sticky-left");
@@ -4032,7 +4032,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridStickyColumnsResizerTest()
         {
-            var comp = Context.RenderComponent<DataGridStickyColumnsResizerTest>();
+            var comp = Context.Render<DataGridStickyColumnsResizerTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridStickyColumnsResizerTest.Model>>();
 
             var header = dataGrid.Find(".mud-table-toolbar");
@@ -4054,7 +4054,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridCellContextTest()
         {
-            var comp = Context.RenderComponent<DataGridCellContextTest>();
+            var comp = Context.Render<DataGridCellContextTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellContextTest.Model>>();
 
             var item = dataGrid.Instance.Items.FirstOrDefault();
@@ -4077,7 +4077,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridAggregationTest()
         {
-            var comp = Context.RenderComponent<DataGridAggregationTest>();
+            var comp = Context.Render<DataGridAggregationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridAggregationTest.Model>>();
 
             dataGrid.FindAll("td.footer-cell")[1].TrimmedText().Should().Be("Average age is 56");
@@ -4088,7 +4088,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridSequenceContainsNoElementsTest()
         {
             // Arrange & Act
-            var component = Context.RenderComponent<DataGridSequenceContainsNoElementsTest>();
+            var component = Context.Render<DataGridSequenceContainsNoElementsTest>();
             var dataGridComponent = () => component.FindComponent<MudDataGrid<DataGridSequenceContainsNoElementsTest.Model>>();
 
             // This test will result in an error if the 'sequence contains no elements' issue is present.
@@ -4099,7 +4099,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridObservabilityTest()
         {
-            var comp = Context.RenderComponent<DataGridObservabilityTest>();
+            var comp = Context.Render<DataGridObservabilityTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridObservabilityTest.Model>>();
 
             var addButton = comp.Find(".add-item-btn");
@@ -4127,7 +4127,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var sup = Context.RenderComponent<DataGridObservabilityTest>();
+            var sup = Context.Render<DataGridObservabilityTest>();
             var comp = sup.Instance;
             var dataGrid = sup.FindComponent<MudDataGrid<DataGridObservabilityTest.Model>>();
 
@@ -4157,7 +4157,7 @@ namespace MudBlazor.UnitTests.Components
 
         public void TableFilterGuid()
         {
-            var comp = Context.RenderComponent<DataGridFilterGuid<Guid>>();
+            var comp = Context.Render<DataGridFilterGuid<Guid>>();
             var grid = comp.Instance.MudGridRef;
 
             grid.Items.Count().Should().Be(2);
@@ -4196,7 +4196,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableFilterNullableGuid()
         {
-            var comp = Context.RenderComponent<DataGridFilterGuid<Guid?>>();
+            var comp = Context.Render<DataGridFilterGuid<Guid?>>();
             var grid = comp.Instance.MudGridRef;
 
             grid.Items.Count().Should().Be(2);
@@ -4239,7 +4239,7 @@ namespace MudBlazor.UnitTests.Components
         //[Test]
         //public async Task TableFilterGuidInDictionary()
         //{
-        //    var comp = Context.RenderComponent<DataGridFilterDictionaryGuid>();
+        //    var comp = Context.Render<DataGridFilterDictionaryGuid>();
         //    var grid = comp.Instance.MudGridRef;
 
         //    grid.Items.Count().Should().Be(2);
@@ -4278,7 +4278,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCultureColumnSimpleTest()
         {
-            var comp = Context.RenderComponent<DataGridCultureSimpleTest>();
+            var comp = Context.Render<DataGridCultureSimpleTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureSimpleTest.Model>>();
 
             dataGrid.FindAll("td")[2].TextContent.Trim().Should().Be("3.5");
@@ -4288,7 +4288,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCultureColumnEditableTest()
         {
-            var comp = Context.RenderComponent<DataGridCultureEditableTest>();
+            var comp = Context.Render<DataGridCultureEditableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
 
             dataGrid.FindAll("td input")[2].GetAttribute("value").Trim().Should().Be("3.5");
@@ -4298,7 +4298,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCultureColumnFilterTest()
         {
-            var comp = Context.RenderComponent<DataGridCultureSimpleTest>();
+            var comp = Context.Render<DataGridCultureSimpleTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureSimpleTest.Model>>();
 
             // amount with invariant culture (decimals separated by point)
@@ -4339,7 +4339,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCultureColumnFilterHeaderTest()
         {
-            var comp = Context.RenderComponent<DataGridCultureEditableTest>();
+            var comp = Context.Render<DataGridCultureEditableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
 
             // amount with invariant culture (decimals separated by point)
@@ -4371,7 +4371,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridCultureColumnOverridesTest()
         {
-            var comp = Context.RenderComponent<DataGridCulturesTest>();
+            var comp = Context.Render<DataGridCulturesTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCulturesTest.Model>>();
 
             // amount with invariant culture (decimals separated by point)
@@ -4385,7 +4385,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSortIndicatorTest()
         {
-            var comp = Context.RenderComponent<DataGridSortableTest>();
+            var comp = Context.Render<DataGridSortableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTest.Item>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Value", SortDirection.Ascending, x => x.Value));
@@ -4414,7 +4414,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridParentAndChildSamePropertyNameSortTest()
         {
-            var comp = Context.RenderComponent<DataGridChildPropertiesWithSameNameSortTest>();
+            var comp = Context.Render<DataGridChildPropertiesWithSameNameSortTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridChildPropertiesWithSameNameSortTest.Employee>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Manager.Name", SortDirection.Ascending, x => x.Manager.Name));
@@ -4437,7 +4437,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridCustomSortTest()
         {
-            var comp = Context.RenderComponent<DataGridCustomSortableTest>();
+            var comp = Context.Render<DataGridCustomSortableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridCustomSortableTest.Item>>();
             await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.SortMode, SortMode.Single));
             dataGrid.Instance.SortMode.Should().Be(SortMode.Single);
@@ -4519,7 +4519,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridPropertyColumnFormatTest()
         {
-            var comp = Context.RenderComponent<DataGridFormatTest>();
+            var comp = Context.Render<DataGridFormatTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFormatTest.Employee>>();
 
             comp.FindAll("tbody.mud-table-body td")[3].TextContent.Should().Be("$87,000.00");
@@ -4534,7 +4534,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFilteredItemsCacheTest()
         {
-            var comp = Context.RenderComponent<DataGridSortableTest>();
+            var comp = Context.Render<DataGridSortableTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTest.Item>>();
 
             var initialFilterCount = dataGrid.Instance.FilteringRunCount;
@@ -4581,7 +4581,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridMultiSelectOnRowClickTest()
         {
-            var comp = Context.RenderComponent<DataGridMultiSelectionTest>();
+            var comp = Context.Render<DataGridMultiSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridMultiSelectionTest.Item>>();
 
             // click on the first row
@@ -4612,7 +4612,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSingleSelectOnRowClickTest()
         {
-            var comp = Context.RenderComponent<DataGridSingleSelectionTest>();
+            var comp = Context.Render<DataGridSingleSelectionTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridSingleSelectionTest.Item>>();
 
             // click on the first row
@@ -4648,7 +4648,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridDragAndDropTest()
         {
-            var comp = Context.RenderComponent<DataGridDragAndDropTest>();
+            var comp = Context.Render<DataGridDragAndDropTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridDragAndDropTest.Model>>();
             dataGrid.Instance.DropContainerHasChanged();
 
@@ -4689,7 +4689,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridEditFormDialogIsCustomizableTest()
         {
-            var comp = Context.RenderComponent<DataGridEditFormCustomizedDialogTest>();
+            var comp = Context.Render<DataGridEditFormCustomizedDialogTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditFormCustomizedDialogTest.Model>>();
 
             //open edit dialog
@@ -4708,7 +4708,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridDragAndDropWithDynamicColumnsTest()
         {
-            var comp = Context.RenderComponent<DataGridDragAndDropWithDynamicColumnsTest>();
+            var comp = Context.Render<DataGridDragAndDropWithDynamicColumnsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridDragAndDropWithDynamicColumnsTest.Model>>();
             dataGrid.Instance.DropContainerHasChanged();
 
@@ -4749,7 +4749,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridRedundantMenuTest()
         {
-            var comp = Context.RenderComponent<DataGridRedundantMenuTest>();
+            var comp = Context.Render<DataGridRedundantMenuTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridRedundantMenuTest.Model>>();
 
             await dataGrid.SetParametersAndRenderAsync(parameters => parameters
@@ -4766,7 +4766,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridDynamicColumnsTest()
         {
-            var comp = Context.RenderComponent<DataGridDynamicColumnsTest>();
+            var comp = Context.Render<DataGridDynamicColumnsTest>();
 
             comp.Instance.GridRenderedColumnsCount.Should().Be(0);
 
@@ -4786,7 +4786,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridSelectColumnTest()
         {
-            var comp = Context.RenderComponent<DataGridSelectColumnTest>();
+            var comp = Context.Render<DataGridSelectColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<int>>();
             var rowCheckbox = dataGrid.FindAll("td input");
             var selectAllCheckboxes = dataGrid.FindComponents<MudCheckBox<bool?>>();
@@ -4818,7 +4818,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FilterDefinitionTestHasFilterProperty()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
 
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFiltersTest.Model>
@@ -4849,7 +4849,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<DataGridHideAndResizeTest>();
+            var comp = Context.Render<DataGridHideAndResizeTest>();
             var dgComp = comp.FindComponent<MudDataGrid<DataGridHideAndResizeTest.Model>>();
 
             // Act : Hide the middle column and resize the first column
@@ -4909,7 +4909,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void QueryFilterExtensionTest()
         {
-            var comp = Context.RenderComponent<DataGridFiltersTest>();
+            var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
 
             var nameFilter = new FilterDefinition<DataGridFiltersTest.Model>
@@ -4960,7 +4960,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridEnumLocalization()
         {
-            var comp = Context.RenderComponent<DataGridFilterEnumLocalizationTest>();
+            var comp = Context.Render<DataGridFilterEnumLocalizationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterEnumLocalizationTest.Item>>();
 
             IElement FilterButton() => dataGrid.FindAll(".filter-button")[0];
@@ -4983,7 +4983,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DataGridValidatorFormBinding()
         {
-            var comp = Context.RenderComponent<DataGridValidatorTest>();
+            var comp = Context.Render<DataGridValidatorTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridValidatorTest.Item>>().Instance;
             dataGrid.Validator.Should().BeSameAs(form);
@@ -5012,7 +5012,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestCurrentPageParameterTwoWayBinding()
         {
-            var comp = Context.RenderComponent<DataGridCurrentPageParameterTwoWayBindingTest>();
+            var comp = Context.Render<DataGridCurrentPageParameterTwoWayBindingTest>();
             var dataGridComponent = comp.FindComponent<MudDataGrid<int>>();
             var dataGrid = dataGridComponent.Instance;
 
@@ -5038,7 +5038,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridUniqueRowKey()
         {
             //Test the normal case
-            var comp = Context.RenderComponent<DataGridUniqueRowKeyTest>();
+            var comp = Context.Render<DataGridUniqueRowKeyTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<string>>();
 
             var sortByColumnName = dataGrid.Instance.RenderedColumns.FirstOrDefault().PropertyName;
@@ -5068,7 +5068,7 @@ namespace MudBlazor.UnitTests.Components
             int selectedItem = 3;
             var items = new List<int> { 1, 2, 3, 4, 5 };
             HashSet<int> selectedItems = new HashSet<int> { selectedItem };
-            var comp = Context.RenderComponent<MudDataGrid<int>>(parameters =>
+            var comp = Context.Render<MudDataGrid<int>>(parameters =>
             {
                 parameters.Add(x => x.Items, items);
                 parameters.Bind(x => x.SelectedItem, selectedItem, x => selectedItem = x);
@@ -5103,7 +5103,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridSelectedItemEventsTest()
         {
-            var comp = Context.RenderComponent<DataGridEventCallbacksTest>();
+            var comp = Context.Render<DataGridEventCallbacksTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEventCallbacksTest.Item>>();
 
             // Test single selection mode
@@ -5177,7 +5177,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridHeaderToggleHierarchyTest()
         {
             // Render with EnableHeaderToggle = true to enable header toggle functionality
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(parameters =>
+            var comp = Context.Render<DataGridHierarchyColumnTest>(parameters =>
                 parameters.Add(p => p.EnableHeaderToggle, true));
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
@@ -5211,7 +5211,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridHeaderToggleIconTest(bool rightToLeft)
         {
             // Render with EnableHeaderToggle = true and set RTL mode
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(parameters =>
+            var comp = Context.Render<DataGridHierarchyColumnTest>(parameters =>
             {
                 parameters.Add(p => p.EnableHeaderToggle, true);
                 parameters.Add(p => p.RightToLeft, rightToLeft);
@@ -5252,7 +5252,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridToggleHierarchyMethodTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             var headerCell = dataGrid.FindComponents<HeaderCell<DataGridHierarchyColumnTest.Model>>().First();
@@ -5276,7 +5276,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridGetHierarchyGroupIconTest()
         {
             // Create a test component
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             // Get a reference to a HeaderCell to test GetGroupIcon method
@@ -5303,7 +5303,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_HierarchyExpandSingleRowTest()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>(parameters => parameters
+            var comp = Context.Render<DataGridHierarchyColumnTest>(parameters => parameters
                 .Add(p => p.ExpandSingleRow, false));
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
@@ -5322,7 +5322,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridRowDetailInitiallyExpandedMultipleTest()
         {
             // just setting Items
-            var comp = Context.RenderComponent<DataGridHierarchyColumnTest>();
+            var comp = Context.Render<DataGridHierarchyColumnTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyColumnTest.Model>>();
 
             var item = dataGrid.Instance.Items.FirstOrDefault(x => x.Name == "Ira");
@@ -5345,7 +5345,7 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridRowDetailInitiallyExpandedObservableMultipleTest()
         {
             // updating an observable collection of items after initial load
-            var comp = Context.RenderComponent<DataGridHierarchyInitiallyExpandedItemsTest>();
+            var comp = Context.Render<DataGridHierarchyInitiallyExpandedItemsTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyInitiallyExpandedItemsTest.Model>>();
 
             var item = dataGrid.Instance.Items.FirstOrDefault(x => x.Name == "Ira");
@@ -5368,7 +5368,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridRowDetailInitiallyExpandedServerMultipleTest()
         {
             // ServerReload different pages
-            var comp = Context.RenderComponent<DataGridHierarchyInitiallyExpandedServerDataTest>();
+            var comp = Context.Render<DataGridHierarchyInitiallyExpandedServerDataTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyInitiallyExpandedServerDataTest.Model>>();
 
             comp.WaitForAssertion(() => comp.Markup.Should().Contain("uid = Ira|27|Success|"));
@@ -5417,7 +5417,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridShouldAllowUnsortedAscDescOnly()
         {
-            var comp = Context.RenderComponent<DataGridAllowUnsortedTest>(parameters => parameters
+            var comp = Context.Render<DataGridAllowUnsortedTest>(parameters => parameters
                 .Add(p => p.AllowUnsorted, false));
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridAllowUnsortedTest.Item>>();
             var headerCell = dataGrid.FindComponents<HeaderCell<DataGridAllowUnsortedTest.Item>>()[0];
@@ -5443,7 +5443,7 @@ namespace MudBlazor.UnitTests.Components
             cells[3].TextContent.Should().Be("B");
             cells[6].TextContent.Should().Be("C");
 
-            comp = Context.RenderComponent<DataGridAllowUnsortedTest>(parameters => parameters
+            comp = Context.Render<DataGridAllowUnsortedTest>(parameters => parameters
                 .Add(p => p.AllowUnsorted, true));
             dataGrid = comp.FindComponent<MudDataGrid<DataGridAllowUnsortedTest.Item>>();
             headerCell = dataGrid.FindComponents<HeaderCell<DataGridAllowUnsortedTest.Item>>()[0];
@@ -5473,7 +5473,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_HierarchyVisibilityToggled_SingleRowToggle()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();
+            var comp = Context.Render<DataGridHierarchyVisibilityToggledTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyVisibilityToggledTest.Model>>();
             var testComponent = comp.Instance;
 
@@ -5495,7 +5495,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_HierarchyVisibilityToggled_CollapseAll()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();
+            var comp = Context.Render<DataGridHierarchyVisibilityToggledTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyVisibilityToggledTest.Model>>();
             var testComponent = comp.Instance;
 
@@ -5512,7 +5512,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGrid_HierarchyVisibilityToggled_ExpandAll()
         {
-            var comp = Context.RenderComponent<DataGridHierarchyVisibilityToggledTest>();
+            var comp = Context.Render<DataGridHierarchyVisibilityToggledTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyVisibilityToggledTest.Model>>();
             var testComponent = comp.Instance;
 
@@ -5526,7 +5526,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataGridFilterIconsTest()
         {
-            var comp = Context.RenderComponent<DataGridFilterIconsTest>();
+            var comp = Context.Render<DataGridFilterIconsTest>();
             MudIconButton FirstFilterButton() =>
                 comp.FindComponents<MudIconButton>().FirstOrDefault(x => x.Markup.Contains("filter-button"))?.Instance;
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Default()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             var picker = comp.Instance;
 
             picker.Text.Should().Be(null);
@@ -43,7 +43,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerOpenButtonDefaultAriaLabel()
         {
-            var comp = Context.RenderComponent<DatePickerValidationTest>();
+            var comp = Context.Render<DatePickerValidationTest>();
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerLabelFor()
         {
-            var comp = Context.RenderComponent<DatePickerValidationTest>();
+            var comp = Context.Render<DatePickerValidationTest>();
             var label = comp.Find(".mud-input-label");
             label.Attributes.GetNamedItem("for")?.Value.Should().Be("datePickerLabelTest");
         }
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerInputId()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleMudDatePickerTest>(parameters => parameters
                 .Add(c => c.InputId, "birthday"));
 
             comp.Find("input[id='birthday']").Should().NotBeNull();
@@ -70,12 +70,12 @@ namespace MudBlazor.UnitTests.Components
         public void DatePicker_Render_Performance()
         {
             // warmup
-            Context.RenderComponent<MudDatePicker>();
+            Context.Render<MudDatePicker>();
             // measure
             var watch = Stopwatch.StartNew();
             for (var i = 0; i < 1000; i++)
             {
-                Context.RenderComponent<MudDatePicker>();
+                Context.Render<MudDatePicker>();
             }
 
             watch.Stop();
@@ -86,7 +86,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePicker_OpenClose_Performance()
         {
             // warmup
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             var datepicker = comp.Instance;
             // measure
             var watch = Stopwatch.StartNew();
@@ -103,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SetPickerValue_CheckDate_SetPickerDate_CheckValue()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -117,7 +117,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_Should_ApplyDateFormat()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -134,7 +134,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_Should_ApplyDateFormatAfterDate()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -150,7 +150,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_Should_ApplyCultureDateFormat()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -175,7 +175,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_Should_DateFormatTakesPrecedenceOverCulture()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -191,7 +191,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ReadOnlyShouldNotHaveClearButton()
         {
-            var comp = Context.RenderComponent<MudDatePicker>(p => p
+            var comp = Context.Render<MudDatePicker>(p => p
                 .Add(x => x.Text, "some value")
                 .Add(x => x.Clearable, true)
                 .Add(x => x.ReadOnly, false));
@@ -205,7 +205,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_Should_Clear()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.ReadOnly.Should().Be(false);
@@ -226,7 +226,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataPicker_ShouldClearText_WhenDateSetNull()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
 
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -250,7 +250,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataPicker_ShouldDeBounceSetDate_WhenDateSetToTheSameValueQuickly()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
 
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -271,7 +271,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DataPicker_ShouldDisplayError_WhenTextSetToInvalidValue()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
 
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -285,7 +285,7 @@ namespace MudBlazor.UnitTests.Components
         public void Check_Initial_Date_Format()
         {
             DateTime? date = new DateTime(2021, 1, 13);
-            var comp = Context.RenderComponent<MudDatePicker>(parameters => parameters
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(p => p.Culture, CultureInfo.InvariantCulture)
                 .Add(p => p.DateFormat, "dd/MM/yyyy")
                 .Add(p => p.Date, date)
@@ -315,11 +315,11 @@ namespace MudBlazor.UnitTests.Components
             IRenderedComponent<SimpleMudDatePickerTest> comp;
             if (parameterBuilder is null)
             {
-                comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+                comp = Context.Render<SimpleMudDatePickerTest>();
             }
             else
             {
-                comp = Context.RenderComponent<SimpleMudDatePickerTest>(parameterBuilder);
+                comp = Context.Render<SimpleMudDatePickerTest>(parameterBuilder);
             }
 
             // should not be open
@@ -474,7 +474,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerStaticWithPickerActionsDayClick_Test()
         {
-            var comp = Context.RenderComponent<DatePickerStaticTest>();
+            var comp = Context.Render<DatePickerStaticTest>();
             var picker = comp.FindComponent<MudDatePicker>();
 
             picker.Markup.Should().Contain("mud-selected"); //confirm selected date is shown
@@ -494,7 +494,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerBindingTest()
         {
-            var comp = Context.RenderComponent<DatePickerBindingTest>();
+            var comp = Context.Render<DatePickerBindingTest>();
 
             comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
             comp.Find(".mud-input-adornment button").Click();
@@ -662,7 +662,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Open_Programmatically_CheckOpen_Close_Programmatically_CheckClosed()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             comp.FindAll("div.mud-picker-content").Count.Should().Be(0);
             // open programmatically
             await comp.InvokeAsync(comp.Instance.Open);
@@ -681,7 +681,7 @@ namespace MudBlazor.UnitTests.Components
             cal.GetMonth(date).Should().Be(11);
             cal.GetDayOfMonth(date).Should().Be(26);
             // ---------------------------------------------------------------
-            var comp = Context.RenderComponent<PersianDatePickerTest>();
+            var comp = Context.Render<PersianDatePickerTest>();
             var datePicker = comp.FindComponent<MudDatePicker>();
             await comp.InvokeAsync(() => datePicker.Instance.OpenAsync());
 
@@ -692,7 +692,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task PersianCalendarTest_GoToDate()
         {
             var cal = new PersianCalendar();
-            var comp = Context.RenderComponent<PersianDatePickerTest>();
+            var comp = Context.Render<PersianDatePickerTest>();
             var datePicker = comp.FindComponent<MudDatePicker>().Instance;
             await comp.InvokeAsync(() => datePicker.OpenAsync());
             datePicker.Text.Should().Be("1399/11/26");
@@ -711,7 +711,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.AddSingleton<TimeProvider>(timeProvider);
             timeProvider.SetUtcNow(new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc));
 
-            var comp = Context.RenderComponent<PersianDatePickerTest>(paramter => paramter.Add(p => p.Date, null));
+            var comp = Context.Render<PersianDatePickerTest>(paramter => paramter.Add(p => p.Date, null));
             var datePicker = comp.FindComponent<MudDatePicker>().Instance;
             await comp.InvokeAsync(() => datePicker.OpenAsync());
 
@@ -727,7 +727,7 @@ namespace MudBlazor.UnitTests.Components
             var cal = new PersianCalendar();
             var date = new DateTime(1404, 1, 1, cal);
 
-            var comp = Context.RenderComponent<PersianDatePickerTest>(parameter => parameter.Add(p => p.Date, date).Add(p => p.FixDay, 1));
+            var comp = Context.Render<PersianDatePickerTest>(parameter => parameter.Add(p => p.Date, date).Add(p => p.FixDay, 1));
 
             comp.FindAll("button.mud-picker-month").Count.Should().Be(0);
             comp.Find("input").Click();
@@ -740,7 +740,7 @@ namespace MudBlazor.UnitTests.Components
         public void SetPickerValue_CheckText()
         {
             var date = DateTime.Now;
-            var comp = Context.RenderComponent<MudDatePicker>(parameters => parameters
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(x => x.Date, date));
             // select elements needed for the test
             var picker = comp.Instance;
@@ -932,7 +932,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var wasEventCallbackCalled = false;
             Func<DateTime, bool> isDisabledFunc = _ => true;
-            var comp = Context.RenderComponent<MudDatePicker>(parameters => parameters
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
                 .Add(x => x.DateChanged, (DateTime? _) => wasEventCallbackCalled = true));
 
@@ -948,7 +948,7 @@ namespace MudBlazor.UnitTests.Components
             var wasEventCallbackCalled = false;
             var today = DateTime.Today;
             Func<DateTime, bool> isDisabledFunc = date => date < today;
-            var comp = Context.RenderComponent<MudDatePicker>(parameters => parameters
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
                 .Add(x => x.DateChanged, (DateTime? _) => wasEventCallbackCalled = true));
 
@@ -1002,7 +1002,7 @@ namespace MudBlazor.UnitTests.Components
             var now = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
 
             // Get access to the datepicker of the instance
-            var comp = Context.RenderComponent<AutoCompleteDatePickerTest>();
+            var comp = Context.Render<AutoCompleteDatePickerTest>();
             var datePicker = comp.FindComponent<MudDatePicker>();
 
             // Open the datepicker
@@ -1075,7 +1075,7 @@ namespace MudBlazor.UnitTests.Components
             var now = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
 
             // Get access to the datepicker of the instance
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var picker = comp.Instance;
 
             // Open the datepicker
@@ -1139,7 +1139,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CheckDateTimeMinValueTest()
         {
             // Get access to the datepicker of the instance
-            var comp = Context.RenderComponent<DateTimeMinValueDatePickerTest>();
+            var comp = Context.Render<DateTimeMinValueDatePickerTest>();
             var datePicker = comp.FindComponent<MudDatePicker>();
 
             // Open the datepicker
@@ -1159,7 +1159,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void CheckButtonTypeTest(bool navigateToMonthSelection)
         {
-            var dateComp = Context.RenderComponent<MudDatePicker>(p =>
+            var dateComp = Context.Render<MudDatePicker>(p =>
             p.Add(x => x.PickerVariant, PickerVariant.Dialog));
 
             //open picker
@@ -1182,7 +1182,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_Editable()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
 
             var cultureInfo = new CultureInfo("en-US");
 
@@ -1204,7 +1204,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_KeyboardNavigation()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
 
@@ -1258,7 +1258,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_KeyboardNavigation_SelectDate()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             var expectedDate1 = new DateTime(2021, 1, 23, new CultureInfo("en-US").Calendar);
             var expectedDate2 = new DateTime(2023, 11, 22, new CultureInfo("en-US").Calendar);
@@ -1320,7 +1320,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_KeyboardNavigation_SelectMonth()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             var expectedDate1 = new DateTime(2022, 1, 28, new CultureInfo("en-US").Calendar);
             var expectedDate2 = new DateTime(2023, 1, 28, new CultureInfo("en-US").Calendar);
@@ -1365,7 +1365,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_KeyboardNavigation_BackspacePreviousView()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(parameter => parameter.Date, startDate)
@@ -1402,7 +1402,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_KeyboardNavigation_MinMaxYearLimits()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(parameter => parameter.Date, startDate)
@@ -1440,7 +1440,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_GoToDate()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
 
             var datePicker = comp.FindComponent<MudDatePicker>().Instance;
 
@@ -1460,7 +1460,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePickerTest_CheckIfMonthsAreDisabled()
         {
-            var comp = Context.RenderComponent<SimpleMudDatePickerTest>();
+            var comp = Context.Render<SimpleMudDatePickerTest>();
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
 
@@ -1508,7 +1508,7 @@ namespace MudBlazor.UnitTests.Components
         {
             string? changedText = null;
 
-            var comp = Context.RenderComponent<MudDatePicker>(parameters => parameters
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(x => x.TextChanged, x => changedText = x));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters
@@ -1555,7 +1555,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OldDateWithDefinedKind_SetValue_KindUnchanged()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
             var picker = comp.Instance;
             var oldDate = DateTime.Now;
             var newDate = oldDate.AddDays(1);
@@ -1570,7 +1570,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Display_SelectedDate_WhenWrapped()
         {
-            var comp = Context.RenderComponent<WrappedDatePickerTest>();
+            var comp = Context.Render<WrappedDatePickerTest>();
 
             comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
             comp.Find(".mud-input-adornment button").Click();
@@ -1587,7 +1587,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudDatePicker>(parameters =>
+            var comp = Context.Render<MudDatePicker>(parameters =>
                 parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -1602,7 +1602,7 @@ namespace MudBlazor.UnitTests.Components
         public void DatePickerWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "test-id";
-            var comp = Context.RenderComponent<MudDatePicker>(parameters
+            var comp = Context.Render<MudDatePicker>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object?>
@@ -1621,7 +1621,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalDatePicker_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1633,7 +1633,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredDatePicker_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudDatePicker>(parameters => parameters
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -1646,7 +1646,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredDatePickerAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudDatePicker>();
+            var comp = Context.Render<MudDatePicker>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1668,7 +1668,7 @@ namespace MudBlazor.UnitTests.Components
             var timeProvider = new FakeTimeProvider();
             Context.Services.AddSingleton<TimeProvider>(timeProvider);
             timeProvider.SetUtcNow(new DateTime(2003, 4, 4, 0, 0, 0, DateTimeKind.Utc));
-            var comp = Context.RenderComponent<DatePickerCustomDateTest>();
+            var comp = Context.Render<DatePickerCustomDateTest>();
 
             // click to open menu
             comp.Find("input").Click();
@@ -1683,7 +1683,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public async Task DatePickerWithFixYearAndFixMonthTest()
         {
-            var comp = Context.RenderComponent<FixYearFixMonthTest>();
+            var comp = Context.Render<FixYearFixMonthTest>();
             await comp.Find("input").TriggerEventAsync("onclick", new MouseEventArgs());
             await Task.Delay(500);
             comp.Find(".mud-button-year").GetInnerText().Should().Be("2022");
@@ -1695,7 +1695,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePickerToolbar_DisplaysSelectedDate()
         {
             var selectedDate = new DateTime(2025, 1, 10);
-            var comp = Context.RenderComponent<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
+            var comp = Context.Render<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
 
             comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).ToMarkup().Should().Contain("mud-selected");
             comp.Find("button.mud-button-date .mud-button-label").InnerHtml.Should().Be("Fri, 10 Jan");
@@ -1733,7 +1733,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePicker_HighlightSelectedMonthOnly()
         {
             var selectedDate = new DateTime(2025, 1, 10);
-            var comp = Context.RenderComponent<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
+            var comp = Context.Render<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
 
             //go to month view
             await comp.Find("button.mud-button-month").ClickAsync(new MouseEventArgs());
@@ -1768,7 +1768,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePicker_HighlightSelectedYearOnly()
         {
             var selectedDate = new DateTime(2025, 1, 10);
-            var comp = Context.RenderComponent<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
+            var comp = Context.Render<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
 
             //go to year view
             await comp.Find("button.mud-button-month").ClickAsync(new MouseEventArgs());
@@ -1790,7 +1790,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePicker_JumpToYear()
         {
             var selectedDate = new DateTime(2025, 1, 10);
-            var comp = Context.RenderComponent<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
+            var comp = Context.Render<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
             var picker = comp.Instance;
 
             await comp.Find("button.mud-button-month").ClickAsync(new MouseEventArgs());

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -5,6 +5,7 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
@@ -19,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Default()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             var picker = comp.Instance;
 
             picker.Text.Should().Be(null);
@@ -45,7 +46,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DateRangePickerPlaceHolders()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             await comp.SetParametersAndRenderAsync(parameters =>
                 parameters
                     .Add(picker => picker.PlaceholderStart, "Start")
@@ -60,7 +61,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DateRangePickerSeparatorIcon()
         {
             var newIcon = Icons.Material.Filled.Star;
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             await comp.SetParametersAndRenderAsync(parameters =>
                 parameters
                     .Add(picker => picker.SeparatorIcon, newIcon)
@@ -79,7 +80,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DateRangePickerOpenButtonDefaultAriaLabel()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
@@ -87,7 +88,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DateRangePicker_Preset_No_Timestamp()
         {
-            var comp = Context.RenderComponent<DateRangePickerPresetWithoutTimestampTest>();
+            var comp = Context.Render<DateRangePickerPresetWithoutTimestampTest>();
 
             comp.Markup.Should().Contain("mud-range-start-selected");
             comp.Markup.Should().Contain("mud-range-end-selected");
@@ -96,7 +97,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DateRangePicker_Preset_Timestamp()
         {
-            var comp = Context.RenderComponent<DateRangePickerPresetRangeWithTimestampTest>();
+            var comp = Context.Render<DateRangePickerPresetRangeWithTimestampTest>();
 
             comp.Markup.Should().Contain("mud-range-start-selected");
             comp.Markup.Should().Contain("mud-range-end-selected");
@@ -105,7 +106,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DateRangePickerLabelFor()
         {
-            var comp = Context.RenderComponent<DateRangePickerValidationTest>();
+            var comp = Context.Render<DateRangePickerValidationTest>();
             var label = comp.Find(".mud-input-label");
             label.Attributes.GetNamedItem("for")?.Value.Should().Be("dateRangeLabelTest");
         }
@@ -115,12 +116,12 @@ namespace MudBlazor.UnitTests.Components
         public void RenderDateRangePicker_10000_Times_CheckPerformance()
         {
             // warmup
-            Context.RenderComponent<MudDateRangePicker>();
+            Context.Render<MudDateRangePicker>();
             // measure
             var watch = Stopwatch.StartNew();
             for (var i = 0; i < 10000; i++)
             {
-                Context.RenderComponent<MudDateRangePicker>();
+                Context.Render<MudDateRangePicker>();
             }
 
             watch.Stop();
@@ -132,7 +133,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Open_Close_DateRangePicker_10000_Times_CheckPerformance()
         {
             // warmup
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             var datepicker = comp.Instance;
             // measure
             var watch = Stopwatch.StartNew();
@@ -148,7 +149,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SetPickerValue_CheckDateRange_SetPickerDate_CheckValue()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().BeNullOrEmpty();
@@ -211,11 +212,11 @@ namespace MudBlazor.UnitTests.Components
             IRenderedComponent<SimpleMudMudDateRangePickerTest> comp;
             if (parameterBuilder is null)
             {
-                comp = Context.RenderComponent<SimpleMudMudDateRangePickerTest>();
+                comp = Context.Render<SimpleMudMudDateRangePickerTest>();
             }
             else
             {
-                comp = Context.RenderComponent<SimpleMudMudDateRangePickerTest>(parameterBuilder);
+                comp = Context.Render<SimpleMudMudDateRangePickerTest>(parameterBuilder);
             }
 
             // should not be open
@@ -416,7 +417,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Open_Programmatically_CheckOpen_Close_Programmatically_CheckClosed()
         {
-            var comp = Context.RenderComponent<SimpleMudMudDateRangePickerTest>();
+            var comp = Context.Render<SimpleMudMudDateRangePickerTest>();
             comp.FindAll("div.mud-picker-content").Count.Should().Be(0);
             // open programmatically
             await comp.Instance.Open();
@@ -431,7 +432,7 @@ namespace MudBlazor.UnitTests.Components
         public void SetPickerValue_CheckText()
         {
             var date = DateTime.Now;
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.DateRange, new DateRange(date, date.AddDays(5))));
             // select elements needed for the test
             var picker = comp.Instance;
@@ -475,7 +476,7 @@ namespace MudBlazor.UnitTests.Components
             var wasEventCallbackCalled = false;
 
             Func<DateTime, bool> isDisabledFunc = date => date == yesterday;
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
                 .Add(x => x.DateRangeChanged, (DateRange _) => wasEventCallbackCalled = true));
 
@@ -495,7 +496,7 @@ namespace MudBlazor.UnitTests.Components
 
             Func<DateTime, bool> isDisabledFunc = date => date == twoDaysAgo;
             var range = new DateRange(yesterday, today);
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
                 .Add(x => x.DateRangeChanged, (DateRange _) => wasEventCallbackCalled = true));
 
@@ -533,7 +534,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SetRangeTextFunc_NullInputNoError()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters =>
+            var comp = Context.Render<MudDateRangePicker>(parameters =>
                 parameters.Add(p => p.DateRange,
                     new DateRange(new DateTime(2020, 12, 26), null)));
             comp.Find("input").Change("");
@@ -546,7 +547,7 @@ namespace MudBlazor.UnitTests.Components
         public void SetRangeTextFunc_NullRangeTextNoError()
         {
             var dateTime = new DateTime(2020, 12, 26);
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters =>
+            var comp = Context.Render<MudDateRangePicker>(parameters =>
                 parameters.Add(p => p.DateRange, null)
                     .Add(p => p.Culture, CultureInfo.CurrentCulture));
             comp.Find("input").Change(dateTime.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern));
@@ -563,7 +564,7 @@ namespace MudBlazor.UnitTests.Components
 
             var wasEventCallbackCalled = false;
 
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.DateRange, dr1)
                 .Add(x => x.DateRangeChanged, (DateRange _) => wasEventCallbackCalled = true));
 
@@ -612,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
             var endDate = DateTime.Now.Date.AddDays(2);
 
             // create the component
-            var dateRangePickerComponent = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var dateRangePickerComponent = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.Required, true)
                 .Add(x => x.RequiredError, errorMessage));
 
@@ -663,7 +664,7 @@ namespace MudBlazor.UnitTests.Components
                 new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
 
             // Get access to the date range picker of the instance
-            var comp = Context.RenderComponent<AutoCloseDateRangePickerTest>(parameters => parameters
+            var comp = Context.Render<AutoCloseDateRangePickerTest>(parameters => parameters
                 .Add(x => x.DateRange, initialDateRange));
 
             // Open the date range picker
@@ -689,7 +690,7 @@ namespace MudBlazor.UnitTests.Components
                   new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
 
             // Get access to the date range picker of the instance
-            var comp = Context.RenderComponent<AutoCloseDateRangePickerTest>(parameters => parameters
+            var comp = Context.Render<AutoCloseDateRangePickerTest>(parameters => parameters
                 .Add(x => x.DateRange, initialDateRange)
                 .Add(x => x.AutoClose, true));
 
@@ -733,7 +734,7 @@ namespace MudBlazor.UnitTests.Components
             var today = DateTime.Today;
             var initialRange = new DateRange(new DateTime(today.Year, today.Month, 01), new DateTime(today.Year, today.Month, 05));
 
-            var comp = Context.RenderComponent<AutoCloseDateRangePickerTest>(parameters => parameters
+            var comp = Context.Render<AutoCloseDateRangePickerTest>(parameters => parameters
                 .Add(x => x.DateRange, initialRange));
 
             comp.Find("input").Click();
@@ -756,7 +757,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DateRangePicker_Should_Clear()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.Text.Should().Be(null);
@@ -799,7 +800,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalDateRangePicker_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
 
             comp.FindAll("input").Should().AllSatisfy(input =>
             {
@@ -814,7 +815,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredDateRangePicker_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.FindAll("input").Should().AllSatisfy(input =>
@@ -830,7 +831,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredDateRangePickerAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
 
             comp.FindAll("input").Should().AllSatisfy(input =>
             {
@@ -853,7 +854,7 @@ namespace MudBlazor.UnitTests.Components
         public void FormatFirst_Should_RenderCorrectly()
         {
             DateRange range = new DateRange(new DateTime(2024, 04, 22), new DateTime(2024, 04, 23));
-            var comp = Context.RenderComponent<DateRangePickerFormatTest>
+            var comp = Context.Render<DateRangePickerFormatTest>
             (parameters =>
             {
                 parameters.Add(p => p.DateRange, range);
@@ -871,7 +872,7 @@ namespace MudBlazor.UnitTests.Components
         public void FormatLast_Should_RenderCorrectly()
         {
             DateRange range = new DateRange(new DateTime(2024, 04, 22), new DateTime(2024, 04, 23));
-            var comp = Context.RenderComponent<DateRangePickerFormatTest>
+            var comp = Context.Render<DateRangePickerFormatTest>
             (parameters =>
             {
                 parameters.Add(p => p.DateRange, range);
@@ -895,7 +896,7 @@ namespace MudBlazor.UnitTests.Components
                 new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
 
             // Get access to the date range picker of the instance
-            var comp = Context.RenderComponent<DateRangePickerCloseOnClearTest>(parameters => parameters
+            var comp = Context.Render<DateRangePickerCloseOnClearTest>(parameters => parameters
                 .Add(x => x.DateRange, initialDateRange)
                 .Add(x => x.CloseOnClear, closeOnClear));
 
@@ -923,9 +924,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Should_respect_underline_parameter()
         {
-            var underlinedComp = Context.RenderComponent<MudDateRangePicker>(parameters
+            var underlinedComp = Context.Render<MudDateRangePicker>(parameters
                 => parameters.Add(p => p.Underline, true));
-            var notUnderlinedComp = Context.RenderComponent<MudDateRangePicker>(parameters
+            var notUnderlinedComp = Context.Render<MudDateRangePicker>(parameters
                 => parameters.Add(p => p.Underline, false));
 
             underlinedComp.FindAll(".mud-input-underline").Should().HaveCount(1);
@@ -942,7 +943,7 @@ namespace MudBlazor.UnitTests.Components
 
             var range = new DateRange(twoDaysAgo, today);
             Func<DateTime, bool> isDisabledFunc = date => date == yesterday;
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.AllowDisabledDatesInRange, true)
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
                 .Add(x => x.DateRangeChanged, (DateRange _) => wasEventCallbackCalled = true));
@@ -956,7 +957,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestDateRangeClearableWithFormat()
         {
-            var comp = Context.RenderComponent<DateRangePickerClearableTest>();
+            var comp = Context.Render<DateRangePickerClearableTest>();
             var picker = comp.FindComponents<MudDateRangePicker>();
             picker.Count.Should().Be(2);
             var openBtn = picker[0].FindComponents<MudIconButton>();
@@ -988,7 +989,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DateRangePickerToolbar_DisplaysSelectedDate()
         {
             var selectedRange = new DateRange(new DateTime(2025, 1, 10).Date, new DateTime(2025, 1, 20).Date);
-            var comp = Context.RenderComponent<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
+            var comp = Context.Render<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
 
             comp.FindAll("button.mud-picker-calendar-day")
                 .First(x => x.TrimmedText().Equals("10"))
@@ -1031,7 +1032,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DateRangePicker_HighlightSelectedMonthOnly()
         {
             var selectedRange = new DateRange(new DateTime(2025, 1, 10).Date, new DateTime(2025, 1, 20).Date);
-            var comp = Context.RenderComponent<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
+            var comp = Context.Render<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
 
             //go to month view
             await comp.FindAll("button.mud-button-month")[0].ClickAsync(new MouseEventArgs());
@@ -1066,7 +1067,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DateRangePicker_HighlightSelectedYearOnly()
         {
             var selectedRange = new DateRange(new DateTime(2025, 1, 10).Date, new DateTime(2025, 1, 20).Date);
-            var comp = Context.RenderComponent<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
+            var comp = Context.Render<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
 
             //go to year view
             await comp.FindAll("button.mud-button-month")[0].ClickAsync(new MouseEventArgs());
@@ -1088,7 +1089,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task DatePicker_JumpToYear()
         {
             var selectedRange = new DateRange(new DateTime(2025, 1, 10).Date, new DateTime(2025, 1, 20).Date);
-            var comp = Context.RenderComponent<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
+            var comp = Context.Render<DateRangePickerPresetWithoutTimestampTest>(p => p.Add(x => x.DateRange, selectedRange));
             var picker = comp.Instance;
 
             await comp.FindAll("button.mud-button-month")[0].ClickAsync(new MouseEventArgs());
@@ -1118,7 +1119,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //no restrictions - minimum of 3 days
             var startingRange = new DateRange(new DateTime(2025, 1, 1).Date, new DateTime(2025, 1, 1).Date);
-            var comp = Context.RenderComponent<DateRangePickerMinMaxDaysTest>(p => p.Add(x => x.DateRange, startingRange));
+            var comp = Context.Render<DateRangePickerMinMaxDaysTest>(p => p.Add(x => x.DateRange, startingRange));
 
             await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ClickAsync(new MouseEventArgs());
             comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("17")).ToMarkup().Should().Contain("disabled");
@@ -1208,7 +1209,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DateRangePicker_MaxSelectableDateTest()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>();
+            var comp = Context.Render<MudDateRangePicker>();
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.MaxDays, 30)
                                                                 .Add(picker => picker.PickerVariant, PickerVariant.Static)
@@ -1227,7 +1228,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DateRangePicker_BlurAsync()
         {
-            var comp = Context.RenderComponent<MudDateRangePicker>(parameters => parameters
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                     .Add(picker => picker.ReadOnly, false)
                     .Add(picker => picker.Editable, true));
 
@@ -1246,7 +1247,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DateRangePickerInputId()
         {
-            var comp = Context.RenderComponent<SimpleMudMudDateRangePickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleMudMudDateRangePickerTest>(parameters => parameters
                 .Add(c => c.InputId, "event-range"));
 
             comp.Find("input[id='event-range-start']").Should().NotBeNull();
@@ -1259,7 +1260,7 @@ namespace MudBlazor.UnitTests.Components
             var startMonth = new DateTime(2025, 12, 3); //expected Dec. 3rd
             var dateRange = new DateRange(new DateTime(2025, 12, 5), new DateTime(2025, 12, 20));
 
-            var picker = Context.RenderComponent<DateRangePickerImpl>(ps => ps
+            var picker = Context.Render<DateRangePickerImpl>(ps => ps
                 .Add(p => p.StartMonth, startMonth)
                 .Add(p => p.DateRange, dateRange)
             );
@@ -1275,7 +1276,7 @@ namespace MudBlazor.UnitTests.Components
             var dateRangeStart = new DateTime(2025, 12, 3);
             var dateRange = new DateRange(new DateTime(2025, 12, 5), new DateTime(2025, 12, 20));
 
-            var picker = Context.RenderComponent<DateRangePickerImpl>(ps => ps
+            var picker = Context.Render<DateRangePickerImpl>(ps => ps
                 .Add(p => p.DateRange, dateRange)
             );
 
@@ -1289,20 +1290,19 @@ namespace MudBlazor.UnitTests.Components
             public DateTime StartOfMonth() => GetCalendarStartOfMonth();
         }
     }
-
     public static class DatePickerRenderedFragmentExtensions
     {
-        public static void SelectDate(this IRenderedFragment comp, string day, bool firstOccurrence = true)
+        public static void SelectDate(this IRenderedComponent<IComponent> comp, string day, bool firstOccurrence = true)
         {
             comp.ValidateSelection(day, firstOccurrence).Click();
         }
 
-        public static async Task SelectDateAsync(this IRenderedFragment comp, string day, bool firstOccurrence = true)
+        public static async Task SelectDateAsync(this IRenderedComponent<IComponent> comp, string day, bool firstOccurrence = true)
         {
             await comp.ValidateSelection(day, firstOccurrence).ClickAsync(new MouseEventArgs());
         }
 
-        private static IElement ValidateSelection(this IRenderedFragment comp, string day, bool firstOccurrence)
+        private static IElement ValidateSelection(this IRenderedComponent<IComponent> comp, string day, bool firstOccurrence)
         {
             var matchingDays = comp.FindAll("button.mud-picker-calendar-day")
                        .Where(x => !x.ClassList.Contains("mud-hidden") && x.TrimmedText().Equals(day))

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task LifecycleTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             IDialogReference dialogReference = null;
@@ -44,7 +44,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SimpleTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -100,12 +100,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InlineDialogTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var comp1 = Context.RenderComponent<TestInlineDialog>();
+            var comp1 = Context.Render<TestInlineDialog>();
             comp1.FindComponents<MudButton>().Count.Should().Be(1);
             // open the dialog
             comp1.Find("button").Click();
@@ -126,12 +126,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InlineDialogShowMethodTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
 
-            var comp1 = Context.RenderComponent<InlineDialogShowMethod>();
+            var comp1 = Context.Render<InlineDialogShowMethod>();
 
             comp.Markup.Should().NotContain("Here be dragons");
 
@@ -164,8 +164,8 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudDialogProvider>();
-            var sup = Context.RenderComponent<InlineDialogShowMethodTest>();
+            var comp = Context.Render<MudDialogProvider>();
+            var sup = Context.Render<InlineDialogShowMethodTest>();
 
             // Assert : Initial state, dialog should be closed
 
@@ -202,12 +202,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NestedInlineDialogTest()
         {
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             provider.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var comp = Context.RenderComponent<TestNestedInlineDialog>();
+            var comp = Context.Render<TestNestedInlineDialog>();
             comp.FindComponents<MudButton>().Count.Should().Be(1);
             // open the dialog
             comp.Find("button").Click();
@@ -235,12 +235,12 @@ namespace MudBlazor.UnitTests.Components
         {
             await ImproveChanceOfSuccess(() =>
             {
-                var comp = Context.RenderComponent<MudDialogProvider>();
+                var comp = Context.Render<MudDialogProvider>();
                 comp.Markup.Trim().Should().BeEmpty();
                 var service = Context.Services.GetRequiredService<IDialogService>();
                 service.Should().NotBe(null);
                 // displaying the component with the inline dialog only renders the open button
-                var comp1 = Context.RenderComponent<InlineDialogIsVisibleStateTest>();
+                var comp1 = Context.Render<InlineDialogIsVisibleStateTest>();
                 // open the dialog
                 comp1.Find("button").Click();
                 comp.WaitForAssertion(() => comp.Find("div.mud-dialog-container").Should().NotBe(null));
@@ -267,12 +267,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InlineDialogShouldNotCloseAfterStateHasChanged()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var comp1 = Context.RenderComponent<TestInlineDialog>();
+            var comp1 = Context.Render<TestInlineDialog>();
             // open the dialog
             comp1.Find("button").Click();
             // rate star
@@ -290,7 +290,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogShouldUpdateTitleContent()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -313,7 +313,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogShouldNotOverwriteParameters()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -345,12 +345,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PassingEventCallbackToDialogViaParameters()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
 
-            var testComp = Context.RenderComponent<DialogWithEventCallbackTest>();
+            var testComp = Context.Render<DialogWithEventCallbackTest>();
             // open dialog
             testComp.Find("button").Click();
             // in the opened dialog find the text field
@@ -372,7 +372,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.AddScoped<IDialogService>(sp => new CustomDialogService());
 
             //Render our dialog provider and make sure everything is fine
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             //Try to get the current service instance for the type IDialogService and make sure it is our custom implementation
@@ -410,7 +410,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogShouldReturnTheReturnValue()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -433,7 +433,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogKeyboardNavigation()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -459,7 +459,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogKeyboardEvents()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -482,7 +482,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogHandlesOnBackdropClickEvent()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -507,12 +507,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InlineDialogBug4871Test()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var comp1 = Context.RenderComponent<TestInlineDialog>();
+            var comp1 = Context.Render<TestInlineDialog>();
             comp1.FindComponents<MudButton>().Count.Should().Be(1);
             // open the dialog
             comp1.Find("button").Click();
@@ -532,7 +532,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogToggleFullscreenOptions()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -556,7 +556,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncLifecycleTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             await comp.InvokeAsync(async () =>
@@ -582,7 +582,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<ComponentThatOpensAndClosesDialog>();
+            var comp = Context.Render<ComponentThatOpensAndClosesDialog>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBeNull();
 
@@ -597,7 +597,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncSimpleTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -649,7 +649,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task InlineAsyncDialogShouldHonorClass()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -676,7 +676,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogShouldUpdateTitleContent()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -700,7 +700,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogShouldNotOverwriteParameters()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -737,7 +737,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogShouldHonorClass()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -761,7 +761,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.AddScoped<IDialogService>(sp => new CustomDialogService());
 
             //Render our dialog provider and make sure everything is fine
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             //Try to get the current service instance for the type IDialogService and make sure it is our custom implementation
@@ -800,7 +800,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogShouldReturnTheReturnValue()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -826,7 +826,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogKeyboardNavigation()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -855,7 +855,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogHandlesOnBackdropClickEvent()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -877,7 +877,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogToggleFullscreenOptions()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -898,7 +898,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ShowAsyncRenderCompleteTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
 
             var service = Context.Services.GetRequiredService<IDialogService>();
 
@@ -922,7 +922,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogParametersGenericShouldPassParameters()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
@@ -945,7 +945,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowGeneric_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -968,7 +968,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowGeneric_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -983,7 +983,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Show_ShouldRenderComponent()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -997,7 +997,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Show_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1020,7 +1020,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Show_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1035,7 +1035,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Show_ShouldPassDialogParametersToDialog()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1052,7 +1052,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowGenericAsync_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1075,7 +1075,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowGenericAsync_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1090,7 +1090,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Close_ShouldCloseDialogAndInvokeOnDialogCloseRequested()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             var reference = service.CreateReference();
             var invoked = false;
@@ -1114,7 +1114,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
             var service = Context.Services.GetRequiredService<IDialogService>();
-            _ = Context.RenderComponent<MudDialogProvider>();
+            _ = Context.Render<MudDialogProvider>();
             var invoked = false;
             service.DialogInstanceAddedAsync += _ =>
             {
@@ -1134,7 +1134,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowAsync_ShouldProvideDefaultOption()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1156,7 +1156,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowAsync_ShouldProvideDefaultOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1179,7 +1179,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowAsync_ShouldProvideCorrectOptions_WhenOverloadIsCalled()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1194,7 +1194,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShowAsync_ShouldPassDialogParametersToDialog()
         {
             // Arrange
-            var provider = Context.RenderComponent<MudDialogProvider>();
+            var provider = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
             // Act
@@ -1213,7 +1213,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("my-class", true, "mud-dialog-content mud-dialog-no-side-padding my-class")]
         public async Task DialogWithContentClassValueShouldRenderExpectedClassname(string contentClass, bool disablePadding, string expectedClassname)
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBeNull();
@@ -1235,7 +1235,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("my-class", "mud-dialog-actions my-class")]
         public async Task DialogWithActionsClassValueShouldRenderExpectedClassname(string actionsClass, string expectedClassname)
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBeNull();
@@ -1256,7 +1256,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("my-title-class my-second-class", "mud-dialog-title my-title-class my-second-class")]
         public async Task DialogWithTitleClassValueShouldRenderExpectedClassname(string titleClass, string expectedClassname)
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBeNull();
@@ -1276,7 +1276,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogWithNestedDialogOptionShouldNotReset()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
 
@@ -1309,10 +1309,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DuplicateDialogTest()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
-            var comp1 = Context.RenderComponent<InlineDialogDuplicateTest>();
+            var comp1 = Context.Render<InlineDialogDuplicateTest>();
             // open the dialog
             comp1.Find("button").Click();
             await Task.Delay(1000);
@@ -1322,12 +1322,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Dialog_TitleContent_And_ProgressBar_ShouldUpdate()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
 
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            var comp1 = Context.RenderComponent<InlineDialogTitleRefreshTest>();
+            var comp1 = Context.Render<InlineDialogTitleRefreshTest>();
 
             comp1.Find("button").Click();
 
@@ -1368,7 +1368,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             var dialogOptions = new DialogOptions { BackdropClick = false, CloseOnEscapeKey = true };
 
@@ -1406,10 +1406,10 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
 
             // Create a dialog component with OnBackdropClick delegate
-            var dialogComponent = Context.RenderComponent<DialogCloseOnEscapeTest>();
+            var dialogComponent = Context.Render<DialogCloseOnEscapeTest>();
 
             // Act
             await dialogComponent.FindComponent<MudButton>().Find("button").ClickAsync(new MouseEventArgs()); // Open the dialog

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
         public void TemporaryClosed_Open_CheckOpened_Close_CheckClosed()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Temporary));
 
             comp.Find("#toggle-drawer-button").Click();
@@ -76,7 +76,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task Temporary_OverlayAutoClose(bool overlayAutoClose)
         {
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(parameter => parameter.Variant, DrawerVariant.Temporary)
                 .Add(parameter => parameter.OverlayAutoClose, overlayAutoClose));
 
@@ -112,7 +112,7 @@ namespace MudBlazor.UnitTests.Components
         public void TemporaryClosedWithoutOverlay_Open_CheckOverlay()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Temporary)
                 .Add(x => x.Overlay, false));
 
@@ -128,7 +128,7 @@ namespace MudBlazor.UnitTests.Components
         public void TemporaryClosedClipped_Open_CheckState()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Temporary)
                 .Add(x => x.ClipMode, DrawerClipMode.Always));
 
@@ -144,7 +144,7 @@ namespace MudBlazor.UnitTests.Components
         public void PersistentClosed_Open_CheckOpened_Close_CheckClosed()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Persistent));
 
             comp.Find("#toggle-drawer-button").Click();
@@ -160,7 +160,7 @@ namespace MudBlazor.UnitTests.Components
         public void PersistentClosedClipped_Open_CheckState()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Persistent)
                 .Add(x => x.ClipMode, DrawerClipMode.Always));
 
@@ -176,7 +176,7 @@ namespace MudBlazor.UnitTests.Components
         public void MiniClosed_Open_CheckOpened_Close_CheckClosed()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Mini));
 
             comp.Find("#toggle-drawer-button").Click();
@@ -192,7 +192,7 @@ namespace MudBlazor.UnitTests.Components
         public void MiniClosedClipped_Open_CheckState()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerTest1>(parameters => parameters
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
                 .Add(x => x.Variant, DrawerVariant.Mini)
                 .Add(x => x.ClipMode, DrawerClipMode.Always));
 
@@ -208,7 +208,7 @@ namespace MudBlazor.UnitTests.Components
         public void ResponsiveClosed_Open_CheckOpened_Close_CheckClosed()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            var comp = Context.Render<DrawerResponsiveTest>();
 
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
@@ -225,7 +225,7 @@ namespace MudBlazor.UnitTests.Components
         public void ResponsiveSmallClosed_Open_CheckOpenedAndOverlay(Breakpoint point)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(point));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            var comp = Context.Render<DrawerResponsiveTest>();
 
             comp.Find("#toggle-drawer-button").Click();
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
@@ -252,8 +252,8 @@ namespace MudBlazor.UnitTests.Components
         public void ResponsiveClosed_StartLargeScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xl));
-            var providerComp = Context.RenderComponent<MudPopoverProvider>();
-            var comp = Context.RenderComponent<DrawerResponsiveTest>(parameters => parameters
+            var providerComp = Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
                 .Add(x => x.Breakpoint, breakpoint));
 
             comp.Find("#toggle-drawer-button").Click();
@@ -281,7 +281,7 @@ namespace MudBlazor.UnitTests.Components
         public void ResponsiveClosed_StartSmallScreen_SetBreakpoint_Open_CheckState(Breakpoint breakpoint)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>(parameters => parameters
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
                 .Add(x => x.Breakpoint, breakpoint));
 
             comp.Find("#toggle-drawer-button").Click();
@@ -298,7 +298,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ResponsiveClosed_ResizeMultiple_CheckStates()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            var comp = Context.Render<DrawerResponsiveTest>();
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
@@ -349,7 +349,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            var comp = Context.Render<DrawerResponsiveTest>();
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
@@ -385,7 +385,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Responsive_ResizeFromSmall_ToLarge_CheckStates()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>();
+            var comp = Context.Render<DrawerResponsiveTest>();
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
 
@@ -411,7 +411,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var breakpoint = Breakpoint.Always;
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>(parameters => parameters
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
                 .Add(x => x.Breakpoint, breakpoint));
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
@@ -489,7 +489,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var breakpoint = Breakpoint.None;
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
-            var comp = Context.RenderComponent<DrawerResponsiveTest>(parameters => parameters
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
                 .Add(x => x.Breakpoint, breakpoint));
             var mudDrawerComponent = comp.FindComponent<MudDrawer>();
             var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
@@ -566,7 +566,7 @@ namespace MudBlazor.UnitTests.Components
         public void DrawerContainer_RemoveDrawer_CheckStates()
         {
             _ = AddBrowserViewportService();
-            var comp = Context.RenderComponent<DrawerContainerTest1>();
+            var comp = Context.Render<DrawerContainerTest1>();
 
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(1);
 
@@ -602,7 +602,7 @@ namespace MudBlazor.UnitTests.Components
             )] bool initialState)
         {
             _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(breakpoint));
-            var comp = Context.RenderComponent<DrawerNonResponsiveTest>(parameters => parameters
+            var comp = Context.Render<DrawerNonResponsiveTest>(parameters => parameters
                 .Add(x => x.InitialOpenState, initialState));
 
             var expectedDrawerCount = initialState ? 1 : 0;
@@ -626,7 +626,7 @@ namespace MudBlazor.UnitTests.Components
         public void DrawerPersistentTop_HeightTest()
         {
             var drawerHeight = "300px";
-            var comp = Context.RenderComponent<DrawerPersistentTest>(parameters => parameters
+            var comp = Context.Render<DrawerPersistentTest>(parameters => parameters
                 .Add(x => x.Anchor, Anchor.Top)
                 .Add(x => x.DrawerHeight, drawerHeight));
 

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -71,7 +71,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DropZone_GeneralView()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var container = comp.Find(".mud-drop-container");
 
@@ -108,7 +108,7 @@ namespace MudBlazor.UnitTests.Components
             jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudDragAndDrop.initDropZone", It.Is<object[]>(y => y.Length == 1)))
                 .ReturnsAsync(Mock.Of<IJSVoidResult>(), TimeSpan.FromMilliseconds(200)).Verifiable();
 
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             jsRuntimeMock.Verify();
         }
@@ -116,7 +116,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DropZone_DropZoneOverrideContainerRendered()
         {
-            var comp = Context.RenderComponent<DropzoneCustomItemSelectorTest>();
+            var comp = Context.Render<DropzoneCustomItemSelectorTest>();
 
             var container = comp.Find(".mud-drop-container");
 
@@ -139,7 +139,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_SimpleDragAndDrop()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -181,7 +181,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DragAndDropDraggingClass_DragCanceled()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -246,7 +246,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DragAndDropDraggingClass_DragFinished()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -284,7 +284,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DragAndDropDraggingClass_DragFinished_DropNotAllowed()
         {
-            var comp = Context.RenderComponent<DropzoneDraggingTestCantDropSecondZoneTest>();
+            var comp = Context.Render<DropzoneDraggingTestCantDropSecondZoneTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -322,7 +322,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DropItem_DragEnterNotTrackedItem()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var tempContainer = comp.Find(".mud-drop-container");
             tempContainer.Children.Should().HaveCount(2);
@@ -340,7 +340,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DropNotTrackedItem()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
             {
                 var tempContainer = comp.Find(".mud-drop-container");
                 tempContainer.Children.Should().HaveCount(2);
@@ -358,7 +358,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_CheckDropClasses_NotApplyOnDragStarted()
         {
-            var comp = Context.RenderComponent<DropzoneCanDropTest>();
+            var comp = Context.Render<DropzoneCanDropTest>();
 
             var firstDropZone = comp.Find(".first-drop-zone");
             var secondDropZone = comp.Find(".second-drop-zone");
@@ -405,7 +405,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_CheckDropClasses_TransactionNotStarted()
         {
-            var comp = Context.RenderComponent<DropzoneCanDropTest>();
+            var comp = Context.Render<DropzoneCanDropTest>();
 
             var firstDropZone = comp.Find(".first-drop-zone");
             var secondDropZone = comp.Find(".second-drop-zone");
@@ -442,7 +442,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_CheckDropClasses_ApplyOnDrag_OnlySecondZone()
         {
-            var comp = Context.RenderComponent<DropzoneCanDropTest>(
+            var comp = Context.Render<DropzoneCanDropTest>(
                 p => p.Add(x => x.SecondColumnAppliesClassesOnDragStarted, true));
 
             var firstDropZone = comp.Find(".first-drop-zone");
@@ -501,7 +501,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted()
         {
-            var comp = Context.RenderComponent<DropzoneCanDropTest>(p =>
+            var comp = Context.Render<DropzoneCanDropTest>(p =>
             {
                 p.Add(x => x.SecondColumnAppliesClassesOnDragStarted, false);
                 p.Add(x => x.ApplyDropClassesOnDragStarted, true);
@@ -624,7 +624,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted_DragFinished()
         {
-            var comp = Context.RenderComponent<DropzoneCanDropTest>(p =>
+            var comp = Context.Render<DropzoneCanDropTest>(p =>
             {
                 p.Add(x => x.SecondColumnAppliesClassesOnDragStarted, false);
                 p.Add(x => x.ApplyDropClassesOnDragStarted, true);
@@ -661,7 +661,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_CheckDropClasses_ApplyClassesOnDragStarted_DragCanceled()
         {
-            var comp = Context.RenderComponent<DropzoneCanDropTest>(p =>
+            var comp = Context.Render<DropzoneCanDropTest>(p =>
             {
                 p.Add(x => x.SecondColumnAppliesClassesOnDragStarted, false);
                 p.Add(x => x.ApplyDropClassesOnDragStarted, true);
@@ -695,7 +695,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DropZone_CheckDropClasses_DisabledItems()
         {
-            var comp = Context.RenderComponent<DropzoneDisableTest>();
+            var comp = Context.Render<DropzoneDisableTest>();
 
             var firstDropZone = comp.Find(".first-drop-zone");
             var secondDropZone = comp.Find(".second-drop-zone");
@@ -734,7 +734,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DynamicItemsChanges()
         {
-            var comp = Context.RenderComponent<DropzoneDynamicItemCollectionTest>();
+            var comp = Context.Render<DropzoneDynamicItemCollectionTest>();
 
             var firstDropZone = comp.Find(".first-drop-zone");
             var secondDropZone = comp.Find(".second-drop-zone");
@@ -769,7 +769,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_OnlyZone()
         {
-            var comp = Context.RenderComponent<DropzoneVisbilityTest>();
+            var comp = Context.Render<DropzoneVisbilityTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -797,7 +797,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_PlaceIntoEmptyZone()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -837,7 +837,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_MoveWithinContainer_Down()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -874,7 +874,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_MoveWithinContainer_Up()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -912,7 +912,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_MoveWithinContainer_ToBottom()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -950,7 +950,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_MoveWithinContainer_Top()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -987,7 +987,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_MoveWithinContainer_NoChange()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -1017,7 +1017,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_MoveBetweenZones()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -1130,7 +1130,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Item_ClassSelector()
         {
-            var comp = Context.RenderComponent<DropzoneItemClassSelectorTest>();
+            var comp = Context.Render<DropzoneItemClassSelectorTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -1156,7 +1156,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Item_OnItemPicked()
         {
-            var comp = Context.RenderComponent<DropzoneItemOnItemPickedTest>();
+            var comp = Context.Render<DropzoneItemOnItemPickedTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -1179,7 +1179,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_Reorder_NoPreviewOnSameItem()
         {
-            var comp = Context.RenderComponent<DropzoneReorderTest>();
+            var comp = Context.Render<DropzoneReorderTest>();
 
             comp.Find(".mud-drop-container");
             var firstDropZone = comp.Find(".dropzone-1");
@@ -1222,7 +1222,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_DragFinished_DropNotAllowed_KeepOrder()
         {
-            var comp = Context.RenderComponent<DropzoneDraggingTestCantDropSecondZoneTest>();
+            var comp = Context.Render<DropzoneDraggingTestCantDropSecondZoneTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -1254,7 +1254,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_IsOriginTest()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);
@@ -1274,7 +1274,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DropZone_GetTransactionOriginZoneIdentifierTest()
         {
-            var comp = Context.RenderComponent<DropzoneBasicTest>();
+            var comp = Context.Render<DropzoneBasicTest>();
 
             var container = comp.Find(".mud-drop-container");
             container.Children.Should().HaveCount(2);

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -22,7 +22,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DefaultValues()
         {
-            var comp = Context.RenderComponent<MudDynamicTabs>();
+            var comp = Context.Render<MudDynamicTabs>();
             var tabs = comp.Instance;
 
             tabs.Header.Should().NotBeNull();
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void BasicParameters()
         {
-            var comp = Context.RenderComponent<SimpleDynamicTabsTest>();
+            var comp = Context.Render<SimpleDynamicTabsTest>();
 
             // three panels three close icons;
             var closeButtons = comp.FindAll(".my-close-icon-class");
@@ -89,7 +89,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task BasicParameters_WithToolTips()
         {
-            var comp = Context.RenderComponent<SimpleDynamicTabsTestWithToolTips>();
+            var comp = Context.Render<SimpleDynamicTabsTestWithToolTips>();
 
             // three panels three close icons;
             var closeButtons = comp.FindAll(".my-close-icon-class");
@@ -151,7 +151,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestInteractions_AddTab()
         {
-            var comp = Context.RenderComponent<SimpleDynamicTabsInteractionTest>();
+            var comp = Context.Render<SimpleDynamicTabsInteractionTest>();
 
             var addButton = comp.Find(".my-add-icon-class");
             addButton.Click();
@@ -163,7 +163,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestInteractions_RemoveTab()
         {
-            var comp = Context.RenderComponent<SimpleDynamicTabsInteractionTest>();
+            var comp = Context.Render<SimpleDynamicTabsInteractionTest>();
 
             for (var i = 0; i < 3; i++)
             {

--- a/src/MudBlazor.UnitTests/Components/ElementTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ElementTests.cs
@@ -13,7 +13,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Should_Render_An_Anchor_And_Then_A_Button()
         {
-            var comp = Context.RenderComponent<MudElement>(parameters => parameters
+            var comp = Context.Render<MudElement>(parameters => parameters
                 .Add(x => x.HtmlTag, "a")
                 .Add(x => x.Class, "mud-button-root"));
             comp.MarkupMatches("<a class=\"mud-button-root\"></a>");
@@ -31,13 +31,13 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudElement_Should_Not_Attach_A_Null_Event()
         {
-            var comp = Context.RenderComponent<ElementTestEventNull>();
+            var comp = Context.Render<ElementTestEventNull>();
 
             //initially, renders just an empty span, because AttachEvent is false;
             comp.MarkupMatches("<span></span>");
 
             //we set AttachEvent to true, so it has to attach the mouseover event
-            var comp2 = Context.RenderComponent<ElementTestEventNull>(parameters => parameters.Add(x => x.AttachEvent, true));
+            var comp2 = Context.Render<ElementTestEventNull>(parameters => parameters.Add(x => x.AttachEvent, true));
 
             //because we didn't hovered yet the element, the WasHovered property is false
             comp2.Instance.WasHovered.Should().BeFalse();
@@ -50,7 +50,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ElementReferenceCapture()
         {
-            var comp = Context.RenderComponent<ElementReferenceExceptionTest>();
+            var comp = Context.Render<ElementReferenceExceptionTest>();
             comp.Find("#element-button").Click();
         }
     }

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_Respects_Collapsing_Order()
         {
-            var comp = Context.RenderComponent<ExpansionPanelExpansionsTest>();
+            var comp = Context.Render<ExpansionPanelExpansionsTest>();
             //the order in which the panels are going to be clicked
             //First, the first; then, the third, and then the second
             var sequence = new List<int> { 0, 2, 1 };
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_Without_MultiExpansion_Doesnt_Crash_With_Multiple_Expanded_Tabs()
         {
-            var comp = Context.RenderComponent<ExpansionPanelExpandedMultipleWithoutMultipleExpansionSetTest>();
+            var comp = Context.Render<ExpansionPanelExpandedMultipleWithoutMultipleExpansionSetTest>();
 
             //click in the three headers
             //foreach (var header in comp.FindAll(".mud-expand-panel-header"))
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_MultiExpansion_Doesnt_Collapse_Others()
         {
-            var comp = Context.RenderComponent<ExpansionPanelMultiExpansionTest>();
+            var comp = Context.Render<ExpansionPanelMultiExpansionTest>();
 
             //click in the three headers
             foreach (var header in comp.FindAll(".mud-expand-panel-header"))
@@ -100,7 +100,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_IsInitiallyExpanded_Expands()
         {
-            var comp = Context.RenderComponent<ExpansionPanelStartExpandedTest>();
+            var comp = Context.Render<ExpansionPanelStartExpandedTest>();
 
             // one panel is expanded initially
             var panels = comp.FindAll(".mud-panel-expanded").ToList();
@@ -120,7 +120,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_IsInitiallyExpanded_Works_With_Multi_Expanded()
         {
-            var comp = Context.RenderComponent<ExpansionPanelStartExpandedMultipleTest>();
+            var comp = Context.Render<ExpansionPanelStartExpandedMultipleTest>();
 
             // three panels is expanded initially
             var panels = comp.FindAll(".mud-panel-expanded").ToList();
@@ -140,7 +140,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_Other()
         {
-            var comp = Context.RenderComponent<ExpansionPanelStartExpandedTest>();
+            var comp = Context.Render<ExpansionPanelStartExpandedTest>();
             var panel = comp.FindComponent<MudExpansionPanel>();
             await panel.SetParametersAndRenderAsync(parameters => parameters.Add(parameter => parameter.Disabled, true));
 
@@ -167,10 +167,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_ExpandAllAsync()
         {
-            var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
-            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
-            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panels = Context.Render<MudExpansionPanels>();
+            var panel1 = Context.Render<MudExpansionPanel>().Instance;
+            var panel2 = Context.Render<MudExpansionPanel>().Instance;
+            var panel3 = Context.Render<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -192,10 +192,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_CollapseAllAsync()
         {
-            var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
-            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
-            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panels = Context.Render<MudExpansionPanels>();
+            var panel1 = Context.Render<MudExpansionPanel>().Instance;
+            var panel2 = Context.Render<MudExpansionPanel>().Instance;
+            var panel3 = Context.Render<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -220,10 +220,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_CollapseAllExceptAsync()
         {
-            var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
-            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
-            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panels = Context.Render<MudExpansionPanels>();
+            var panel1 = Context.Render<MudExpansionPanel>().Instance;
+            var panel2 = Context.Render<MudExpansionPanel>().Instance;
+            var panel3 = Context.Render<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -248,7 +248,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_TwoWayBinding()
         {
-            var comp = Context.RenderComponent<ExpansionPanelTwoWayBIndingTest>();
+            var comp = Context.Render<ExpansionPanelTwoWayBIndingTest>();
 
             comp.WaitForAssertion(() => comp.Instance.Expansion[0].Should().BeTrue());
             comp.WaitForAssertion(() => comp.Instance.Expansion[1].Should().BeFalse());
@@ -304,7 +304,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_Handles_KeyDown_For_Toggle()
         {
-            var comp = Context.RenderComponent<ExpansionPanelKeyboardTest>();
+            var comp = Context.Render<ExpansionPanelKeyboardTest>();
             var header = comp.Find(".mud-expand-panel-header");
 
             comp.Markup.Should().NotContain("mud-panel-expanded");
@@ -322,7 +322,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_Button_IsInHiddenContainer_When_Panel_Collapsed()
         {
-            var comp = Context.RenderComponent<ExpansionPanelKeyboardTest>();
+            var comp = Context.Render<ExpansionPanelKeyboardTest>();
             var button = comp.Find("button");
             var hiddenParent = button
                 .GetAncestors()
@@ -338,7 +338,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudExpansionPanel_HandleKeyDownAsync_IgnoresKeys_When_Disabled()
         {
-            var comp = Context.RenderComponent<MudExpansionPanel>(parameters => parameters
+            var comp = Context.Render<MudExpansionPanel>(parameters => parameters
                 .Add(p => p.Disabled, true)
                 .Add(p => p.Text, "Disabled Panel"));
 
@@ -360,7 +360,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_KeepContentAlive_True_RendersContentWhenCollapsed()
         {
-            var comp = Context.RenderComponent<MudExpansionPanel>(parameters => parameters
+            var comp = Context.Render<MudExpansionPanel>(parameters => parameters
                 .Add(p => p.Text, "Test Panel")
                 .Add(p => p.KeepContentAlive, true)
                 .Add(p => p.ChildContent, builder => builder.AddMarkupContent(0, "<button>Test Button</button>")));
@@ -378,7 +378,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_KeepContentAlive_False_DoesNotRenderContentWhenCollapsed()
         {
-            var comp = Context.RenderComponent<MudExpansionPanel>(parameters => parameters
+            var comp = Context.Render<MudExpansionPanel>(parameters => parameters
                 .Add(p => p.Text, "Test Panel")
                 .Add(p => p.KeepContentAlive, false)
                 .Add(p => p.ChildContent, builder => builder.AddMarkupContent(0, "<button>Test Button</button>")));
@@ -393,7 +393,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_Gutters_True_AppliesGuttersToHeaderAndContent()
         {
-            var comp = Context.RenderComponent<ExpansionPanelGuttersTrueTest>();
+            var comp = Context.Render<ExpansionPanelGuttersTrueTest>();
 
             var header = comp.Find(".mud-expand-panel-header");
             header.ClassList.Should().Contain("mud-expand-panel-header-gutters");
@@ -408,7 +408,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_Gutters_False_RemovesGuttersFromHeaderAndContent()
         {
-            var comp = Context.RenderComponent<ExpansionPanelGuttersFalseTest>();
+            var comp = Context.Render<ExpansionPanelGuttersFalseTest>();
 
             var header = comp.Find(".mud-expand-panel-header");
             header.ClassList.Should().NotContain("mud-expand-panel-header-gutters");
@@ -423,7 +423,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudExpansionPanel_ParentGuttersFalse_OverridesChildGutters()
         {
-            var comp = Context.RenderComponent<ExpansionPanelParentGuttersFalseTest>();
+            var comp = Context.Render<ExpansionPanelParentGuttersFalseTest>();
 
             var header = comp.Find(".mud-expand-panel-header");
             header.ClassList.Should().NotContain("mud-expand-panel-header-gutters");

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -12,7 +12,7 @@ public class FabMenuTests : BunitTest
     [Test]
     public void RendersCorrectly()
     {
-        var comp = Context.RenderComponent<FabMenuTest>();
+        var comp = Context.Render<FabMenuTest>();
         comp.FindAll(".mud-fab-menu").Count.Should().Be(1);
         comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0);
         comp.FindAll(".mud-fab-menu-item").Count.Should().Be(3);
@@ -21,7 +21,7 @@ public class FabMenuTests : BunitTest
     [Test]
     public void RendersCorrectlyOnClick()
     {
-        var comp = Context.RenderComponent<FabMenuTest>();
+        var comp = Context.Render<FabMenuTest>();
 
         comp.FindAll(".mud-fab-menu-button")[0].Click();
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });
@@ -33,7 +33,7 @@ public class FabMenuTests : BunitTest
     [Test]
     public void RendersCorrectlyOnTouch()
     {
-        var compNoHover = Context.RenderComponent<FabMenuTest>();
+        var compNoHover = Context.Render<FabMenuTest>();
 
         compNoHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compNoHover.FindAll(".mud-fab-menu-button")[0].Click();
@@ -43,7 +43,7 @@ public class FabMenuTests : BunitTest
         compNoHover.FindAll(".mud-fab-menu-item")[0].Click();
         compNoHover.WaitForAssertion(() => { compNoHover.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
 
-        var compHover = Context.RenderComponent<FabMenuTest>(parameters => parameters.Add(p => p.OpenOnMouseHover, true));
+        var compHover = Context.Render<FabMenuTest>(parameters => parameters.Add(p => p.OpenOnMouseHover, true));
 
         compHover.FindAll(".mud-fab-menu-button")[0].TouchStart();
         compHover.FindAll(".mud-fab-menu-button")[0].Click();
@@ -57,7 +57,7 @@ public class FabMenuTests : BunitTest
     [Test]
     public void RendersCorrectlyOnHover()
     {
-        var comp = Context.RenderComponent<FabMenuTest>(parameters => parameters.Add(p => p.OpenOnMouseHover, true));
+        var comp = Context.Render<FabMenuTest>(parameters => parameters.Add(p => p.OpenOnMouseHover, true));
 
         comp.FindAll(".mud-fab-menu-container")[0].TriggerEvent("onmouseenter", new MouseEventArgs());
         comp.WaitForAssertion(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(1); });

--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FieldTest_ShouldRender_Variants()
         {
-            var comp = Context.RenderComponent<FieldTest>();
+            var comp = Context.Render<FieldTest>();
             var fields = comp.FindAll(".mud-grid .mud-input-control.mud-field");
             fields.Should().HaveCount(3);
             fields[0].ClassList.Should().Contain("mud-input-text-with-label");
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FieldTest_ShouldRender_AriaAdornment()
         {
-            var comp = Context.RenderComponent<FieldTest>();
+            var comp = Context.Render<FieldTest>();
             var fields = comp.FindAll(".mud-grid .mud-input-control.mud-field");
             fields.Should().HaveCount(3);
             fields[0].ClassList.Should().Contain("mud-input-text-with-label");
@@ -44,7 +44,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Issue 7533, when ChildContent is null, the mud-shrink class is applied
             // Add a shrink label override to the field in addition to the ChildContent
-            var comp = Context.RenderComponent<FieldStartAdornmentTest>();
+            var comp = Context.Render<FieldStartAdornmentTest>();
             // find all the mud-fields inner area
             var fields = comp.FindAll(".mud-input-control.mud-field > .mud-input-control-input-container > .mud-input");
             var fieldLabels = comp.FindAll(".mud-input-control.mud-field > .mud-input-control-input-container label");

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.UnitTests.Components
             var provider = new MockLoggerProvider();
             var logger = provider.CreateLogger(GetType().FullName) as MockLogger;
             Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider)); //set up the logging provider
-            var comp = Context.RenderComponent<MudFileUpload<MudTextField<string>>>();
+            var comp = Context.Render<MudFileUpload<MudTextField<string>>>();
 
             var entries = logger.GetEntries();
             entries.Count.Should().Be(1);
@@ -43,7 +43,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FileUpload_CSSTest()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IBrowserFile>>(parameters => parameters
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>(parameters => parameters
                 .Add(x => x.Class, "outer-test")
                 .Add(x => x.InputClass, "inner-test"));
 
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FileUpload_MultipleTest()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
+            var comp = Context.Render<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
 
             var input = comp.Find("input");
             input.HasAttribute("multiple").Should().BeTrue();
@@ -71,7 +71,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FileUpload_HiddenTest1()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
+            var comp = Context.Render<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
 
             var input = comp.Find("input");
             input.HasAttribute("hidden").Should().BeTrue();
@@ -83,7 +83,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FileUpload_HiddenTest2()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>(parameters =>
+            var comp = Context.Render<MudFileUpload<IReadOnlyList<IBrowserFile>>>(parameters =>
                 parameters.Add(x => x.Hidden, false));
 
             var input = comp.Find("input");
@@ -96,7 +96,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FileUpload_AcceptTest()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IBrowserFile>>(parameters => parameters
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>(parameters => parameters
                 .Add(x => x.Accept, ".png, .jpg"));
 
             var input = comp.Find("input");
@@ -109,7 +109,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FileUpload_ButtonTemplateContextTest_Renders()
         {
-            var comp = Context.RenderComponent<FileUploadWithDragAndDropActivatorTest>();
+            var comp = Context.Render<FileUploadWithDragAndDropActivatorTest>();
 
             var openFilePickerButton = comp.Find("button#open-file-picker-button");
             openFilePickerButton.ToMarkup().Should().Contain("Open file picker");
@@ -126,7 +126,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var fileName = "cat.jpg";
             var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", []);
-            var comp = Context.RenderComponent<FileUploadWithDragAndDropActivatorTest>(parameters =>
+            var comp = Context.Render<FileUploadWithDragAndDropActivatorTest>(parameters =>
                 parameters.Add(x => x.File, defaultFile));
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
             var fileUploadInstance = fileUploadComp.Instance;
@@ -149,7 +149,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FileUpload_OpenFilePickerAsync_Should_OpenFilePicker_When_Clicked()
         {
-            var comp = Context.RenderComponent<FileUploadWithDragAndDropActivatorTest>();
+            var comp = Context.Render<FileUploadWithDragAndDropActivatorTest>();
 
             await comp.InvokeAsync(() => comp.Find("button#open-file-picker-button").Click());
 
@@ -164,7 +164,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var fileContent = InputFileContent.CreateFromText("Garderoben is a farmer!", "upload.txt");
 
-            var comp = Context.RenderComponent<FileUploadOnFilesChangedTest>();
+            var comp = Context.Render<FileUploadOnFilesChangedTest>();
 
             var input = comp.FindComponent<InputFile>();
             input.UploadFiles(fileContent);
@@ -187,7 +187,7 @@ namespace MudBlazor.UnitTests.Components
                 InputFileContent.CreateFromText("A Balrog, servant of Morgoth", "upload2.txt")
             };
 
-            var comp = Context.RenderComponent<FileUploadFormValidationTest>();
+            var comp = Context.Render<FileUploadFormValidationTest>();
 
             var inputs = comp.FindComponents<InputFile>();
             inputs.Count.Should().Be(2);
@@ -225,7 +225,7 @@ namespace MudBlazor.UnitTests.Components
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture; //<<< rework this!
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
-            var comp = Context.RenderComponent<FileUploadFormValidationTest>();
+            var comp = Context.Render<FileUploadFormValidationTest>();
 
             var form = comp.Instance.Form;
             await comp.InvokeAsync(() => form.Validate());
@@ -275,7 +275,7 @@ namespace MudBlazor.UnitTests.Components
 
             Files.Count.Should().Be(11); //ensure there are 11 files
 
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>();
+            var comp = Context.Render<FileUploadMultipleFilesTest>();
 
             var multiple = comp.FindComponent<MudFileUpload<IReadOnlyList<IBrowserFile>>>();
             var multipleInput = multiple.FindComponent<InputFile>();
@@ -291,7 +291,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FileUploadDisabledTest()
         {
-            var comp = Context.RenderComponent<FileUploadDisabledTest>();
+            var comp = Context.Render<FileUploadDisabledTest>();
             comp.FindComponent<MudFileUpload<IBrowserFile>>().Find("input").HasAttribute("disabled").Should().BeFalse();
             comp.FindComponent<MudFileUpload<IBrowserFile>>().Find("button").HasAttribute("disabled").Should().BeFalse();
 
@@ -313,7 +313,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void FileUploadAppendMultipleTest(bool appendMultiple)
         {
-            var comp = Context.RenderComponent<FileUploadAppendMultipleTest>(p =>
+            var comp = Context.Render<FileUploadAppendMultipleTest>(p =>
                 p.Add(x => x.AppendMultipleFiles, appendMultiple));
 
             var input = comp.FindComponent<InputFile>();
@@ -335,7 +335,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalFileUpload_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IBrowserFile>>();
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -347,7 +347,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredFileUpload_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IBrowserFile>>(parameters => parameters
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -360,7 +360,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredFileUploadAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IBrowserFile>>();
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -378,7 +378,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Generate_new_InputFile_on_file_change()
         {
-            var comp = Context.RenderComponent<MudFileUpload<IBrowserFile>>();
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>();
 
             // only 1 input element should be present
             comp.FindAll("input").Should().HaveCount(1);
@@ -400,7 +400,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Should_trigger_file_change_callbacks_as_expected()
         {
-            var comp = Context.RenderComponent<FileUploadChangeCountTests>();
+            var comp = Context.Render<FileUploadChangeCountTests>();
 
             // first file change should trigger both callbacks
             var fileContent = new byte[5];
@@ -433,7 +433,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_SingleFile_WithinLimit()
         {
-            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.Render<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file = CreateDummyFile("test.txt", 50);
             var input = comp.FindComponent<InputFile>();
@@ -448,7 +448,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_SingleFile_ExceedsLimit()
         {
-            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.Render<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file = CreateDummyFile("test.txt", 150);
             var input = comp.FindComponent<InputFile>();
@@ -464,7 +464,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_SingleFile_NoLimit()
         {
-            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
+            var comp = Context.Render<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
 
             var file = CreateDummyFile("test.txt", 200);
             var input = comp.FindComponent<InputFile>();
@@ -482,7 +482,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_MultipleFiles_AllWithinLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.Render<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file1 = CreateDummyFile("test1.txt", 50);
             var file2 = CreateDummyFile("test2.txt", 70);
@@ -503,7 +503,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_MultipleFiles_SomeExceedLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.Render<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file1 = CreateDummyFile("test1.txt", 50);
             var file2 = CreateDummyFile("test2.txt", 120);
@@ -526,7 +526,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_MultipleFiles_AllExceedLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
+            var comp = Context.Render<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100L));
 
             var file1 = CreateDummyFile("test1.txt", 120);
             var file2 = CreateDummyFile("test2.txt", 150);
@@ -549,7 +549,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MaxFileSize_MultipleFiles_NoLimit()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
+            var comp = Context.Render<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, null));
 
             var file1 = CreateDummyFile("test1.txt", 200);
             var file2 = CreateDummyFile("test2.txt", 300);
@@ -570,7 +570,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaxFileSize_ClearValidationAfterError()
         {
-            var comp = Context.RenderComponent<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100));
+            var comp = Context.Render<FileUploadMultipleFilesTest>(parameters => parameters.Add(p => p.MaxFileSize, 100));
 
             var file1 = CreateDummyFile("test1.txt", 200);
             var file2 = CreateDummyFile("test2.txt", 300);
@@ -599,7 +599,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaxFileSize_ResetValidationAfterError()
         {
-            var comp = Context.RenderComponent<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100));
+            var comp = Context.Render<FileUploadSingleFileTest>(parameters => parameters.Add(p => p.MaxFileSize, 100));
 
             var file1 = CreateDummyFile("test1.txt", 200);
 

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormIsValidTest()
         {
-            var comp = Context.RenderComponent<FormIsValidTest>();
+            var comp = Context.Render<FormIsValidTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             var textField = textFieldcomp.Instance;
@@ -65,7 +65,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormIsValidTest2()
         {
-            var comp = Context.RenderComponent<FormIsValidTest2>();
+            var comp = Context.Render<FormIsValidTest2>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             // check initial state: form should be valid due to field not being required!
@@ -80,7 +80,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormIsValidTest3()
         {
-            var comp = Context.RenderComponent<FormIsValidTest3>();
+            var comp = Context.Render<FormIsValidTest3>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textFields = comp.FindComponents<MudTextField<string>>();
             // check initial state: form should be invalid due to having a required field that is not filled
@@ -101,7 +101,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormIsValidTest4()
         {
-            var comp = Context.RenderComponent<FormIsValidTest4>();
+            var comp = Context.Render<FormIsValidTest4>();
             var form = comp.FindComponent<MudForm>().Instance;
             // check initial state: form should be valid due to having no required field, but the user's two-way binding did override that value to false
             comp.WaitForAssertion(() => form.IsValid.Should().Be(true));
@@ -114,7 +114,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormIsTouchedTest()
         {
-            var comp = Context.RenderComponent<FormIsTouchedTest>();
+            var comp = Context.Render<FormIsTouchedTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             var dateComp = comp.FindComponent<MudDatePicker>();
@@ -143,7 +143,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormIsTouchedAndNestedFormIsNotTouchedWhenParentFormFieldIsTouchedTest()
         {
-            var comp = Context.RenderComponent<FormIsTouchedNestedTest>();
+            var comp = Context.Render<FormIsTouchedNestedTest>();
             var formsComp = comp.FindComponents<MudForm>();
             var textCompFields = comp.FindComponents<MudTextField<string>>();
             var form = formsComp[0].Instance;
@@ -179,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormIsUnTouchedWhenNestedFormTouchedTest()
         {
-            var comp = Context.RenderComponent<FormIsTouchedNestedTest>();
+            var comp = Context.Render<FormIsTouchedNestedTest>();
             var formsComp = comp.FindComponents<MudForm>();
             var textCompFields = comp.FindComponents<MudTextField<string>>();
             var dateCompFields = comp.FindComponents<MudDatePicker>();
@@ -217,7 +217,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormIsTouchedResetTest()
         {
-            var comp = Context.RenderComponent<FormIsTouchedTest>();
+            var comp = Context.Render<FormIsTouchedTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
             // check initial state: form should not be touched
@@ -238,7 +238,7 @@ namespace MudBlazor.UnitTests.Components
         public void FormValidationTest1()
         {
             var validationFunc = new Func<string, bool>(x => x?.StartsWith("Marilyn") == true);
-            var comp = Context.RenderComponent<FormValidationTest>(parameters => parameters.Add(p => p.Validation, validationFunc));
+            var comp = Context.Render<FormValidationTest>(parameters => parameters.Add(p => p.Validation, validationFunc));
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             var textField = textFieldcomp.Instance;
@@ -289,7 +289,7 @@ namespace MudBlazor.UnitTests.Components
                     return "Not a star!";
                 return null;
             });
-            var comp = Context.RenderComponent<FormValidationTest>(parameters => parameters.Add(p => p.Validation, validationFunc));
+            var comp = Context.Render<FormValidationTest>(parameters => parameters.Add(p => p.Validation, validationFunc));
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             form.IsValid.Should().Be(false);
@@ -320,7 +320,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormValidationTest3()
         {
-            var comp = Context.RenderComponent<FormValidationTest>();
+            var comp = Context.Render<FormValidationTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textFieldcomp = comp.FindComponent<MudTextField<string>>();
             var textField = textFieldcomp.Instance;
@@ -350,7 +350,7 @@ namespace MudBlazor.UnitTests.Components
                 await Task.Delay(valid ? ValidDelay : InvalidDelay);
                 return valid ? null : "invalid";
             });
-            var comp = Context.RenderComponent<FormValidationTest>(parameters => parameters.Add(p => p.Validation, validationFunc));
+            var comp = Context.Render<FormValidationTest>(parameters => parameters.Add(p => p.Validation, validationFunc));
             var textFieldComp = comp.FindComponent<MudTextField<string>>();
             var textField = textFieldComp.Instance;
             // validate initial field state
@@ -374,7 +374,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormAsyncValidationWithFieldChangedSubscriberTest()
         {
-            var comp = Context.RenderComponent<FormAsyncValidationWithFieldChangedSubscriberTest>();
+            var comp = Context.Render<FormAsyncValidationWithFieldChangedSubscriberTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var input = comp.Find("input");
             input.Input(new ChangeEventArgs { Value = "test" });
@@ -404,7 +404,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void EditFormOnFieldChangedTest()
         {
-            var comp = Context.RenderComponent<EditFormOnFieldChangedTest>();
+            var comp = Context.Render<EditFormOnFieldChangedTest>();
             var textFields = comp.FindAll("input");
             textFields.Count.Should().Be(3);
             var chips = comp.FindAll("span.mud-chip-content");
@@ -437,7 +437,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormWithCheckboxTest()
         {
-            var comp = Context.RenderComponent<FormWithCheckBoxAndTextFieldsTest>();
+            var comp = Context.Render<FormWithCheckBoxAndTextFieldsTest>();
             var textFields = comp.FindAll("input");
             textFields.Count.Should().Be(4); // three textfields, one checkbox
             // let's fill in some values
@@ -467,7 +467,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormWithCheckboxTest2()
         {
-            var comp = Context.RenderComponent<FormWithCheckBoxAndTextFieldsTest>();
+            var comp = Context.Render<FormWithCheckBoxAndTextFieldsTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             form.IsValid.Should().BeTrue(because: "none of the fields are required");
         }
@@ -478,7 +478,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Form_Should_BecomeValidIfUntouchedFieldsAreNotRequired()
         {
-            var comp = Context.RenderComponent<FormValidationTest2>();
+            var comp = Context.Render<FormValidationTest2>();
             var form = comp.FindComponent<MudForm>().Instance;
             form.IsValid.Should().BeFalse(because: "textfield is required");
             var textfield = comp.FindComponent<MudTextField<string>>();
@@ -492,7 +492,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Form_Should_BecomeInValidWhenAConversionErrorOccurs()
         {
-            var comp = Context.RenderComponent<FormConversionErrorTest>();
+            var comp = Context.Render<FormConversionErrorTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             form.IsValid.Should().BeTrue();
             var textfield = comp.FindComponent<MudTextField<int>>();
@@ -508,7 +508,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudFormExampleTest()
         {
-            var comp = Context.RenderComponent<FormValidationTest4>();
+            var comp = Context.Render<FormValidationTest4>();
             var form = comp.FindComponent<MudForm>().Instance;
             comp.FindComponent<MudForm>().SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ValidationDelay, 0));
             comp.WaitForAssertion(() => form.IsValid.Should().BeFalse(because: "it contains required fields that are not filled out"));
@@ -572,7 +572,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithRadioGroupIsValidTest()
         {
-            var comp = Context.RenderComponent<FormWithRadioGroupTest>();
+            var comp = Context.Render<FormWithRadioGroupTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var radioGroupcomp = comp.FindComponent<MudRadioGroup<string>>();
             var radioGroup = radioGroupcomp.Instance;
@@ -601,7 +601,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_ColorPicker_When_ColorSelectedViaInputs()
         {
-            var comp = Context.RenderComponent<FormWithColorPickerTest>();
+            var comp = Context.Render<FormWithColorPickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var colorPickerComp = comp.FindComponent<MudColorPicker>();
             var colorPicker = comp.FindComponent<MudColorPicker>().Instance;
@@ -634,7 +634,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_ValidateColorPickerTest_When_ColorSelectedViaPicker()
         {
-            var comp = Context.RenderComponent<FormWithColorPickerTest>();
+            var comp = Context.Render<FormWithColorPickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var colorPickerComp = comp.FindComponent<MudColorPicker>();
             var colorPicker = comp.FindComponent<MudColorPicker>().Instance;
@@ -679,7 +679,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithDatePickerTest()
         {
-            var comp = Context.RenderComponent<FormWithDatePickerTest>();
+            var comp = Context.Render<FormWithDatePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
             var datepicker = comp.FindComponent<MudDatePicker>().Instance;
@@ -708,7 +708,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_ValidateDatePickerTest()
         {
-            var comp = Context.RenderComponent<FormWithDatePickerTest>();
+            var comp = Context.Render<FormWithDatePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
             var datepicker = comp.FindComponent<MudDatePicker>().Instance;
@@ -734,7 +734,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs()
         {
-            var comp = Context.RenderComponent<FormWithDateRangePickerTest>();
+            var comp = Context.Render<FormWithDateRangePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateRangeComp = comp.FindComponent<MudDateRangePicker>();
             var dateRangePicker = comp.FindComponent<MudDateRangePicker>().Instance;
@@ -767,7 +767,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaPicker()
         {
-            var comp = Context.RenderComponent<FormWithDateRangePickerTest>();
+            var comp = Context.Render<FormWithDateRangePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateRangePicker = comp.FindComponent<MudDateRangePicker>().Instance;
             // check initial state: form should not be valid because dateRangePicker is required
@@ -801,7 +801,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithTimePickerTest()
         {
-            var comp = Context.RenderComponent<FormWithTimePickerTest>();
+            var comp = Context.Render<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var timePickerComp = comp.FindComponent<MudTimePicker>();
             var timePicker = comp.FindComponent<MudTimePicker>().Instance;
@@ -830,7 +830,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_ValidateTimePickerTest()
         {
-            var comp = Context.RenderComponent<FormWithTimePickerTest>();
+            var comp = Context.Render<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var timeComp = comp.FindComponent<MudTimePicker>();
             var timePicker = comp.FindComponent<MudTimePicker>().Instance;
@@ -855,7 +855,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_FileUpload_When_FileAdded()
         {
-            var comp = Context.RenderComponent<FormWithFileUploadTest>();
+            var comp = Context.Render<FormWithFileUploadTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
             var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
@@ -898,7 +898,7 @@ namespace MudBlazor.UnitTests.Components
             var fileName = "cat.jpg";
             var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>());
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
-            var comp = Context.RenderComponent<FormWithFileUploadTest>(parameters =>
+            var comp = Context.Render<FormWithFileUploadTest>(parameters =>
                 parameters.Add(x => x.File, defaultFile));
             var form = comp.FindComponent<MudForm>().Instance;
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
@@ -942,7 +942,7 @@ namespace MudBlazor.UnitTests.Components
             var fileName = "cat.jpg";
             var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>());
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
-            var comp = Context.RenderComponent<FormWithFileUploadTest>(
+            var comp = Context.Render<FormWithFileUploadTest>(
                 parameters => parameters.Add(x => x.File, defaultFile));
             var form = comp.FindComponent<MudForm>().Instance;
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
@@ -985,7 +985,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var fileName = "cat.jpg";
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
-            var comp = Context.RenderComponent<FormWithFileUploadAndDragAndDropActivatorTest>();
+            var comp = Context.Render<FormWithFileUploadAndDragAndDropActivatorTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
             var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
@@ -1026,7 +1026,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void EditFormExample_EmptyValidation()
         {
-            var comp = Context.RenderComponent<FormValidationTest3>();
+            var comp = Context.Render<FormValidationTest3>();
             // same effect as clicking the validate button
             comp.Find("form").Submit();
             var textfields = comp.FindComponents<MudTextField<string>>();
@@ -1050,7 +1050,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void EditFormExample_FillInValues()
         {
-            var comp = Context.RenderComponent<FormValidationTest3>();
+            var comp = Context.Render<FormValidationTest3>();
             comp.FindAll("input")[0].Change("Rick Sanchez");
             comp.FindAll("input")[0].Blur();
             comp.FindAll("input")[1].Change("rick.sanchez@citadel-of-ricks.com");
@@ -1080,7 +1080,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void EditForm_Validation_NullContext()
         {
-            var comp = Context.RenderComponent<EditFormIssue1229>();
+            var comp = Context.Render<EditFormIssue1229>();
             // Check first run attribute
             EditFormIssue1229.TestAttribute.ValidationContextOnCall.Should().BeEmpty();
             // Trigger change
@@ -1101,7 +1101,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudForm_MustNot_ValidateOnInitialRender()
         {
-            var comp = Context.RenderComponent<FormValidationTest4>();
+            var comp = Context.Render<FormValidationTest4>();
             await Task.Delay(100);
             var form = comp.FindComponent<MudForm>().Instance;
             form.Errors.Should().BeEmpty();
@@ -1114,7 +1114,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormExample_FillInValuesRootForm()
         {
-            var comp = Context.RenderComponent<FormValidationTest5>();
+            var comp = Context.Render<FormValidationTest5>();
             comp.FindAll("input")[0].Input("Rick Sanchez");
             comp.FindAll("input")[0].Blur();
             comp.FindAll("input")[1].Input("rick.sanchez@citadel-of-ricks.com");
@@ -1165,7 +1165,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormExample_FillInValuesNestedForm()
         {
-            var comp = Context.RenderComponent<FormValidationTest5>();
+            var comp = Context.Render<FormValidationTest5>();
             comp.FindAll("input")[8].Change("SomeWork");
             comp.FindAll("input")[8].Blur();
             comp.FindAll("input")[9].Change("99");
@@ -1210,7 +1210,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormExample_FillInValues()
         {
-            var comp = Context.RenderComponent<FormValidationTest5>();
+            var comp = Context.Render<FormValidationTest5>();
             comp.FindAll("input")[0].Input("Rick Sanchez");
             comp.FindAll("input")[0].Blur();
             comp.FindAll("input")[1].Input("rick.sanchez@citadel-of-ricks.com");
@@ -1265,7 +1265,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormComponent_ValidationWithModel_UnexpectedErrorInValidationFunc3()
         {
-            var comp = Context.RenderComponent<FormWithSingleTextField>();
+            var comp = Context.Render<FormWithSingleTextField>();
             var form = comp.FindComponent<MudForm>();
             var model = new { data = "asdf" };
             await form.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Model, model));
@@ -1289,7 +1289,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormComponent_ValidationWithModelWithNoFor_ShouldShow_ExpectedError()
         {
-            var comp = Context.RenderComponent<FormWithSingleTextField>();
+            var comp = Context.Render<FormWithSingleTextField>();
             var form = comp.FindComponent<MudForm>();
             var model = new { data = "asdf" };
             await form.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Model, model));
@@ -1308,7 +1308,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormComponent_AsyncValidationWithModelWithNoFor_ShouldShow_ExpectedError()
         {
-            var comp = Context.RenderComponent<FormWithSingleTextField>();
+            var comp = Context.Render<FormWithSingleTextField>();
             var form = comp.FindComponent<MudForm>();
             var model = new { data = "asdf" };
             await form.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Model, model));
@@ -1329,7 +1329,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudFormComponent_ValidationWithModel_UnexpectedErrorInValidationFunc5()
         {
-            var comp = Context.RenderComponent<FormWithSingleTextField>();
+            var comp = Context.Render<FormWithSingleTextField>();
             var form = comp.FindComponent<MudForm>();
             var model = new { data = "asdf" };
             await form.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Model, model));
@@ -1354,7 +1354,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReset_Should_ClearTextField()
         {
-            var comp = Context.RenderComponent<FormResetTest>();
+            var comp = Context.Render<FormResetTest>();
             var form = comp.FindComponent<MudForm>();
             var textFieldComp = comp.FindComponents<MudTextField<string>>()[1]; //the picker includes a MudTextField, so the MudTextField we want is the second in the DOM
             var textField = textFieldComp.Instance;
@@ -1383,7 +1383,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReset_Should_ClearNumericField()
         {
-            var comp = Context.RenderComponent<FormResetTest>();
+            var comp = Context.Render<FormResetTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var numericFieldComp = comp.FindComponent<MudNumericField<int?>>();
             var numericField = numericFieldComp.Instance;
@@ -1413,7 +1413,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReset_Should_ClearDatePicker()
         {
-            var comp = Context.RenderComponent<FormResetTest>();
+            var comp = Context.Render<FormResetTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var datePickerComp = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComp.Instance;
@@ -1446,7 +1446,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReset_Should_ResetFormStateForFieldsThatWrapMudInput()
         {
-            var comp = Context.RenderComponent<FormResetTest>();
+            var comp = Context.Render<FormResetTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var datePickerComp = comp.FindComponent<MudDatePicker>();
             var textFieldComp = comp.FindComponents<MudTextField<string>>()[1]; //the picker includes a MudTextField, so the MudTextField we want is the second in the DOM
@@ -1473,7 +1473,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudForm_Should_RegisterOnlyTopSubscribeToParentFormFormControls()
         {
-            var comp = Context.RenderComponent<FormShouldRegisterOnlyTopSubscribeToParentFormFormControlsTest>();
+            var comp = Context.Render<FormShouldRegisterOnlyTopSubscribeToParentFormFormControlsTest>();
             var form = comp.FindComponent<MudFormTestable>().Instance;
 
             form.FormControls.Count.Should().Be(14);
@@ -1485,7 +1485,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudForm_Validation_Should_OverrideFieldValidation()
         {
-            var comp = Context.RenderComponent<FormValidationOverrideFieldValidationTest>();
+            var comp = Context.Render<FormValidationOverrideFieldValidationTest>();
             var textFields = comp.FindComponents<MudTextField<string>>();
             var numericFields = comp.FindComponents<MudNumericField<int>>();
             var defaultValidation = "v";
@@ -1508,7 +1508,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FieldValidationWithoutRequiredForm_ShouldNot_Validate()
         {
-            var comp = Context.RenderComponent<FieldValidationWithoutRequiredFormTest>();
+            var comp = Context.Render<FieldValidationWithoutRequiredFormTest>();
 
             Assert.Throws<ElementNotFoundException>(() => comp.Find(".mud-input-error"));
         }
@@ -1519,7 +1519,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FieldChangedEventShouldTriggerTest()
         {
-            var comp = Context.RenderComponent<FormFieldChangedTest>();
+            var comp = Context.Render<FormFieldChangedTest>();
             var formsComp = comp.FindComponents<MudForm>();
 
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
@@ -1564,7 +1564,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FieldChangedEventShouldTriggerPickerTest()
         {
-            var comp = Context.RenderComponent<FormFieldChangedPickerTest>();
+            var comp = Context.Render<FormFieldChangedPickerTest>();
             var formsComp = comp.FindComponents<MudForm>();
 
             var datePicker = comp.FindComponent<MudDatePicker>();
@@ -1595,7 +1595,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormAutoValidationSetTest()
         {
-            var comp = Context.RenderComponent<FormAutomaticValidationTest>();
+            var comp = Context.Render<FormAutomaticValidationTest>();
             var textComps = comp.FindComponents<MudTextField<string>>();
             var dateComps = comp.FindComponents<MudDatePicker>();
 
@@ -1617,7 +1617,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReadonlyTest()
         {
-            var comp = Context.RenderComponent<FormReadOnlyDisabledTest>();
+            var comp = Context.Render<FormReadOnlyDisabledTest>();
 
             var textField = comp.FindComponents<MudTextField<string>>()[0];
             var maskedTextField = comp.FindComponents<MudTextField<string>>()[1];
@@ -1686,7 +1686,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormDisabledTest()
         {
-            var comp = Context.RenderComponent<FormReadOnlyDisabledTest>();
+            var comp = Context.Render<FormReadOnlyDisabledTest>();
 
             var textField = comp.FindComponents<MudTextField<string>>()[0];
             var maskedTextField = comp.FindComponents<MudTextField<string>>()[1];
@@ -1775,7 +1775,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormNestedReadOnlyTest()
         {
-            var comp = Context.RenderComponent<FormNestedReadOnlyDisabledTest>();
+            var comp = Context.Render<FormNestedReadOnlyDisabledTest>();
             comp.FindAll(".mud-checkbox.mud-readonly").Count.Should().Be(0);
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ReadOnly, true));
@@ -1797,7 +1797,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormNestedDisabledTest()
         {
-            var comp = Context.RenderComponent<FormNestedReadOnlyDisabledTest>();
+            var comp = Context.Render<FormNestedReadOnlyDisabledTest>();
             comp.FindAll(".mud-checkbox.mud-disabled").Count.Should().Be(0);
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Disabled, true));
@@ -1816,7 +1816,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormWithChildFormTest()
         {
-            var comp = Context.RenderComponent<FormWithChildForm>();
+            var comp = Context.Render<FormWithChildForm>();
             var childFormSwitch = comp.Find(".mud-switch-input");
             var parentForm = comp.FindComponent<MudForm>().Instance;
             var parentTextFieldCmp = comp.FindComponent<MudTextField<string>>();
@@ -1848,7 +1848,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormComponent_Should_UpdateValidationMessagesOnEditContextChanged()
         {
-            var comp = Context.RenderComponent<FormComponentUpdateValidationMessagesOnEditContextChangedTest>();
+            var comp = Context.Render<FormComponentUpdateValidationMessagesOnEditContextChangedTest>();
             var validator = comp.FindComponent<FormComponentUpdateValidationMessagesValidator>();
             var errorMessage = "some error";
 
@@ -1868,7 +1868,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormComponentTest_ErrorTextTwoWayBinding()
         {
-            var comp = Context.RenderComponent<FormWithErrorTextTwoWayBindingTest>();
+            var comp = Context.Render<FormWithErrorTextTwoWayBindingTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var textInput = comp.Find("input");
@@ -1896,7 +1896,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormWithCheckBoxTest_When_CheckBoxTickedUsingMouse()
         {
-            var comp = Context.RenderComponent<FormWithCheckBoxTest>();
+            var comp = Context.Render<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var checkBox = comp.FindComponent<MudCheckBox<bool>>().Instance;
 
@@ -1928,7 +1928,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormWithCheckBoxTest_When_CheckBoxTickedUsingKeyboard()
         {
-            var comp = Context.RenderComponent<FormWithCheckBoxTest>();
+            var comp = Context.Render<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var checkBox = comp.FindComponent<MudCheckBox<bool>>().Instance;
 
@@ -1957,7 +1957,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormSpacingClass()
         {
-            var comp = Context.RenderComponent<MudForm>();
+            var comp = Context.Render<MudForm>();
 
             for (var i = 0; i <= 20; i++)
             {
@@ -1969,7 +1969,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ChildForm_TouchChangedPropogate()
         {
-            var comp = Context.RenderComponent<FormWithChildForm>();
+            var comp = Context.Render<FormWithChildForm>();
             var childFormSwitch = comp.Find(".mud-switch-input");
             var parentForm = comp.FindComponent<MudForm>().Instance;
             var parentTextFieldCmp = comp.FindComponent<MudTextField<string>>();

--- a/src/MudBlazor.UnitTests/Components/HiddenTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HiddenTests.cs
@@ -39,7 +39,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var comp = Context.RenderComponent<SimpleMudHiddenTest>(parameterBuilder =>
+            var comp = Context.Render<SimpleMudHiddenTest>(parameterBuilder =>
             {
                 parameterBuilder.Add(parameter => parameter.Breakpoint, Breakpoint.Lg);
                 parameterBuilder.Add(parameter => parameter.Invert, invert);
@@ -74,7 +74,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var component = Context.RenderComponent<SimpleMudHiddenTest>(parameterBuilder =>
+            var component = Context.Render<SimpleMudHiddenTest>(parameterBuilder =>
             {
                 parameterBuilder.Add(parameter => parameter.Breakpoint, Breakpoint.Lg);
                 parameterBuilder.Add(parameter => parameter.Invert, false);
@@ -113,7 +113,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var comp = Context.RenderComponent<SimpleMudHiddenTest>(p =>
+            var comp = Context.Render<SimpleMudHiddenTest>(p =>
             {
                 p.Add(x => x.Breakpoint, Breakpoint.Lg);
                 p.Add(x => x.Invert, false);
@@ -146,7 +146,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var component = Context.RenderComponent<SimpleMudHiddenTest>(parameterBuilder =>
+            var component = Context.Render<SimpleMudHiddenTest>(parameterBuilder =>
             {
                 parameterBuilder.Add(parameter => parameter.Breakpoint, Breakpoint.Lg);
                 parameterBuilder.Add(parameter => parameter.Invert, false);
@@ -179,7 +179,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var component = Context.RenderComponent<SimpleMudHiddenTest>(parameterBuilder =>
+            var component = Context.Render<SimpleMudHiddenTest>(parameterBuilder =>
             {
                 parameterBuilder.Add(parameter => parameter.Breakpoint, Breakpoint.Lg);
                 parameterBuilder.Add(parameter => parameter.Invert, false);
@@ -203,7 +203,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var component = Context.RenderComponent<BreakpointProviderWithMudHiddenTest>(parameterBuilder =>
+            var component = Context.Render<BreakpointProviderWithMudHiddenTest>(parameterBuilder =>
             {
                 parameterBuilder.Add(parameter => parameter.Breakpoint, Breakpoint.Lg);
             });
@@ -242,7 +242,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var component = Context.RenderComponent<BreakpointProviderWithMudHiddenTest>(parameterBuilder =>
+            var component = Context.Render<BreakpointProviderWithMudHiddenTest>(parameterBuilder =>
             {
                 parameterBuilder.Add(parameter => parameter.Breakpoint, Breakpoint.Lg);
             });
@@ -298,7 +298,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton<IBrowserViewportService>(browserViewportService);
 
-            var component = Context.RenderComponent<RenderMultipleHiddenInParallel>();
+            var component = Context.Render<RenderMultipleHiddenInParallel>();
 
             component.WaitForAssertion(() => component.FindAll(".xl").Should().HaveCount(10), TimeSpan.FromSeconds(1));
             component.WaitForAssertion(() => component.FindAll(".lg-and-up").Should().HaveCount(10), TimeSpan.FromSeconds(1));

--- a/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
+++ b/src/MudBlazor.UnitTests/Components/HighlighterTests.cs
@@ -280,7 +280,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupUsingHighlightedTextParameterTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedText, "item"));
             comp.MarkupMatches("This is the first <mark>item</mark>");
@@ -292,7 +292,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupUsingHighlightedTextsParameterWithOneElementTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedTexts, new string[] { "item" }));
             comp.MarkupMatches("This is the first <mark>item</mark>");
@@ -304,7 +304,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupUsingHighlightedTextsParameterWithMultipleElementsTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedTexts, new string[] { "item", "This" }));
             comp.MarkupMatches("<mark>This</mark> is the first <mark>item</mark>");
@@ -316,7 +316,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupUsingHighlightedTextParameterAndHighlightedTextsParameterWithOneElementTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedText, "This")
                 .Add(x => x.HighlightedTexts, new string[] { "item" }));
@@ -329,7 +329,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupUsingHighlightedTextParameterAndHighlightedTextsParameterWithMultipleElementsTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedText, "This")
                 .Add(x => x.HighlightedTexts, new string[] { "item", "first" }));
@@ -342,7 +342,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_Nulls_Test()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, null)
                 .Add(x => x.HighlightedText, null));
             comp.MarkupMatches(string.Empty);
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupWithRegexTextTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedText, "["));
             comp.MarkupMatches("This is the first item");
@@ -366,7 +366,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighterMarkupUntilNextBoundaryTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, TEXT)
                 .Add(x => x.HighlightedText, "it")
                 .Add(x => x.UntilNextBoundary, true));
@@ -379,7 +379,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudHighlighterMarkupCaseSensitiveTest()
         {
-            var comp = Context.RenderComponent<MudHighlighter>(parameters => parameters
+            var comp = Context.Render<MudHighlighter>(parameters => parameters
                 .Add(x => x.Text, "This is this")
                 .Add(x => x.HighlightedText, "this")
                 .Add(x => x.CaseSensitive, true));
@@ -404,7 +404,7 @@ namespace MudBlazor.UnitTests.Components
             var rawOutput = "&lt;i&gt;<mark>Mud</mark>Blazor&lt;/i&gt;";
             var formattedOutput = "<i><mark>Mud</mark>Blazor</i>";
 
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, markupText)
                 .Add(p => p.HighlightedText, searchFor)
                 .Add(p => p.Markup, false)
@@ -412,7 +412,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().Contain(rawOutput);
 
-            comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, markupText)
                 .Add(p => p.HighlightedText, searchFor)
                 .Add(p => p.Markup, true)
@@ -424,7 +424,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HtmlInText_ShouldHighlightCorrectly()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "<span>Hello</span> World")
                 .Add(p => p.HighlightedText, "Hello")
                 .Add(p => p.Markup, true)
@@ -436,7 +436,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HtmlSensitiveCharInHighlightedText_ShouldEncodeAndHighlight()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Hello <World>")
                 .Add(p => p.HighlightedText, "<World>")
                 .Add(p => p.Markup, true)
@@ -448,7 +448,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HtmlInText_ShouldNotHighlightInTags()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "<div class='foo'>div content div</div>")
                 .Add(p => p.HighlightedText, "div")
                 .Add(p => p.Markup, true)
@@ -460,7 +460,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HtmlTag_ShouldNotHighlight()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Hello <i>Mud</i> World")
                 .Add(p => p.HighlightedText, "<i>")
                 .Add(p => p.Markup, true)
@@ -472,7 +472,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_TextWithHtmlEntities_HighlightedTextIsEntityText()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Hello &amp; World")
                 .Add(p => p.HighlightedText, "&amp;")
                 .Add(p => p.Markup, true)
@@ -484,7 +484,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HighlightedTextWithSingleQuotes_ShouldHighlight()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "This is a 'quoted' text and a \"double quoted\" text.")
                 .Add(p => p.HighlightedText, "'quoted'")
                 .Add(p => p.Markup, true)
@@ -496,7 +496,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HighlightedTextWithDoubleQuotes_ShouldHighlight()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "This is a 'quoted' text and a \"double quoted\" text.")
                 .Add(p => p.HighlightedText, "\"double quoted\"")
                 .Add(p => p.Markup, true)
@@ -508,7 +508,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_HighlightedTextAsAttributeValue_ShouldNotHighlightInAttribute()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "<i>MudBlazor</i> is <span style='color:red'>important</span>")
                 .Add(p => p.HighlightedText, "nothing")
                 .Add(p => p.Markup, true)
@@ -520,7 +520,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_FormattingPreservation_ItalicsAndColor()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "<i>MudBlazor</i> is <span style='color:red'>important</span>")
                 .Add(p => p.HighlightedText, "MudBlazor")
                 .Add(p => p.Markup, true)
@@ -532,7 +532,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_FormattingPreservation_Bold()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Normal <b>bold</b> normal")
                 .Add(p => p.HighlightedText, "bold")
                 .Add(p => p.Markup, true)
@@ -544,7 +544,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_NonStandardTag_NoHighlight()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Hello <ambitious> world")
                 .Add(p => p.HighlightedText, "")
                 .Add(p => p.Markup, true)
@@ -556,7 +556,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_NonStandardTag_WithHighlightAfterTag()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Hello <ambitious> world")
                 .Add(p => p.HighlightedText, "world")
                 .Add(p => p.Markup, true)
@@ -568,7 +568,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_NonStandardTag_WithHighlightInsideTag()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Hello <ambitious> world")
                 .Add(p => p.HighlightedText, "bit")
                 .Add(p => p.Markup, true)
@@ -580,7 +580,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_NoFragments_RendersTextAsMarkupString()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Some text")
                 .Add(p => p.HighlightedText, "zip")
                 .Add(p => p.Markup, true)
@@ -592,7 +592,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudHighlighter_MarkupTrue_WithClass_RendersMarkWithClass()
         {
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, "Highlight this")
                 .Add(p => p.HighlightedText, "Highlight")
                 .Add(p => p.Markup, true)
@@ -609,7 +609,7 @@ namespace MudBlazor.UnitTests.Components
             var initialHighlightedText = "highlight";
 
             // 1. Render initially with Markup = true
-            var comp = Context.RenderComponent<BasicHighlighterTest>(parameters => parameters
+            var comp = Context.Render<BasicHighlighterTest>(parameters => parameters
                 .Add(p => p.Text, initialText)
                 .Add(p => p.HighlightedText, initialHighlightedText)
                 .Add(p => p.Markup, true)

--- a/src/MudBlazor.UnitTests/Components/IconTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconTests.cs
@@ -14,7 +14,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ShouldRenderIconWithStyle()
         {
             var colorStyle = "color: greenyellow;";
-            var comp = Context.RenderComponent<MudIcon>(parameters => parameters
+            var comp = Context.Render<MudIcon>(parameters => parameters
                 .Add(x => x.Icon, Icons.Material.Filled.Add)
                 .Add(x => x.Style, colorStyle));
             comp.Markup.Trim().Should().StartWith("<svg")
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var title = "Title and tooltip";
             //svg
-            var comp = Context.RenderComponent<MudIcon>(parameters => parameters
+            var comp = Context.Render<MudIcon>(parameters => parameters
                 .Add(x => x.Icon, Icons.Material.Filled.Add)
                 .Add(x => x.Title, title));
             comp.Find("svg Title").TextContent.Should().Be(title);
@@ -54,7 +54,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldParseCorrectSyntax()
         {
-            var comp = Context.RenderComponent<MudIcon>(parameters =>
+            var comp = Context.Render<MudIcon>(parameters =>
                 parameters.Add(parameter => parameter.Icon, "material-symbols-outlined/database"));
 
             comp.Markup.Should().Be("<span class=\"mud-icon-root mud-icon-size-medium material-symbols-outlined\" aria-hidden=\"true\" role=\"img\">database</span>");
@@ -63,7 +63,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldNotParseWhenWrongSyntax()
         {
-            var comp = Context.RenderComponent<MudIcon>(parameters =>
+            var comp = Context.Render<MudIcon>(parameters =>
                 parameters.Add(parameter => parameter.Icon, "material-symbols-outlined(database)"));
 
             comp.Markup.Should().Be("<span class=\"mud-icon-root mud-icon-size-medium material-symbols-outlined(database)\" aria-hidden=\"true\" role=\"img\"></span>");
@@ -72,7 +72,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldNotParseWhenEmpty()
         {
-            var comp = Context.RenderComponent<MudIcon>(parameters =>
+            var comp = Context.Render<MudIcon>(parameters =>
                 parameters.Add(parameter => parameter.Icon, string.Empty));
 
             comp.Markup.Should().Be("<span class=\"mud-icon-root mud-icon-size-medium \" aria-hidden=\"true\" role=\"img\"></span>");
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldUseChildContentWhenAssigned()
         {
-            var comp = Context.RenderComponent<MudIcon>(parameters =>
+            var comp = Context.Render<MudIcon>(parameters =>
                 parameters
                     .Add(parameter => parameter.Icon, "material-symbols-outlined")
                     .AddChildContent("database"));
@@ -92,7 +92,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldBeEmptyChildContent()
         {
-            var comp = Context.RenderComponent<MudIcon>(parameters =>
+            var comp = Context.Render<MudIcon>(parameters =>
                 parameters
                     .Add(parameter => parameter.Icon, "material-symbols-outlined"));
 

--- a/src/MudBlazor.UnitTests/Components/ImageTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ImageTests.cs
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
         public void Image_GeneralStructure()
         {
 
-            var comp = Context.RenderComponent<MudImage>(p =>
+            var comp = Context.Render<MudImage>(p =>
             {
                 p.Add(x => x.Fluid, true);
                 p.Add(x => x.Src, "https://myimgsource.com/image.png");
@@ -63,7 +63,7 @@ namespace MudBlazor.UnitTests.Components
         public void Image_ObjectFitToClassMapping(ObjectFit fit, string expectedClass)
         {
 
-            var comp = Context.RenderComponent<MudImage>(p =>
+            var comp = Context.Render<MudImage>(p =>
             {
                 p.Add(x => x.ObjectFit, fit);
             });
@@ -85,7 +85,7 @@ namespace MudBlazor.UnitTests.Components
         public void Image_ObjectPositionToClassMapping(ObjectPosition position, string expectedClass)
         {
 
-            var comp = Context.RenderComponent<MudImage>(p =>
+            var comp = Context.Render<MudImage>(p =>
             {
                 p.Add(x => x.ObjectPosition, position);
             });
@@ -100,7 +100,7 @@ namespace MudBlazor.UnitTests.Components
             var initialSrc = "primary-image.jpg";
             var fallbackSrc = "fallback-image.jpg";
 
-            var comp = Context.RenderComponent<MudImage>(parameters => parameters
+            var comp = Context.Render<MudImage>(parameters => parameters
                 .Add(p => p.Src, initialSrc)
                 .Add(p => p.FallbackSrc, fallbackSrc)
             );
@@ -118,7 +118,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var initialSrc = "primary-image.jpg";
 
-            var comp = Context.RenderComponent<MudImage>(parameters => parameters
+            var comp = Context.Render<MudImage>(parameters => parameters
                 .Add(p => p.Src, initialSrc)
             );
 

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -11,7 +11,7 @@ public class InputTests : BunitTest
     [Test]
     public async Task ReadOnlyShouldNotHaveClearButton()
     {
-        var comp = Context.RenderComponent<MudInput<string>>(p => p
+        var comp = Context.Render<MudInput<string>>(p => p
             .Add(x => x.Text, "some value")
             .Add(x => x.Clearable, true)
             .Add(x => x.ReadOnly, false));

--- a/src/MudBlazor.UnitTests/Components/LinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/LinkTests.cs
@@ -14,7 +14,7 @@ public class LinkTests : BunitTest
     [Test]
     public void DefaultPropertyValues()
     {
-        var comp = Context.RenderComponent<MudLink>();
+        var comp = Context.Render<MudLink>();
 
         comp.Instance.Color.Should().Be(Color.Primary);
         comp.Instance.Typo.Should().Be(Typo.inherit);
@@ -27,7 +27,7 @@ public class LinkTests : BunitTest
     [Test]
     public void DefaultTypo_ShouldInheritParentTypography()
     {
-        var comp = Context.RenderComponent<MudLink>();
+        var comp = Context.Render<MudLink>();
 
         var linkElement = comp.Find("a");
         linkElement.GetAttribute("class").Should().NotContain("mud-typography-");
@@ -36,7 +36,7 @@ public class LinkTests : BunitTest
     [Test]
     public void InlineLink_ShouldRenderWithParentTypography()
     {
-        var comp = Context.RenderComponent<MudText>(parameters => parameters
+        var comp = Context.Render<MudText>(parameters => parameters
             .Add(p => p.Typo, Typo.caption)
             .AddChildContent(childBuilder =>
             {
@@ -60,7 +60,7 @@ public class LinkTests : BunitTest
     [Test]
     public void DisabledProperty_DisplaysAsDisabled()
     {
-        var comp = Context.RenderComponent<MudLink>(parameters => parameters
+        var comp = Context.Render<MudLink>(parameters => parameters
             .Add(x => x.Href, "#")
             .Add(x => x.Disabled, true));
 
@@ -75,7 +75,7 @@ public class LinkTests : BunitTest
     public async Task ShouldExecute_OnClick(bool disabled)
     {
         var calls = 0;
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .Add(p => p.OnClick, e => calls++)
             .Add(p => p.Disabled, disabled)
         );
@@ -95,10 +95,10 @@ public class LinkTests : BunitTest
     [Test]
     public async Task OnClickErrorContentCaughtException()
     {
-        var comp = Context.RenderComponent<LinkErrorContenCaughtException>();
+        var comp = Context.Render<LinkErrorContenCaughtException>();
         IElement AlertText() => MudAlert().Find("div.mud-alert-message");
         IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
-        IRefreshableElementCollection<IElement> Links() => comp.FindAll("a.mud-link");
+        IReadOnlyList<IElement> Links() => comp.FindAll("a.mud-link");
         IElement MudLink() => Links()[0];
 
         await MudLink().ClickAsync(new MouseEventArgs());
@@ -111,7 +111,7 @@ public class LinkTests : BunitTest
     [TestCase(Color.Tertiary, "mud-tertiary-text")]
     public void ColorProperty_AppliesCorrectClass(Color color, string expectedClass)
     {
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .Add(p => p.Color, color)
         );
 
@@ -124,7 +124,7 @@ public class LinkTests : BunitTest
     [TestCase(Typo.caption, "mud-typography-caption")]
     public void TypoProperty_AppliesCorrectClass(Typo typo, string expectedClass)
     {
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .Add(p => p.Typo, typo)
         );
 
@@ -137,7 +137,7 @@ public class LinkTests : BunitTest
     [TestCase(Underline.Always, "mud-link-underline-always")]
     public void UnderlineProperty_AppliesCorrectClass(Underline underline, string expectedClass)
     {
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .Add(p => p.Underline, underline)
         );
 
@@ -151,7 +151,7 @@ public class LinkTests : BunitTest
     [TestCase("_top")]
     public void TargetProperty_AppliesCorrectAttribute(string target)
     {
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .Add(p => p.Href, "#")
             .Add(p => p.Target, target)
         );
@@ -163,7 +163,7 @@ public class LinkTests : BunitTest
     [Test]
     public void ChildContent_IsRenderedCorrectly()
     {
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .AddChildContent("<span>Test content</span>")
         );
 
@@ -174,7 +174,7 @@ public class LinkTests : BunitTest
     [Test]
     public void UserAttributes_OverrideDefaultAttributes()
     {
-        var comp = Context.RenderComponent<MudLink>(builder => builder
+        var comp = Context.Render<MudLink>(builder => builder
             .Add(p => p.Href, "#")
             .Add(p => p.Target, "_self")
             .Add(p => p.UserAttributes, new()

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -13,7 +13,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ListRenderTest()
         {
-            var comp = Context.RenderComponent<ListSelectionTest>();
+            var comp = Context.Render<ListSelectionTest>();
             var listItem = comp.FindComponent<MudListItem<string>>();
             comp.Markup.Should().Contain("Sparkling Water");
             comp.Markup.Should().NotContain("Roger Waters");
@@ -33,7 +33,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ListSelectionTest()
         {
-            var comp = Context.RenderComponent<ListSelectionTest>();
+            var comp = Context.Render<ListSelectionTest>();
             var list = comp.FindComponent<MudList<string>>().Instance;
             list.SelectedValue.Should().Be(null);
             // we have seven choices, none is active
@@ -64,7 +64,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ListToggleSelectionTest()
         {
-            var comp = Context.RenderComponent<ListSelectionTest>(self => self.Add(x => x.SelectionMode, SelectionMode.ToggleSelection));
+            var comp = Context.Render<ListSelectionTest>(self => self.Add(x => x.SelectionMode, SelectionMode.ToggleSelection));
             var list = comp.FindComponent<MudList<string>>().Instance;
             list.SelectedValue.Should().Be(null);
             // we have seven choices, none is active
@@ -95,7 +95,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ListMultiSelectionInitialValuesTest()
         {
-            var comp = Context.RenderComponent<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Milk", "Cafe Latte"]));
+            var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Milk", "Cafe Latte"]));
             var list = comp.FindComponent<MudList<string>>().Instance;
             comp.Find("p.selected-values").TrimmedText().Should().Be("Cafe Latte, Milk");
             var GetCheckBox = (string text) => comp.FindComponents<MudListItem<string>>().FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
@@ -106,7 +106,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ListMultiSelectionBindingTest()
         {
-            var comp = Context.RenderComponent<ListMultiSelectionBindingTest>();
+            var comp = Context.Render<ListMultiSelectionBindingTest>();
             var list1 = comp.FindComponents<MudList<string>>().FirstOrDefault(x => x.Instance.Class == "list-1");
             var list2 = comp.FindComponents<MudList<string>>().FirstOrDefault(x => x.Instance.Class == "list-2");
             list1.FindComponents<MudListItem<string>>().Count.Should().Be(8);
@@ -168,7 +168,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ListWithPreSelectedValueTest()
         {
-            var comp = Context.RenderComponent<ListSelectionInitialValueTest>();
+            var comp = Context.Render<ListSelectionInitialValueTest>();
             var list = comp.FindComponent<MudList<string>>().Instance;
             list.SelectedValue.Should().Be("Sparkling Water");
             // we have seven choices, 1 is active because of the initial value of SelectedValue
@@ -207,7 +207,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Dark)]
         public void ListColorTest(Color color)
         {
-            var comp = Context.RenderComponent<ListSelectionInitialValueTest>(x => x.Add(c => c.Color, color));
+            var comp = Context.Render<ListSelectionInitialValueTest>(x => x.Add(c => c.Color, color));
 
             var list = comp.FindComponent<MudList<string>>().Instance;
             list.SelectedValue.Should().Be("Sparkling Water");
@@ -228,7 +228,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false, true, 4)]
         public void ListDenseInheritanceTest(bool dense, bool? innerListDense, int expectedDenseClassCount)
         {
-            var comp = Context.RenderComponent<ListDenseInheritanceTest>(x => x.Add(c => c.Dense, dense).Add(c => c.InnerListDense, innerListDense));
+            var comp = Context.Render<ListDenseInheritanceTest>(x => x.Add(c => c.Dense, dense).Add(c => c.InnerListDense, innerListDense));
 
             comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
             comp.FindAll("div.mud-list-item-dense").Count.Should().Be(expectedDenseClassCount); // 7 choices, 2 groups
@@ -237,7 +237,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ListItem_HasRipple_WhenRippleIsTrue()
         {
-            var comp = Context.RenderComponent<ListItemRippleTest>(parameters => parameters.Add(p => p.Ripple, true));
+            var comp = Context.Render<ListItemRippleTest>(parameters => parameters.Add(p => p.Ripple, true));
             comp.FindAll("div.mud-ripple").Count.Should().BeGreaterThan(0);
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Ripple, false));
@@ -247,7 +247,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ListItemTabIndexTest()
         {
-            var comp = Context.RenderComponent<ListItemTabIndexTest>();
+            var comp = Context.Render<ListItemTabIndexTest>();
             comp.FindAll("div")[1].GetAttribute("tabindex").Should().Be("-1");
         }
 
@@ -260,7 +260,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false, false, false)]
         public void SettingGuttersOnList_Should_OverrideGuttersOnItemsWithoutGuttersSettingTest(bool listGutters, bool? itemGutters, bool resultingGutters)
         {
-            var comp = Context.RenderComponent<ListItemGuttersTest>(self => self
+            var comp = Context.Render<ListItemGuttersTest>(self => self
                 .Add(x => x.ListGutters, listGutters)
                 .Add(x => x.ItemGutters, itemGutters)
             );

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters =>
+            var comp = Context.Render<MudTextField<string>>(parameters =>
             {
                 parameters.Add(m => m.Mask, mask);
                 parameters.Add(m => m.Value, initialValue);
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_Fundamentals1()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
             comp.WaitForAssertion(() => maskField.Instance.Value.Should().BeNullOrEmpty());
@@ -196,7 +196,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_Fundamentals2()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
 
@@ -234,7 +234,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_Int()
         {
-            var comp = Context.RenderComponent<MudTextField<int?>>();
+            var comp = Context.Render<MudTextField<int?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(0)0-0)") { Placeholder = '_', CleanDelimiters = true }));
             var tf = comp.Instance;
             var maskField = comp.FindComponent<MudMask>();
@@ -276,7 +276,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_InsertCharactersIntoMiddle()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
 
@@ -310,7 +310,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_ChangeMask1()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
 
@@ -337,7 +337,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_ChangeMask2()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(LL) UU")
             {
                 Placeholder = '_',
@@ -374,7 +374,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_KeepInputBlockPositions()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             var maskField = comp.Instance;
 
             await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true })));
@@ -419,7 +419,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_Paste()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
 
@@ -449,7 +449,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_Selection()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("0000 0000 000") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp.Instance;
 
@@ -511,7 +511,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_TwoWayBinding()
         {
-            var comp = Context.RenderComponent<MaskTwoWayBindingTest>();
+            var comp = Context.Render<MaskTwoWayBindingTest>();
             var maskField1 = comp.FindComponents<MudMask>().First();
             var maskField2 = comp.FindComponents<MudMask>().Last();
             comp.WaitForAssertion(() => maskField1.Instance.Value.Should().Be(""));
@@ -578,7 +578,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_TimeSpan()
         {
-            var comp = Context.RenderComponent<MudTextField<TimeSpan?>>();
+            var comp = Context.Render<MudTextField<TimeSpan?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("00:00") { CleanDelimiters = false, }));
             var tf = comp.Instance;
             var maskField = comp.FindComponent<MudMask>().Instance;
@@ -613,7 +613,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_MoreCoverage()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             var maskField = comp.Instance;
             var impl = maskField.Mask;
             comp.WaitForAssertion(() => maskField.GetInputType().Should().Be(InputType.Text));
@@ -690,7 +690,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_MultipleTFsLinkedViaTwoWayBinding()
         {
-            var comp = Context.RenderComponent<MaskedTextFieldTwoWayBindingTest>();
+            var comp = Context.Render<MaskedTextFieldTwoWayBindingTest>();
             var tfs = comp.FindComponents<MudTextField<string>>().Select(x => x.Instance).ToArray();
             var masks = comp.FindComponents<MudMask>().Select(x => x.Instance).ToArray();
             await comp.InvokeAsync(() => masks[0].OnPaste("123456"));
@@ -711,7 +711,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReset_Should_ClearMaskedField()
         {
-            var comp = Context.RenderComponent<FormResetMaskTest>();
+            var comp = Context.Render<FormResetMaskTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var mask = comp.FindComponent<MudMask>().Instance;
@@ -751,7 +751,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MaskTest_Readonly()
         {
-            var comp = Context.RenderComponent<ReadonlyMaskedTextFieldTest>();
+            var comp = Context.Render<ReadonlyMaskedTextFieldTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var mask = comp.FindComponent<MudMask>().Instance;
             var originalValue = textField.Text;
@@ -800,7 +800,7 @@ namespace MudBlazor.UnitTests.Components
         public void DifferentMaskImplementationTests()
         {
             // arrange
-            var comp = Context.RenderComponent<DifferentMaskImplementationTest>();
+            var comp = Context.Render<DifferentMaskImplementationTest>();
             var masks = comp.FindComponents<MudMask>();
             var textFields = comp.FindComponents<MudTextField<string>>();
             var blockMaskComponent = masks[0];
@@ -844,7 +844,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalMask_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -856,7 +856,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredMask_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudMask>(parameters => parameters
+            var comp = Context.Render<MudMask>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -869,7 +869,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredMaskAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -887,7 +887,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalMaskWithMultipleLines_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudMask>(parameters => parameters
+            var comp = Context.Render<MudMask>(parameters => parameters
                 .Add(p => p.Lines, 5));
 
             comp.Find("textarea").HasAttribute("required").Should().BeFalse();
@@ -900,7 +900,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredMaskWithMultipleLines_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudMask>(parameters => parameters
+            var comp = Context.Render<MudMask>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.Lines, 5));
 
@@ -914,7 +914,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredMaskWithMultipleLinesAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudMask>(parameters => parameters
+            var comp = Context.Render<MudMask>(parameters => parameters
                 .Add(p => p.Lines, 5));
 
             comp.Find("textarea").HasAttribute("required").Should().BeFalse();
@@ -930,7 +930,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ClearableReadOnlyMask_Should_NotHaveClearButton()
         {
-            var comp = Context.RenderComponent<MudMask>();
+            var comp = Context.Render<MudMask>();
             var maskField = comp.Instance;
             maskField.Clearable.Should().Be(false);
             maskField.ReadOnly.Should().Be(false);
@@ -962,7 +962,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MetaKeyShortcuts_Should_NotIntroduceExtraCharacters()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, RegexMask.Email()));
             var tf = comp.Instance;
             var maskField = comp.FindComponent<MudMask>().Instance;
@@ -1015,7 +1015,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CutShortcut_Should_ClearSelectionAndCopyItToClipboard()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, RegexMask.Email()));
             var tf = comp.Instance;
             var maskField = comp.FindComponent<MudMask>().Instance;
@@ -1077,7 +1077,7 @@ namespace MudBlazor.UnitTests.Components
             var mask = new PatternMask("(000) 000-0000");
             var autofillValue = "(123) 456-7890";
 
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Mask, mask)
                 .Add(p => p.DebounceInterval, 0)
             );

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -21,7 +21,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // https://github.com/MudBlazor/MudBlazor/issues/4063
 
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             var menu = comp.FindComponent<MudMenu>();
 
             comp.FindAll("button.mud-button-root")[0].Click();
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OpenMenu_ClickSecondItem_CheckClosed()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -70,7 +70,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OpenMenu_ClickThirdItem_CheckClosed()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OpenMenu_ClickClassItem_CheckClass()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -91,7 +91,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OpenMenu_CheckClass()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.Find("div.mud-popover").ClassList.Should().Contain("menu-popover-class");
         }
@@ -99,7 +99,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task IsOpen_CheckState()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             var menu = comp.FindComponent<MudMenu>().Instance;
             menu.GetState(x => x.Open).Should().BeFalse();
 
@@ -114,7 +114,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MouseOver_PointerLeave_ShouldClose()
         {
-            var comp = Context.RenderComponent<MenuTestMouseOver>();
+            var comp = Context.Render<MenuTestMouseOver>();
 
             // Briefly hover over the button and wait for it to open.
             comp.Find("div.mud-menu").PointerEnter();
@@ -128,7 +128,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MouseOver_Hover_ShouldOpenMenu()
         {
-            var comp = Context.RenderComponent<MenuTestMouseOver>();
+            var comp = Context.Render<MenuTestMouseOver>();
 
             IElement Menu() => comp.Find(".mud-menu");
             comp.Markup.Should().NotContain("mud-popover-open");
@@ -149,7 +149,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MouseOver_Click_ShouldKeepMenuOpen()
         {
-            var comp = Context.RenderComponent<MenuTestMouseOver>();
+            var comp = Context.Render<MenuTestMouseOver>();
 
             // Enter opens the menu (after a delay).
             comp.Find("div.mud-menu").PointerEnter();
@@ -186,7 +186,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ActivatorContent_Disabled_CheckDisabled()
         {
-            var comp = Context.RenderComponent<MenuTestDisabledCustomActivator>();
+            var comp = Context.Render<MenuTestDisabledCustomActivator>();
             var activator = comp.Find("div.mud-menu-activator");
             activator.ClassList.Should().Contain("mud-disabled");
             activator.GetAttribute("disabled").Should().NotBeNull();
@@ -195,7 +195,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Default_Disabled_CheckDisabled()
         {
-            var comp = Context.RenderComponent<MenuTest1>(x =>
+            var comp = Context.Render<MenuTest1>(x =>
                 x.Add(p => p.DisableMenu, true)
             );
 
@@ -207,7 +207,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ToggleEventArgs()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             var menu = comp.FindComponent<MudMenu>();
 
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
@@ -226,7 +226,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ToggleMenuDoesNotWorkIfDisabled()
         {
-            var comp = Context.RenderComponent<MenuTest1>(x =>
+            var comp = Context.Render<MenuTest1>(x =>
                 x.Add(p => p.DisableMenu, true)
             );
 
@@ -245,7 +245,7 @@ namespace MudBlazor.UnitTests.Components
         public void MenuTest_LeftAndRightClick_CheckClosed()
         {
             //Standart button menu -- left click
-            var comp = Context.RenderComponent<MenuTestVariants>();
+            var comp = Context.Render<MenuTestVariants>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
@@ -307,7 +307,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MenuItem_Should_RenderIcons()
         {
-            var comp = Context.RenderComponent<MenuItemIconTest>();
+            var comp = Context.Render<MenuItemIconTest>();
 
             comp.Find(".mud-menu-button-activator").Click();
             comp.WaitForElement("div.mud-popover-open");
@@ -318,7 +318,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MenuItem_Should_RenderIconColors()
         {
-            var comp = Context.RenderComponent<MenuItemIconTest>();
+            var comp = Context.Render<MenuItemIconTest>();
 
             comp.Find(".mud-menu-button-activator").Click();
             comp.WaitForElement("div.mud-popover-open");
@@ -337,7 +337,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OnClickErrorContentCaughtException()
         {
-            var comp = Context.RenderComponent<MenuErrorContenCaughtException>();
+            var comp = Context.Render<MenuErrorContenCaughtException>();
             await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs());
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
@@ -350,7 +350,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OpenMenu_CloseMenuOnClick_CheckStillOpen()
         {
-            var comp = Context.RenderComponent<MenuTest1>();
+            var comp = Context.Render<MenuTest1>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-menu-item").Count.Should().Be(2);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -361,7 +361,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task IsOpenChanged_InvokedWhenOpened_CheckTrueInvocationCountIsOne()
         {
-            var comp = Context.RenderComponent<MenuIsOpenChangedTest>();
+            var comp = Context.Render<MenuIsOpenChangedTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Menu.OpenMenuAsync(EventArgs.Empty));
             comp.Instance.TrueInvocationCount.Should().Be(1);
             comp.Instance.FalseInvocationCount.Should().Be(0);
@@ -370,7 +370,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task IsOpenChanged_InvokedWhenClosed_CheckTrueInvocationCountIsOneClickFalseInvocationCountIsOne()
         {
-            var comp = Context.RenderComponent<MenuIsOpenChangedTest>();
+            var comp = Context.Render<MenuIsOpenChangedTest>();
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Menu.OpenMenuAsync(EventArgs.Empty));
             await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Menu.CloseMenuAsync());
             comp.Instance.TrueInvocationCount.Should().Be(1);
@@ -380,7 +380,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ItemsWithHrefShouldRenderAsAnchor()
         {
-            var comp = Context.RenderComponent<MenuHrefTest>();
+            var comp = Context.Render<MenuHrefTest>();
             comp.FindAll("button.mud-button-root")[0].Click();
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(3);
@@ -400,7 +400,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("x", "Close menu", "Close menu")]
         public void MenuWithLabelAndAriaLabel_Should_HaveExpectedAriaLabel(string label, string ariaLabel, string expectedAriaLabel)
         {
-            var comp = Context.RenderComponent<MenuAccessibilityTest>(parameters => parameters
+            var comp = Context.Render<MenuAccessibilityTest>(parameters => parameters
                 .Add(p => p.Label, label)
                 .Add(p => p.AriaLabel, ariaLabel));
 
@@ -412,7 +412,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(null, null, Description = "Ensures aria-label is not present instead of empty string")]
         public void IconMenuWithAriaLabel_Should_HaveExpectedAriaLabel(string ariaLabel, string expectedAriaLabel)
         {
-            var comp = Context.RenderComponent<MenuAccessibilityTest>(parameters => parameters
+            var comp = Context.Render<MenuAccessibilityTest>(parameters => parameters
                 .Add(p => p.Icon, Icons.Material.Filled.Accessibility)
                 .Add(p => p.Label, "Accessibility")
                 .Add(p => p.AriaLabel, ariaLabel));
@@ -424,7 +424,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task OpenMenuAsync_Should_Set_FixedPosition()
         {
             // Arrange
-            var comp = Context.RenderComponent<MenuPositionAtCursorTest>();
+            var comp = Context.Render<MenuPositionAtCursorTest>();
             var menuComponent = comp.FindComponent<MudMenu>();
             var mudMenuContext = menuComponent.Instance;
             mudMenuContext.Should().NotBeNull();
@@ -448,7 +448,7 @@ namespace MudBlazor.UnitTests.Components
         public void ContextMenu_Should_NotHaveButton_And_NotBeVisible()
         {
             // Arrange
-            var comp = Context.RenderComponent<ContextMenuTest>();
+            var comp = Context.Render<ContextMenuTest>();
             var menuComponent = comp.FindComponent<MudMenu>();
 
             // Assert
@@ -460,7 +460,7 @@ namespace MudBlazor.UnitTests.Components
         public void ContextMenu_WithLabel_Should_HaveButton_And_BeVisible()
         {
             // Arrange
-            var comp = Context.RenderComponent<ContextMenuTest>(parameters
+            var comp = Context.Render<ContextMenuTest>(parameters
                 => parameters.Add(p => p.Label, "Context Menu"));
             var menuComponent = comp.FindComponent<MudMenu>();
 
@@ -473,7 +473,7 @@ namespace MudBlazor.UnitTests.Components
         public void ContextMenu_WithActivatorContent_Should_HaveActivatorContent_And_BeVisible()
         {
             // Arrange
-            var comp = Context.RenderComponent<ContextMenuTest>(parameters
+            var comp = Context.Render<ContextMenuTest>(parameters
                 => parameters.Add(p => p.ActivatorContent, "<div id=\"custom-activator\">Custom Activator Content</div>"));
             var menuComponent = comp.FindComponent<MudMenu>();
 
@@ -486,7 +486,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Open_TwoWayBinding()
         {
-            var comp = Context.RenderComponent<MenuTwoWayTest>();
+            var comp = Context.Render<MenuTwoWayTest>();
             var menu = comp.FindComponent<MudMenu>();
             IElement SwitchElement() => comp.Find("#switch");
 
@@ -546,7 +546,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ActivatorClass()
         {
-            var comp = Context.RenderComponent<MenuActivatorsTest>();
+            var comp = Context.Render<MenuActivatorsTest>();
 
             comp.FindAll(".mud-menu")[0].FirstElementChild.ClassName.Should().Contain("mud-menu-button-activator");
 
@@ -562,7 +562,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldRenderLabelOrChildContent()
         {
-            var comp = Context.RenderComponent<MenuItemLabelTest>();
+            var comp = Context.Render<MenuItemLabelTest>();
 
             var childContent = comp.FindAll(".mud-menu-item")[0].InnerHtml;
             var label = comp.FindAll(".mud-menu-item")[1].InnerHtml;
@@ -576,7 +576,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OpenNestedMenu()
         {
-            var comp = Context.RenderComponent<MenuWithNestingTest>();
+            var comp = Context.Render<MenuWithNestingTest>();
 
             // Open the first menu.
             comp.Find("button:contains('1')").Click();
@@ -592,7 +592,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ClickingMenuItem_ClosesNestedMenu()
         {
-            var comp = Context.RenderComponent<MenuWithNestingTest>();
+            var comp = Context.Render<MenuWithNestingTest>();
 
             // Open the first menu.
             comp.Find("button:contains('1')").Click();
@@ -616,7 +616,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task IActivatable_Activate_Should_ToggleMenu_Except_For_InputAdornmentIconButton()
         {
             // Arrange
-            var comp = Context.RenderComponent<MudMenu>(parameters => parameters
+            var comp = Context.Render<MudMenu>(parameters => parameters
                 .Add(p => p.ActivatorContent, builder =>
                 {
                     builder.OpenComponent<MudIconButton>(0);
@@ -640,7 +640,7 @@ namespace MudBlazor.UnitTests.Components
             comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should not open when Activate is called with an mud-no-activator selector"));
 
             // Special case with regular button
-            var compButton = Context.RenderComponent<MudButton>(p => p.Add(p => p.Class, "mud-no-activator")).Instance;
+            var compButton = Context.Render<MudButton>(p => p.Add(p => p.Class, "mud-no-activator")).Instance;
             activatable.Activate(compButton, new MouseEventArgs());
             comp.WaitForAssertion(() => menu.GetState(x => x.Open).Should().BeFalse("Menu should not open when Activate is called with an mud-no-activator selector"));
 
@@ -651,8 +651,8 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Menu_ButtonActivator()
         {
-            var provider = Context.RenderComponent<MudPopoverProvider>();
-            var comp = Context.RenderComponent<MudMenu>(parameters => parameters
+            var provider = Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<MudMenu>(parameters => parameters
                 .Add(p => p.ActivatorContent, builder =>
                 {
                     builder.OpenComponent<MudButton>(0);
@@ -667,7 +667,7 @@ namespace MudBlazor.UnitTests.Components
             provider.FindAll("div.mud-popover-open").Count.Should().Be(1);
             button.Click();
             // Render component with MudIconButton inside ActivatorContent
-            comp = Context.RenderComponent<MudMenu>(parameters => parameters
+            comp = Context.Render<MudMenu>(parameters => parameters
                 .Add(p => p.ActivatorContent, builder =>
                 {
                     builder.OpenComponent<MudIconButton>(0);
@@ -693,7 +693,7 @@ namespace MudBlazor.UnitTests.Components
             var hoverDelay = 300;
             MudGlobal.MenuDefaults.HoverDelay = hoverDelay;
 
-            var comp = Context.RenderComponent<MenuWithNestingTest>();
+            var comp = Context.Render<MenuWithNestingTest>();
 
             // Open the main menu first
             comp.Find("button:contains('1')").Click();
@@ -736,7 +736,7 @@ namespace MudBlazor.UnitTests.Components
             var hoverDelay = 300;
             MudGlobal.MenuDefaults.HoverDelay = hoverDelay;
 
-            var comp = Context.RenderComponent<MenuWithNestingTest>();
+            var comp = Context.Render<MenuWithNestingTest>();
 
             // Open the main menu first
             comp.Find("button:contains('1')").Click();
@@ -775,7 +775,7 @@ namespace MudBlazor.UnitTests.Components
             var hoverDelay = 300;
             MudGlobal.MenuDefaults.HoverDelay = hoverDelay;
 
-            var comp = Context.RenderComponent<MenuWithNestingTest>();
+            var comp = Context.Render<MenuWithNestingTest>();
 
             // Open the main menu first
             comp.Find("button:contains('1')").Click();
@@ -815,7 +815,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_ArrowDown_FocusSecondItem()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             await comp.InvokeAsync(async () =>
             {
@@ -837,7 +837,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_ArrowUp_FocusLastItem()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             await comp.InvokeAsync(async () =>
             {
@@ -866,7 +866,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_ArrowRight_OpensNestedMenu()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index -1)
             await comp.InvokeAsync(async () =>
@@ -899,7 +899,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_ArrowRight_NoFurtherAction()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index 0)
             await comp.InvokeAsync(async () =>
@@ -922,7 +922,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_ArrowLeft_ClosesMenu()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index 0)
             await comp.InvokeAsync(async () =>
@@ -945,7 +945,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_ArrowLeft_ClosesNestedMenu()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
             await comp.InvokeAsync(async () =>
@@ -984,7 +984,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_Enter_ClosesMenuOnLinkItem()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
             await comp.InvokeAsync(async () =>
@@ -1014,7 +1014,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_Tab_ClosesAllMenus()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
             await comp.InvokeAsync(async () =>
@@ -1047,7 +1047,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_Escape_ClosesSubmenuAndReturnsFocus()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
             await comp.InvokeAsync(async () =>
@@ -1081,7 +1081,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_DisabledItem_IsFocusableButNotInvokable()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             await comp.InvokeAsync(async () =>
             {
@@ -1113,7 +1113,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_DisabledItem_HasCorrectAccessibilityAttributes()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
 
             await comp.InvokeAsync(async () =>
             {
@@ -1140,7 +1140,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TrackKeyboardInteraction_WhenMenuClosed_DoesNothing()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Menu should start closed
@@ -1161,7 +1161,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TrackKeyboardInteraction_WhenArrowDown_FocusesFirstItem()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Open the menu through its activator
@@ -1190,7 +1190,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TrackKeyboardInteraction_WhenArrowUp_FocusesLastItem()
         {
-            var comp = Context.RenderComponent<MenuKeydownTest>();
+            var comp = Context.Render<MenuKeydownTest>();
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Open the menu through its activator
@@ -1223,7 +1223,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PopoverSettings_SetsDefaultValues()
         {
-            var menu = Context.RenderComponent<MudMenu>();
+            var menu = Context.Render<MudMenu>();
 
             menu.Instance.PopoverFixed.Should().BeFalse();
             menu.Instance.OverflowBehavior.Should().Be(MudGlobal.PopoverDefaults.OverflowBehavior);
@@ -1236,7 +1236,7 @@ namespace MudBlazor.UnitTests.Components
             try
             {
                 MudGlobal.PopoverDefaults.OverflowBehavior = OverflowBehavior.FlipNever;
-                var menu = Context.RenderComponent<MudMenu>(p =>
+                var menu = Context.Render<MudMenu>(p =>
                 {
                     p.Add(p => p.PopoverFixed, true);
                 });

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(2, true)]
         public async Task MessageBox_Should_ReturnTrue(int clickButtonIndex, bool? expectedResult)
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetService<IDialogService>() as DialogService;
             service.Should().NotBe(null);
@@ -61,7 +61,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(2, true)]
         public async Task MessageBox_Should_ReturnTrueWithMarkupVariant(int clickButtonIndex, bool? expectedResult)
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetService<IDialogService>() as DialogService;
             service.Should().NotBe(null);
@@ -104,7 +104,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MessageBox_CloseOnEscapeKey_NoOptions_NoMudDefaults()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = (DialogService)Context.Services.GetService<IDialogService>()!;
             service.Should().NotBe(null);
@@ -180,7 +180,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MessageBox_CloseOnEscapeKey_WithOptions_NoMudDefaults()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>();
+            var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = (DialogService)Context.Services.GetService<IDialogService>();
             service.Should().NotBe(null);
@@ -250,7 +250,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MessageBox_CloseOnEscapeKey_NoOptions_WithMudDefaults()
         {
-            var comp = Context.RenderComponent<MudDialogProvider>(builder =>
+            var comp = Context.Render<MudDialogProvider>(builder =>
             {
                 builder.Add(p => p.CloseOnEscapeKey, true);
             });

--- a/src/MudBlazor.UnitTests/Components/MudHotkeyTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MudHotkeyTests.cs
@@ -21,7 +21,7 @@ public class MudHotkeyTests : BunitTest
     public async Task Hotkey_ShouldShowChildContent()
     {
         // Arrange
-        var comp = Context.RenderComponent<MudHotkeyTest>(p => p.Add(x => x.HideChildContentOnRepress, false));
+        var comp = Context.Render<MudHotkeyTest>(p => p.Add(x => x.HideChildContentOnRepress, false));
         var hotKeyComponent = comp.FindComponent<MudHotkey>();
 
         // Act
@@ -36,7 +36,7 @@ public class MudHotkeyTests : BunitTest
     public async Task Hotkey_ShouldNotShowChildContent()
     {
         // Arrange
-        var comp = Context.RenderComponent<MudHotkeyTest>(p => p.Add(x => x.HideChildContentOnRepress, true));
+        var comp = Context.Render<MudHotkeyTest>(p => p.Add(x => x.HideChildContentOnRepress, true));
         var hotKeyComponent = comp.FindComponent<MudHotkey>();
         var hotKeyChildContent = () => comp.Find("#hotkey-child");
 
@@ -50,18 +50,18 @@ public class MudHotkeyTests : BunitTest
     }
 
     [Test]
-    public void Hotkey_JsTestComponentLifetimeCycle()
+    public async Task Hotkey_JsTestComponentLifetimeCycle()
     {
         var jsRuntimeMock = new Mock<IJSRuntime>();
         jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.registerOrUpdateHotkey", It.IsAny<object[]>()));
         jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.unregisterHotkey", It.IsAny<object[]>()));
         Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-        Context.RenderComponent<MudHotkeyTest>();
+        Context.Render<MudHotkeyTest>();
         jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.registerOrUpdateHotkey", It.IsAny<object[]>()), Times.Exactly(1));
         jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.unregisterHotkey", It.IsAny<object[]>()), Times.Never);
 
-        Context.DisposeComponents();
+        await Context.DisposeComponentsAsync();
         jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.registerOrUpdateHotkey", It.IsAny<object[]>()), Times.Exactly(1));
         jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.unregisterHotkey", It.IsAny<object[]>()), Times.Exactly(1));
     }
@@ -74,7 +74,7 @@ public class MudHotkeyTests : BunitTest
         jsRuntimeMock.Setup(x => x.InvokeAsync<IJSVoidResult>("mudHotkeyListener.unregisterHotkey", It.IsAny<object[]>()));
         Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-        var comp = Context.RenderComponent<MudHotkeyTest>();
+        var comp = Context.Render<MudHotkeyTest>();
         await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Key, JsKey.KeyB));
         await comp.SetParametersAndRenderAsync(p => p.Add(x => x.KeyModifiers, [JsKeyModifier.ShiftLeft]));
         await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Disabled, true));

--- a/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Two_Way_Bindable_Disabled()
         {
-            var comp = Context.RenderComponent<NavMenuGroupDisabledTest>();
+            var comp = Context.Render<NavMenuGroupDisabledTest>();
 
             comp.Markup.Should().NotContain("mud-nav-group-disabled");
             comp.Markup.Should().NotContain("mud-expanded");
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         public void NavGroup_Should_UseNavTag()
         {
             var expectedTitle = "navgroup-title";
-            var comp = Context.RenderComponent<MudNavGroup>(parameters =>
+            var comp = Context.Render<MudNavGroup>(parameters =>
                     parameters.Add(p => p.Title, expectedTitle));
 
             comp.FindAll("nav").Should().Contain(navNode => navNode.GetAttribute("aria-label") == expectedTitle);
@@ -44,7 +44,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NavGroup_Should_Expand_Via_Expanded_Binding()
         {
-            var comp = Context.RenderComponent<NavGroupWithExpandedBindingTest>();
+            var comp = Context.Render<NavGroupWithExpandedBindingTest>();
             GetExpandedState().Should().BeFalse();
 
             await comp.InvokeAsync(() => comp.Find("#navgroup-switch").Change(true));

--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -22,7 +22,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("myFrameName", "noopener noreferrer")]
         public void NavLink_CheckRelAttribute(string target, string expectedRel)
         {
-            var comp = Context.RenderComponent<MudNavLink>(parameters => parameters.Add(x => x.Target, target));
+            var comp = Context.Render<MudNavLink>(parameters => parameters.Add(x => x.Target, target));
             // print the generated html
             // select elements needed for the test
             comp.Find("a").GetAttribute("rel").Should().Be(expectedRel);
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         public void NavLink_CheckOnClickEvent()
         {
             var clicked = false;
-            var comp = Context.RenderComponent<MudNavLink>(parameters => parameters.Add(x => x.OnClick, (MouseEventArgs args) => { clicked = true; }));
+            var comp = Context.Render<MudNavLink>(parameters => parameters.Add(x => x.OnClick, (MouseEventArgs args) => { clicked = true; }));
             // print the generated html
             comp.FindAll("a").Should().BeEmpty();
             comp.Find(".mud-nav-link").Click();
@@ -43,7 +43,7 @@ namespace MudBlazor.UnitTests.Components
         public void NavLink_Active()
         {
             const string activeClass = "Custom__nav_active_css";
-            var comp = Context.RenderComponent<MudNavLink>(parameters => parameters.Add(x => x.ActiveClass, activeClass));
+            var comp = Context.Render<MudNavLink>(parameters => parameters.Add(x => x.ActiveClass, activeClass));
             comp.Find(".mud-nav-link").Click();
             comp.Markup.Should().Contain(activeClass);
         }
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NavLink_Enabled_CheckNavigation()
         {
-            var comp = Context.RenderComponent<NavLinkDisabledTest>(parameters => parameters.Add(x => x.Disabled, false));
+            var comp = Context.Render<NavLinkDisabledTest>(parameters => parameters.Add(x => x.Disabled, false));
             comp.Find("a").Click();
             comp.Instance.IsNavigated.Should().BeTrue();
         }
@@ -59,7 +59,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NavLink_Disabled_CheckNoNavigation()
         {
-            var comp = Context.RenderComponent<NavLinkDisabledTest>(parameters => parameters.Add(x => x.Disabled, true));
+            var comp = Context.Render<NavLinkDisabledTest>(parameters => parameters.Add(x => x.Disabled, true));
             comp.Find("a").Click();
             comp.Instance.IsNavigated.Should().BeFalse();
         }
@@ -67,10 +67,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NavLinkOnClickErrorContentCaughtException()
         {
-            var comp = Context.RenderComponent<NavLinkErrorContenCaughtException>();
+            var comp = Context.Render<NavLinkErrorContenCaughtException>();
             IElement AlertText() => MudAlert().Find("div.mud-alert-message");
             IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
-            IRefreshableElementCollection<IElement> Links() => comp.FindAll(".mud-nav-link");
+            IReadOnlyList<IElement> Links() => comp.FindAll(".mud-nav-link");
             IElement MudLink() => Links()[0];
 
             await MudLink().ClickAsync(new MouseEventArgs());

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -14,7 +14,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NavMenuTests_DefaultValues()
         {
-            var comp = Context.RenderComponent<MudNavMenu>();
+            var comp = Context.Render<MudNavMenu>();
 
             comp.Instance.Bordered.Should().Be(false);
             comp.Instance.Color.Should().Be(Color.Default);
@@ -35,7 +35,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NavMenuTests_CheckAllStyling()
         {
-            var comp = Context.RenderComponent<MudNavMenu>(x =>
+            var comp = Context.Render<MudNavMenu>(x =>
             {
                 x.Add(p => p.Bordered, true);
                 x.Add(p => p.Color, Color.Success);
@@ -58,7 +58,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void One_Way_Bindable()
         {
-            var comp = Context.RenderComponent<NavMenuOneWay>();
+            var comp = Context.Render<NavMenuOneWay>();
             comp.Markup.Should().Contain("mud-expanded");
             comp.Markup.Should().Contain("aria-hidden=\"false\"");
 
@@ -76,7 +76,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Two_Way_Bindable()
         {
-            var comp = Context.RenderComponent<NavMenuTwoWay>();
+            var comp = Context.Render<NavMenuTwoWay>();
             comp.Markup.Should().NotContain("mud-expanded");
             comp.Markup.Should().Contain("aria-hidden=\"true\"");
             var expanded = comp.Instance.Expanded;

--- a/src/MudBlazor.UnitTests/Components/NavigationAccessibilityTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavigationAccessibilityTests.cs
@@ -19,7 +19,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void ActiveNavGroups_Should_BeFocusable()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
         var navGroups = comp
             .FindComponents<MudNavGroup>()
             .Where(navGroup => navGroup.Instance.Disabled is false)
@@ -42,7 +42,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void DisabledNavGroups_Should_NotBeFocusable()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
         var navGroups = comp
             .FindComponents<MudNavGroup>()
             .Where(navGroup => navGroup.Instance.Disabled)
@@ -65,7 +65,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void ActiveNavLinkInActiveNavGroup_Should_BeFocusable()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
 
         comp.FindAll("#second-level-navgroup a.mud-nav-link:not(.mud-nav-link-disabled)").Should().HaveCount(1);
         comp.FindAll("#second-level-navgroup a.mud-nav-link:not(.mud-nav-link-disabled)")
@@ -83,7 +83,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void DisabledNavLinksInActiveNavGroup_Should_NotBeFocusable()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
 
         comp.FindAll("#second-level-navgroup a.mud-nav-link.mud-nav-link-disabled").Should().HaveCount(2);
         comp.FindAll("#second-level-navgroup a.mud-nav-link.mud-nav-link-disabled")
@@ -101,7 +101,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void EverythingWithinDisabledNavGroups_Should_NotBeFocusable()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>(parameters =>
+        var comp = Context.Render<NavigationAccessibilityTest>(parameters =>
             parameters.Add(p => p.TopLevelDisabled, true));
 
         comp.FindAll("[tabindex]").Should().HaveCountGreaterThan(0).And.AllSatisfy(node => node.GetAttribute("tabindex").Should().Be("-1"));
@@ -113,7 +113,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void MudCollapseWithinCollapsedNavGroup_Should_BeAriaHidden()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>(parameters =>
+        var comp = Context.Render<NavigationAccessibilityTest>(parameters =>
             parameters.Add(p => p.TopLevelExpanded, false));
 
         comp.FindAll(".mud-collapse-container").Should().HaveCountGreaterThan(0).And.AllSatisfy(node => node.GetAttribute("aria-hidden").Should().Be("true"));
@@ -125,7 +125,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void MudCollapseWithinExpandedNavGroup_Should_NotBeAriaHidden()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
 
         comp.FindAll("#second-level-navgroup .mud-collapse-container").Should().HaveCountGreaterThan(0).And.AllSatisfy(node => node.GetAttribute("aria-hidden").Should().Be("false"));
     }
@@ -136,7 +136,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void NavGroupButtons_Should_HaveCorrectAriaExpandedValue()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
         var navGroups = comp.FindComponents<MudNavGroup>();
 
         navGroups
@@ -155,7 +155,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void NavGroupButtons_Should_HaveValidAriaControlsValue_And_NavMenus_Should_HaveAnId()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
         var navGroups = comp.FindComponents<MudNavGroup>();
         var navMenus = comp.FindComponents<MudNavMenu>();
         var ariaControlsIds = navGroups
@@ -178,7 +178,7 @@ public class NavigationAccessibilityTests : BunitTest
     [Test]
     public void NavGroupButtons_Should_HaveAriaLabel()
     {
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>();
+        var comp = Context.Render<NavigationAccessibilityTest>();
         var navGroups = comp.FindComponents<MudNavGroup>();
 
         navGroups
@@ -198,7 +198,7 @@ public class NavigationAccessibilityTests : BunitTest
     public void NavGroups_Should_HaveAriaLabel_WhenTitleIsProvided()
     {
         var expectedTitle = "expected title";
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>(parameters =>
+        var comp = Context.Render<NavigationAccessibilityTest>(parameters =>
             parameters.Add(p => p.SecondLevelTitle, expectedTitle));
 
         comp.Find("#second-level-navgroup")
@@ -214,7 +214,7 @@ public class NavigationAccessibilityTests : BunitTest
     public void NavGroupButtonsAriaLabel_Should_ContainTitle_WhenTitleIsProvided()
     {
         var expectedTitle = "expected title";
-        var comp = Context.RenderComponent<NavigationAccessibilityTest>(parameters =>
+        var comp = Context.Render<NavigationAccessibilityTest>(parameters =>
             parameters.Add(p => p.SecondLevelTitle, expectedTitle));
 
         comp.Find("#second-level-navgroup > button")

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -124,7 +124,7 @@ namespace MudBlazor.UnitTests.Components
         /// Value should not change immediately. Should respect the Debounce Interval
         /// </summary>
         [Test]
-        public async Task ShouldRespectDebounceIntervalPropertyInNumericFieldTest()
+        public void ShouldRespectDebounceIntervalPropertyInNumericFieldTest()
         {
             var comp = Context.Render<MudNumericField<int?>>(parameters => parameters
                 .Add(x => x.DebounceInterval, 200d));
@@ -139,12 +139,11 @@ namespace MudBlazor.UnitTests.Components
             numericField.Value.Should().BeNull();
             numericField.Text.Should().Be("100");
             //DebounceInterval is 200 ms, so at 100 ms Value should not change in NumericField
-            await Task.Delay(100);
+            comp.WaitForAssertion(() => numericField.Value.Should().NotBe(100), TimeSpan.FromMilliseconds(100));
             numericField.Value.Should().BeNull();
             numericField.Text.Should().Be("100");
-            //More than 200 ms had elapsed, so Value should be updated
-            await Task.Delay(150);
-            numericField.Value.Should().Be(100);
+            //More than 200 ms had elapsed, so Value should be updated (CPU time will likely take more than 200ms)
+            comp.WaitForAssertion(() => numericField.Value.Should().Be(100), TimeSpan.FromMilliseconds(300));
             numericField.Text.Should().Be("100");
         }
 

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericFieldLabelFor()
         {
-            var comp = Context.RenderComponent<NumericFieldTest>();
+            var comp = Context.Render<NumericFieldTest>();
             var label = comp.FindAll(".mud-input-label");
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("numericFieldLabelTest");
         }
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldTest1()
         {
-            var comp = Context.RenderComponent<MudNumericField<double>>();
+            var comp = Context.Render<MudNumericField<double>>();
             // print the generated html
             // select elements needed for the test
             var numericField = comp.Instance;
@@ -75,7 +75,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericFieldTest2()
         {
-            var comp = Context.RenderComponent<MudNumericField<double?>>();
+            var comp = Context.Render<MudNumericField<double?>>();
             // print the generated html
             // select elements needed for the test
             var numericField = comp.Instance;
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericField_WithNullableTypes_ShouldAllowNulls<T>(T value) where T : struct
         {
-            var comp = Context.RenderComponent<MudNumericField<T?>>(parameters => parameters.Add(x => x.Value, value));
+            var comp = Context.Render<MudNumericField<T?>>(parameters => parameters.Add(x => x.Value, value));
             // print the generated html
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, null));
             comp.Find("input").Blur();
@@ -108,7 +108,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //no interval passed, so, by default is 0
             // We pass the Immediate parameter set to true, in order to bind to oninput
-            var comp = Context.RenderComponent<MudNumericField<int?>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int?>>(parameters => parameters
                 .Add(x => x.Immediate, true));
             var numericField = comp.Instance;
             var input = comp.Find("input");
@@ -126,7 +126,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ShouldRespectDebounceIntervalPropertyInNumericFieldTest()
         {
-            var comp = Context.RenderComponent<MudNumericField<int?>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int?>>(parameters => parameters
                 .Add(x => x.DebounceInterval, 200d));
             var numericField = comp.Instance;
             var input = comp.Find("input");
@@ -157,7 +157,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //Arrange
             //with no placeholder, label is not shrunk
-            var comp = Context.RenderComponent<MudNumericField<int?>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int?>>(parameters => parameters
                 .Add(x => x.Label, "label"));
             comp.Markup.Should().NotContain("shrink");
             //with placeholder label is shrunk
@@ -197,7 +197,7 @@ namespace MudBlazor.UnitTests.Components
             var validator = new FluentValueValidator<string>(x => x.Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .Length(1, 100));
-            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
                 .Add(x => x.Validation, validator.Validation)
                 .Add(x => x.Max, 100M));
             var numericField = comp.Instance;
@@ -218,7 +218,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericField_HandleDecimalPrecisionAndValues()
         {
-            var comp = Context.RenderComponent<MudNumericField<decimal>>();
+            var comp = Context.Render<MudNumericField<decimal>>();
             var numericField = comp.Instance;
 
             // first try set max decimal value
@@ -238,7 +238,7 @@ namespace MudBlazor.UnitTests.Components
         [Test, CancelAfter(1000)]
         public async Task NumericFieldUpdateLoopProtectionTest()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(x => x.Converter, Conversions.From((int s) => s.ToString(), int.Parse)));
             // these conversion funcs are nonsense of course, but they are designed this way to
             // test against an infinite update loop that numericFields and other inputs are now protected against.
@@ -255,7 +255,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task NumericField_Should_FireValueChangedOnTextParameterChange()
         {
             var changed_value = 4;
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(x => x.ValueChanged, x => changed_value = x));
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Text, "4"));
             changed_value.Should().Be(4);
@@ -265,7 +265,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task NumericField_Should_FireTextChangedOnValueParameterChange()
         {
             var changed_text = "4";
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(x => x.TextChanged, x => changed_text = x));
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, 4));
             changed_text.Should().Be("4");
@@ -276,7 +276,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var changed_value = 4;
             string changed_text = null;
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(x => x.ValueChanged, x => changed_value = x)
                 .Add(x => x.TextChanged, x => changed_text = x));
             comp.Find("input").Change("4");
@@ -310,7 +310,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
         {
-            var comp = Context.RenderComponent<NumericFieldRequiredTest>();
+            var comp = Context.Render<NumericFieldRequiredTest>();
             var numericField = comp.FindComponent<MudNumericField<int?>>().Instance;
             numericField.Touched.Should().BeFalse();
             numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
@@ -327,7 +327,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public void NumericField_OfAnyType_Should_Render<T>(T value)
         {
-            Assert.DoesNotThrow(() => Context.RenderComponent<MudNumericField<T>>(), $"{typeof(MudNumericField<>)}<{typeof(T)}> render failed.");
+            Assert.DoesNotThrow(() => Context.Render<MudNumericField<T>>(), $"{typeof(MudNumericField<>)}<{typeof(T)}> render failed.");
         }
 
         /// <summary>
@@ -336,7 +336,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldTest_KeyboardInput()
         {
-            var comp = Context.RenderComponent<MudNumericField<double>>();
+            var comp = Context.Render<MudNumericField<double>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Culture, CultureInfo.InvariantCulture)
                 .Add(x => x.Format, "F2")
@@ -369,7 +369,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldTest_KeyboardInput_Disabled()
         {
-            var comp = Context.RenderComponent<MudNumericField<double>>();
+            var comp = Context.Render<MudNumericField<double>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Culture, CultureInfo.InvariantCulture)
                 .Add(x => x.Format, "F2")
@@ -389,7 +389,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldTest_KeyboardInput_Readonly()
         {
-            var comp = Context.RenderComponent<MudNumericField<double>>();
+            var comp = Context.Render<MudNumericField<double>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Culture, CultureInfo.InvariantCulture)
                 .Add(x => x.Format, "F2")
@@ -409,7 +409,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldTest_MouseWheel()
         {
-            var comp = Context.RenderComponent<MudNumericField<double>>();
+            var comp = Context.Render<MudNumericField<double>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, 1234.56));
             var numericField = comp.Instance;
 
@@ -455,7 +455,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldTest_Wheel_Firefox()
         {
-            var comp = Context.RenderComponent<MudNumericField<double>>();
+            var comp = Context.Render<MudNumericField<double>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, 1234.56));
             var numericField = comp.Instance;
 
@@ -501,7 +501,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericFieldTestCultureFormat()
         {
-            var comp = Context.RenderComponent<NumericFieldCultureTest>();
+            var comp = Context.Render<NumericFieldCultureTest>();
             var inputs = comp.FindAll("input");
             var immediate = inputs.First();
             var notImmediate = inputs.Last();
@@ -541,7 +541,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericField_should_RejectIllegalCharacters()
         {
-            var comp = Context.RenderComponent<NumericFieldCultureTest>();
+            var comp = Context.Render<NumericFieldCultureTest>();
             //german
             comp.FindAll("input").Last().Change("abcd");
             comp.FindAll("input").Last().Blur();
@@ -574,7 +574,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericField_should_ReformatTextOnBlur()
         {
-            var comp = Context.RenderComponent<NumericFieldCultureTest>();
+            var comp = Context.Render<NumericFieldCultureTest>();
             // english
             comp.FindAll("input").First().Input("1,234.56");
             comp.FindAll("input").First().Blur();
@@ -598,7 +598,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericField_Validation<T>(T value)
         {
-            var comp = Context.RenderComponent<MudNumericField<T>>();
+            var comp = Context.Render<MudNumericField<T>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Max, value)
                 .Add(x => x.Min, value)
@@ -614,7 +614,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var min = (T)Convert.ChangeType(1, typeof(T));
             var max = (T)Convert.ChangeType(10, typeof(T));
-            var comp = Context.RenderComponent<MudNumericField<T>>();
+            var comp = Context.Render<MudNumericField<T>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Min, min)
                 .Add(x => x.Max, max));
@@ -635,7 +635,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var min = (T)Convert.ChangeType(1, typeof(T));
             var max = (T)Convert.ChangeType(10, typeof(T));
-            var comp = Context.RenderComponent<MudNumericField<T?>>();
+            var comp = Context.Render<MudNumericField<T?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Min, min)
                 .Add(x => x.Max, max));
@@ -654,7 +654,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericField_Increment_Decrement<T>(T value)
         {
-            var comp = Context.RenderComponent<MudNumericField<T>>();
+            var comp = Context.Render<MudNumericField<T>>();
             var max = Convert.ChangeType(10, typeof(T));
             var min = Convert.ChangeType(0, typeof(T));
             await comp.SetParametersAndRenderAsync(parameters => parameters
@@ -677,7 +677,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericFieldNullable_Increment_Decrement<T>(T value) where T : struct
         {
-            var comp = Context.RenderComponent<MudNumericField<T?>>();
+            var comp = Context.Render<MudNumericField<T?>>();
             var max = Convert.ChangeType(10, typeof(T));
             var min = Convert.ChangeType(0, typeof(T));
             await comp.SetParametersAndRenderAsync(parameters => parameters
@@ -700,7 +700,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericFieldNullable_NoMinMax_Increment_Decrement<T>(T value) where T : struct
         {
-            var comp = Context.RenderComponent<MudNumericField<T?>>();
+            var comp = Context.Render<MudNumericField<T?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, value));
 
             await comp.InvokeAsync(() => comp.Instance.Increment());
@@ -720,7 +720,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericField_Increment_Decrement_OverflowHandled<T>(T value)
         {
-            var comp = Context.RenderComponent<MudNumericField<T>>();
+            var comp = Context.Render<MudNumericField<T>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, value));
 
             // test max overflow
@@ -737,7 +737,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericFieldNullable_Increment_Decrement_OverflowHandled<T>(T value) where T : struct
         {
-            var comp = Context.RenderComponent<MudNumericField<T?>>();
+            var comp = Context.Render<MudNumericField<T?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, value));
 
             // test max overflow
@@ -758,7 +758,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(-20, -10, -15)]
         public async Task NumericFieldCanBeCleared(int min, int max, int value)
         {
-            var comp = Context.RenderComponent<MudNumericField<int?>>();
+            var comp = Context.Render<MudNumericField<int?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Min, min)
                 .Add(x => x.Max, max)
@@ -776,7 +776,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldWithCurrencyFormat()
         {
-            var comp = Context.RenderComponent<MudNumericField<int?>>();
+            var comp = Context.Render<MudNumericField<int?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Format, "€0")
                 .Add(x => x.Culture, CultureInfo.InvariantCulture));
@@ -806,7 +806,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldThousandsSeparator()
         {
-            var comp = Context.RenderComponent<MudNumericField<int?>>();
+            var comp = Context.Render<MudNumericField<int?>>();
             var numericField = comp.Instance;
 
             numericField.Value.Should().Be(null);
@@ -833,7 +833,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DebouncedNumericFieldRerenderTest()
         {
-            var comp = Context.RenderComponent<DebouncedNumericFieldRerenderTest>();
+            var comp = Context.Render<DebouncedNumericFieldRerenderTest>();
             var numericField = comp.FindComponent<MudNumericField<int>>().Instance;
             var delayedRerenderButton = comp.Find("button#re-render");
             var converter = new DefaultConverter<int>();
@@ -864,7 +864,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var defaultValue = 1;
             var converter = new DefaultConverter<int>();
-            var comp = Context.RenderComponent<DebouncedNumericFieldRerenderTest>(parameters => parameters
+            var comp = Context.Render<DebouncedNumericFieldRerenderTest>(parameters => parameters
                 .Add(x => x.Value, defaultValue));
             var textfield = comp.FindComponent<MudNumericField<int>>().Instance;
             textfield.Text.Should().Be(converter.Convert(defaultValue));
@@ -876,7 +876,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DebouncedNumericFieldCultureChangeRerenderTest()
         {
-            var comp = Context.RenderComponent<DebouncedNumericFieldCultureChangeRerenderTest>();
+            var comp = Context.Render<DebouncedNumericFieldCultureChangeRerenderTest>();
             var numericField = comp.FindComponent<MudNumericField<double>>().Instance;
             var delayedCultureChange = comp.Find("button#culture-change");
             // ensure text is updated on initialize
@@ -910,7 +910,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NumericFieldWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters
                 => parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -925,7 +925,7 @@ namespace MudBlazor.UnitTests.Components
         public void NumericFieldWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -945,7 +945,7 @@ namespace MudBlazor.UnitTests.Components
         public void NumericFieldWithLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -965,7 +965,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalNumericField_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>();
+            var comp = Context.Render<MudNumericField<int>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -977,7 +977,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredNumericField_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -990,7 +990,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredNumericFieldAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>();
+            var comp = Context.Render<MudNumericField<int>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1005,7 +1005,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Should_render_appropriate_type()
         {
-            var comp = Context.RenderComponent<NumericFieldRenderTest>();
+            var comp = Context.Render<NumericFieldRenderTest>();
             var field = comp.Find("#num-field-id");
 
             comp.Markup.Should().NotContain("pattern");
@@ -1027,7 +1027,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("ru-RU")]
         public void Should_ignore_default_culture()
         {
-            var comp = Context.RenderComponent<NumericFieldRenderTest>();
+            var comp = Context.Render<NumericFieldRenderTest>();
             var numericField = comp.FindComponent<MudNumericField<decimal>>();
 
             comp.Find("input").Change("123.45");
@@ -1042,7 +1042,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("ru-RU")]
         public void Format_should_use_default_culture()
         {
-            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
                                 .Add(p => p.Format, "N3"));
 
             comp.Find("input").Change("123,45");
@@ -1057,7 +1057,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("ru-RU")]
         public void Pattern_should_use_default_culture()
         {
-            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
                                 .Add(p => p.Pattern, "[0-9,.\\-]"));
 
             comp.Find("input").Change("123,45");
@@ -1072,7 +1072,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("ru-RU")]
         public void Should_apply_defined_culture()
         {
-            var comp = Context.RenderComponent<NumericFieldCultureTest>();
+            var comp = Context.Render<NumericFieldCultureTest>();
             var inputs = comp.FindAll("input");
             var immediate = inputs.First();
             var notImmediate = inputs.Last();
@@ -1096,7 +1096,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("ru-RU")]
         public void Format_should_use_defined_culture()
         {
-            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
                                 .Add(p => p.Format, "N3")
                                 .Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US")));
 
@@ -1112,7 +1112,7 @@ namespace MudBlazor.UnitTests.Components
         [SetUICulture("ru-RU")]
         public void Pattern_should_use_defined_culture()
         {
-            var comp = Context.RenderComponent<MudNumericField<decimal>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
                                 .Add(p => p.Pattern, "[0-9,.\\-]")
                                 .Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US")));
 
@@ -1127,7 +1127,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Should_render_conversion_error_message()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(p => p.ErrorId, "error-id")
                 .Add(p => p.Text, "not a number")
                 .Add(p => p.Converter, new DummyErrorConverter()));
@@ -1141,7 +1141,7 @@ namespace MudBlazor.UnitTests.Components
         public void Should_render_aria_label_for_adornment_if_provided(Adornment adornment)
         {
             var ariaLabel = "the aria label";
-            var comp = Context.RenderComponent<MudNumericField<int>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
                 .Add(p => p.Adornment, adornment)
                 .Add(p => p.AdornmentIcon, Icons.Material.Filled.Accessibility)
                 .Add(p => p.AdornmentAriaLabel, ariaLabel));
@@ -1177,7 +1177,7 @@ namespace MudBlazor.UnitTests.Components
                     ? $"{inputId}-helper-text"
                     : null;
 
-            var comp = Context.RenderComponent<MudNumericField<string>>(parameters => parameters
+            var comp = Context.Render<MudNumericField<string>>(parameters => parameters
                 .Add(p => p.InputId, inputId)
                 .Add(p => p.HelperId, helperId)
                 .Add(p => p.HelperText, helperText)
@@ -1219,7 +1219,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericFieldConverterErrorReset()
         {
-            var comp = Context.RenderComponent<MudNumericField<int>>();
+            var comp = Context.Render<MudNumericField<int>>();
             var numericField = comp.Instance;
 
             // insert an invalid int number, greater then maximum int value

--- a/src/MudBlazor.UnitTests/Components/OverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/OverlayTests.cs
@@ -16,8 +16,8 @@ public class OverlayTests : BunitTest
     [Test]
     public void ShouldNotRenderByDefault()
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>();
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>();
         comp.Markup.Should().BeEmpty();
         providerComp.FindAll("div.mud-overlay").Count.Should().Be(0);
     }
@@ -25,8 +25,8 @@ public class OverlayTests : BunitTest
     [Test]
     public void ShouldRenderWhenVisibleIsTrue()
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
         );
 
@@ -38,8 +38,8 @@ public class OverlayTests : BunitTest
     [TestCase(false)]
     public async Task AutoClose_OnClick(bool autoClose)
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.AutoClose, autoClose)
         );
@@ -61,8 +61,8 @@ public class OverlayTests : BunitTest
     {
         var counter = 0;
         void CloseHandler() => counter++;
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.AutoClose, true)
             .Add(p => p.OnClosed, CloseHandler)
@@ -76,8 +76,8 @@ public class OverlayTests : BunitTest
     [Test]
     public async Task AutoClose_VisibleBinding()
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<OverlayVisibleBindingWithAutoCloseTest>();
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<OverlayVisibleBindingWithAutoCloseTest>();
         IElement Button() => comp.Find("#showBtn");
 
         comp.Instance.Visible.Should().BeFalse();
@@ -92,8 +92,8 @@ public class OverlayTests : BunitTest
     [Test]
     public void ShouldApplyCorrectZIndex()
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.ZIndex, 10)
         );
@@ -108,8 +108,8 @@ public class OverlayTests : BunitTest
     [TestCase(false, false)]
     public void ShouldApplyBackgroundColor(bool darkBackground, bool lightBackground)
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.DarkBackground, darkBackground)
             .Add(p => p.LightBackground, lightBackground)
@@ -138,8 +138,8 @@ public class OverlayTests : BunitTest
     [TestCase(false)]
     public void ShouldApplyAbsoluteClass(bool absolute)
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.Absolute, absolute)
         );
@@ -159,8 +159,8 @@ public class OverlayTests : BunitTest
     [TestCase(false)]
     public void ShouldApplyCorrectPointerEvents(bool modal)
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.Modal, modal)
         );
@@ -178,8 +178,8 @@ public class OverlayTests : BunitTest
     [Test]
     public void ShouldHaveId()
     {
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
         );
         providerComp.Find("div.mud-overlay").Attributes["id"].Value.Should().NotBeNullOrEmpty();
@@ -193,11 +193,11 @@ public class OverlayTests : BunitTest
     public void ShouldRender_SectionLocation(bool absolute, string expectedClass, bool hasChildContent, int testNum)
     {
         var childContent = "<div class='child-content'>Hello World</div>";
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
+        var providerComp = Context.Render<MudPopoverProvider>();
         IRenderedComponent<MudOverlay> comp;
         if (hasChildContent)
         {
-            comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+            comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.Class, expectedClass)
             .Add(p => p.Absolute, absolute)
@@ -206,7 +206,7 @@ public class OverlayTests : BunitTest
         }
         else
         {
-            comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+            comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .Add(p => p.Class, expectedClass)
             .Add(p => p.Absolute, absolute)
@@ -250,7 +250,7 @@ public class OverlayTests : BunitTest
     [Test]
     public void ShouldRenderChildContent()
     {
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
             .AddChildContent("<div class='child-content'>Hello World</div>")
         );
@@ -277,7 +277,7 @@ public class OverlayTests : BunitTest
             .Verifiable();
         Context.Services.AddScoped(_ => serviceMock.Object);
 
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, visible)
             .Add(p => p.AutoClose, autoClose)
             .Add(p => p.Modal, modal)
@@ -290,8 +290,8 @@ public class OverlayTests : BunitTest
     public void Overlay_ShouldHaveElementId_AndMatchRenderedDivId()
     {
         // Arrange
-        var providerComp = Context.RenderComponent<MudPopoverProvider>();
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var providerComp = Context.Render<MudPopoverProvider>();
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Visible, true)
         );
 
@@ -317,7 +317,7 @@ public class OverlayTests : BunitTest
         var visible = true;
 
         // === Initial: Visible = true, should lock scroll if conditions match ===
-        var comp = Context.RenderComponent<MudOverlay>(parameters => parameters
+        var comp = Context.Render<MudOverlay>(parameters => parameters
             .Add(p => p.Absolute, absolute)
             .Bind(p => p.Visible, visible, p => visible = p)
             .Add(p => p.LockScroll, lockscroll)
@@ -410,8 +410,8 @@ public class OverlayTests : BunitTest
                 It.IsAny<object[]>()))
             .Throws(new Exception("unlockScroll should not be called!"));
 
-        var dialog = Context.RenderComponent<MudDialogProvider>();
-        var comp = Context.RenderComponent<OverlayScrollLockedTest>();
+        var dialog = Context.Render<MudDialogProvider>();
+        var comp = Context.Render<OverlayScrollLockedTest>();
         // click the button opening dialog
         var button = comp.Find("button");
         button.Click();

--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DefaultValues()
         {
-            var comp = Context.RenderComponent<MudPageContentNavigation>();
+            var comp = Context.Render<MudPageContentNavigation>();
 
             comp.Instance.ActiveSection.Should().BeNull();
             comp.Instance.Sections.Should().BeEmpty();
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task AddSection(bool withUpdate)
         {
-            var comp = Context.RenderComponent<MudPageContentNavigation>();
+            var comp = Context.Render<MudPageContentNavigation>();
 
             var section1 = new MudPageContentSection("my section", "my-id");
             var section2 = new MudPageContentSection("my section 2", "my-id-2");
@@ -86,7 +86,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockScrollSpyFactory(mockedScrollSpy);
             Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
-            var comp = Context.RenderComponent<MudPageContentNavigation>();
+            var comp = Context.Render<MudPageContentNavigation>();
 
             var section1 = new MudPageContentSection("my section", "my-id");
             var section2 = new MudPageContentSection("different section", "my-id-2");
@@ -119,7 +119,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockScrollSpyFactory(mockedScrollSpy);
             Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
-            var comp = Context.RenderComponent<MudPageContentNavigation>(p => p.Add(x => x.ActivateFirstSectionAsDefault, true));
+            var comp = Context.Render<MudPageContentNavigation>(p => p.Add(x => x.ActivateFirstSectionAsDefault, true));
 
             var section1 = new MudPageContentSection("my section", "my-id");
             var section2 = new MudPageContentSection("my section 2", "my-id-2");
@@ -153,7 +153,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockScrollSpyFactory(spyMock);
             Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
-            var comp = Context.RenderComponent<MudPageContentNavigation>();
+            var comp = Context.Render<MudPageContentNavigation>();
 
             var section1 = new MudPageContentSection("my first section", "my-id1");
             var section2 = new MudPageContentSection("my second section", "my-id2");
@@ -191,7 +191,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockScrollSpyFactory(spyMock);
             Context.Services.Add(new ServiceDescriptor(typeof(IScrollSpyFactory), factory));
 
-            var comp = Context.RenderComponent<MudPageContentNavigation>(x => x.Add(y => y.SectionClassSelector, "my-section-class"));
+            var comp = Context.Render<MudPageContentNavigation>(x => x.Add(y => y.SectionClassSelector, "my-section-class"));
 
             spyMock.SpyingInitiated.Should().BeTrue();
             spyMock.SpyingClassSelector.Should().Be("my-section-class");
@@ -232,7 +232,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task HideContentIfOnlyOneSectionIsAdded()
         {
-            var comp = Context.RenderComponent<MudPageContentNavigation>();
+            var comp = Context.Render<MudPageContentNavigation>();
 
             var section = new MudPageContentSection("my section", "my-id");
 

--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -1,6 +1,7 @@
 ﻿using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.Pagination;
 using NUnit.Framework;
@@ -27,7 +28,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PaginationControlButtonClickTest(Page controlButton, int numberOfClicks, int initiallySelectedPage, int expectedSelectedPage, bool expectedDisabled)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
 
             var pagination = comp.FindComponent<MudPagination>().Instance;
             //navigate to the specified page
@@ -59,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaginationControlButtonAriaLabelTest(Page controlButton, string expectedButtonAriaLabel)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
 
             //get control button
             var button = FindControlButton(comp, controlButton);
@@ -81,7 +82,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaginationPageButtonAriaLabelTest(int index, string label)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
             var buttons = comp.FindAll(".mud-pagination-item button");
             var button = buttons[index];
             button.Attributes.GetNamedItem("aria-label")?.Value.Should().Be(label);
@@ -103,7 +104,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaginationControlButtonEventCallbackTest(Page controlButton, int expectedButtonClickedValue)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
 
             //Click control button
             FindControlButton(comp, controlButton).Click();
@@ -119,7 +120,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void HidePageButtonTest()
         {
-            var comp = Context.RenderComponent<PaginationHidePageButtonsTest>();
+            var comp = Context.Render<PaginationHidePageButtonsTest>();
 
             comp.FindAll(".mud-pagination-item button").Count.Should().Be(2);
         }
@@ -138,7 +139,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task PaginationPageButtonClickTest(int clickIndexPage, int initiallySelectedPage,
             int expectedSelectedPage)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
 
             var pagination = comp.FindComponent<MudPagination>().Instance;
             //navigate to the specified page
@@ -154,7 +155,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         //returns the specified control button
-        private static IElement FindControlButton(IRenderedFragment comp, Page controlButton)
+        private static IElement FindControlButton(IRenderedComponent<IComponent> comp, Page controlButton)
         {
             var buttons = comp.FindAll(".mud-pagination-item button");
             var button = controlButton switch
@@ -182,7 +183,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PaginationNavigateToPageTest(Page page, int expectedSelectedPage)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
 
             var pagination = comp.FindComponent<MudPagination>().Instance;
 
@@ -207,7 +208,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PaginationNavigateToPageTest(int page, int expectedSelectedPage)
         {
-            var comp = Context.RenderComponent<PaginationButtonTest>();
+            var comp = Context.Render<PaginationButtonTest>();
 
             var pagination = comp.FindComponent<MudPagination>().Instance;
 
@@ -234,7 +235,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaginationCountWithoutEllipsisTest(int count, int middleCount, int boundaryCount)
         {
-            var comp = Context.RenderComponent<PaginationCountTest>();
+            var comp = Context.Render<PaginationCountTest>();
 
             var pagination = comp.FindComponent<MudPagination>().Instance;
             comp.Find(".mud-pagination-test-middle-count input").Change(middleCount.ToString());
@@ -279,7 +280,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task PaginationCountWithEllipsisTest(int selectedPage, int count, int middleCount,
             int boundaryCount, string[] expectedValues)
         {
-            var comp = Context.RenderComponent<PaginationCountTest>();
+            var comp = Context.Render<PaginationCountTest>();
 
             var pagination = comp.FindComponent<MudPagination>().Instance;
             //set count variables
@@ -305,7 +306,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PaginationStylesTest()
         {
-            var comp = Context.RenderComponent<PaginationStylesTest>();
+            var comp = Context.Render<PaginationStylesTest>();
 
             var buttons = comp.FindAll(".mud-pagination-item button");
             var pagination = comp.Find("ul.mud-pagination");

--- a/src/MudBlazor.UnitTests/Components/PickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PickerTests.cs
@@ -17,7 +17,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PickerTest_Fundamentals()
         {
-            var comp = Context.RenderComponent<SimplePickerTest>();
+            var comp = Context.Render<SimplePickerTest>();
             var picker = comp.FindComponent<MudPicker<DateTime?>>();
 
             await comp.InvokeAsync(async () => await picker.Instance.SelectAsync());
@@ -31,17 +31,17 @@ namespace MudBlazor.UnitTests.Components
         {
             var value = new DisplayNameLabelClass();
 
-            var comp = Context.RenderComponent<MudPicker<DateTime?>>(x => x.Add(f => f.For, () => value.Date));
+            var comp = Context.Render<MudPicker<DateTime?>>(x => x.Add(f => f.For, () => value.Date));
             comp.Instance.Label.Should().Be("Date LabelAttribute"); //label should be set by the attribute
 
-            var comp2 = Context.RenderComponent<MudPicker<DateTime?>>(x => x.Add(f => f.For, () => value.Date).Add(l => l.Label, "Label Parameter"));
+            var comp2 = Context.Render<MudPicker<DateTime?>>(x => x.Add(f => f.For, () => value.Date).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
 
         [Test]
         public void PickerHasImmediateText()
         {
-            var comp = Context.RenderComponent<MudPicker<DateTime?>>(parameters => parameters.Add(p => p.ImmediateText, true));
+            var comp = Context.Render<MudPicker<DateTime?>>(parameters => parameters.Add(p => p.ImmediateText, true));
             comp.Instance.ImmediateText.Should().Be(true);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/PickerToolbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PickerToolbarTests.cs
@@ -14,7 +14,7 @@ public class PickerToolbarTests : BunitTest
     [Test]
     public void PickerToolbar_ShouldBeLandscape_WhenStaticAndOrientationLandscape()
     {
-        var component = Context.RenderComponent<MudPickerToolbar>(parameters => parameters
+        var component = Context.Render<MudPickerToolbar>(parameters => parameters
             .Add(p => p.PickerVariant, PickerVariant.Static)
             .Add(p => p.Orientation, Orientation.Landscape));
 
@@ -27,7 +27,7 @@ public class PickerToolbarTests : BunitTest
     [TestCase(PickerVariant.Dialog)]
     public void PickerToolbar_ShouldNotBeLandscape_WhenNonStaticAndOrientationLandscape(PickerVariant pickerVariant)
     {
-        var component = Context.RenderComponent<MudPickerToolbar>(parameters => parameters
+        var component = Context.Render<MudPickerToolbar>(parameters => parameters
             .Add(p => p.PickerVariant, pickerVariant)
             .Add(p => p.Orientation, Orientation.Landscape));
 

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Components
         //        .Verifiable();
 
 
-        //    var comp = Context.RenderComponent<MudBadge>(p =>
+        //    var comp = Context.Render<MudBadge>(p =>
         //    {
         //        p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
         //        p.Add(x => x.Tag, "my tag");
@@ -77,7 +77,7 @@ namespace MudBlazor.UnitTests.Components
         //        .Verifiable();
 
 
-        //    var comp = Context.RenderComponent<MudBadge>(p =>
+        //    var comp = Context.Render<MudBadge>(p =>
         //    {
         //        p.Add(x => x.UserAttributes, new Dictionary<string, object> { { "myprop1", "myValue1" } });
         //        p.Add(x => x.Tag, "my tag");
@@ -119,7 +119,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudPopover_OpenAndClose()
         {
-            var comp = Context.RenderComponent<PopoverTest>();
+            var comp = Context.Render<PopoverTest>();
 
             //popup is close, so only the popover-content should be there
             var provider = comp.Find(".mud-popover-provider");
@@ -149,7 +149,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_MaxHeight()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(x => x.MaxHeight, 100));
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(x => x.MaxHeight, 100));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
 
@@ -159,7 +159,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_TransitionDuration()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(x => x.Duration, 100));
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(x => x.Duration, 100));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
 
@@ -169,7 +169,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_Fixed()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.Fixed, true));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -180,7 +180,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_RelativeWidth()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.RelativeWidth, true));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -191,7 +191,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_Paper()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.Paper, true));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -202,7 +202,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_PaperAndSqaure()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p =>
+            var comp = Context.Render<PopoverPropertyTest>(p =>
             {
                 p.Add(x => x.Paper, true);
                 p.Add(x => x.Square, true);
@@ -217,7 +217,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_Elevation()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p =>
+            var comp = Context.Render<PopoverPropertyTest>(p =>
             {
                 p.Add(x => x.Paper, true);
                 p.Add(x => x.Elevation, 10);
@@ -240,7 +240,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Origin.TopRight, "top-right")]
         public void MudPopover_Property_TransformOrigin(Origin transformOrigin, string expectedClass)
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.TransformOrigin, transformOrigin));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -260,7 +260,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Origin.TopRight, "top-right")]
         public void MudPopover_Property_AnchorOrigin(Origin anchorOrigin, string expectedClass)
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.AnchorOrigin, anchorOrigin));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -274,7 +274,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(OverflowBehavior.FlipAlways, "flip-always")]
         public void MudPopover_Property_OverflowBehavior(OverflowBehavior overflowBehavior, string expectedClass)
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.OverflowBehavior, overflowBehavior));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -285,7 +285,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopover_Property_DropShadow_False_NoElevation()
         {
-            var comp = Context.RenderComponent<PopoverPropertyTest>(p => p.Add(
+            var comp = Context.Render<PopoverPropertyTest>(p => p.Add(
                 x => x.DropShadow, false));
 
             var popoverElement = comp.Find(".test-popover-content").ParentElement;
@@ -296,7 +296,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudPopover_WithDynamicContent()
         {
-            var comp = Context.RenderComponent<PopoverComplexContent>();
+            var comp = Context.Render<PopoverComplexContent>();
 
             var dynamicContentElement = comp.Find(".dynamic-content");
             dynamicContentElement.ChildNodes.Should().BeEmpty();
@@ -328,7 +328,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MudPopoverProvider_RenderElementsBasedOnEnableState()
         {
-            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderEnabled, true));
+            var comp = Context.Render<PopoverProviderTest>(p => p.Add(x => x.ProviderEnabled, true));
             comp.Find("#my-content").TextContent.Should().Be("Popover content");
 
             for (var i = 0; i < 3; i++)
@@ -344,7 +344,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MudPopoverProvider_NoRenderWhenEnabledIsFalse()
         {
-            var comp = Context.RenderComponent<PopoverProviderTest>(p => p.Add(x => x.ProviderEnabled, false));
+            var comp = Context.Render<PopoverProviderTest>(p => p.Add(x => x.ProviderEnabled, false));
             Assert.Throws<ElementNotFoundException>(() => comp.Find("#my-content"));
         }
 
@@ -362,12 +362,12 @@ namespace MudBlazor.UnitTests.Components
 
             if (throwOnDuplicateProvider)
             {
-                var ex = Assert.Throws<InvalidOperationException>(() => Context.RenderComponent<PopoverDuplicationTest>());
+                var ex = Assert.Throws<InvalidOperationException>(() => Context.Render<PopoverDuplicationTest>());
                 ex.Message.Should().StartWith("Duplicate MudPopoverProvider detected");
             }
             else
             {
-                var comp = Context.RenderComponent<PopoverDuplicationTest>();
+                var comp = Context.Render<PopoverDuplicationTest>();
                 await comp.Instance.Open();
                 await comp.Instance.Close();
             }

--- a/src/MudBlazor.UnitTests/Components/ProgressCircularTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressCircularTests.cs
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
             var valueValue = -400;
             var strokeWidthValue = 50;
 
-            var comp = Context.RenderComponent<MudProgressCircular>(x =>
+            var comp = Context.Render<MudProgressCircular>(x =>
                 {
                     x.Add(y => y.Value, valueValue);
                     x.Add(y => y.Min, minValue);
@@ -76,7 +76,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void TestClassesForRounded(bool rounded)
         {
-            var comp = Context.RenderComponent<MudProgressCircular>(x => x.Add(y => y.Rounded, rounded));
+            var comp = Context.Render<MudProgressCircular>(x => x.Add(y => y.Rounded, rounded));
 
             var container = comp.Find(".mud-progress-circular-circle");
 
@@ -95,7 +95,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void TestClassesForIntermediate(bool indeterminate)
         {
-            var comp = Context.RenderComponent<MudProgressCircular>(x => x.Add(y => y.Indeterminate, indeterminate));
+            var comp = Context.Render<MudProgressCircular>(x => x.Add(y => y.Indeterminate, indeterminate));
 
             var container = comp.Find(".mud-progress-circular");
 
@@ -130,7 +130,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Size.Small, "small")]
         public void TestClassesForSize(Size size, string expectedString)
         {
-            var comp = Context.RenderComponent<MudProgressCircular>(x => x.Add(y => y.Size, size));
+            var comp = Context.Render<MudProgressCircular>(x => x.Add(y => y.Size, size));
 
             var container = comp.Find(".mud-progress-circular");
 
@@ -143,7 +143,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Error, "error")]
         public void TestClassesForColor(Color color, string expectedString)
         {
-            var comp = Context.RenderComponent<MudProgressCircular>(x => x.Add(y => y.Color, color));
+            var comp = Context.Render<MudProgressCircular>(x => x.Add(y => y.Color, color));
 
             var container = comp.Find(".mud-progress-circular");
 
@@ -158,7 +158,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(0, "24 24 40 40")]
         public void MudProgressCircular_ShouldHaveCorrectViewBox_BasedOnStrokeWidth(int strokeWidth, string expectedViewBox)
         {
-            var comp = Context.RenderComponent<MudProgressCircular>(parameters => parameters
+            var comp = Context.Render<MudProgressCircular>(parameters => parameters
                 .Add(p => p.StrokeWidth, strokeWidth)
             );
 
@@ -171,7 +171,7 @@ namespace MudBlazor.UnitTests.Components
             viewBoxAttribute.Should().Be(expectedViewBox);
 
             // Test with Indeterminate = true as well
-            var compIndeterminate = Context.RenderComponent<MudProgressCircular>(parameters => parameters
+            var compIndeterminate = Context.Render<MudProgressCircular>(parameters => parameters
                 .Add(p => p.StrokeWidth, strokeWidth)
                 .Add(p => p.Indeterminate, true)
             );

--- a/src/MudBlazor.UnitTests/Components/ProgressLinearTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ProgressLinearTests.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(200, 400, 230, 220, 15, 10)]
         public void CheckingPercentageAndBufferValue(double min, double max, double value, double buffervalue, double expectedValue, double expectedBufferValue)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Min, min);
                 x.Add(y => y.Max, max);
@@ -66,7 +66,7 @@ namespace MudBlazor.UnitTests.Components
 
         public void EnsureMaxAndMinConsitency(double min, double max, double value, double buffervalue, double expectedValue, double expectedBufferValue)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Min, min);
                 x.Add(y => y.Max, max);
@@ -86,7 +86,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void DefaultStructure(bool isVertical)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
                 {
                     x.Add(y => y.Min, -500);
                     x.Add(y => y.Max, 500);
@@ -115,7 +115,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void IndeterminateStructure()
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Min, -500);
                 x.Add(y => y.Max, 500);
@@ -145,7 +145,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void BufferStructure(bool isVertical)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Min, -500);
                 x.Add(y => y.Max, 500);
@@ -187,7 +187,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void IndeterminateWithChildContent()
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Min, -500);
                 x.Add(y => y.Max, 500);
@@ -224,7 +224,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void TestClassesForRounded(bool rounded)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x => x.Add(y => y.Rounded, rounded));
+            var comp = Context.Render<MudProgressLinear>(x => x.Add(y => y.Rounded, rounded));
 
             var container = comp.Find(".mud-progress-linear");
 
@@ -243,7 +243,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void TestClassesForStriped(bool striped)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x => x.Add(y => y.Striped, striped));
+            var comp = Context.Render<MudProgressLinear>(x => x.Add(y => y.Striped, striped));
 
             var container = comp.Find(".mud-progress-linear");
 
@@ -262,7 +262,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void TestClassesForIntermediate(bool indeterminate)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x => x.Add(y => y.Indeterminate, indeterminate));
+            var comp = Context.Render<MudProgressLinear>(x => x.Add(y => y.Indeterminate, indeterminate));
 
             var container = comp.Find(".mud-progress-linear");
 
@@ -283,7 +283,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true, true)]
         public void TestClassesForBuffer(bool buffer, bool indeterminate)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Indeterminate, indeterminate);
                 x.Add(y => y.Buffer, buffer);
@@ -308,7 +308,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Size.Small, "small")]
         public void TestClassesForSize(Size size, string expectedString)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x => x.Add(y => y.Size, size));
+            var comp = Context.Render<MudProgressLinear>(x => x.Add(y => y.Size, size));
 
             var container = comp.Find(".mud-progress-linear");
 
@@ -321,7 +321,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Error, "error")]
         public void TestClassesForColor(Color color, string expectedString)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x => x.Add(y => y.Color, color));
+            var comp = Context.Render<MudProgressLinear>(x => x.Add(y => y.Color, color));
 
             var container = comp.Find(".mud-progress-linear");
 
@@ -333,7 +333,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public void TestClassesForVertical(bool vertical)
         {
-            var comp = Context.RenderComponent<MudProgressLinear>(x => x.Add(y => y.Vertical, vertical));
+            var comp = Context.Render<MudProgressLinear>(x => x.Add(y => y.Vertical, vertical));
 
             var container = comp.Find(".mud-progress-linear");
 
@@ -362,7 +362,7 @@ namespace MudBlazor.UnitTests.Components
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = culture;
 
-            var comp = Context.RenderComponent<MudProgressLinear>(x =>
+            var comp = Context.Render<MudProgressLinear>(x =>
             {
                 x.Add(y => y.Min, 10.2);
                 x.Add(y => y.Max, 125.22);

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadiGroup_CheckClassTest()
         {
-            var comp = Context.RenderComponent<RadioGroupTest1>();
+            var comp = Context.Render<RadioGroupTest1>();
 
             var inputControl = comp.FindComponent<MudInputControl>();
             inputControl.Instance.InputContent.Should().NotBeNull();
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupTest1()
         {
-            var comp = Context.RenderComponent<RadioGroupTest1>();
+            var comp = Context.Render<RadioGroupTest1>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
             var inputs = comp.FindAll("input").ToArray();
@@ -73,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupTest2()
         {
-            var comp = Context.RenderComponent<RadioGroupTest2>();
+            var comp = Context.Render<RadioGroupTest2>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
             // check initial state, should be initialized to second radio by default
@@ -86,7 +86,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupTest3()
         {
-            var comp = Context.RenderComponent<RadioGroupTest3>();
+            var comp = Context.Render<RadioGroupTest3>();
             // select elements needed for the test
             var groups = comp.FindComponents<MudRadioGroup<string>>();
             var inputs = comp.FindAll("input").ToArray();
@@ -121,7 +121,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupTest4()
         {
-            var comp = Context.RenderComponent<RadioGroupTest4>();
+            var comp = Context.Render<RadioGroupTest4>();
             // select elements needed for the test
             var groups = comp.FindComponents<MudRadioGroup<string>>();
 
@@ -155,7 +155,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupTest5()
         {
-            var comp = Context.RenderComponent<RadioGroupTest5>();
+            var comp = Context.Render<RadioGroupTest5>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
             // check initial state
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupTest6()
         {
-            var comp = Context.RenderComponent<RadioGroupTest6>();
+            var comp = Context.Render<RadioGroupTest6>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
             // check dense
@@ -200,7 +200,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioTest_BindAfter()
         {
-            var comp = Context.RenderComponent<RadioGroupTest5>();
+            var comp = Context.Render<RadioGroupTest5>();
             // select elements needed for the test
             var group = comp.FindComponent<MudRadioGroup<string>>();
             var inputs = comp.FindAll("input").ToArray();
@@ -219,7 +219,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioTest_KeyboardInput()
         {
-            var comp = Context.RenderComponent<RadioGroupTest1>();
+            var comp = Context.Render<RadioGroupTest1>();
             // print the generated html
             // select elements needed for the test
             var radio = comp.FindComponent<MudRadioGroup<string>>();
@@ -237,7 +237,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RadioTest_Other()
         {
-            var comp = Context.RenderComponent<RadioGroupTest1>();
+            var comp = Context.Render<RadioGroupTest1>();
             var group = comp.FindComponent<MudRadioGroup<string>>();
             var radio = comp.FindComponent<MudRadio<string>>();
 
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
         {
             try
             {
-                var comp = Context.RenderComponent<RadioGroupExceptionTest>();
+                var comp = Context.Render<RadioGroupExceptionTest>();
             }
             catch (Exception ex)
             {
@@ -270,7 +270,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioDisabledTest()
         {
-            var comp = Context.RenderComponent<RadioGroupTest7>();
+            var comp = Context.Render<RadioGroupTest7>();
             comp.Instance.SelectedOption.Should().BeNull();
 
             comp.FindAll("input")[2].Click(); //click enabled radio
@@ -287,7 +287,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupDisabledTest()
         {
-            var comp = Context.RenderComponent<RadioReadOnlyDisabledTest>();
+            var comp = Context.Render<RadioReadOnlyDisabledTest>();
             var radioGroup = comp.FindComponents<MudRadioGroup<string>>()[1];
 
             var radios = radioGroup.FindComponents<MudRadio<string>>();
@@ -304,7 +304,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RadioGroupReadOnlyTest()
         {
-            var comp = Context.RenderComponent<RadioReadOnlyDisabledTest>();
+            var comp = Context.Render<RadioReadOnlyDisabledTest>();
             var radioGroup = comp.FindComponents<MudRadioGroup<string>>()[0];
 
             var radios = radioGroup.FindComponents<MudRadio<string>>();
@@ -321,7 +321,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalRadioGroup_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<RadioGroupRequiredTest>();
+            var comp = Context.Render<RadioGroupRequiredTest>();
 
             comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("false");
@@ -333,7 +333,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredRadioGroup_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<RadioGroupRequiredTest>(parameters => parameters
+            var comp = Context.Render<RadioGroupRequiredTest>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeTrue();
@@ -346,7 +346,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredRadioGroupAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<RadioGroupRequiredTest>();
+            var comp = Context.Render<RadioGroupRequiredTest>();
 
 
             comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
@@ -362,7 +362,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ReadOnlyDisabled_ShouldNot_Ripple()
         {
-            var create = (bool readOnly, bool disabled) => Context.RenderComponent<MudRadioGroup<bool>>(self => self
+            var create = (bool readOnly, bool disabled) => Context.Render<MudRadioGroup<bool>>(self => self
                 .Add(x => x.Disabled, disabled)
                 .Add(x => x.ReadOnly, readOnly)
                 .AddChildContent<MudRadio<bool>>(self => self.Add(x => x.Ripple, true)));
@@ -378,7 +378,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
-            var create = (bool readOnly, bool disabled) => Context.RenderComponent<MudRadioGroup<bool>>(self => self
+            var create = (bool readOnly, bool disabled) => Context.Render<MudRadioGroup<bool>>(self => self
                 .Add(x => x.Disabled, disabled)
                 .Add(x => x.ReadOnly, readOnly)
                 .AddChildContent<MudRadio<bool>>(self => self.Add(x => x.UncheckedColor, Color.Default)));

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -17,10 +17,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RatingTest1()
         {
-            var comp = Context.RenderComponent<MudRating>();
+            var comp = Context.Render<MudRating>();
             // select elements needed for the test
-            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
-            IRefreshableElementCollection<IElement> Inputs() => comp.FindAll("input[type=\"radio\"].mud-rating-input");
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+            IReadOnlyList<IElement> Inputs() => comp.FindAll("input[type=\"radio\"].mud-rating-input");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
             RatingItemsSpans().Count.Should().Be(5);
@@ -56,9 +56,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RatingTest2()
         {
-            var comp = Context.RenderComponent<MudRating>();
+            var comp = Context.Render<MudRating>();
             // select elements needed for the test
-            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
             RatingItemsSpans().Count.Should().Be(5);
@@ -94,7 +94,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RatingTest3()
         {
-            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+            var comp = Context.Render<MudRating>(parameters => parameters
                 .Add(p => p.SelectedValue, 3));
             // print the generated html
             // check initial state
@@ -107,12 +107,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RatingTest4()
         {
-            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+            var comp = Context.Render<MudRating>(parameters => parameters
                 .Add(p => p.Disabled, true)
                 .Add(p => p.SelectedValue, 2));
             // print the generated html
             // select elements needed for the test
-            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(2);
             RatingItemsSpans().Count.Should().Be(5);
@@ -144,11 +144,11 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RatingTest5()
         {
-            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+            var comp = Context.Render<MudRating>(parameters => parameters
                 .Add(p => p.MaxValue, 12));
             // print the generated html
             // select elements needed for the test
-            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
             // check initial state
             comp.Instance.GetState(x => x.SelectedValue).Should().Be(0);
             RatingItemsSpans().Count.Should().Be(12);
@@ -165,14 +165,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RatingTestIconColors()
         {
-            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+            var comp = Context.Render<MudRating>(parameters => parameters
                 .Add(p => p.SelectedValue, 2)
                 .Add(p => p.EmptyIconColor, Color.Tertiary)
                 .Add(p => p.FullIconColor, Color.Primary));
 
             // Select elements needed for the test
-            IRefreshableElementCollection<IElement> SvgColors() => comp.FindAll("svg.mud-icon-root");
-            IRefreshableElementCollection<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+            IReadOnlyList<IElement> SvgColors() => comp.FindAll("svg.mud-icon-root");
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
 
             // Check initial state
             SvgColors()[0].ClassName.Should().Contain("mud-primary-text");
@@ -224,7 +224,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RatingTest_KeyboardNavigation()
         {
-            var comp = Context.RenderComponent<MudRating>(parameters => parameters
+            var comp = Context.Render<MudRating>(parameters => parameters
                 .Add(p => p.MaxValue, 12));
             var item = comp.FindComponent<MudRatingItem>();
             // print the generated html

--- a/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ScrollToTopTests.cs
@@ -14,7 +14,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ScrollToTopTest()
         {
-            var comp = Context.RenderComponent<ScrollToTopTest>();
+            var comp = Context.Render<ScrollToTopTest>();
 
             comp.Instance.Clicked.Should().BeFalse(because: "Not clicked yet");
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_CheckListClass()
         {
-            var comp = Context.RenderComponent<SelectRequiredTest>();
+            var comp = Context.Render<SelectRequiredTest>();
             var select = comp.FindComponent<MudSelect<string>>();
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter" }));
             await comp.InvokeAsync(async () => await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ListClass, "my-list-class")));
@@ -25,7 +25,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_CheckLayerClass()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>();
+            var comp = Context.Render<MudSelect<string>>();
             await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.OuterClass, "my-outer-class")));
             await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Class, "my-main-class")));
             await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.InputClass, "my-input-class")));
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectLabelFor()
         {
-            var comp = Context.RenderComponent<SelectRequiredTest>();
+            var comp = Context.Render<SelectRequiredTest>();
             var label = comp.FindAll(".mud-input-label");
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("selectLabelTest");
         }
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest1()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             // print the generated html
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_KeyDown_WhileClosed()
         {
-            var comp = Context.RenderComponent<SelectFocusAndTypeTest>();
+            var comp = Context.Render<SelectFocusAndTypeTest>();
             var select = comp.FindComponent<MudSelect<string>>();
 
             //open menu on keydown
@@ -135,7 +135,7 @@ namespace MudBlazor.UnitTests.Components
         {
             await ImproveChanceOfSuccess(async () =>
             {
-                var comp = Context.RenderComponent<MultiSelectTest1>();
+                var comp = Context.Render<MultiSelectTest1>();
                 // print the generated html
                 // select elements needed for the test
                 var select = comp.FindComponent<MudSelect<string>>();
@@ -185,7 +185,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MultiSelectWithValueContainZeroTest()
         {
-            var comp = Context.RenderComponent<MultiSelectWithValueContainZeroTest>();
+            var comp = Context.Render<MultiSelectWithValueContainZeroTest>();
             var inputs = comp.FindAll("input");
             inputs.Count.Should().Be(3);
             inputs[1].GetAttribute("value").Should().Be("Value2");
@@ -210,7 +210,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectWithEnumTest()
         {
-            var comp = Context.RenderComponent<SelectWithEnumTest>();
+            var comp = Context.Render<SelectWithEnumTest>();
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<MyEnum>>();
             var input = comp.Find("div.mud-input-control");
@@ -219,7 +219,6 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Text.Should().Be(default(MyEnum).ToString());
 
             comp.Find("input").Attributes["value"]?.Value.Should().Be("First");
-            comp.RenderCount.Should().Be(1);
             input.MouseDown();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
@@ -233,7 +232,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectUnrepresentableValueTest()
         {
-            var comp = Context.RenderComponent<SelectUnrepresentableValueTest>();
+            var comp = Context.Render<SelectUnrepresentableValueTest>();
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<int>>();
             var input = comp.Find("div.mud-input-control");
@@ -255,7 +254,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectUnrepresentableValueTest2()
         {
-            var comp = Context.RenderComponent<SelectUnrepresentableValueTest2>();
+            var comp = Context.Render<SelectUnrepresentableValueTest2>();
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<int>>();
             var input = comp.Find("div.mud-input-control");
@@ -282,7 +281,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectNullValueTest()
         {
-            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var comp = Context.Render<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
 
             // Initial state: null value
@@ -317,7 +316,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectRegisterShadowItemNullTest()
         {
-            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var comp = Context.Render<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
 
             var registerAction = () => select.Instance.RegisterShadowItem(null);
@@ -331,9 +330,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectRegisterShadowItemWithNullValueTest()
         {
-            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var comp = Context.Render<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
-            var itemWithNullValue = Context.RenderComponent<MudSelectItem<int?>>(parameters => parameters.Add(x => x.Value, null));
+            var itemWithNullValue = Context.Render<MudSelectItem<int?>>(parameters => parameters.Add(x => x.Value, null));
 
             var registerAction = () => select.Instance.RegisterShadowItem(itemWithNullValue.Instance);
 
@@ -346,7 +345,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectUnregisterShadowItemNullTest()
         {
-            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var comp = Context.Render<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
 
             var unregisterAction = () => select.Instance.UnregisterShadowItem(null);
@@ -360,9 +359,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectUnregisterShadowItemWithNullValueTest()
         {
-            var comp = Context.RenderComponent<SelectNullValueTest>();
+            var comp = Context.Render<SelectNullValueTest>();
             var select = comp.FindComponent<MudSelect<int?>>();
-            var itemWithNullValue = Context.RenderComponent<MudSelectItem<int?>>(parameters => parameters.Add(x => x.Value, null));
+            var itemWithNullValue = Context.Render<MudSelectItem<int?>>(parameters => parameters.Add(x => x.Value, null));
 
             select.Instance.RegisterShadowItem(itemWithNullValue.Instance);
             var unregisterAction = () => select.Instance.UnregisterShadowItem(itemWithNullValue.Instance);
@@ -376,7 +375,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectWithoutItemPresentersTest()
         {
-            var comp = Context.RenderComponent<SelectWithoutItemPresentersTest>();
+            var comp = Context.Render<SelectWithoutItemPresentersTest>();
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<int>>();
             var input = comp.Find("div.mud-input-control");
@@ -384,7 +383,6 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.Value.Should().Be(1);
             select.Instance.Text.Should().Be("1");
             comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none");
-            comp.RenderCount.Should().Be(1);
 
             input.MouseDown();
             comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -399,7 +397,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_Should_FireTextChangedWithNewValue()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var select = comp.FindComponent<MudSelect<string>>();
             string text = null;
             await select.SetParametersAndRenderAsync(parameters => parameters.Add(s => s.TextChanged, (Action<string>)(x => text = x)));
@@ -440,7 +438,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SingleSelect_Should_FireTextChangedBeforeSelectedValuesChanged()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var select = comp.FindComponent<MudSelect<string>>();
             string text = null;
             IEnumerable<string> selectedValues = null;
@@ -500,7 +498,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MulitSelect_Should_FireTextChangedBeforeSelectedValuesChanged()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var select = comp.FindComponent<MudSelect<string>>();
             string text = null;
             IEnumerable<string> selectedValues = null;
@@ -546,7 +544,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_Should_FireOnBlur()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var select = comp.FindComponent<MudSelect<string>>();
             var eventCounter = 0;
             await select.SetParametersAndRenderAsync(parameters => parameters.Add(s => s.OnBlur, () => eventCounter++));
@@ -561,7 +559,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Disabled_SelectItem_Should_Be_Respected()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var select = comp.FindComponent<MudSelect<string>>();
 
             var selectElement = comp.Find("div.mud-input-control");
@@ -577,7 +575,7 @@ namespace MudBlazor.UnitTests.Components
         {
             await ImproveChanceOfSuccess(async () =>
             {
-                var comp = Context.RenderComponent<MultiSelectTest1>();
+                var comp = Context.Render<MultiSelectTest1>();
                 // print the generated html
                 // select elements needed for the test
                 var select = comp.FindComponent<MudSelect<string>>();
@@ -619,7 +617,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MultiSelect_SelectAll()
         {
-            var comp = Context.RenderComponent<MultiSelectTest2>();
+            var comp = Context.Render<MultiSelectTest2>();
             // select element needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
             string validatedValue = null;
@@ -643,7 +641,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiSelect_SelectAll2()
         {
-            var comp = Context.RenderComponent<MultiSelectTest3>();
+            var comp = Context.Render<MultiSelectTest3>();
             // select element needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
             var menu = comp.Find("div.mud-popover");
@@ -678,7 +676,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiSelect_SelectAll3()
         {
-            var comp = Context.RenderComponent<MultiSelectTest4>();
+            var comp = Context.Render<MultiSelectTest4>();
             // select element needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
             var menu = comp.Find("div.mud-popover");
@@ -693,7 +691,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiSelect_SelectAll4()
         {
-            var comp = Context.RenderComponent<MultiSelectTest7>();
+            var comp = Context.Render<MultiSelectTest7>();
             // select element needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
             var menu = comp.Find("div.mud-popover");
@@ -719,7 +717,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SingleSelect_Should_CallValidationFunc()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var select = comp.FindComponent<MudSelect<string>>();
             string validatedValue = null;
             await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Validation, (object)new Func<string, bool>(value =>
@@ -761,7 +759,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiSelect_Initial_Values()
         {
-            var comp = Context.RenderComponent<MultiSelectWithInitialValuesTest>();
+            var comp = Context.Render<MultiSelectWithInitialValuesTest>();
             // print the generated html
 
             // select the input of the select
@@ -778,7 +776,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiSelectCustomizedTextTest()
         {
-            var comp = Context.RenderComponent<MultiSelectCustomizedTextTest>();
+            var comp = Context.Render<MultiSelectCustomizedTextTest>();
 
             // Select the input of the select
             var input = comp.Find("input");
@@ -793,7 +791,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectClearableTest()
         {
-            var comp = Context.RenderComponent<SelectClearableTest>();
+            var comp = Context.Render<SelectClearableTest>();
             var select = comp.FindComponent<MudSelect<string>>();
             var input = comp.Find("div.mud-input-control");
 
@@ -822,7 +820,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectReselectTest()
         {
-            var comp = Context.RenderComponent<ReselectValueTest>();
+            var comp = Context.Render<ReselectValueTest>();
             // print the generated html
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
@@ -857,7 +855,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_Should_Validate_Data_Attribute_Fail()
         {
-            var comp = Context.RenderComponent<SelectValidationDataAttrTest>();
+            var comp = Context.Render<SelectValidationDataAttrTest>();
             var selectcomp = comp.FindComponent<MudSelect<string>>();
             var select = selectcomp.Instance;
             // Select invalid option
@@ -875,7 +873,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_Should_Validate_Data_Attribute_Success()
         {
-            var comp = Context.RenderComponent<SelectValidationDataAttrTest>();
+            var comp = Context.Render<SelectValidationDataAttrTest>();
             var selectcomp = comp.FindComponent<MudSelect<string>>();
             var select = selectcomp.Instance;
             // Select valid option
@@ -895,7 +893,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_Should_SetRequiredTrue()
         {
-            var comp = Context.RenderComponent<SelectRequiredTest>();
+            var comp = Context.Render<SelectRequiredTest>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.ValidateAsync());
@@ -908,7 +906,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_Should_HilightSelectedValue()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             // print the generated html
             var select = comp.FindComponent<MudSelect<string>>();
             var input = comp.Find("div.mud-input-control");
@@ -944,7 +942,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Select_Should_HilightInitiallySelectedValue()
         {
-            var comp = Context.RenderComponent<SelectTest2>();
+            var comp = Context.Render<SelectTest2>();
             // print the generated html
             var select = comp.FindComponent<MudSelect<string>>();
             comp.Find("div.mud-popover").ClassList.Should().Contain("select-popover-class");
@@ -973,7 +971,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Select_Should_AllowReloadingItems()
         {
-            var comp = Context.RenderComponent<ReloadSelectItemsTest>();
+            var comp = Context.Render<ReloadSelectItemsTest>();
             var select = comp.FindComponent<MudSelect<string>>();
             // normal, without reloading
             comp.Find("div.mud-input-control").MouseDown();
@@ -1014,7 +1012,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_ToggleOpenCloseMenuMethods()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             // print the generated html
             // select elements needed for the test
 
@@ -1045,7 +1043,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_KeyboardNavigation_SingleSelect()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             // print the generated html
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
@@ -1113,7 +1111,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_KeyboardNavigation_MultiSelect()
         {
-            var comp = Context.RenderComponent<MultiSelectTest3>();
+            var comp = Context.Render<MultiSelectTest3>();
             // print the generated html
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<string>>();
@@ -1174,7 +1172,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectTest_KeyboardNavigation_MultiSelect_Focus()
         {
-            var comp = Context.RenderComponent<MultiSelectTest6>();
+            var comp = Context.Render<MultiSelectTest6>();
             var select = comp.FindComponent<MudSelect<string>>();
             var mudSelectElement = comp.Find(".mud-select");
             comp.Find("div.mud-input-control").MouseDown();
@@ -1192,7 +1190,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectTest_ItemlessSelect()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>();
+            var comp = Context.Render<MudSelect<string>>();
 
             // print the generated html
 
@@ -1208,7 +1206,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiSelectWithCustomComparerTest()
         {
-            var comp = Context.RenderComponent<MultiSelectWithCustomComparerTest>();
+            var comp = Context.Render<MultiSelectWithCustomComparerTest>();
             // print the generated html
             // Click select button
             comp.Find("#set-selection-button").Click();
@@ -1231,7 +1229,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Select_Item_Collection_Should_Match_Number_Of_Select_Options()
         {
-            var comp = Context.RenderComponent<SelectTest1>();
+            var comp = Context.Render<SelectTest1>();
             var sut = comp.FindComponent<MudSelect<string>>();
 
             var input = comp.Find("div.mud-input-control");
@@ -1244,7 +1242,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_ValueChangeEventCountTest()
         {
-            var comp = Context.RenderComponent<SelectEventCountTest>(x =>
+            var comp = Context.Render<SelectEventCountTest>(x =>
             {
                 x.Add(c => c.MultiSelection, false);
             });
@@ -1275,7 +1273,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //1a. Check When SelectedItems is empty - Validation Should Fail
             //Check on String type
-            var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
+            var comp = Context.Render<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.ValidateAsync());
@@ -1308,7 +1306,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MultiSelectClearAndReset()
         {
-            var comp = Context.RenderComponent<MultiSelectTestRequiredValue>();
+            var comp = Context.Render<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.ValidateAsync());
@@ -1396,7 +1394,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MultiSelectAttributesOrder()
         {
-            var comp = Context.RenderComponent<MultiSelectTest5>();
+            var comp = Context.Render<MultiSelectTest5>();
             var selectComponent = comp.FindComponent<MudSelect<string>>();
             var select = selectComponent.Instance;
             select.SelectedValues.Count().Should().Be(2);
@@ -1412,7 +1410,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>(parameters
+            var comp = Context.Render<MudSelect<string>>(parameters
                 => parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -1427,7 +1425,7 @@ namespace MudBlazor.UnitTests.Components
         public void SelectWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudSelect<string>>(parameters
+            var comp = Context.Render<MudSelect<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1447,7 +1445,7 @@ namespace MudBlazor.UnitTests.Components
         public void SelectWithLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudSelect<string>>(parameters
+            var comp = Context.Render<MudSelect<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1467,7 +1465,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalSelect_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>();
+            var comp = Context.Render<MudSelect<string>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1479,7 +1477,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredSelect_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>(parameters => parameters
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -1492,7 +1490,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredSelectAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>();
+            var comp = Context.Render<MudSelect<string>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1507,7 +1505,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Should_render_conversion_error_message()
         {
-            var comp = Context.RenderComponent<MudSelect<int>>(parameters => parameters
+            var comp = Context.Render<MudSelect<int>>(parameters => parameters
                 .Add(p => p.ErrorId, "error-id")
                 .Add(p => p.Text, "not a number")
                 .Add(p => p.Converter, new DummyErrorConverter()));
@@ -1521,7 +1519,7 @@ namespace MudBlazor.UnitTests.Components
         public void Should_render_aria_label_for_adornment_if_provided(Adornment adornment)
         {
             var ariaLabel = "the aria label";
-            var comp = Context.RenderComponent<MudSelect<string>>(parameters => parameters
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
                 .Add(p => p.Adornment, adornment)
                 .Add(p => p.AdornmentIcon, Icons.Material.Filled.Accessibility)
                 .Add(p => p.AdornmentAriaLabel, ariaLabel));
@@ -1557,7 +1555,7 @@ namespace MudBlazor.UnitTests.Components
                     ? $"{inputId}-helper-text"
                     : null;
 
-            var comp = Context.RenderComponent<MudSelect<string>>(parameters => parameters
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
                 .Add(p => p.InputId, inputId)
                 .Add(p => p.HelperId, helperId)
                 .Add(p => p.HelperText, helperText)
@@ -1595,7 +1593,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ReadOnlyShouldNotHaveClearButton()
         {
-            var comp = Context.RenderComponent<MudSelect<string>>(p => p
+            var comp = Context.Render<MudSelect<string>>(p => p
                 .Add(x => x.Text, "some value")
                 .Add(x => x.Clearable, true)
                 .Add(x => x.ReadOnly, false));
@@ -1609,7 +1607,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectPopoverFullWidthTest()
         {
-            var comp = Context.RenderComponent<SelectPopoverRelativeWidthTest>();
+            var comp = Context.Render<SelectPopoverRelativeWidthTest>();
 
             comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
@@ -1634,7 +1632,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SelectFitContentTest()
         {
-            var comp = Context.RenderComponent<SelectFitContentTest>();
+            var comp = Context.Render<SelectFitContentTest>();
 
             //default values
             comp.Instance.FullWidth.Should().BeFalse();
@@ -1670,7 +1668,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_HandleMouseDown(MouseEventArgs args)
         {
-            var comp = Context.RenderComponent<MudSelect<string>>(p => p
+            var comp = Context.Render<MudSelect<string>>(p => p
                 .Add(x => x.Text, "some value")
                 .Add(x => x.Clearable, true)
                 .Add(x => x.ReadOnly, false));
@@ -1696,7 +1694,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SelectMultiSelectFieldChangedTest()
         {
-            var comp = Context.RenderComponent<SelectMultiSelectFieldChangedTest>();
+            var comp = Context.Render<SelectMultiSelectFieldChangedTest>();
 
             //default values
             comp.Instance.FormFieldChangedEventArgs.Should().BeNull();
@@ -1716,7 +1714,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PopoverSettings_SetsDefaultValues()
         {
-            var select = Context.RenderComponent<MudSelect<string>>();
+            var select = Context.Render<MudSelect<string>>();
 
             select.Instance.PopoverFixed.Should().BeFalse();
             select.Instance.OverflowBehavior.Should().Be(MudGlobal.PopoverDefaults.OverflowBehavior);
@@ -1729,7 +1727,7 @@ namespace MudBlazor.UnitTests.Components
             try
             {
                 MudGlobal.PopoverDefaults.OverflowBehavior = OverflowBehavior.FlipNever;
-                var select = Context.RenderComponent<MudSelect<string>>(p =>
+                var select = Context.Render<MudSelect<string>>(p =>
                 {
                     p.Add(p => p.PopoverFixed, true);
                 });

--- a/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SkeletonStyleIsAppliedAfterInitialRendering()
         {
-            var comp = Context.RenderComponent<MudSkeleton>();
+            var comp = Context.Render<MudSkeleton>();
 
             var skeleton = comp.Instance;
             var span = comp.Find("span");
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SkeletonHeightIsAppliedAfterInitialRendering()
         {
-            var comp = Context.RenderComponent<MudSkeleton>(p => p.Add(x => x.Height, "100px"));
+            var comp = Context.Render<MudSkeleton>(p => p.Add(x => x.Height, "100px"));
 
             var skeleton = comp.Instance;
             var span = comp.Find("span");
@@ -50,7 +50,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SkeletonWidthIsAppliedAfterInitialRendering()
         {
-            var comp = Context.RenderComponent<MudSkeleton>(p => p.Add(x => x.Width, "300px"));
+            var comp = Context.Render<MudSkeleton>(p => p.Add(x => x.Width, "300px"));
 
             var skeleton = comp.Instance;
             var span = comp.Find("span");

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -46,7 +46,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Size.Large, "large")]
         public void CheckSizeCssClass(Size size, string expectedSizeClass)
         {
-            var comp = Context.RenderComponent<MudSlider<int>>(x => x.Add(p => p.Size, size));
+            var comp = Context.Render<MudSlider<int>>(x => x.Add(p => p.Size, size));
 
             IElement Slider() => comp.Find(".mud-slider");
             Slider().ClassList.Should().ContainInOrder(new[] { "mud-slider", $"mud-slider-{expectedSizeClass}" });
@@ -56,12 +56,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckVerticalClass()
         {
-            var verticalSliderComponent = Context.RenderComponent<MudSlider<int>>(x => x.Add(p => p.Vertical, true));
+            var verticalSliderComponent = Context.Render<MudSlider<int>>(x => x.Add(p => p.Vertical, true));
 
             IElement VerticalSlider() => verticalSliderComponent.Find(".mud-slider");
             VerticalSlider().ClassList.Should().ContainInOrder(new[] { "mud-slider", "mud-slider-small", "mud-slider-vertical" });
 
-            var horizontalSliderComponent = Context.RenderComponent<MudSlider<int>>(x => x.Add(p => p.Vertical, true));
+            var horizontalSliderComponent = Context.Render<MudSlider<int>>(x => x.Add(p => p.Vertical, true));
 
             IElement HorizontalSlider() => horizontalSliderComponent.Find(".mud-slider");
             HorizontalSlider().ClassList.Should().ContainInOrder(new[] { "mud-slider", "mud-slider-small" });
@@ -73,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Size.Large, "large")]
         public void CheckInputSizeCssClass(Size size, string expectedSizeClass)
         {
-            var comp = Context.RenderComponent<MudSlider<int>>(x => x.Add(p => p.Size, size));
+            var comp = Context.Render<MudSlider<int>>(x => x.Add(p => p.Size, size));
 
             IElement Slider() => comp.Find(".mud-slider");
             Slider().ClassList.Should().ContainInOrder(new[] { "mud-slider", $"mud-slider-{expectedSizeClass}", "mud-slider-primary" });
@@ -94,7 +94,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Surface, "surface")]
         public void CheckColorCssClass(Color color, string expectedColorClass)
         {
-            var comp = Context.RenderComponent<MudSlider<int>>(x => x.Add(p => p.Color, color));
+            var comp = Context.Render<MudSlider<int>>(x => x.Add(p => p.Color, color));
 
             IElement Slider() => comp.Find(".mud-slider");
             Slider().ClassList.Should().ContainInOrder(new[] { "mud-slider", "mud-slider-small", $"mud-slider-{expectedColorClass}" });
@@ -103,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void GeneralStructure()
         {
-            var comp = Context.RenderComponent<MudSlider<double>>(x =>
+            var comp = Context.Render<MudSlider<double>>(x =>
             {
                 x.Add(p => p.Min, 100.0);
                 x.Add(p => p.Max, 200.0);
@@ -149,7 +149,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Structure_WithChildContent()
         {
-            var comp = Context.RenderComponent<SliderWithContentTest>(x => x.Add(p => p.Text, "my text"));
+            var comp = Context.Render<SliderWithContentTest>(x => x.Add(p => p.Text, "my text"));
 
             comp.Nodes.Should().ContainSingle();
 
@@ -172,7 +172,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Structure_WithFilled()
         {
-            var comp = Context.RenderComponent<MudSlider<double>>(x =>
+            var comp = Context.Render<MudSlider<double>>(x =>
             {
                 x.Add(p => p.Value, 20.0);
                 x.Add(p => p.Variant, Variant.Filled);
@@ -202,7 +202,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TickMarksEnabled_ButNoLabels()
         {
-            var comp = Context.RenderComponent<MudSlider<double>>(x =>
+            var comp = Context.Render<MudSlider<double>>(x =>
             {
                 x.Add(p => p.Value, 20.0);
                 x.Add(p => p.Step, 25.0);
@@ -246,7 +246,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var labels = new[] { "red", "green", "yellow", "blue", "black" };
 
-            var comp = Context.RenderComponent<MudSlider<double>>(x =>
+            var comp = Context.Render<MudSlider<double>>(x =>
             {
                 x.Add(p => p.Value, 20.0);
                 x.Add(p => p.Step, 25.0);
@@ -300,7 +300,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(-200.0, -100.0, 25.0, 5)]
         public void TickMarksEnabled_CheckAmount(double min, double max, double step, int expectedAmount)
         {
-            var comp = Context.RenderComponent<MudSlider<double>>(x =>
+            var comp = Context.Render<MudSlider<double>>(x =>
             {
                 x.Add(p => p.Min, min);
                 x.Add(p => p.Max, max);
@@ -355,7 +355,7 @@ namespace MudBlazor.UnitTests.Components
                 CultureInfo.CurrentCulture = culture;
                 CultureInfo.CurrentUICulture = culture;
 
-                var comp = Context.RenderComponent<MudSlider<double>>(x =>
+                var comp = Context.Render<MudSlider<double>>(x =>
                 {
                     x.Add(p => p.Max, max);
                     x.Add(p => p.Min, min);
@@ -377,7 +377,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task CheckInput(bool immediate)
         {
-            var comp = Context.RenderComponent<MudSlider<double>>(x =>
+            var comp = Context.Render<MudSlider<double>>(x =>
             {
                 x.Add(p => p.Max, 200);
                 x.Add(p => p.Min, 100);
@@ -413,7 +413,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public async Task NullableBinding(double? value)
         {
-            var comp = Context.RenderComponent<SliderWithNullable>();
+            var comp = Context.Render<SliderWithNullable>();
             comp.Instance.NullableValue.Should().BeNull();
 
             IElement Input() => comp.Find(".mud-slider-input");
@@ -430,7 +430,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public async Task TwoBindValues1(double? value)
         {
-            var comp = Context.RenderComponent<SliderWithTwoBindValues>();
+            var comp = Context.Render<SliderWithTwoBindValues>();
             comp.Instance.NullableValue.Should().BeNull();
             comp.Instance.Value.Should().Be(0);
 
@@ -443,7 +443,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TwoBindValues2()
         {
-            var comp = Context.RenderComponent<SliderWithTwoBindValues>();
+            var comp = Context.Render<SliderWithTwoBindValues>();
             comp.Instance.NullableValue.Should().BeNull();
             comp.Instance.Value.Should().Be(0);
 
@@ -477,7 +477,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var customCulture = (CultureInfo)CultureInfo.GetCultureInfo("en").Clone();
             customCulture.NumberFormat.CurrencySymbol = "$";
-            var comp = Context.RenderComponent<MudSlider<decimal>>(x =>
+            var comp = Context.Render<MudSlider<decimal>>(x =>
             {
                 x.Add(p => p.Value, value);
                 x.Add(p => p.Step, 0.5m);
@@ -493,7 +493,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CustomValueLabelContent()
         {
-            var comp = Context.RenderComponent<SliderWithCustomValueLabelContentTest>();
+            var comp = Context.Render<SliderWithCustomValueLabelContentTest>();
             IElement AlertText() => MudAlert().Find("div.mud-alert-message");
             IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
             AlertText().InnerHtml.Should().Be("20");

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -18,7 +18,7 @@ namespace MudBlazor.UnitTests.Components
         public void SnackbarSetUp()
         {
             _service = Context.Services.GetService<ISnackbar>();
-            _provider = Context.RenderComponent<MudSnackbarProvider>();
+            _provider = Context.Render<MudSnackbarProvider>();
             _provider.Find("#mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
         }
 
@@ -95,7 +95,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TestWithRenderFragmentLiteral()
         {
-            var testComponent = Context.RenderComponent<SnackbarRenderFragmentMessageTest>();
+            var testComponent = Context.Render<SnackbarRenderFragmentMessageTest>();
 
             testComponent.Find("button").Click();
             _provider.WaitForAssertion(() =>
@@ -107,7 +107,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TestWithCustomComponent()
         {
-            var testComponent = Context.RenderComponent<SnackbarCustomComponentMessageTest>();
+            var testComponent = Context.Render<SnackbarCustomComponentMessageTest>();
 
             testComponent.Find("button").Click();
             _provider.WaitForAssertion(() =>
@@ -236,7 +236,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SnackbarIconConfigurationTest()
         {
-            var testComponent = Context.RenderComponent<SnackbarIconConfiguationTest>();
+            var testComponent = Context.Render<SnackbarIconConfiguationTest>();
 
             testComponent.Find("button").Click();
 

--- a/src/MudBlazor.UnitTests/Components/StackTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StackTests.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckDefaultClass()
         {
-            var stack = Context.RenderComponent<MudStack>();
+            var stack = Context.Render<MudStack>();
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", "gap-3" });
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckRowClass()
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Row, true));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.Row, true));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-row", "gap-3" });
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckReverseClass()
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Reverse, true));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.Reverse, true));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column-reverse", "gap-3" });
@@ -67,7 +67,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(16)]
         public void CheckSpacingClass(int spacing)
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Spacing, spacing));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.Spacing, spacing));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", $"gap-{spacing}" });
@@ -124,7 +124,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Breakpoint.XlAndUp, true, true)]
         public void CheckBreakpointClass(Breakpoint breakpoint, bool row = false, bool reverse = false)
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Breakpoint, breakpoint).Add(c => c.Row, row).Add(c => c.Reverse, reverse));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.Breakpoint, breakpoint).Add(c => c.Row, row).Add(c => c.Reverse, reverse));
 
             // Get the Default and Reverse States
             string defaultState = (row ? "row" : "column") + (reverse ? "-reverse" : string.Empty);
@@ -200,7 +200,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Justify.SpaceEvenly, "space-evenly")]
         public void CheckJustifyClass(Justify justify, string expectedClass)
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Justify, justify));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.Justify, justify));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", $"justify-{expectedClass}", "gap-3" });
@@ -214,7 +214,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(AlignItems.Stretch, "stretch")]
         public void CheckAlignItemsClass(AlignItems align, string expectedClass)
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.AlignItems, align));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.AlignItems, align));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", $"align-{expectedClass}", "gap-3" });
@@ -229,7 +229,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(StretchItems.All, "all")]
         public void CheckStretchItemsClass(StretchItems stretch, string expectedClass)
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.StretchItems, stretch));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.StretchItems, stretch));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().Contain(["d-flex", $"flex-grow-{expectedClass}"]);
@@ -238,7 +238,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void CheckStretchItemsNoneClass()
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.StretchItems, StretchItems.None));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.StretchItems, StretchItems.None));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().NotContain(["flex-grow-start", "flex-grow-end", "flex-grow-start-and-end", "flex-grow-all"]);
@@ -250,7 +250,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Wrap.WrapReverse, "wrap-reverse")]
         public void CheckWrapClass(Wrap wrap, string expectedClass)
         {
-            var stack = Context.RenderComponent<MudStack>(x => x.Add(c => c.Wrap, wrap));
+            var stack = Context.Render<MudStack>(x => x.Add(c => c.Wrap, wrap));
 
             var stackClass = stack.Find(".d-flex");
             stackClass.ClassList.Should().ContainInOrder(new[] { "d-flex", "flex-column", $"flex-{expectedClass}", "gap-3" });

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void StepperContent_ShouldDisplayActiveStepContent()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step =>
                 {
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
             MudStepContext? firstStepContext = null;
             MudStepContext? secondStepContext = null;
 
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step =>
                 {
@@ -103,7 +103,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Stepper_ShouldDisplayContentOfActiveStep()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, true);
                 self.AddChildContent<MudStep>(step =>
@@ -140,7 +140,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Stepper_ShouldNavigateViaNextAndPrevious()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, false);
                 self.AddChildContent<MudStep>(step =>
@@ -192,7 +192,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Stepper_ShouldBeginWithFirstEnabledStep()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Disabled, true));
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Disabled, true));
@@ -205,7 +205,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PreviousAndNext_ShouldCorrectlyHandleDisabledSteps()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, true);
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Disabled, true));
@@ -231,7 +231,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Stepper_ShouldBeAbleToSkipSkippableSteps()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, false);
                 self.AddChildContent<MudStep>(step =>
@@ -269,7 +269,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ActiveIndex_ShouldBeTwoWayBindable()
         {
-            var comp = Context.RenderComponent<StepperTwoWayBindingTestComponent>();
+            var comp = Context.Render<StepperTwoWayBindingTestComponent>();
             var stepper1 = comp.FindComponents<MudStepper>()[0];
             var stepper2 = comp.FindComponents<MudStepper>()[1];
             stepper1.Instance.ActiveStep?.Title.Should().Be("A");
@@ -299,7 +299,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ManipulatingStepsProgrammatically_ShouldUpdateTheUi()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step =>
                 {
@@ -345,7 +345,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FirstStep_ShouldBeActiveIfActiveIndexNotSet()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Title, "A"));
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Title, "B"));
@@ -360,7 +360,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InitialActiveIndex_ShouldBeRespectedIfSet()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.ActiveIndex, 1);
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Title, "A"));
@@ -374,7 +374,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task RemoveStep_ShouldUpdateActiveIndex()
         {
             int activeIndex = 2;
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Bind(x => x.ActiveIndex, activeIndex, newValue => activeIndex = newValue);
                 self.AddChildContent<MudStep>(step => step.Add(x => x.Title, "A"));
@@ -401,13 +401,12 @@ namespace MudBlazor.UnitTests.Components
         public async Task AddStep_ShouldUpdateActiveIndexAndStep()
         {
             int activeIndex = -1;
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Bind(x => x.ActiveIndex, activeIndex, newValue => activeIndex = newValue);
             });
-            var stepper1 = Context.RenderComponent<MudStep>(parameters => parameters.Add(x => x.Title, "X"));
-            var stepper2 = Context.RenderComponent<MudStep>(parameters => parameters.Add(x => x.Title, "Y"));
-            stepper.WaitForAssertion(() => stepper.RenderCount.Should().Be(1));
+            var stepper1 = Context.Render<MudStep>(parameters => parameters.Add(x => x.Title, "X"));
+            var stepper2 = Context.Render<MudStep>(parameters => parameters.Add(x => x.Title, "Y"));
             activeIndex.Should().Be(-1);
             // adding a step changes active index to 0
             stepper1.Instance.IsActive.Should().Be(false); // <-- fight partial line coverage
@@ -423,7 +422,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Stepper_ShouldNavigateViaProgrammaticApi()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, false);
                 self.AddChildContent<MudStep>(step =>
@@ -471,7 +470,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CompletedContent_ShouldShowUpIfAllStepsAreComplete_Horizontal()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.CompletedContent, markupFactory => markupFactory.AddMarkupContent(0, "voilà"));
                 self.AddChildContent<MudStep>(step =>
@@ -499,7 +498,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CompletedContent_ShouldShowUpIfAllStepsAreComplete_Vertical()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.Vertical, true);
                 self.Add(x => x.CompletedContent, markupFactory => markupFactory.AddMarkupContent(0, "voilà"));
@@ -526,7 +525,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task UpdatingStepProperties_ShouldUpdateStepper()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step =>
                 {
@@ -570,7 +569,7 @@ namespace MudBlazor.UnitTests.Components
         {
             int aClick = 0;
             int bClick = 0;
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, true);
                 self.AddChildContent<MudStep>(step =>
@@ -595,9 +594,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ActionContentTemplate_ShouldReplaceTheNavButtons()
         {
-            var stepper = Context.RenderComponent<MudStepper>();
+            var stepper = Context.Render<MudStepper>();
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(2, "because no action content defined"); // prev, next
-            stepper = Context.RenderComponent<MudStepper>(self =>
+            stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.Tag, "je ne sais pas");
                 // this replaces the action buttons prev, skip and next with just text
@@ -610,13 +609,13 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShowReset_ShouldControlResetButtonVisibilty()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.ShowResetButton, true);
             });
             stepper.FindAll(".mud-card-actions .mud-button").Count.Should().Be(3); // reset, previous, next
             stepper.FindAll(".mud-card-actions .mud-stepper-button-reset").Count.Should().Be(1);
-            stepper = Context.RenderComponent<MudStepper>(self =>
+            stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.ShowResetButton, false);
             });
@@ -627,7 +626,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ResetButton_ShouldResetActiveStep()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.ShowResetButton, true);
                 self.AddChildContent<MudStep>(step =>
@@ -673,7 +672,7 @@ namespace MudBlazor.UnitTests.Components
                 args.Cancel = cancel;
                 return Task.CompletedTask;
             }
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
                 self.Add(x => x.ShowResetButton, true);
@@ -716,7 +715,7 @@ namespace MudBlazor.UnitTests.Components
                 args.Cancel = cancel;
                 return Task.CompletedTask;
             }
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
                 self.Add(x => x.ShowResetButton, true);
@@ -760,7 +759,7 @@ namespace MudBlazor.UnitTests.Components
                 args.Cancel = cancel;
                 return Task.CompletedTask;
             }
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
                 self.Add(x => x.ShowResetButton, true);
@@ -791,7 +790,7 @@ namespace MudBlazor.UnitTests.Components
                 args.Cancel = cancel;
                 return Task.CompletedTask;
             }
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
                 self.Add(x => x.ShowResetButton, true);
@@ -824,7 +823,7 @@ namespace MudBlazor.UnitTests.Components
                 args.Cancel = cancel;
                 return Task.CompletedTask;
             }
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
                 self.Add(x => x.ShowResetButton, true);
@@ -863,7 +862,7 @@ namespace MudBlazor.UnitTests.Components
                 args.Cancel = cancel;
                 return Task.CompletedTask;
             }
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.OnPreviewInteraction, OnPreviewInteraction);
                 self.Add(x => x.ShowResetButton, true);
@@ -929,7 +928,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void HasCompletedClassIfLinear()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.CompletedStepColor, Color.Success);
                 self.Add(x => x.CurrentStepColor, Color.Secondary);
@@ -949,7 +948,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false, false)]
         public void HasRippleClass(bool ripple, bool hasClass)
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.Ripple, ripple);
 
@@ -976,7 +975,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false, false)]
         public void HasClickableClassIfNonLinear(bool nonLinear, bool hasClass)
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.Add(x => x.NonLinear, nonLinear);
 
@@ -1005,7 +1004,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Stepper_ShouldHandleNullChildContent()
         {
-            var stepper = Context.RenderComponent<MudStepper>(self =>
+            var stepper = Context.Render<MudStepper>(self =>
             {
                 self.AddChildContent<MudStep>(step =>
                 {

--- a/src/MudBlazor.UnitTests/Components/SwipeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwipeTests.cs
@@ -12,7 +12,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SwipeTest_1()
         {
-            var comp = Context.RenderComponent<SwipeAreaTest>();
+            var comp = Context.Render<SwipeAreaTest>();
             var swipe = comp.FindComponent<MudSwipeArea>();
 
             await comp.InvokeAsync(() => swipe.Instance._yDown = 50);
@@ -28,7 +28,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SwipeTest_2()
         {
-            var comp = Context.RenderComponent<SwipeAreaOnSwipeEndTest>();
+            var comp = Context.Render<SwipeAreaOnSwipeEndTest>();
             var swipe = comp.FindComponent<MudSwipeArea>();
 
             // Swipe below the sensitivity should not make change.
@@ -55,7 +55,7 @@ namespace MudBlazor.UnitTests.Components
             var handler = Context.JSInterop.Setup<int[]>(invocation => invocation.Identifier == "mudElementRef.addDefaultPreventingHandlers")
                 .SetResult(listenerIds);
 
-            var comp = Context.RenderComponent<MudSwipeArea>(parameters => parameters.Add(p => p.PreventDefault, true));
+            var comp = Context.Render<MudSwipeArea>(parameters => parameters.Add(p => p.PreventDefault, true));
 
             comp.WaitForState(() => comp.Instance.PreventDefault);
             comp.Instance._listenerIds.Should().BeEquivalentTo(listenerIds);
@@ -73,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
             Context.JSInterop.Setup<int[]>(invocation => invocation.Identifier == "mudElementRef.addDefaultPreventingHandlers")
                 .SetResult(listenerIds);
 
-            var comp = Context.RenderComponent<MudSwipeArea>(parameters => parameters.Add(p => p.PreventDefault, true));
+            var comp = Context.Render<MudSwipeArea>(parameters => parameters.Add(p => p.PreventDefault, true));
 
             var handler = Context.JSInterop.SetupVoid(invocation => invocation.Identifier == "mudElementRef.removeDefaultPreventingHandlers")
                 .SetVoidResult();

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -13,7 +13,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SwitchTest_KeyboardNavigation()
         {
-            var comp = Context.RenderComponent<MudSwitch<bool>>();
+            var comp = Context.Render<MudSwitch<bool>>();
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(true));
@@ -53,7 +53,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Dark, Color.Primary)]
         public void SwitchColorTest(Color color, Color uncheckedcolor)
         {
-            var comp = Context.RenderComponent<MudSwitch<bool>>(x => x.Add(c => c.Color, color).Add(b => b.UncheckedColor, uncheckedcolor));
+            var comp = Context.Render<MudSwitch<bool>>(x => x.Add(c => c.Color, color).Add(b => b.UncheckedColor, uncheckedcolor));
 
             var box = comp.Instance;
 
@@ -71,14 +71,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SwitchDisabledTest()
         {
-            var comp = Context.RenderComponent<SwitchWithLabelTest>();
+            var comp = Context.Render<SwitchWithLabelTest>();
             comp.FindAll("label.mud-switch")[3].ClassList.Should().Contain("mud-disabled"); // 4rd switch
         }
 
         [Test]
         public void SwitchLabelPlacementTest()
         {
-            var comp = Context.RenderComponent<SwitchWithLabelTest>();
+            var comp = Context.Render<SwitchWithLabelTest>();
 
             comp.FindAll("label.mud-switch")[0].ClassList.Should().Contain("mud-input-content-placement-end"); // 1st switch: (default) Placement.End
             comp.FindAll("label.mud-switch")[2].ClassList.Should().Contain("mud-input-content-placement-start"); // 3rd switch: Placement.Start
@@ -89,10 +89,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var value = new DisplayNameLabelClass();
 
-            var comp = Context.RenderComponent<MudSwitch<bool>>(x => x.Add(f => f.For, () => value.Boolean));
+            var comp = Context.Render<MudSwitch<bool>>(x => x.Add(f => f.For, () => value.Boolean));
             comp.Instance.Label.Should().Be("Boolean LabelAttribute"); //label should be set by the attribute
 
-            var comp2 = Context.RenderComponent<MudSwitch<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
+            var comp2 = Context.Render<MudSwitch<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
 
@@ -102,7 +102,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalSwitch_Should_NotHaveRequiredAttribute()
         {
-            var comp = Context.RenderComponent<MudSwitch<bool>>();
+            var comp = Context.Render<MudSwitch<bool>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
         }
@@ -113,7 +113,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredSwitch_Should_HaveRequiredAttribute()
         {
-            var comp = Context.RenderComponent<MudSwitch<bool>>(parameters => parameters
+            var comp = Context.Render<MudSwitch<bool>>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -125,7 +125,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredSwitchAttribute_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudSwitch<bool>>();
+            var comp = Context.Render<MudSwitch<bool>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
 
@@ -139,12 +139,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
-            Context.RenderComponent<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().Contain("hover:mud-default-hover");
-            Context.RenderComponent<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, true)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
-            Context.RenderComponent<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, true).Add(x => x.Disabled, false)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
-            Context.RenderComponent<MudSwitch<bool>>(self => self.Add(x => x.Disabled, false)).Find("span.mud-button-root").ClassList.Should().Contain("hover:mud-default-hover");
-            Context.RenderComponent<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
-            Context.RenderComponent<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, true)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().Contain("hover:mud-default-hover");
+            Context.Render<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, true)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, true).Add(x => x.Disabled, false)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, false)).Find("span.mud-button-root").ClassList.Should().Contain("hover:mud-default-hover");
+            Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
+            Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, true)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -18,7 +18,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CustomTableClass()
         {
-            var comp = Context.RenderComponent<TableRowClickTest>();
+            var comp = Context.Render<TableRowClickTest>();
             var table = comp.FindComponent<MudTable<int>>();
             await table.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.TableClass, "table-custom-class"));
             table.Markup.Should().Contain("class=\"mud-table-root table-custom-class\"");
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableRowClick()
         {
-            var comp = Context.RenderComponent<TableRowClickTest>();
+            var comp = Context.Render<TableRowClickTest>();
             comp.Find("p").TextContent.Trim().Should().BeEmpty();
             var trs = comp.FindAll("tr");
             trs[1].Click();
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableRowHover()
         {
-            var comp = Context.RenderComponent<TableRowHoverTest>();
+            var comp = Context.Render<TableRowHoverTest>();
             comp.Find("p").TextContent.Trim().Should().Be("Current: '', last: ''");
 
             var trs = comp.FindAll("tr");
@@ -82,7 +82,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableDisabledSort()
         {
             // Get access to the table
-            var comp = Context.RenderComponent<TableDisabledSortTest>();
+            var comp = Context.Render<TableDisabledSortTest>();
 
             // Count the number of rows including header
             comp.FindAll("tr").Count.Should().Be(4); // Three rows + header row
@@ -134,7 +134,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableLoadingTest()
         {
-            var comp = Context.RenderComponent<TableLoadingTest>();
+            var comp = Context.Render<TableLoadingTest>();
 
             // Count the number of rows
             var trs = comp.FindAll("tr");
@@ -163,7 +163,7 @@ namespace MudBlazor.UnitTests.Components
         public void LoadingSwitchAddsRowToHeaderWithoutAffectingBody()
         {
             // Render the component
-            var comp = Context.RenderComponent<TableLoadingTest>();
+            var comp = Context.Render<TableLoadingTest>();
 
             // Initial count of header and body rows
             var initialHeaderRows = comp.FindAll("thead tr");
@@ -196,7 +196,7 @@ namespace MudBlazor.UnitTests.Components
         public void DynamicColumnsDoNotAffectLoadingRow()
         {
             // Render the component
-            var comp = Context.RenderComponent<TableLoadingTest>();
+            var comp = Context.Render<TableLoadingTest>();
 
             // Ensure table initially has 6 columns
             var headersRow = comp.FindAll("thead tr")[0];
@@ -233,7 +233,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableGroupLoadingAndNoRecordsTest()
         {
-            var comp = Context.RenderComponent<TableGroupLoadingAndNoRecordsTest>();
+            var comp = Context.Render<TableGroupLoadingAndNoRecordsTest>();
             var searchString = comp.Find("#searchString");
             var switchElement = comp.Find("#switch");
 
@@ -265,7 +265,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableHeadContentTest()
         {
-            var comp = Context.RenderComponent<TableLoadingTest>();
+            var comp = Context.Render<TableLoadingTest>();
             var searchString = comp.Find("#searchString");
             var switchElement = comp.Find("#switch");
 
@@ -291,7 +291,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableHeadContentBodyTest()
         {
-            var comp = Context.RenderComponent<TableLoadingBodyTest>();
+            var comp = Context.Render<TableLoadingBodyTest>();
             var searchString = comp.Find("#searchString");
             var switchElement = comp.Find("#switch");
 
@@ -327,7 +327,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TableEditTrigger.EditButton)]
         public void TableSingleSelection(TableEditTrigger trigger)
         {
-            var comp = Context.RenderComponent<TableSingleSelectionTest1>(parameters => parameters
+            var comp = Context.Render<TableSingleSelectionTest1>(parameters => parameters
                 .Add(p => p.EditTrigger, trigger));
             // print the generated html
             // select elements needed for the test
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableFilter()
         {
-            var comp = Context.RenderComponent<TableFilterTest1>();
+            var comp = Context.Render<TableFilterTest1>();
             // print the generated html
             var table = comp.FindComponent<MudTable<string>>().Instance;
             var searchString = comp.Find("#searchString");
@@ -382,7 +382,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableFilterCachingTest()
         {
-            var comp = Context.RenderComponent<TableFilterTest1>();
+            var comp = Context.Render<TableFilterTest1>();
             // print the generated html
             var table = comp.FindComponent<MudTable<string>>().Instance;
             var searchString = comp.Find("#searchString");
@@ -407,7 +407,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TablePagingNavigationButtons()
         {
-            var comp = Context.RenderComponent<TablePagingTest1>();
+            var comp = Context.Render<TablePagingTest1>();
             // print the generated html
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
@@ -416,7 +416,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".mud-table-pagination-before-button").IsDisabled().Should().Be(true);
             comp.Find(".mud-table-pagination-next-button").IsDisabled().Should().Be(false);
             comp.Find(".mud-table-pagination-last-button").IsDisabled().Should().Be(false);
-            IRefreshableElementCollection<IElement> PagingButtons() => comp.FindAll(".mud-table-pagination-actions button");
+            IReadOnlyList<IElement> PagingButtons() => comp.FindAll(".mud-table-pagination-actions button");
             // click next page
             PagingButtons()[2].Click();
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
@@ -462,7 +462,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableNavigateToPage(int pageIndex, string expectedFirstItem)
         {
-            var comp = Context.RenderComponent<TablePagingTest1>();
+            var comp = Context.Render<TablePagingTest1>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<string>>();
@@ -477,7 +477,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TablePageSizeOptions()
         {
-            var comp = Context.RenderComponent<TablePageSizeOptionsTest>();
+            var comp = Context.Render<TablePageSizeOptionsTest>();
             // print the generated html
             // select elements needed for the test
             var pager = comp.FindComponent<MudSelect<int>>().Instance;
@@ -490,7 +490,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TablePagingChangePageSize()
         {
-            var comp = Context.RenderComponent<TablePagingTest1>();
+            var comp = Context.Render<TablePagingTest1>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<string>>();
@@ -530,7 +530,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TablePagingAllTest()
         {
-            var comp = Context.RenderComponent<TablePagingTest1>();
+            var comp = Context.Render<TablePagingTest1>();
 
             var table = comp.FindComponent<MudTable<string>>();
             var pager = comp.FindComponent<MudSelect<int>>().Instance;
@@ -554,7 +554,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TablePagingChangePageSizeAfterPaging()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest2>();
+            var comp = Context.Render<TableServerSideDataTest2>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>();
@@ -595,7 +595,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TablePagingFilter()
         {
-            var comp = Context.RenderComponent<TablePagingTest1>();
+            var comp = Context.Render<TablePagingTest1>();
             var searchString = comp.Find("#searchString");
             // search returns 3 items
             searchString.Change("Ala");
@@ -613,12 +613,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TablePagingFilterAdjustCurrentPage()
         {
-            var comp = Context.RenderComponent<TablePagingTest1>();
+            var comp = Context.Render<TablePagingTest1>();
             // print the generated html
             // after initial load
             comp.FindAll("tr.mud-table-row").Count.Should().Be(10);
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 59");
-            IRefreshableElementCollection<IElement> PagingButtons() => comp.FindAll(".mud-table-pagination-actions button");
+            IReadOnlyList<IElement> PagingButtons() => comp.FindAll(".mud-table-pagination-actions button");
             // goto page 3
             PagingButtons()[2].Click();
             PagingButtons()[2].Click();
@@ -643,7 +643,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableMultiSelectionSelectedItemsEqualsNull()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest1>();
+            var comp = Context.Render<TableMultiSelectionTest1>();
             // print the generated html
             // select elements needed for the test
             var tableComponent = comp.FindComponent<MudTable<int>>();
@@ -661,7 +661,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelection_CheckboxAndRowClickTest()
         {
-            var comp = Context.RenderComponent<TableMultiSelection_CheckboxAndRowClickTest>();
+            var comp = Context.Render<TableMultiSelection_CheckboxAndRowClickTest>();
             var checkboxes = comp.FindComponent<MudTable<int>>().FindAll("input").ToArray();
             var table = comp.FindComponent<MudTable<int>>().Instance;
 
@@ -679,7 +679,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelection_IgnoreCheckbox_RowClickTest()
         {
-            var comp = Context.RenderComponent<TableMultiSelection_IgnoreCheckbox_RowClickTest>();
+            var comp = Context.Render<TableMultiSelection_IgnoreCheckbox_RowClickTest>();
             var rows = comp.FindComponent<MudTable<int>>().FindAll("tr").ToArray();
             var table = comp.FindComponent<MudTable<int>>().Instance;
 
@@ -690,7 +690,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest()
         {
-            var comp = Context.RenderComponent<TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest>();
+            var comp = Context.Render<TableMultiSelection_MultiGrouping_DefaultCheckboxStatesTest>();
             var mudTable = comp.Instance.MudTable;
 
             // All row checkbox states must be false.
@@ -712,7 +712,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest2()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest2>();
+            var comp = Context.Render<TableMultiSelectionTest2>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
@@ -745,7 +745,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest2B()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest2B>();
+            var comp = Context.Render<TableMultiSelectionTest2B>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
@@ -778,7 +778,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest3()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest3>();
+            var comp = Context.Render<TableMultiSelectionTest3>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
@@ -804,7 +804,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest4()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest4>();
+            var comp = Context.Render<TableMultiSelectionTest4>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
@@ -828,7 +828,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableMultiSelectionTest5()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest5>();
+            var comp = Context.Render<TableMultiSelectionTest5>();
             // print the generated html
             // select elements needed for the test
             var tableComponent = comp.FindComponent<MudTable<int>>();
@@ -854,7 +854,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest6()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest6>();
+            var comp = Context.Render<TableMultiSelectionTest6>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
@@ -887,7 +887,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest6B()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest6B>();
+            var comp = Context.Render<TableMultiSelectionTest6B>();
             // print the generated html
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
@@ -920,7 +920,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest7()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest7>();
+            var comp = Context.Render<TableMultiSelectionTest7>();
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -966,7 +966,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest8()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest8>();
+            var comp = Context.Render<TableMultiSelectionTest8>();
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -1006,7 +1006,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionTest9()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionTest9>();
+            var comp = Context.Render<TableMultiSelectionTest9>();
             // select elements needed for the test
             var tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
             var table = tableComponent.Instance;
@@ -1027,7 +1027,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionServerDataTest()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionServerDataTest>();
+            var comp = Context.Render<TableMultiSelectionServerDataTest>();
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<TableMultiSelectionServerDataTest.ComplexObject>>().Instance;
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -1072,7 +1072,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelectionItemsTest1_PageChange()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionItemsTest1>();
+            var comp = Context.Render<TableMultiSelectionItemsTest1>();
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<TableMultiSelectionItemsTest1.ComplexObject>>().Instance;
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -1121,7 +1121,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableMultiSelectionItemsTest1_FilterChange()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionItemsTest1>();
+            var comp = Context.Render<TableMultiSelectionItemsTest1>();
             // select elements needed for the test
             var table = comp.FindComponent<MudTable<TableMultiSelectionItemsTest1.ComplexObject>>().Instance;
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -1171,7 +1171,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableMultiSelection_Checkbox_Executes_Callback()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionCheckboxExecutesCallback>();
+            var comp = Context.Render<TableMultiSelectionCheckboxExecutesCallback>();
 
             var table = comp.FindComponent<MudTable<int>>().Instance;
             var inputs = comp.FindAll("input").ToArray();
@@ -1187,7 +1187,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TablePaginationTest1()
         {
-            var comp = Context.RenderComponent<TablePaginationTest1>();
+            var comp = Context.Render<TablePaginationTest1>();
             await Task.Delay(200);
             comp.FindAll("tr.mud-table-row").Count.Should().Be(11); // ten rows + header row
             comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
@@ -1199,7 +1199,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest1()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest1>();
+            var comp = Context.Render<TableServerSideDataTest1>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
@@ -1212,7 +1212,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest2()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest2>();
+            var comp = Context.Render<TableServerSideDataTest2>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
@@ -1238,7 +1238,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest3()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest3>();
+            var comp = Context.Render<TableServerSideDataTest3>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("3");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("2");
@@ -1260,7 +1260,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest4()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest4>();
+            var comp = Context.Render<TableServerSideDataTest4>();
             comp.WaitForAssertion(() => comp.FindAll("tr").Count.Should().Be(4)); // three rows + header row
             comp.WaitForAssertion(() => comp.FindAll("td")[0].TextContent.Trim().Should().Be("1"));
             comp.WaitForAssertion(() => comp.FindAll("td")[2].TextContent.Trim().Should().Be("2"));
@@ -1279,7 +1279,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest4b()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest4b>();
+            var comp = Context.Render<TableServerSideDataTest4b>();
             comp.FindAll("tr").Count.Should().Be(4); // three rows + header row
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("1");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("2");
@@ -1297,7 +1297,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest5()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest5>();
+            var comp = Context.Render<TableServerSideDataTest5>();
             comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
 
             comp.FindAll("div.mud-table-pagination-actions button")[2].Click(); // next >
@@ -1346,7 +1346,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerSideDataTest6()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest5>();
+            var comp = Context.Render<TableServerSideDataTest5>();
             comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
 
             comp.Find("span.mud-clickable.mud-table-sort-label").Click(); // sort
@@ -1379,7 +1379,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<TableServerSideDataTest2>();
+            var comp = Context.Render<TableServerSideDataTest2>();
             var table = comp.FindComponent<MudTable<int>>();
             await table.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CurrentPage, 2));
             var serverDataCallCount = 0;
@@ -1406,7 +1406,7 @@ namespace MudBlazor.UnitTests.Components
         public void TableServerSideDataNull()
         {
             // Arrange & Act
-            var renderComponent = () => Context.RenderComponent<TableServerSideDataTest6>();
+            var renderComponent = () => Context.Render<TableServerSideDataTest6>();
 
             // Assert
             renderComponent.Should().NotThrow();
@@ -1418,7 +1418,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task StopLoadingDataWhenDisposedTest()
         {
-            var comp = Context.RenderComponent<TableServerSideDataTest7>();
+            var comp = Context.Render<TableServerSideDataTest7>();
             var table = comp.FindComponent<MudTable<int>>();
             table.Instance.Dispose();
             await Task.Delay(2000);
@@ -1432,7 +1432,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableServerDataLoadingTest()
         {
-            var comp = Context.RenderComponent<TableServerDataLoadingTest>();
+            var comp = Context.Render<TableServerDataLoadingTest>();
             comp.Instance.NoRecordsHasRendered.Should().BeFalse();
         }
 
@@ -1444,7 +1444,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableServerDataLoadingTestWithCancel()
         {
             // Render the server-side data (with cancellation) test
-            var comp = Context.RenderComponent<TableServerDataLoadingTestWithCancel>();
+            var comp = Context.Render<TableServerDataLoadingTestWithCancel>();
             // Get the MudTable<int> component
             var table = comp.FindComponent<MudTable<int>>();
 
@@ -1491,7 +1491,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableRowClassStyleTest()
         {
-            var comp = Context.RenderComponent<TableRowClassStyleTest>();
+            var comp = Context.Render<TableRowClassStyleTest>();
             var trs = comp.FindAll("tr");
             trs.Count.Should().Be(5); // four rows + header row
 
@@ -1520,7 +1520,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableInlineEdit_SetValidatorModel()
         {
-            var comp = Context.RenderComponent<TableInlineEditTest>();
+            var comp = Context.Render<TableInlineEditTest>();
             var validator = comp.Instance.Table.Validator;
 
             var trs = comp.FindAll("tr");
@@ -1537,7 +1537,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableInlineEdit_TableRowValidator()
         {
-            var comp = Context.RenderComponent<TableInlineEditTest>();
+            var comp = Context.Render<TableInlineEditTest>();
             var validator = new TableRowValidatorTest();
             comp.Instance.Table.Validator = validator;
 
@@ -1559,7 +1559,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TableApplyButtonPosition.End)]
         public void TableInlineEdit_ApplyButtonPosition(TableApplyButtonPosition position)
         {
-            var comp = Context.RenderComponent<TableInlineEditTestApplyButtons>(
+            var comp = Context.Render<TableInlineEditTestApplyButtons>(
                 p => p.Add(x => x.ApplyButtonPosition, position));
 
             var trs = comp.FindAll("tr");
@@ -1606,7 +1606,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableInlineEdit_RowSwitching()
         {
-            var comp = Context.RenderComponent<TableInlineEditTest>();
+            var comp = Context.Render<TableInlineEditTest>();
 
             var trs = comp.FindAll("tr");
 
@@ -1627,7 +1627,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableInlineEdit_RowSwitchingBlocked()
         {
-            var comp = Context.RenderComponent<TableInlineEditRowBlockingTest>();
+            var comp = Context.Render<TableInlineEditRowBlockingTest>();
 
             var trs = comp.FindAll("tr");
 
@@ -1651,7 +1651,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableInlineEditSortTest()
         {
-            var comp = Context.RenderComponent<TableInlineEditSortTest>();
+            var comp = Context.Render<TableInlineEditSortTest>();
 
             // Count the number of rows including header
             comp.FindAll("tr").Count.Should().Be(4); // Three rows + header row
@@ -1696,7 +1696,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableInlineEditCancelTest()
         {
-            var comp = Context.RenderComponent<TableInlineEditCancelTest>();
+            var comp = Context.Render<TableInlineEditCancelTest>();
 
             // Check that the value in the second row is equal to 'B'
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
@@ -1735,7 +1735,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableInlineEditCancel2Test()
         {
-            var comp = Context.RenderComponent<TableInlineEditCancelTest>();
+            var comp = Context.Render<TableInlineEditCancelTest>();
 
             // Check that the value in the second row is equal to 'B'
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("B");
@@ -1767,7 +1767,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableInlineEditCancel3Test()
         {
-            var comp = Context.RenderComponent<TableInlineEditCancelTest>();
+            var comp = Context.Render<TableInlineEditCancelTest>();
             var tableComponent = comp.FindComponent<MudTable<TableInlineEditCancelTest.Element>>();
             var taskCompletionSource = new TaskCompletionSource<bool>();
 
@@ -1816,7 +1816,7 @@ namespace MudBlazor.UnitTests.Components
         public void TableInlineEditCancel4Test()
         {
             // Get access to the test table
-            var comp = Context.RenderComponent<TableInlineEditCancelNoSelectedItemTest>();
+            var comp = Context.Render<TableInlineEditCancelNoSelectedItemTest>();
 
             // List all the rows
             var trs = comp.FindAll("tr");
@@ -1855,13 +1855,13 @@ namespace MudBlazor.UnitTests.Components
             IRenderedComponent<ComponentBase> comp;
             if (customButton)
             {
-                comp = Context.RenderComponent<TableCustomEditButtonRenderTest>(parameters => parameters
+                comp = Context.Render<TableCustomEditButtonRenderTest>(parameters => parameters
                     .Add(p => p.ApplyButtonPosition, buttonApplyPosition)
                     .Add(p => p.EditButtonPosition, buttonEditPosition));
             }
             else
             {
-                comp = Context.RenderComponent<TableEditButtonRenderTest>(parameters => parameters
+                comp = Context.Render<TableEditButtonRenderTest>(parameters => parameters
                     .Add(p => p.ApplyButtonPosition, buttonApplyPosition)
                     .Add(p => p.EditButtonPosition, buttonEditPosition));
             }
@@ -1909,7 +1909,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableEditButtonTriggerTest()
         {
-            var comp = Context.RenderComponent<TableEditButtonRenderTest>();
+            var comp = Context.Render<TableEditButtonRenderTest>();
             var trs = comp.FindAll("tr");
             trs[1].InnerHtml.Contains("input").Should().BeFalse();
 
@@ -1931,7 +1931,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableCustomEditButtonTriggerTest()
         {
-            var comp = Context.RenderComponent<TableCustomEditButtonRenderTest>();
+            var comp = Context.Render<TableCustomEditButtonRenderTest>();
             var trs = comp.FindAll("tr");
             trs[1].InnerHtml.Contains("input").Should().BeFalse();
 
@@ -1953,9 +1953,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableCustomEditButtonItemContext()
         {
-            var comp = Context.RenderComponent<TableCustomEditButtonItemContextRenderTest>();
+            var comp = Context.Render<TableCustomEditButtonItemContextRenderTest>();
 
-            IRefreshableElementCollection<IElement> Buttons() => comp.FindAll("button");
+            IReadOnlyList<IElement> Buttons() => comp.FindAll("button");
             Buttons()[0].Click();
             comp.Instance.LatestButtonClickItem.Should().Be("A");
 
@@ -1972,7 +1972,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableEditButtonRowSwitchBlockTest()
         {
-            var comp = Context.RenderComponent<TableEditButtonRenderTest>(parameters => parameters
+            var comp = Context.Render<TableEditButtonRenderTest>(parameters => parameters
                     .Add(p => p.BlockRowSwitching, true));
             var trs = comp.FindAll("tr");
             trs[1].InnerHtml.Contains("input").Should().BeFalse();
@@ -2000,7 +2000,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 timesClicked++;
             }
-            var comp = Context.RenderComponent<TableEditButtonRenderTest>(parameters => parameters
+            var comp = Context.Render<TableEditButtonRenderTest>(parameters => parameters
                     .Add(p => p.RowClicked, OnRowClick));
 
             var trs = comp.FindAll("tr");
@@ -2023,15 +2023,15 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableGroupingTest()
         {
             // without grouping, to ensure that anything was broken:
-            var comp = Context.RenderComponent<TableGroupingTest>();
+            var comp = Context.Render<TableGroupingTest>();
             var tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
             //var table = comp.Instance.TableInstance;
             tableComponent.Instance.Context.HeaderRows.Count.Should().Be(1);
             tableComponent.Instance.Context.GroupRows.Count.Should().Be(0);
             tableComponent.Instance.Context.Rows.Count.Should().Be(9);
 
-            IRefreshableElementCollection<IElement> Inputs() => comp.FindAll("input");
-            IRefreshableElementCollection<IElement> Buttons() => comp.FindAll("button");
+            IReadOnlyList<IElement> Inputs() => comp.FindAll("input");
+            IReadOnlyList<IElement> Buttons() => comp.FindAll("button");
 
             // now, with multi selection:
             await tableComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.MultiSelection, true));
@@ -2043,7 +2043,7 @@ namespace MudBlazor.UnitTests.Components
             tableComponent.Instance.SelectedItems.Count.Should().Be(0);
 
             //group by Racing Category:
-            comp = Context.RenderComponent<TableGroupingTest>();
+            comp = Context.Render<TableGroupingTest>();
             tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
             await tableComponent.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.GroupBy,
@@ -2075,7 +2075,7 @@ namespace MudBlazor.UnitTests.Components
             tableComponent.Instance.SelectedItems.Count.Should().Be(0);
 
             //group by Racing Category and Brand:
-            comp = Context.RenderComponent<TableGroupingTest>();
+            comp = Context.Render<TableGroupingTest>();
             tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
             await tableComponent.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.GroupBy,
@@ -2180,7 +2180,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<TableGroupingTest3>();
+            var comp = Context.Render<TableGroupingTest3>();
             var table = comp.Instance.TableInstance;
             comp.Render();
 
@@ -2227,7 +2227,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<TableGroupingNestedTest>();
+            var comp = Context.Render<TableGroupingNestedTest>();
             var table = comp.Instance.TableInstance;
             comp.Render();
 
@@ -2298,7 +2298,7 @@ namespace MudBlazor.UnitTests.Components
         public void TableGroupingAndPaginationTest()
         {
             // without grouping, to ensure that anything was broken:
-            var comp = Context.RenderComponent<TableGroupingTest2>();
+            var comp = Context.Render<TableGroupingTest2>();
             var table = comp.Instance.TableInstance;
             table.Context.HeaderRows.Count.Should().Be(1);
 
@@ -2343,7 +2343,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TableGroupIsInitiallyExpandedTest()
         {
             // group by Racing Category and collapse groups as default:
-            var comp = Context.RenderComponent<TableGroupingTest>();
+            var comp = Context.Render<TableGroupingTest>();
             var tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
             await tableComponent.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.GroupBy,
@@ -2362,7 +2362,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ExpandAndCollapseAllGroupsTest()
         {
-            var comp = Context.RenderComponent<TableGroupingTest>();
+            var comp = Context.Render<TableGroupingTest>();
             var tableComponent = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
 
             await tableComponent.SetParametersAndRenderAsync(parameters => parameters
@@ -2396,7 +2396,7 @@ namespace MudBlazor.UnitTests.Components
         public void TablePagerInfoTextTest1()
         {
             // create the component
-            var tableComponent = Context.RenderComponent<TablePagerInfoTextTest1>();
+            var tableComponent = Context.Render<TablePagerInfoTextTest1>();
 
             // print the generated html
 
@@ -2434,7 +2434,7 @@ namespace MudBlazor.UnitTests.Components
         public void TablePagerInfoTextTest2(string infoFormat, string expectedInfoText)
         {
             // create the component
-            var tableComponent = Context.RenderComponent<TablePagerInfoTextTest2>(parameters => parameters
+            var tableComponent = Context.Render<TablePagerInfoTextTest2>(parameters => parameters
                 .Add(p => p.InfoFormat, infoFormat));
 
             // assert correct info-text
@@ -2453,7 +2453,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TablePagerControlButtonAriaLabelTest(Page controlButton, string expectedButtonAriaLabel)
         {
-            var tableComponent = Context.RenderComponent<TablePagerInfoTextTest1>();
+            var tableComponent = Context.Render<TablePagerInfoTextTest1>();
 
             //get control button
             var buttons = tableComponent.FindAll("div.mud-table-pagination-actions button");
@@ -2479,7 +2479,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var rowsPerPage = 5;
             var newRowsPerPage = 25;
-            var comp = Context.RenderComponent<TableRowsPerPageTwoWayBindingTest>(parameters => parameters
+            var comp = Context.Render<TableRowsPerPageTwoWayBindingTest>(parameters => parameters
                 .Add(p => p.RowsPerPage, rowsPerPage)
                 .Add(p => p.RowsPerPageChanged, (s) =>
                 {
@@ -2505,7 +2505,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableRowClickNotEditable()
         {
-            var comp = Context.RenderComponent<TableRowClickNotEditableTest>();
+            var comp = Context.Render<TableRowClickNotEditableTest>();
 
             // Get table instance
             var tableInstance = comp.FindComponent<MudTable<string>>().Instance;
@@ -2533,7 +2533,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TableEditTrigger.EditButton)]
         public void AllowEditRowPreventsEdit(TableEditTrigger trigger)
         {
-            var comp = Context.RenderComponent<TableNotEditableRowTest>(parameters => parameters.Add(x => x.EditTrigger, trigger));
+            var comp = Context.Render<TableNotEditableRowTest>(parameters => parameters.Add(x => x.EditTrigger, trigger));
 
             // Get table instance
             var tableInstance = comp.FindComponent<MudTable<int>>().Instance;
@@ -2585,7 +2585,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RowsPerPageChangeValueFromCode()
         {
-            var testComponent = Context.RenderComponent<TablePagerChangeRowsPerPageTest>();
+            var testComponent = Context.Render<TablePagerChangeRowsPerPageTest>();
             var table = testComponent.FindComponent<MudTable<string>>().Instance;
             var buttonComponent = testComponent.FindComponent<MudButton>();
             testComponent.WaitForAssertion(() => table.RowsPerPage.Should().Be(35));
@@ -2603,7 +2603,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TableRecordEditingMultiSelectTest()
         {
-            var comp = Context.RenderComponent<TableRecordComparerTest>();
+            var comp = Context.Render<TableRecordComparerTest>();
             var table = comp.FindComponent<MudTable<TableRecordComparerTest.Element>>().Instance;
 
             var checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
@@ -2644,7 +2644,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableComparerContextTest()
         {
-            var comp = Context.RenderComponent<TableComparerContextTest>();
+            var comp = Context.Render<TableComparerContextTest>();
             var table = comp.FindComponent<MudTable<TableComparerContextTest.Element>>().Instance;
 
             // Comparer is null by default
@@ -2667,7 +2667,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestVirtualizedTableWithMultiSelection()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionVirtualizedTest>();
+            var comp = Context.Render<TableMultiSelectionVirtualizedTest>();
             var table = comp.FindComponent<MudTable<TableMultiSelectionVirtualizedTest.TestItem>>();
             var virtualized = comp.FindComponent<Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize<TableMultiSelectionVirtualizedTest.TestItem>>();
             // find first checkbox item and check it
@@ -2697,7 +2697,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TestSelectedItemsChangedWithMultiSelection()
         {
-            var comp = Context.RenderComponent<TableMultiSelectionSelectedItemsChangedTest>();
+            var comp = Context.Render<TableMultiSelectionSelectedItemsChangedTest>();
             var selectAllCheckbox = comp.Find("input");
             selectAllCheckbox.Change(true);
             comp.Find("#counter").TextContent.Should().Be("1");
@@ -2711,7 +2711,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TestCurrentPageParameterTwoWayBinding()
         {
-            var comp = Context.RenderComponent<TableCurrentPageParameterTwoWayBindingTest>();
+            var comp = Context.Render<TableCurrentPageParameterTwoWayBindingTest>();
             var tableComponent = comp.FindComponent<MudTable<int>>();
 
             // Assert starting page index is 0 (default).
@@ -2742,7 +2742,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<TableCurrentPageParameterIntialized>();
+            var comp = Context.Render<TableCurrentPageParameterIntialized>();
             var table = comp.FindComponent<MudTable<int>>().Instance;
 
             // Assert : DataGrid is initialized with CurrentPage at 2
@@ -2760,7 +2760,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(SortDirection.Descending)]
         public void TableSortLabelDirectionClasses(SortDirection direction)
         {
-            var comp = Context.RenderComponent<MudTableSortLabel<string>>(parameters => parameters
+            var comp = Context.Render<MudTableSortLabel<string>>(parameters => parameters
                 .Add(p => p.SortDirection, direction)
             );
 
@@ -2799,7 +2799,7 @@ namespace MudBlazor.UnitTests.Components
             var items = GetTestItems(10);
             var itemToScrollTo = items[5]; // 6th item, index 5
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, false) // Ensure non-virtualized
                 .Add(p => p.RowTemplate, (context) => builder =>
@@ -2827,7 +2827,7 @@ namespace MudBlazor.UnitTests.Components
             var items = GetTestItems(50); // Larger list for virtualization
             var itemToScrollTo = items[25];
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, true)
                 .Add(p => p.FixedHeader, true)
@@ -2860,7 +2860,7 @@ namespace MudBlazor.UnitTests.Components
             var items = GetTestItems(5);
             var itemToScrollTo = new TestItem { Id = 99, Name = "NonExistent" };
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, false)
                 .Add(p => p.HeaderContent, builder =>
@@ -2888,7 +2888,7 @@ namespace MudBlazor.UnitTests.Components
             var items = GetTestItems(5);
             var itemToScrollTo = new TestItem { Id = 99, Name = "NonExistent" };
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, true)
                 .Add(p => p.Height, "300px")
@@ -2924,7 +2924,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, false)
                 .Add(p => p.HeaderContent, builder =>
@@ -2963,7 +2963,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, true)
                 .Add(p => p.FixedHeader, true)
@@ -3005,7 +3005,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, false)
                 .Add(p => p.HeaderContent, builder =>
@@ -3040,7 +3040,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.AddSingleton(jsRuntimeMock.Object);
 
-            var comp = Context.RenderComponent<MudTable<TestItem>>(parameters => parameters
+            var comp = Context.Render<MudTable<TestItem>>(parameters => parameters
                 .Add(p => p.Items, items)
                 .Add(p => p.Virtualize, true)
                 .Add(p => p.Height, "300px")
@@ -3067,7 +3067,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TableAriaLabel_RendersOnTable()
         {
-            var comp = Context.RenderComponent<TableRowClickTest>();
+            var comp = Context.Render<TableRowClickTest>();
             var tableEl = comp.Find("table");
             tableEl.HasAttribute("aria-label").Should().BeFalse();
 

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1507,7 +1507,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Tab_DragAndDrop_ActiveIndexShouldNotChangeDisplay()
+        public void Tab_DragAndDrop_ActiveIndexShouldNotChangeDisplay()
         {
             // defaulting the ActiveIndex to something other than 0 caused a display issue where it tried to make
             // that tab the FIRST tab putting any leading tabs underneath an arrow to "go left" (or right if rtl)

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Reflection;
+using AngleSharp.Dom;
 using Bunit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Components.Web;
@@ -23,7 +24,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void AddingAndRemovingTabPanels()
         {
-            var comp = Context.RenderComponent<TabsAddingRemovingTabsTest>();
+            var comp = Context.Render<TabsAddingRemovingTabsTest>();
             comp.Find("div.mud-tabs-panels").InnerHtml.Trim().Should().BeEmpty();
             comp.FindAll("div.mud-tab").Should().BeEmpty();
             comp.Instance.Tabs.Panels.Should().NotBeNull().And.BeEmpty();
@@ -76,7 +77,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void KeepTabsAliveTest()
         {
-            var comp = Context.RenderComponent<TabsKeepAliveTest>();
+            var comp = Context.Render<TabsKeepAliveTest>();
             // all panels should be evident in the markup:
             comp.FindAll("button").Count.Should().Be(3);
             // every panel should be rendered first exactly once throughout the test:
@@ -133,7 +134,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void KeepTabs_Not_AliveTest()
         {
-            var comp = Context.RenderComponent<TabsKeepAliveTest>(parameters => parameters.Add(p => p.KeepPanelsAlive, false));
+            var comp = Context.Render<TabsKeepAliveTest>(parameters => parameters.Add(p => p.KeepPanelsAlive, false));
             // only one panel should be evident in the markup:
             comp.FindAll("button").Count.Should().Be(1);
             // only the first panel should be rendered first
@@ -172,7 +173,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TabHeaderClassPropagated()
         {
-            var comp = Context.RenderComponent<MudTabs>();
+            var comp = Context.Render<MudTabs>();
 
             await comp.SetParametersAndRenderAsync(builder => builder.Add(tabs => tabs.TabHeaderClass, "testA testB"));
 
@@ -182,7 +183,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ScrollToItem_NoScrollingNeeded()
         {
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             for (var i = 0; i < 6; i++)
             {
@@ -213,7 +214,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.AddTransient<IResizeObserverFactory>(_ => factory);
 
-            var comp = Context.RenderComponent<ScrollableTabsRenderTest>();
+            var comp = Context.Render<ScrollableTabsRenderTest>();
 
             var toolbarWrapper = comp.Find(".mud-tabs-tabbar-wrapper");
             var tabs = comp.FindAll(".mud-tab");
@@ -246,7 +247,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             await comp.Instance.SetPanelActiveAsync(2);
 
@@ -279,7 +280,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
             await comp.Instance.ChangePositionAsync(true);
 
             await comp.Instance.SetPanelActiveAsync(2);
@@ -308,7 +309,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             var expectedTranslations = new Dictionary<int, double>
             {
@@ -339,7 +340,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Scroll_NotEnabled_EnoughSpace()
         {
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
 
@@ -364,7 +365,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
@@ -392,7 +393,7 @@ namespace MudBlazor.UnitTests.Components
 
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
@@ -418,7 +419,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
@@ -452,7 +453,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
@@ -487,7 +488,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             await comp.Instance.SetPanelActiveAsync(1);
 
@@ -514,7 +515,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
             await comp.Instance.SetPanelActiveAsync(5);
 
             observer.UpdateTotalPanelSize(501.0);
@@ -547,7 +548,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
             await comp.Instance.SetPanelActiveAsync(1);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
@@ -578,7 +579,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
             await comp.Instance.SetPanelActiveAsync(4);
 
             var scrollButtons = comp.FindComponents<MudIconButton>();
@@ -610,7 +611,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.AlwaysShowScrollButtons, false));
             await comp.Instance.SetPanelActiveAsync(5);
 
@@ -643,7 +644,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.AlwaysShowScrollButtons, false));
             await comp.Instance.SetPanelActiveAsync(5);
 
@@ -673,7 +674,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             await comp.Instance.SetPanelActiveAsync(1);
 
@@ -700,7 +701,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             await comp.Instance.SetPanelActiveAsync(4);
 
@@ -740,7 +741,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             await comp.Instance.SetPanelActiveAsync(2);
 
@@ -777,7 +778,7 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<ScrollableTabsTest>();
+            var comp = Context.Render<ScrollableTabsTest>();
 
             await comp.Instance.SetPanelActiveAsync(2);
 
@@ -819,28 +820,25 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<SimplifiedScrollableTabsTest>();
+            var comp = Context.Render<SimplifiedScrollableTabsTest>();
 
-            var buttonContainer = comp.FindAll(".mud-tabs-scroll-button");
-            buttonContainer.Should().HaveCount(0);
+            IReadOnlyList<IElement> ButtonContainer() => comp.FindAll(".mud-tabs-scroll-button");
+            ButtonContainer().Should().HaveCount(0);
 
             //add the first panel, buttons shouldn't be visible
             await comp.Instance.AddPanel();
 
-            buttonContainer.Refresh();
-            buttonContainer.Should().HaveCount(0);
+            ButtonContainer().Should().HaveCount(0);
 
             //add second panel, buttons shouldn't be visible
             await comp.Instance.AddPanel();
 
-            buttonContainer.Refresh();
-            buttonContainer.Should().HaveCount(0);
+            ButtonContainer().Should().HaveCount(0);
 
             //add third panel, buttons should be visible
             await comp.Instance.AddPanel();
 
-            buttonContainer.Refresh();
-            buttonContainer.Should().HaveCount(2);
+            ButtonContainer().Should().HaveCount(2);
         }
 
         [Test]
@@ -855,28 +853,25 @@ namespace MudBlazor.UnitTests.Components
             var factory = new MockResizeObserverFactory(observer);
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
 
-            var comp = Context.RenderComponent<SimplifiedScrollableTabsTest>(p => p.Add(x => x.StartAmount, 5));
+            var comp = Context.Render<SimplifiedScrollableTabsTest>(p => p.Add(x => x.StartAmount, 5));
 
-            var buttonContainer = comp.FindAll(".mud-tabs-scroll-button");
-            buttonContainer.Should().HaveCount(2);
+            IReadOnlyList<IElement> ButtonContainer() => comp.FindAll(".mud-tabs-scroll-button");
+            ButtonContainer().Should().HaveCount(2);
 
             //remove 5th panel, buttons should be visible
             await comp.Instance.RemoveLastPanel();
 
-            buttonContainer.Refresh();
-            buttonContainer.Should().HaveCount(2);
+            ButtonContainer().Should().HaveCount(2);
 
             //remove 4th panel, buttons should be visible
             await comp.Instance.RemoveLastPanel();
 
-            buttonContainer.Refresh();
-            buttonContainer.Should().HaveCount(2);
+            ButtonContainer().Should().HaveCount(2);
 
             //remove 3rd panel, buttons shouldn't be visible
             await comp.Instance.RemoveLastPanel();
 
-            buttonContainer.Refresh();
-            buttonContainer.Should().HaveCount(0);
+            ButtonContainer().Should().HaveCount(0);
         }
 
         [Test]
@@ -896,7 +891,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 for (var k = 0; k < 2; k++)
                 {
-                    var comp = Context.RenderComponent<ActivateDisabledTabsTest>();
+                    var comp = Context.Render<ActivateDisabledTabsTest>();
 
                     if (k == 0)
                     {
@@ -907,30 +902,27 @@ namespace MudBlazor.UnitTests.Components
                         await comp.Instance.EnableTabAsync(0);
                     }
 
-                    var panels = comp.FindAll(".test-panel-selector");
-                    var activePanels = comp.FindAll(".mud-tab-active");
+                    IReadOnlyList<IElement> Panels() => comp.FindAll(".test-panel-selector");
+                    IReadOnlyList<IElement> ActivePanels() => comp.FindAll(".mud-tab-active");
 
                     //checking expected default values
-                    panels.Should().HaveCount(5);
-                    activePanels.Should().HaveCount(1);
-                    panels[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
+                    Panels().Should().HaveCount(5);
+                    ActivePanels().Should().HaveCount(1);
+                    Panels()[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
 
                     for (var i = 1; i < comp.Instance.Tabs.Count; i++)
                     {
                         await invoker(comp, comp.Instance.Tabs[i]);
 
-                        panels.Refresh();
-                        activePanels.Refresh();
-
                         if (k == 0)
                         {
-                            panels[i - 1].ClassList.Contains("mud-tab-active").Should().BeFalse();
-                            panels[i].ClassList.Contains("mud-tab-active").Should().BeTrue();
+                            Panels()[i - 1].ClassList.Contains("mud-tab-active").Should().BeFalse();
+                            Panels()[i].ClassList.Contains("mud-tab-active").Should().BeTrue();
                         }
                         else
                         {
-                            panels[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
-                            panels[i].ClassList.Contains("mud-disabled").Should().BeTrue();
+                            Panels()[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
+                            Panels()[i].ClassList.Contains("mud-disabled").Should().BeTrue();
                         }
                     }
                 }
@@ -948,23 +940,21 @@ namespace MudBlazor.UnitTests.Components
 
             foreach (var invoker in activator)
             {
-                var comp = Context.RenderComponent<ActivateDisabledTabsTest>();
+                var comp = Context.Render<ActivateDisabledTabsTest>();
 
-                var panels = comp.FindAll(".test-panel-selector");
+                IReadOnlyList<IElement> Panels() => comp.FindAll(".test-panel-selector");
 
                 //checking expected default values
-                panels.Should().HaveCount(5);
-                panels[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
+                Panels().Should().HaveCount(5);
+                Panels()[0].ClassList.Contains("mud-tab-active").Should().BeTrue();
 
                 for (var i = 1; i < comp.Instance.Tabs.Count; i++)
                 {
                     invoker(comp, comp.Instance.Tabs[i]);
 
-                    panels.Refresh();
-
-                    panels[i - 1].ClassList.Contains("mud-tab-active").Should().BeFalse();
-                    panels[i].ClassList.Contains("mud-tab-active").Should().BeTrue();
-                    panels[i].ClassList.Contains("mud-disabled").Should().BeTrue();
+                    Panels()[i - 1].ClassList.Contains("mud-tab-active").Should().BeFalse();
+                    Panels()[i].ClassList.Contains("mud-tab-active").Should().BeTrue();
+                    Panels()[i].ClassList.Contains("mud-disabled").Should().BeTrue();
 
                     var contentElement = comp.Find(".test-active-panel");
 
@@ -977,7 +967,7 @@ namespace MudBlazor.UnitTests.Components
         public void SelectedIndex_Binding()
         {
             //starting with index 1:
-            var comp = Context.RenderComponent<SelectedIndexTabsTest>();
+            var comp = Context.Render<SelectedIndexTabsTest>();
             comp.Instance.Tabs.ActivePanelIndex.Should().Be(1);
             var panels = comp.FindAll(".mud-tab");
             var activePanels = comp.FindAll(".mud-tab-active");
@@ -986,7 +976,7 @@ namespace MudBlazor.UnitTests.Components
 
             //starting with index 2:
             SelectedIndexTabsTest.SelectedTab = 2;
-            comp = Context.RenderComponent<SelectedIndexTabsTest>();
+            comp = Context.Render<SelectedIndexTabsTest>();
             comp.Instance.Tabs.ActivePanelIndex.Should().Be(2);
             panels = comp.FindAll(".mud-tab");
             activePanels = comp.FindAll(".mud-tab-active");
@@ -995,7 +985,7 @@ namespace MudBlazor.UnitTests.Components
 
             //starting with index 0:
             SelectedIndexTabsTest.SelectedTab = 0;
-            comp = Context.RenderComponent<SelectedIndexTabsTest>();
+            comp = Context.Render<SelectedIndexTabsTest>();
             comp.Instance.Tabs.ActivePanelIndex.Should().Be(0);
             panels = comp.FindAll(".mud-tab");
             activePanels = comp.FindAll(".mud-tab-active");
@@ -1025,7 +1015,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TabHeaderPosition.Before)]
         public async Task RenderHeaderBasedOnPosition(TabHeaderPosition position)
         {
-            var comp = Context.RenderComponent<TabsWithHeaderTest>();
+            var comp = Context.Render<TabsWithHeaderTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabHeaderPosition, position));
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
 
@@ -1055,7 +1045,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RenderHeaderBasedOnPosition_None()
         {
-            var comp = Context.RenderComponent<TabsWithHeaderTest>();
+            var comp = Context.Render<TabsWithHeaderTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
 
@@ -1071,7 +1061,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(TabHeaderPosition.Before)]
         public async Task RenderHeaderPanelBasedOnPosition(TabHeaderPosition position)
         {
-            var comp = Context.RenderComponent<TabsWithHeaderTest>();
+            var comp = Context.Render<TabsWithHeaderTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabPanelHeaderPosition, position));
 
@@ -1106,7 +1096,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RenderHeaderPanelBasedOnPosition_None()
         {
-            var comp = Context.RenderComponent<TabsWithHeaderTest>();
+            var comp = Context.Render<TabsWithHeaderTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabHeaderPosition, TabHeaderPosition.None));
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.TabPanelHeaderPosition, TabHeaderPosition.None));
 
@@ -1117,7 +1107,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TabPanelIconColorOverridesTabIconColor()
         {
-            var comp = Context.RenderComponent<TabPanelIconColorTest>();
+            var comp = Context.Render<TabPanelIconColorTest>();
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.MudTabPanelIconColor, Color.Success));
 
             var iconRef = comp.Find(".mud-icon-root.mud-svg-icon");
@@ -1127,7 +1117,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TabPanelIconColorOverridesTabIconColorExceptWhenDisabled()
         {
-            var comp = Context.RenderComponent<TabPanelIconColorTest>();
+            var comp = Context.Render<TabPanelIconColorTest>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DisableTab, true));
             await comp.SetParametersAndRenderAsync(x => x.Add(y => y.MudTabPanelIconColor, Color.Success));
 
@@ -1139,7 +1129,7 @@ namespace MudBlazor.UnitTests.Components
         public void HtmlTextTabs()
         {
             // get the tab panels, we must have 2 tabs, one with html text and one without
-            var comp = Context.RenderComponent<HtmlTextTabsTest>();
+            var comp = Context.Render<HtmlTextTabsTest>();
             var panels = comp.FindAll(".mud-tab");
             panels.Should().HaveCount(2);
 
@@ -1160,7 +1150,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //The first tab should be active because for the rest the slider position is calculated by JS
             //and before the calculation the slider is hidden to avoid movement on first load
-            var comp = Context.RenderComponent<ToggleTabsSlideAnimationTest>(p => p.Add(x => x.SelectedTab, 0));
+            var comp = Context.Render<ToggleTabsSlideAnimationTest>(p => p.Add(x => x.SelectedTab, 0));
 
             //Set SliderAnimation to true
             //Check if style attr does not contain transform: none
@@ -1182,7 +1172,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MinimumTabWidth()
         {
-            var comp = Context.RenderComponent<MinimumWidthTabs>();
+            var comp = Context.Render<MinimumWidthTabs>();
 
             //Check if style respects minimum width from test
             comp.Find(".mud-tab").GetAttribute("style").Contains("min-width").Should().BeTrue();
@@ -1196,7 +1186,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MenuInHeaderPanelCloseOnClickOutside()
         {
-            var comp = Context.RenderComponent<TabsWithMenuInHeader>();
+            var comp = Context.Render<TabsWithMenuInHeader>();
 
             //open the menu
             comp.Find("button").Click();
@@ -1214,7 +1204,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PrePanelContent()
         {
-            var comp = Context.RenderComponent<TabsWithPrePanelContent>(p => p.Add(x => x.SelectedIndex, 0));
+            var comp = Context.Render<TabsWithPrePanelContent>(p => p.Add(x => x.SelectedIndex, 0));
 
             var content = comp.Find(".pre-panel-content-custom");
 
@@ -1238,7 +1228,7 @@ namespace MudBlazor.UnitTests.Components
         {
             Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 
-            var comp = Context.RenderComponent<CancelActivationTabsTest>();
+            var comp = Context.Render<CancelActivationTabsTest>();
             await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Position, Position.Left));
 
             await comp.Instance.SetPanelActiveAsync(2);
@@ -1266,7 +1256,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DynamicTabs_CollectionRenderSyncTest()
         {
-            var comp = Context.RenderComponent<DynamicTabsSimpleTest>();
+            var comp = Context.Render<DynamicTabsSimpleTest>();
 
             var userTabs = comp.Instance.UserTabs;
             var mudTabs = comp.FindComponent<MudDynamicTabs>();
@@ -1306,7 +1296,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TabPanel_ShowCloseIconTest()
         {
-            var comp = Context.RenderComponent<DynamicTabsSimpleTest>();
+            var comp = Context.Render<DynamicTabsSimpleTest>();
             var tabs = comp.FindAll("div.mud-tab");
             tabs[0].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeTrue();
             tabs[1].InnerHtml.Contains("mud-icon-root mud-svg-icon").Should().BeFalse(); // The close icon is not shown.
@@ -1316,7 +1306,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Tabs_HaveRipple_WhenRippleIsTrue()
         {
-            var comp = Context.RenderComponent<TabsRippleTest>(parameters => parameters.Add(p => p.Ripple, true));
+            var comp = Context.Render<TabsRippleTest>(parameters => parameters.Add(p => p.Ripple, true));
             comp.FindAll("div.mud-ripple").Count.Should().BeGreaterThan(0);
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Ripple, false));
@@ -1327,7 +1317,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public void TabPanel_Hidden_Class(bool visible)
         {
-            var comp = Context.RenderComponent<TabsVisibleTest>(parameters => parameters.Add(x => x.Visible, visible));
+            var comp = Context.Render<TabsVisibleTest>(parameters => parameters.Add(x => x.Visible, visible));
 
             var panel = comp.FindAll(".mud-tab-panel")[1];
             if (visible)
@@ -1347,7 +1337,7 @@ namespace MudBlazor.UnitTests.Components
             bool onItemDroppedCalled = false;
             MudItemDropInfo<MudTabPanel>? finalDropInfo = null;
 
-            var comp = Context.RenderComponent<TabsDragAndDropTest>(
+            var comp = Context.Render<TabsDragAndDropTest>(
                 parameters => parameters.Add(p => p.ItemDroppedFired, (MudItemDropInfo<MudTabPanel> info) =>
                 {
                     onItemDroppedCalled = true;
@@ -1383,7 +1373,7 @@ namespace MudBlazor.UnitTests.Components
         public void LabelSorting_NaturalOrderIfSortingUnspecified()
         {
             // all parameters unspecified
-            var comp = Context.RenderComponent<LabelSortTest>();
+            var comp = Context.Render<LabelSortTest>();
 
             // all labels should be present and in natural order
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
@@ -1398,7 +1388,7 @@ namespace MudBlazor.UnitTests.Components
             /* ***
              * all labels should be present and in natural order
              */
-            var comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            var comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortDirection, SortDirection.None)
             );
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
@@ -1409,7 +1399,7 @@ namespace MudBlazor.UnitTests.Components
             /* ***
              * all labels should be present and in lexicographically ascending order
              */
-            comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortDirection, SortDirection.Ascending)
             );
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
@@ -1420,7 +1410,7 @@ namespace MudBlazor.UnitTests.Components
             /* ***
              * all labels should be present and in lexicographically descending order
              */
-            comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortDirection, SortDirection.Descending)
             );
             comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab").Count.Should().Be(3);
@@ -1438,7 +1428,7 @@ namespace MudBlazor.UnitTests.Components
             /* ***
              * all labels should be present and in natural order
              */
-            var comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            var comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortDirection, SortDirection.None)
                 .Add(p => p.SortKeys, sortKeys)
             );
@@ -1452,7 +1442,7 @@ namespace MudBlazor.UnitTests.Components
             /* ***
              * all labels should be present and in lexicographically ascending order
              */
-            comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortDirection, SortDirection.Ascending)
                 .Add(p => p.SortKeys, sortKeys)
             );
@@ -1466,7 +1456,7 @@ namespace MudBlazor.UnitTests.Components
             /* ***
              * all labels should be present and in lexicographically descending order
              */
-            comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortDirection, SortDirection.Descending)
                 .Add(p => p.SortKeys, sortKeys)
             );
@@ -1487,7 +1477,7 @@ namespace MudBlazor.UnitTests.Components
              * are set to Apple=3, Banana=2, Cherry=1, so there is no combination of SortKey, Label
              * or SortDirection that could ellicit the same sort order as we get from TestComparer.
              */
-            var comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            var comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortComparer, new LabelSortTest.TestComparer())
                 .Add(p => p.SortDirection, SortDirection.Descending)
             );
@@ -1506,7 +1496,7 @@ namespace MudBlazor.UnitTests.Components
              * are set to Apple=3, Banana=2, Cherry=1, so there is no combination of SortKey, Label
              * or SortDirection that could ellicit the same sort order as we get from TestComparer.
              */
-            var comp = Context.RenderComponent<LabelSortTest>(parameters => parameters
+            var comp = Context.Render<LabelSortTest>(parameters => parameters
                 .Add(p => p.SortComparer, new LabelSortTest.TestComparer())
                 .Add(p => p.SortDirection, null)
             );
@@ -1522,7 +1512,7 @@ namespace MudBlazor.UnitTests.Components
             // defaulting the ActiveIndex to something other than 0 caused a display issue where it tried to make
             // that tab the FIRST tab putting any leading tabs underneath an arrow to "go left" (or right if rtl)
             // https://github.com/MudBlazor/MudBlazor/issues/11519
-            var comp = Context.RenderComponent<ActivatePanelDragAndDropTest>();
+            var comp = Context.Render<ActivatePanelDragAndDropTest>();
             var divs = comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab");
             // no drop container
             comp.FindAll("div.mud-drop-container").Count().Should().Be(0);
@@ -1558,7 +1548,7 @@ namespace MudBlazor.UnitTests.Components
             // and calling .Refresh() on ActivatePanel (clicking, drag and drop, etc). Basically the changes were too deep
             // for blazor to know it should update state
             // https://github.com/MudBlazor/MudBlazor/issues/11549
-            var comp = Context.RenderComponent<ActivatePanelDragAndDropTest>();
+            var comp = Context.Render<ActivatePanelDragAndDropTest>();
             var divs = comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab");
             // no drop container
             comp.FindAll("div.mud-drop-container").Count().Should().Be(0);
@@ -1599,7 +1589,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task KeyboardActivation_DisablesDisabledTab_LeftRight()
         {
-            var comp = Context.RenderComponent<TabsKeyboardAccessibilityTest>();
+            var comp = Context.Render<TabsKeyboardAccessibilityTest>();
             comp.Find("div.mud-tabs-panels").InnerHtml.Should().Contain("Content One");
 
             await comp.InvokeAsync(async () =>
@@ -1633,7 +1623,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task VerticalTabs_SupportsArrowUpDownNavigation()
         {
-            var comp = Context.RenderComponent<VerticalTabsKeyboardAccessibilityTest>();
+            var comp = Context.Render<VerticalTabsKeyboardAccessibilityTest>();
             await comp.InvokeAsync(async () =>
             {
                 var tabs = comp.FindAll("div.mud-tab");
@@ -1668,7 +1658,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task KeyboardNavigation_LeftArrow_WrapsToLastEnabledTab()
         {
-            var comp = Context.RenderComponent<TabsKeyboardAccessibilityTest>();
+            var comp = Context.Render<TabsKeyboardAccessibilityTest>();
             await comp.InvokeAsync(async () =>
             {
                 var tabs = comp.FindAll("div.mud-tab");
@@ -1702,7 +1692,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TabListId_ReturnsCorrectId()
         {
-            var comp = Context.RenderComponent<MudTabs>();
+            var comp = Context.Render<MudTabs>();
             var instance = comp.Instance;
 
             // Use reflection to set the internal field _tabListId
@@ -1726,7 +1716,7 @@ namespace MudBlazor.UnitTests.Components
         public void TabWrapperTest(bool enableDrag)
         {
             // initial pass at false fail at true, github issue 12006
-            var comp = Context.RenderComponent<TabWrapperContentTest>(t => t.Add(x => x.EnableDragAndDrop, enableDrag));
+            var comp = Context.Render<TabWrapperContentTest>(t => t.Add(x => x.EnableDragAndDrop, enableDrag));
             var wrapperDiv = comp.Find(".wrapper-class-content");
             wrapperDiv.Should().NotBeNull();
             var tooltipDiv = comp.Find(".mud-tabs-tabbar-content .mud-tooltip-root .mud-popover-cascading-value");
@@ -1742,7 +1732,7 @@ namespace MudBlazor.UnitTests.Components
             var tabButtonClasses = "class1";
             var panelClasses = "class2";
 
-            var comp = Context.RenderComponent<TabPanelCssClassesMatchTest>(parameters => parameters
+            var comp = Context.Render<TabPanelCssClassesMatchTest>(parameters => parameters
                 .Add(p => p.TabButtonClass, tabButtonClasses)
                 .Add(p => p.PanelClass, panelClasses));
 
@@ -1764,7 +1754,7 @@ namespace MudBlazor.UnitTests.Components
             var tabButtonClasses = "class1";
             var tabPanelClasses = "class2";
 
-            var comp = Context.RenderComponent<TabsCssClassesMatchTest>(parameters => parameters
+            var comp = Context.Render<TabsCssClassesMatchTest>(parameters => parameters
                 .Add(p => p.TabButtonClass, tabButtonClasses)
                 .Add(p => p.TabPanelClass, tabPanelClasses));
 
@@ -1783,7 +1773,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Tabs_And_TabPanel_CombinedClassesTest()
         {
-            var comp = Context.RenderComponent<TabsAndTabPanelCssClassesMatchTest>();
+            var comp = Context.Render<TabsAndTabPanelCssClassesMatchTest>();
 
             var tabButtons = comp.FindAll(".mud-tab");
             tabButtons.Should().AllSatisfy(x => x.ClassList.Should().Contain("mud-tabs-button-class"));
@@ -1801,14 +1791,14 @@ namespace MudBlazor.UnitTests.Components
             tabsPanels.ClassList.Should().NotContain("mud-tabs-button-class");
 
             TabsAndTabPanelCssClassesMatchTest.SelectedTab = 0;
-            comp = Context.RenderComponent<TabsAndTabPanelCssClassesMatchTest>();
+            comp = Context.Render<TabsAndTabPanelCssClassesMatchTest>();
             var activeTabPanel = comp.Find(":not(.mud-tab).mud-tab-panel");
             activeTabPanel.ClassList.Should().Contain("mud-tab-panel-panel-class-1");
             activeTabPanel.ClassList.Should().NotContain("mud-tab-panel-button-class-1");
             activeTabPanel.ClassList.Should().NotContain("mud-tabs-panel-class");
 
             TabsAndTabPanelCssClassesMatchTest.SelectedTab = 1;
-            comp = Context.RenderComponent<TabsAndTabPanelCssClassesMatchTest>();
+            comp = Context.Render<TabsAndTabPanelCssClassesMatchTest>();
             activeTabPanel = comp.Find(":not(.mud-tab).mud-tab-panel");
             activeTabPanel.ClassList.Should().Contain("mud-tab-panel-panel-class-2");
             activeTabPanel.ClassList.Should().NotContain("mud-tab-panel-button-class-2");
@@ -1821,7 +1811,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TabHeaderMouseDownEvents()
         {
-            var comp = Context.RenderComponent<ClosableTabsWithHeaderTest>();
+            var comp = Context.Render<ClosableTabsWithHeaderTest>();
 
             // Close the tab with the mouse wheel click.
             var tabs = comp.FindAll("div.mud-tab");

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -25,7 +25,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TestFieldLabelFor()
         {
-            var comp = Context.RenderComponent<FormIsValidTest3>();
+            var comp = Context.Render<FormIsValidTest3>();
             var label = comp.FindAll(".mud-input-label");
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("textFieldLabelTest");
             label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldLabelFor()
         {
-            var comp = Context.RenderComponent<FieldTest>();
+            var comp = Context.Render<FieldTest>();
             var label = comp.FindAll(".mud-input-label");
             label[0].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
             label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
@@ -50,7 +50,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextFieldTest1()
         {
-            var comp = Context.RenderComponent<MudTextField<double>>();
+            var comp = Context.Render<MudTextField<double>>();
             // print the generated html
             // select elements needed for the test
             var textfield = comp.Instance;
@@ -74,7 +74,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldTest2()
         {
-            var comp = Context.RenderComponent<MudTextField<double?>>();
+            var comp = Context.Render<MudTextField<double?>>();
             // print the generated html
             // select elements needed for the test
             var textfield = comp.Instance;
@@ -89,7 +89,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextFieldWithNullableTypes()
         {
-            var comp = Context.RenderComponent<MudTextField<int?>>(parameters => parameters.Add(p => p.Value, 17));
+            var comp = Context.Render<MudTextField<int?>>(parameters => parameters.Add(p => p.Value, 17));
             // print the generated html
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, null));
             comp.Find("input").Blur();
@@ -105,7 +105,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldConversionError()
         {
-            var comp = Context.RenderComponent<MudTextField<int?>>();
+            var comp = Context.Render<MudTextField<int?>>();
             // print the generated html
             comp.Find("input").Change("seventeen");
             comp.Find("input").Blur();
@@ -121,7 +121,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //no interval passed, so, by default is 0
             // We pass the Immediate parameter set to true, in order to bind to oninput
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.Immediate, true));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.Immediate, true));
             var textField = comp.Instance;
             var input = comp.Find("input");
             //Act
@@ -137,7 +137,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ShouldRespectDebounceIntervalPropertyInTextFieldTest()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.DebounceInterval, 200d));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.DebounceInterval, 200d));
             var textField = comp.Instance;
             var input = comp.Find("input");
             //Act
@@ -164,7 +164,7 @@ namespace MudBlazor.UnitTests.Components
         {
             //Arrange
             //with no placeholder, label is not shrinked
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.Label, "label"));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.Label, "label"));
             comp.Markup.Should().NotContain("shrink");
             //with placeholder label is shrinked
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Placeholder, "placeholder"));
@@ -177,7 +177,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void LabelShouldShrinkWhenShrinkLabelIsSet()
         {
-            var comp = Context.RenderComponent<TextFieldShrinkLabelTest>();
+            var comp = Context.Render<TextFieldShrinkLabelTest>();
             var noMask = comp.FindComponents<MudTextField<string>>()[0];
             var masked = comp.FindComponents<MudTextField<string>>()[1];
 
@@ -217,7 +217,7 @@ namespace MudBlazor.UnitTests.Components
                 .NotEmpty()
                 .Length(1, 100)
                 .CreditCard());
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.Validation, validator.Validation));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.Validation, validator.Validation));
             var textfield = comp.Instance;
             // first try a valid credit card number
             comp.Find("input").Change("4012 8888 8888 1881");
@@ -236,7 +236,7 @@ namespace MudBlazor.UnitTests.Components
         [Test, CancelAfter(1000)]
         public async Task TextFieldUpdateLoopProtectionTest()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(x => x.Converter, Conversions.From<string, string>(s => $"{s}x", s => $"{s}y")));
             // these conversion funcs are nonsense of course, but they are designed this way to
             // test against an infinite update loop that textfields and other inputs are now protected against.
@@ -253,7 +253,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextField_Should_FireValueChangedOnTextParameterChange()
         {
             string changed_value = null;
-            _ = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            _ = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.ValueChanged, x => changed_value = x)
                 .Add(p => p.Text, "A"));
             changed_value.Should().Be("A");
@@ -263,7 +263,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextField_Should_FireTextChangedOnValueParameterChange()
         {
             string changed_text = null;
-            _ = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            _ = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.TextChanged, x => changed_text = x)
                 .Add(p => p.Value, "A"));
             changed_text.Should().Be("A");
@@ -274,7 +274,7 @@ namespace MudBlazor.UnitTests.Components
         {
             string changed_value = null;
             string changed_text = null;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.ValueChanged, x => changed_value = x)
                 .Add(p => p.TextChanged, x => changed_text = x)
             );
@@ -290,7 +290,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextField_ShouldNot_ShowRequiredErrorWhenThereIsAConversionError()
         {
-            var comp = Context.RenderComponent<MudTextField<int?>>(parameters => parameters.Add(p => p.Required, true));
+            var comp = Context.Render<MudTextField<int?>>(parameters => parameters.Add(p => p.Required, true));
             var textfield = comp.Instance;
             comp.Find("input").Change("A");
             comp.Find("input").Blur();
@@ -306,7 +306,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextField_ShouldNot_ShowRequiredErrorWhenInitialTextIsEmpty()
         {
-            var comp = Context.RenderComponent<TextFieldRequiredTest>();
+            var comp = Context.Render<TextFieldRequiredTest>();
             var textfield = comp.FindComponent<MudTextField<string>>().Instance;
             textfield.Touched.Should().BeFalse();
             textfield.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
@@ -320,7 +320,7 @@ namespace MudBlazor.UnitTests.Components
         public void DebouncedTextField_ShouldNot_ThrowException()
         {
             // Arrange & Act
-            var renderComponent = () => Context.RenderComponent<DebouncedTextFieldTest>();
+            var renderComponent = () => Context.Render<DebouncedTextFieldTest>();
 
             // Assert
             renderComponent.Should().NotThrow();
@@ -330,7 +330,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldMultiline_CheckRenderedText()
         {
             var text = "Hello world!";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Text, text)
                 .Add(p => p.Lines, 2));
             // print the generated html
@@ -346,7 +346,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldMultilineWithMask_CheckRendered()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Mask, new RegexMask(@"\d"))
                 .Add(p => p.Lines, 2));
             comp.Find("textarea").Should().NotBeNull();
@@ -355,7 +355,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MultilineTextField_Should_UpdateTextOnInput()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             var textfield = comp.Instance;
             comp.Find("input").Change("A");
             comp.Find("input").Blur();
@@ -375,7 +375,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MultiLineTextField_ShouldBe_TwoWayBindable()
         {
-            var comp = Context.RenderComponent<MultilineTextfieldBindingTest>();
+            var comp = Context.Render<MultilineTextfieldBindingTest>();
             // print the generated html
             var tf1 = comp.FindComponents<MudTextField<string>>()[0].Instance;
             var tf2 = comp.FindComponents<MudTextField<string>>()[1].Instance;
@@ -399,7 +399,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutoGrowTextField_Should_InvokeJavaScriptInitOnRender()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.AutoGrow, true)
                 .Add(p => p.MaxLines, 5));
 
@@ -422,7 +422,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldClearableTest()
         {
-            var comp = Context.RenderComponent<TextFieldClearableTest>();
+            var comp = Context.Render<TextFieldClearableTest>();
             var textField = comp.FindComponent<MudTextField<string>>();
             // No button when initialized
             comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
@@ -450,7 +450,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextField_ClearButton_TabIndex_Test()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(parameter => parameter.Clearable, true)
                 .Add(x => x.Text, "Test"));
 
@@ -462,7 +462,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_Should_Validate_Data_Attribute_Fail()
         {
-            var comp = Context.RenderComponent<TextFieldValidationDataAttrTest>();
+            var comp = Context.Render<TextFieldValidationDataAttrTest>();
             var textfieldcomp = comp.FindComponent<MudTextField<string>>();
             var textfield = textfieldcomp.Instance;
             await textfieldcomp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
@@ -481,7 +481,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_Should_Validate_Data_Attribute_Success()
         {
-            var comp = Context.RenderComponent<TextFieldValidationDataAttrTest>();
+            var comp = Context.Render<TextFieldValidationDataAttrTest>();
             var textfieldcomp = comp.FindComponent<MudTextField<string>>();
             var textfield = textfieldcomp.Instance;
             await textfieldcomp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
@@ -513,7 +513,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TextField_Should_HaveCorrectMessageWithCustomAttr_Failing()
         {
             var model = new TestFailingModel();
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo)));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo)));
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
@@ -533,7 +533,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TextField_Should_HaveCorrectMessageWithCustomAttr_Override_Failing()
         {
             TestFailingModel model = new TestFailingModel2();
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.For, (Expression<Func<string>>)(() => (model as TestFailingModel2).Foo))
             //ComponentParameter.CreateParameter("ForModel", typeof(TestFailingModel2)) // Explicitly set the `For` class
             );
@@ -562,7 +562,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TextField_Should_HaveCorrectMessageWithCustomAttr_Throwing()
         {
             var model = new TestThrowingModel();
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo)));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo)));
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
@@ -575,7 +575,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_ClearTest1()
         {
-            var comp = Context.RenderComponent<MudTextField<int>>();
+            var comp = Context.Render<MudTextField<int>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Text, "17"));
             var textfield = comp.Instance;
             textfield.Value.Should().Be(17);
@@ -588,7 +588,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_ClearTest2()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             comp.Find("input").Change("Viva la ignorancia");
             var textfield = comp.Instance;
             textfield.Value.Should().Be("Viva la ignorancia");
@@ -601,7 +601,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_CharacterCount()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             var inputControl = comp.FindComponent<MudInputControl>();
             //Condition 1
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Counter, null));
@@ -632,7 +632,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_TextUpdateSuppression()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             var input = comp.FindComponent<MudInput<string>>();
             var textfield = comp.Instance;
             comp.Find("input").Change("Vat of acid");
@@ -671,7 +671,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextField_Should_UpdateOnBoundValueChange_WhenFocused_WithTextUpdateSuppressionOff()
         {
-            var comp = Context.RenderComponent<TextFieldUpdateViaBindingTest>();
+            var comp = Context.Render<TextFieldUpdateViaBindingTest>();
             var input = comp.FindComponent<MudInput<string>>();
             // this will make the input focused!
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
@@ -691,7 +691,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextField_ElementReferenceId_ShouldNot_BeEmpty()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
             var inputId = comp.Instance.InputReference.ElementReference.Id;
 
             inputId.Should().NotBeEmpty();
@@ -714,7 +714,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TextField_Data_Annotation_Resolve_Name_Of_Field()
         {
             var model = new TestDataAnnotationModel();
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo1)));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo1)));
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
@@ -733,7 +733,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TextField_Data_Annotation_Resolve_Display_Name_Of_Field()
         {
             var model = new TestDataAnnotationModel();
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo2)));
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.For, (Expression<Func<string>>)(() => model.Foo2)));
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
             comp.Instance.GetState(x => x.Error).Should().BeTrue();
             comp.Instance.ValidationErrors.Should().HaveCount(1);
@@ -746,7 +746,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var model = new TestDataAnnotationModel();
             var value = "Foo";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.For, (Expression<Func<string>>)(() => model.Foo2))
                 .Add(p => p.Value, value));
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
@@ -771,7 +771,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InputMode_DefaultValue_IsText()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
 
             comp.Instance.InputMode.Should().Be(InputMode.text);
             comp
@@ -787,7 +787,7 @@ namespace MudBlazor.UnitTests.Components
         public void InputMode_DefaultValueWithMask_IsText()
         {
             var mask = new PatternMask("0000");
-            var comp = Context.RenderComponent<MudTextField<string>>(
+            var comp = Context.Render<MudTextField<string>>(
                 x => x.Add(x => x.Mask, mask));
 
             comp.Instance.InputMode.Should().Be(InputMode.text);
@@ -803,7 +803,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InputMode_ChangedValue_IsPropagated()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(
+            var comp = Context.Render<MudTextField<string>>(
                 x => x.Add(x => x.InputMode, InputMode.numeric));
 
             comp.Instance.InputMode.Should().Be(InputMode.numeric);
@@ -820,7 +820,7 @@ namespace MudBlazor.UnitTests.Components
         public void InputMode_ChangedValueWithMask_IsPropagated()
         {
             var mask = new PatternMask("0000");
-            var comp = Context.RenderComponent<MudTextField<string>>(
+            var comp = Context.Render<MudTextField<string>>(
                 x => x
                 .Add(x => x.InputMode, InputMode.numeric)
                 .Add(x => x.Mask, mask));
@@ -838,7 +838,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_OnlyValidateIfDirty_Is_True_Should_OnlyHaveInputErrorWhenValueChanged()
         {
-            var comp = Context.RenderComponent<MudTextField<int?>>(parameters => parameters
+            var comp = Context.Render<MudTextField<int?>>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.OnlyValidateIfDirty, true));
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
@@ -881,7 +881,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_OnlyValidateIfDirty_Is_False_Should_HaveInputErrorWhenFocusChanged()
         {
-            var comp = Context.RenderComponent<MudTextField<int?>>(parameters => parameters
+            var comp = Context.Render<MudTextField<int?>>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.OnlyValidateIfDirty, false));
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
@@ -917,10 +917,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var value = new DisplayNameLabelClass();
 
-            var comp = Context.RenderComponent<MudTextField<string>>(x => x.Add(f => f.For, () => value.String));
+            var comp = Context.Render<MudTextField<string>>(x => x.Add(f => f.For, () => value.String));
             comp.Instance.Label.Should().Be("String LabelAttribute"); //label should be set by the attribute
 
-            var comp2 = Context.RenderComponent<MudTextField<string>>(x => x.Add(f => f.For, () => value.String).Add(l => l.Label, "Label Parameter"));
+            var comp2 = Context.Render<MudTextField<string>>(x => x.Add(f => f.For, () => value.String).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
 
@@ -930,7 +930,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ReadOnlyTextFieldShouldNotValidate()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
             .Add(p => p.ReadOnly, true)
             .Add(p => p.Required, true));
 
@@ -944,7 +944,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OnBlurErrorContentCaughtException()
         {
-            var comp = Context.RenderComponent<TextFieldErrorContenCaughtException>();
+            var comp = Context.Render<TextFieldErrorContenCaughtException>();
             await comp.Find("input").BlurAsync(new FocusEventArgs());
             var mudAlert = comp.FindComponent<MudAlert>();
             var text = mudAlert.Find("div.mud-alert-message");
@@ -958,7 +958,7 @@ namespace MudBlazor.UnitTests.Components
         public void OnBlurWithModifiedValueTriggerValidationOnce1()
         {
             var callCounter = 0;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Validation, (string value) => { callCounter++; return true; })
             );
             comp.Find("input").Change("A");
@@ -974,7 +974,7 @@ namespace MudBlazor.UnitTests.Components
         public void OnBlurWithModifiedValueTriggerValidationOnce2()
         {
             var callCounter = 0;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.OnlyValidateIfDirty, true)
                 .Add(p => p.Validation, (string value) => { callCounter++; return true; })
             );
@@ -991,7 +991,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task OnBlurWithModifiedValueTriggerValidationOnce3()
         {
             var callCounter = 0;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.OnlyValidateIfDirty, true)
                 .Add(p => p.Validation, async (string value) =>
                 {
@@ -1010,7 +1010,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OnKeyDownErrorContentCaughtException()
         {
-            var comp = Context.RenderComponent<TextFieldErrorContenCaughtException>();
+            var comp = Context.Render<TextFieldErrorContenCaughtException>();
             await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter", Type = "keydown" });
             var mudAlert = comp.FindComponent<MudAlert>();
             var text = mudAlert.Find("div.mud-alert-message");
@@ -1020,7 +1020,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OnKeyUpErrorContentCaughtException()
         {
-            var comp = Context.RenderComponent<TextFieldErrorContenCaughtException>();
+            var comp = Context.Render<TextFieldErrorContenCaughtException>();
             await comp.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "Enter", Type = "keyup" });
             var mudAlert = comp.FindComponent<MudAlert>();
             var text = mudAlert.Find("div.mud-alert-message");
@@ -1033,7 +1033,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DebouncedTextFieldRerenderTest()
         {
-            var comp = Context.RenderComponent<DebouncedTextFieldRerenderTest>();
+            var comp = Context.Render<DebouncedTextFieldRerenderTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             comp.Find("input").Input(new ChangeEventArgs { Value = "test" });
             // trigger first value change
@@ -1061,7 +1061,7 @@ namespace MudBlazor.UnitTests.Components
         public void DebouncedTextField_Should_RenderDefaultValueTextOnFirstRender()
         {
             var defaultValue = "test";
-            var comp = Context.RenderComponent<DebouncedTextFieldRerenderTest>(parameters => parameters
+            var comp = Context.Render<DebouncedTextFieldRerenderTest>(parameters => parameters
                 .Add(p => p.Value, defaultValue));
             var textfield = comp.FindComponent<MudTextField<string>>().Instance;
             textfield.Text.Should().Be(defaultValue);
@@ -1073,7 +1073,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DebouncedTextFieldFormatChangeRerenderTest()
         {
-            var comp = Context.RenderComponent<DebouncedTextFieldFormatChangeRerenderTest>();
+            var comp = Context.Render<DebouncedTextFieldFormatChangeRerenderTest>();
             var textField = comp.FindComponent<MudTextField<DateTime>>().Instance;
             DateTime expectedFinalDateTime = default;
             // ensure text is updated on initialize
@@ -1106,7 +1106,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldAutoGrowHasClass()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
             .Add(p => p.AutoGrow, true));
 
             comp.Find("div.mud-input").ClassList.Should().Contain("mud-input-auto-grow");
@@ -1118,7 +1118,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -1133,7 +1133,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1153,7 +1153,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1173,7 +1173,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldWithMultipleLinesAndLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.Lines, 5));
@@ -1190,7 +1190,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithMultipleLinesAndLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1211,7 +1211,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithMultipleLinesAndLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1232,7 +1232,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldWithMaskAndLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.Mask, new PatternMask("0000")));
@@ -1249,7 +1249,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithMaskAndLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
 
@@ -1273,7 +1273,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithMaskAndLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1296,7 +1296,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TextFieldWithMaskAndMultipleLinesAndLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.Mask, new PatternMask("0000"))
@@ -1314,7 +1314,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithMaskAndMultipleLinesAndLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "userattributes-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1338,7 +1338,7 @@ namespace MudBlazor.UnitTests.Components
         public void TextFieldWithMaskAndMultipleLinesAndLabelAndUserAttributesIdAndInputId_Should_UseInputIdForInputAndAccompanyingLabel()
         {
             var expectedId = "input-id";
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters
+            var comp = Context.Render<MudTextField<string>>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -1362,7 +1362,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalTextField_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1374,7 +1374,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredTextField_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Required, true));
 
             comp.Find("input").HasAttribute("required").Should().BeTrue();
@@ -1390,7 +1390,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters =>
+            var comp = Context.Render<MudTextField<string>>(parameters =>
                 parameters.Add(p => p.Required, true)
             );
             var textfield = comp.Instance;
@@ -1410,7 +1410,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredTextFieldAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>();
+            var comp = Context.Render<MudTextField<string>>();
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
             comp.Find("input").GetAttribute("aria-required").Should().Be("false");
@@ -1428,7 +1428,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalTextFieldWithAutoGrow_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.AutoGrow, true));
 
             comp.Find("textarea").HasAttribute("required").Should().BeFalse();
@@ -1441,7 +1441,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredTextFieldWithAutoGrow_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.AutoGrow, true));
 
@@ -1455,7 +1455,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredTextFieldWithAutoGrowAttributes_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.AutoGrow, true));
 
             comp.Find("textarea").HasAttribute("required").Should().BeFalse();
@@ -1474,7 +1474,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalTextFieldWithMask_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Mask, new PatternMask("0000")));
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
@@ -1487,7 +1487,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredTextFieldWithMask_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.Mask, new PatternMask("0000")));
 
@@ -1501,7 +1501,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredTextFieldWithMask_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Mask, new PatternMask("0000")));
 
             comp.Find("input").HasAttribute("required").Should().BeFalse();
@@ -1520,7 +1520,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OptionalTextFieldWithMaskAndMultipleLines_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Lines, 5)
                 .Add(p => p.Mask, new PatternMask("0000")));
 
@@ -1534,7 +1534,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RequiredTextFieldWithMaskAndMultipleLines_Should_HaveRequiredAndAriaRequiredAttributes()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Lines, 5)
                 .Add(p => p.Required, true)
                 .Add(p => p.Mask, new PatternMask("0000")));
@@ -1549,7 +1549,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredAndAriaRequiredTextFieldWithMaskAndMultipleLines_Should_BeDynamic()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Lines, 5)
                 .Add(p => p.Mask, new PatternMask("0000")));
 
@@ -1566,7 +1566,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Should_render_conversion_error_message()
         {
-            var comp = Context.RenderComponent<MudTextField<int>>(parameters => parameters
+            var comp = Context.Render<MudTextField<int>>(parameters => parameters
                 .Add(p => p.ErrorId, "error-id")
                 .Add(p => p.Text, "not a number")
                 .Add(p => p.Converter, new DummyErrorConverter()));
@@ -1588,7 +1588,7 @@ namespace MudBlazor.UnitTests.Components
             var ariaLabel = "the aria label";
             var lines = withMultipleLines ? 5 : 1;
             var mask = withMask ? new PatternMask("0000") : null;
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Adornment, adornment)
                 .Add(p => p.AdornmentIcon, Icons.Material.Filled.Accessibility)
                 .Add(p => p.AdornmentAriaLabel, ariaLabel)
@@ -1642,7 +1642,7 @@ namespace MudBlazor.UnitTests.Components
                     ? $"{inputId}-helper-text"
                     : null;
 
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.InputId, inputId)
                 .Add(p => p.HelperId, helperId)
                 .Add(p => p.HelperText, helperText)
@@ -1682,7 +1682,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ReadOnlyShouldNotHaveClearButton()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(p => p
+            var comp = Context.Render<MudTextField<string>>(p => p
                 .Add(x => x.Text, "some value")
                 .Add(x => x.Clearable, true)
                 .Add(x => x.ReadOnly, false));
@@ -1696,13 +1696,13 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void OutlineLegendRenderTest()
         {
-            var comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Variant, Variant.Outlined)
                 .Add(p => p.Label, "Test Label"));
             var elem = comp.Find("legend");
             elem.InnerHtml.Should().Be("Test Label");
 
-            comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Variant, Variant.Outlined)
                 .Add(p => p.Label, ""));
             Assert.Throws<ElementNotFoundException>(() =>
@@ -1710,14 +1710,14 @@ namespace MudBlazor.UnitTests.Components
                 elem = comp.Find("legend");
             });
 
-            comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Variant, Variant.Outlined)
                 .Add(p => p.Mask, new PatternMask("0000"))
                 .Add(p => p.Label, "test"));
             elem = comp.Find("legend");
             elem.InnerHtml.Should().Be("test");
 
-            comp = Context.RenderComponent<MudTextField<string>>(parameters => parameters
+            comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Variant, Variant.Outlined)
                 .Add(p => p.Mask, new PatternMask("0000"))
                 .Add(p => p.Label, ""));

--- a/src/MudBlazor.UnitTests/Components/TextTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextTests.cs
@@ -10,7 +10,7 @@ public class TextTests : BunitTest
     [Test]
     public void DefaultPropertyValues()
     {
-        var comp = Context.RenderComponent<MudText>();
+        var comp = Context.Render<MudText>();
 
         comp.Instance.Typo.Should().Be(Typo.body1);
         comp.Instance.Align.Should().Be(Align.Inherit);
@@ -24,7 +24,7 @@ public class TextTests : BunitTest
     public void CustomAttributes_ShouldRender()
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .AddUnmatched("data-test", "test-value")
         );
 
@@ -44,7 +44,7 @@ public class TextTests : BunitTest
     public void Align_And_RightToLeft_AppliesCorrectClass(Align align, bool rightToLeft, string expectedClass)
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .Add(p => p.Align, align)
             .Add(p => p.RightToLeft, rightToLeft)
         );
@@ -66,7 +66,7 @@ public class TextTests : BunitTest
     public void ColorProperty_AppliesCorrectClass(Color color, string expectedClass)
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .Add(p => p.Color, color)
         );
 
@@ -80,7 +80,7 @@ public class TextTests : BunitTest
     public void GutterBottom_AppliesCorrectClass(bool gutterBottom)
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .Add(p => p.GutterBottom, gutterBottom)
         );
 
@@ -99,7 +99,7 @@ public class TextTests : BunitTest
     public void ChildContent_IsRenderedInsideComponent()
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .AddChildContent("Hello, World!")
         );
 
@@ -123,7 +123,7 @@ public class TextTests : BunitTest
     public void Typo_ChangesTag(Typo typo, string expectedTag)
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .Add(p => p.Typo, typo)
         );
 
@@ -141,7 +141,7 @@ public class TextTests : BunitTest
     public void ActualTag_With_TypoProperty_Or_HtmlTagProperty(Typo typo, string htmlTag, string expectedTag)
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .Add(p => p.Typo, typo)
             .Add(p => p.HtmlTag, htmlTag)
         );
@@ -155,7 +155,7 @@ public class TextTests : BunitTest
     public void InlineProperty_AppliesCorrectClass(bool inline)
     {
         // Arrange
-        var comp = Context.RenderComponent<MudText>(builder => builder
+        var comp = Context.Render<MudText>(builder => builder
             .Add(p => p.Inline, inline)
         );
 

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -26,7 +26,7 @@ namespace MudBlazor.UnitTests.Components
             CultureInfo.CurrentCulture = culture;
             CultureInfo.CurrentUICulture = culture;
 
-            var comp = Context.RenderComponent<MudThemeProvider>();
+            var comp = Context.Render<MudThemeProvider>();
 
             var styleNodes = comp.Nodes.OfType<IHtmlStyleElement>().ToArray();
             styleNodes.Should().HaveCount(3);
@@ -258,7 +258,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void IsDarkModeTest()
         {
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.IsDarkMode, true));
             comp.Should().NotBeNull();
             comp.Instance.GetState(x => x.IsDarkMode).Should().BeTrue();
@@ -326,7 +326,7 @@ namespace MudBlazor.UnitTests.Components
                 systemMockValue = newValue;
                 return Task.CompletedTask;
             }
-            var comp = Context.RenderComponent<MudThemeProvider>();
+            var comp = Context.Render<MudThemeProvider>();
             await comp.Instance.WatchSystemDarkModeAsync(SystemChangedResult);
             await comp.Instance.SystemDarkModeChangedAsync(true);
             systemMockValue.Should().BeTrue();
@@ -347,7 +347,7 @@ namespace MudBlazor.UnitTests.Components
                     Scope = scope
                 }
             };
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters.Add(p => p.Theme, mudTheme));
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters.Add(p => p.Theme, mudTheme));
             comp.Should().NotBeNull();
 
             var styleNodes = comp.Nodes.OfType<IHtmlStyleElement>().ToArray();
@@ -378,7 +378,7 @@ namespace MudBlazor.UnitTests.Components
                     Scope = Scope
                 }
             };
-            var comp = Context.RenderComponent<MudThemeProvider>(
+            var comp = Context.Render<MudThemeProvider>(
                 parameters =>
                     parameters.Add(p => p.Theme, mudTheme)
                         .Add(p => p.IsDarkMode, true)
@@ -409,7 +409,7 @@ namespace MudBlazor.UnitTests.Components
             // Arrange & Act
             Context.JSInterop.SetupVoid("stopWatchingDarkThemeMedia");
             Context.JSInterop.SetupVoid("watchDarkThemeMedia");
-            var themeProvider = Context.RenderComponent<ThemeProviderObserveSystemDarkModeChangeTest>();
+            var themeProvider = Context.Render<ThemeProviderObserveSystemDarkModeChangeTest>();
 
             // Assert
             Context.JSInterop.VerifyNotInvoke("watchDarkThemeMedia");
@@ -431,14 +431,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Dispose_ShouldInvokeJs()
+        public async Task Dispose_ShouldInvokeJs()
         {
             // Arrange
             Context.JSInterop.SetupVoid("stopWatchingDarkThemeMedia");
-            Context.RenderComponent<MudThemeProvider>();
+            Context.Render<MudThemeProvider>();
 
             //Act
-            Context.DisposeComponents();
+            await Context.DisposeComponentsAsync();
 
             // Assert
             Context.JSInterop.VerifyInvoke("stopWatchingDarkThemeMedia");
@@ -449,7 +449,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Act & Arrange
             Context.JSInterop.SetupVoid("watchDarkThemeMedia");
-            Context.RenderComponent<MudThemeProvider>();
+            Context.Render<MudThemeProvider>();
 
             // Assert
             Context.JSInterop.VerifyInvoke("watchDarkThemeMedia");
@@ -470,7 +470,7 @@ namespace MudBlazor.UnitTests.Components
                     Scope = Scope
                 }
             };
-            var comp = Context.RenderComponent<MudThemeProvider>(
+            var comp = Context.Render<MudThemeProvider>(
                 parameters =>
                     parameters.Add(p => p.Theme, mudTheme)
                         .Add(p => p.IsDarkMode, true)
@@ -487,7 +487,7 @@ namespace MudBlazor.UnitTests.Components
         public void CurrentPalette_ShouldBeLight_WhenNotInDarkMode()
         {
             // Arrange & Act
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.IsDarkMode, false));
 
             // Assert
@@ -499,7 +499,7 @@ namespace MudBlazor.UnitTests.Components
         public void CurrentPalette_ShouldBeDark_WhenInDarkMode()
         {
             // Arrange & Act
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.IsDarkMode, true));
 
             // Assert
@@ -511,7 +511,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CurrentPalette_ShouldUpdateToLight_WhenDarkModeChangesToFalse()
         {
             // Arrange
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.IsDarkMode, true));
 
             // Verify initial state
@@ -529,7 +529,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CurrentPalette_ShouldUpdateToDark_WhenDarkModeChangesToTrue()
         {
             // Arrange
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.IsDarkMode, false));
 
             // Verify initial state
@@ -556,7 +556,7 @@ namespace MudBlazor.UnitTests.Components
             };
 
             // Act
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.Theme, customTheme)
                 .Add(p => p.IsDarkMode, false));
 
@@ -571,7 +571,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
             Palette? capturedPalette = null;
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.IsDarkMode, false)
                 .Add(p => p.CurrentPaletteChanged, EventCallback.Factory.Create<Palette?>(this, palette => capturedPalette = palette)));
 
@@ -604,7 +604,7 @@ namespace MudBlazor.UnitTests.Components
                 }
             };
 
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.Theme, theme1)
                 .Add(p => p.IsDarkMode, false));
 
@@ -635,7 +635,7 @@ namespace MudBlazor.UnitTests.Components
                 }
             };
 
-            var comp = Context.RenderComponent<MudThemeProvider>(parameters => parameters
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
                 .Add(p => p.Theme, customTheme)
                 .Add(p => p.IsDarkMode, false));
 
@@ -654,7 +654,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CurrentPalette_Binding_ShouldWorkInTestComponent()
         {
             // Arrange
-            var comp = Context.RenderComponent<ThemeProviderCurrentPaletteTest>();
+            var comp = Context.Render<ThemeProviderCurrentPaletteTest>();
 
             // Initial state - light mode
             comp.Instance.GetCurrentPalette().Should().BeOfType<PaletteLight>();

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -14,11 +14,11 @@ namespace MudBlazor.UnitTests.Components
             IRenderedComponent<SimpleTimePickerTest> comp;
             if (parameterBuilder is null)
             {
-                comp = Context.RenderComponent<SimpleTimePickerTest>();
+                comp = Context.Render<SimpleTimePickerTest>();
             }
             else
             {
-                comp = Context.RenderComponent<SimpleTimePickerTest>(parameterBuilder);
+                comp = Context.Render<SimpleTimePickerTest>(parameterBuilder);
             }
 
             // should not be open
@@ -33,7 +33,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TimePickerOpenButtonDefaultAriaLabel()
         {
-            var comp = Context.RenderComponent<MudTimePicker>();
+            var comp = Context.Render<MudTimePicker>();
             var openButton = comp.Find(".mud-input-adornment button");
             openButton.Attributes.GetNamedItem("aria-label")?.Value.Should().Be("Open");
         }
@@ -41,7 +41,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TimePicker_Should_Clear()
         {
-            var comp = Context.RenderComponent<MudTimePicker>();
+            var comp = Context.Render<MudTimePicker>();
             // select elements needed for the test
             var picker = comp.Instance;
             picker.ReadOnly.Should().Be(false);
@@ -159,7 +159,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InputStringValues_CheckParsing()
         {
-            var comp = Context.RenderComponent<MudTimePicker>();
+            var comp = Context.Render<MudTimePicker>();
             var picker = comp.Instance;
 
             // valid time
@@ -197,7 +197,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Open_Programmatically_CheckOpen_Close_Programmatically_CheckClosed()
         {
-            var comp = Context.RenderComponent<SimpleTimePickerTest>();
+            var comp = Context.Render<SimpleTimePickerTest>();
             comp.FindAll("div.mud-picker-content").Count.Should().Be(0);
             // clicking the button should open the picker
             await comp.Instance.Open();
@@ -210,7 +210,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TimePickerTest_KeyboardNavigation()
         {
-            var comp = Context.RenderComponent<SimpleTimePickerTest>();
+            var comp = Context.Render<SimpleTimePickerTest>();
             var timePickerComponent = comp.FindComponent<MudTimePicker>();
             var timePicker = timePickerComponent.Instance;
 
@@ -318,7 +318,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DatePickerWithLabel_Should_GenerateIdForInputAndAccompanyingLabel()
         {
-            var comp = Context.RenderComponent<MudTimePicker>(parameters
+            var comp = Context.Render<MudTimePicker>(parameters
                 => parameters.Add(p => p.Label, "Test Label"));
 
             comp.Find("input").Id.Should().NotBeNullOrEmpty();
@@ -333,7 +333,7 @@ namespace MudBlazor.UnitTests.Components
         public void DatePickerWithLabelAndUserAttributesId_Should_UseUserAttributesIdForInputAndAccompanyingLabel()
         {
             var expectedId = "test-id";
-            var comp = Context.RenderComponent<MudTimePicker>(parameters
+            var comp = Context.Render<MudTimePicker>(parameters
                 => parameters
                     .Add(p => p.Label, "Test Label")
                     .Add(p => p.UserAttributes, new Dictionary<string, object>
@@ -349,7 +349,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TimePickerInputId()
         {
-            var comp = Context.RenderComponent<SimpleTimePickerTest>(parameters => parameters
+            var comp = Context.Render<SimpleTimePickerTest>(parameters => parameters
                 .Add(c => c.InputId, "start-time"));
 
             comp.Find("input[id='start-time']").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/TimelineTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimelineTests.cs
@@ -17,7 +17,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TimelineTest_DefaultValues()
         {
-            var comp = Context.RenderComponent<MudTimeline>();
+            var comp = Context.Render<MudTimeline>();
 
             comp.Instance.TimelineOrientation.Should().Be(TimelineOrientation.Vertical);
             comp.Instance.TimelinePosition.Should().Be(TimelinePosition.Alternate);
@@ -34,7 +34,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TimelineTest()
         {
-            var comp = Context.RenderComponent<TimelineTest>();
+            var comp = Context.Render<TimelineTest>();
             // print the generated html
             //// select elements needed for the test
             var timeline = comp.FindComponent<MudTimeline>().Instance;
@@ -100,7 +100,7 @@ namespace MudBlazor.UnitTests.Components
 
         public async Task TimelineTest_Position(TimelineOrientation orientation, TimelinePosition position, bool rtl, string[] expectedClass)
         {
-            var comp = Context.RenderComponent<TimelineTest>(p => p.AddCascadingValue("RightToLeft", rtl));
+            var comp = Context.Render<TimelineTest>(p => p.AddCascadingValue("RightToLeft", rtl));
 
             var timeline = comp.FindComponent<MudTimeline>();
 
@@ -120,7 +120,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TimelineTest_SelectItem()
         {
-            var comp = Context.RenderComponent<TimelineTest>();
+            var comp = Context.Render<TimelineTest>();
 
             var itemsDiv = comp.FindAll(".mud-timeline-item");
 
@@ -137,7 +137,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TimelineTest_DotStyles()
         {
-            var comp = Context.RenderComponent<TimelineTest>();
+            var comp = Context.Render<TimelineTest>();
             var firstItem = comp.FindComponent<MudTimelineItem>();
             comp.Find("div.mud-timeline-item-dot-inner").GetStyle()["background-color"].Should().Be("");
 
@@ -155,7 +155,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void HorizontalTimelineInsideVerticalTimeline_Test()
         {
-            var comp = Context.RenderComponent<HorizontalTimelineInsideVerticalTimelineTest>();
+            var comp = Context.Render<HorizontalTimelineInsideVerticalTimelineTest>();
             // select elements needed for the test
             var timeline = comp.FindComponent<MudTimeline>().Instance;
             // validating some renders

--- a/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleGroupTests.cs
@@ -21,7 +21,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_Bind_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupBindTest>();
+            var comp = Context.Render<ToggleGroupBindTest>();
             var toggleFirst = comp.FindComponents<MudToggleGroup<string>>().First();
             var toggleSecond = comp.FindComponents<MudToggleGroup<string>>().Last();
             IElement ToggleItem() => comp.FindAll(".mud-toggle-item").GetItemByIndex(1);
@@ -36,7 +36,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_CustomFragmentBind_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupCustomFragmentTest>();
+            var comp = Context.Render<ToggleGroupCustomFragmentTest>();
             var toggleFirst = comp.FindComponents<MudToggleGroup<string>>().First();
             var toggleSecond = comp.FindComponents<MudToggleGroup<string>>().Last();
             IElement ToggleItem() => comp.FindAll(".mud-toggle-item").GetItemByIndex(1);
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_SelectionMode_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupBindMultiSelectionTest>();
+            var comp = Context.Render<ToggleGroupBindMultiSelectionTest>();
             var group1 = comp.FindComponents<MudToggleGroup<string>>().First();
             var group2 = comp.FindComponents<MudToggleGroup<string>>().Last();
             IElement ToggleItemSecond() => comp.FindAll(".mud-toggle-item").GetItemByIndex(1);
@@ -73,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_Initialize_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupInitializeTest>();
+            var comp = Context.Render<ToggleGroupInitializeTest>();
             var toggleFirst = comp.FindComponents<MudToggleGroup<string>>().First();
             var toggleSecond = comp.FindComponents<MudToggleGroup<string>>().Last();
 
@@ -90,7 +90,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_ToggleSelection_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupToggleSelectionTest>();
+            var comp = Context.Render<ToggleGroupToggleSelectionTest>();
             var toggle = comp.FindComponent<MudToggleGroup<string>>();
             IElement ToggleItem() => comp.FindAll(".mud-toggle-item").GetItemByIndex(0);
 
@@ -104,7 +104,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_ToggleRemove_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupRemoveTest>();
+            var comp = Context.Render<ToggleGroupRemoveTest>();
             var toggle = comp.FindComponent<MudToggleGroup<string>>();
             var toggleGroup = toggle.Instance;
             IElement Button() => comp.Find("#remove_btn");
@@ -120,7 +120,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Size.Large)]
         public void ToggleGroup_SizeClasses_Test(Size size)
         {
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            var comp = Context.Render<MudToggleGroup<string>>(builder =>
             {
                 builder.Add(x => x.Size, size);
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"));
@@ -151,7 +151,7 @@ namespace MudBlazor.UnitTests.Components
         [Test(Description = "Ensures the checkmark is a direct descendant of the button label, is using the right name, and correctly contains a custom class definition")]
         public void ToggleGroup_CheckMarkClass()
         {
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            var comp = Context.Render<MudToggleGroup<string>>(builder =>
             {
                 builder.Add(x => x.CheckMarkClass, "c69");
                 builder.Add(x => x.CheckMark, true);
@@ -164,7 +164,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_ItemRegistration_Test()
         {
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            var comp = Context.Render<MudToggleGroup<string>>(builder =>
             {
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"));
                 builder.AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"));
@@ -184,7 +184,7 @@ namespace MudBlazor.UnitTests.Components
             Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider)); //set up the logging provider
             foreach (var mode in new[] { SelectionMode.SingleSelection, SelectionMode.ToggleSelection })
             {
-                Context.RenderComponent<MudToggleGroup<string>>(builder =>
+                Context.Render<MudToggleGroup<string>>(builder =>
                 {
                     builder.Add(x => x.SelectionMode, mode);
                     builder.Add(x => x.ValuesChanged, new Action<IEnumerable<string>>(_ => { }));
@@ -192,7 +192,7 @@ namespace MudBlazor.UnitTests.Components
                 logger!.GetEntries().Last().Level.Should().Be(LogLevel.Warning);
                 logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {mode} you should bind {nameof(MudToggleGroup<string>.Value)} instead of {nameof(MudToggleGroup<string>.Values)}");
             }
-            Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            Context.Render<MudToggleGroup<string>>(builder =>
             {
                 builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
                 builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
@@ -201,7 +201,7 @@ namespace MudBlazor.UnitTests.Components
             logger.GetEntries().Last().Message.Should().Be($"For SelectionMode {SelectionMode.MultiSelection} you should bind {nameof(MudToggleGroup<string>.Values)} instead of {nameof(MudToggleGroup<string>.Value)}");
             logger.GetEntries().Count.Should().Be(3);
             // no warning if both are bound
-            Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            Context.Render<MudToggleGroup<string>>(builder =>
             {
                 builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
                 builder.Add(x => x.ValueChanged, new Action<string>(_ => { }));
@@ -209,7 +209,7 @@ namespace MudBlazor.UnitTests.Components
             });
             logger.GetEntries().Count.Should().Be(3);
             // no warning if none are bound
-            Context.RenderComponent<MudToggleGroup<string>>(builder =>
+            Context.Render<MudToggleGroup<string>>(builder =>
             {
                 builder.Add(x => x.SelectionMode, SelectionMode.MultiSelection);
             });
@@ -219,7 +219,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_Disabled_Test()
         {
-            var comp = Context.RenderComponent<ToggleGroupDisabledTest>();
+            var comp = Context.Render<ToggleGroupDisabledTest>();
             var toggleGroups = comp.FindComponents<MudToggleGroup<string>>();
             var disabledToggleGroup = toggleGroups[0];
             var enabledToggleGroup = toggleGroups[1];
@@ -248,7 +248,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ToggleGroup_SetSelectedFromValuesTest(SelectionMode selMode, string selectedValues)
         {
             // Arrange
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.SelectionMode, selMode)
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"))
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"))
@@ -299,7 +299,7 @@ namespace MudBlazor.UnitTests.Components
         public void ToggleGroup_UnselectPreviousValue_OnToggle_Test(SelectionMode selMode)
         {
             // Arrange
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.SelectionMode, selMode)
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"))
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"))
@@ -332,7 +332,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ToggleGroup_SetSelectedFromValuesTest_WithAsyncItems(SelectionMode selMode, string selectedValues)
         {
             // Arrange
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.SelectionMode, selMode)
                 .AddChildContent<Virtualize<string>>(v =>
                     v.Add(x => x.Items, ["a", "b", "c"])
@@ -382,7 +382,7 @@ namespace MudBlazor.UnitTests.Components
         public void ToggleGroup_RTLTest(bool isRTL)
         {
             // Arrange
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.RightToLeft, isRTL)
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"))
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"))
@@ -406,7 +406,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ToggleGroup_VerticalTest()
         {
             // Arrange & Act
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.Vertical, true)
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"))
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"))
@@ -430,7 +430,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ToggleGroup_FixedContentTest()
         {
             // Arrange & Act
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.FixedContent, true)
                 .Add(p => p.CheckMark, true)
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"))
@@ -450,7 +450,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task ToggleGroup_MultipleSelectionTest()
         {
             // Arrange
-            var comp = Context.RenderComponent<MudToggleGroup<string>>(parameters => parameters
+            var comp = Context.Render<MudToggleGroup<string>>(parameters => parameters
                 .Add(p => p.SelectionMode, SelectionMode.MultiSelection)
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "a"))
                 .AddChildContent<MudToggleItem<string>>(item => item.Add(x => x.Value, "b"))
@@ -503,7 +503,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToggleGroup_ToggleSelectionTest()
         {
-            var comp = Context.RenderComponent<ToggleGroupInterceptValueTest>();
+            var comp = Context.Render<ToggleGroupInterceptValueTest>();
             IElement GetYesButton() => comp.FindAll(".mud-toggle-group .mud-toggle-item")[0];
             IElement GetNoButton() => comp.FindAll(".mud-toggle-group .mud-toggle-item")[1];
             IElement GetMaybeButton() => comp.FindAll(".mud-toggle-group .mud-toggle-item")[2];

--- a/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
+++ b/src/MudBlazor.UnitTests/Components/ToggleIconButtonTest.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DefaultState()
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>();
+            var comp = Context.Render<MudToggleIconButton>();
             comp.Instance.Toggled.Should().BeFalse();
             comp.Instance.Icon.Should().BeNull();
             comp.Instance.ToggledIcon.Should().BeNull();
@@ -32,7 +32,7 @@ namespace MudBlazor.UnitTests.Components
         public void ShouldToggleOnClick()
         {
             var boundValue = false;
-            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+            var comp = Context.Render<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Toggled, boundValue)
                 .Add(p => p.ToggledChanged, (toggleValue) => boundValue = toggleValue)
             );
@@ -42,14 +42,12 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("button").Click();
             boundValue.Should().BeFalse();
-
-            comp.RenderCount.Should().Be(3);
         }
 
         [Test]
         public void ShouldSetAriaPressedAttribute()
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>();
+            var comp = Context.Render<MudToggleIconButton>();
 
             comp.Find("button").GetAttribute("aria-pressed").Should().Be("false");
 
@@ -63,7 +61,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ShouldSynchronizeStateWithOtherComponent()
         {
-            var comp = Context.RenderComponent<ToggleIconButtonTest1>();
+            var comp = Context.Render<ToggleIconButtonTest1>();
             // select elements needed for the test
             var group = comp.FindComponents<MudToggleIconButton>();
             var comp1 = group[0];
@@ -81,7 +79,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Disabled_ShouldPreventInteraction()
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+            var comp = Context.Render<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Disabled, true)
             );
 
@@ -100,7 +98,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("icon-default", null, "icon-default", "icon-default")]
         public void GetIcon_ShouldReturnCorrectValue(string icon, string toggledIcon, string expectedIcon, string expectedToggledIcon)
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+            var comp = Context.Render<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Icon, icon)
                 .Add(p => p.ToggledIcon, toggledIcon)
             );
@@ -119,7 +117,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Size.Small, null, Size.Small, Size.Small)]
         public void GetSize_ShouldReturnCorrectValue(Size size, Size? toggledSize, Size expectedSize, Size expectedToggledSize)
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+            var comp = Context.Render<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Size, size)
                 .Add(p => p.ToggledSize, toggledSize)
             );
@@ -138,7 +136,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Tertiary, null, Color.Tertiary, Color.Tertiary)]
         public void GetColor_ShouldReturnCorrectValue(Color color, Color? toggledColor, Color expectedColor, Color expectedToggledColor)
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+            var comp = Context.Render<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Color, color)
                 .Add(p => p.ToggledColor, toggledColor)
             );
@@ -157,7 +155,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Variant.Outlined, null, Variant.Outlined, Variant.Outlined)]
         public void GetVariant_ShouldReturnCorrectValue(Variant variant, Variant? toggledVariant, Variant expectedVariant, Variant expectedToggledVariant)
         {
-            var comp = Context.RenderComponent<MudToggleIconButton>(parameters => parameters
+            var comp = Context.Render<MudToggleIconButton>(parameters => parameters
                 .Add(p => p.Variant, variant)
                 .Add(p => p.ToggledVariant, toggledVariant)
             );

--- a/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolBarTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToolBarWrapContentTest()
         {
-            var component = Context.RenderComponent<ToolBarWrapContentTest>();
+            var component = Context.Render<ToolBarWrapContentTest>();
             var mudToolBar = component.Find(".mud-toolbar");
 
             mudToolBar.ClassList.Should().Contain("mud-toolbar-wrap-content");
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void ToolBar_WrapContent_ShouldBeFalseByDefault()
         {
-            var comp = Context.RenderComponent<MudToolBar>();
+            var comp = Context.Render<MudToolBar>();
             comp.Instance.WrapContent.Should().Be(false);
         }
     }

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -30,7 +30,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public async Task RenderContent(bool usingFocusout)
         {
-            var comp = Context.RenderComponent<TooltipWithTextTest>(p => p.Add(
+            var comp = Context.Render<TooltipWithTextTest>(p => p.Add(
                 x => x.TooltipTextContent, "my tooltip content text"
                 ));
 
@@ -82,7 +82,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NoPopoverIfThereIsNoContent()
         {
-            var comp = Context.RenderComponent<TooltipWithTextTest>(p => p.Add(
+            var comp = Context.Render<TooltipWithTextTest>(p => p.Add(
                 x => x.TooltipTextContent, null
                 ));
 
@@ -101,7 +101,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true)]
         public async Task RenderTooltipFragment(bool usingFocusout)
         {
-            var comp = Context.RenderComponent<TooltipWithRenderFragmentContentTest>();
+            var comp = Context.Render<TooltipWithRenderFragmentContentTest>();
 
             // content should always be visible
             var button = comp.Find("#sample-button");
@@ -148,7 +148,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true, new[] { "mud-tooltip-root", "mud-tooltip-inline" })]
         public void ContainerClass_PropertyRelations(bool inlineValue, string[] expectedClasses)
         {
-            var comp = Context.RenderComponent<ToolTipContainerPropertyTest>(p =>
+            var comp = Context.Render<ToolTipContainerPropertyTest>(p =>
             p.Add(x => x.Inline, inlineValue));
 
             comp.Nodes.Last().Should().BeAssignableTo<IHtmlElement>();
@@ -161,7 +161,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task InnerClass_ChildContentWrapper()
         {
-            var comp = Context.RenderComponent<ToolTipPopoverClassPropertyTest>();
+            var comp = Context.Render<ToolTipPopoverClassPropertyTest>();
 
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onpointerenter", new PointerEventArgs());
@@ -176,7 +176,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(true, new[] { "mud-tooltip", "mud-tooltip-arrow" })]
         public async Task PopoverClass_PropertyArrow(bool arrowValue, string[] expectedClasses)
         {
-            var comp = Context.RenderComponent<ToolTipPopoverClassPropertyTest>(p =>
+            var comp = Context.Render<ToolTipPopoverClassPropertyTest>(p =>
             p.Add(x => x.Arrow, arrowValue));
 
             var button = comp.Find("button");
@@ -194,7 +194,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Dark, new[] { "mud-tooltip", "mud-theme-dark" })]
         public async Task PopoverClass_PropertyColor(Color colorValue, string[] expectedClasses)
         {
-            var comp = Context.RenderComponent<ToolTipPopoverClassPropertyTest>(p =>
+            var comp = Context.Render<ToolTipPopoverClassPropertyTest>(p =>
             p.Add(x => x.Color, colorValue));
 
             var button = comp.Find("button");
@@ -212,7 +212,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Success, false, new[] { "mud-tooltip", "mud-theme-success" })]
         public async Task PopoverClass_PropertyColorAndArrow(Color colorValue, bool arrowValue, string[] expectedClasses)
         {
-            var comp = Context.RenderComponent<ToolTipPopoverClassPropertyTest>(p =>
+            var comp = Context.Render<ToolTipPopoverClassPropertyTest>(p =>
             {
                 p.Add(x => x.Color, colorValue);
                 p.Add(x => x.Arrow, arrowValue);
@@ -242,7 +242,7 @@ namespace MudBlazor.UnitTests.Components
 
         public async Task PopoverClass_Placement(Placement placementValue, bool rtlValue, string[] expectedClasses)
         {
-            var comp = Context.RenderComponent<ToolTipPlacementPropertyTest>(p =>
+            var comp = Context.Render<ToolTipPlacementPropertyTest>(p =>
             {
                 p.Add(x => x.Placement, placementValue);
                 p.Add(x => x.RightToLeft, rtlValue);
@@ -259,7 +259,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Tooltip_On_Focus()
         {
-            var comp = Context.RenderComponent<ToolTipPlacementPropertyTest>();
+            var comp = Context.Render<ToolTipPlacementPropertyTest>();
 
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onfocusin", new FocusEventArgs());
@@ -272,7 +272,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Tooltip_On_Click()
         {
-            var comp = Context.RenderComponent<TooltipClickTest>();
+            var comp = Context.Render<TooltipClickTest>();
             var tooltipComp = comp.FindComponent<MudTooltip>().Instance;
             tooltipComp.Visible.Should().BeFalse();
             var button = comp.Find("button");
@@ -288,7 +288,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task Visible_ByDefault(bool usingFocusout)
         {
-            var comp = Context.RenderComponent<TooltipVisiblePropTest>(p =>
+            var comp = Context.Render<TooltipVisiblePropTest>(p =>
             {
                 p.Add(x => x.TooltipVisible, true);
             });
@@ -315,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Tooltip_Style_Respected()
         {
-            var comp = Context.RenderComponent<TestComponents.Tooltip.TooltipStylingTest>();
+            var comp = Context.Render<TestComponents.Tooltip.TooltipStylingTest>();
             var tooltipComp = comp.FindComponent<MudTooltip>().Instance;
             var button = comp.Find("button");
             await button.ParentElement.TriggerEventAsync("onpointerup", new PointerEventArgs());
@@ -327,7 +327,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Tooltip_Disabled_Default_False()
         {
-            var comp = Context.RenderComponent<TooltipDisabledPropertyTest>();
+            var comp = Context.Render<TooltipDisabledPropertyTest>();
             var tooltipComp = comp.FindComponent<MudTooltip>().Instance;
             tooltipComp.Disabled.Should().BeFalse();
         }
@@ -335,7 +335,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Tooltip_Disabled_Button_OnFocusIn_NoPopover()
         {
-            var comp = Context.RenderComponent<TooltipDisabledPropertyTest>(p =>
+            var comp = Context.Render<TooltipDisabledPropertyTest>(p =>
             {
                 p.Add(x => x.TooltipDisabled, true);
             });
@@ -348,7 +348,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Tooltip_Disabled_Button_OnPointerEnter_NoPopover()
         {
-            var comp = Context.RenderComponent<TooltipDisabledPropertyTest>(p =>
+            var comp = Context.Render<TooltipDisabledPropertyTest>(p =>
             {
                 p.Add(x => x.TooltipDisabled, true);
             });
@@ -363,7 +363,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false)]
         public async Task Tooltip_Handle_Pointer_Events(bool showOnHover)
         {
-            var comp = Context.RenderComponent<MudTooltip>(parameters => parameters
+            var comp = Context.Render<MudTooltip>(parameters => parameters
                 .Add(x => x.ShowOnHover, showOnHover)
                 .Add(x => x.ShowOnClick, true)
                 .Add(x => x.Text, "tooltip text")

--- a/src/MudBlazor.UnitTests/Components/TooltipViewerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TooltipViewerTests.cs
@@ -11,7 +11,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Tooltip_InlineTrue_Allows_FullWidth_Child()
         {
-            var comp = Context.RenderComponent<TooltipFullWidthViewerTest>();
+            var comp = Context.Render<TooltipFullWidthViewerTest>();
 
             var inlineWrapper = comp.Find(".mud-tooltip-root.mud-tooltip-inline");
             inlineWrapper.Should().NotBeNull();
@@ -22,7 +22,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Tooltip_InlineFalse_Control_Renders_FullWidth_Child()
         {
-            var comp = Context.RenderComponent<TooltipFullWidthViewerTest>();
+            var comp = Context.Render<TooltipFullWidthViewerTest>();
             comp.Find("#btn-block-full").TagName.Should().Be("BUTTON");
         }
     }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_ClickWhileDisabled_DoesNotChangeSelection()
         {
-            var comp = Context.RenderComponent<DisabledTreeViewTest>(parameters => parameters.Add(x => x.Disabled, true));
+            var comp = Context.Render<DisabledTreeViewTest>(parameters => parameters.Add(x => x.Disabled, true));
             comp.Find("div.mud-treeview-item-content").Click();
             var GetSelectedValue = () => comp.Find("p.selected-value").TrimmedText();
             GetSelectedValue().Should().BeNullOrWhiteSpace();
@@ -27,7 +27,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_ClickWhileActive_DoesChangeSelection()
         {
-            var comp = Context.RenderComponent<DisabledTreeViewTest>(self => self.Add(x => x.Disabled, false));
+            var comp = Context.Render<DisabledTreeViewTest>(self => self.Add(x => x.Disabled, false));
             comp.Find("div.mud-treeview-item-content").Click();
             var GetSelectedValue = () => comp.Find("p.selected-value").TrimmedText();
             GetSelectedValue().Should().NotBeNullOrWhiteSpace();
@@ -47,14 +47,14 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("item1.2")]
         public void TreeViewWithSingleSelection_Should_RespectInitialSelectedValue(string value)
         {
-            var comp = Context.RenderComponent<SimpleTreeViewTest>(self => self.Add(x => x.SelectedValue, value));
+            var comp = Context.Render<SimpleTreeViewTest>(self => self.Add(x => x.SelectedValue, value));
             comp.Find("div.mud-treeview-item-selected").QuerySelector(".mud-treeview-item-label").TrimmedText().Should().Be(value);
         }
 
         [Test]
         public void TreeViewWith_SingleSelection_TwoWayBindingTest()
         {
-            var comp = Context.RenderComponent<TreeViewSelectionBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));
+            var comp = Context.Render<TreeViewSelectionBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));
             // check initial selection
             comp.Find(".tree1 .item-1 .mud-treeview-item-content").ClassList.Should().NotContain("mud-treeview-item-selected");
             comp.Find(".tree2 .item-1 .mud-treeview-item-content").ClassList.Should().NotContain("mud-treeview-item-selected");
@@ -98,7 +98,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewWith_ToggleSelection_TwoWayBindingTest()
         {
-            var comp = Context.RenderComponent<TreeViewSelectionBindingTest>(self => self
+            var comp = Context.Render<TreeViewSelectionBindingTest>(self => self
                 .Add(x => x.SelectedValue, "item1.2")
                 .Add(x => x.SelectionMode, SelectionMode.ToggleSelection));
             // check initial selection
@@ -144,7 +144,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewWith_MultiSelection_TwoWayBindingTest()
         {
-            var comp = Context.RenderComponent<TreeViewSelectionBindingTest>(self => self
+            var comp = Context.Render<TreeViewSelectionBindingTest>(self => self
                 .Add(x => x.SelectedValues, ["item1", "item1.2"])
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             // check initial selection
@@ -186,7 +186,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewWith_MultiSelection_ShouldNotAutoSelectParent()
         {
-            var comp = Context.RenderComponent<TreeViewAutoSelectParentTest>(self => self
+            var comp = Context.Render<TreeViewAutoSelectParentTest>(self => self
                 .Add(x => x.SelectedValues, ["item1.2"])
                 .Add(x => x.AutoSelectParent, false));
             // check initial selection
@@ -220,7 +220,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItemSelected_ShouldBeInitializedCorrectly_SingleSelection()
         {
-            var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));
+            var comp = Context.Render<TreeViewItemSelectedBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));
             comp.Find("p.selected-value").TrimmedText().Should().Be("item1.2");
             comp.Find("p.item1-selected").TrimmedText().Should().Be("False");
             comp.Find("p.item1-1-selected").TrimmedText().Should().Be("False");
@@ -230,7 +230,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InitialValueOfTreeViewItemSelected_Should_InfluenceSelectedValue_SingleSelection()
         {
-            var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self
+            var comp = Context.Render<TreeViewItemSelectedBindingTest>(self => self
                 .Add(x => x.SelectedValue, "item1.2")
                 .Add(x => x.Item1Selected, true));
             comp.Find("p.selected-value").TrimmedText().Should().Be("item1");
@@ -242,7 +242,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItemSelected_ShouldBeInitializedCorrectly_MultiSelection()
         {
-            var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self
+            var comp = Context.Render<TreeViewItemSelectedBindingTest>(self => self
                 .Add(x => x.SelectedValues, ["item1", "item1.2"])
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.Find("p.selected-values").TrimmedText().Should().Be("item1, item1.2");
@@ -254,7 +254,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItemVisible_RendersWhenVisibleIsTrue()
         {
-            var comp = Context.RenderComponent<ItemVisibleTreeViewTest>(element =>
+            var comp = Context.Render<ItemVisibleTreeViewTest>(element =>
             {
                 element.Add(x => x.IsElementVisible, true);
             });
@@ -265,7 +265,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItemVisible_RendersNotWhenVisibleIsFalse()
         {
-            var comp = Context.RenderComponent<ItemVisibleTreeViewTest>(element =>
+            var comp = Context.Render<ItemVisibleTreeViewTest>(element =>
             {
                 element.Add(x => x.IsElementVisible, false);
             });
@@ -278,7 +278,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange and act
             var searchPhrase = "Trash";
-            var comp = Context.RenderComponent<TreeViewFilterFuncTest>(element =>
+            var comp = Context.Render<TreeViewFilterFuncTest>(element =>
             {
                 element.Add(x => x.SearchPhrase, searchPhrase);
                 element.Add(x => x.FilterFunc, (e) =>
@@ -308,7 +308,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange and act
             var searchPhrase = "Categories";
-            var comp = Context.RenderComponent<TreeViewFilterFuncTest>(element =>
+            var comp = Context.Render<TreeViewFilterFuncTest>(element =>
             {
                 element.Add(x => x.SearchPhrase, searchPhrase);
                 element.Add(x => x.FilterFunc, (e) =>
@@ -338,7 +338,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange and act
             var searchPhrase = "Social";
-            var comp = Context.RenderComponent<TreeViewFilterFuncTest>(element =>
+            var comp = Context.Render<TreeViewFilterFuncTest>(element =>
             {
                 element.Add(x => x.SearchPhrase, searchPhrase);
                 element.Add(x => x.FilterFunc, (e) =>
@@ -368,7 +368,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange and act
             var searchPhrase = "Social";
-            var comp = Context.RenderComponent<TreeViewFilterFuncTest>(element =>
+            var comp = Context.Render<TreeViewFilterFuncTest>(element =>
             {
                 element.Add(x => x.SearchPhrase, "Social");
                 element.Add(x => x.AreItemsPopulated, false);
@@ -390,7 +390,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewFilterFunc_FilterFuncIsNull()
         {
-            var comp = Context.RenderComponent<TreeViewFilterFuncTest>(element =>
+            var comp = Context.Render<TreeViewFilterFuncTest>(element =>
             {
                 element.Add(x => x.SearchPhrase, "Social");
             });
@@ -409,7 +409,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void InitialValueOfTreeViewItemSelected_Should_InfluenceSelectedValue_MultiSelection()
         {
-            var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self
+            var comp = Context.Render<TreeViewItemSelectedBindingTest>(self => self
                 .Add(x => x.SelectedValues, ["item1", "item1.2"])
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
                 .Add(x => x.Item11Selected, true));
@@ -425,7 +425,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItem_Selected_TwoWayBindingTest_SingleSelection()
         {
-            var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));
+            var comp = Context.Render<TreeViewItemSelectedBindingTest>(self => self.Add(x => x.SelectedValue, "item1.2"));
             // check initial selection
             comp.Find(".tree1 .item-1 .mud-treeview-item-content").ClassList.Should().NotContain("mud-treeview-item-selected");
             comp.Find(".tree2 .item-1 .mud-treeview-item-content").ClassList.Should().NotContain("mud-treeview-item-selected");
@@ -467,7 +467,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItem_Selected_TwoWayBindingTest_MultiSelection()
         {
-            var comp = Context.RenderComponent<TreeViewItemSelectedBindingTest>(self => self
+            var comp = Context.Render<TreeViewItemSelectedBindingTest>(self => self
                 .Add(x => x.SelectedValues, ["item1", "item1.2"])
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             // check initial selection
@@ -518,7 +518,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeView_WhenDisabled_DoesNotHaveRipple()
         {
-            var comp = Context.RenderComponent<TreeViewRippleTest>(self => self.Add(x => x.Disabled, true));
+            var comp = Context.Render<TreeViewRippleTest>(self => self.Add(x => x.Disabled, true));
 
             comp.FindAll("div.mud-ripple").Count.Should().Be(0);
 
@@ -529,7 +529,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeView_WhenRippleDisabled_DoesNotHaveRipple()
         {
-            var comp = Context.RenderComponent<TreeViewRippleTest>(self => self.Add(x => x.Ripple, false));
+            var comp = Context.Render<TreeViewRippleTest>(self => self.Add(x => x.Ripple, false));
 
             comp.FindAll("div.mud-ripple").Count.Should().Be(0);
 
@@ -540,7 +540,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Collapsed_ClickOnArrowButton_CheckClose()
         {
-            var comp = Context.RenderComponent<TreeViewTest1>();
+            var comp = Context.Render<TreeViewTest1>();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
@@ -553,7 +553,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DoubleClickOnArrowButton_ShouldNotSelectItem()
         {
-            var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+            var comp = Context.Render<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("input.mud-checkbox-input").Count.Should().Be(10);
@@ -575,7 +575,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Collapsed_ClickOnTreeItem_CheckClose()
         {
-            var comp = Context.RenderComponent<TreeViewTest2>();
+            var comp = Context.Render<TreeViewTest2>();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
@@ -590,7 +590,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Unselected_Select_CheckSelected_Deselect_CheckDeselected()
         {
-            var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+            var comp = Context.Render<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
             comp.Find("button.mud-treeview-item-expand-button").Click();
             comp.FindAll("li.mud-treeview-item .mud-collapse-container.mud-collapse-entering").Count.Should().Be(1);
@@ -606,7 +606,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Normal_Activate_CheckActivated_ActivateAnother_CheckBoth()
         {
-            var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+            var comp = Context.Render<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
             comp.FindAll(".mud-checkbox-true").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
             comp.Instance.Item1Selected.Should().BeTrue();
@@ -621,7 +621,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_WillUnselectItems_WhenNotMultiSelect()
         {
-            var comp = Context.RenderComponent<TreeViewTest7>();
+            var comp = Context.Render<TreeViewTest7>();
             comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
             comp.Instance.Item1Selected.Should().BeTrue();
@@ -636,7 +636,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void Normal_Activate_CheckActivated_Deactivate_Check()
         {
-            var comp = Context.RenderComponent<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.ToggleSelection));
+            var comp = Context.Render<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.ToggleSelection));
             comp.FindAll("div.mud-treeview-item-content.mud-treeview-item-selected").Count.Should().Be(0);
             comp.Find("div.mud-treeview-item-content").Click();
             comp.Instance.Item1Selected.Should().BeTrue();
@@ -651,14 +651,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void RenderWithTemplate_CheckResult()
         {
-            var comp = Context.RenderComponent<TreeViewTemplateTest>();
+            var comp = Context.Render<TreeViewTemplateTest>();
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(8);
         }
 
         [Test]
         public void TreeViewServerTest()
         {
-            var comp = Context.RenderComponent<TreeViewServerTest>();
+            var comp = Context.Render<TreeViewServerTest>();
             string.Join('|', comp.FindAll("div.mud-treeview-item-content").Select(x => x.TextContent)).Should()
                 .Be("All Mail|Categories|Social|Updates|Trash");
             comp.FindAll("li.mud-treeview-item").Count.Should().Be(5);
@@ -679,7 +679,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeViewServerData_BindsItems()
         {
-            var comp = Context.RenderComponent<TreeViewServerTest>();
+            var comp = Context.Render<TreeViewServerTest>();
             var target = comp.FindComponents<MudTreeViewItem<string?>>()
                 .First(x => x.Instance.Value == "All Mail");
             await comp.InvokeAsync(target.Instance.ReloadAsync);
@@ -694,7 +694,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeViewItem_ShouldBeAbleTo_ReloadInCollapsedState()
         {
-            var comp = Context.RenderComponent<TreeViewServerTest2>();
+            var comp = Context.Render<TreeViewServerTest2>();
             var treeviewItem = comp.FindComponents<MudTreeViewItem<string>>().FirstOrDefault();
             treeviewItem!.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded)).Should().Be(false);
             comp.FindAll("div.mud-treeview-item-arrow button").Count.Should().Be(2);
@@ -762,7 +762,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeViewItem_DoubleClick_CheckExpanded()
         {
-            var comp = Context.RenderComponent<TreeViewTest3>();
+            var comp = Context.Render<TreeViewTest3>();
             var itemExpanded = false;
 
             var item = comp.FindComponent<MudTreeViewItem<string>>();
@@ -782,7 +782,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeViewItem_DoubleClick_CheckSelected()
         {
-            var comp = Context.RenderComponent<TreeViewTest3>();
+            var comp = Context.Render<TreeViewTest3>();
             string selectedItem = null;
 
             var tree = comp.FindComponent<MudTreeView<string>>();
@@ -796,7 +796,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeViewItem_ProgrammaticallySelect()
         {
-            var comp = Context.RenderComponent<TreeViewTest4>();
+            var comp = Context.Render<TreeViewTest4>();
             var treeView = comp.FindComponent<MudTreeView<string>>();
 
             await comp.InvokeAsync(() => comp.Instance.ClickFirst());
@@ -813,7 +813,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeViewItem_BodyContent()
         {
-            var comp = Context.RenderComponent<TreeViewTest5>();
+            var comp = Context.Render<TreeViewTest5>();
             var treeView = comp.FindComponent<MudTreeView<string>>();
             var treeViewItem = comp.FindComponents<MudTreeViewItem<string>>()[2];
 
@@ -851,7 +851,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeView_SetSelectedValue_SetsSelectedValue()
         {
-            var comp = Context.RenderComponent<TreeViewTest6>();
+            var comp = Context.Render<TreeViewTest6>();
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SelectedValue, "logo.png"));
 
@@ -861,7 +861,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeView_SetSelectedValue_IsSetNullWhenNotFound()
         {
-            var comp = Context.RenderComponent<TreeViewTest6>();
+            var comp = Context.Render<TreeViewTest6>();
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SelectedValue, "logo.png"));
 
@@ -875,7 +875,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TreeView_SetSelectedValue_IsSetNullWhenInitialValueIsInvalid()
         {
-            var comp = Context.RenderComponent<TreeViewTest6>();
+            var comp = Context.Render<TreeViewTest6>();
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SelectedValue, "xxxxxx"));
 
@@ -886,7 +886,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TreeView_SelectedValue_ShouldUseComparer()
         {
             // test tree with items ("Ax", "Bx", "Cx", "Dx")
-            var comp = Context.RenderComponent<TreeViewCompareTest>();
+            var comp = Context.Render<TreeViewCompareTest>();
             string GetSelectedValue() => comp.Find("p.selected-value").TrimmedText();
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SelectedValue, "Ax"));
@@ -930,7 +930,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task TreeView_SelectedValues_ShouldUseComparer()
         {
             // tree containing two children with values AA and AC
-            var comp = Context.RenderComponent<TreeViewComparerMultiSelectTest>(self => self.Add(x => x.SelectedValues, ["AA"]));
+            var comp = Context.Render<TreeViewComparerMultiSelectTest>(self => self.Add(x => x.SelectedValues, ["AA"]));
 
             comp.Instance.Item1Selected.Should().BeTrue();
             comp.Instance.Item2Selected.Should().BeFalse();
@@ -966,7 +966,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewItem_TwoWayBindingTest()
         {
-            var comp = Context.RenderComponent<TreeViewItemBindingTest>();
+            var comp = Context.Render<TreeViewItemBindingTest>();
             // check initial selection
             comp.Find(".item-config .mud-treeview-item-content").ClassList.Should().NotContain("mud-treeview-item-selected");
             comp.Find(".item-launch .mud-treeview-item-content").ClassList.Should().Contain("mud-treeview-item-selected");
@@ -1084,7 +1084,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewAutoExpansionTest()
         {
-            var comp = Context.RenderComponent<TreeViewAutoExpandTest>(self => self.Add(x => x.AutoExpand, true));
+            var comp = Context.Render<TreeViewAutoExpandTest>(self => self.Add(x => x.AutoExpand, true));
             var isExpanded = (string value) => comp.FindComponents<MudTreeViewItem<string>>()
                 .FirstOrDefault(x => x.Instance.Value == value)?.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded));
             var select = (string value) => comp.FindComponents<MudChip<string>>().FirstOrDefault(x => x.Instance.Text == value)?.Find("button.mud-chip").Click();
@@ -1124,7 +1124,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewAutoExpansion_ShouldNot_ExpandNonExpandableItems()
         {
-            var comp = Context.RenderComponent<TreeViewAutoExpandTest>(self => self.Add(x => x.AutoExpand, true).Add(x => x.ConfigCanExpand, false));
+            var comp = Context.Render<TreeViewAutoExpandTest>(self => self.Add(x => x.AutoExpand, true).Add(x => x.ConfigCanExpand, false));
             var isExpanded = (string value) => comp.FindComponents<MudTreeViewItem<string>>()
                 .FirstOrDefault(x => x.Instance.Value == value)?.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded));
             var select = (string value) => comp.FindComponents<MudChip<string>>().FirstOrDefault(x => x.Instance.Text == value)?.Find("button.mud-chip").Click();
@@ -1164,7 +1164,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewExpandAllCollapseAllTest()
         {
-            var comp = Context.RenderComponent<TreeViewAutoExpandTest>(self => self.Add(x => x.AutoExpand, false));
+            var comp = Context.Render<TreeViewAutoExpandTest>(self => self.Add(x => x.AutoExpand, false));
             var isExpanded = (string value) => comp.FindComponents<MudTreeViewItem<string>>()
                 .FirstOrDefault(x => x.Instance.Value == value)?.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded));
             isExpanded("C:").Should().Be(false);
@@ -1192,7 +1192,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeViewExpandAll_ShouldNot_ExpandNonExpandableItems()
         {
-            var comp = Context.RenderComponent<TreeViewAutoExpandTest>(self => self.Add(x => x.ConfigCanExpand, false));
+            var comp = Context.Render<TreeViewAutoExpandTest>(self => self.Add(x => x.ConfigCanExpand, false));
             var isExpanded = (string value) => comp.FindComponents<MudTreeViewItem<string>>()
                 .FirstOrDefault(x => x.Instance.Value == value)?.Instance.GetState<bool>(nameof(MudTreeViewItem<string>.Expanded));
             isExpanded("C:").Should().Be(false);
@@ -1222,7 +1222,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
-                var comp = Context.RenderComponent<TreeViewTest8>();
+                var comp = Context.Render<TreeViewTest8>();
                 comp.FindAll("li.mud-treeview-item").Count.Should().Be(4);
             });
 
@@ -1237,7 +1237,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_ClickItemWhileActive_DoesChangeSelection()
         {
-            var comp = Context.RenderComponent<ItemSelectableTreeViewTest>();
+            var comp = Context.Render<ItemSelectableTreeViewTest>();
 
             var parentItemButton = comp.Find(".parent-item button.mud-treeview-item-expand-button");
             var parentItemContent = comp.Find(".parent-item > div.mud-treeview-item-content");
@@ -1260,7 +1260,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_ClickItemWhileReadOnly_DoesNotChangeSelection()
         {
-            var comp = Context.RenderComponent<ItemSelectableTreeViewTest>(self => self.Add(x => x.ParentItemReadOnly, true));
+            var comp = Context.Render<ItemSelectableTreeViewTest>(self => self.Add(x => x.ParentItemReadOnly, true));
 
             var parentItemButton = comp.Find(".parent-item button.mud-treeview-item-expand-button");
             var parentItemContent = comp.Find(".parent-item > div.mud-treeview-item-content");
@@ -1282,7 +1282,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_ClickItemWhileDisabled_DoesNotChangeSelectionAndExpanded()
         {
-            var comp = Context.RenderComponent<ItemSelectableTreeViewTest>(self => self.Add(x => x.ParentItemDisabled, true));
+            var comp = Context.Render<ItemSelectableTreeViewTest>(self => self.Add(x => x.ParentItemDisabled, true));
 
             var parentItemButton = comp.Find(".parent-item button.mud-treeview-item-expand-button");
             var parentItemContent = comp.Find(".parent-item > div.mud-treeview-item-content");
@@ -1304,7 +1304,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void TreeView_ClickHeterogeneousTreeElement_ShouldNotThrow()
         {
-            var comp = Context.RenderComponent<TreeViewHeterogeneous>();
+            var comp = Context.Render<TreeViewHeterogeneous>();
             var l2 = comp.Find(".L2 > div.mud-treeview-item-content");
             var act = () => l2.Click();
             act.Should().NotThrow();

--- a/src/MudBlazor.UnitTests/Components/UserAttributes/MudComponentFactory.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/MudComponentFactory.cs
@@ -2,20 +2,17 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using Bunit;
-using TestContext = Bunit.TestContext;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor.UnitTests.UserAttributes
 {
     internal sealed class MudComponentFactory
     {
-        private readonly ConcurrentDictionary<Type, Func<TestContext, IRenderedFragment>> _customFactories = new();
+        private readonly ConcurrentDictionary<Type, Func<BunitContext, IRenderedComponent<IComponent>>> _customFactories = new();
 
         public MudComponentFactory()
         {
@@ -25,17 +22,17 @@ namespace MudBlazor.UnitTests.UserAttributes
                 .Add(x => x.Items, [new("text", "href")]));
 
             RegisterCustomFactoryFor<MudCarouselItem>((builder, testContext) => builder
-                .Add(x => x.Parent, testContext.RenderComponent<MudCarousel<string>>(attributes => attributes
+                .Add(x => x.Parent, testContext.Render<MudCarousel<string>>(attributes => attributes
                         .Add(x => x.SelectedIndex, 0))
                     .Instance));
 
             RegisterCustomFactoryFor<MudDialog>((builder, testContext) => builder
-                .AddCascadingValue(testContext.RenderComponent<MudDialogContainer>().Instance));
+                .AddCascadingValue(testContext.Render<MudDialogContainer>().Instance));
 
             RegisterCustomFactoryFor<MudElement>(builder => builder.Add(x => x.HtmlTag, "div"));
 
             RegisterCustomFactoryFor<MudMessageBox>((builder, testContext) => builder
-                .AddCascadingValue(testContext.RenderComponent<MudDialogContainer>().Instance));
+                .AddCascadingValue(testContext.Render<MudDialogContainer>().Instance));
 
             RegisterCustomFactoryFor<MudOverlay>(builder => builder.Add(x => x.Visible, true));
 
@@ -44,14 +41,14 @@ namespace MudBlazor.UnitTests.UserAttributes
                 .Add(x => x.HighlightedText, "Hello"));
 
             RegisterCustomFactoryFor<MudTabPanel>((builder, testContext) => builder
-                .AddCascadingValue(testContext.RenderComponent<MudTabs>(attributes => attributes
+                .AddCascadingValue(testContext.Render<MudTabs>(attributes => attributes
                         .Add(x => x.KeepPanelsAlive, true))
                     .Instance));
         }
 
         public Dictionary<string, object> UserAttributes { get; set; } = null;
 
-        public IRenderedFragment Create(Type componentType, TestContext testContext)
+        public IRenderedComponent<IComponent> Create(Type componentType, BunitContext testContext)
         {
             if (_customFactories.TryGetValue(componentType, out var factory))
                 return factory(testContext);
@@ -62,7 +59,7 @@ namespace MudBlazor.UnitTests.UserAttributes
             return factory(testContext);
         }
 
-        private Func<TestContext, IRenderedFragment> BuildDefaultFactory(Type componentType)
+        private Func<BunitContext, IRenderedComponent<IComponent>> BuildDefaultFactory(Type componentType)
         {
             // Use string as generic type parameter for generic components
             if (componentType.IsGenericType)
@@ -85,23 +82,23 @@ namespace MudBlazor.UnitTests.UserAttributes
                 ?.MakeGenericMethod(componentType);
 
             return defaultFactoryMethod != null
-                ? testContext => defaultFactoryMethod.Invoke(this, new object[] { testContext }) as IRenderedFragment
+                ? testContext => defaultFactoryMethod.Invoke(this, [testContext]) as IRenderedComponent<IComponent>
                 : null;
         }
 
-        private IRenderedFragment DefaultFactory<TComponent>(TestContext testContext)
+        private IRenderedComponent<TComponent> DefaultFactory<TComponent>(BunitContext testContext)
             where TComponent : MudComponentBase
-            => testContext.RenderComponent<TComponent>(builder => ApplyAdditionalParameters(builder));
+            => testContext.Render<TComponent>(builder => ApplyAdditionalParameters(builder));
 
         private void RegisterCustomFactoryFor<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>> parameterBuilder)
             where TComponent : MudComponentBase
             => _customFactories.TryAdd(typeof(TComponent), testContext => testContext
-                .RenderComponent<TComponent>(builder => parameterBuilder(ApplyAdditionalParameters(builder))));
+                .Render<TComponent>(builder => parameterBuilder(ApplyAdditionalParameters(builder))));
 
-        private void RegisterCustomFactoryFor<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>, TestContext> parameterBuilder)
+        private void RegisterCustomFactoryFor<TComponent>(Action<ComponentParameterCollectionBuilder<TComponent>, BunitContext> parameterBuilder)
             where TComponent : MudComponentBase
             => _customFactories.TryAdd(typeof(TComponent), testContext => testContext
-                .RenderComponent<TComponent>(builder => parameterBuilder(ApplyAdditionalParameters(builder), testContext)));
+                .Render<TComponent>(builder => parameterBuilder(ApplyAdditionalParameters(builder), testContext)));
 
         private ComponentParameterCollectionBuilder<TComponent> ApplyAdditionalParameters<TComponent>(ComponentParameterCollectionBuilder<TComponent> builder)
             where TComponent : MudComponentBase

--- a/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
+++ b/src/MudBlazor.UnitTests/Components/UserAttributes/UserAttributesTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Charts;
 using MudBlazor.Services;
 using NUnit.Framework;
-using TestContext = Bunit.TestContext;
 
 namespace MudBlazor.UnitTests.UserAttributes
 {
@@ -31,10 +30,10 @@ namespace MudBlazor.UnitTests.UserAttributes
         }
 
         [Test]
-        public void AllMudComponents_ShouldForwardUserAttributes()
+        public async Task AllMudComponents_ShouldForwardUserAttributes()
         {
             // Arrange
-            using var testContext = new TestContext();
+            await using var testContext = new BunitContext();
             testContext.AddTestServices();
             testContext.Services.Add(new ServiceDescriptor(typeof(IResizeObserver), new MockResizeObserver()));
 

--- a/src/MudBlazor.UnitTests/Components/VirtualizeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/VirtualizeTests.cs
@@ -13,7 +13,7 @@ public class VirtualizeTests : BunitTest
     [Test]
     public void VirtualizeRenderTest()
     {
-        var comp = Context.RenderComponent<VirtualizeTest>();
+        var comp = Context.Render<VirtualizeTest>();
         var virtualize = comp.FindComponent<MudVirtualize<string>>();
         virtualize.Instance.ChildContent.Should().NotBeNull();
         comp.FindComponents<MudText>().Count.Should().Be(1);
@@ -22,7 +22,7 @@ public class VirtualizeTests : BunitTest
     [Test]
     public void VirtualizeNoRecordTest()
     {
-        var comp = Context.RenderComponent<VirtualizeNoRecordsContentTest>();
+        var comp = Context.Render<VirtualizeNoRecordsContentTest>();
 
         IElement ItemNoData() => comp.Find("#items_nodata");
         IElement ItemVirtualizedNoData() => comp.Find("#items_virtualized_nodata");

--- a/src/MudBlazor.UnitTests/Extensions/IRenderedComponentExtensions.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IRenderedComponentExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using Bunit;
 using Bunit.Rendering;
@@ -10,25 +13,22 @@ namespace MudBlazor.UnitTests;
 #nullable enable
 public static class IRenderedComponentExtensions
 {
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "SetDirectParametersAsync")]
-    private static extern Task SetDirectParametersAsync(TestRenderer renderer, IRenderedFragmentBase renderedComponent, ParameterView parameters);
-
     /// <summary>
     /// Render the component under test again with the provided <paramref name="parameters"/>.
     /// </summary>
     /// <param name="renderedComponent">The rendered component to re-render with new parameters.</param>
     /// <param name="parameters">Parameters to pass to the component upon rendered.</param>
     /// <typeparam name="TComponent">The type of the component.</typeparam>
-    public static async Task SetParametersAndRenderAsync<TComponent>(this IRenderedComponentBase<TComponent> renderedComponent, ParameterView parameters)
+    public static async Task SetParametersAndRenderAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, ParameterView parameters)
         where TComponent : IComponent
     {
         ArgumentNullException.ThrowIfNull(renderedComponent);
 
-        var renderer = (TestRenderer)renderedComponent.Services.GetRequiredService<TestContextBase>().Renderer;
+        var renderer = renderedComponent.Services.GetRequiredService<BunitContext>().Renderer;
 
         try
         {
-            await SetDirectParametersAsync(renderer, renderedComponent, parameters);
+            await BunitRendererAccessors.SetDirectParametersAsync(renderer, renderedComponent, parameters);
         }
         catch (AggregateException e) when (e.InnerExceptions.Count == 1)
         {
@@ -42,37 +42,149 @@ public static class IRenderedComponentExtensions
     /// <param name="renderedComponent">The rendered component to re-render with new parameters.</param>
     /// <param name="parameterBuilder">An action that receives a <see cref="ComponentParameterCollectionBuilder{TComponent}"/>.</param>
     /// <typeparam name="TComponent">The type of the component.</typeparam>
-    public static Task SetParametersAndRenderAsync<TComponent>(this IRenderedComponentBase<TComponent> renderedComponent, Action<ComponentParameterCollectionBuilder<TComponent>> parameterBuilder)
+    public static Task SetParametersAndRenderAsync<TComponent>(this IRenderedComponent<TComponent> renderedComponent, Action<ComponentParameterCollectionBuilder<TComponent>> parameterBuilder)
         where TComponent : IComponent
     {
-        ArgumentNullException.ThrowIfNull(parameterBuilder);
-        ArgumentNullException.ThrowIfNull(renderedComponent);
-
         var builder = new ComponentParameterCollectionBuilder<TComponent>(parameterBuilder);
-        return SetParametersAndRenderAsync(renderedComponent, ToParameterView(builder.Build()));
+#if NET10_0_OR_GREATER
+        var parameters = ComponentParameterCollectionBuilderAccessors<TComponent>.Build(builder);
+#else
+        var parameters = TryGetParametersViaBuild(builder);
+#endif
+
+        var parameterView = ToParameterView(parameters);
+
+        return renderedComponent.SetParametersAndRenderAsync(parameterView);
     }
 
-    private static ParameterView ToParameterView(IReadOnlyCollection<ComponentParameter> parameters)
+#if NET10_0_OR_GREATER
+    private static ParameterView ToParameterView(object parameters)
     {
         var parameterView = ParameterView.Empty;
 
-        if (parameters.Count > 0)
+        if (ComponentParameterCollectionAccessors.GetCount(parameters) > 0)
         {
             var paramDict = new Dictionary<string, object?>(StringComparer.Ordinal);
 
-            foreach (var param in parameters)
+            var enumerator = ComponentParameterCollectionAccessors.GetEnumerator(parameters);
+            while (enumerator.MoveNext())
             {
-                if (param.IsCascadingValue)
-                    throw new InvalidOperationException($"You cannot provide a new cascading value through the {nameof(SetParametersAndRenderAsync)} method.");
-                if (param.Name is null)
-                    throw new InvalidOperationException("A parameters name is required.");
+                var param = enumerator.Current;
+                if (param is null)
+                    continue;
 
-                paramDict.Add(param.Name, param.Value);
+                if (ComponentParameterRefAccessors.GetIsCascadingValue(param))
+                    throw new InvalidOperationException("Cannot provide cascading values here.");
+
+                var name = ComponentParameterRefAccessors.GetName(param);
+                if (name is null)
+                    throw new InvalidOperationException("Parameter name is required.");
+
+                var value = ComponentParameterRefAccessors.GetValue(param);
+                paramDict.Add(name, value);
             }
 
             parameterView = ParameterView.FromDictionary(paramDict);
         }
 
         return parameterView;
+    }
+
+    private static class ComponentParameterCollectionBuilderAccessors<TComponent> where TComponent : IComponent
+    {
+        // Accessors for Build (internal method)
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Build")]
+        [return: UnsafeAccessorType("Bunit.ComponentParameterCollection, bunit")]
+        public static extern object Build(ComponentParameterCollectionBuilder<TComponent> builder);
+    }
+
+    // Accessors for ComponentParameterCollection (internal type)
+    private static class ComponentParameterCollectionAccessors
+    {
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "System.Collections.IEnumerable.GetEnumerator")]
+        public static extern IEnumerator GetEnumerator([UnsafeAccessorType("Bunit.ComponentParameterCollection, bunit")] object collection);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_Count")]
+        public static extern int GetCount([UnsafeAccessorType("Bunit.ComponentParameterCollection, bunit")] object collection);
+    }
+#else
+    private static object TryGetParametersViaBuild<TComponent>(ComponentParameterCollectionBuilder<TComponent> builder)
+        where TComponent : IComponent
+    {
+        var type = typeof(ComponentParameterCollectionBuilder<TComponent>);
+        var build = type.GetMethod("Build", BindingFlags.Instance | BindingFlags.NonPublic);
+        return build?.Invoke(builder, null)!;
+    }
+
+    private static ParameterView ToParameterView(object parameters)
+    {
+        // Get Count
+        var countProp = parameters.GetType().GetProperty("Count", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var count = (int)(countProp?.GetValue(parameters) ?? 0);
+        if (count == 0) return ParameterView.Empty;
+
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        // Enumerate
+        var enumerable = (IEnumerable)parameters;
+        foreach (var param in enumerable)
+        {
+            var isCascading = ComponentParameterRefAccessors.GetIsCascadingValue(param);
+            if (isCascading)
+                throw new InvalidOperationException("You cannot provide a new cascading value through SetParametersAndRenderAsync.");
+
+            var name = ComponentParameterRefAccessors.GetName(param);
+            if (name is null)
+                throw new InvalidOperationException("A parameter name is required.");
+
+            var value = ComponentParameterRefAccessors.GetValue(param);
+            dict.Add(name, value);
+        }
+
+        return ParameterView.FromDictionary(dict);
+    }
+#endif
+    private static class BunitRendererAccessors
+    {
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "SetDirectParametersAsync")]
+        public static extern Task SetDirectParametersAsync<TComponent>(BunitRenderer renderer, IRenderedComponent<TComponent> renderedComponent, ParameterView parameters) where TComponent : IComponent;
+    }
+    public static class ComponentParameterRefAccessors
+    {
+        private static readonly Type _componentParameterType = Type.GetType("Bunit.ComponentParameter, bunit", throwOnError: true)!;
+
+        public static readonly Func<object, string?> GetName;
+        public static readonly Func<object, object?> GetValue;
+        public static readonly Func<object, bool> GetIsCascadingValue;
+
+        static ComponentParameterRefAccessors()
+        {
+            var nameProp = _componentParameterType.GetProperty("Name", BindingFlags.Instance | BindingFlags.Public);
+            var valueProp = _componentParameterType.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+            var isCascadingProp = _componentParameterType.GetProperty("IsCascadingValue", BindingFlags.Instance | BindingFlags.Public);
+
+            GetName = BuildGetter<string?>(nameProp);
+            GetValue = BuildGetter<object?>(valueProp);
+            GetIsCascadingValue = BuildGetter<bool>(isCascadingProp);
+        }
+
+        private static Func<object, T> BuildGetter<T>(PropertyInfo? property)
+        {
+            ArgumentNullException.ThrowIfNull(property);
+            var objParam = Expression.Parameter(typeof(object), "obj");
+
+            // Convert object -> actual struct type
+            var typed = Expression.Convert(objParam, _componentParameterType);
+
+            // Access property
+            var propertyAccess = Expression.Property(typed, property);
+
+            // Convert return type if necessary
+            var converted = Expression.Convert(propertyAccess, typeof(T));
+
+            // Compile lambda: (object obj) => ((ComponentParameter)obj).Property
+            var lambda = Expression.Lambda<Func<object, T>>(converted, objParam);
+            return lambda.Compile();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/NodePrintExtensions.cs.cs
+++ b/src/MudBlazor.UnitTests/Extensions/NodePrintExtensions.cs.cs
@@ -1,0 +1,68 @@
+﻿using AngleSharp;
+using AngleSharp.Dom;
+using AngleSharp.Html;
+
+namespace MudBlazor.UnitTests;
+
+
+/// <summary>
+/// Helper methods for pretty printing markup from <see cref="INode"/> and <see cref="INodeList"/>.
+/// </summary>
+internal static class NodePrintExtensions
+{
+    /// <summary>
+    /// Writes the serialization of the node guided by the formatter.
+    /// </summary>
+    /// <param name="nodes">The nodes to serialize.</param>
+    /// <param name="writer">The output target of the serialization.</param>
+    /// <param name="formatter">The formatter to use.</param>
+    public static void ToHtml(this IEnumerable<INode> nodes, TextWriter writer, IMarkupFormatter formatter)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        foreach (var node in nodes)
+        {
+            node.ToHtml(writer, formatter);
+        }
+    }
+
+    /// <summary>
+    /// Uses the <see cref="PrettyMarkupFormatter"/> to generate a HTML markup string
+    /// from a <see cref="IEnumerable{INode}"/> <paramref name="nodes"/>.
+    /// </summary>
+    public static string ToMarkup(this IEnumerable<INode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+        using var sw = new StringWriter();
+        var formatter = new PrettyMarkupFormatter
+        {
+            NewLine = Environment.NewLine,
+
+            Indentation = "  ",
+        };
+
+        nodes.ToHtml(sw, formatter);
+
+        return sw.ToString();
+    }
+
+    /// <summary>
+    /// Uses the <see cref="PrettyMarkupFormatter"/> to generate a HTML markup
+    /// from a <see cref="IMarkupFormattable"/> <paramref name="markupFormattable"/>.
+    /// </summary>
+    public static string ToMarkup(this IMarkupFormattable markupFormattable)
+    {
+        ArgumentNullException.ThrowIfNull(markupFormattable);
+        using var sw = new StringWriter();
+
+        var formatter = new PrettyMarkupFormatter
+        {
+            NewLine = Environment.NewLine,
+            Indentation = "  ",
+        };
+
+        markupFormattable.ToHtml(sw, formatter);
+
+        return sw.ToString();
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
+++ b/src/MudBlazor.UnitTests/Services/BoundingClientRectTests.cs
@@ -8,12 +8,12 @@ namespace MudBlazor.UnitTests.Components;
 [TestFixture]
 public class BoundingClientRectTests
 {
-    private Bunit.TestContext _ctx;
+    private Bunit.BunitContext _ctx;
 
     [SetUp]
     public void Setup()
     {
-        _ctx = new Bunit.TestContext();
+        _ctx = new Bunit.BunitContext();
         _ctx.AddTestServices();
     }
 

--- a/src/MudBlazor.UnitTests/Services/SnackbarServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/SnackbarServiceTests.cs
@@ -13,12 +13,12 @@ namespace MudBlazor.UnitTests.Services;
 [TestFixture]
 public class SnackbarServiceTests : BunitTest
 {
-    private FakeNavigationManager _navigationManager;
+    private BunitNavigationManager _navigationManager;
 
     public override void Setup()
     {
         base.Setup();
-        _navigationManager = Context.Services.GetRequiredService<FakeNavigationManager>();
+        _navigationManager = Context.Services.GetRequiredService<BunitNavigationManager>();
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
@@ -15,7 +15,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void DoesNotThrowExceptionWhenScopeCreatedMultipleTimes()
     {
-        var createComp = () => Context.RenderComponent<ParameterStateMultipleScopeTestComp>();
+        var createComp = () => Context.Render<ParameterStateMultipleScopeTestComp>();
 
         createComp.Should().NotThrow<Exception>();
     }
@@ -23,7 +23,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void ShouldHaveTwoScopes()
     {
-        var comp = Context.RenderComponent<ParameterStateMultipleScopeTestComp>();
+        var comp = Context.Render<ParameterStateMultipleScopeTestComp>();
 
         comp.Instance.ParameterContainer.Count.Should().Be(2);
     }
@@ -31,7 +31,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void SharedHandlerIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateSharedHandlerTestComp>();
+        var comp = Context.Render<ParameterStateSharedHandlerTestComp>();
 
         // note: the handler for abc and the one for xyz are each called once per click
         // the handlers for o and p are lambdas which are excluded from this optimization, so they
@@ -56,7 +56,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void InheritanceIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateSharedInheritanceHandlerTestComp>();
+        var comp = Context.Render<ParameterStateSharedInheritanceHandlerTestComp>();
 
         // note: the handler for abc and the one for xyz are each called once per click
         // the handlers for o and p are lambdas which are excluded from this optimization, so they
@@ -81,7 +81,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void EventArgsIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateEventArgsTestComp>();
+        var comp = Context.Render<ParameterStateEventArgsTestComp>();
         comp.Find(".parameter-changes").Children.Length.Should().Be(0);
         comp.Find("button.increment-int-param").Click();
         comp.Find(".parameter-changes").Children.Length.Should().Be(1);
@@ -94,7 +94,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public async Task StaticComparerIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateComparerStaticTestComp>(parameters => parameters
+        var comp = Context.Render<ParameterStateComparerStaticTestComp>(parameters => parameters
             .Add(parameter => parameter.DoubleParam, 10000f));
         IElement ParamChanges() => comp.Find(".parameter-changes");
         comp.Find(".parameter-changes").Children.Length.Should().Be(1);
@@ -112,7 +112,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public async Task SwapComparerInSequenceIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateComparerSwapTestComp>(parameters => parameters
+        var comp = Context.Render<ParameterStateComparerSwapTestComp>(parameters => parameters
             .Add(parameter => parameter.DoubleParam, 10000f));
         IElement ParamChanges() => comp.Find(".parameter-changes");
         comp.Find(".parameter-changes").Children.Length.Should().Be(1);
@@ -130,7 +130,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test(Description = "Tests a very special case described in ParameterStateInternal.HasParameterChanged when the associated value and comparer change at same time.")]
     public async Task SwapComparerAtSameTimeIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateComparerSwapTestComp>(parameters => parameters
+        var comp = Context.Render<ParameterStateComparerSwapTestComp>(parameters => parameters
             .Add(parameter => parameter.DoubleParam, 10000f));
         IElement ParamChanges() => comp.Find(".parameter-changes");
         comp.Find(".parameter-changes").Children.Length.Should().Be(1);
@@ -147,7 +147,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void GetStateTestIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateEventArgsTestComp>();
+        var comp = Context.Render<ParameterStateEventArgsTestComp>();
         IElement IncrementButton() => comp.Find("button.increment-int-param");
         IRenderedComponent<ParameterStateTestComp> StateComponent() => comp.FindComponent<ParameterStateTestComp>();
 
@@ -168,7 +168,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public void GetStateTestFailureIntegrationTest()
     {
-        var comp = Context.RenderComponent<ParameterStateEventArgsTestComp>();
+        var comp = Context.Render<ParameterStateEventArgsTestComp>();
         IRenderedComponent<ParameterStateTestComp> StateComponent() => comp.FindComponent<ParameterStateTestComp>();
 
         Action keyNotFoundAct1 = () => StateComponent().Instance.GetState(x => x.NonStateDummyIntParam);
@@ -195,7 +195,7 @@ public class ParameterStateUsageTests : BunitTest
     {
         var expanded = false;
 
-        var comp = Context.RenderComponent<ParameterStateChildBindingTestComp>(parameters =>
+        var comp = Context.Render<ParameterStateChildBindingTestComp>(parameters =>
             parameters.Bind(parameter => parameter.Expanded, expanded, newValue => expanded = newValue));
 
         var alertTextFunc = () => MudAlert().Find("div.mud-alert-message");
@@ -256,7 +256,7 @@ public class ParameterStateUsageTests : BunitTest
         var callBackEvents = new List<bool>();
         Action<bool> expandedCallBack = value => { callBackEvents.Add(value); };
 
-        var comp = Context.RenderComponent<ParameterStateChildBindingTestComp>(parameters =>
+        var comp = Context.Render<ParameterStateChildBindingTestComp>(parameters =>
             parameters.Add(parameter => parameter.ExpandedChanged, expandedCallBack));
 
         var alertTextFunc = () => MudAlert().Find("div.mud-alert-message");
@@ -306,7 +306,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public async Task Parent_TwoWayBinding_Test()
     {
-        var comp = Context.RenderComponent<ParameterStateParentBindingTestComp>();
+        var comp = Context.Render<ParameterStateParentBindingTestComp>();
 
         var alertChild1TextFunc = () => comp.Find("#childAlert1 div.mud-alert-message");
         var alertChild2TextFunc = () => comp.Find("#childAlert2 div.mud-alert-message");
@@ -510,7 +510,7 @@ public class ParameterStateUsageTests : BunitTest
     [Test]
     public async Task ParentChild_IsChildOriginatedChange_Test()
     {
-        var comp = Context.RenderComponent<ParameterStateChildParentTestComp>();
+        var comp = Context.Render<ParameterStateChildParentTestComp>();
         IElement ButtonParent() => comp.Find("#parentBtn");
         IElement ButtonChild1() => comp.Find("#childBtn1");
         IElement ButtonChild2() => comp.Find("#childBtn2");

--- a/src/MudBlazor.UnitTests/Utilities/EventUtilTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/EventUtilTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Utilities
         [Test]
         public void EventUtil_ShouldPreventRenderCycle()
         {
-            var comp = Context.RenderComponent<EventUtil1Test>();
+            var comp = Context.Render<EventUtil1Test>();
             comp.Find("#clicks").TrimmedText().Should().Be("Clicks: 0/0/0");
             comp.RenderCount.Should().Be(1);
             // normal click handler causes a re-render automatically (normal Blazor behavior)

--- a/src/MudBlazor.UnitTests/Utilities/LoggerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/LoggerTests.cs
@@ -23,7 +23,7 @@ namespace MudBlazor.UnitTests.Utilities
             var provider = new MockLoggerProvider();
             var logger = provider.CreateLogger(GetType().FullName) as MockLogger;
             Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider)); //set up the logging provider
-            var comp = Context.RenderComponent<LoggerTest>();
+            var comp = Context.Render<LoggerTest>();
 
             var entries = logger.GetEntries();
             entries.Count.Should().Be(4);


### PR DESCRIPTION
Preliminary work:
https://github.com/MudBlazor/MudBlazor/pull/12224
https://github.com/MudBlazor/MudBlazor/pull/12226, https://github.com/MudBlazor/MudBlazor/issues/12225
https://github.com/MudBlazor/MudBlazor/pull/12228, https://github.com/MudBlazor/MudBlazor/issues/12227
https://github.com/MudBlazor/MudBlazor/pull/12229
https://github.com/MudBlazor/MudBlazor/pull/12231, https://github.com/MudBlazor/MudBlazor/issues/12230
https://github.com/MudBlazor/MudBlazor/pull/12233, https://github.com/MudBlazor/MudBlazor/issues/12232
https://github.com/MudBlazor/MudBlazor/pull/12234
https://github.com/MudBlazor/MudBlazor/pull/12235

All this work was necessary because some stuff got removed/made internal inside bUnit 2.x, we also had many own API to set the parameter value for some reason, now it's down to only just `SetParametersAndRenderAsync`

Fixes: https://github.com/MudBlazor/MudBlazor/issues/12131

All assertions that checked `RenderCount` were removed, since bUnit now reports a different count—what used to be `1` is now `12`. I don't think there's much value in keeping these checks. Only six tests used them, and the check itself was somewhat arbitrary.

Also, you probably noticed the heavy use of reflection in `IRenderedComponentExtensions` for `SetParametersAndRenderAsync`. The issue is that bUnit made many types internal, which forces the use of even more reflection. This won’t be as problematic with the improved `UnsafeAccessor` in .NET 10, since it will behave almost like direct calls. There is one limitation: `UnsafeAccessor` doesn’t work with value types (`ComponentParameter`). Fortunately, it's not generic, so you can simply write cached lambdas for the access, which is also fast. Why not use bUnit’s native `Render(ComponentParameterCollectionBuilder)`? Well, I don’t really agree with their choice to do a blocking `GetWaiter().GetResult()` on `SetDirectParametersAsync`.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
