### PR TITLE
SequenceComparer: Optimize by using SequenceEqual

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/Comparer/CollectionComparerTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Comparer/CollectionComparerTests.cs
@@ -3,10 +3,10 @@ using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Utilities.Comparer;
 
+#nullable enable
 [TestFixture]
 public class CollectionComparerTests
 {
-
     [Test]
     public void EqualsTest()
     {
@@ -49,13 +49,6 @@ public class CollectionComparerTests
         comparer.GetHashCode([1, 2, 3]).Should().NotBe(comparer.GetHashCode([1, 2]));
         comparer.GetHashCode([1, 2, 3]).Should().NotBe(comparer.GetHashCode([1, 2, 4]));
         comparer.GetHashCode([1, 2, 3]).Should().NotBe(comparer.GetHashCode([1, 2, 4]));
-    }
-
-    private class LowercaseEqualityComparer : IEqualityComparer<string>
-    {
-        public bool Equals(string x, string y) => EqualityComparer<string>.Default.Equals(x?.ToLowerInvariant(), y?.ToLowerInvariant());
-
-        public int GetHashCode(string obj) => EqualityComparer<string>.Default.GetHashCode(obj?.ToLowerInvariant());
     }
 
     [Test]
@@ -102,5 +95,20 @@ public class CollectionComparerTests
         comparer.GetHashCode(["a", "b", "c"]).Should().NotBe(comparer.GetHashCode(["a", "b"]));
         comparer.GetHashCode(["a", "b", "c"]).Should().NotBe(comparer.GetHashCode(["a", "b", "x"]));
         comparer.GetHashCode(["a", "b", "c"]).Should().NotBe(comparer.GetHashCode(["a", "a", "x"]));
+    }
+
+    private class LowercaseEqualityComparer : IEqualityComparer<string?>
+    {
+        public bool Equals(string? x, string? y) => EqualityComparer<string>.Default.Equals(x?.ToLowerInvariant(), y?.ToLowerInvariant());
+
+        public int GetHashCode(string? obj)
+        {
+            if (obj is null)
+            {
+                return 0;
+            }
+
+            return EqualityComparer<string>.Default.GetHashCode(obj.ToLowerInvariant());
+        }
     }
 }

--- a/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
@@ -2,10 +2,14 @@
 
 #nullable enable
 /// <summary>
-/// Provides a comparer for <see cref="IReadOnlyCollection{T}"/> values by using a <see cref="IEqualityComparer{T}"/>.
-/// Equality is based on HashSet and the given IEqualityComparer
+/// Provides a comparer for <see cref="IReadOnlyCollection{T}"/> values using a <see cref="IEqualityComparer{T}"/>.
+/// Equality is set-based: two collections are equal if they contain the same distinct elements,
+/// regardless of order or the number of duplicates. Null is only equal to null.
 /// 
-/// Note: Order of the sequence is not relevant, neither are multiple entries of the same value !
+/// Note:
+/// - The order of elements does not affect equality or hash code.
+/// - Multiple entries of the same value are ignored.
+/// - Null and empty collections are treated as distinct values.
 /// </summary>
 public class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollection<T>?>
 {

--- a/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace MudBlazor;
+﻿namespace MudBlazor;
 
 #nullable enable
 /// <summary>
@@ -50,30 +47,27 @@ public class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollection<T>?>
     public int GetHashCode(IReadOnlyCollection<T>? obj)
     {
         if (obj is null)
-            return 0;
-
-        return CombineHashCodes(obj.Distinct(_comparer).Select(x => _comparer.GetHashCode(x!)).OrderBy(x => x));
-    }
-
-    // System.String.GetHashCode(): http://referencesource.microsoft.com/#mscorlib/system/string.cs,0a17bbac4851d0d4
-    // System.Web.Util.StringUtil.GetStringHashCode(System.String): http://referencesource.microsoft.com/#System.Web/Util/StringUtil.cs,c97063570b4e791a
-    public static int CombineHashCodes(IEnumerable<int> hashCodes)
-    {
-        var hash1 = (5381 << 16) + 5381;
-        var hash2 = hash1;
-
-        var i = 0;
-        foreach (var hashCode in hashCodes)
         {
-            if (i % 2 == 0)
-                hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ hashCode;
-            else
-                hash2 = ((hash2 << 5) + hash2 + (hash2 >> 27)) ^ hashCode;
-
-            ++i;
+            return 0;
+        }
+        if (obj.Count == 0)
+        {
+            // Empty collection seed
+            return 0x34502209;
         }
 
-        return hash1 + (hash2 * 1566083941);
+        var hash = 0;
+        var seen = new HashSet<T>(_comparer);
+
+        foreach (var item in obj)
+        {
+            if (seen.Add(item))
+            {
+                hash ^= _comparer.GetHashCode(item!);
+            }
+        }
+
+        return hash;
     }
 
     public static readonly CollectionComparer<T> Default = new();

--- a/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
@@ -6,10 +6,12 @@
 /// Equality is set-based: two collections are equal if they contain the same distinct elements,
 /// regardless of order or the number of duplicates. Null is only equal to null.
 /// 
-/// Note:
-/// - The order of elements does not affect equality or hash code.
-/// - Multiple entries of the same value are ignored.
-/// - Null and empty collections are treated as distinct values.
+/// <para>Note:</para>
+/// <list type="bullet">
+///   <item>The order of elements does not affect equality or hash code.</item>
+///   <item>Multiple entries of the same value are ignored.</item>
+///   <item>Null and empty collections are treated as distinct values.</item>
+/// </list>
 /// </summary>
 public class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollection<T>?>
 {

--- a/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
@@ -69,7 +69,7 @@ public class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollection<T>?>
         {
             if (seen.Add(item))
             {
-                hash ^= _comparer.GetHashCode(item!);
+                hash ^= item is null ? 0 : _comparer.GetHashCode(item);
             }
         }
 

--- a/src/MudBlazor/Utilities/Comparer/SequenceComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/SequenceComparer.cs
@@ -34,16 +34,7 @@ internal class SequenceComparer<T> : IEqualityComparer<IEnumerable<T?>?>
         if (ReferenceEquals(x, y)) return true;
         if (x is null || y is null) return false;
 
-        using var e1 = x.GetEnumerator();
-        using var e2 = y.GetEnumerator();
-
-        while (true)
-        {
-            var m1 = e1.MoveNext();
-            var m2 = e2.MoveNext();
-            if (!m1 || !m2) return m1 == m2;
-            if (!_elementComparer.Equals(e1.Current, e2.Current)) return false;
-        }
+        return x.SequenceEqual(y, _elementComparer);
     }
 
     /// <summary>


### PR DESCRIPTION
It's faster as it checks for `ICollection`, `IList`, also checks if it can use spans in case of primitive types etc.

Also improved `CollectionComparer.GetHashCode`.

The old implementation used `Distinct` + `OrderBy` + a combiner to normalize hash codes:

* Sorting was used to make the combination order-independent.
* This worked, but sorting is unnecessary, allocates memory, and costs `O(n log n)` time.
* Hash codes are called frequently by dictionaries and hash sets, so they should be cheap.

The new implementation avoids sorting:

* Uses a HashSet to process distinct elements only.
* Combines hash codes with XOR in a single pass.
* No extra allocations for sorting, much faster, simpler.

It directly matches the documented semantics:

> *Order of the sequence is not relevant, neither are multiple entries of the same value.*

https://github.com/MudBlazor/MudBlazor/blob/c9c23d502310b3063ec7c3f42b231a1411160e54/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs#L8

So the new `GetHashCode` is simpler, faster, and fully correct for the intended behavior.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
