### PR TITLE
MudBaseInput: Make GetInputType protected

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -762,7 +762,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <see cref="InputType.Text"/>.
         /// </remarks>
-        internal virtual InputType GetInputType() => InputType.Text;
+        protected internal virtual InputType GetInputType() => InputType.Text;
 
         protected internal string? ReadText => _textState.Value;
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -69,7 +69,7 @@ namespace MudBlazor
         /// If it is sub-component, it will NOT do form validation!!
         /// </summary>
         [CascadingParameter(Name = "SubscribeToParentForm")]
-        internal bool SubscribeToParentForm { get; set; } = true;
+        protected bool SubscribeToParentForm { get; set; } = true;
 
         /// <summary>
         /// Requires an input value.

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -49,7 +49,7 @@ namespace MudBlazor
                 .AddClass("mud-no-activator")
                 .Build();
 
-        internal override InputType GetInputType() => InputType;
+        protected internal override InputType GetInputType() => InputType;
 
         protected string InputTypeString => InputType.ToDescriptionString();
 

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor
                   || !string.IsNullOrWhiteSpace(PlaceholderEnd)
                   || ShrinkLabel);
 
-        internal override InputType GetInputType() => InputType;
+        protected internal override InputType GetInputType() => InputType;
 
         protected string InputClassname => MudInputCssHelper.GetInputClassname(this);
 

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -321,7 +321,7 @@ namespace MudBlazor
             await UpdateAsync();
         }
 
-        internal override InputType GetInputType() => InputType;
+        protected internal override InputType GetInputType() => InputType;
 
         private string GetCounterText() => Counter switch
         {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -215,7 +215,7 @@ namespace MudBlazor
             return base.SetTextAndUpdateValueAsync(text, updateValue);
         }
 
-        internal override InputType GetInputType() => InputType;
+        protected internal override InputType GetInputType() => InputType;
 
         private bool ShowClearButton()
         {


### PR DESCRIPTION
This makes sense to align with the other APIs. It’s also something that individual components might want to override, so access for third-party components is necessary for this API.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
