### PR TITLE
MudDialog: Prevent default on close button to not trigger validations

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1483,6 +1483,23 @@ namespace MudBlazor.UnitTests.Components
             // Close the dialog
             await comp.InvokeAsync(() => service.Close(dialogReference));
         }
+
+        [Test]
+        public async Task CloseButton_ShouldHavePreventDefaultOnMouseDownAttribute()
+        {
+            // Arrange
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            // Act
+            await comp.InvokeAsync(async () =>
+                await service.ShowAsync<DialogOkCancel>("Custom title", new DialogOptions { CloseButton = true }));
+
+            // Assert
+            var closeBtn = comp.Find(".mud-button-close");
+            closeBtn.Should().NotBeNull();
+            closeBtn.GetAttribute("blazor:onmousedown:preventdefault").Should().Be("");
+        }
     }
     internal class CustomDialogService : DialogService
     {

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -23,7 +23,7 @@
                 }
                 @if (GetCloseButton())
                 {
-                    <MudIconButton aria-label="@Localizer[LanguageResource.MudDialog_Close]" Icon="@CloseIcon" @onclick="((IMudDialogInstance)this).Cancel" Class="mud-button-close" />
+                    <MudIconButton aria-label="@Localizer[LanguageResource.MudDialog_Close]" @onmousedown:preventDefault="true" Icon="@CloseIcon" @onclick="((IMudDialogInstance)this).Cancel" Class="mud-button-close" />
                 }
             </div>
          }


### PR DESCRIPTION
This is small one.
When there is form with validated fields in dialog, closing dialog will trigger validations on focused input resulting in brief red noise.
