### PR TITLE
Range<T>: Remove setters

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionItemsTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionItemsTest1.razor
@@ -1,4 +1,4 @@
-﻿<MudDateRangePicker @bind-DateRange="_dateRange" />
+﻿<MudDateRangePicker DateRange="DateRange" />
 
 <MudTable T="ComplexObject" Items="_simulatedServerData" Filter="Filter" MultiSelection @bind-SelectedItems="_selectedItems" Comparer="_comparer" Dense>
     <HeaderContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionItemsTest1.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionItemsTest1.razor.cs
@@ -10,14 +10,11 @@ public partial class TableMultiSelectionItemsTest1
 {
     public static string __description__ = "The selected items should not be cleared when the page changes or filters are applied.";
 
-    private DateRange _dateRange = new();
     private readonly ElementComparer _comparer = new();
     private HashSet<ComplexObject> _selectedItems = [];
 
     [Parameter]
-    public DateTime? StartDate { get => _dateRange.Start; set => _dateRange.Start = value; }
-    [Parameter]
-    public DateTime? EndDate { get => _dateRange.End; set => _dateRange.End = value; }
+    public DateRange DateRange { get; set; } = new();
 
     private readonly List<ComplexObject> _simulatedServerData = Enumerable
         .Range(1, 25)
@@ -31,7 +28,7 @@ public partial class TableMultiSelectionItemsTest1
         .ToList();
 
     protected bool Filter(ComplexObject item)
-        => (StartDate is null || item.DateTime > StartDate) && (EndDate is null || item.DateTime < EndDate);
+        => (DateRange.Start is null || item.DateTime > DateRange.Start) && (DateRange.End is null || item.DateTime < DateRange.End);
 
     private class ElementComparer : IEqualityComparer<ComplexObject?>
     {

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1137,8 +1137,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Change filter
             await comp.SetParametersAndRenderAsync(parameters => parameters
-                .Add(x => x.StartDate, DateTime.Parse("2024-04-07 00:00:00"))
-                .Add(x => x.EndDate, DateTime.Parse("2024-04-13 00:00:00")));
+                .Add(x => x.DateRange, new DateRange(DateTime.Parse("2024-04-07 00:00:00"), DateTime.Parse("2024-04-13 00:00:00"))));
 
             checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
 
@@ -1151,8 +1150,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Clear filters
             await comp.SetParametersAndRenderAsync(parameters => parameters
-                .Add(x => x.StartDate, null)
-                .Add(x => x.EndDate, null));
+                .Add(x => x.DateRange, new DateRange(null, null)));
 
             checkboxes = comp.FindComponents<MudCheckBox<bool>>().Select(x => x.Instance).ToArray();
 

--- a/src/MudBlazor/Components/DatePicker/DateRange.cs
+++ b/src/MudBlazor/Components/DatePicker/DateRange.cs
@@ -2,124 +2,123 @@
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 
-namespace MudBlazor
-{
+namespace MudBlazor;
+
 #nullable enable
+/// <summary>
+/// Represents a date range used by a <see cref="MudDatePicker"/>.
+/// </summary>
+public class DateRange : Range<DateTime?>, IEquatable<DateRange?>
+{
     /// <summary>
-    /// Represents a date range used by a <see cref="MudDatePicker"/>.
+    /// Creates a new instance.
     /// </summary>
-    public class DateRange : Range<DateTime?>, IEquatable<DateRange>
+    public DateRange() : this(null, null)
     {
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        public DateRange() : base(null, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        /// <param name="start">The earliest date.</param>
-        /// <param name="end">The most recent date.</param>
-        public DateRange(DateTime? start, DateTime? end) : base(start, end)
-        {
-        }
-
-        /// <summary>
-        /// Formats this range as a string.
-        /// </summary>
-        /// <param name="converter">The converter used to convert to a <c>string</c>.</param>
-        /// <returns>The formatted string.</returns>
-        public string ToString(IConverter<DateTime?, string?> converter)
-        {
-            if (Start is null || End is null)
-            {
-                return string.Empty;
-            }
-
-            return RangeUtility.Join(converter.Convert(Start.Value), converter.Convert(End.Value));
-        }
-
-        /// <summary>
-        /// Formats this range as an ISO 8601 string.
-        /// </summary>
-        /// <returns>The formatted string.</returns>
-        public string ToIsoDateString()
-        {
-            if (Start is null || End is null)
-            {
-                return string.Empty;
-            }
-
-            return RangeUtility.Join(Start.ToIsoDateString(), End.ToIsoDateString());
-        }
-
-        /// <summary>
-        /// Parses the specified string value into a date range.
-        /// </summary>
-        /// <param name="value">A string with both the start and end dates.</param>
-        /// <param name="converter">The converter for parsing string values.</param>
-        /// <param name="date">The result of the parse.</param>
-        /// <returns><c>true</c> if the string was successfully interpreted as a date.</returns>
-        public static bool TryParse(string? value, IConverter<DateTime?, string?> converter, [NotNullWhen(true)] out DateRange? date)
-        {
-            if (!RangeUtility.Split(value, out var start, out var end))
-            {
-                date = null;
-                return false;
-            }
-
-            return TryParse(start, end, converter, out date);
-        }
-
-        /// <summary>
-        /// Parses the specified string value into a date range.
-        /// </summary>
-        /// <param name="start">The minimum date to parse.</param>
-        /// <param name="end">The maximum date to parse.</param>
-        /// <param name="converter">The converter for parsing string values.</param>
-        /// <param name="date">The result of the parse.</param>
-        /// <returns><c>true</c> if the string was successfully interpreted as a date.</returns>
-        public static bool TryParse(string? start, string? end, IConverter<DateTime?, string?> converter, [NotNullWhen(true)] out DateRange? date)
-        {
-            var endDate = converter.TryConvertBack(end);
-            if (!endDate.Success)
-            {
-                date = null;
-                return false;
-            }
-
-            var startDate = converter.TryConvertBack(start);
-            if (!startDate.Success)
-            {
-                date = null;
-                return false;
-            }
-
-            date = new DateRange(startDate.Value, endDate.Value);
-            return true;
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(Start, End);
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as DateRange);
-
-        /// <inheritdoc />
-        public bool Equals(DateRange? other) => other is not null && Start == other.Start && End == other.End;
-
-        public static bool operator ==(DateRange? dateRange1, DateRange? dateRange2)
-        {
-            if (ReferenceEquals(dateRange1, dateRange2))
-                return true;
-            if (dateRange1 is null || dateRange2 is null)
-                return false;
-
-            return dateRange1.Equals(dateRange2);
-        }
-
-        public static bool operator !=(DateRange? dateRange1, DateRange? dateRange2) => !(dateRange1 == dateRange2);
     }
+
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    /// <param name="start">The earliest date.</param>
+    /// <param name="end">The most recent date.</param>
+    public DateRange(DateTime? start, DateTime? end) : base(start, end)
+    {
+    }
+
+    /// <summary>
+    /// Formats this range as a string.
+    /// </summary>
+    /// <param name="converter">The converter used to convert to a <c>string</c>.</param>
+    /// <returns>The formatted string.</returns>
+    public string ToString(IConverter<DateTime?, string?> converter)
+    {
+        if (Start is null || End is null)
+        {
+            return string.Empty;
+        }
+
+        return RangeUtility.Join(converter.Convert(Start.Value), converter.Convert(End.Value));
+    }
+
+    /// <summary>
+    /// Formats this range as an ISO 8601 string.
+    /// </summary>
+    /// <returns>The formatted string.</returns>
+    public string ToIsoDateString()
+    {
+        if (Start is null || End is null)
+        {
+            return string.Empty;
+        }
+
+        return RangeUtility.Join(Start.ToIsoDateString(), End.ToIsoDateString());
+    }
+
+    /// <summary>
+    /// Parses the specified string value into a date range.
+    /// </summary>
+    /// <param name="value">A string with both the start and end dates.</param>
+    /// <param name="converter">The converter for parsing string values.</param>
+    /// <param name="date">The result of the parse.</param>
+    /// <returns><c>true</c> if the string was successfully interpreted as a date.</returns>
+    public static bool TryParse(string? value, IConverter<DateTime?, string?> converter, [NotNullWhen(true)] out DateRange? date)
+    {
+        if (!RangeUtility.Split(value, out var start, out var end))
+        {
+            date = null;
+            return false;
+        }
+
+        return TryParse(start, end, converter, out date);
+    }
+
+    /// <summary>
+    /// Parses the specified string value into a date range.
+    /// </summary>
+    /// <param name="start">The minimum date to parse.</param>
+    /// <param name="end">The maximum date to parse.</param>
+    /// <param name="converter">The converter for parsing string values.</param>
+    /// <param name="date">The result of the parse.</param>
+    /// <returns><c>true</c> if the string was successfully interpreted as a date.</returns>
+    public static bool TryParse(string? start, string? end, IConverter<DateTime?, string?> converter, [NotNullWhen(true)] out DateRange? date)
+    {
+        var endDate = converter.TryConvertBack(end);
+        if (!endDate.Success)
+        {
+            date = null;
+            return false;
+        }
+
+        var startDate = converter.TryConvertBack(start);
+        if (!startDate.Success)
+        {
+            date = null;
+            return false;
+        }
+
+        date = new DateRange(startDate.Value, endDate.Value);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is DateRange dateRange && Equals(dateRange);
+
+    /// <inheritdoc />
+    public bool Equals(DateRange? other) => other is not null && other.Start == Start && other.End == End;
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(Start, End);
+
+    public static bool operator ==(DateRange? dateRange1, DateRange? dateRange2)
+    {
+        if (ReferenceEquals(dateRange1, dateRange2))
+            return true;
+        if (dateRange1 is null || dateRange2 is null)
+            return false;
+
+        return dateRange1.Equals(dateRange2);
+    }
+
+    public static bool operator !=(DateRange? dateRange1, DateRange? dateRange2) => !(dateRange1 == dateRange2);
 }

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
-using MudBlazor.Utilities.Converter;
 
 #nullable enable
 namespace MudBlazor

--- a/src/MudBlazor/Components/Input/Range.cs
+++ b/src/MudBlazor/Components/Input/Range.cs
@@ -1,54 +1,46 @@
 ﻿#nullable enable
-namespace MudBlazor
+namespace MudBlazor;
+
+/// <summary>
+/// A range of values.
+/// </summary>
+/// <typeparam name="T">The type of value for the range.</typeparam>
+public class Range<T> : IEquatable<Range<T>?>
 {
     /// <summary>
-    /// A range of values.
+    /// The minimum value.
     /// </summary>
-    /// <typeparam name="T">The type of value for the range.</typeparam>
-    public class Range<T>
+    public T? Start { get; }
+
+    /// <summary>
+    /// The maximum value.
+    /// </summary>
+    public T? End { get; }
+
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    public Range() : this(default, default)
     {
-        /// <summary>
-        /// The minimum value.
-        /// </summary>
-        public T? Start { get; set; }
-
-        /// <summary>
-        /// The maximum value.
-        /// </summary>
-        public T? End { get; set; }
-
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        public Range()
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance.
-        /// </summary>
-        /// <param name="start">The minimum value.</param>
-        /// <param name="end">The maximum value.</param>
-        public Range(T? start, T? end)
-        {
-            Start = start;
-            End = end;
-        }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj)
-        {
-            return obj is Range<T> r
-                && null != r.Start
-                && r.Start.Equals(Start)
-                && null != r.End
-                && r.End.Equals(End);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
     }
+
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    /// <param name="start">The minimum value.</param>
+    /// <param name="end">The maximum value.</param>
+    public Range(T? start, T? end)
+    {
+        Start = start;
+        End = end;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(Range<T>? other) => other is not null && other.Start is not null && other.End is not null && other.Start.Equals(Start) && other.End.Equals(End);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is Range<T> range && Equals(range);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(Start, End);
 }


### PR DESCRIPTION
This is necessary, because for the `GetHashCode` the properties should not mutate.

Instead of changing the `.End`, `.Start` you should just create new `Range`, `DateRange`.

Maybe it would also be preferable if it was just a readonly struct?

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
