### PR TITLE
DialogService: Rename ShowMessageBox to ShowMessageBoxAsync

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetForKeyboardNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/Examples/ChipSetForKeyboardNavigationExample.razor
@@ -42,5 +42,5 @@
         => _chips.Remove(chip.Value);
 
     private Task OpenDialogAsync()
-        => DialogService.ShowMessageBox("Dialog", "This is a dialog");
+        => DialogService.ShowMessageBoxAsync("Dialog", "This is a dialog");
 }

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample_Dialog.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogKeyboardNavigationExample_Dialog.razor
@@ -35,7 +35,7 @@
             case "Enter":
             case "NumpadEnter":
                 if (string.IsNullOrEmpty(_returnValue)) {
-                    await DialogService.ShowMessageBox(
+                    await DialogService.ShowMessageBoxAsync(
                         "Sorry",
                         @"You must either select a coffee and close with Enter or cancel with Escape!", 
                         yesText:"Got it", 

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxMarkupContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxMarkupContentExample.razor
@@ -12,7 +12,7 @@
 
     private async void OnButtonClicked()
     {
-        bool? result = await DialogService.ShowMessageBox(
+        bool? result = await DialogService.ShowMessageBoxAsync(
             "Secure The Ring", 
             (MarkupString) $"You <br /> Shall <br /> not <br /> <b>Pass!<b/>",
             yesText:"Fire Whip!", cancelText:"Smash Ground");

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxOptionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxOptionsExample.razor
@@ -45,7 +45,7 @@
         }
         else
         {
-            result = await DialogService.ShowMessageBox(
+            result = await DialogService.ShowMessageBoxAsync(
                         "Warning",
                         (MarkupString)"Deleting can <b><i>not</i></b> be undone!",
                         yesText: "Delete!", cancelText: "Cancel", options: options);

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxSimpleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxSimpleExample.razor
@@ -12,7 +12,7 @@
 
     private async void OnButtonClicked()
     {
-        bool? result = await DialogService.ShowMessageBox(
+        bool? result = await DialogService.ShowMessageBoxAsync(
             "Warning", 
             "Deleting can not be undone!", 
             yesText:"Delete!", cancelText:"Cancel");

--- a/src/MudBlazor.Docs/Pages/Components/Stepper/Examples/StepperControlledNavigationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/Examples/StepperControlledNavigationExample.razor
@@ -39,14 +39,14 @@
             case 0:
                 if (_step1Complete != true) 
                 {
-                    await DialogService.ShowMessageBox("Error", "You have not flipped the switch in step 1");
+                    await DialogService.ShowMessageBoxAsync("Error", "You have not flipped the switch in step 1");
                     arg.Cancel = true;
                 }
                 break;
             case 1:
                 if ((_step2TextInput?.Length ?? 0) == 0) 
                 {
-                    await DialogService.ShowMessageBox("Error", "You have not entered text in step 2");
+                    await DialogService.ShowMessageBoxAsync("Error", "You have not entered text in step 2");
                     arg.Cancel = true;
                 }
                 break;
@@ -59,14 +59,14 @@
             case 1:
                 if (_step1Complete != true) 
                 {
-                    await DialogService.ShowMessageBox("Error", "Finish step 1 first");
+                    await DialogService.ShowMessageBoxAsync("Error", "Finish step 1 first");
                     arg.Cancel = true;
                 }
                 break;
             case 2:
                 if (_step1Complete != true || (_step2TextInput?.Length ?? 0) == 0) 
                 {
-                    await DialogService.ShowMessageBox("Error", "Finish step 1 and 2 first");
+                    await DialogService.ShowMessageBoxAsync("Error", "Finish step 1 and 2 first");
                     arg.Cancel = true;
                 }
                 break;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOptionMutation.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogOptionMutation.razor
@@ -29,5 +29,5 @@
 
     private void Submit() => MudDialog.Close(DialogResult.Ok(true));
 
-    private Task DoSomething() => DialogService.ShowMessageBox("Warning", "Are you sure you wish to do something?", yesText: "Do it", cancelText: "Cancel");
+    private Task DoSomething() => DialogService.ShowMessageBoxAsync("Warning", "Are you sure you wish to do something?", yesText: "Do it", cancelText: "Cancel");
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethod.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogShowMethod.razor
@@ -26,16 +26,16 @@
 
             if (result is not null)
             {
-                await DialogService.ShowMessageBox("result", (string?)result.Data ?? string.Empty);
+                await DialogService.ShowMessageBoxAsync("result", (string?)result.Data ?? string.Empty);
             }
             else
             {
-                await DialogService.ShowMessageBox("error", "result was null");
+                await DialogService.ShowMessageBoxAsync("error", "result was null");
             }
         }
         catch (Exception exception)
         {
-            await DialogService.ShowMessageBox("error", exception.ToString());
+            await DialogService.ShowMessageBoxAsync("error", exception.ToString());
         }
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/TestInlineDialog.razor
@@ -24,6 +24,6 @@
     {
         _visible = false;
 
-        return DialogService.ShowMessageBox(title: "hello from inline", message: "BUG4871", yesText: "BUG4871");
+        return DialogService.ShowMessageBoxAsync(title: "hello from inline", message: "BUG4871", yesText: "BUG4871");
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -24,7 +24,7 @@ namespace MudBlazor.UnitTests.Components
             Task<bool?> yesNoCancel = null;
             await comp.InvokeAsync(() =>
             {
-                yesNoCancel = service?.ShowMessageBox(
+                yesNoCancel = service?.ShowMessageBoxAsync(
                     "Boom!",
                     "I'm a pickle. What do you make of that?",
                     "Great",
@@ -70,7 +70,7 @@ namespace MudBlazor.UnitTests.Components
             Task<bool?> yesNoCancel = null;
             await comp.InvokeAsync(() =>
             {
-                yesNoCancel = service?.ShowMessageBox(
+                yesNoCancel = service?.ShowMessageBoxAsync(
                     "Boom!",
                     (MarkupString)"I'm a pickle. What do you make of that?",
                     "Great",

--- a/src/MudBlazor/Services/Dialog/DialogService.cs
+++ b/src/MudBlazor/Services/Dialog/DialogService.cs
@@ -24,8 +24,7 @@ namespace MudBlazor
     public class DialogService : IDialogService
     {
         /// <summary>
-        /// This internal wrapper components prevents overwriting parameters of once
-        /// instantiated dialog instances
+        /// This internal wrapper component prevents overwriting parameters of once instantiated dialog instances.
         /// See: https://github.com/MudBlazor/MudBlazor/issues/10659#issuecomment-2602911059
         /// </summary>
         private class DialogHelperComponent : IComponent
@@ -134,10 +133,10 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public Task<bool?> ShowMessageBox(string? title, string message, string yesText = "OK",
+        public Task<bool?> ShowMessageBoxAsync(string? title, string message, string yesText = "OK",
             string? noText = null, string? cancelText = null, DialogOptions? options = null)
         {
-            return ShowMessageBox(new MessageBoxOptions
+            return ShowMessageBoxAsync(new MessageBoxOptions
             {
                 Title = title,
                 Message = message,
@@ -148,10 +147,10 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public Task<bool?> ShowMessageBox(string? title, MarkupString markupMessage, string yesText = "OK",
+        public Task<bool?> ShowMessageBoxAsync(string? title, MarkupString markupMessage, string yesText = "OK",
             string? noText = null, string? cancelText = null, DialogOptions? options = null)
         {
-            return ShowMessageBox(new MessageBoxOptions
+            return ShowMessageBoxAsync(new MessageBoxOptions
             {
                 Title = title,
                 MarkupMessage = markupMessage,
@@ -162,7 +161,7 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public async Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions? options = null)
+        public async Task<bool?> ShowMessageBoxAsync(MessageBoxOptions messageBoxOptions, DialogOptions? options = null)
         {
             var parameters = new DialogParameters
             {

--- a/src/MudBlazor/Services/Dialog/IDialogService.cs
+++ b/src/MudBlazor/Services/Dialog/IDialogService.cs
@@ -131,7 +131,7 @@ namespace MudBlazor
         /// <param name="cancelText">The text of the "Cancel" button.  Defaults to <c>null</c>.</param>
         /// <param name="options">The custom display options for the dialog.  Defaults to <c>null</c>.</param>
         /// <returns>Returns <c>null</c> if the <c>Cancel</c> button was clicked, <c>true</c> if the <c>Yes</c> button was clicked, or <c>false</c> if the <c>No</c> button was clicked.</returns>
-        Task<bool?> ShowMessageBox(string? title, string message, string yesText = "OK",
+        Task<bool?> ShowMessageBoxAsync(string? title, string message, string yesText = "OK",
             string? noText = null, string? cancelText = null, DialogOptions? options = null);
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace MudBlazor
         /// <param name="cancelText">The text of the "Cancel" button.  Defaults to <c>null</c>.</param>
         /// <param name="options">The custom display options for the dialog.  Defaults to <c>null</c>.</param>
         /// <returns>Returns <c>null</c> if the <c>Cancel</c> button was clicked, <c>true</c> if the <c>Yes</c> button was clicked, or <c>false</c> if the <c>No</c> button was clicked.</returns>
-        Task<bool?> ShowMessageBox(string? title, MarkupString markupMessage, string yesText = "OK",
+        Task<bool?> ShowMessageBoxAsync(string? title, MarkupString markupMessage, string yesText = "OK",
             string? noText = null, string? cancelText = null, DialogOptions? options = null);
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace MudBlazor
         /// <param name="messageBoxOptions">The options for the message box.</param>
         /// <param name="options">The custom display options for the dialog.  Defaults to <c>null</c>.</param>
         /// <returns>Returns <c>null</c> if the <c>Cancel</c> button was clicked, <c>true</c> if the <c>Yes</c> button was clicked, or <c>false</c> if the <c>No</c> button was clicked.</returns>
-        Task<bool?> ShowMessageBox(MessageBoxOptions messageBoxOptions, DialogOptions? options = null);
+        Task<bool?> ShowMessageBoxAsync(MessageBoxOptions messageBoxOptions, DialogOptions? options = null);
 
         /// <summary>
         /// Hides an existing dialog.


### PR DESCRIPTION
This PR renames `IDialogService.ShowMessageBox` to `IDialogService.ShowMessageBoxAsync`.
Note: This is a breaking change.