### PR TITLE
Docs: Clarify MudOverlay 'overlay view'

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
@@ -103,7 +103,7 @@
           <SectionHeader Title="Positioning">
             <Description>
               By default, <CodeInline>MudOverlay</CodeInline> is scaffolded into the <CodeInline>MudPopoverProvider</CodeInline>, producing a singleton stack where the most recently created overlay sits on top and stacks back down in reverse creation order as overlays close.
-              In this context, an "overlay view" simply means an overlay instance (the scrim plus optional child content) that gets added to the stack by a component such as a popover, menu, or select.
+	              In this context, an "overlay view" simply means a scaffolded overlay instance (the scrim/backdrop) that gets added to the stack by a component such as a popover, menu, or select.
               <MudAlert Dense Severity="Severity.Info">The scaffolded ZIndex will be the higher value between the explicit `ZIndex` parameter and the internally calculated value. This means an explicit `ZIndex` does not automatically override the scaffolded value if the latter is higher.</MudAlert>
               <ul class="bullet-list">
                 <li>Set <CodeInline>Absolute="true"</CodeInline> to scope the overlay to its parent (excluded from scaffolding).</li>

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
@@ -103,6 +103,7 @@
           <SectionHeader Title="Positioning">
             <Description>
               By default, <CodeInline>MudOverlay</CodeInline> is scaffolded into the <CodeInline>MudPopoverProvider</CodeInline>, producing a singleton stack where the most recently created overlay sits on top and stacks back down in reverse creation order as overlays close.
+              In this context, an "overlay view" simply means an overlay instance (the scrim plus optional child content) that gets added to the stack by a component such as a popover, menu, or select.
               <MudAlert Dense Severity="Severity.Info">The scaffolded ZIndex will be the higher value between the explicit `ZIndex` parameter and the internally calculated value. This means an explicit `ZIndex` does not automatically override the scaffolded value if the latter is higher.</MudAlert>
               <ul class="bullet-list">
                 <li>Set <CodeInline>Absolute="true"</CodeInline> to scope the overlay to its parent (excluded from scaffolding).</li>


### PR DESCRIPTION
Fixes #7761.\n\nAdds a short clarification explaining what the term "overlay view" refers to in the context of MudOverlay being scaffolded via MudPopoverProvider (overlay instance = scrim + optional child content).