### PR TITLE
Tests: Link Button Find with Click EventPropogation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -22,21 +22,27 @@ namespace MudBlazor.UnitTests.Components
     public class AutocompleteTests : BunitTest
     {
         [Test]
-        public void Autocomplete_Should_Handle_Converter_WithStrict()
+        public async Task Autocomplete_Should_Handle_Converter_WithStrict()
         {
             var comp = Context.Render<AutocompleteConverterStrictTest>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<AutocompleteConverterStrictTest.ConverterElement>>();
             comp.Markup.Should().NotContain("mud-popover-open");
 
-            // Don't replace autocompleteComponent with comp, as then the test will be flaky (problem after migrating to bUnit 2.x)
-            IElement ButtonActivator() => autocompleteComponent.Find(".mud-button-root.mud-no-activator");
+            // https://github.com/bUnit-dev/bUnit/discussions/474
+            // https://github.com/bUnit-dev/bUnit/issues/517
+            // https://github.com/bUnit-dev/bUnit/issues/634
+            Func<Task> ButtonClicker = async () =>
+            {
+                var button = autocompleteComponent.WaitForElement(".mud-button-root.mud-no-activator");
+                await autocompleteComponent.InvokeAsync(() => button.Click());
+            };
 
-            ButtonActivator().Click(); // open popover
+            await ButtonClicker(); // open popover
             var pop = comp.WaitForElement("div.mud-popover"); // doesn't return until popover exists
             comp.WaitForAssertion(() => pop.ClassList.Should().Contain("mud-popover-open")); // wait for popover to open
             var items = comp.FindComponents<MudListItem<AutocompleteConverterStrictTest.ConverterElement>>();
             items.Count.Should().Be(10, "The popover should contain 10 items."); // default maxitems is 10
-            ButtonActivator().Click(); // close popover
+            await ButtonClicker(); // close popover
             comp.WaitForAssertion(() => pop.ClassList.Should().NotContain("mud-popover-open"));
 
             // set search


### PR DESCRIPTION
Link the button find with the click event async so they can't get separated between potential renders and 2nd components.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Adjust test to both find and click the button on demand to prevent separation between renders on a 2nd component.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
