### PR TITLE
MudPopover: Move transition defaults from MudGlobal to PopoverOptions

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverPropertyTest.razor
@@ -48,7 +48,7 @@
     public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipNever;
 
     [Parameter]
-    public double Duration { get; set; } = 251;
+    public double? Duration { get; set; }
 
     [Parameter]
     public bool DropShadow { get; set; } = true;

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -1,4 +1,5 @@
-﻿using Bunit;
+﻿using System;
+using Bunit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.TestComponents.Popover;
@@ -18,6 +19,8 @@ namespace MudBlazor.UnitTests.Components
             options.ContainerClass.Should().Be("mud-popover-provider");
             options.FlipMargin.Should().Be(0);
             options.ThrowOnDuplicateProvider.Should().Be(true);
+            options.Delay.Should().Be(TimeSpan.Zero);
+            options.Duration.Should().Be(TimeSpan.FromMilliseconds(251));
         }
 
         //[Test]
@@ -113,7 +116,19 @@ namespace MudBlazor.UnitTests.Components
             popover.TransformOrigin.Should().Be(Origin.TopLeft);
             popover.RelativeWidth.Should().Be(DropdownWidth.Ignore);
             popover.OverflowBehavior.Should().BeNull();
-            popover.Duration.Should().Be(251);
+            popover.Duration.Should().BeNull();
+        }
+
+        [Test]
+        public void MudPopover_DefaultStyles_UsePopoverOptions()
+        {
+            var comp = Context.Render<PopoverPropertyTest>();
+
+            var popoverElement = comp.Find(".test-popover-content").ParentElement;
+            var style = popoverElement.GetAttribute("style");
+
+            style.Should().Contain("transition-duration:251ms");
+            style.Should().Contain("transition-delay:0ms");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -529,6 +529,8 @@ public class ServiceCollectionExtensionsTests
             options.PopoverOptions.Mode = PopoverMode.Default;
             options.PopoverOptions.ModalOverlay = true;
             options.PopoverOptions.OverflowBehavior = OverflowBehavior.FlipNever;
+            options.PopoverOptions.Delay = TimeSpan.FromSeconds(1);
+            options.PopoverOptions.Duration = TimeSpan.FromSeconds(2);
 
             expectedOptions = options;
         });
@@ -595,6 +597,8 @@ public class ServiceCollectionExtensionsTests
         actualPopoverOptions.Mode.Should().Be(expectedOptions.PopoverOptions.Mode);
         actualPopoverOptions.ModalOverlay.Should().Be(expectedOptions.PopoverOptions.ModalOverlay);
         actualPopoverOptions.OverflowBehavior.Should().Be(expectedOptions.PopoverOptions.OverflowBehavior);
+        actualPopoverOptions.Delay.Should().Be(expectedOptions.PopoverOptions.Delay);
+        actualPopoverOptions.Duration.Should().Be(expectedOptions.PopoverOptions.Duration);
 
         actualResizeObserverOptions.EnableLogging.Should().Be(expectedOptions.ResizeObserverOptions.EnableLogging);
         actualResizeObserverOptions.ReportRate.Should().Be(expectedOptions.ResizeObserverOptions.ReportRate);

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -109,7 +109,7 @@
                 RelativeWidth="@RelativeWidth"
                 Fixed="@PopoverFixed"
                 DropShadow="@DropShadow"
-                Duration="@(GetDense() ? 0 : MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)">
+                Duration="@GetTransitionDuration()">
         <CascadingValue Value="@this">
             <div id="@_elementId"
                  data-testid="menu-wrapper"

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -364,6 +364,11 @@ namespace MudBlazor
         protected bool GetModal() => Modal ?? PopoverService.PopoverOptions.ModalOverlay;
 
         /// <summary>
+        /// Gets the transition duration for the popover, using dense menus to disable animations.
+        /// </summary>
+        protected double GetTransitionDuration() => GetDense() ? 0 : PopoverService.PopoverOptions.Duration.TotalMilliseconds;
+
+        /// <summary>
         /// The <see cref="MudMenuItem" /> components within this menu.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -53,8 +53,8 @@ namespace MudBlazor
 
         protected string PickerPaperStylename =>
             new StyleBuilder()
-                .AddStyle("transition-duration", $"{Math.Round(MudGlobal.TransitionDefaults.Duration.TotalMilliseconds)}ms")
-                .AddStyle("transition-delay", $"{Math.Round(MudGlobal.TransitionDefaults.Delay.TotalMilliseconds)}ms")
+                .AddStyle("transition-duration", $"{Math.Round(PopoverService.PopoverOptions.Duration.TotalMilliseconds)}ms")
+                .AddStyle("transition-delay", $"{Math.Round(PopoverService.PopoverOptions.Delay.TotalMilliseconds)}ms")
                 .AddStyle(Style)
                 .Build();
 

--- a/src/MudBlazor/Components/Popover/MudPopover.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopover.razor.cs
@@ -31,8 +31,8 @@ namespace MudBlazor
 
         protected internal override string PopoverStyles =>
             new StyleBuilder()
-                .AddStyle("transition-duration", $"{Duration}ms")
-                .AddStyle("transition-delay", $"{Delay}ms")
+                .AddStyle("transition-duration", $"{GetDuration()}ms")
+                .AddStyle("transition-delay", $"{GetDelay()}ms")
                 .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
                 .AddStyle(Style)
                 .Build();
@@ -118,21 +118,21 @@ namespace MudBlazor
         /// The length of time that the opening transition takes to complete.
         /// </summary>
         /// <remarks>
-        /// Defaults to 251ms in <see cref="MudGlobal.TransitionDefaults.Duration"/>.
+        /// Defaults to <see cref="PopoverOptions.Duration"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public double Duration { get; set; } = MudGlobal.TransitionDefaults.Duration.TotalMilliseconds;
+        public double? Duration { get; set; }
 
         /// <summary>
         /// The amount of time, in milliseconds, from opening the popover to beginning the transition. 
         /// </summary>
         /// <remarks>
-        /// Defaults to 0ms in <see cref="MudGlobal.TransitionDefaults.Delay"/>.
+        /// Defaults to <see cref="PopoverOptions.Delay"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Popover.Appearance)]
-        public double Delay { get; set; } = MudGlobal.TransitionDefaults.Delay.TotalMilliseconds;
+        public double? Delay { get; set; }
 
         /// <summary>
         /// The location this popover will appear relative to its parent container.
@@ -168,6 +168,16 @@ namespace MudBlazor
         /// Gets the resolved overflow behavior, using the global default from <see cref="PopoverOptions"/> if not explicitly set.
         /// </summary>
         protected OverflowBehavior GetOverflowBehavior() => OverflowBehavior ?? PopoverService.PopoverOptions.OverflowBehavior;
+
+        /// <summary>
+        /// Gets the resolved transition duration in milliseconds, using the global default from <see cref="PopoverOptions"/> if not explicitly set.
+        /// </summary>
+        protected double GetDuration() => Duration ?? PopoverService.PopoverOptions.Duration.TotalMilliseconds;
+
+        /// <summary>
+        /// Gets the resolved transition delay in milliseconds, using the global default from <see cref="PopoverOptions"/> if not explicitly set.
+        /// </summary>
+        protected double GetDelay() => Delay ?? PopoverService.PopoverOptions.Delay.TotalMilliseconds;
 
         /// <summary>
         /// Determines the width of this popover in relation the parent container.

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -413,6 +413,8 @@ namespace MudBlazor.Services
                     popoverOptions.OverflowPadding = options.PopoverOptions.OverflowPadding;
                     popoverOptions.ModalOverlay = options.PopoverOptions.ModalOverlay;
                     popoverOptions.OverflowBehavior = options.PopoverOptions.OverflowBehavior;
+                    popoverOptions.Delay = options.PopoverOptions.Delay;
+                    popoverOptions.Duration = options.PopoverOptions.Duration;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -39,28 +39,10 @@ public static class MudGlobal
         /// <summary>
         /// The amount of time in milliseconds to wait from opening the <see cref="MudTooltip"/> before beginning to perform the transition.
         /// </summary>
-        public static TimeSpan Delay { get; set; } = TransitionDefaults.Delay;
-
-        /// <summary>
-        /// The length of time that the opening transition for <see cref="MudTooltip"/> takes to complete.
-        /// </summary>
-        public static TimeSpan Duration { get; set; } = TransitionDefaults.Duration;
-    }
-
-    /// <summary>
-    /// Default settings for transitions in MudBlazor components.
-    /// <br/>
-    /// <b>Warning:</b> This feature is under development and breaking changes to the API <b>will occur</b> between releases.
-    /// </summary>
-    public static class TransitionDefaults
-    {
-        /// <summary>
-        /// The length of time that the opening transition takes to complete.
-        /// </summary>
         public static TimeSpan Delay { get; set; } = TimeSpan.Zero;
 
         /// <summary>
-        /// The amount of time in milliseconds to wait from opening the popover before beginning to perform the transition.
+        /// The length of time that the opening transition for <see cref="MudTooltip"/> takes to complete.
         /// </summary>
         public static TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
     }

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -11,6 +11,18 @@ namespace MudBlazor;
 public class PopoverOptions
 {
     /// <summary>
+    /// Gets or sets the amount of time in milliseconds to wait from opening the popover before beginning to perform the transition.
+    /// The default value is <c>0</c>.
+    /// </summary>
+    public TimeSpan Delay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Gets or sets the length of time that the opening transition takes to complete.
+    /// The default value is <c>251 milliseconds</c>.
+    /// </summary>
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
+
+    /// <summary>
     /// Gets or sets a value indicating whether to check for the presence of a popover provider <see cref="MudPopoverProvider"/>.
     /// The default value is <c>true</c>.
     /// </summary>


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Part of a series of changes reorganizing MudGlobal by moving settings into the right places.

This pull request refactors how transition durations and delays are managed for popover components, centralizing their configuration in `PopoverOptions` and updating related components and tests to use these new defaults. The changes improve consistency and flexibility in how transition timings are set and overridden across MudBlazor components.

**Popover transition timing centralization and usage:**

* Added `Delay` and `Duration` properties to `PopoverOptions` with defaults (`0ms` and `251ms` respectively), making them the central source for popover transition timings.
* Updated `MudPopover`, `MudMenu`, and `MudPicker` components to use the values from `PopoverOptions` for transition duration and delay, allowing for global or per-instance overrides. [[1]](diffhunk://#diff-5a3b16473b39b29ec4adab6dbb225eb71ba221ecd42f9e38b583c29c4fd15464L121-R135) [[2]](diffhunk://#diff-5a3b16473b39b29ec4adab6dbb225eb71ba221ecd42f9e38b583c29c4fd15464R172-R181) [[3]](diffhunk://#diff-875bc46224a3c8b1cb70b4630930af4df12768d62b640aad77998cdb7caef96fL112-R112) [[4]](diffhunk://#diff-997ba40486ef3b48fdf722a2fa92ad565bea6676d157e80be684f4e46802304eR366-R370) [[5]](diffhunk://#diff-81b943d086e03959252eebdd02074f6da133e05296b8da73bbdf46fe07bfc206L56-R57)
* Updated dependency injection and service registration to support the new `Delay` and `Duration` options in `PopoverOptions`. [[1]](diffhunk://#diff-c6821e8ab8e8aa9813e31b7b5d2fe67f0e7b2e35a71e1dfd58b9f576daa6bb42R416-R417) [[2]](diffhunk://#diff-133df1eebb298b8c5b06ae7395a503f5654aeb0f6390aab3f61e4484a32fba54R532-R533) [[3]](diffhunk://#diff-133df1eebb298b8c5b06ae7395a503f5654aeb0f6390aab3f61e4484a32fba54R600-R601)

**Unit test updates for new defaults:**

* Modified unit tests to check for the new default values and their propagation, including verifying that popover styles reflect the correct transition timings. [[1]](diffhunk://#diff-1a814374f3ed7b45943709581ceb83afabb0ec3cc5325a2fd5ab768f23b2bce1R22-R23) [[2]](diffhunk://#diff-1a814374f3ed7b45943709581ceb83afabb0ec3cc5325a2fd5ab768f23b2bce1L116-R131) [[3]](diffhunk://#diff-7e83991cd1d9dce7cb1837ae878cf25be8cf175d04fd377a1d2532f6c8dfb522L51-R51)

**Code cleanup and documentation:**

* Updated XML documentation to reference the new centralized `PopoverOptions` defaults for transition timings.
* Removed redundant transition timing properties from `TooltipDefaults`, consolidating transition timing management.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
