### PR TITLE
Tests: Use new InputAsync / ChangeAsync overload

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -263,7 +263,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act
 
-            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
+            await comp.Find("input").InputAsync("Al");
 
             // Assert : debounce disable, so menu is opened immediately
 
@@ -305,7 +305,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act
 
-            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
+            await comp.Find("input").InputAsync("Al");
 
             // Assert : debounce enable, so menu is not opened immediately
 
@@ -1229,12 +1229,12 @@ namespace MudBlazor.UnitTests.Components
                 await comp.InvokeAsync(() => autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "Enter" }));
                 await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
                 await comp.InvokeAsync(() => autocomplete.OnEnterKeyAsync());
-                await autocompleteComponent.Find("input").InputAsync(new ChangeEventArgs() { Value = "abc" });
+                await autocompleteComponent.Find("input").InputAsync("abc");
                 await comp.InvokeAsync(async () => await autocomplete.SelectAsync());
                 await comp.InvokeAsync(async () => await autocomplete.SelectRangeAsync(0, 1));
                 await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
 
-                await autocompleteComponent.Find("input").InputAsync(new ChangeEventArgs() { Value = "" });
+                await autocompleteComponent.Find("input").InputAsync("");
                 await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
 
                 await comp.InvokeAsync(() => autocomplete.OnEnterKeyAsync());
@@ -1290,7 +1290,7 @@ namespace MudBlazor.UnitTests.Components
                 Times.AtMost(1));
 
             var input = comp.Find("input");
-            await input.InputAsync(new ChangeEventArgs { Value = "Wyo" });
+            await input.InputAsync("Wyo");
 
             await input.KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
 

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -380,7 +380,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<FormAsyncValidationWithFieldChangedSubscriberTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var input = () => comp.Find("input");
-            await input().InputAsync(new ChangeEventArgs { Value = "test" });
+            await input().InputAsync("test");
             // trigger validation
             await Task.Delay(comp.Instance.DebounceInterval);
             // imitate "typing in progress" by extending the debounce interval until the async validation terminates
@@ -390,7 +390,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "a";
-                await input().InputAsync(new ChangeEventArgs { Value = currentText });
+                await input().InputAsync(currentText);
                 await Task.Delay(delay);
                 elapsedTime += delay;
             }

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -1087,7 +1087,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act
             // Simulate the 'oninput' event that occurs during browser autofill
-            await inputElement.InputAsync(new ChangeEventArgs() { Value = autofillValue });
+            await inputElement.InputAsync(autofillValue);
 
             // Assert
             textField.ReadText.Should().Be(autofillValue);

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -388,17 +388,17 @@ namespace MudBlazor.UnitTests.Components
 
             IElement Input() => comp.Find(".mud-slider-input");
             IElement Filling() => comp.Find(".mud-slider-filled");
-            var eventArgs = new ChangeEventArgs { Value = "180" };
+            var value = "180";
 
             if (immediate == false)
             {
-                Assert.ThrowsAsync<MissingEventHandlerException>(() => Input().InputAsync(eventArgs));
-                await Input().ChangeAsync(eventArgs);
+                Assert.ThrowsAsync<MissingEventHandlerException>(() => Input().InputAsync(value));
+                await Input().ChangeAsync(value);
             }
             else
             {
-                Assert.ThrowsAsync<MissingEventHandlerException>(() => Input().ChangeAsync(eventArgs));
-                await Input().InputAsync(eventArgs);
+                Assert.ThrowsAsync<MissingEventHandlerException>(() => Input().ChangeAsync(value));
+                await Input().InputAsync(value);
             }
 
             Filling().GetAttribute("style").Should().Be($"width:80%;");

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1109,7 +1109,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "a";
-                await comp.Find("input").InputAsync(new ChangeEventArgs { Value = currentText });
+                await comp.Find("input").InputAsync(currentText);
                 await Task.Delay(delay);
                 elapsedTime += delay;
             }


### PR DESCRIPTION
Use new bUnit overload that are more convenient.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
