### PR TITLE
ParameterState: use ToHashSet

### DIFF
--- a/src/MudBlazor/State/ParameterContainer.cs
+++ b/src/MudBlazor/State/ParameterContainer.cs
@@ -90,7 +90,7 @@ internal class ParameterContainer : IParameterContainer
         var parametersHandlerShouldFire = _parameterScopeContainers.SelectMany(parameter => parameter)
             .Where(parameter => parameter.HasHandler && parameter.HasParameterChanged(parameters))
             .Select(x => x.CreateInvocationSnapshot())
-            .ToFrozenSet(ParameterHandlerUniquenessComparer.Default);
+            .ToHashSet(ParameterHandlerUniquenessComparer.Default);
 
         await baseSetParametersAsync(parameters);
 

--- a/src/MudBlazor/State/ParameterScopeContainer.cs
+++ b/src/MudBlazor/State/ParameterScopeContainer.cs
@@ -114,7 +114,7 @@ internal class ParameterScopeContainer : IParameterScopeContainer
         var parametersHandlerShouldFire = _parameters.Value.Values
             .Where(parameter => parameter.HasHandler && parameter.HasParameterChanged(parameters))
             .Select(x => x.CreateInvocationSnapshot())
-            .ToFrozenSet(ParameterHandlerUniquenessComparer.Default);
+            .ToHashSet(ParameterHandlerUniquenessComparer.Default);
 
         await baseSetParametersAsync(parameters);
 


### PR DESCRIPTION
There is no point to use `ToHashSet` in this places, since nobody has access to modify it and we just doing for loop, so the frozen is eating the performance. The FrozenSet only makes sense on the parameter factory where we do lookups etc,

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
