### PR TITLE
MudIcon: Allow null Size to inherit font size & Align middle vertically

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontAwesomeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontAwesomeExample.razor
@@ -7,6 +7,6 @@
 <MudIcon Icon="fas fa-search" />
 <MudIconButton Icon="fas fa-sync-alt" />
 <MudButton StartIcon="fas fa-paper-plane" Color="Color.Info" Variant="Variant.Filled">Send</MudButton>
-<MudLink Class="ms-2" Href="https://fontawesome.com/icons" Target="_blank">
-    Explore icons <MudIcon Icon="fas fa-arrow-right" Size="Size.Small" />
+<MudLink Href="https://fontawesome.com/icons" Target="_blank">
+    Explore icons <MudIcon Icon="fas fa-arrow-right" Size="null" />
 </MudLink>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontAwesomeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontAwesomeExample.razor
@@ -7,3 +7,6 @@
 <MudIcon Icon="fas fa-search" />
 <MudIconButton Icon="fas fa-sync-alt" />
 <MudButton StartIcon="fas fa-paper-plane" Color="Color.Info" Variant="Variant.Filled">Send</MudButton>
+<MudLink Class="ms-2" Href="https://fontawesome.com/icons" Target="_blank">
+    Explore icons <MudIcon Icon="fas fa-arrow-right" Size="Size.Small" />
+</MudLink>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontMaterialSymbolsSyntaxExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontMaterialSymbolsSyntaxExample.razor
@@ -7,3 +7,6 @@
 <MudIcon Icon="material-symbols-outlined/search" />
 <MudIconButton Icon="material-symbols-outlined/refresh" aria-label="refresh"/>
 <MudButton StartIcon="material-symbols-outlined/send" Color="Color.Info" Variant="Variant.Filled">Send</MudButton>
+<MudLink Class="ms-2" Href="https://fonts.google.com/icons" Target="_blank">
+    Explore icons <MudIcon Icon="material-symbols-outlined/arrow_forward" Size="Size.Small" />
+</MudLink>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontMaterialSymbolsSyntaxExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/Examples/IconsFontMaterialSymbolsSyntaxExample.razor
@@ -7,6 +7,6 @@
 <MudIcon Icon="material-symbols-outlined/search" />
 <MudIconButton Icon="material-symbols-outlined/refresh" aria-label="refresh"/>
 <MudButton StartIcon="material-symbols-outlined/send" Color="Color.Info" Variant="Variant.Filled">Send</MudButton>
-<MudLink Class="ms-2" Href="https://fonts.google.com/icons" Target="_blank">
-    Explore icons <MudIcon Icon="material-symbols-outlined/arrow_forward" Size="Size.Small" />
+<MudLink Href="https://fonts.google.com/icons" Target="_blank">
+    Explore icons <MudIcon Icon="material-symbols-outlined/arrow_forward" Size="null" />
 </MudLink>

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
                 .AddClass("mud-icon-default", Color == Color.Default && !Disabled)
                 .AddClass("mud-svg-icon", !string.IsNullOrEmpty(Icon) && Icon.Trim().StartsWith("<"))
                 .AddClass($"mud-{Color.ToDescriptionString()}-text", Color != Color.Default && Color != Color.Inherit && !Disabled)
-                .AddClass($"mud-icon-size-{Size.ToDescriptionString()}")
+                .AddClass($"mud-icon-size-{Size?.ToDescriptionString()}", Size.HasValue)
                 .AddClass(Class)
                 .Build();
 
@@ -49,11 +49,11 @@ namespace MudBlazor
         /// The size of this icon.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Size.Medium"/>.
+        /// Defaults to <see cref="Size.Medium"/>. When <c>null</c>, the icon inherits its font-size.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Icon.Appearance)]
-        public Size Size { get; set; } = Size.Medium;
+        public Size? Size { get; set; } = MudBlazor.Size.Medium;
 
         /// <summary>
         /// Ignores any custom color.

--- a/src/MudBlazor/Styles/components/_icons.scss
+++ b/src/MudBlazor/Styles/components/_icons.scss
@@ -13,9 +13,11 @@
   width: 1em;
   height: 1em;
   display: inline-block;
+  vertical-align: middle;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   flex-shrink: 0;
   user-select: none;
+  font-size: inherit;
 
   &:focus {
     outline: none;

--- a/src/MudBlazor/Styles/components/_link.scss
+++ b/src/MudBlazor/Styles/components/_link.scss
@@ -1,3 +1,4 @@
+
 .mud-link {
   &.mud-link-underline-none {
     text-decoration: none;

--- a/src/MudBlazor/Styles/components/_link.scss
+++ b/src/MudBlazor/Styles/components/_link.scss
@@ -1,5 +1,9 @@
 
 .mud-link {
+  .mud-icon-root {
+    vertical-align: middle;
+  }
+
   &.mud-link-underline-none {
     text-decoration: none;
   }

--- a/src/MudBlazor/Styles/components/_link.scss
+++ b/src/MudBlazor/Styles/components/_link.scss
@@ -1,9 +1,4 @@
-
 .mud-link {
-  .mud-icon-root {
-    vertical-align: middle;
-  }
-
   &.mud-link-underline-none {
     text-decoration: none;
   }


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. 
-->

Applied vertical alignment on the icon root and made MudIcon.Size nullable so it skips the size class unless explicitly set, allowing font-size to inherit by default.

MudLink Before:

<img width="246" height="79" alt="image" src="https://github.com/user-attachments/assets/cf637101-f0cd-4ea9-b413-960f937f5d1c" />


MudLink After:

<img width="243" height="77" alt="image" src="https://github.com/user-attachments/assets/90578576-997e-4731-8055-fe7f6058cb8e" />


Closes #12360 and Closes #12052

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
