### PR TITLE
MudSelect: Use ParameterState for MultiSelection

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -2,10 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Services;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 
@@ -30,10 +30,20 @@ namespace MudBlazor
         private MudInput<string> _elementReference = null!;
         private HashSet<T?> _selectedValues = new HashSet<T?>();
         protected internal List<MudSelectItem<T>> _items = new();
-        private string _elementId = Identifier.Create("select");
+        private readonly string _elementId = Identifier.Create("select");
         private string _searchText = string.Empty;
         private string? _lastSelectedId = string.Empty;
         private DateTime _lastSearchTime = DateTime.MinValue;
+
+        public MudSelect()
+        {
+            Adornment = Adornment.End;
+            IconSize = Size.Medium;
+            using var registerScope = CreateRegisterScope();
+            registerScope.RegisterParameter<bool>(nameof(MultiSelection))
+                .WithParameter(() => MultiSelection)
+                .WithChangeHandler(() => UpdateTextPropertyAsync(false));
+        }
 
         protected string OuterClassname =>
             new CssBuilder("mud-select")
@@ -483,12 +493,6 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.ListBehavior)]
         public Func<T?, string?>? ToStringFunc { get; set; }
 
-        public MudSelect()
-        {
-            Adornment = Adornment.End;
-            IconSize = Size.Medium;
-        }
-
         protected override void OnAfterRender(bool firstRender)
         {
             base.OnAfterRender(firstRender);
@@ -584,28 +588,15 @@ namespace MudBlazor
 
         internal event Action<ICollection<T?>>? SelectionChangedFromOutside;
 
-        private bool _multiSelection;
-
         /// <summary>
         /// Allows multiple values to be selected via checkboxes.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.  When <c>false</c>, only one value can be selected at a time.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool MultiSelection
-        {
-            get => _multiSelection;
-            set
-            {
-                if (_multiSelection != value)
-                {
-                    _multiSelection = value;
-                    UpdateTextPropertyAsync(false).CatchAndLog();
-                }
-            }
-        }
+        public bool MultiSelection { get; set; }
 
         /// <summary>
         /// The list of choices the user can select.


### PR DESCRIPTION
We must not modify auto-properties of Blazor parameters.
```C#
if (_multiSelection != value)
{
    _multiSelection = value;
    UpdateTextPropertyAsync(false).CatchAndLog(); // <--- problem
}
```

This is a major issue because these setters run *before* `OnInitialized` is invoked, essentially before any Blazor lifecycle events occur. This becomes problematic when migrating `Text` and `Value` to a `ParameterState` in `MudInputBase`, since `ParameterState` doesn't like this.

In this scenario, if we move `MudInput`’s `Text` parameter into a parameter state, then when `UpdateTextPropertyAsync` is invoked, the text value will still be empty. `_textState.SetValueAsync` would already have been called, but because `IsInitialized` is still `false`, it would return the default value from `_getParameterValueFunc`, which is empty. As a potential workaround, I could introduce a forced initialization step inside `SetValueAsync` for problematic components like this AutoComplete and Select (since others don't really care).

On a side note, the good thing about using `WithChangeHandler(() => UpdateTextPropertyAsync(false))` is that it only triggers once the component is already fully initialized, avoiding this entire issue.

P.S. Since `MultiSelection` is only one way property, we scan skip making a field for `ParameterState` and read from it. Therefore we use `ParameterState(ParameterUsage = ParameterUsageOptions.None)`.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
