### PR TITLE
ParameterState: Micro optimization, improve example explanation.

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateDependencyCompTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateDependencyCompTest.razor
@@ -25,6 +25,36 @@
 
     private void OnValueAndColorSetDifferent()
     {
+        // Note for ParameterStateDependencyComp1:
+        //
+        // First click:
+        // ParameterChangedContext:
+        //   [Value: any_value -> "#30102a", Text: any_value -> "#662f18"]
+        // - ResolveEffectiveParameter prefers `_value1` (since "Value" is dominant),
+        //   so "#30102a" becomes the effective value.
+        //
+        // Second click:
+        // - `_value1` and `_text` are already "#30102a".
+        // - Setting `_text1` to "#662f18" creates a mismatch.
+        // - The change handler detects a change in `_text` (while `_value1` remains unchanged),
+        //   so a new parameter change is stored with:
+        //     ParameterChangedContext: [Text: "#30102a" -> "#662f18"]
+        // - This time "#662f18" becomes the effective value.
+        //
+        // Subsequent clicks:
+        // - The same sequence repeats, causing the effective value to toggle
+        //   between "#30102a" and "#662f18" on each click.
+        //
+        // In theory, ResolveEffectiveParameter could restore the current Value and always treat it as dominant (if it is selected as one).
+        // However, it is not clear what the correct or most intuitive strategy would be.
+        //
+        // In general, consumers should avoid binding both Text and Value at the same time. If one of them is
+        // used only for read-only display, this is usually fine, but writing to both simultaneously can lead
+        // to ambiguous behavior.
+        //
+        // ResolveEffectiveParameter is primarily intended to simplify the management of dependent parameters
+        // and keep them loosely in sync without introducing infinite update cycles. It is not designed to
+        // handle every possible edge case.
         _value1 = "#30102a";
         _value2 = "#30102a";
         _text1 = "#662f18";
@@ -47,6 +77,24 @@
 
     private void OnValueSetTextNull()
     {
+        // Note for ParameterStateDependencyComp1:
+        //
+        // On second click scenario:
+        // - When the same value ("#fcefe5") is selected again.
+        // - `_value1` does not change, so no Value change is recorded.
+        // - `_text1` is set to null, which triggers the change handler.
+        //
+        // ParameterChangedContext:
+        //   [Text: "#fcefe5" -> null]
+        //
+        // Result:
+        // - Only Text is stored as changed.
+        // - ResolveEffectiveParameter clears the effective parameter.
+        // - Both Text and Value end up null.
+        //
+        // To avoid this:
+        // - Do not set one parameter to null while the other remains unchanged.
+        // - Prefer the update pattern used in OnValueSetOnly / OnTextSetOnly.
         _text1 = null;
         _text2 = null;
         _value1 = "#fcefe5";
@@ -61,6 +109,24 @@
 
     private void OnTextSetValueNull()
     {
+        // Note for ParameterStateDependencyComp1:
+        //
+        // On second click scenario:
+        // - When the same value ("#5fa9e2") is selected again.
+        // - `_text1` does not change, so no Value change is recorded.
+        // - `_value1` is set to null, which triggers the change handler.
+        //
+        // ParameterChangedContext:
+        //   [Value: "#5fa9e2" -> null]
+        //
+        // Result:
+        // - Only Value is stored as changed.
+        // - ResolveEffectiveParameter clears the effective parameter.
+        // - Both Text and Value end up null.
+        //
+        // To avoid this:
+        // - Do not set one parameter to null while the other remains unchanged.
+        // - Prefer the update pattern used in OnValueSetOnly / OnTextSetOnly.
         _text1 = "#5fa9e2";
         _text2 = "#5fa9e2";
         _value1 = null;

--- a/src/MudBlazor.UnitTests/State/ParameterScopeContainerTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterScopeContainerTests.cs
@@ -114,6 +114,41 @@ public class ParameterScopeContainerTests
     }
 
     [Test]
+    public async Task SetParametersAsync_NoHandlers()
+    {
+        // Arrange
+        const int Parameter1 = 1;
+        const int Parameter2 = 2;
+        const int Parameter1NewValue = 2;
+        const int Parameter2NewValue = 3;
+        const string Parameter1Name = nameof(Parameter1);
+        const string Parameter2Name = nameof(Parameter2);
+        var parametersDictionary = new Dictionary<string, object?>
+        {
+            { Parameter1Name, Parameter1NewValue },
+            { Parameter2Name, Parameter2NewValue }
+        };
+        var parameterView = ParameterView.FromDictionary(parametersDictionary);
+        var parameter1State = ParameterAttachBuilder
+            .Create<int>()
+            .WithMetadata(new ParameterMetadata(Parameter1Name))
+            .WithGetParameterValueFunc(() => Parameter1)
+            .Attach();
+        var parameter2State = ParameterAttachBuilder
+            .Create<int>()
+            .WithMetadata(new ParameterMetadata(Parameter2Name))
+            .WithGetParameterValueFunc(() => Parameter2)
+            .Attach();
+        using var parameterScopeContainer = new ParameterScopeContainer(parameter1State, parameter2State);
+
+        // Act
+        await parameterScopeContainer.SetParametersAsync(_ => Task.CompletedTask, parameterView);
+
+        // Assert
+        parameterScopeContainer.Count(scopeContainer => scopeContainer.HasHandler).Should().Be(0);
+    }
+
+    [Test]
     public async Task SetParametersAsync_ActionHandlerShouldFire()
     {
         // Arrange
@@ -399,6 +434,8 @@ public class ParameterScopeContainerTests
 
         // Assert
         handlerFireCount.Should().Be(1);
+        parameterScopeContainer.Count(scopeContainer => scopeContainer.HasHandler).Should().Be(3, "In total there are 3, but it's unique and shared among them");
+        parameterScopeContainer.All(scopeContainer => scopeContainer.Metadata.HandlerName == nameof(OnParameterChange)).Should().BeTrue();
     }
 
     [Test]
@@ -715,6 +752,46 @@ public class ParameterScopeContainerTests
         {
             new ParameterChangedEventArgs<double[]>(parameterView, ParameterName, parameter, parameterNewValue)
         });
+    }
+
+    [Test]
+    public void TryGetValue_WhenKeyExists_ShouldReturnTrue_AndSetOutParameter()
+    {
+        // Arrange
+        var parameterName = "SomeParameter";
+        var parameterState = ParameterAttachBuilder
+            .Create<double>()
+            .WithMetadata(new ParameterMetadata(parameterName))
+            .WithGetParameterValueFunc(() => 0)
+            .Attach();
+        using var parameterScopeContainer = new ParameterScopeContainer(parameterState);
+
+        // Act
+        var result = parameterScopeContainer.TryGetValue(parameterName, out var actual);
+
+        // Assert
+        result.Should().BeTrue();
+        actual.Should().BeSameAs(parameterState);
+    }
+
+    [Test]
+    public void TryGetValue_WhenKeyDoesNotExist_ShouldReturnFalse_AndSetOutParameterToNull()
+    {
+        // Arrange
+        var parameterName = "SomeParameter";
+        var parameterState = ParameterAttachBuilder
+            .Create<double>()
+            .WithMetadata(new ParameterMetadata(parameterName))
+            .WithGetParameterValueFunc(() => 0)
+            .Attach();
+        using var parameterScopeContainer = new ParameterScopeContainer(parameterState);
+
+        // Act
+        var result = parameterScopeContainer.TryGetValue("Random", out var actual);
+
+        // Assert
+        result.Should().BeFalse();
+        actual.Should().BeNull();
     }
 
     [Test]

--- a/src/MudBlazor/State/ParameterContainer.cs
+++ b/src/MudBlazor/State/ParameterContainer.cs
@@ -85,12 +85,11 @@ internal class ParameterContainer : IParameterContainer
     /// </summary>
     /// <param name="baseSetParametersAsync">A func to call the base class' <see cref="ComponentBase.SetParametersAsync"/>.</param>
     /// <param name="parameters">The ParameterView coming from Blazor's  <see cref="ComponentBase.SetParametersAsync"/>.</param>
-    public async Task SetParametersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
+    public Task SetParametersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
     {
         if (Count == 0)
         {
-            await baseSetParametersAsync(parameters);
-            return;
+            return baseSetParametersAsync(parameters);
         }
 
         VerifyOnAuto();
@@ -98,15 +97,22 @@ internal class ParameterContainer : IParameterContainer
         // Fast path: if no parameters have change handlers, skip handler detection entirely
         if (GetHandlerCount() == 0)
         {
-            await baseSetParametersAsync(parameters);
-            return;
+            return baseSetParametersAsync(parameters);
+
         }
 
+        // IMPORTANT: Do not inline the async implementation here.
+        // Avoid async state machine allocation on the common path by returning the Task directly.
+        // The async state machine is only used when parameter change handlers must be invoked.
+        return SetParametersWithHandlersAsync(baseSetParametersAsync, parameters);
+    }
+
+    private async Task SetParametersWithHandlersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
+    {
         var handlerCollection = CollectChangedHandlers(parameters);
 
-        await baseSetParametersAsync(parameters);
-
-        await ParameterChangeHandlerUtility.InvokeHandlersAsync(handlerCollection);
+        await baseSetParametersAsync(parameters).ConfigureAwait(false);
+        await ParameterChangeHandlerUtility.InvokeHandlersAsync(handlerCollection).ConfigureAwait(false);
     }
 
     private ParameterChangeHandlerUtility.HandlerCollection? CollectChangedHandlers(ParameterView parameters)

--- a/src/MudBlazor/State/ParameterScopeContainer.cs
+++ b/src/MudBlazor/State/ParameterScopeContainer.cs
@@ -21,8 +21,10 @@ namespace MudBlazor.State;
 internal class ParameterScopeContainer : IParameterScopeContainer
 {
     private readonly IParameterStatesReader _parameterStatesReader;
-
     private readonly Lazy<FrozenDictionary<string, IParameterComponentLifeCycle>> _parameters;
+
+    // Cache handler count for fast path optimization
+    private int _handlerCount = -1;  // -1 means not computed yet
 
     /// <inheritdoc/>
     public bool IsLocked { get; private set; }
@@ -112,13 +114,32 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// </summary>
     /// <param name="baseSetParametersAsync">A func to call the base class' <see cref="ComponentBase.SetParametersAsync"/>.</param>
     /// <param name="parameters">The ParameterView coming from Blazor's <see cref="ComponentBase.SetParametersAsync"/>.</param>
-    public async Task SetParametersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
+    public Task SetParametersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
+    {
+        // Fast path: if no parameters have change handlers, skip handler detection entirely
+        if (GetHandlerCount() == 0)
+        {
+            return baseSetParametersAsync(parameters);
+        }
+
+        // IMPORTANT: Do not inline the async implementation here.
+        // Avoid async state machine allocation on the common path by returning the Task directly.
+        // The async state machine is only used when parameter change handlers must be invoked.
+        return SetParametersWithHandlersAsync(baseSetParametersAsync, parameters);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue(string parameterName, [MaybeNullWhen(false)] out IParameterComponentLifeCycle parameterComponentLifeCycle)
+    {
+        return _parameters.Value.TryGetValue(parameterName, out parameterComponentLifeCycle);
+    }
+
+    private async Task SetParametersWithHandlersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
     {
         var handlerCollection = CollectChangedHandlers(parameters);
 
-        await baseSetParametersAsync(parameters);
-
-        await ParameterChangeHandlerUtility.InvokeHandlersAsync(handlerCollection);
+        await baseSetParametersAsync(parameters).ConfigureAwait(false);
+        await ParameterChangeHandlerUtility.InvokeHandlersAsync(handlerCollection).ConfigureAwait(false);
     }
 
     private ParameterChangeHandlerUtility.HandlerCollection? CollectChangedHandlers(ParameterView parameters)
@@ -139,10 +160,25 @@ internal class ParameterScopeContainer : IParameterScopeContainer
         return ParameterChangeHandlerUtility.CreateHandlerCollection(parametersHandlerShouldFire, parameterStateValues, parameters);
     }
 
-    /// <inheritdoc/>
-    public bool TryGetValue(string parameterName, [MaybeNullWhen(false)] out IParameterComponentLifeCycle parameterComponentLifeCycle)
+    /// <summary>
+    /// Gets the total count of parameters with change handlers.
+    /// This is computed once and cached for the fast path optimization.
+    /// </summary>
+    private int GetHandlerCount()
     {
-        return _parameters.Value.TryGetValue(parameterName, out parameterComponentLifeCycle);
+        if (_handlerCount == -1)
+        {
+            _handlerCount = 0;
+            foreach (var parameter in this)
+            {
+                if (parameter.HasHandler)
+                {
+                    _handlerCount++;
+                }
+            }
+        }
+
+        return _handlerCount;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Added a micro-optimization to avoid creating an async state machine on short paths.
Improved the explanation of `ParameterStateDependencyComp1` to better clarify what’s happening internally.
This explanation can later be reused for documentation (see https://github.com/MudBlazor/MudBlazor/issues/12348) to help explain the purpose and behavior of `ResolveEffectiveParameter`.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
