### PR TITLE
Revert "Update dependency NUnit3TestAdapter to 6.0.1"

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
+++ b/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="ReportGenerator" Version="5.5.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="ReportGenerator" Version="5.5.1" />
   </ItemGroup>


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#12331

It seems `NUnit3TestAdapter` 6.0.1 is breaking the unit tests when testing via ReSharper. However, `dotnet test` and the VS "Test Explorer" work fine, 6.0.0 worked fine everywhere. I’m going to revert to 6.0.0