### PR TITLE
MudBreadcrumb: Add aria-label and aria-current support

### DIFF
--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -36,6 +36,28 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void MudBreadcrumbs_ShouldRenderWithCurrentPageAria()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            {
+                new("Link", "link", disabled: true, ariaCurrent: true)
+            }));
+
+            comp.Find("a").GetAttribute("aria-current").Should().Be("page");
+        }
+
+        [Test]
+        public void MudBreadcrumbs_ShouldRenderWithoutCurrentPageAria()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            {
+                new("Link", "link", disabled: true)
+            }));
+
+            comp.Find("a").GetAttribute("aria-current").Should().BeNull();
+        }
+
+        [Test]
         public void MudBreadcrumbs_ShouldRenderWithCustomAria()
         {
             var comp = Context.Render<MudBreadcrumbs>(parameters => parameters

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -22,6 +22,37 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void MudBreadcrumbs_ShouldRenderWithDefaultAria()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            {
+                new("Link 1", "link1"),
+                new("Link 2", "link2"),
+                new("Link 3", "link3", disabled: true)
+            }));
+
+            
+            comp.Find("nav").GetAttribute("aria-label").Should().Be("Breadcrumb");
+        }
+
+        [Test]
+        public void MudBreadcrumbs_ShouldRenderWithCustomAria()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters
+                .Add(x => x.Items, new List<BreadcrumbItem>
+                {
+                    new("Link 1", "link1"),
+                    new("Link 2", "link2"),
+                    new("Link 3", "link3", disabled: true)
+                })
+                .Add(x => x.AriaLabel, "AlternativeBreadcrumbs")
+            );
+
+            
+            comp.Find("nav").GetAttribute("aria-label").Should().Be("AlternativeBreadcrumbs");
+        }
+
+        [Test]
         public void MudBreadcrumbs_ShouldRenderItemsWithIcons()
         {
             var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -47,6 +47,18 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void MudBreadcrumbs_ShouldRenderWithFalseCurrentPageAria()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            {
+                new("Link", "link", disabled: true, ariaCurrent: false)
+            }));
+
+            comp.Find("a").GetAttribute("aria-current").Should().BeNull();
+        }
+
+
+        [Test]
         public void MudBreadcrumbs_ShouldRenderWithoutCurrentPageAria()
         {
             var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -31,7 +31,7 @@ namespace MudBlazor.UnitTests.Components
                 new("Link 3", "link3", disabled: true)
             }));
 
-            
+
             comp.Find("nav").GetAttribute("aria-label").Should().Be("Breadcrumb");
         }
 
@@ -48,7 +48,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.AriaLabel, "AlternativeBreadcrumbs")
             );
 
-            
+
             comp.Find("nav").GetAttribute("aria-label").Should().Be("AlternativeBreadcrumbs");
         }
 

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
@@ -31,17 +31,24 @@ public record BreadcrumbItem
     public string? Icon { get; }
 
     /// <summary>
+    /// Set aria-current to indicate this item is the current page.
+    /// </summary>
+    public bool AriaCurrent { get; }
+
+    /// <summary>
     /// Creates a new instance.
     /// </summary>
     /// <param name="text">The text to display for this item.</param>
     /// <param name="href">The URL to navigate to when this item is clicked.</param>
     /// <param name="disabled">Whether the item cannot be clicked.</param>
     /// <param name="icon">The custom icon to display for this item.</param>
-    public BreadcrumbItem(string text, string? href, bool disabled = false, string? icon = null)
+    /// <param name="ariaCurrent">Set aria-current to indicate this item is the current page.</param>
+    public BreadcrumbItem(string text, string? href, bool disabled = false, string? icon = null, bool ariaCurrent = false)
     {
         Text = text;
         Disabled = disabled;
         Href = href;
         Icon = icon;
+        AriaCurrent = ariaCurrent;
     }
 }

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor
@@ -4,7 +4,8 @@
 <li class="@Classname">
     @if (Parent?.ItemTemplate is null)
     {
-        <a href="@(Item?.Href ?? "#")">
+        <a @attributes="Attributes()">
+        
             @if (Item?.Icon != null)
             {
                 <MudIcon Icon="@Item?.Icon" Size="Size.Small" />

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
@@ -40,7 +40,7 @@ public partial class BreadcrumbLink
             {"href", Item?.Href ?? "#"}
         };
 
-        if(Item?.AriaCurrent ?? false)
+        if (Item?.AriaCurrent ?? false)
         {
             attributeValues.Add("aria-current", "page");
         }

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
@@ -32,4 +32,19 @@ public partial class BreadcrumbLink
     private string Classname => new CssBuilder("mud-breadcrumb-item")
         .AddClass("mud-disabled", Item?.Disabled)
         .Build();
+
+    private Dictionary<string, object> Attributes()
+    {
+        Dictionary<string, object> attributeValues = new()
+        {
+            {"href", Item?.Href ?? "#"}
+        };
+
+        if(Item?.AriaCurrent ?? false)
+        {
+            attributeValues.Add("aria-current", "page");
+        }
+
+        return attributeValues;
+    }
 }

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
@@ -8,7 +8,7 @@
 }
 
 <CascadingValue Value="this" IsFixed="true">
-    <nav>
+    <nav aria-label="@AriaLabel">
         <ol @attributes="UserAttributes" class="@Classname" style="@Style">
             @if (MaxItems != null && Collapsed && Items.Count > MaxItems)
             {

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
@@ -36,6 +36,16 @@ namespace MudBlazor
         public string Separator { get; set; } = "/";
 
         /// <summary>
+        /// The aria-label for the enclosing nav element
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>Breadcrumb</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Breadcrumbs.Behavior)]
+        public string AriaLabel { get; set; } = "Breadcrumb";
+
+        /// <summary>
         /// The content shown between items.
         /// </summary>
         [Parameter]


### PR DESCRIPTION
This PR adds the aria-label to the nav element created by MudBreadcrumb. It also adds a new optional property to MudBreadcrumb to allow the value of that aria-label to be set to a custom value. The default value used is "Breadcrumb" in line with W3C guidance [here ](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/)

Fixes: #12255

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
