### PR TITLE
NumberConverter: Handle percentage format in ConvertBack (#7017)

### DIFF
--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -904,6 +904,14 @@ public class DefaultConverterTests
     }
 
     [Test]
+    public void Number_ConvertBack_Double_ValidValue_ReturnsParsedDouble_WithPercentage()
+    {
+        var conv = CreateNumberConverter<double>(format: () => "P3");
+        const string Text = "3.140%";
+        conv.ConvertBack(Text).Should().BeApproximately(0.0314, 1e-10);
+    }
+
+    [Test]
     public void Number_ConvertBack_Int_ValidValue_ReturnsParsedInt()
     {
         var conv = CreateNumberConverter<int>(() => CultureInfo.InvariantCulture);

--- a/src/MudBlazor/Converters/DefaultConverter.Number.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.Number.cs
@@ -26,10 +26,16 @@ internal partial class DefaultConverter
             }
 
             var currentCulture = culture.Invoke();
+            var isPercentage = format.Invoke()?.StartsWith("P") ?? false;
+
+            if (isPercentage)
+            {
+                input = input.Replace("%", string.Empty);
+            }
 
             if (TNumber.TryParse(input, NumberStyles.Any, currentCulture, out var result))
             {
-                return result;
+                return isPercentage ? result / (TNumber)(object)100.0 : result;
             }
 
             throw new ConversionException(LanguageResource.Converter_InvalidNumber);


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
Fixes #7017.

Simply adds a special case in [NumberConverter](https://github.com/MudBlazor/MudBlazor/tree/dev/src/MudBlazor/Converters/DefaultConverter.Number.cs#L30) to remove the precent character from the string input to parse and to divide the result by 100 if the format is `P[x]`.

Also added a test for the convert back on double, not sure if I should add more.
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
