### PR TITLE
MudFormComponent: change ReadValue() -> ReadValue

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -66,7 +66,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-popover-open");
 
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
 
             // now let's type a different state to see the popup open
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
             // check popover class
             comp.Find("div.mud-popover").ClassList.Should().Contain("autocomplete-popover-class");
             // check state
-            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue().Should().Be("California"));
+            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue.Should().Be("California"));
             autocomplete.ReadText.Should().Be("California");
         }
 
@@ -174,7 +174,7 @@ namespace MudBlazor.UnitTests.Components
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
             // set a value the search won't find
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Text, "Austria"));
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
             await autocompleteComponent.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
         }
 
@@ -200,14 +200,14 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.DebounceInterval, 0)
                 .Add(x => x.CoerceValue, true));
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
             // set a value the search won't find
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, "Austria"));
 
             // now trigger the coercion by toggling the the menu (it won't even open for invalid values, but it will coerce)
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
-            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue().Should().Be("Austria"));
+            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue.Should().Be("Austria"));
             autocomplete.ReadText.Should().Be("Austria");
         }
 
@@ -226,12 +226,12 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.CoerceText, false)
                 .Add(x => x.Immediate, true));
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
             // set a value the search won't find
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, "Austria"));
 
-            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue().Should().Be("Austria"));
+            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue.Should().Be("Austria"));
             autocomplete.ReadText.Should().Be("Austria");
         }
 
@@ -256,7 +256,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Open.Should().BeFalse();
-            autocomplete.ReadValue().Should().BeNull();
+            autocomplete.ReadValue.Should().BeNull();
             autocomplete.ReadText.Should().BeNull();
             comp.Instance.SearchFuncCallCount.Should().Be(0);
             valueChangedCount.Should().Be(0);
@@ -273,7 +273,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : CoercedValue and immediate enabled, so value is set immediately on text input
 
             autocompletecomp.Instance.ReadText.Should().Be("Al");
-            autocompletecomp.Instance.ReadValue().Should().Be("Al");
+            autocompletecomp.Instance.ReadValue.Should().Be("Al");
             valueChangedCount.Should().Be(1);
         }
 
@@ -298,7 +298,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Open.Should().BeFalse();
-            autocomplete.ReadValue().Should().BeNull();
+            autocomplete.ReadValue.Should().BeNull();
             autocomplete.ReadText.Should().BeNull();
             comp.Instance.SearchFuncCallCount.Should().Be(0);
             valueChangedCount.Should().Be(0);
@@ -315,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : CoercedValue and immediate enabled, so value is set immediately on text input
 
             autocompletecomp.Instance.ReadText.Should().Be("Al");
-            autocompletecomp.Instance.ReadValue().Should().Be("Al");
+            autocompletecomp.Instance.ReadValue.Should().Be("Al");
             valueChangedCount.Should().Be(1);
 
             // Act : Wait the debounce timer that open the menu
@@ -326,7 +326,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : value and text unchanged
 
             autocompletecomp.Instance.ReadText.Should().Be("Al");
-            autocompletecomp.Instance.ReadValue().Should().Be("Al");
+            autocompletecomp.Instance.ReadValue.Should().Be("Al");
             valueChangedCount.Should().Be(1);
         }
 
@@ -347,7 +347,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Initial
 
             comp.Instance.ReadText.Should().BeNull();
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -356,7 +356,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Immediate false, so value is not set on text changed
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -365,7 +365,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : CoercedValue enabled, so value is set on focus lost
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().Be("ABC");
+            comp.Instance.ReadValue.Should().Be("ABC");
         }
 
         [Test]
@@ -385,7 +385,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Initial
 
             comp.Instance.ReadText.Should().BeNull();
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -394,7 +394,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Immediate false, so value is not set on text changed
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -403,7 +403,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : CoercedValue disabled, so value is not set on focus lost
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
         }
 
         [Test]
@@ -422,7 +422,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Initial
 
             comp.Instance.ReadText.Should().BeNull();
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -431,7 +431,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Immediate false, so value is not set
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -440,7 +440,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : CoercedValue enabled, so value is set on key enter pressed
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().Be("ABC");
+            comp.Instance.ReadValue.Should().Be("ABC");
         }
 
         [Test]
@@ -459,7 +459,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Initial
 
             comp.Instance.ReadText.Should().BeNull();
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -468,7 +468,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : Immediate false, so value is not set
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
 
             // Act
 
@@ -477,7 +477,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : CoercedValue disabled, so value is not set on key enter pressed
 
             comp.Instance.ReadText.Should().Be("ABC");
-            comp.Instance.ReadValue().Should().BeNull();
+            comp.Instance.ReadValue.Should().BeNull();
         }
 
         [Test]
@@ -488,14 +488,14 @@ namespace MudBlazor.UnitTests.Components
             var autocomplete = autocompleteComponent.Instance;
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CoerceText, false));
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
             // set a value the search won't find
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Text, "Austria"));
             // now trigger the coercion by closing the menu
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Austria");
         }
 
@@ -508,7 +508,7 @@ namespace MudBlazor.UnitTests.Components
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CoerceText, true));
 
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
 
             // set a value the search won't find
@@ -517,7 +517,7 @@ namespace MudBlazor.UnitTests.Components
 
             // now trigger the coercion by call MudInput.BlurAsync
             autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
         }
 
@@ -532,7 +532,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.ResetValueOnEmptyText, true));
 
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
 
             // set a value the search won't find
@@ -541,7 +541,7 @@ namespace MudBlazor.UnitTests.Components
 
             // now trigger the coercion by call MudInput.BlurAsync
             autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
-            autocomplete.ReadValue().Should().Be(null);
+            autocomplete.ReadValue.Should().Be(null);
             autocomplete.ReadText.Should().Be(expected: null);
         }
 
@@ -711,7 +711,7 @@ namespace MudBlazor.UnitTests.Components
             // Set invalid option
             await comp.InvokeAsync(() => autocomplete.SelectOptionAsync("Quux"));
             // check initial state
-            autocomplete.ReadValue().Should().Be("Quux");
+            autocomplete.ReadValue.Should().Be("Quux");
             autocomplete.ReadText.Should().Be("Quux");
             // check validity
             await comp.InvokeAsync(autocomplete.ValidateAsync);
@@ -730,7 +730,7 @@ namespace MudBlazor.UnitTests.Components
             // Set valid option
             await comp.InvokeAsync(() => autocomplete.SelectOptionAsync("Qux"));
             // check initial state
-            autocomplete.ReadValue().Should().Be("Qux");
+            autocomplete.ReadValue.Should().Be("Qux");
             autocomplete.ReadText.Should().Be("Qux");
             // check validity
             await comp.InvokeAsync(autocomplete.ValidateAsync);
@@ -778,7 +778,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Tab closes the drop-down and does not select the selected value (California)
             // because SelectValueOnTab is false by default
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
         }
 
         [Test]
@@ -803,7 +803,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Tab closes the drop-down and selects the selected value (California)
             // because SelectValueOnTab is true
-            autocomplete.ReadValue().Should().Be("California");
+            autocomplete.ReadValue.Should().Be("California");
         }
 
         /// <summary>
@@ -828,7 +828,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-popover-open");
 
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
 
             // now let's type a different state to see the popup open
@@ -859,14 +859,14 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-popover-open");
 
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
 
             // ToggleMenu to open menu and Clear to close it and check the text and value
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
             await comp.InvokeAsync(() => autocomplete.ClearAsync());
             comp.Markup.Should().NotContain("mud-popover-open");
-            autocomplete.ReadValue().Should().Be(null);
+            autocomplete.ReadValue.Should().Be(null);
             autocomplete.ReadText.Should().Be("");
 
             // now let's type a different state
@@ -879,7 +879,7 @@ namespace MudBlazor.UnitTests.Components
             // Clearing it and check the close status text and value again
             await comp.InvokeAsync(() => autocomplete.ClearAsync());
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            autocomplete.ReadValue().Should().Be(null);
+            autocomplete.ReadValue.Should().Be(null);
             autocomplete.ReadText.Should().Be("");
         }
 
@@ -937,14 +937,14 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-popover-open");
 
             // check initial state
-            autocomplete.ReadValue().Should().Be("Alabama");
+            autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
 
             // Reset it
             await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
             await comp.InvokeAsync(autocomplete.ResetAsync);
             comp.Markup.Should().NotContain("mud-popover-open");
-            autocomplete.ReadValue().Should().Be(null);
+            autocomplete.ReadValue.Should().Be(null);
             autocomplete.ReadText.Should().Be("");
 
             // now let's type a different state
@@ -957,7 +957,7 @@ namespace MudBlazor.UnitTests.Components
             // Resetting it should close popover and set Text and Value to null again
             await comp.InvokeAsync(autocomplete.ResetAsync);
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            autocomplete.ReadValue().Should().Be(null);
+            autocomplete.ReadValue.Should().Be(null);
             autocomplete.ReadText.Should().Be("");
         }
 
@@ -999,7 +999,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Open.Should().BeFalse();
-            autocomplete.ReadValue().Should().BeNull();
+            autocomplete.ReadValue.Should().BeNull();
             autocomplete.ReadText.Should().BeNull();
             comp.Instance.SearchFuncCallCount.Should().Be(0);
 
@@ -1010,7 +1010,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : menu closed, text empty and value null
 
             comp.Markup.Should().NotContain("mud-popover-open");
-            autocomplete.ReadValue().Should().BeNull();
+            autocomplete.ReadValue.Should().BeNull();
             autocomplete.ReadText.Should().BeEmpty();
             comp.Instance.SearchFuncCallCount.Should().Be(0);
         }
@@ -1040,7 +1040,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().NotContain("mud-popover-open");
             autocomplete.Open.Should().BeFalse();
-            autocomplete.ReadValue().Should().Be("Idaho");
+            autocomplete.ReadValue.Should().Be("Idaho");
             autocomplete.ReadText.Should().Be("Idaho");
             comp.Instance.SearchFuncCallCount.Should().Be(0);
 
@@ -1051,7 +1051,7 @@ namespace MudBlazor.UnitTests.Components
             // Assert : menu closed, text empty and value null
 
             comp.Markup.Should().NotContain("mud-popover-open");
-            autocomplete.ReadValue().Should().BeNull();
+            autocomplete.ReadValue.Should().BeNull();
             autocomplete.ReadText.Should().BeEmpty();
             comp.Instance.SearchFuncCallCount.Should().Be(0);
         }
@@ -1140,13 +1140,13 @@ namespace MudBlazor.UnitTests.Components
                 // TextUpdateSuppression has been removed - text now always updates
                 // check initial state
                 await comp.WaitForAssertionAsync(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Florida"));
-                autocomplete.ReadValue().Should().Be("Florida");
+                autocomplete.ReadValue.Should().Be("Florida");
                 autocomplete.ReadText.Should().Be("Florida");
 
                 //Get the button to toggle the value
                 comp.Find(".toggle-value-button").Click();
                 await comp.WaitForAssertionAsync(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Georgia"));
-                autocomplete.ReadValue().Should().Be("Georgia");
+                autocomplete.ReadValue.Should().Be("Georgia");
                 autocomplete.ReadText.Should().Be("Georgia");
 
                 //Change the value of the current bound value component
@@ -1187,20 +1187,20 @@ namespace MudBlazor.UnitTests.Components
 
                 //The value of the input should be Alabama
                 await comp.WaitForAssertionAsync(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
-                autocomplete.ReadValue().Should().Be("Alabama");
+                autocomplete.ReadValue.Should().Be("Alabama");
                 autocomplete.ReadText.Should().Be("Alabama");
 
                 //Again Change the bound object
                 comp.Find(".toggle-value-button").Click();
 
                 await comp.WaitForAssertionAsync(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Florida"));
-                autocomplete.ReadValue().Should().Be("Florida");
+                autocomplete.ReadValue.Should().Be("Florida");
                 autocomplete.ReadText.Should().Be("Florida");
 
                 //Change the bound object back and check again.
                 comp.Find(".toggle-value-button").Click();
                 await comp.WaitForAssertionAsync(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
-                autocomplete.ReadValue().Should().Be("Alabama");
+                autocomplete.ReadValue.Should().Be("Alabama");
                 autocomplete.ReadText.Should().Be("Alabama");
 
                 await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp" }));
@@ -1220,7 +1220,7 @@ namespace MudBlazor.UnitTests.Components
                 await comp.WaitForAssertionAsync(() => autocompleteComponent.Find("input").GetAttribute("value").Should().Be("Alabama"));
 
                 await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true }));
-                await comp.WaitForAssertionAsync(() => autocompleteComponent.Instance.ReadValue().Should().Be(null));
+                await comp.WaitForAssertionAsync(() => autocompleteComponent.Instance.ReadValue.Should().Be(null));
 
                 await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" }));
                 await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
@@ -1294,7 +1294,7 @@ namespace MudBlazor.UnitTests.Components
 
             await input.KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
 
-            autocompleteComponent.Instance.ReadValue().Should().Be("Wyoming");
+            autocompleteComponent.Instance.ReadValue.Should().Be("Wyoming");
         }
 
         /// <summary>
@@ -1546,7 +1546,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
             await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
             autocomplete.ReadText.Should().Be(californiaString);
-            autocomplete.ReadValue().StateName.Should().Be(californiaString);
+            autocomplete.ReadValue.StateName.Should().Be(californiaString);
 
             //California should appear as index 5 and be selected
             await comp.InvokeAsync(autocompleteComponent.Instance.OpenMenuAsync); // reopen menu because Enter closes it.
@@ -1564,7 +1564,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
             await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
             autocomplete.ReadText.Should().Be(virginiaString);
-            autocomplete.ReadValue().StateName.Should().Be(virginiaString);
+            autocomplete.ReadValue.StateName.Should().Be(virginiaString);
 
             await comp.InvokeAsync(autocompleteComponent.Instance.OpenMenuAsync); // reopen menu because Enter closes it.
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover")[index].ClassList.Should().Contain("mud-popover-open"));
@@ -1641,7 +1641,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find(popoverSelector).ClassList.Should().Contain("mud-popover-open"));
             await comp.InvokeAsync(async () => await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
             autocomplete.ReadText.Should().Be(selectedItemString);
-            autocomplete.ReadValue().Should().Be(selectedItemString);
+            autocomplete.ReadValue.Should().Be(selectedItemString);
 
             // Opening the list of autocomplete
             await comp.InvokeAsync(autocompleteComponent.Instance.OpenMenuAsync);
@@ -2138,7 +2138,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert
 
-            autocomplete.ReadValue().Should().Be(null);
+            autocomplete.ReadValue.Should().Be(null);
             await comp.WaitForAssertionAsync(() => comp.Instance.SearchCount.Should().Be(1));
         }
 

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -48,12 +48,12 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var box = comp.Instance;
             // check initial state
-            box.ReadValue().Should().Be(false);
+            box.ReadValue.Should().Be(false);
             // click and check if it has toggled
             comp.Find("input").Change(true);
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
             comp.Find("input").Change(false);
-            box.ReadValue().Should().Be(false);
+            box.ReadValue.Should().Be(false);
         }
 
         /// <summary>
@@ -66,12 +66,12 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var box = comp.Instance;
             // check initial state
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
             // click and check if it has toggled
             comp.Find("input").Change(false);
-            box.ReadValue().Should().Be(false);
+            box.ReadValue.Should().Be(false);
             comp.Find("input").Change(true);
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
         }
 
         /// <summary>
@@ -84,24 +84,24 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var boxes = comp.FindComponents<MudCheckBox<bool>>();
             // check initial state
-            boxes[0].Instance.ReadValue().Should().Be(true);
-            boxes[1].Instance.ReadValue().Should().Be(true);
+            boxes[0].Instance.ReadValue.Should().Be(true);
+            boxes[1].Instance.ReadValue.Should().Be(true);
             // click and check if it has toggled
             comp.FindAll("input")[0].Change(false);
-            boxes[0].Instance.ReadValue().Should().Be(false);
-            boxes[1].Instance.ReadValue().Should().Be(false);
+            boxes[0].Instance.ReadValue.Should().Be(false);
+            boxes[1].Instance.ReadValue.Should().Be(false);
 
             comp.FindAll("input")[0].Change(true);
-            boxes[0].Instance.ReadValue().Should().Be(true);
-            boxes[1].Instance.ReadValue().Should().Be(true);
+            boxes[0].Instance.ReadValue.Should().Be(true);
+            boxes[1].Instance.ReadValue.Should().Be(true);
 
             comp.FindAll("input")[1].Change(false);
-            boxes[0].Instance.ReadValue().Should().Be(false);
-            boxes[1].Instance.ReadValue().Should().Be(false);
+            boxes[0].Instance.ReadValue.Should().Be(false);
+            boxes[1].Instance.ReadValue.Should().Be(false);
 
             comp.FindAll("input")[1].Change(true);
-            boxes[0].Instance.ReadValue().Should().Be(true);
-            boxes[1].Instance.ReadValue().Should().Be(true);
+            boxes[0].Instance.ReadValue.Should().Be(true);
+            boxes[1].Instance.ReadValue.Should().Be(true);
         }
 
         /// <summary>
@@ -136,18 +136,18 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var box = comp.Instance;
             // check initial state
-            box.ReadValue().Should().BeNull();
+            box.ReadValue.Should().BeNull();
             // click and check if it has toggled
             comp.Find("input").Change(true);
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
             comp.Find("input").Change(false);
-            box.ReadValue().Should().Be(false);
+            box.ReadValue.Should().Be(false);
             // click and check if this is the indeterminate value
             comp.Find("input").Change(false);
-            box.ReadValue().Should().BeNull();
+            box.ReadValue.Should().BeNull();
             // click and check if this is the true value
             comp.Find("input").Change(true);
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
         }
 
         /// <summary>
@@ -256,43 +256,43 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var checkbox = comp.Instance;
-            checkbox.ReadValue().Should().Be(null);
+            checkbox.ReadValue.Should().Be(null);
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(false));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(false));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(false));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(false));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
             //Backspace should not change state on non-tristate checkbox
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.TriState, false));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
             //Check tristate space key
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(false));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(false));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
         }
         /// <summary>
         /// Test if the keyboard-disabling switch works
@@ -307,43 +307,43 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var checkbox = comp.Instance;
-            checkbox.ReadValue().Should().Be(null);
+            checkbox.ReadValue.Should().Be(null);
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             //Backspace should not change state on non-tristate checkbox
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.TriState, false));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
             //Check tristate space key
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => checkbox.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
         }
 
         [Test]
@@ -363,12 +363,12 @@ namespace MudBlazor.UnitTests.Components
             var box = comp.Instance;
 
             // check initial state
-            box.ReadValue().Should().Be(false);
+            box.ReadValue.Should().Be(false);
             comp.Find(".mud-button-root.mud-icon-button").ClassList.Should().ContainInOrder(new[] { $"mud-{uncheckedcolor.ToDescriptionString()}-text", $"hover:mud-{uncheckedcolor.ToDescriptionString()}-hover" });
 
             // click and check if it has new color
             comp.Find("input").Change(true);
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
             comp.Find(".mud-button-root.mud-icon-button").ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
         }
 

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -157,7 +157,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ColorPickerMode.Should().Be(ColorPickerMode.RGB);
             comp.Instance.ColorPickerView.Should().Be(ColorPickerView.Spectrum);
             comp.Instance.UpdateBindingIfOnlyHSLChanged.Should().BeFalse();
-            comp.Instance.ReadValue().Should().Be(_defaultColor);
+            comp.Instance.ReadValue.Should().Be(_defaultColor);
             comp.Instance.Palette.Should().BeEquivalentTo(_mudGridPaletteDefaultColors);
             comp.Instance.DragEffect.Should().BeTrue();
         }
@@ -1062,7 +1062,7 @@ namespace MudBlazor.UnitTests.Components
             var expectedColor = _defaultColor;
 
             await CheckColorRelatedValues(comp, _defaultXForColorPanel, _defaultYForColorPanel, expectedColor, ColorPickerMode.HSL, false);
-            comp.FindComponent<MudColorPicker>().Instance.ReadValue().Should().Be(_defaultColor);
+            comp.FindComponent<MudColorPicker>().Instance.ReadValue.Should().Be(_defaultColor);
         }
 
         [Test]
@@ -1162,7 +1162,7 @@ namespace MudBlazor.UnitTests.Components
                 {
                     overlay.PointerDown(new PointerEventArgs { OffsetX = x, OffsetY = y });
 
-                    comp.Instance.ReadValue().H.Should().Be(expectedHue);
+                    comp.Instance.ReadValue.H.Should().Be(expectedHue);
                 }
             }
         }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3574,36 +3574,36 @@ namespace MudBlazor.UnitTests.Components
             var switches = comp.FindComponents<MudSwitch<bool>>();
             switches.Count.Should().Be(6);
 
-            switches[0].Instance.ReadValue().Should().BeFalse();
-            switches[1].Instance.ReadValue().Should().BeTrue();
-            switches[2].Instance.ReadValue().Should().BeFalse();
-            switches[3].Instance.ReadValue().Should().BeFalse();
-            switches[4].Instance.ReadValue().Should().BeFalse();
-            switches[0].Instance.ReadValue().Should().BeFalse();
+            switches[0].Instance.ReadValue.Should().BeFalse();
+            switches[1].Instance.ReadValue.Should().BeTrue();
+            switches[2].Instance.ReadValue.Should().BeFalse();
+            switches[3].Instance.ReadValue.Should().BeFalse();
+            switches[4].Instance.ReadValue.Should().BeFalse();
+            switches[0].Instance.ReadValue.Should().BeFalse();
 
             var buttons = comp.FindComponents<MudButton>();
 
             // this is the hide all button
             buttons[0].Find("button").Click();
             //all hideable columns should be hidden;
-            switches[0].Instance.ReadValue().Should().BeTrue();
-            switches[1].Instance.ReadValue().Should().BeTrue();
-            switches[2].Instance.ReadValue().Should().BeTrue();
-            switches[3].Instance.ReadValue().Should().BeFalse();
-            switches[4].Instance.ReadValue().Should().BeFalse();
-            switches[5].Instance.ReadValue().Should().BeFalse();
+            switches[0].Instance.ReadValue.Should().BeTrue();
+            switches[1].Instance.ReadValue.Should().BeTrue();
+            switches[2].Instance.ReadValue.Should().BeTrue();
+            switches[3].Instance.ReadValue.Should().BeFalse();
+            switches[4].Instance.ReadValue.Should().BeFalse();
+            switches[5].Instance.ReadValue.Should().BeFalse();
 
             // 6 columns, 3 hidden (+ already collapsed)
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(4);
 
             // this is the show all button
             buttons[1].Find("button").Click();
-            switches[0].Instance.ReadValue().Should().BeFalse();
-            switches[1].Instance.ReadValue().Should().BeFalse();
-            switches[2].Instance.ReadValue().Should().BeFalse();
-            switches[3].Instance.ReadValue().Should().BeFalse();
-            switches[4].Instance.ReadValue().Should().BeFalse();
-            switches[5].Instance.ReadValue().Should().BeFalse();
+            switches[0].Instance.ReadValue.Should().BeFalse();
+            switches[1].Instance.ReadValue.Should().BeFalse();
+            switches[2].Instance.ReadValue.Should().BeFalse();
+            switches[3].Instance.ReadValue.Should().BeFalse();
+            switches[4].Instance.ReadValue.Should().BeFalse();
+            switches[5].Instance.ReadValue.Should().BeFalse();
 
             // 6 columns, 0 hidden (1 permanently collapsed)
             dataGrid.FindAll(".mud-table-head th").Count.Should().Be(7);
@@ -4791,28 +4791,28 @@ namespace MudBlazor.UnitTests.Components
             var rowCheckbox = dataGrid.FindAll("td input");
             var selectAllCheckboxes = dataGrid.FindComponents<MudCheckBox<bool?>>();
 
-            selectAllCheckboxes[0].Instance.ReadValue().Should().BeFalse();
-            selectAllCheckboxes[1].Instance.ReadValue().Should().BeFalse();
+            selectAllCheckboxes[0].Instance.ReadValue.Should().BeFalse();
+            selectAllCheckboxes[1].Instance.ReadValue.Should().BeFalse();
 
             rowCheckbox[0].Change(true);
 
-            selectAllCheckboxes[0].Instance.ReadValue().Should().BeNull();
-            selectAllCheckboxes[1].Instance.ReadValue().Should().BeNull();
+            selectAllCheckboxes[0].Instance.ReadValue.Should().BeNull();
+            selectAllCheckboxes[1].Instance.ReadValue.Should().BeNull();
 
             rowCheckbox[1].Change(true);
 
-            selectAllCheckboxes[0].Instance.ReadValue().Should().BeTrue();
-            selectAllCheckboxes[1].Instance.ReadValue().Should().BeTrue();
+            selectAllCheckboxes[0].Instance.ReadValue.Should().BeTrue();
+            selectAllCheckboxes[1].Instance.ReadValue.Should().BeTrue();
 
             rowCheckbox[1].Change(false);
 
-            selectAllCheckboxes[0].Instance.ReadValue().Should().BeNull();
-            selectAllCheckboxes[1].Instance.ReadValue().Should().BeNull();
+            selectAllCheckboxes[0].Instance.ReadValue.Should().BeNull();
+            selectAllCheckboxes[1].Instance.ReadValue.Should().BeNull();
 
             rowCheckbox[0].Change(false);
 
-            selectAllCheckboxes[0].Instance.ReadValue().Should().BeFalse();
-            selectAllCheckboxes[1].Instance.ReadValue().Should().BeFalse();
+            selectAllCheckboxes[0].Instance.ReadValue.Should().BeFalse();
+            selectAllCheckboxes[1].Instance.ReadValue.Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -87,13 +87,13 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should be invalid due to having a required field that is not filled
             form.IsValid.Should().Be(false);
             form.IsTouched.Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>()[0].Instance.ReadValue().Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>()[1].Instance.ReadValue().Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>()[0].Instance.ReadValue.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>()[1].Instance.ReadValue.Should().Be(false);
             // filling in the required field
             textFields[1].Find("input").Change("Fill in the required field to make this form valid");
             form.IsValid.Should().Be(true);
-            comp.FindComponents<MudSwitch<bool>>()[0].Instance.ReadValue().Should().Be(true);
-            comp.FindComponents<MudSwitch<bool>>()[1].Instance.ReadValue().Should().Be(true);
+            comp.FindComponents<MudSwitch<bool>>()[0].Instance.ReadValue.Should().Be(true);
+            comp.FindComponents<MudSwitch<bool>>()[1].Instance.ReadValue.Should().Be(true);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace MudBlazor.UnitTests.Components
             var form = comp.FindComponent<MudForm>().Instance;
             // check initial state: form should be valid due to having no required field, but the user's two-way binding did override that value to false
             await comp.WaitForAssertionAsync(() => form.IsValid.Should().Be(true));
-            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudSwitch<bool>>().Instance.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudSwitch<bool>>().Instance.ReadValue.Should().Be(true));
         }
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace MudBlazor.UnitTests.Components
             // the validation func must validate non-required empty fields as valid.
             //
             //// value is not required, so don't call the validation func on empty text
-            //await comp.InvokeAsync(() => textField.ReadValue() = "");
+            //await comp.InvokeAsync(() => textField.ReadValue = "");
             //form.IsValid.Should().Be(true);
             //form.Errors.Length.Should().Be(0);
             //textField.Error.Should().BeFalse();
@@ -304,7 +304,7 @@ namespace MudBlazor.UnitTests.Components
             // the validation func must validate non-required empty fields as valid.
             //
             //// value is not required, so don't call the validation func on empty text
-            //await comp.InvokeAsync(() => textField.ReadValue() = "");
+            //await comp.InvokeAsync(() => textField.ReadValue = "");
             //form.IsValid.Should().Be(true);
 
             // clearly a star
@@ -330,7 +330,7 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().Be(true);
             // calling Reset() should reset the textField's value
             await comp.InvokeAsync(() => form.ResetAsync());
-            textField.ReadValue().Should().Be(null);
+            textField.ReadValue.Should().Be(null);
             textField.ReadText.Should().Be(null);
             form.IsValid.Should().Be(false); // because we did reset validation state as a side-effect.
         }
@@ -396,7 +396,7 @@ namespace MudBlazor.UnitTests.Components
             }
             // after the final debounce, the value should be updated without swallowing any user input
             await Task.Delay(comp.Instance.DebounceInterval);
-            textField.ReadValue().Should().Be(currentText);
+            textField.ReadValue.Should().Be(currentText);
             textField.ReadText.Should().Be(currentText);
         }
 
@@ -452,15 +452,15 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("input")[2].Blur();
             foreach (var tf in comp.FindComponents<MudTextField<string>>())
                 tf.Instance.ReadText.Should().NotBeNullOrEmpty();
-            comp.FindComponent<MudTextField<int>>().Instance.ReadValue().Should().Be(17);
+            comp.FindComponent<MudTextField<int>>().Instance.ReadValue.Should().Be(17);
             // then click the checkbox
-            comp.FindComponent<MudCheckBox<bool>>().Instance.ReadValue().Should().Be(true);
+            comp.FindComponent<MudCheckBox<bool>>().Instance.ReadValue.Should().Be(true);
             comp.FindAll("input")[3].Change(false); // it was on before
-            comp.FindComponent<MudCheckBox<bool>>().Instance.ReadValue().Should().Be(false);
+            comp.FindComponent<MudCheckBox<bool>>().Instance.ReadValue.Should().Be(false);
             // the text fields should be unchanged
             foreach (var tf in comp.FindComponents<MudTextField<string>>())
                 tf.Instance.ReadText.Should().NotBeNullOrEmpty();
-            comp.FindComponent<MudTextField<int>>().Instance.ReadValue().Should().Be(17);
+            comp.FindComponent<MudTextField<int>>().Instance.ReadValue.Should().Be(17);
         }
 
         /// <summary>
@@ -564,7 +564,7 @@ namespace MudBlazor.UnitTests.Components
             textfields[2].Instance.ReadText.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => checkbox.Instance.HasErrors.Should().BeFalse());
             checkbox.Instance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
-            await comp.WaitForAssertionAsync(() => checkbox.Instance.ReadValue().Should().BeFalse());
+            await comp.WaitForAssertionAsync(() => checkbox.Instance.ReadValue.Should().BeFalse());
             // TODO: fill out the form with errors, field after field, check how fields get validation errors after blur
         }
 
@@ -1364,19 +1364,19 @@ namespace MudBlazor.UnitTests.Components
 
             // input some text
             textFieldComp.Find("input").Input("asdf");
-            textField.ReadValue().Should().Be("asdf");
+            textField.ReadValue.Should().Be("asdf");
             textField.ReadText.Should().Be("asdf");
             // call reset directly
             await comp.InvokeAsync(() => form.Instance.ResetAsync());
-            textField.ReadValue().Should().BeNullOrEmpty();
+            textField.ReadValue.Should().BeNullOrEmpty();
             textField.ReadText.Should().BeNullOrEmpty();
             // input some text
             textFieldComp.Find("input").Input("asdf");
-            textField.ReadValue().Should().Be("asdf");
+            textField.ReadValue.Should().Be("asdf");
             textField.ReadText.Should().Be("asdf");
             // hit reset button
             comp.Find("button.reset").Click();
-            textField.ReadValue().Should().BeNullOrEmpty();
+            textField.ReadValue.Should().BeNullOrEmpty();
             textField.ReadText.Should().BeNullOrEmpty();
         }
 

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -99,8 +99,8 @@ namespace MudBlazor.UnitTests.Components
             var list = comp.FindComponent<MudList<string>>().Instance;
             comp.Find("p.selected-values").TrimmedText().Should().Be("Cafe Latte, Milk");
             var GetCheckBox = (string text) => comp.FindComponents<MudListItem<string>>().FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
-            GetCheckBox("Milk").ReadValue().Should().Be(true);
-            GetCheckBox("Cafe Latte").ReadValue().Should().Be(true);
+            GetCheckBox("Milk").ReadValue.Should().Be(true);
+            GetCheckBox("Cafe Latte").ReadValue.Should().Be(true);
         }
 
         [Test]
@@ -117,48 +117,48 @@ namespace MudBlazor.UnitTests.Components
             // click water on list1
             Select(list1, "Sparkling Water");
             comp.Find("p.selected-values").TrimmedText().Should().Be("Carbonated H²O");
-            GetCheckBox(list1, "Milk").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Sparkling Water").ReadValue().Should().Be(true);
-            GetCheckBox(list1, "English Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Chinese Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Irish Coffee").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Double Espresso").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Milk").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Sparkling Water").ReadValue().Should().Be(true);
-            GetCheckBox(list2, "English Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Chinese Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Irish Coffee").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Double Espresso").ReadValue().Should().Be(false);
+            GetCheckBox(list1, "Milk").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Sparkling Water").ReadValue.Should().Be(true);
+            GetCheckBox(list1, "English Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Chinese Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Irish Coffee").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Double Espresso").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Milk").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Sparkling Water").ReadValue.Should().Be(true);
+            GetCheckBox(list2, "English Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Chinese Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Irish Coffee").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Double Espresso").ReadValue.Should().Be(false);
             // click Irish on list2
             Select(list2, "Irish Coffee");
             comp.Find("p.selected-values").TrimmedText().Should().Be("Carbonated H²O, Irish Coffee");
-            GetCheckBox(list1, "Milk").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Sparkling Water").ReadValue().Should().Be(true);
-            GetCheckBox(list1, "English Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Chinese Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Irish Coffee").ReadValue().Should().Be(true);
-            GetCheckBox(list1, "Double Espresso").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Milk").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Sparkling Water").ReadValue().Should().Be(true);
-            GetCheckBox(list2, "English Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Chinese Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Irish Coffee").ReadValue().Should().Be(true);
-            GetCheckBox(list2, "Double Espresso").ReadValue().Should().Be(false);
+            GetCheckBox(list1, "Milk").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Sparkling Water").ReadValue.Should().Be(true);
+            GetCheckBox(list1, "English Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Chinese Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Irish Coffee").ReadValue.Should().Be(true);
+            GetCheckBox(list1, "Double Espresso").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Milk").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Sparkling Water").ReadValue.Should().Be(true);
+            GetCheckBox(list2, "English Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Chinese Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Irish Coffee").ReadValue.Should().Be(true);
+            GetCheckBox(list2, "Double Espresso").ReadValue.Should().Be(false);
             // click off water on list2
             Select(list2, "Sparkling Water");
             comp.Find("p.selected-values").TrimmedText().Should().Be("Irish Coffee");
-            GetCheckBox(list1, "Milk").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Sparkling Water").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "English Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Chinese Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list1, "Irish Coffee").ReadValue().Should().Be(true);
-            GetCheckBox(list1, "Double Espresso").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Milk").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Sparkling Water").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "English Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Chinese Tea").ReadValue().Should().Be(false);
-            GetCheckBox(list2, "Irish Coffee").ReadValue().Should().Be(true);
-            GetCheckBox(list2, "Double Espresso").ReadValue().Should().Be(false);
+            GetCheckBox(list1, "Milk").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Sparkling Water").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "English Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Chinese Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list1, "Irish Coffee").ReadValue.Should().Be(true);
+            GetCheckBox(list1, "Double Espresso").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Milk").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Sparkling Water").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "English Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Chinese Tea").ReadValue.Should().Be(false);
+            GetCheckBox(list2, "Irish Coffee").ReadValue.Should().Be(true);
+            GetCheckBox(list2, "Double Espresso").ReadValue.Should().Be(false);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -37,7 +37,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert : Initial state
 
-            textField.ReadValue().Should().Be(initialValue);
+            textField.ReadValue.Should().Be(initialValue);
             textField.ReadText.Should().Be(initialValue);
             maskField.Value.Should().Be(initialValue);
             maskField.ReadText.Should().Be(initialValue);
@@ -48,7 +48,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert
 
-            textField.ReadValue().Should().Be(setValue);
+            textField.ReadValue.Should().Be(setValue);
             textField.ReadText.Should().Be(setValue);
             maskField.Value.Should().Be(setValue);
             maskField.ReadText.Should().Be(setValue);
@@ -63,133 +63,133 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().BeNullOrEmpty());
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().BeNullOrEmpty());
             //Unmatched keys should have no effect
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
-            maskField.Instance.ReadValue().Should().BeNullOrEmpty();
+            maskField.Instance.ReadValue.Should().BeNullOrEmpty();
             maskField.Instance.Mask.ToString().Should().Be("|");
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(a__) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(2));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             //Symbols should have no effect in letter
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "+" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             //Symbol as a mask character should have no effect in letter
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "*" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             //Check uppercase character
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "C" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(6));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "d" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC"));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
             //Symbols should have no effect in digit
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "+" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
             //Symbol as a mask character should have no effect in letter
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "*" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 12_-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC12"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC12"));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "0" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(10));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "A" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-A_"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120A"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120A"));
             //Check culture character
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ı" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-Aı"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120Aı"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120Aı"));
             //Keys should have no effect if the mask completed
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Z" }));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "0" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-Aı"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120Aı"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120Aı"));
 
             //Middle input should move the after characters
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(9));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-bA"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120bA"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120bA"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(11));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "c" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-bc"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120bc"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120bc"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(12));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-b_"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120b"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120b"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(11));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC120"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120"));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 12_-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC12"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC12"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(8));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC"));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(3));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(a__) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a"));
 
             //Backspace should have no effect on empty value
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(0));
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(0));
         }
 
@@ -207,7 +207,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("(|abc) 120-ac"));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(bca) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("bca"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("bca"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(1));
 
             await comp.InvokeAsync(() => maskField.Instance.Clear());
@@ -218,16 +218,16 @@ namespace MudBlazor.UnitTests.Components
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("(ab|a) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(aba) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("aba"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("aba"));
 
             await comp.InvokeAsync(() => maskField.Instance.Clear());
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be(""));
 
             await comp.InvokeAsync(() => maskField.Instance.OnFocused(new FocusEventArgs()));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(a__) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(2));
         }
 
@@ -240,37 +240,37 @@ namespace MudBlazor.UnitTests.Components
             var maskField = comp.FindComponent<MudMask>();
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(1));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
             //Unmatched keys should have no effect
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)_-_)"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(1));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(1));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)2-_)"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(12));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(12));
 
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "3" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)2-3)"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(123));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(123));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)2-_)"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(12));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(12));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)_-_)"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(1));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(1));
 
             await comp.InvokeAsync(
                 () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
         }
 
         [Test]
@@ -291,20 +291,20 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) |___-__"));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) 1|__-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("a1"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a1"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(10));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) 1__-|__"));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) 1__-a|_"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("a1a"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a1a"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(1));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(|a__) 1__-a_"));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(b|a_) _1_-_a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ba_) _1_-_a"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ba1a"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ba1a"));
         }
 
         [Test]
@@ -331,7 +331,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a|__) ___-__"));
             await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
         }
 
         [Test]
@@ -352,19 +352,19 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(a_) __"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("a"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "A" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(a_) __"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("a"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(aa) __"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("aa"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("aa"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "A" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(aa) A_"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("aaA"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("aaA"));
         }
 
         /// <summary>
@@ -382,38 +382,38 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(1));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(a__) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("a"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ab_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ab"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "c" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(abc) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("abc"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("abc"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(3));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ac_) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("ac"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ac"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(6));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ac_) 1__-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("ac1"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ac1"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "0" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ac_) 10_-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("ac10"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ac10"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(1));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(c__) ___-__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("c"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("c"));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be(""));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be(""));
         }
 
         [Test]
@@ -428,22 +428,22 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(10));
             await comp.InvokeAsync(() => maskField.Instance.OnPasteAsync("zxc"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abc) ___-zx"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("abczx"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abczx"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(2));
             await comp.InvokeAsync(() => maskField.Instance.OnPasteAsync("defgh"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ade) ___-zx"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("adezx"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("adezx"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(7));
             await comp.InvokeAsync(() => maskField.Instance.OnPasteAsync("120"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ade) _12-zx"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ade12zx"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ade12zx"));
             //Symbols should not be paste but remove the related index
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(1));
             await comp.InvokeAsync(() => maskField.Instance.OnPasteAsync("+-"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ade) _12-zx"));
-            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue().Should().Be("ade12zx"));
+            await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ade12zx"));
         }
 
         [Test]
@@ -463,20 +463,20 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234 5678 |9__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1234 5678 9__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("123456789"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123456789"));
             //Select with a whitespace and test again
             await comp.InvokeAsync(() => maskField.OnSelect(4, 8));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234[ 567]8 9__"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234| 89__ ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1234 89__ ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("123489"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123489"));
 
             await comp.InvokeAsync(() => maskField.OnSelect(7, 11));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234 89[__ _]__"));
             await comp.InvokeAsync(() => maskField.OnPasteAsync("567"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1234 8956 7__"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("123489567"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123489567"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(0));
             await comp.InvokeAsync(() => maskField.OnSelect(0, 1));
@@ -484,13 +484,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("|2348 9567 ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("2348 9567 ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("23489567"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("23489567"));
 
             await comp.InvokeAsync(() => maskField.OnSelect(6, 11));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("2348 9[567 _]__"));
             await comp.InvokeAsync(() => maskField.OnPasteAsync("1Mud9"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("2348 919_ ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("2348919"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("2348919"));
 
             await comp.InvokeAsync(() => maskField.Clear());
             await comp.InvokeAsync(() => maskField.OnPasteAsync("1234 81__ _9_"));
@@ -499,13 +499,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1[23]4 81__ _9_"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1481 ___9 ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("14819"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("14819"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(3));
             await comp.InvokeAsync(() => maskField.OnSelect(3, 7));
             await comp.InvokeAsync(() => maskField.OnPasteAsync("a1a"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1481 _9__ ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("14819"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("14819"));
         }
 
         [Test]
@@ -514,65 +514,65 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MaskTwoWayBindingTest>();
             var maskField1 = comp.FindComponents<MudMask>().First();
             var maskField2 = comp.FindComponents<MudMask>().Last();
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be(""));
 
             await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(a"));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("a"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(a"));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("a"));
 
             await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(ab"));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("ab"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(ab"));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("ab"));
 
             await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "C" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) "));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.Mask.CaretPos.Should().Be(6));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) "));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC"));
 
             await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 1"));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) 1"));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 12"));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("abC12"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC12"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) 12"));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("abC12"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC12"));
 
             await comp.InvokeAsync(() =>
                 maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 1"));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) 1"));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("abC1"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.InvokeAsync(() =>
                 maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) "));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) "));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("abC"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC"));
 
             await comp.InvokeAsync(() => maskField1.Instance.OnPasteAsync("123"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 123-"));
-            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue().Should().Be("abC123"));
+            await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC123"));
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) 123-"));
-            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue().Should().Be("abC123"));
+            await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC123"));
         }
 
         [Test]
@@ -586,28 +586,28 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnFocused(new FocusEventArgs()));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(TimeSpan.FromDays(1)));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(TimeSpan.FromDays(1)));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("12:"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "3" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("12:3"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(new TimeSpan(12, 3, 00)));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(new TimeSpan(12, 3, 00)));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "4" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("12:34"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(new TimeSpan(12, 34, 00)));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(new TimeSpan(12, 34, 00)));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(2));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("13:4"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(new TimeSpan(13, 4, 00)));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(new TimeSpan(13, 4, 00)));
 
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("14:"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
         }
 
         [Test]
@@ -627,7 +627,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await maskField.FocusAsync());
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1__ ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("1"));
 
             await comp.InvokeAsync(async () => await maskField.SelectAsync());
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(0));
@@ -635,22 +635,22 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnSelect(0, 7));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("2__ ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("2"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(0));
             await comp.InvokeAsync(() => maskField.OnFocused(new FocusEventArgs()));
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Text, "123"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("123 ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("123"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123"));
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Text, "123 ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("123 ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("123"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123"));
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "321"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("321 ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("321"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("321"));
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "321"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("321 ___"));
-            await comp.WaitForAssertionAsync(() => maskField.ReadValue().Should().Be("321"));
+            await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("321"));
             await comp.InvokeAsync(() => maskField.OnBlurredAsync(new FocusEventArgs()));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Clearable, true));
@@ -718,31 +718,31 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => mask.OnPasteAsync("1234567890"));
             await comp.WaitForAssertionAsync(() => mask.Mask.ToString().Should().Be("(123) 456-7890|"));
             await comp.WaitForAssertionAsync(() => textField.ReadText.Should().Be("(123) 456-7890"));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("(123) 456-7890"));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("(123) 456-7890"));
 
             await comp.InvokeAsync(() => form.ResetAsync());
             await comp.WaitForAssertionAsync(() => mask.Mask.ToString().Should().Be("|"));
             await comp.WaitForAssertionAsync(() => textField.ReadText.Should().BeNullOrEmpty());
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().BeNullOrEmpty());
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().BeNullOrEmpty());
 
             await comp.InvokeAsync(async () => await textField.FocusAsync());
             await comp.InvokeAsync(async () => await textField.SelectAsync());
             await comp.InvokeAsync(async () => await textField.SelectRangeAsync(0, 1));
             await comp.InvokeAsync(() => textField.Clear());
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(null));
 
             //This gives error
             await comp.InvokeAsync(() => textField.SetText("123"));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("(123) "));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("(123) "));
 
             //ctrl+backspace
             await comp.InvokeAsync(() => form.ResetAsync());
             await comp.InvokeAsync(() => mask.OnPasteAsync("1234567890"));
             await comp.WaitForAssertionAsync(() => mask.Mask.ToString().Should().Be("(123) 456-7890|"));
             await comp.WaitForAssertionAsync(() => textField.ReadText.Should().Be("(123) 456-7890"));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("(123) 456-7890"));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("(123) 456-7890"));
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(""));
         }
 
         /// <summary>
@@ -764,17 +764,17 @@ namespace MudBlazor.UnitTests.Components
                 mask.OnSelect(0, mask.ReadText.Length);
                 return mask.OnPasteAsync("1234567890");
             });
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be(originalValue));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(originalValue));
             // backspace
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be(originalValue));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(originalValue));
             // cut
             await comp.InvokeAsync(() =>
             {
                 mask.OnSelect(0, mask.ReadText.Length);
                 comp.Find("input").CutAsync(new ClipboardEventArgs { Type = "cut" });
             });
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be(originalValue));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(originalValue));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ReadOnly, false));
             // paste
@@ -783,17 +783,17 @@ namespace MudBlazor.UnitTests.Components
                 mask.OnSelect(0, mask.ReadText.Length);
                 return mask.OnPasteAsync("2222 2222 2222 2222");
             });
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("2222 2222 2222 2222"));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("2222 2222 2222 2222"));
             // backspace
             await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("2222 2222 2222 222"));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("2222 2222 2222 222"));
             // cut
             await comp.InvokeAsync(() =>
             {
-                mask.OnSelect(0, textField.ReadValue().Length);
+                mask.OnSelect(0, textField.ReadValue.Length);
                 comp.Find("input").Cut(new ClipboardEventArgs { Type = "cut" });
             });
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(""));
         }
 
         [Test]
@@ -974,19 +974,19 @@ namespace MudBlazor.UnitTests.Components
                 Key = "a"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("a"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("a"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
             {
                 Key = "b"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("ab"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("ab"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
             {
                 Key = "c"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("abc"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
 
             // test common shortcuts
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
@@ -995,21 +995,21 @@ namespace MudBlazor.UnitTests.Components
                 MetaKey = true
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("abc"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
             {
                 Key = "v",
                 MetaKey = true
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("abc"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
             {
                 Key = "x",
                 MetaKey = true
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("abc"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
         }
 
         [Test]
@@ -1027,19 +1027,19 @@ namespace MudBlazor.UnitTests.Components
                 Key = "a"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("a"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("a"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
             {
                 Key = "b"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("ab"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("ab"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("ab"));
             await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
             {
                 Key = "c"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("abc"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
 
             // select middle character ('b') and cut it
             await comp.InvokeAsync(() =>
@@ -1051,7 +1051,7 @@ namespace MudBlazor.UnitTests.Components
                 });
             });
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("ac"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("ac"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("ac"));
             Context.JSInterop.VerifyInvoke("mudWindow.copyToClipboard", 1);
             Context.JSInterop.Invocations["mudWindow.copyToClipboard"].Single().Arguments.Should().BeEquivalentTo(["b"]);
 
@@ -1065,7 +1065,7 @@ namespace MudBlazor.UnitTests.Components
                 });
             });
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("a"));
-            await comp.WaitForAssertionAsync(() => tf.ReadValue().Should().Be("a"));
+            await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("a"));
             Context.JSInterop.VerifyInvoke("mudWindow.copyToClipboard", 2);
             Context.JSInterop.Invocations["mudWindow.copyToClipboard"][1].Arguments.Should().BeEquivalentTo(["c"]);
         }

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -56,7 +56,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var numericField = comp.Instance;
-            numericField.ReadValue().Should().Be(0.0);
+            numericField.ReadValue.Should().Be(0.0);
             numericField.ReadText.Should().Be("0");
             //
             0.0.ToString("F1", CultureInfo.InvariantCulture).Should().Be("0.0");
@@ -65,7 +65,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Format, "F1")
                 .Add(x => x.Culture, CultureInfo.InvariantCulture));
 
-            numericField.ReadValue().Should().Be(0.0);
+            numericField.ReadValue.Should().Be(0.0);
             numericField.ReadText.Should().Be("0.0");
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
         }
@@ -80,7 +80,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var numericField = comp.Instance;
-            numericField.ReadValue().Should().Be(null);
+            numericField.ReadValue.Should().Be(null);
             numericField.ReadText.Should().BeNullOrEmpty();
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
         }
@@ -117,7 +117,7 @@ namespace MudBlazor.UnitTests.Components
             input.Input(new ChangeEventArgs() { Value = "100" });
             //Assert
             //input value has changed, DebounceInterval is 0, so Value should change in NumericField immediately
-            numericField.ReadValue().Should().Be(100);
+            numericField.ReadValue.Should().Be(100);
             numericField.ReadText.Should().Be("100");
         }
 
@@ -137,14 +137,14 @@ namespace MudBlazor.UnitTests.Components
             //if DebounceInterval is set, Immediate should be true by default
             numericField.Immediate.Should().BeTrue();
             //input value has changed, but elapsed time is 0, so Value should not change in NumericField
-            numericField.ReadValue().Should().BeNull();
+            numericField.ReadValue.Should().BeNull();
             numericField.ReadText.Should().Be("100");
             //DebounceInterval is 200 ms, so at 100 ms Value should not change in NumericField
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().NotBe(100), TimeSpan.FromMilliseconds(100));
-            numericField.ReadValue().Should().BeNull();
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().NotBe(100), TimeSpan.FromMilliseconds(100));
+            numericField.ReadValue.Should().BeNull();
             numericField.ReadText.Should().Be("100");
             //More than 200 ms had elapsed, so Value should be updated (CPU time will likely take more than 200ms)
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(100), TimeSpan.FromMilliseconds(300));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(100), TimeSpan.FromMilliseconds(300));
             numericField.ReadText.Should().Be("100");
         }
 
@@ -208,7 +208,7 @@ namespace MudBlazor.UnitTests.Components
             // now try something that's outside of range
             comp.Find("input").Change("100.1");
             numericField.GetState(x => x.Error).Should().BeFalse(because: "The value should be set to Max (100)");
-            numericField.ReadValue().Should().Be(100M);
+            numericField.ReadValue.Should().Be(100M);
             numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
@@ -223,12 +223,12 @@ namespace MudBlazor.UnitTests.Components
 
             // first try set max decimal value
             comp.Find("input").Change(decimal.MaxValue);
-            numericField.ReadValue().Should().Be(decimal.MaxValue);
+            numericField.ReadValue.Should().Be(decimal.MaxValue);
             numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // next try set minimum decimal value
             comp.Find("input").Change(decimal.MinValue);
-            numericField.ReadValue().Should().Be(decimal.MinValue);
+            numericField.ReadValue.Should().Be(decimal.MinValue);
             numericField.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
         }
 
@@ -244,10 +244,10 @@ namespace MudBlazor.UnitTests.Components
             // test against an infinite update loop that numericFields and other inputs are now protected against.
             var numericField = comp.Instance;
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, 1));
-            numericField.ReadValue().Should().Be(1);
+            numericField.ReadValue.Should().Be(1);
             numericField.ReadText.Should().Be("1");
             comp.Find("input").Change("3");
-            numericField.ReadValue().Should().Be(3);
+            numericField.ReadValue.Should().Be(3);
             numericField.ReadText.Should().Be("3");
         }
 
@@ -297,7 +297,7 @@ namespace MudBlazor.UnitTests.Components
         //    var numericField = comp.Instance;
         //    comp.Find("input").Change("A");
         //    comp.Find("input").Blur();
-        //    numericField.ReadValue().Should().BeNull();
+        //    numericField.ReadValue.Should().BeNull();
         //    numericField.HasErrors.Should().Be(true);
         //    numericField.GetState(x => x.ErrorText).Should().Be("Not a valid number");
         //}
@@ -344,23 +344,23 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var numericField = comp.Instance;
-            numericField.ReadValue().Should().Be(1234.56);
+            numericField.ReadValue.Should().Be(1234.56);
             numericField.ReadText.Should().Be("1234.56");
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1235.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1235.56));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
         }
 
         /// <summary>
@@ -375,12 +375,12 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Format, "F2")
                 .Add(x => x.Value, 1234.56)
                 .Add(x => x.Disabled, true));
-            comp.Instance.ReadValue().Should().Be(1234.56);
+            comp.Instance.ReadValue.Should().Be(1234.56);
             comp.Instance.ReadText.Should().Be("1234.56");
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
         }
 
         /// <summary>
@@ -395,12 +395,12 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Format, "F2")
                 .Add(x => x.Value, 1234.56)
                 .Add(x => x.ReadOnly, true));
-            comp.Instance.ReadValue().Should().Be(1234.56);
+            comp.Instance.ReadValue.Should().Be(1234.56);
             comp.Instance.ReadText.Should().Be("1234.56");
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
             comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
         }
 
         /// <summary>
@@ -415,38 +415,38 @@ namespace MudBlazor.UnitTests.Components
 
             //MouseWheel up
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1235.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1235.56));
 
             //MouseWheel down
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
 
             //Invert MouseWheel
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.InvertMouseWheel, true));
 
             //MouseWheel up
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1233.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1233.56));
 
             //MouseWheel down
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
 
             //Try with different step
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, 0.5));
 
             //MouseWheel up
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.06));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.06));
 
             //MouseWheel down
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
 
             //MouseWheel without Shift doesn't do anything
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = 77, ShiftKey = false });
             await comp.Find("input").WheelAsync(new WheelEventArgs() { DeltaY = -17, ShiftKey = false });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
         }
 
         /// <summary>
@@ -461,38 +461,38 @@ namespace MudBlazor.UnitTests.Components
 
             //MouseWheel up
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1235.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1235.56));
 
             //MouseWheel down
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
 
             //Invert MouseWheel
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.InvertMouseWheel, true));
 
             //MouseWheel up
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1233.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1233.56));
 
             //MouseWheel down
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
 
             //Try with different step
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, 0.5));
 
             //MouseWheel up
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.06));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.06));
 
             //MouseWheel down
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 1, ShiftKey = true });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
 
             //MouseWheel without Shift doesn't do anything
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = 77, ShiftKey = false });
             comp.Find("input").Wheel(new WheelEventArgs() { DeltaY = -17, ShiftKey = false });
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
         }
 
         /// <summary>
@@ -509,32 +509,32 @@ namespace MudBlazor.UnitTests.Components
             NotImmediate().Change("1234");
             await NotImmediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be("1.234,00"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(1234.0));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(1234.0));
             NotImmediate().GetAttribute("type").Should().Be("text");
             NotImmediate().GetAttribute("value").Should().Be("1.234,00");
             NotImmediate().Change("0");
             await NotImmediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be("0,00"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(0.0));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(0.0));
             NotImmediate().Change("");
             await NotImmediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be(null));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(null));
             // English
             Immediate().Input("1234");
             await Immediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("1,234.00"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(1234.0));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(1234.0));
             Immediate().GetAttribute("type").Should().Be("text");
             Immediate().GetAttribute("value").Should().Be("1,234.00");
             Immediate().Input("0");
             await Immediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("0.00"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(0.0));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(0.0));
             Immediate().Input("");
             await Immediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be(null));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(null));
         }
 
         /// <summary>
@@ -548,29 +548,29 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("input").Last().Change("abcd");
             comp.FindAll("input").Last().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be(null));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(null));
             // English
             comp.FindAll("input").First().Input("abcd");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be(null));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(null));
             // English
             comp.FindAll("input").First().Input("-12-34abc.56");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be(null));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(null));
             comp.FindAll("input").First().Input("-1234.56");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("-1,234.56"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(-1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(-1234.56));
             comp.FindAll("input").Last().Change("x+17,9y9z");
             comp.FindAll("input").Last().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be(null));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(null));
             comp.FindAll("input").Last().Change("17,99");
             comp.FindAll("input").Last().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be("17,99"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(17.99));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(17.99));
         }
 
         [Test]
@@ -581,20 +581,20 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("input").First().Input("1,234.56");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("1,234.56"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(1234.56));
             comp.FindAll("input").First().Input("1234.56");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("1,234.56"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(1234.56));
             // german
             comp.FindAll("input").Last().Change("7.000,99");
             comp.FindAll("input").Last().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be("7.000,99"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(7000.99));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(7000.99));
             comp.FindAll("input").Last().Change("7000,99");
             comp.FindAll("input").Last().Blur();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be("7.000,99"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(7000.99));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(7000.99));
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -606,9 +606,9 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Min, value)
                 .Add(x => x.Value, value));
             var numericField = comp.Instance;
-            numericField.ReadValue().Should().Be(value);
+            numericField.ReadValue.Should().Be(value);
             await comp.InvokeAsync(numericField.ValidateAsync);
-            numericField.ReadValue().Should().Be(value);
+            numericField.ReadValue.Should().Be(value);
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -624,12 +624,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("15");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(max));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(max));
 
             comp.Find("input").Change("0");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(min));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(min));
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -645,12 +645,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("15");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(max));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(max));
 
             comp.Find("input").Change("0");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(min));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(min));
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -666,14 +666,14 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Value, value));
             await comp.InvokeAsync(() => comp.Instance.Increment());
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(value);
+            comp.Instance.ReadValue.Should().Be(value);
             // setting min and max to value will cover the boundary checking code
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Max, value)
                 .Add(x => x.Min, value));
             await comp.InvokeAsync(() => comp.Instance.Increment());
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(value);
+            comp.Instance.ReadValue.Should().Be(value);
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -689,14 +689,14 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Value, value));
             await comp.InvokeAsync(() => comp.Instance.Increment());
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(value);
+            comp.Instance.ReadValue.Should().Be(value);
             // setting min and max to value will cover the boundary checking code
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.Max, value)
                 .Add(x => x.Min, value));
             await comp.InvokeAsync(() => comp.Instance.Increment());
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(value);
+            comp.Instance.ReadValue.Should().Be(value);
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -706,7 +706,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Step, value));
 
             await comp.InvokeAsync(() => comp.Instance.Increment());
-            comp.Instance.ReadValue().Should().Be(value);
+            comp.Instance.ReadValue.Should().Be(value);
 
             comp.Find("input").Change("");
 
@@ -716,7 +716,7 @@ namespace MudBlazor.UnitTests.Components
                 value = (T)Convert.ChangeType(-Convert.ToDouble(value), typeof(T));
 
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(value);
+            comp.Instance.ReadValue.Should().Be(value);
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -728,12 +728,12 @@ namespace MudBlazor.UnitTests.Components
             // test max overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Max));
             await comp.InvokeAsync(() => comp.Instance.Increment());
-            comp.Instance.ReadValue().Should().Be(comp.Instance.Max);
+            comp.Instance.ReadValue.Should().Be(comp.Instance.Max);
 
             // test min overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Min));
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(comp.Instance.Min);
+            comp.Instance.ReadValue.Should().Be(comp.Instance.Min);
         }
 
         [TestCaseSource(nameof(TypeCases))]
@@ -745,12 +745,12 @@ namespace MudBlazor.UnitTests.Components
             // test max overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Max));
             await comp.InvokeAsync(() => comp.Instance.Increment());
-            comp.Instance.ReadValue().Should().Be(comp.Instance.Max);
+            comp.Instance.ReadValue.Should().Be(comp.Instance.Max);
 
             // test min overflow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, comp.Instance.Min));
             await comp.InvokeAsync(() => comp.Instance.Decrement());
-            comp.Instance.ReadValue().Should().Be(comp.Instance.Min);
+            comp.Instance.ReadValue.Should().Be(comp.Instance.Min);
         }
 
         /// <summary>
@@ -769,7 +769,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().BeNull());
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().BeNull());
         }
 
         /// <summary>
@@ -785,7 +785,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var numericField = comp.Instance;
-            numericField.ReadValue().Should().Be(null);
+            numericField.ReadValue.Should().Be(null);
             numericField.ReadText.Should().Be(null);
             //
             77.ToString("€0", CultureInfo.InvariantCulture).Should().Be("€77");
@@ -799,7 +799,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("input").First().Change("1234");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be("€1234"));
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1234));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234));
         }
 
         /// <summary>
@@ -811,7 +811,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudNumericField<int?>>();
             var numericField = comp.Instance;
 
-            numericField.ReadValue().Should().Be(null);
+            numericField.ReadValue.Should().Be(null);
             numericField.ReadText.Should().Be(null);
 
             // comma separator
@@ -819,14 +819,14 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("input").First().Change("1,000");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be("1000"));
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1000));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1000));
 
             // period separator
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Culture, new CultureInfo("de-DE", false)));
             comp.FindAll("input").First().Change("1.000");
             comp.FindAll("input").First().Blur();
             await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be("1000"));
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue().Should().Be(1000));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1000));
         }
 
         /// <summary>
@@ -1050,7 +1050,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("123,45");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(123.45M));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(123.45M));
             comp.Instance.ReadText.Should().Be("123,450");
             comp.Instance.Culture.Name.Should().Be("ru-RU");
         }
@@ -1065,7 +1065,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("123,45");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(123.45M));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(123.45M));
             comp.Instance.ReadText.Should().Be("123,45");
             comp.Instance.GetState(x => x.Culture).Name.Should().Be("ru-RU");
         }
@@ -1082,14 +1082,14 @@ namespace MudBlazor.UnitTests.Components
             NotImmediate().Change("1.234,56");
             await NotImmediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadText.Should().Be("1.234,56"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(1234.56));
             comp.Instance.FieldNotImmediate.Culture.Name.Should().Be("de-DE");
 
             // English
             Immediate().Input("1234.56");
             await Immediate().BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadText.Should().Be("1,234.56"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue().Should().Be(1234.56));
+            await comp.WaitForAssertionAsync(() => comp.Instance.FieldImmediate.ReadValue.Should().Be(1234.56));
             comp.Instance.FieldImmediate.Culture.Name.Should().Be("en-US");
         }
 
@@ -1104,7 +1104,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("123.45");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(123.45M));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(123.45M));
             comp.Instance.ReadText.Should().Be("123.450");
             comp.Instance.Culture.Name.Should().Be("en-US");
         }
@@ -1120,7 +1120,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("123.45");
             comp.Find("input").Blur();
 
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(123.45M));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(123.45M));
             comp.Instance.ReadText.Should().Be("123.45");
             comp.Instance.Culture.Name.Should().Be("en-US");
         }
@@ -1230,7 +1230,7 @@ namespace MudBlazor.UnitTests.Components
             // conversion is not possible and conversion error is set
             await comp.WaitForAssertionAsync(() =>
             {
-                numericField.ReadValue().Should().Be(0);
+                numericField.ReadValue.Should().Be(0);
                 numericField.HasErrors.Should().Be(true);
                 numericField.ConversionError.Should().Be(true);
                 numericField.ConversionErrorMessage.Should().NotBeNullOrEmpty();
@@ -1242,7 +1242,7 @@ namespace MudBlazor.UnitTests.Components
             // conversion error is cleared
             await comp.WaitForAssertionAsync(() =>
             {
-                numericField.ReadValue().Should().Be(0);
+                numericField.ReadValue.Should().Be(0);
                 numericField.HasErrors.Should().Be(false);
                 numericField.ConversionError.Should().Be(false);
                 numericField.ConversionErrorMessage.Should().BeNull();

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -243,7 +243,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => radio.Instance.IMudRadioGroup = null);
             await comp.InvokeAsync(() => radio.Instance.OnClickAsync());
-            await comp.WaitForAssertionAsync(() => radio.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => radio.Instance.ReadValue.Should().Be("1"));
             await radio.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             await comp.WaitForAssertionAsync(() => group.Instance.Value.Should().Be(null));
 

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Components
             // check popover class
             menu.ClassList.Should().Contain("select-popover-class");
             // check initial state
-            select.Instance.ReadValue().Should().BeNullOrEmpty();
+            select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
             await input.MouseDownAsync();
@@ -73,7 +73,7 @@ namespace MudBlazor.UnitTests.Components
             await items[1].ClickAsync();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => menu.ClassList.Should().NotContain("mud-popover-open"));
-            select.Instance.ReadValue().Should().Be("2");
+            select.Instance.ReadValue.Should().Be("2");
             // now we cheat and click the list without opening the menu ;)
 
             await input.MouseDownAsync();
@@ -81,7 +81,7 @@ namespace MudBlazor.UnitTests.Components
             items = comp.FindAll("div.mud-list-item").ToArray();
 
             await items[0].ClickAsync();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             //Check user on blur implementation works
             IElement Switch() => comp.Find("#switch");
             Switch().Change(true);
@@ -100,7 +100,7 @@ namespace MudBlazor.UnitTests.Components
             // check popover class
             menu.ClassList.Should().Contain("select-popover-class");
             // check initial state
-            select.Instance.ReadValue().Should().NotBeNull();
+            select.Instance.ReadValue.Should().NotBeNull();
             Input().GetAttribute("value").Should().Be("Diavolo");
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
@@ -126,34 +126,34 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "t", Type = "keydown" }));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Tennessee"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Tennessee"));
 
             //cycle through matching results
             await Task.Delay(210);
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "t", Type = "keydown" }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Texas"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Texas"));
             await Task.Delay(210);
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "t", Type = "keydown" }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Tennessee"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Tennessee"));
 
             //multi-string search
             await Task.Delay(210);
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "c", Type = "keydown" }));
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "o", Type = "keydown" }));
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "l", Type = "keydown" }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Colorado"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Colorado"));
 
             //paused search
             await Task.Delay(210);
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "i", Type = "keydown" }));
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "o", Type = "keydown" }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Iowa"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Iowa"));
 
             await Task.Delay(210);
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "i", Type = "keydown" }));
             await Task.Delay(210);
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "o", Type = "keydown" }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Ohio"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Ohio"));
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace MudBlazor.UnitTests.Components
                 var menu = comp.Find("div.mud-popover");
                 var input = comp.Find("div.mud-input-control");
                 // check initial state
-                select.Instance.ReadValue().Should().BeNullOrEmpty();
+                select.Instance.ReadValue.Should().BeNullOrEmpty();
                 await comp.WaitForAssertionAsync(() =>
                     comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
                 // click and check if it has toggled the menu
@@ -244,7 +244,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<MyEnum>>();
             var input = comp.Find("div.mud-input-control");
 
-            select.Instance.ReadValue().Should().Be(default(MyEnum));
+            select.Instance.ReadValue.Should().Be(default(MyEnum));
             select.Instance.ReadText.Should().Be(default(MyEnum).ToString());
 
             comp.Find("input").Attributes["value"]?.Value.Should().Be("First");
@@ -265,7 +265,7 @@ namespace MudBlazor.UnitTests.Components
             // select elements needed for the test
             var select = comp.FindComponent<MudSelect<int>>();
             var input = comp.Find("div.mud-input-control");
-            select.Instance.ReadValue().Should().Be(17);
+            select.Instance.ReadValue.Should().Be(17);
             select.Instance.ReadText.Should().Be("17");
             comp.Find("input").Attributes["value"]?.Value.Should().Be("17");
             input.MouseDown();
@@ -273,7 +273,7 @@ namespace MudBlazor.UnitTests.Components
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-input-slot").TextContent.Trim().Should().Be("Two"));
-            select.Instance.ReadValue().Should().Be(2);
+            select.Instance.ReadValue.Should().Be(2);
             select.Instance.ReadText.Should().Be("2");
         }
 
@@ -288,19 +288,19 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<int>>();
             var input = comp.Find("div.mud-input-control");
 
-            select.Instance.ReadValue().Should().Be(17);
+            select.Instance.ReadValue.Should().Be(17);
             select.Instance.ReadText.Should().Be("17");
             await Task.Delay(100);
             // BUT: we have a select with Strict="true" so the Text will not be shown because it is not in the list of selectable values
-            comp.FindComponent<MudInput<string>>().Instance.ReadValue().Should().Be(null);
+            comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be(null);
             comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
             input.MouseDown();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be(2));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(2));
             select.Instance.ReadText.Should().Be("2");
-            comp.FindComponent<MudInput<string>>().Instance.ReadValue().Should().Be("2");
+            comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be("2");
             comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Text); // because list item has no render fragment, so we show it as text
         }
 
@@ -314,7 +314,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<int?>>();
 
             // Initial state: null value
-            select.Instance.ReadValue().Should().Be(null);
+            select.Instance.ReadValue.Should().Be(null);
             select.Find("div.mud-input-slot").TextContent.Should().Be("None");
             select.Markup.Should().Contain("mud-shrink");
 
@@ -324,7 +324,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item").ToArray()[1].Click(); // Select "One" (value = 1)
 
             // Verify non-null value
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be(1));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(1));
             select.Find("div.mud-input-slot").TextContent.Should().Be("One");
             select.Markup.Should().Contain("mud-shrink");
 
@@ -334,7 +334,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item").ToArray()[0].Click(); // Select "None" (value = null)
 
             // Verify back to null value
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(null));
             select.Find("div.mud-input-slot").TextContent.Should().Be("None");
             select.Markup.Should().Contain("mud-shrink");
         }
@@ -409,7 +409,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<int>>();
             var input = comp.Find("div.mud-input-control");
 
-            select.Instance.ReadValue().Should().Be(1);
+            select.Instance.ReadValue.Should().Be(1);
             select.Instance.ReadText.Should().Be("1");
             comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none");
 
@@ -419,7 +419,7 @@ namespace MudBlazor.UnitTests.Components
             items[1].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none"));
-            select.Instance.ReadValue().Should().Be(2);
+            select.Instance.ReadValue.Should().Be(2);
             select.Instance.ReadText.Should().Be("2");
         }
 
@@ -433,7 +433,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // check initial state
-            select.Instance.ReadValue().Should().BeNullOrEmpty();
+            select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
             input.MouseDown();
@@ -444,7 +444,7 @@ namespace MudBlazor.UnitTests.Components
             items[1].Click();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             select.Instance.ReadText.Should().Be("2");
             text.Should().Be("2");
 
@@ -454,7 +454,7 @@ namespace MudBlazor.UnitTests.Components
             items = comp.FindAll("div.mud-list-item").ToArray();
 
             items[0].Click();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             select.Instance.ReadText.Should().Be("1");
             text.Should().Be("1");
         }
@@ -487,7 +487,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // check initial state
-            select.Instance.ReadValue().Should().BeNullOrEmpty();
+            select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
             input.MouseDown();
@@ -499,7 +499,7 @@ namespace MudBlazor.UnitTests.Components
             items[1].Click();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             select.Instance.ReadText.Should().Be("2");
             text.Should().Be("2");
             selectedValuesChangedCount.Should().Be(1);
@@ -511,7 +511,7 @@ namespace MudBlazor.UnitTests.Components
             items = comp.FindAll("div.mud-list-item").ToArray();
 
             items[0].Click();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             select.Instance.ReadText.Should().Be("1");
             text.Should().Be("1");
             string.Join(",", selectedValues).Should().Be("1");
@@ -552,7 +552,7 @@ namespace MudBlazor.UnitTests.Components
             var items = comp.FindAll("div.mud-list-item").ToArray();
             // click list item
             items[1].Click();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             select.Instance.ReadText.Should().Be("2");
             text.Should().Be("2");
             selectedValuesChangedCount.Should().Be(1);
@@ -562,7 +562,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
             items[0].Click();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2, 1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2, 1"));
             select.Instance.ReadText.Should().Be("2, 1");
             text.Should().Be("2, 1");
             string.Join(",", selectedValues).Should().Be("2,1");
@@ -596,7 +596,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item-disabled").Count.Should().Be(1));
             comp.FindAll("div.mud-list-item-disabled")[0].Click();
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().BeNull());
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().BeNull());
         }
 
         [Test]
@@ -617,7 +617,7 @@ namespace MudBlazor.UnitTests.Components
                 var menu = comp.Find("div.mud-popover");
                 var input = comp.Find("div.mud-input-control");
                 // check initial state
-                select.Instance.ReadValue().Should().BeNullOrEmpty();
+                select.Instance.ReadValue.Should().BeNullOrEmpty();
                 await comp.WaitForAssertionAsync(() =>
                     comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
                 // click and check if it has toggled the menu
@@ -757,7 +757,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // check initial state
-            select.Instance.ReadValue().Should().BeNullOrEmpty();
+            select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
             input.MouseDown();
@@ -768,7 +768,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item")[1].Click();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => menu.ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             select.Instance.ReadText.Should().Be("2");
             validatedValue.Should().Be("2");
 
@@ -776,7 +776,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             comp.FindAll("div.mud-list-item")[0].Click();
 
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             select.Instance.ReadText.Should().Be("1");
             validatedValue.Should().Be("1");
         }
@@ -850,7 +850,7 @@ namespace MudBlazor.UnitTests.Components
                     .ClassList.Should().NotContain("mud-popover-open"));
 
             // Value is set
-            select.Instance.ReadValue().Should().Be("2");
+            select.Instance.ReadValue.Should().Be("2");
 
             // Clear button appears
             comp.FindAll(".mud-input-clear-button").Should().ContainSingle();
@@ -864,7 +864,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Value cleared
             await comp.WaitForAssertionAsync(() =>
-                select.Instance.ReadValue().Should().BeNullOrEmpty());
+                select.Instance.ReadValue.Should().BeNullOrEmpty());
 
             // Clear button removed
             comp.FindAll(".mud-input-clear-button").Should().BeEmpty();
@@ -888,7 +888,7 @@ namespace MudBlazor.UnitTests.Components
 
             input.MouseDown();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            select.Instance.ReadValue().Should().Be("Apple");
+            select.Instance.ReadValue.Should().Be("Apple");
 
             // now click an item and see the value change
             var items = comp.FindAll("div.mud-list-item").ToArray();
@@ -896,7 +896,7 @@ namespace MudBlazor.UnitTests.Components
 
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => menu.ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Orange"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Orange"));
             comp.Instance.ChangeCount.Should().Be(1);
 
             // now click an item and see the value change
@@ -905,7 +905,7 @@ namespace MudBlazor.UnitTests.Components
             items = comp.FindAll("div.mud-list-item").ToArray();
             items[1].Click();
 
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Orange"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Orange"));
             comp.Instance.ChangeCount.Should().Be(1);
 
         }
@@ -971,7 +971,7 @@ namespace MudBlazor.UnitTests.Components
             var input = comp.Find("div.mud-input-control");
 
             comp.Find("div.mud-popover").ClassList.Should().Contain("select-popover-class");
-            select.Instance.ReadValue().Should().BeNullOrEmpty();
+            select.Instance.ReadValue.Should().BeNullOrEmpty();
             comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
             // open the select
             comp.Find("div.mud-input-control").MouseDown();
@@ -981,7 +981,7 @@ namespace MudBlazor.UnitTests.Components
             // now click an item and see the value change
             comp.FindAll("div.mud-list-item")[1].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             // open again and check hilited option
             comp.Find("div.mud-input-control").MouseDown();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1005,7 +1005,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             var select = comp.FindComponent<MudSelect<string>>();
             comp.Find("div.mud-popover").ClassList.Should().Contain("select-popover-class");
-            select.Instance.ReadValue().Should().Be("2");
+            select.Instance.ReadValue.Should().Be("2");
             comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
             // open the select
             comp.Find("div.mud-input-control").MouseDown();
@@ -1016,7 +1016,7 @@ namespace MudBlazor.UnitTests.Components
             // now click an item and see the value change
             comp.FindAll("div.mud-list-item")[0].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             // open again and check hilited option
             comp.Find("div.mud-input-control").MouseDown();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1037,17 +1037,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[0].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("American Samoa"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("American Samoa"));
             comp.Find("div.mud-input-control").MouseDown();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[1].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Arizona"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Arizona"));
             comp.Find("div.mud-input-control").MouseDown();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[2].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Arkansas"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Arkansas"));
             // reloading!
             comp.Find(".reload").Click();
             // check again, different values expected now
@@ -1055,17 +1055,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[0].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Alabama"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Alabama"));
             comp.Find("div.mud-input-control").MouseDown();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[1].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("Alaska"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Alaska"));
             comp.Find("div.mud-input-control").MouseDown();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.FindAll("div.mud-list-item")[2].Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("American Samoa"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("American Samoa"));
         }
 
         [Test]
@@ -1118,7 +1118,7 @@ namespace MudBlazor.UnitTests.Components
             //If we didn't select an item with mouse or arrow keys yet, value should remains null.
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(null));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -1128,7 +1128,7 @@ namespace MudBlazor.UnitTests.Components
             //If dropdown is closed, arrow key should not set a value.
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(null));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -1137,29 +1137,29 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             //End key should not select the last disabled item
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "End", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("3"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("3"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Home", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
             //Arrow up should select still the first item
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "End", Type = "keydown", }));
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("3"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("3"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "2", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "2", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("2"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             await comp.WaitForAssertionAsync(() => select.Instance.GetState(x => x.SelectedValues).Should().HaveCount(1));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
@@ -1179,17 +1179,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "a", CtrlKey = true, Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("0 feline has been selected"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("0 feline has been selected"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "A", CtrlKey = true, Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("7 felines have been selected"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("7 felines have been selected"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("6 felines have been selected"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("6 felines have been selected"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "A", CtrlKey = true, Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue().Should().Be("7 felines have been selected"));
+            await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("7 felines have been selected"));
 
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -1259,7 +1259,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "End", Type = "keydown", }));
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.Instance.GetState(x => x.SelectedValues).Should().HaveCount(0));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(null));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(null));
         }
 
         [Test]
@@ -1314,14 +1314,14 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => select.Instance.ForceUpdate());
             await comp.WaitForAssertionAsync(() => comp.Instance.ValueChangeCount.Should().Be(1));
             comp.Instance.ValuesChangeCount.Should().Be(1);
-            select.Instance.ReadValue().Should().Be("1");
+            select.Instance.ReadValue.Should().Be("1");
 
             // Changing value programmatically without ForceUpdate should change value, but should not fire change events
             // Its by design, so this part can be change if design changes
             await comp.InvokeAsync(async () => await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "2")));
             await comp.WaitForAssertionAsync(() => comp.Instance.ValueChangeCount.Should().Be(1));
             comp.Instance.ValuesChangeCount.Should().Be(1);
-            select.Instance.ReadValue().Should().Be("2");
+            select.Instance.ReadValue.Should().Be("2");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -16,29 +16,29 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudSwitch<bool>>();
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(false));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(false));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(false));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(false));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(false));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(false));
 
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue().Should().Be(true));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
         }
 
         [Test]
@@ -59,12 +59,12 @@ namespace MudBlazor.UnitTests.Components
 
             var checkboxClasses = comp.Find(".mud-button-root.mud-icon-button.mud-switch-base");
             // check initial state
-            box.ReadValue().Should().Be(false);
+            box.ReadValue.Should().Be(false);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{uncheckedcolor.ToDescriptionString()}-text", $"hover:mud-{uncheckedcolor.ToDescriptionString()}-hover" });
 
             // click and check if it has new color
             comp.Find("input").Change(true);
-            box.ReadValue().Should().Be(true);
+            box.ReadValue.Should().Be(true);
             checkboxClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToDescriptionString()}-text", $"hover:mud-{color.ToDescriptionString()}-hover" });
         }
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -731,12 +731,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -764,12 +764,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -787,15 +787,15 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(1); // selected items should be empty
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(1);
-            checkboxes[0].ReadValue().Should().Be(false);
-            checkboxes[1].ReadValue().Should().Be(true);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(1);
+            checkboxes[0].ReadValue.Should().Be(false);
+            checkboxes[1].ReadValue.Should().Be(true);
             // uncheck it
             checkboxRendered[1].Find("input").Change(false);
             // check result
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -813,13 +813,13 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3);
             // uncheck only row 1 => header checkbox should be off then
             checkboxRendered[2].Find("input").Change(false);
-            checkboxes[0].ReadValue().Should().Be(true); // header checkbox should be on
+            checkboxes[0].ReadValue.Should().Be(true); // header checkbox should be on
             table.SelectedItems.Count.Should().Be(2);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(2);
         }
 
         /// <summary>
@@ -837,15 +837,15 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = checkboxRendered.Select(x => x.Instance).ToArray();
             tableComponent.Instance.SelectedItems?.Count.Should().Be(4);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2, 3 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(2);
             // uncheck a row then switch to page 2 and both checkboxes on page 2 should be checked
             checkboxRendered[1].Find("input").Change(false);
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(1);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(1);
             // switch page
             await tableComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.CurrentPage, 1));
             // now two checkboxes should be checked on page 2
             checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(2);
         }
 
         /// <summary>
@@ -873,12 +873,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[4].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[4].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -906,12 +906,12 @@ namespace MudBlazor.UnitTests.Components
             inputs[4].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3);
             inputs = comp.FindAll("input").ToArray();
             inputs[4].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -941,7 +941,7 @@ namespace MudBlazor.UnitTests.Components
             inputs()[0].Change(true);
             table.SelectedItems.Count.Should().Be(1);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1 }"); // only "1" should be present
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(1);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(1);
             inputs()[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
@@ -952,11 +952,11 @@ namespace MudBlazor.UnitTests.Components
             inputs()[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2 }"); // we reset search, so all three numbers should be searched
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3);
             inputs()[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
             comp.Find("p").TextContent.Should().Be("SelectedItems {  }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
         }
 
         /// <summary>
@@ -975,7 +975,7 @@ namespace MudBlazor.UnitTests.Components
             inputs.Change(true);
             table.SelectedItems.Count.Should().Be(5);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 2, 3, 4 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(5);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(5);
 
             // click delete button
             var buttons = comp.FindAll("button");
@@ -994,9 +994,9 @@ namespace MudBlazor.UnitTests.Components
             //verify selection
             table.SelectedItems.Count.Should().Be(4);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 0, 1, 3, 4 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(4);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(4);
 
-            checkboxes[0].ReadValue().Should().BeTrue(); //manually verify header is checked after deleting item
+            checkboxes[0].ReadValue.Should().BeTrue(); //manually verify header is checked after deleting item
         }
 
         /// <summary>
@@ -1036,7 +1036,7 @@ namespace MudBlazor.UnitTests.Components
             inputs.Change(true);
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(10);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(10);
 
             // click next page button
             var buttons = comp.FindAll("button[aria-label=\"Next page\"]");
@@ -1056,13 +1056,13 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
             // No item from current page should be checked
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
 
             // Click the checkbox of the row with id 12
             inputs2[2].Change(true);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12 }");
             // One checkbox of the current page should be checked
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(1);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(1);
         }
 
         /// <summary>
@@ -1084,7 +1084,7 @@ namespace MudBlazor.UnitTests.Components
             }
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(10);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(10);
 
             // click next page button
             var buttons = comp.FindAll("button[aria-label=\"Next page\"]");
@@ -1105,13 +1105,13 @@ namespace MudBlazor.UnitTests.Components
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
             // No item from current page should be checked
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0);
 
             // Click the checkbox of the row with id 12
             inputs2.ElementAt(1).Change(true);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12 }");
             // One checkbox of the current page should be checked
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(1);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(1);
         }
 
         /// <summary>
@@ -1133,7 +1133,7 @@ namespace MudBlazor.UnitTests.Components
             }
             table.SelectedItems.Count.Should().Be(10);
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(10);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(10);
 
             // Change filter
             await comp.SetParametersAndRenderAsync(parameters => parameters
@@ -1145,7 +1145,7 @@ namespace MudBlazor.UnitTests.Components
             // Find checkboxes, and skip date filter and table header checkbox
             inputs = comp.FindAll("input").Skip(3);
             inputs.Count().Should().Be(5); // one checkbox per row + one for the header + two date filters
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(2);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(2);
             // Selection should remain intact
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
 
@@ -1159,7 +1159,7 @@ namespace MudBlazor.UnitTests.Components
             // Find checkboxes, and skip date filter and table header checkbox
             inputs = comp.FindAll("input").Skip(3);
             inputs.Count().Should().Be(10); // one checkbox per row + one for the header + two date filters
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(10);
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(10);
             // Selection should remain intact
             comp.Find("p").TextContent.Should().Be("SelectedItems { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }");
         }
@@ -2614,7 +2614,7 @@ namespace MudBlazor.UnitTests.Components
             inputs[0].Change(true);
             table.SelectedItems.Count.Should().Be(3);
 
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3); //there should be 3 items
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3); //there should be 3 items
             comp.Find("p").TextContent.Should().Be("Elements { A, B, C }");
 
             // Click on the second row
@@ -2627,13 +2627,13 @@ namespace MudBlazor.UnitTests.Components
 
             table.SelectedItems.Count.Should().Be(3);
 
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(3); //there should be 3 items
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(3); //there should be 3 items
             comp.Find("p").TextContent.Should().Be("Elements { A, Change, C }");
 
             // Uncheck and verify that all items are removed
             inputs[0].Change(false);
             table.SelectedItems.Count.Should().Be(0);
-            checkboxes.Sum(x => x.ReadValue() ? 1 : 0).Should().Be(0); //there should be 4 items
+            checkboxes.Sum(x => x.ReadValue ? 1 : 0).Should().Be(0); //there should be 4 items
             comp.Find("p").TextContent.Should().Be("Elements {  }");
         }
 

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -54,7 +54,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var textfield = comp.Instance;
-            textfield.ReadValue().Should().Be(0.0);
+            textfield.ReadValue.Should().Be(0.0);
             textfield.ReadText.Should().Be("0");
             //
             0.0.ToString("F1", CultureInfo.InvariantCulture).Should().Be("0.0");
@@ -63,7 +63,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Format, "F1")
                 .Add(x => x.Culture, CultureInfo.InvariantCulture));
 
-            textfield.ReadValue().Should().Be(0.0);
+            textfield.ReadValue.Should().Be(0.0);
             textfield.ReadText.Should().Be("0.0");
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
         }
@@ -78,7 +78,7 @@ namespace MudBlazor.UnitTests.Components
             // print the generated html
             // select elements needed for the test
             var textfield = comp.Instance;
-            textfield.ReadValue().Should().Be(null);
+            textfield.ReadValue.Should().Be(null);
             textfield.ReadText.Should().BeNullOrEmpty();
             comp.FindAll("div.mud-input-error").Count.Should().Be(0);
         }
@@ -128,7 +128,7 @@ namespace MudBlazor.UnitTests.Components
             input.Input(new ChangeEventArgs() { Value = "Some Value" });
             //Assert
             //input value has changed, DebounceInterval is 0, so Value should change in TextField immediately
-            textField.ReadValue().Should().Be("Some Value");
+            textField.ReadValue.Should().Be("Some Value");
         }
 
         /// <summary>
@@ -146,13 +146,13 @@ namespace MudBlazor.UnitTests.Components
             //if DebounceInterval is set, Immediate should be true by default
             textField.Immediate.Should().BeTrue();
             //input value has changed, but elapsed time is 0, so Value should not change in TextField
-            textField.ReadValue().Should().BeNull();
+            textField.ReadValue.Should().BeNull();
             //DebounceInterval is 200 ms, so at 100 ms Value should not change in TextField
             await Task.Delay(100);
-            textField.ReadValue().Should().BeNull();
+            textField.ReadValue.Should().BeNull();
             //More than 200 ms had elapsed, so Value should be updated
             await Task.Delay(150);
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("Some Value"));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Some Value"));
         }
 
         /// <summary>
@@ -173,11 +173,11 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DebounceInterval, 200.0000001));
 
             // Assert - Value should still be null (debounce still pending)
-            textField.ReadValue().Should().BeNull();
+            textField.ReadValue.Should().BeNull();
 
             // Wait for the debounce to complete
             await Task.Delay(250);
-            await comp.WaitForAssertionAsync(() => textField.ReadValue().Should().Be("Test Value"));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Test Value"));
         }
 
         /// <summary>
@@ -267,10 +267,10 @@ namespace MudBlazor.UnitTests.Components
             // test against an infinite update loop that textfields and other inputs are now protected against.
             var textfield = comp.Instance;
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, "A"));
-            textfield.ReadValue().Should().Be("A");
+            textfield.ReadValue.Should().Be("A");
             textfield.ReadText.Should().Be("Ax");
             comp.Find("input").Change("B");
-            textfield.ReadValue().Should().Be("By");
+            textfield.ReadValue.Should().Be("By");
             textfield.ReadText.Should().Be("B");
         }
 
@@ -385,12 +385,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("A");
             comp.Find("input").Blur();
             textfield.ReadText.Should().Be("A");
-            textfield.ReadValue().Should().Be("A");
+            textfield.ReadValue.Should().Be("A");
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Lines, 2));
             comp.Find("textarea").Change("B\nC");
             comp.Find("textarea").Blur();
             textfield.ReadText.Should().Be("B\nC");
-            textfield.ReadValue().Should().Be("B\nC");
+            textfield.ReadValue.Should().Be("B\nC");
         }
 
         /// <summary>
@@ -494,7 +494,7 @@ namespace MudBlazor.UnitTests.Components
             // Set invalid text
             comp.Find("input").Change("Quux");
             // check initial state
-            textfield.ReadValue().Should().Be("Quux");
+            textfield.ReadValue.Should().Be("Quux");
             textfield.ReadText.Should().Be("Quux");
             // check validity
             await comp.InvokeAsync(() => textfield.ValidateAsync());
@@ -513,7 +513,7 @@ namespace MudBlazor.UnitTests.Components
             // Set valid text
             comp.Find("input").Change("Qux");
             // check initial state
-            textfield.ReadValue().Should().Be("Qux");
+            textfield.ReadValue.Should().Be("Qux");
             textfield.ReadText.Should().Be("Qux");
             // check validity
             await comp.InvokeAsync(() => textfield.ValidateAsync());
@@ -603,10 +603,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudTextField<int>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Text, "17"));
             var textfield = comp.Instance;
-            textfield.ReadValue().Should().Be(17);
+            textfield.ReadValue.Should().Be(17);
             textfield.ReadText.Should().Be("17");
             await comp.InvokeAsync(async () => await textfield.Clear());
-            textfield.ReadValue().Should().Be(0);
+            textfield.ReadValue.Should().Be(0);
             textfield.ReadText.Should().Be(null);
         }
 
@@ -616,10 +616,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudTextField<string>>();
             comp.Find("input").Change("Viva la ignorancia");
             var textfield = comp.Instance;
-            textfield.ReadValue().Should().Be("Viva la ignorancia");
+            textfield.ReadValue.Should().Be("Viva la ignorancia");
             textfield.ReadText.Should().Be("Viva la ignorancia");
             await comp.InvokeAsync(async () => await textfield.Clear());
-            textfield.ReadValue().Should().Be(null);
+            textfield.ReadValue.Should().Be(null);
             textfield.ReadText.Should().Be(null);
         }
 
@@ -663,30 +663,30 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Change("Vat of acid");
             // this will make the input focused!
             comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
-            textfield.ReadValue().Should().Be("Vat of acid");
+            textfield.ReadValue.Should().Be("Vat of acid");
             textfield.ReadText.Should().Be("Vat of acid");
 
             // TextUpdateSuppression has been removed - text now always updates
             // Setting value directly will always update the text
             await input.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, ""));
-            input.Instance.ReadValue().Should().Be("");
+            input.Instance.ReadValue.Should().Be("");
             input.Instance.ReadText.Should().Be("");
 
             // Set a new value
             await input.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "In case of ladle"));
-            input.Instance.ReadValue().Should().Be("In case of ladle");
+            input.Instance.ReadValue.Should().Be("In case of ladle");
             input.Instance.ReadText.Should().Be("In case of ladle");
 
             // Set empty again
             await input.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, ""));
-            input.Instance.ReadValue().Should().Be("");
+            input.Instance.ReadValue.Should().Be("");
             input.Instance.ReadText.Should().Be("");
 
             // force text update (should still work)
             await input.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "Test"));
             await comp.InvokeAsync(() => input.Instance.ForceRender(forceTextUpdate: true));
 
-            input.Instance.ReadValue().Should().Be("Test");
+            input.Instance.ReadValue.Should().Be("Test");
             input.Instance.ReadText.Should().Be("Test");
         }
 
@@ -701,12 +701,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").Input("The Stormlight Archive");
             // check binding update
             comp.Find("span").TrimmedText().Should().Be("value: The Stormlight Archive");
-            input.Instance.ReadValue().Should().Be("The Stormlight Archive");
+            input.Instance.ReadValue.Should().Be("The Stormlight Archive");
             input.Instance.ReadText.Should().Be("The Stormlight Archive");
             // now hit Enter to cause the clearing of the focused text field
             await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => comp.Find("span").TrimmedText().Should().Be("value:"));
-            await comp.WaitForAssertionAsync(() => input.Instance.ReadValue().Should().Be(""));
+            await comp.WaitForAssertionAsync(() => input.Instance.ReadValue.Should().Be(""));
             await comp.WaitForAssertionAsync(() => input.Instance.ReadText.Should().Be(""));
         }
 
@@ -1075,7 +1075,7 @@ namespace MudBlazor.UnitTests.Components
             }
             // after the final debounce, the value should be updated without swallowing any user input
             await Task.Delay(comp.Instance.DebounceInterval);
-            textField.ReadValue().Should().Be(currentText);
+            textField.ReadValue.Should().Be(currentText);
             textField.ReadText.Should().Be(currentText);
         }
 
@@ -1118,7 +1118,7 @@ namespace MudBlazor.UnitTests.Components
             // once debounce occurs, both value and text are reset because they define an invalid DateTime,
             // now with the new Format
             await Task.Delay(comp.Instance.DebounceInterval);
-            textField.ReadValue().Should().Be(expectedFinalDateTime);
+            textField.ReadValue.Should().Be(expectedFinalDateTime);
             textField.ReadText.Should().Be(expectedFinalDateTime.ToString(comp.Instance.Format, CultureInfo.InvariantCulture));
         }
 

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -981,12 +981,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "tasks.json").Selected.Should().Be(false);
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "logo.png").Selected.Should().Be(false);
             // switches
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue().Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue().Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue.Should().Be(false);
             // checkboxes
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue().Should().Be(true);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue().Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue.Should().Be(true);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue.Should().Be(false);
 
             // select logo.png via tree item
             comp.Find(".item-logo .mud-treeview-item-content").Click();
@@ -1004,12 +1004,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "tasks.json").Selected.Should().Be(false);
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "logo.png").Selected.Should().Be(true);
             // switches
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue().Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue().Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue.Should().Be(false);
             // checkboxes
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue().Should().Be(true);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue.Should().Be(true);
 
             // expand config via tree item
             comp.Find(".item-config .mud-treeview-item-arrow button").Click();
@@ -1027,12 +1027,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "tasks.json").Selected.Should().Be(false);
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "logo.png").Selected.Should().Be(true);
             // switches
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue().Should().Be(true);
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue().Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue.Should().Be(true);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue.Should().Be(false);
             // checkboxes
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue().Should().Be(true);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue.Should().Be(true);
 
             // collapse config via switch
             comp.Find(".switch-config input").Change(false);
@@ -1050,12 +1050,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "tasks.json").Selected.Should().Be(false);
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "logo.png").Selected.Should().Be(true);
             // switches
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue().Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue().Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue.Should().Be(false);
             // checkboxes
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue().Should().Be(true);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue.Should().Be(true);
 
             // select launch.json via checkbox
             comp.Find(".checkbox-launch input").Change(true);
@@ -1073,12 +1073,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "tasks.json").Selected.Should().Be(false);
             comp.FindComponents<MudTreeViewItem<string>>().Select(x => x.Instance).First(x => x.Text == "logo.png").Selected.Should().Be(false);
             // switches
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue().Should().Be(false);
-            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue().Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-config").ReadValue.Should().Be(false);
+            comp.FindComponents<MudSwitch<bool>>().Select(x => x.Instance).First(x => x.Class == "switch-images").ReadValue.Should().Be(false);
             // checkboxes
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue().Should().Be(true);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue().Should().Be(false);
-            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue().Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-launch").ReadValue.Should().Be(true);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-tasks").ReadValue.Should().Be(false);
+            comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).First(x => x.Class == "checkbox-logo").ReadValue.Should().Be(false);
         }
 
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -445,7 +445,7 @@ namespace MudBlazor
         /// </remarks>
         protected virtual Task UpdateTextPropertyAsync(bool updateValue)
         {
-            return SetTextAndUpdateValueAsync(ConvertSet(ReadValue()), updateValue);
+            return SetTextAndUpdateValueAsync(ConvertSet(ReadValue), updateValue);
         }
 
         /// <summary>
@@ -528,7 +528,7 @@ namespace MudBlazor
 
         protected virtual async Task SetValueAsync(T? value, bool updateText = true, bool force = false)
         {
-            var valueChanged = !EqualityComparer<T?>.Default.Equals(ReadValue(), value);
+            var valueChanged = !EqualityComparer<T?>.Default.Equals(ReadValue, value);
 
             if (!valueChanged && !force)
             {
@@ -577,7 +577,7 @@ namespace MudBlazor
         /// <summary>
         /// Override to read Value from ParameterState instead of backing field.
         /// </summary>
-        protected internal override T? ReadValue() => _valueState.Value;
+        protected internal override T? ReadValue => _valueState.Value;
 
         /// <summary>
         /// Override to write Value to ParameterState instead of backing field.
@@ -595,7 +595,7 @@ namespace MudBlazor
         /// </returns>
         public virtual Task ForceUpdate()
         {
-            return SetValueAsync(ReadValue(), force: true);
+            return SetValueAsync(ReadValue, force: true);
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -162,7 +162,7 @@ namespace MudBlazor
             await SetBoolValueAsync(ConvertSet(_valueState.Value));
         }
 
-        protected internal override T? ReadValue() => _valueState.Value;
+        protected internal override T? ReadValue => _valueState.Value;
 
         protected override Task WriteValueAsync(T? value) => _valueState.SetValueAsync(value);
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -287,13 +287,13 @@ namespace MudBlazor
         {
             Func<Task> execute = async () =>
             {
-                var value = ReadValue();
+                var value = ReadValue;
 
                 await task;
 
                 // we validate only if the value hasn't changed while we waited for task.
                 // if it has in fact changed, another validate call will follow anyway
-                if (EqualityComparer<T>.Default.Equals(value, ReadValue()))
+                if (EqualityComparer<T>.Default.Equals(value, ReadValue))
                 {
                     await BeginValidateAsync();
                 }
@@ -306,11 +306,11 @@ namespace MudBlazor
         {
             Func<Task> execute = async () =>
             {
-                var value = ReadValue();
+                var value = ReadValue;
 
                 await ValidateValue();
 
-                if (EqualityComparer<T>.Default.Equals(value, ReadValue()))
+                if (EqualityComparer<T>.Default.Equals(value, ReadValue))
                 {
                     EditFormValidate();
                 }
@@ -354,19 +354,19 @@ namespace MudBlazor
                 // validation errors
                 if (Validation is ValidationAttribute validationAttribute)
                 {
-                    ValidateWithAttribute(validationAttribute, ReadValue(), errors);
+                    ValidateWithAttribute(validationAttribute, ReadValue, errors);
                 }
                 else if (Validation is Func<T?, bool> funcBooleanValidation)
                 {
-                    ValidateWithFunc(funcBooleanValidation, ReadValue(), errors);
+                    ValidateWithFunc(funcBooleanValidation, ReadValue, errors);
                 }
                 else if (Validation is Func<T?, string?> funcStringValidation)
                 {
-                    ValidateWithFunc(funcStringValidation, ReadValue(), errors);
+                    ValidateWithFunc(funcStringValidation, ReadValue, errors);
                 }
                 else if (Validation is Func<T?, IEnumerable<string?>> funcEnumerableValidation)
                 {
-                    ValidateWithFunc(funcEnumerableValidation, ReadValue(), errors);
+                    ValidateWithFunc(funcEnumerableValidation, ReadValue, errors);
                 }
                 else if (Validation is Func<object, string, IEnumerable<string?>> funcModelWithFullPathOfMember)
                 {
@@ -374,26 +374,26 @@ namespace MudBlazor
                 }
                 else
                 {
-                    var value = ReadValue();
+                    var value = ReadValue;
 
                     if (Validation is Func<T?, Task<bool>> funcTaskBooleanValidation)
                     {
-                        await ValidateWithFunc(funcTaskBooleanValidation, ReadValue(), errors);
+                        await ValidateWithFunc(funcTaskBooleanValidation, ReadValue, errors);
                     }
                     else if (Validation is Func<T?, Task<string?>> funcTaskStringValidation)
                     {
-                        await ValidateWithFunc(funcTaskStringValidation, ReadValue(), errors);
+                        await ValidateWithFunc(funcTaskStringValidation, ReadValue, errors);
                     }
                     else if (Validation is Func<T?, Task<IEnumerable<string?>>> funcTaskEnumerableValidation)
                     {
-                        await ValidateWithFunc(funcTaskEnumerableValidation, ReadValue(), errors);
+                        await ValidateWithFunc(funcTaskEnumerableValidation, ReadValue, errors);
                     }
                     else if (Validation is Func<object, string, Task<IEnumerable<string?>>> funcTaskModelWithFullPathOfMember)
                     {
                         await ValidateModelWithFullPathOfMember(funcTaskModelWithFullPathOfMember, errors);
                     }
 
-                    changed = !EqualityComparer<T>.Default.Equals(value, ReadValue());
+                    changed = !EqualityComparer<T>.Default.Equals(value, ReadValue);
                 }
 
                 // Run each validation attributes of the property targeted with `For`
@@ -401,14 +401,14 @@ namespace MudBlazor
                 {
                     foreach (var attr in _validationAttrsFor)
                     {
-                        ValidateWithAttribute(attr, ReadValue(), errors);
+                        ValidateWithAttribute(attr, ReadValue, errors);
                     }
                 }
 
                 // required error (must be last, because it is least important!)
                 if (Required)
                 {
-                    if (Touched && !HasValue(ReadValue()))
+                    if (Touched && !HasValue(ReadValue))
                     {
                         errors.Add(RequiredError);
                     }
@@ -924,7 +924,7 @@ namespace MudBlazor
             _setConversionResult = null;
         }
 
-        protected internal virtual T? ReadValue() => _value;
+        protected internal virtual T? ReadValue => _value;
 
         protected virtual Task WriteValueAsync(T? value)
         {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -580,7 +580,7 @@ namespace MudBlazor
         protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
-            var text = GetItemString(ReadValue());
+            var text = GetItemString(ReadValue);
             if (!string.IsNullOrWhiteSpace(text))
             {
                 await SetTextAsync(text);
@@ -708,7 +708,7 @@ namespace MudBlazor
                 }
 
                 // Search while selected if enabled and the Text is equivalent to the Value.
-                searchingWhileSelected = !_isValueCoerced && !Strict && ReadValue() != null && (ReadValue()!.ToString() == ReadText || (ToStringFunc != null && ToStringFunc(ReadValue()!) == ReadText));
+                searchingWhileSelected = !_isValueCoerced && !Strict && ReadValue != null && (ReadValue!.ToString() == ReadText || (ToStringFunc != null && ToStringFunc(ReadValue!) == ReadText));
                 _cancellationTokenSrc ??= new CancellationTokenSource();
                 var searchText = searchingWhileSelected ? string.Empty : ReadText;
                 var searchTask = SearchFunc?.Invoke(searchText, _cancellationTokenSrc.Token);
@@ -738,10 +738,10 @@ namespace MudBlazor
             if (MaxItems.HasValue)
             {
                 // Get range of items based off selected item so the selected item can be scrolled to when strict is set to false
-                if (!Strict && searchedItems.Length != 0 && !EqualityComparer<T>.Default.Equals(ReadValue(), default(T)))
+                if (!Strict && searchedItems.Length != 0 && !EqualityComparer<T>.Default.Equals(ReadValue, default(T)))
                 {
                     int maxItems = MaxItems.Value;
-                    int valueIndex = Array.IndexOf(searchedItems, ReadValue());
+                    int valueIndex = Array.IndexOf(searchedItems, ReadValue);
 
                     // Center the selected item in the list if possible
                     int half = maxItems / 2;
@@ -774,7 +774,7 @@ namespace MudBlazor
             _enabledItemIndices = enabledItems.Select(tuple => tuple.idx).ToList();
             if (searchingWhileSelected) //compute the index of the currently select value, if it exists
             {
-                _selectedListItemIndex = Array.IndexOf(_items, ReadValue());
+                _selectedListItemIndex = Array.IndexOf(_items, ReadValue);
             }
             else
             {
@@ -1133,7 +1133,7 @@ namespace MudBlazor
 
             _debounceTimer?.Dispose();
 
-            var text = ReadValue() == null ? null : GetItemString(ReadValue());
+            var text = ReadValue == null ? null : GetItemString(ReadValue);
 
             // Don't update the value to prevent the popover from opening again after coercion
             if (text != ReadText)

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -140,7 +140,7 @@ namespace MudBlazor
             if (TriState && typeof(T) == typeof(bool?))
             {
                 // The cycle is forced with the following steps: true, false, indeterminate, true, false, indeterminate...
-                var boolValue = (bool?)(object?)ReadValue();
+                var boolValue = (bool?)(object?)ReadValue;
                 if (!boolValue.HasValue)
                 {
                     return SetBoolValueAsync(true, true);

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -452,7 +452,7 @@ namespace MudBlazor
 
         protected override Task WriteTextAsync(string? value) => SetInputStringAsync(value);
 
-        protected internal override MudColor? ReadValue() => _valueState.Value;
+        protected internal override MudColor? ReadValue => _valueState.Value;
 
         protected override Task WriteValueAsync(MudColor? value) => SetColorAsync(value);
 

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -314,7 +314,7 @@ namespace MudBlazor
             FieldChanged(value);
         }
 
-        protected internal override T? ReadValue() => _filesState.Value;
+        protected internal override T? ReadValue => _filesState.Value;
 
         protected override Task WriteValueAsync(T? value) => _filesState.SetValueAsync(value);
 

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -45,7 +45,7 @@ namespace MudBlazor
             var suppressTextUpdate = !updateValue
                                      && DebounceInterval > 0
                                      && _debouncer is not null
-                                     && (!ReadValue()?.Equals(ConvertGet(ReadText)) ?? false);
+                                     && (!ReadValue?.Equals(ConvertGet(ReadText)) ?? false);
 
             return suppressTextUpdate
                 ? Task.CompletedTask

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -255,12 +255,12 @@ namespace MudBlazor
                 return false;
             }
 
-            if (ReadValue() is string stringValue)
+            if (ReadValue is string stringValue)
             {
                 return !string.IsNullOrWhiteSpace(stringValue);
             }
 
-            return ReadValue() is not string and not null;
+            return ReadValue is not string and not null;
         }
 
         protected virtual async Task HandleClearButtonAsync(MouseEventArgs e)

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -177,7 +177,7 @@ namespace MudBlazor
 
         protected string InputTypeString => InputType.ToDescriptionString();
 
-        protected bool IsClearable() => Clearable && ReadValue() is not null;
+        protected bool IsClearable() => Clearable && ReadValue is not null;
 
         protected override async Task UpdateTextPropertyAsync(bool updateValue)
         {

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -289,7 +289,7 @@ namespace MudBlazor
             // allow this only via changes from the outside
             if (_updating)
                 return;
-            var text = ConvertSet(ReadValue());
+            var text = ConvertSet(ReadValue);
             var cleanText = Mask.GetCleanText();
             if (string.IsNullOrEmpty(cleanText) && string.IsNullOrEmpty(text))
                 return;

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -223,11 +223,11 @@ namespace MudBlazor
                 var nextValue = GetNextValue(factor) ?? Num.To<T>(0);
 
                 // validate that the data type is a value type before we compare them
-                if (typeof(T).IsValueType && ReadValue() is not null)
+                if (typeof(T).IsValueType && ReadValue is not null)
                 {
-                    if (factor > 0 && _comparer.Compare(nextValue, ReadValue()) < 0)
+                    if (factor > 0 && _comparer.Compare(nextValue, ReadValue) < 0)
                         nextValue = Max;
-                    else if (factor < 0 && _comparer.Compare(nextValue, ReadValue()) > 0)
+                    else if (factor < 0 && _comparer.Compare(nextValue, ReadValue) > 0)
                         nextValue = Min;
                 }
 
@@ -244,12 +244,12 @@ namespace MudBlazor
         private T? GetNextValue(double factor)
         {
             if (typeof(T) == typeof(decimal) || typeof(T) == typeof(decimal?))
-                return (T)(object)Convert.ToDecimal(FromDecimal(ReadValue()) + (FromDecimal(Step) * (decimal)factor));
+                return (T)(object)Convert.ToDecimal(FromDecimal(ReadValue) + (FromDecimal(Step) * (decimal)factor));
             if (typeof(T) == typeof(long) || typeof(T) == typeof(long?))
-                return (T)(object)Convert.ToInt64(FromInt64(ReadValue()) + (FromInt64(Step) * factor));
+                return (T)(object)Convert.ToInt64(FromInt64(ReadValue) + (FromInt64(Step) * factor));
             if (typeof(T) == typeof(ulong) || typeof(T) == typeof(ulong?))
-                return (T)(object)Convert.ToUInt64(FromUInt64(ReadValue()) + (FromUInt64(Step) * factor));
-            return Num.To<T>(Num.From(ReadValue()) + (Num.From(Step) * factor));
+                return (T)(object)Convert.ToUInt64(FromUInt64(ReadValue) + (FromUInt64(Step) * factor));
+            return Num.To<T>(Num.From(ReadValue) + (Num.From(Step) * factor));
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -129,7 +129,7 @@ namespace MudBlazor
 
                 if (updateRadio)
                 {
-                    var radio = _radios.FirstOrDefault(r => OptionEquals(r.ReadValue(), _value));
+                    var radio = _radios.FirstOrDefault(r => OptionEquals(r.ReadValue, _value));
                     await SetSelectedRadioAsync(radio, false);
                 }
 
@@ -185,7 +185,7 @@ namespace MudBlazor
 
             if (_selectedRadio is null)
             {
-                if (OptionEquals(radio.ReadValue(), _value))
+                if (OptionEquals(radio.ReadValue, _value))
                 {
                     return SetSelectedRadioAsync(radio, false);
                 }
@@ -216,7 +216,7 @@ namespace MudBlazor
 
         private static T? GetValueOrDefault(MudRadio<T>? radio)
         {
-            return radio is not null ? radio.ReadValue() : default;
+            return radio is not null ? radio.ReadValue : default;
         }
 
         private static bool OptionEquals(T? option1, T? option2)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -550,7 +550,7 @@ namespace MudBlazor
             {
                 if (MultiSelection)
                     return false;
-                if (!_shadowLookup.TryGetValue(ReadValue(), out var item))
+                if (!_shadowLookup.TryGetValue(ReadValue, out var item))
                     return false;
                 return item.ChildContent != null;
             }
@@ -560,13 +560,13 @@ namespace MudBlazor
         {
             get
             {
-                return _shadowLookup.TryGetValue(ReadValue(), out _);
+                return _shadowLookup.TryGetValue(ReadValue, out _);
             }
         }
 
         protected RenderFragment? GetSelectedValuePresenter()
         {
-            if (!_shadowLookup.TryGetValue(ReadValue(), out var item))
+            if (!_shadowLookup.TryGetValue(ReadValue, out var item))
                 return null; //<-- for now. we'll add a custom template to present values (set from outside) which are not on the list?
             return item.ChildContent;
         }
@@ -630,13 +630,13 @@ namespace MudBlazor
                 _items.Add(item);
 
                 _valueLookup[item.Value] = item;
-                if (EqualityComparer<T?>.Default.Equals(item.Value, ReadValue()) && !MultiSelection)
+                if (EqualityComparer<T?>.Default.Equals(item.Value, ReadValue) && !MultiSelection)
                     result = true;
             }
             UpdateSelectAllChecked();
             if (result.HasValue == false)
             {
-                result = item.Value?.Equals(ReadValue());
+                result = item.Value?.Equals(ReadValue);
             }
             return result == true;
         }
@@ -791,7 +791,7 @@ namespace MudBlazor
                 // Early return if value hasn't changed (but after updating SelectedValues)
                 // Use Comparer if available, otherwise use default
                 var comparer = Comparer ?? EqualityComparer<T?>.Default;
-                if (comparer.Equals(ReadValue(), value))
+                if (comparer.Equals(ReadValue, value))
                 {
                     // Still need to publish SelectedValues to ParameterState in case it wasn't initialized
                     await _selectedValuesState.SetValueAsync(new HashSet<T?>(_selectedValues, Comparer));
@@ -837,7 +837,7 @@ namespace MudBlazor
             if (MultiSelection)
                 HighlightItem(_items.FirstOrDefault(x => !x.Disabled));
             else
-                HighlightItemForValueAsync(ReadValue());
+                HighlightItemForValueAsync(ReadValue);
         }
 
         private void UpdateSelectAllChecked()
@@ -1386,7 +1386,7 @@ namespace MudBlazor
             await base.ForceUpdate();
             if (MultiSelection == false)
             {
-                await _selectedValuesState.SetValueAsync(new HashSet<T?>(Comparer) { ReadValue() });
+                await _selectedValuesState.SetValueAsync(new HashSet<T?>(Comparer) { ReadValue });
             }
             else
             {


### PR DESCRIPTION
ReadValue() was not consistent, since for `Text` we have `ReadText`.
I think having it as property is better, especially when there is `bind` involved and if there was a `ValueExpression` we would need a property.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
