### PR TITLE
MudLink: Vertically align icons

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontAwesomeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontAwesomeExample.razor
@@ -7,3 +7,6 @@
 <MudIcon Icon="fas fa-search" />
 <MudIconButton Icon="fas fa-sync-alt" />
 <MudButton StartIcon="fas fa-paper-plane" Color="Color.Info" Variant="Variant.Filled">Send</MudButton>
+<MudLink Class="ms-2" Href="https://fontawesome.com/icons" Target="_blank">
+    Explore icons <MudIcon Icon="fas fa-arrow-right" Size="Size.Small" />
+</MudLink>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontMaterialSymbolsSyntaxExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontMaterialSymbolsSyntaxExample.razor
@@ -7,3 +7,6 @@
 <MudIcon Icon="material-symbols-outlined/search" />
 <MudIconButton Icon="material-symbols-outlined/refresh" aria-label="refresh"/>
 <MudButton StartIcon="material-symbols-outlined/send" Color="Color.Info" Variant="Variant.Filled">Send</MudButton>
+<MudLink Class="ms-2" Href="https://fonts.google.com/icons" Target="_blank">
+    Explore icons <MudIcon Icon="material-symbols-outlined/arrow_forward" Size="Size.Small" />
+</MudLink>

--- a/src/MudBlazor/Styles/components/_link.scss
+++ b/src/MudBlazor/Styles/components/_link.scss
@@ -1,5 +1,9 @@
 
 .mud-link {
+  .mud-icon-root {
+    vertical-align: middle;
+  }
+
   &.mud-link-underline-none {
     text-decoration: none;
   }


### PR DESCRIPTION
Icons are not vertically centered inside MudLink by default. Closes #12052

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Before

<img width="1337" height="1202" alt="image" src="https://github.com/user-attachments/assets/55944970-59e6-41d5-bb71-8d22bbe26dbf" />

After

<img width="1336" height="1201" alt="image" src="https://github.com/user-attachments/assets/c93c75bb-0609-4fca-b369-36b005ac509e" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
