### PR TITLE
Build: Globally enable nullable for MudBlazor.csproj

### DIFF
--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor
@@ -14,6 +14,9 @@
     }
     else
     {
-        @Parent?.ItemTemplate(Item)
+        if (Parent.ItemTemplate is not null && Item is not null)
+        {
+            @Parent.ItemTemplate(Item)
+        }
     }
 </li>

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -41,7 +41,7 @@
                     </g>
                 }
 
-            @if (item is SvgPolygon points)
+            @if (item is SvgPolygon points && ChartDataPoints is not null)
             {
                 @ChartDataPoints(points)
             }

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -169,7 +169,7 @@
             </g>
 
             // XAxis Labels
-            var xAxisLabels = ChartLabels ?? [];
+            var xAxisLabels = ChartLabels;
             @if (row == 0 && _options?.XAxisLabelPosition == XAxisLabelPosition.Top && col < xAxisLabels.Length)
             {
                 <g transform="translate(@((x + _cellDimension.Width / 2).ToStr()), @((y - CellPadding).ToStr()))">
@@ -348,7 +348,7 @@
             LabelX = x,
             LabelY = y,
             LabelXValue = ChartLabels.Length > _hoveredCell.Column ? ChartLabels[_hoveredCell.Column] : string.Empty,
-            LabelYValue = _hoveredCell.Value.ToString(),
+            LabelYValue = _hoveredCell.Value.ToString() ?? string.Empty,
         };
 
         var (tooltipX, tooltipY) = TooltipPositionFunc?.Invoke(path) is { } pos
@@ -364,8 +364,8 @@
         else
         {
             var hoveredSeries = ChartSeries[_hoveredCell.Row];
-            var tooltipTitleFormat = hoveredSeries.TooltipTitleFormat ?? ChartOptions.TooltipTitleFormat;
-            var tooltipSubtitleFormat = hoveredSeries.TooltipSubtitleFormat ?? ChartOptions.TooltipSubtitleFormat;
+            var tooltipTitleFormat = hoveredSeries.TooltipTitleFormat ?? ChartOptions!.TooltipTitleFormat;
+            var tooltipSubtitleFormat = hoveredSeries.TooltipSubtitleFormat ?? ChartOptions!.TooltipSubtitleFormat;
 
             if (!string.IsNullOrWhiteSpace(tooltipTitleFormat))
             {

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -551,7 +551,7 @@ namespace MudBlazor.Charts
             }).CatchAndLog();
         }
 
-        private void OnCellMouseOver(MouseEventArgs _, HeatMapCell<T> cell)
+        private void OnCellMouseOver(MouseEventArgs _, HeatMapCell<T>? cell)
         {
             _hoveredCell = cell;
         }

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -53,7 +53,7 @@
 
             if (ChartOptions?.ShowLabels is true || kv.Key == ActiveNode)
             {
-                <ChartTooltip Title="@(ChartOptions.ShowNodeValues ? $"{kv.Key} ({NodeValues.GetValueOrDefault(kv.Key!)})" : kv.Key!)"
+                <ChartTooltip Title="@(ChartOptions!.ShowNodeValues ? $"{kv.Key} ({NodeValues.GetValueOrDefault(kv.Key!)})" : kv.Key!)"
                               Color="rgba(0,0,0,0.25)"
                               X="@(kv.Value.X + (kv.Value.X <= 10 ? kv.Value.Width : 0))"
                               Y="@(kv.Value.Y + kv.Value.Height / 2)"
@@ -85,7 +85,7 @@
                               Y="@edge.LabelY"
                               ShowTriangle="false"
                               StrokeWidth="0"
-                              FontSize="@ChartOptions.LabelFontSize"
+                              FontSize="@ChartOptions!.LabelFontSize"
                               PaddingSize="@ChartOptions.LabelPadding"/>
             }
         }

--- a/src/MudBlazor/Components/Chip/MudChip.razor
+++ b/src/MudBlazor/Components/Chip/MudChip.razor
@@ -11,7 +11,7 @@
                 Class="@Classname"
                 Style="@Style"
                 @attributes="GetAttributes()"
-                @onclick="@(IsButton ? this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickAsync) : null)">
+                @onclick="@((IsButton ? this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickAsync) : null)!)">
         @{
             if (AvatarContent is not null)
             {

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -22,7 +22,7 @@
             }
             <MudSpacer />
 
-        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_SpectrumView] : null))">
+        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_SpectrumView] : string.Empty))">
             <MudIconButton Class="pa-1"
                            Size="Size.Small"
                            Color="GetButtonColor(ColorPickerView.Spectrum)"
@@ -31,7 +31,7 @@
                            aria-label="@Localizer[LanguageResource.MudColorPicker_SpectrumView]" />
         </MudTooltip>
 
-        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_GridView] : null))">
+        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_GridView] : string.Empty))">
             <MudIconButton Class="pa-1 mx-1"
                            Size="Size.Small"
                            Color="GetButtonColor(ColorPickerView.Grid)"
@@ -40,7 +40,7 @@
                            aria-label="@Localizer[LanguageResource.MudColorPicker_GridView]" />
         </MudTooltip>
 
-        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_PaletteView] : null))">
+        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_PaletteView] : string.Empty))">
             <MudIconButton Class="pa-1"
                            Size="Size.Small"
                            Color="GetButtonColor(ColorPickerView.Palette)"
@@ -263,7 +263,7 @@
                                 @if (ShowModeSwitch)
                                 {
                                     <div class="mud-picker-control-switch">
-                                        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_ModeSwitch] : null))">
+                                        <MudTooltip Text="@((ShowTooltips ? Localizer[LanguageResource.MudColorPicker_ModeSwitch] : string.Empty))">
                                             <MudIconButton OnClick="ChangeMode"
                                                            Icon="@ImportExportIcon"
                                                            Class="pa-1 me-n1"

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -59,7 +59,7 @@ namespace MudBlazor
             _cellContext = new CellContext<T>(_dataGrid, _item);
         }
 
-        public async Task StringValueChangedAsync(string value)
+        public async Task StringValueChangedAsync(string? value)
         {
             _column.SetProperty(_item, value);
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
         /// The data grid which owns this column.
         /// </summary>
         [CascadingParameter]
-        public required MudDataGrid<T> DataGrid { get; set; }
+        public MudDataGrid<T> DataGrid { get; set; } = null!;
 
         //[CascadingParameter(Name = "HeaderCell")] public HeaderCell<T> HeaderCell { get; set; }
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
         /// The data grid which owns this column.
         /// </summary>
         [CascadingParameter]
-        public MudDataGrid<T>? DataGrid { get; set; }
+        public required MudDataGrid<T> DataGrid { get; set; }
 
         //[CascadingParameter(Name = "HeaderCell")] public HeaderCell<T> HeaderCell { get; set; }
 
@@ -557,7 +557,7 @@ namespace MudBlazor
         #endregion
 
         internal int SortIndex { get; set; } = -1;
-        internal HeaderCell<T>? HeaderCell { get; set; }
+        internal HeaderCell<T> HeaderCell { get; set; } = null!;
 
         private Func<T, object?>? _sortBy;
         internal Func<T, object?>? groupBy;

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
@@ -28,7 +28,7 @@
     <!-- The last group will have items, otherwise we need the next group row -->
     @if (GroupDefinition.InnerGroup != null)
     {
-        var innerGroupItems = DataGrid?.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
+        var innerGroupItems = DataGrid.GetItemsOfGroup(GroupDefinition.InnerGroup, Items);
         var groupDefinitions = DataGrid.GetGroupDefinitions(GroupDefinition.InnerGroup, innerGroupItems);
         @foreach (var group in groupDefinitions)
         {

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -6,9 +6,9 @@
 
 @inject InternalMudLocalizer Localizer
 
-@if (Column != null && !Column.HiddenState.Value)
+@if (!Column.HiddenState.Value)
 {
-    <th scope="col" class="@Classname" style="@Stylename" colspan="@Column?.HeaderColSpan" @attributes="@UserAttributes">
+    <th scope="col" class="@Classname" style="@Stylename" colspan="@Column.HeaderColSpan" @attributes="@UserAttributes">
         @if (Column.filterable && Column.FilterTemplate != null)
         {
             @Column.FilterTemplate(Column.FilterContext)

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
         /// The <see cref="MudDataGrid{T}"/> containing this filter cell.
         /// </summary>
         [CascadingParameter]
-        public required MudDataGrid<T> DataGrid { get; set; }
+        public MudDataGrid<T> DataGrid { get; set; } = null!;
 
         /// <summary>
         /// The column associated with this filter cell.

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
         /// The <see cref="MudDataGrid{T}"/> containing this filter cell.
         /// </summary>
         [CascadingParameter]
-        public MudDataGrid<T>? DataGrid { get; set; }
+        public required MudDataGrid<T> DataGrid { get; set; }
 
         /// <summary>
         /// The column associated with this filter cell.

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -157,7 +157,7 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     <MudGrid>
                         <MudItem xs="12">
-                            @DataGrid?.Filter(Column.FilterContext.FilterDefinition, Column)
+                            @DataGrid?.Filter(Column.FilterContext.FilterDefinition!, Column)
                         </MudItem>
                         <MudItem xs="12" Class="d-flex justify-end">
                             <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
         /// The <see cref="MudDataGrid{T}"/> which contains this header cell.
         /// </summary>
         [CascadingParameter]
-        public MudDataGrid<T>? DataGrid { get; set; }
+        public required MudDataGrid<T> DataGrid { get; set; }
 
         /// <summary>
         /// Displays the content right-to-left.

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -30,7 +30,7 @@ namespace MudBlazor
         /// The <see cref="MudDataGrid{T}"/> which contains this header cell.
         /// </summary>
         [CascadingParameter]
-        public required MudDataGrid<T> DataGrid { get; set; }
+        public MudDataGrid<T> DataGrid { get; set; } = null!;
 
         /// <summary>
         /// Displays the content right-to-left.

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -127,19 +127,19 @@
                                                                     </MudStack>
                                                                 }
 
-                                                                @if (context?.GroupingState.Value ?? false)
+                                                                @if (context.GroupingState.Value)
                                                                 {
-                                                                    <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.AccountTree" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Ungroup] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.UngroupColumnAsync())"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.AccountTree" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Ungroup] Disabled="!context.groupable" OnClick="@(e => context.HeaderCell.UngroupColumnAsync())"></MudIconButton>
                                                                 }
                                                                 else
                                                                 {
-                                                                    <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.TableRows" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Group] Disabled="!context.groupable" OnClick="@(e => context?.HeaderCell.GroupColumnAsync())"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@Icons.Material.Filled.TableRows" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Group] Disabled="!context.groupable" OnClick="@(e => context.HeaderCell.GroupColumnAsync())"></MudIconButton>
                                                                 }
                                                                 <MudSwitch T="bool" Ripple="false" Class="flex-grow-1" Color="Color.Primary" Disabled="@(!context.hideable)" Value="@context.HiddenState.Value" ValueChanged="@context.ToggleAsync" Converter="_oppositeBoolConverter" Label="@context.Title" />
                                                                 <MudSpacer />
 
                                                                 <div>
-                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context?.HeaderCell.SortChangedAsync(e))"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context.HeaderCell.SortChangedAsync(e))"></MudIconButton>
                                                                     @if (context.DataGrid.SortMode == SortMode.Multiple)
                                                                     {
                                                                         if (context.SortIndex < 0)
@@ -209,7 +209,7 @@
                                     if (IsGrouped)
                                     {
                                         var groupItemsPage = GroupItemsPage;
-                                        var groupDefinitions = GetGroupDefinitions(_groupDefinition, groupItemsPage);
+                                        var groupDefinitions = GetGroupDefinitions(_groupDefinition!, groupItemsPage);
                                         if (!groupItemsPage.Any())
                                         {
                                             <tr>
@@ -284,7 +284,7 @@
                 <MudForm @ref="_editForm" FieldChanged="FormFieldChanged">
                     @foreach (var column in RenderedColumns)
                     {
-                        var cell = new Cell<T>(this, column, _editingItem);
+                        var cell = new Cell<T>(this, column, _editingItem!);
 
                         if (column.EditTemplate != null)
                         {
@@ -405,7 +405,7 @@
                      {
                          if (column.ContentFormat is not null)
                          {
-                             @(((IFormattable)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
+                             @(((IFormattable?)cell._valueNumber)?.ToString(column.ContentFormat, column.Culture))
                          }
                          else
                          {
@@ -416,7 +416,7 @@
                      {
                          if (column.ContentFormat is not null)
                          {
-                             @(((IFormattable)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
+                             @(((IFormattable?)cell.ComputedValue)?.ToString(column.ContentFormat, column.Culture))
                          }
                          else
                          {
@@ -427,7 +427,7 @@
              </td>
          </text>;
 
-    internal RenderFragment Filter(IFilterDefinition<T> filterDefinition, Column<T> column) =>
+    internal RenderFragment Filter(IFilterDefinition<T> filterDefinition, Column<T>? column) =>
         @<text>
             @{
                 var filter = new Filter<T>(this, filterDefinition, column);
@@ -451,7 +451,7 @@
                     <MudItem xs="3">
                         <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Operator]" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-operator">
-                            @foreach (var fieldOperator in filterDefinition.Column.GetFilterOperators(fieldType))
+                            @foreach (var fieldOperator in filterDefinition.Column!.GetFilterOperators(fieldType))
                             {
                                 <MudSelectItem Value="@fieldOperator">@Localizer[FilterOperator.GetTranslationKeyByOperatorName(fieldOperator)]</MudSelectItem>
                             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -36,10 +36,10 @@
     @if (ShowNavigation)
     {
         <div class="mud-table-pagination-actions">
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.First))" aria-label="@Localizer[LanguageResource.MudDataGridPager_FirstPage]" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Previous))" aria-label="@Localizer[LanguageResource.MudDataGridPager_PreviousPage]" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Next))" aria-label="@Localizer[LanguageResource.MudDataGridPager_NextPage]" />
-            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid.NavigateTo(Page.Last))" aria-label="@Localizer[LanguageResource.MudDataGridPager_LastPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.FirstPage" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid?.NavigateTo(Page.First))" aria-label="@Localizer[LanguageResource.MudDataGridPager_FirstPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateBefore" Disabled="@BackButtonsDisabled" @onclick="@(() => DataGrid?.NavigateTo(Page.Previous))" aria-label="@Localizer[LanguageResource.MudDataGridPager_PreviousPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.NavigateNext" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid?.NavigateTo(Page.Next))" aria-label="@Localizer[LanguageResource.MudDataGridPager_NextPage]" />
+            <MudIconButton Class="mud-flip-x-rtl" Icon="@Icons.Material.Filled.LastPage" Disabled="@ForwardButtonsDisabled" @onclick="@(() => DataGrid?.NavigateTo(Page.Last))" aria-label="@Localizer[LanguageResource.MudDataGridPager_LastPage]" />
         </div>
     }
 

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -14,7 +14,7 @@
                                  ValueChanged="@context.Actions.SetSelectAllAsync" />;
         }
 
-        return null;
+        return null!;
     };
 
     public RenderFragment<CellContext<T>> GetSelectCellTemplate() => context =>
@@ -35,6 +35,6 @@
                                  ValueChanged="@context.Actions.SetSelectAllAsync" />;
         }
 
-        return null;
+        return null!;
     };
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -125,7 +125,7 @@
                                             {
                                                 var selectedDay = !firstMonthFirstYear ? day : day.AddDays(-1);
                                                 <button @key="@(!firstMonthFirstYear ? selectedDay : tempId)" type="button" style="--day-id: @(!firstMonthFirstYear ? tempId : tempId + 1);"
-                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month.Value.Day? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
+                                                        class="mud-button-root mud-icon-button mud-ripple mud-ripple-icon mud-picker-calendar-day @(!firstMonthFirstYear || day.Day == _picker_month!.Value.Day ? GetDayClasses(tempMonth, day) : GetDayClasses(tempMonth, selectedDay))"
                                                         @onclick="@(async () => { var d = selectedDay; await OnDayClickedAsync(d); })"
                                                         @onclick:stopPropagation="true"
                                                         onpointerover="@(async () => await HandleMouseoverOnPickerCalendarDayButton(!firstMonthFirstYear ? tempId : tempId + 1))"

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor
@@ -57,7 +57,7 @@ else if (!string.IsNullOrEmpty(Text))
 }
 
 @code {
-    private string RenderAttributes(IDictionary<string, object> attributes)
+    private string RenderAttributes(IDictionary<string, object?> attributes)
     {
         if (attributes == null) return string.Empty;
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -483,7 +483,7 @@ namespace MudBlazor
         //https://stackoverflow.com/questions/1546113/double-to-string-conversion-without-scientific-notation
         private const string TagFormat = "0.###################################################################################################################################################################################################################################################################################################################################################";
 
-        private static string? FormatParam(T value)
+        private static string? FormatParam(T? value)
         {
             if (value is IFormattable f)
                 return f.ToString(TagFormat, CultureInfo.InvariantCulture.NumberFormat);

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -93,10 +93,10 @@
                         @if (CurrentPageItems != null && CurrentPageItems.Any())
                         {
                             var rowIndex = 0;
-                            <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
+                            <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                 @{
                                     var itemIndex = FilteredItems.ToList().IndexOf(item);
-                                    string generatedRowId = itemIndex != -1 ? $"{_tableId}_row_{itemIndex}" : null;
+                                    var generatedRowId = itemIndex != -1 ? $"{_tableId}_row_{itemIndex}" : null;
                                     var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, itemIndex)).Build();
                                     var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, itemIndex)).Build();
                                 }
@@ -199,7 +199,7 @@
 @code
 {
     // moved to code to avoid repeatedly code on markup block
-    internal RenderFragment RenderRows(IEnumerable<T> source, string customClass = null, bool expandable = false)
+    internal RenderFragment RenderRows(IEnumerable<T>? source, string? customClass = null, bool expandable = false)
     {
         var rowIndex = 0;
 
@@ -213,7 +213,7 @@
              @<text>
              @{
                  var itemIndexForId = FilteredItems.ToList().IndexOf(item);
-                 string generatedRowId = itemIndexForId != -1 ? $"{_tableId}_row_{itemIndexForId}" : null;
+                 var generatedRowId = itemIndexForId != -1 ? $"{_tableId}_row_{itemIndexForId}" : null;
 
                  var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, itemIndexForId)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).Build();
                  var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, itemIndexForId)).Build();

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -108,7 +108,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.Table.Behavior)]
-        public RenderFragment<T>? Columns { get; set; }
+        public RenderFragment<T?>? Columns { get; set; }
 
         // Workaround because "where T : new()" didn't work with Blazor components
         // T must have a default constructor, otherwise we cannot show headers when Items collection

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -70,8 +70,8 @@ else
             {
                 <MudTd/>
             }
-            @FooterTemplate(new TableGroupData<object, T>(GroupDefinition.GroupName, Items.Key, Items.ToList()))
-            @if ((Context?.Table.Editable ?? false))
+            @FooterTemplate(new TableGroupData<object, T>(GroupDefinition?.GroupName, Items?.Key, Items?.ToList() ?? []))
+            @if ((Context?.Table?.Editable ?? false))
             {
                 <MudTd />
             }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -65,7 +65,7 @@
                 }
             </div>
         </div>
-        @if (PrePanelContent != null)
+        @if (PrePanelContent is not null && ActivePanel is not null)
         {
             @PrePanelContent(ActivePanel)
         }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -309,7 +309,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.TreeView.Data)]
-        public Func<T?, Task<IReadOnlyCollection<TreeItemData<T?>>>>? ServerData { get; set; }
+        public Func<T?, Task<IReadOnlyCollection<TreeItemData<T>>>>? ServerData { get; set; }
 
         /// <summary>
         /// Prevents selections from being changed.

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -23,7 +23,7 @@ namespace MudBlazor
         private bool _isServerLoaded;
         private readonly ParameterState<bool> _selectedState;
         private readonly ParameterState<bool> _expandedState;
-        private readonly ParameterState<IReadOnlyCollection<ITreeItemData<T?>>?> _itemsState;
+        private readonly ParameterState<IReadOnlyCollection<ITreeItemData<T>>?> _itemsState;
         private readonly IConverter<T?, string?> _converter = new DefaultConverter<T?>();
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
 
@@ -37,7 +37,7 @@ namespace MudBlazor
                 .WithParameter(() => Selected)
                 .WithEventCallback(() => SelectedChanged)
                 .WithChangeHandler(OnSelectedParameterChangedAsync);
-            _itemsState = registerScope.RegisterParameter<IReadOnlyCollection<ITreeItemData<T?>>?>(nameof(Items))
+            _itemsState = registerScope.RegisterParameter<IReadOnlyCollection<ITreeItemData<T>>?>(nameof(Items))
                 .WithParameter(() => Items)
                 .WithEventCallback(() => ItemsChanged);
         }
@@ -215,13 +215,13 @@ namespace MudBlazor
         /// </summary>
         [Parameter, ParameterState]
         [Category(CategoryTypes.TreeView.Data)]
-        public IReadOnlyCollection<ITreeItemData<T?>>? Items { get; set; }
+        public IReadOnlyCollection<ITreeItemData<T>>? Items { get; set; }
 
         /// <summary>
         /// Occurs when <see cref="Items"/> has changed.
         /// </summary>
         [Parameter]
-        public EventCallback<IReadOnlyCollection<ITreeItemData<T?>>?> ItemsChanged { get; set; }
+        public EventCallback<IReadOnlyCollection<ITreeItemData<T>>?> ItemsChanged { get; set; }
 
         /// <summary>
         /// Shows the children items underneath this item.
@@ -564,7 +564,7 @@ namespace MudBlazor
         {
             if (_itemsState.Value is not null)
             {
-                await _itemsState.SetValueAsync(Array.Empty<ITreeItemData<T?>>());
+                await _itemsState.SetValueAsync(Array.Empty<ITreeItemData<T>>());
             }
             await TryInvokeServerLoadFunc();
 

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Part of #6535 (epic for adding nullable annotation support in MudBlazor)

> [Nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) enable you to declare if variables of a reference type should or shouldn't be assigned a null value. The compiler's static analysis and warnings when your code might dereference null are the most important benefit of this feature. Once enabled, the compiler generates warnings that help you avoid throwing a [System.NullReferenceException](https://learn.microsoft.com/en-us/dotnet/api/system.nullreferenceexception) when your code runs.

https://learn.microsoft.com/en-us/dotnet/csharp/nullable-migration-strategies

blocked by

- [x] #12303
- [x] #12299
- [x] #10126
- [x] #12305

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
