### PR TITLE
MudFocusTrap: guard against disposal race in OnAfterRenderAsync

### DIFF
--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -77,12 +77,16 @@ namespace MudBlazor
         {
             await base.OnAfterRenderAsync(firstRender);
 
+            // need to check _disposed because we do not want to Save Focus if disposed - will cause an exception
             if (_disposed) return;
             if (firstRender)
             {
                 await SaveFocusAsync();
             }
 
+            // need to check _disposed again because it could have changed during the above await
+            // we do not want to initialize focus if disposed - will cause an exception
+            if (_disposed) return;
             if (!_initialized)
             {
                 await InitializeFocusAsync();


### PR DESCRIPTION
Fixes #11862

## Problem
`MudFocusTrap.OnAfterRenderAsync` can call `InitializeFocusAsync()` after the component has been disposed which causes an exception. This can happen because await `SaveFocusAsync()` yields; during that await, `_disposed` may flip to true, but the method then continues and reaches initialization.

## Fix
Add a second `_disposed` guard after await `SaveFocusAsync()` and before the initialization path. This prevents focus initialization from running after disposal.

## Repro (reliable)
Insert a temporary delay after `SaveFocusAsync()` (e.g. `await Task.Delay(3000)`), open a dialog and immediately close it (“OK”), then wait—without the extra _disposed check, `InitializeFocusAsync()` can run post-dispose and crash.

## Notes
This change only adds a defensive disposal guard; behaviour is unchanged otherwise.

## Additional context and analysis
- See issue comment: https://github.com/MudBlazor/MudBlazor/issues/11862#issuecomment-3524598985
