### PR TITLE
MudBaseInput: Makes the For= definition implicit through Expression binding

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormOnFieldChangedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormOnFieldChangedTest.razor
@@ -2,21 +2,26 @@
     <EditForm EditContext="@_editContext">
         <MudCard>
             <MudCardContent>
-                <MudTextField Label="Field One"
+                <MudTextField Label="Field One (explicit For=)"
                               @bind-Value="_model.Field1"
                               For="@(() => _model.Field1)" />
-                <MudTextField Label="Field Two (no For=)" Class="mt-3"
-                              @bind-Value="_model.Field2" />
-                <MudTextField Label="Field Three" Class="mt-3"
-                              @bind-Value="_model.Field3"
-                              For="@(() => _model.Field3)" />
-
+                <MudTextField Label="Field Two (no For=) (no binding) (no ValueExpression=)" Class="mt-3"
+                              Value="_model.Field2"
+                              ValueChanged="@((string? s) => _model.Field2 = s)"
+                              ValueExpression="@null" />
+                <MudTextField Label="Field Three (no For=) (with full binding)" Class="mt-3"
+                              @bind-Value="_model.Field3" />
+                <MudTextField Label="Field Four (explicit For= to a different field)" Class="mt-3"
+                              @bind-Value="_model.Field4"
+                              For="@(() => _model.Field5)" />
             </MudCardContent>
         </MudCard>
 
         <MudChip T="string" Color="Color.Info" Class="mt-3">@_message1</MudChip>
         <MudChip T="string" Color="Color.Info" Class="mt-3">@_message2</MudChip>
         <MudChip T="string" Color="Color.Info" Class="mt-3">@_message3</MudChip>
+        <MudChip T="string" Color="Color.Info" Class="mt-3">@_message4</MudChip>
+        <MudChip T="string" Color="Color.Info" Class="mt-3">@_message5</MudChip>
     </EditForm>
 </div>
 
@@ -29,6 +34,8 @@
     private string _message1 = "Field1 not changed";
     private string _message2 = "Field2 not changed";
     private string _message3 = "Field3 not changed";
+    private string _message4 = "Field4 not changed";
+    private string _message5 = "Field5 not changed";
 
     protected override void OnInitialized()
     {
@@ -50,6 +57,12 @@
             case "Field3":
                 _message3 = e.FieldIdentifier.FieldName + " changed";
                 break;
+            case "Field4":
+                _message4 = e.FieldIdentifier.FieldName + " changed";
+                break;
+            case "Field5":
+                _message5 = e.FieldIdentifier.FieldName + " changed";
+                break;
         }
     }
 
@@ -60,5 +73,9 @@
         public string? Field2 { get; set; }
 
         public string? Field3 { get; set; }
+        
+        public string? Field4 { get; set; }
+        
+        public string? Field5 { get; set; }
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAutomaticValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAutomaticValidationTest.razor
@@ -3,6 +3,9 @@
 <MudForm Model="@_model" Validation="@(_validationRules.ValidateValue)">
     <MudTextField @bind-Value="_model.String1" For="(() => _model.String1)" />
     <MudTextField @bind-Value="_model.String2" />
+    <MudTextField Value="_model.String3"
+                  ValueChanged="@((string? s) => _model.String3 = s)"
+                  ValueExpression="@null" />
     <MudDatePicker @bind-Date="_model.DateTime1" For="(() => _model.DateTime1)" />
     <MudDatePicker @bind-Date="_model.DateTime2" />
 </MudForm>
@@ -27,6 +30,8 @@
         public string? String1 { get; set; }
 
         public string? String2 { get; set; }
+        
+        public string? String3 { get; set; }
 
         public DateTime? DateTime1 { get; set; }
 

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -409,29 +409,47 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<EditFormOnFieldChangedTest>();
             var textFields = comp.FindAll("input");
-            textFields.Count.Should().Be(3);
+            textFields.Count.Should().Be(4);
             var chips = comp.FindAll("span.mud-chip-content");
-            chips.Count.Should().Be(3);
+            chips.Count.Should().Be(5);
             foreach (var chip in chips)
                 chip.TextContent.Trim().Should().EndWith("not changed");
+            
             comp.FindAll("input")[0].Change(new ChangeEventArgs() { Value = "asdf" });
             comp.FindAll("input")[0].Blur();
             comp.FindComponents<MudTextField<string>>()[0].Instance.ReadText.Should().Be("asdf");
             comp.FindAll("span.mud-chip-content")[0].TextContent.Trim().Should().Be("Field1 changed");
             comp.FindAll("span.mud-chip-content")[1].TextContent.Trim().Should().EndWith("not changed");
             comp.FindAll("span.mud-chip-content")[2].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[3].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[4].TextContent.Trim().Should().EndWith("not changed");
+            
             comp.FindAll("input")[1].Change(new ChangeEventArgs() { Value = "yxcv" });
             comp.FindAll("input")[1].Blur();
             comp.FindComponents<MudTextField<string>>()[1].Instance.ReadText.Should().Be("yxcv");
             comp.FindAll("span.mud-chip-content")[0].TextContent.Trim().Should().Be("Field1 changed");
             comp.FindAll("span.mud-chip-content")[1].TextContent.Trim().Should().EndWith("not changed", "Because it has no For, so the change can not be forwarded to the edit context for lack of a FieldIdentifier");
             comp.FindAll("span.mud-chip-content")[2].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[3].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[4].TextContent.Trim().Should().EndWith("not changed");
+            
             comp.FindAll("input")[2].Change(new ChangeEventArgs() { Value = "qwer" });
             comp.FindAll("input")[2].Blur();
             comp.FindComponents<MudTextField<string>>()[2].Instance.ReadText.Should().Be("qwer");
             comp.FindAll("span.mud-chip-content")[0].TextContent.Trim().Should().Be("Field1 changed");
             comp.FindAll("span.mud-chip-content")[1].TextContent.Trim().Should().EndWith("not changed");
             comp.FindAll("span.mud-chip-content")[2].TextContent.Trim().Should().EndWith("Field3 changed");
+            comp.FindAll("span.mud-chip-content")[3].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[4].TextContent.Trim().Should().EndWith("not changed");
+            
+            comp.FindAll("input")[3].Change(new ChangeEventArgs() { Value = "wolo" });
+            comp.FindAll("input")[3].Blur();
+            comp.FindComponents<MudTextField<string>>()[3].Instance.ReadText.Should().Be("wolo");
+            comp.FindAll("span.mud-chip-content")[0].TextContent.Trim().Should().Be("Field1 changed");
+            comp.FindAll("span.mud-chip-content")[1].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[2].TextContent.Trim().Should().EndWith("Field3 changed");
+            comp.FindAll("span.mud-chip-content")[3].TextContent.Trim().Should().EndWith("not changed");
+            comp.FindAll("span.mud-chip-content")[4].TextContent.Trim().Should().EndWith("Field5 changed");
         }
 
         /// <summary>
@@ -1602,14 +1620,16 @@ namespace MudBlazor.UnitTests.Components
             var textComps = comp.FindComponents<MudTextField<string>>();
             var dateComps = comp.FindComponents<MudDatePicker>();
 
-            textComps[0].Instance.For.Should().NotBeNull(); //For is set
-            textComps[1].Instance.For.Should().BeNull(); //For is not set
+            textComps[0].Instance.For.Should().NotBeNull(); //For is set manually
+            textComps[1].Instance.For.Should().NotBeNull(); //For is set through ValueExpression
+            textComps[2].Instance.For.Should().BeNull(); //For is not set, ValueExpression is not set
             dateComps[0].Instance.For.Should().NotBeNull(); //For is set
             dateComps[1].Instance.For.Should().BeNull(); //For is not set
 
             //Ensure Validation is only set where For is set
             textComps[0].Instance.Validation.Should().NotBeNull(); //Validation is set
-            textComps[1].Instance.Validation.Should().BeNull(); //Validation is not set
+            textComps[1].Instance.Validation.Should().NotBeNull(); //Validation is set
+            textComps[2].Instance.Validation.Should().BeNull(); //Validation is not set
             dateComps[0].Instance.Validation.Should().NotBeNull(); //Validation is set
             dateComps[1].Instance.Validation.Should().BeNull(); //Validation is not set
         }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using MudBlazor.State;
-using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -23,6 +23,11 @@ namespace MudBlazor
         private bool _validated;
         protected bool _isFocused;
         protected bool _forceTextUpdate;
+        
+        /// <summary>
+        /// To find out whether or not ValueExpression parameter has changed we keep a separate reference.
+        /// </summary>
+        private Expression<Func<T>>? _currentValueExpression;
 
         /// <summary>
         /// The resolved input element ID.
@@ -412,6 +417,10 @@ namespace MudBlazor
         [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Data)]
         public T? Value { get; set; }
+        
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Validation)]
+        public Expression<Func<T>>? ValueExpression { get; set; }
 
         /// <summary>
         /// The format applied to values.
@@ -634,6 +643,11 @@ namespace MudBlazor
 
         protected override async Task OnInitializedAsync()
         {
+            // Setting "For" is required before calling the parent in the context of a MudForm parent,
+            // otherwise its validation will not be passed down to our input. 
+            _currentValueExpression = ValueExpression;
+            For ??= _currentValueExpression;
+            
             await base.OnInitializedAsync();
 
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
@@ -702,6 +716,15 @@ namespace MudBlazor
         /// <inheritdoc />
         protected override void OnParametersSet()
         {
+            if (ValueExpression != _currentValueExpression)
+            {
+                _currentValueExpression = ValueExpression;
+                if (!HasForChanged())
+                {
+                    For = ValueExpression;
+                }
+            }
+            
             if (SubscribeToParentForm)
             {
                 base.OnParametersSet();

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -756,6 +756,12 @@ namespace MudBlazor
         private Expression<Func<T>>? _currentFor;
 
         /// <summary>
+        /// Verifies the current value of <see cref="For"/> changed
+        /// since <see cref="OnParametersSet"/> was last executed.
+        /// </summary>
+        protected bool HasForChanged() => For != _currentFor;
+
+        /// <summary>
         /// To find out whether or not EditContext parameter has changed we keep a separate reference
         /// </summary>
         private EditContext? _currentEditContext;
@@ -765,7 +771,7 @@ namespace MudBlazor
             base.OnParametersSet();
 
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
-            if (For is not null && For != _currentFor)
+            if (For is not null && HasForChanged())
             {
                 // if there is an EditContext, there is no need for internal validation as it will get overwritten by 'OnValidationStateChanged'
                 if (EditContext is null)


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
Here is a quick proposal to solve #7659.
This PR is to check if it's on the right track.

Notable issue with this solution:
- Consciously breaking the "Don't overwrite parameters in components!" rule, as I wasn't sure if there was a clean solution that abstracts the current readers and setters of `For` parameter without introducing a breaking change. Though, if breaking changes are acceptable, `For` could stop being a parameter and become a protected property.

Issues that should be solved if the proposal is on the right rack:
- Other types that inherit from `MudFormComponent`, like `MudBooleanInput`, have not been altered, but should be in the final version. Would that be one PR per base component, or should all be edited in one PR for feature parity?
- Docs aren't updated yet.

<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
  - I am missing tests that directly test the newly added code, though I believe that the modified bUnit tests cover them enough.
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
