### PR TITLE
Fix DataGrid stale selection

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectionCleanupTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectionCleanupTest.razor
@@ -1,0 +1,50 @@
+﻿@using System.Collections.ObjectModel
+
+<MudDataGrid @ref="DataGrid" Items="@Items" MultiSelection="true" @bind-SelectedItems="SelectedItems">
+    <Columns>
+        <SelectColumn T="Model" />
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "SelectedItems should be cleaned up when items are removed from an ObservableCollection.";
+
+    public MudDataGrid<Model>? DataGrid { get; set; }
+
+    public ObservableCollection<Model> Items { get; set; } = new ObservableCollection<Model>
+    {
+        new Model("Sam", 56),
+        new Model("Alicia", 54),
+        new Model("Ira", 27),
+        new Model("John", 32)
+    };
+
+    public HashSet<Model> SelectedItems { get; set; } = new();
+
+    public void RemoveFirstItem()
+    {
+        if (Items.Count > 0)
+        {
+            Items.RemoveAt(0);
+        }
+    }
+
+    public void RemoveItem(Model item)
+    {
+        Items.Remove(item);
+    }
+
+    public void ClearItems()
+    {
+        Items.Clear();
+    }
+
+    public void AddItem(Model item)
+    {
+        Items.Add(item);
+    }
+
+    public record Model(string Name, int Age);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5568,5 +5568,208 @@ namespace MudBlazor.UnitTests.Components
             mudIconButton = FirstFilterButton();
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryAlert);
         }
+
+        #region Selection Cleanup Tests
+
+        [Test]
+        public async Task DataGrid_SelectedItems_ShouldUpdateWhenSingleItemRemoved()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(4));
+            dataGrid.Instance.SelectedItems.Count.Should().Be(0);
+
+            var firstItem = testComponent.Items.First();
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, firstItem));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(1);
+                dataGrid.Instance.SelectedItems.Should().Contain(firstItem);
+            });
+
+            await comp.InvokeAsync(() => testComponent.RemoveItem(firstItem));
+
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(0));
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(3));
+        }
+
+        [Test]
+        public async Task DataGrid_SelectedItems_ShouldUpdateWhenMultipleItemsRemoved()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectAllAsync(true));
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(4));
+
+            var firstItem = testComponent.Items.First();
+            var secondItem = testComponent.Items.Skip(1).First();
+
+            await comp.InvokeAsync(() =>
+            {
+                testComponent.RemoveItem(firstItem);
+                testComponent.RemoveItem(secondItem);
+            });
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(2);
+                dataGrid.Instance.SelectedItems.Should().NotContain(firstItem);
+                dataGrid.Instance.SelectedItems.Should().NotContain(secondItem);
+            });
+
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(2));
+        }
+
+        [Test]
+        public async Task DataGrid_SelectedItems_ShouldClearWhenCollectionCleared()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectAllAsync(true));
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(4));
+
+            await comp.InvokeAsync(() => testComponent.ClearItems());
+
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(0));
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(0));
+        }
+
+        [Test]
+        public async Task DataGrid_SelectedItem_ShouldUpdateWhenItemRemoved()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            var firstItem = testComponent.Items.First();
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, firstItem));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(1);
+                dataGrid.Instance.SelectedItems.Should().Contain(firstItem);
+            });
+
+            await comp.InvokeAsync(() => testComponent.RemoveItem(firstItem));
+
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItem.Should().BeNull());
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(0));
+        }
+
+        [Test]
+        public async Task DataGrid_SelectedItems_ShouldNotAffectNonSelectedItems()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            var firstItem = testComponent.Items.First();
+            var secondItem = testComponent.Items.Skip(1).First();
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, firstItem));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, secondItem));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(2);
+                dataGrid.Instance.SelectedItems.Should().Contain(firstItem);
+                dataGrid.Instance.SelectedItems.Should().Contain(secondItem);
+            });
+
+            var thirdItem = testComponent.Items.Skip(2).First();
+            await comp.InvokeAsync(() => testComponent.RemoveItem(thirdItem));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(2);
+                dataGrid.Instance.SelectedItems.Should().Contain(firstItem);
+                dataGrid.Instance.SelectedItems.Should().Contain(secondItem);
+            });
+
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(3));
+        }
+
+        [Test]
+        public async Task DataGrid_SelectedItem_ShouldNotReferenceRemovedItem_WhenMultipleItemsSelectedAndOneRemoved()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            var firstItem = testComponent.Items.First();
+            var secondItem = testComponent.Items.Skip(1).First();
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, firstItem));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, secondItem));
+
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(2));
+
+            await comp.InvokeAsync(() => testComponent.RemoveItem(secondItem));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(1);
+                dataGrid.Instance.SelectedItems.Should().Contain(firstItem);
+                dataGrid.Instance.SelectedItems.Should().NotContain(secondItem);
+            });
+
+            // SelectedItem must never reference a removed item.
+            // It should either be null or point to an item still in the Items collection.
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var selectedItem = dataGrid.Instance.SelectedItem;
+                if (selectedItem != null)
+                {
+                    testComponent.Items.Should().Contain(selectedItem,
+                        "SelectedItem must reference an item still in the collection");
+                }
+            });
+        }
+
+        [Test]
+        public async Task DataGrid_SelectedItems_ShouldKeepRemainingSelectionsWhenOneRemoved()
+        {
+            var comp = Context.Render<DataGridSelectionCleanupTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectionCleanupTest.Model>>();
+            var testComponent = comp.Instance;
+
+            // Select 3 items (not using SelectAll)
+            var firstItem = testComponent.Items.ElementAt(0);
+            var secondItem = testComponent.Items.ElementAt(1);
+            var thirdItem = testComponent.Items.ElementAt(2);
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, firstItem));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, secondItem));
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, thirdItem));
+
+            await comp.WaitForAssertionAsync(() => dataGrid.Instance.SelectedItems.Count.Should().Be(3));
+
+            await comp.InvokeAsync(() => testComponent.RemoveItem(secondItem));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dataGrid.Instance.SelectedItems.Count.Should().Be(2);
+                dataGrid.Instance.SelectedItems.Should().Contain(firstItem);
+                dataGrid.Instance.SelectedItems.Should().Contain(thirdItem);
+                dataGrid.Instance.SelectedItems.Should().NotContain(secondItem);
+            });
+
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll(".mud-table-body .mud-table-row").Count.Should().Be(3));
+        }
+
+        #endregion
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -785,7 +785,7 @@ namespace MudBlazor
             {
                 changed.CollectionChanged += (s, e) =>
                 {
-                    InvokeAsync(() =>
+                    InvokeAsync(async () =>
                     {
                         _currentRenderFilteredItemsCache = null;
 
@@ -793,9 +793,103 @@ namespace MudBlazor
                             GroupItems();
 
                         ApplyInitialExpansionForNewItems(e);
+                        await CleanupRemovedItemsAsync(e);
                         StateHasChanged();
                     });
                 };
+            }
+        }
+
+        private async Task CleanupRemovedItemsAsync(NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                // For reset, check all items in selection against the current items
+                await CleanupStaleSelectionsAsync();
+                CleanupStaleHierarchyExpansions();
+                return;
+            }
+
+            if (e.OldItems is null)
+                return;
+
+            var selectionChanged = false;
+            foreach (T item in e.OldItems)
+            {
+                // Clean up selection
+                if (Selection.Remove(item))
+                {
+                    selectionChanged = true;
+                }
+
+                // Clean up SelectedItem if it matches the removed item
+                if (Comparer.Equals(_selectedItemState.Value, item))
+                {
+                    await _selectedItemState.SetValueAsync(default);
+                }
+
+                // Clean up hierarchy expansions
+                _openHierarchies.Remove(item);
+                _initialExpansions.Remove(item);
+            }
+
+            if (selectionChanged)
+            {
+                await _selectedItemsState.SetValueAsync(Selection);
+                await SelectedItemsChanged.InvokeAsync(Selection);
+                SelectedItemsChangedEvent?.Invoke(Selection);
+            }
+        }
+
+        private async Task CleanupStaleSelectionsAsync()
+        {
+            if (Selection.Count == 0)
+                return;
+
+            // Get current items from the source
+            var currentItems = _items is not null ? new HashSet<T>(_items, Comparer) : new HashSet<T>(Comparer);
+
+            // Find items that are in selection but no longer in items
+            var staleItems = Selection.Where(s => !currentItems.Contains(s)).ToList();
+
+            if (staleItems.Count == 0)
+                return;
+
+            foreach (var item in staleItems)
+            {
+                Selection.Remove(item);
+            }
+
+            // Clean up SelectedItem if it's no longer in items
+            if (_selectedItemState.Value is not null && !currentItems.Contains(_selectedItemState.Value))
+            {
+                await _selectedItemState.SetValueAsync(default);
+            }
+
+            await _selectedItemsState.SetValueAsync(Selection);
+            await SelectedItemsChanged.InvokeAsync(Selection);
+            SelectedItemsChangedEvent?.Invoke(Selection);
+        }
+
+        private void CleanupStaleHierarchyExpansions()
+        {
+            if (_openHierarchies.Count == 0 && _initialExpansions.Count == 0)
+                return;
+
+            var currentItems = _items is not null ? new HashSet<T>(_items, Comparer) : new HashSet<T>(Comparer);
+
+            // Remove items from _openHierarchies that are no longer in the collection
+            var staleHierarchies = _openHierarchies.Where(h => !currentItems.Contains(h)).ToList();
+            foreach (var item in staleHierarchies)
+            {
+                _openHierarchies.Remove(item);
+            }
+
+            // Remove items from _initialExpansions that are no longer in the collection
+            var staleExpansions = _initialExpansions.Where(e => !currentItems.Contains(e)).ToList();
+            foreach (var item in staleExpansions)
+            {
+                _initialExpansions.Remove(item);
             }
         }
 
@@ -826,7 +920,6 @@ namespace MudBlazor
                 }
             }
         }
-
 
         /// <summary>
         /// Shows a loading animation while querying data.
@@ -2442,6 +2535,9 @@ namespace MudBlazor
                     await HierarchyVisibilityToggled.InvokeAsync(new(openedHierarchy, false));
                 }
                 _openHierarchies.Clear();
+                _openHierarchies.Add(item);
+                await InvokeAsync(StateHasChanged);
+                return;
             }
 
             // if item doesn't exist remove will return false and add the item


### PR DESCRIPTION
## Description
Fixes: #12338
Fixes issue where `SelectedItems` and `SelectedItem` retain stale references when items are removed from an `ObservableCollection` bound to the DataGrid.

## Changes
- Added `CleanupRemovedItemsAsync` method to handle item removal from selection
- Added `CleanupStaleSelectionsAsync` for Reset action handling
- Added `CleanupStaleHierarchyExpansions` to clean up hierarchy state
- Properly invokes `SelectedItemsChanged` event after cleanup

## Testing
Added 7 unit tests covering:
- Single item removal
- Multiple item removal  
- Collection clear
- SelectedItem cleanup
- Non-selected item removal (should not affect selection)
- SelectedItem not referencing removed items
- Remaining selections preserved when one is removed
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
