### PR TITLE
MudSplitPanel: Add get and set divider position functions

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/SplitPanel/Examples/SplitPanelBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SplitPanel/Examples/SplitPanelBasicExample.razor
@@ -36,7 +36,7 @@
             <MudToggleIconButton @bind-Toggled="_transparent" Icon="@Icons.Material.Outlined.Visibility" ToggledColor="@Color.Info"/>
         </MudTooltip>
         <MudTooltip Text="Reset sizes">
-            <MudIconButton OnClick="@_splitPanel.ResetSizesAsync" Icon="@Icons.Material.Outlined.Replay" Variant="Variant.Filled"/>
+            <MudIconButton OnClick="@_splitPanel.ResetDividerPositionAsync" Icon="@Icons.Material.Outlined.Replay" Variant="Variant.Filled"/>
         </MudTooltip>
     </MudButtonGroup>
 </MudStack>

--- a/src/MudBlazor.Docs/Pages/Components/SplitPanel/Examples/SplitPanelFunctionsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SplitPanel/Examples/SplitPanelFunctionsExample.razor
@@ -1,0 +1,42 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudStack Class="mud-width-full mud-height-full" Justify="Justify.Center" AlignItems="AlignItems.Center" Style="height: 500px;">
+    <MudSplitPanel @ref="_splitPanel" Class="mud-width-full mud-height-full">
+        <FirstPanel>
+            <MudStack Justify="Justify.Center" AlignItems="AlignItems.Center" Class="mud-width-full mud-height-full">
+                <MudText Typo="Typo.h6">First Panel</MudText>
+            </MudStack>
+        </FirstPanel>
+        <SecondPanel>
+            <MudStack Justify="Justify.Center" AlignItems="AlignItems.Center" Class="mud-width-full mud-height-full">
+                <MudText Typo="Typo.h6">Second Panel</MudText>
+            </MudStack>
+        </SecondPanel>
+    </MudSplitPanel>
+    <MudNumericField @bind-Value="_size" Label="Size [px]"/>
+    <MudStack Row="true">
+        <MudButton OnClick="@GetPositionAsync" Variant="Variant.Filled" EndIcon="@Icons.Material.Outlined.Download">Get Pos.</MudButton>
+        <MudButton OnClick="@SetPositionAsync" Variant="Variant.Filled" EndIcon="@Icons.Material.Outlined.Upload">Set Pos.</MudButton>
+        <MudButton OnClick="@ResetPositionAsync" Variant="Variant.Filled" EndIcon="@Icons.Material.Outlined.Replay">Reset Pos.</MudButton>
+    </MudStack>
+</MudStack>
+
+@code {
+    private MudSplitPanel _splitPanel;
+    private int _size;
+
+    private async Task GetPositionAsync()
+    {
+        _size = await _splitPanel.GetDividerPositionAsync();
+    }
+
+    private async Task SetPositionAsync()
+    {
+        await _splitPanel.SetDividerPositionAsync(_size);
+    }
+
+    private async Task ResetPositionAsync()
+    {
+        await _splitPanel.ResetDividerPositionAsync();
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/SplitPanel/SplitPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SplitPanel/SplitPanelPage.razor
@@ -29,5 +29,11 @@
                 <SplitPanelInsideSplitPanelExample/>
             </SectionContent>
         </DocsPageSection>
+        <DocsPageSection>
+            <SectionHeader Title="Functions"/>
+            <SectionContent Code="@nameof(SplitPanelFunctionsExample)" DarkenBackground="true">
+                <SplitPanelFunctionsExample/>
+            </SectionContent>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SplitPanel/SplitPanelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SplitPanel/SplitPanelTest.razor
@@ -9,5 +9,7 @@
     [Parameter]
     public bool Horizontal { get; set; }
 
-    public Task ResetSizesAsync() => _panel.ResetSizesAsync();
+    public Task ResetDividerPositionAsync() => _panel.ResetDividerPositionAsync();
+    public Task SetDividerPositionAsync(int offset) => _panel.SetDividerPositionAsync(offset);
+    public Task<int> GetDividerPositionAsync() => _panel.GetDividerPositionAsync();
 }

--- a/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
@@ -69,12 +69,32 @@ public class SplitPanelTests : BunitTest
     }
 
     [Test]
-    public async Task ExecutesResetSizesJsCall()
+    public async Task ExecutesResetDividerPositionJsCall()
     {
         var comp = Context.Render<SplitPanelTest>();
-        await comp.Instance.ResetSizesAsync();
+        await comp.Instance.ResetDividerPositionAsync();
 
-        var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_resetSizes");
+        var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_resetDividerPosition");
+        invocation.Arguments.Count.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ExecutesSetDividerPositionJsCall()
+    {
+        var comp = Context.Render<SplitPanelTest>();
+        await comp.Instance.SetDividerPositionAsync(123);
+
+        var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_setDividerPosition");
+        invocation.Arguments.Count.Should().Be(2);
+    }
+
+    [Test]
+    public async Task ExecutesGetDividerPositionJsCall()
+    {
+        var comp = Context.Render<SplitPanelTest>();
+        await comp.Instance.GetDividerPositionAsync();
+
+        var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_getDividerPosition");
         invocation.Arguments.Count.Should().Be(1);
     }
 }

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -202,7 +202,7 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Resets the divider position to their initial values.
+    /// Resets the divider position to its initial value.
     /// </summary>
     public async Task ResetDividerPositionAsync()
     {
@@ -215,8 +215,7 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// <remarks>
     /// Note that this function ignores <see cref="MinPanelSize"/>.
     /// </remarks>
-    /// <Param name="offset">The offset in pixels from the left or top border.</Param>
-    /// <returns></returns>
+    /// <param name="offset">The offset in pixels from the left or top border.</param>
     public async Task SetDividerPositionAsync(int offset)
     {
         await JsRuntime.InvokeVoidAsync("mudSplitPanel_setDividerPosition", _containerId, offset);
@@ -225,7 +224,6 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// <summary>
     /// Returns the current offset of the divider from the left or top border in pixels.
     /// </summary>
-    /// <returns></returns>
     public async Task<int> GetDividerPositionAsync()
     {
         return await JsRuntime.InvokeAsync<int>("mudSplitPanel_getDividerPosition", _containerId);

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -202,11 +202,33 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     }
 
     /// <summary>
-    /// Resets the sizes of the panels to their initial values.
+    /// Resets the divider position to their initial values.
     /// </summary>
-    public async Task ResetSizesAsync()
+    public async Task ResetDividerPositionAsync()
     {
-        await JsRuntime.InvokeVoidAsync("mudSplitPanel_resetSizes", _containerId);
+        await JsRuntime.InvokeVoidAsync("mudSplitPanel_resetDividerPosition", _containerId);
+    }
+
+    /// <summary>
+    /// Sets the divider to the given offset.
+    /// </summary>
+    /// <remarks>
+    /// Note that this function ignores <see cref="MinPanelSize"/>.
+    /// </remarks>
+    /// <Param name="offset">The offset in pixels from the left or top border.</Param>
+    /// <returns></returns>
+    public async Task SetDividerPositionAsync(int offset)
+    {
+        await JsRuntime.InvokeVoidAsync("mudSplitPanel_setDividerPosition", _containerId, offset);
+    }
+
+    /// <summary>
+    /// Returns the current offset of the divider from the left or top border in pixels.
+    /// </summary>
+    /// <returns></returns>
+    public async Task<int> GetDividerPositionAsync()
+    {
+        return await JsRuntime.InvokeAsync<int>("mudSplitPanel_getDividerPosition", _containerId);
     }
 
     /// <inheritdoc/>

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -81,9 +81,9 @@ class MudSplitPanel {
         this.firstPanel.style.height = "100%";
         this.secondPanel.style.height = "100%";
 
-        const firstPanelNewSize = firstPanelSize ?? this.firstPanelInitialSize;
-        if (firstPanelNewSize !== null) {
-            this._setPanelSizes(firstPanelNewSize, this._getContainerSize());
+        const firstPanelSizeNew = firstPanelSize !== null ? firstPanelSize : this.firstPanelInitialSize;
+        if (firstPanelSizeNew !== null) {
+            this._setPanelSizes(firstPanelSizeNew, this._getContainerSize());
         } else {
             this.divider.ariaValueNow = "50";
         }
@@ -92,10 +92,10 @@ class MudSplitPanel {
     getDividerPosition() {
         return this.horizontal ? this.firstPanel.clientHeight : this.firstPanel.clientWidth;
     }
-    
+
     setDividerPosition(offset) {
         this.resetSizes(offset);
-    }   
+    }
 
     _getContainerSize() {
         return this.horizontal ? this.container.offsetHeight : this.container.offsetWidth;

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -75,18 +75,27 @@ class MudSplitPanel {
         }
     }
 
-    resetSizes() {
+    resetSizes(firstPanelSize = null) {
         this.firstPanel.style.width = "100%";
         this.secondPanel.style.width = "100%";
         this.firstPanel.style.height = "100%";
         this.secondPanel.style.height = "100%";
 
-        if (this.firstPanelInitialSize !== null) {
-            this._setPanelSizes(this.firstPanelInitialSize, this._getContainerSize());
+        const firstPanelNewSize = firstPanelSize ?? this.firstPanelInitialSize;
+        if (firstPanelNewSize !== null) {
+            this._setPanelSizes(firstPanelNewSize, this._getContainerSize());
         } else {
             this.divider.ariaValueNow = "50";
         }
     }
+
+    getDividerPosition() {
+        return this.horizontal ? this.firstPanel.clientHeight : this.firstPanel.clientWidth;
+    }
+    
+    setDividerPosition(offset) {
+        this.resetSizes(offset);
+    }   
 
     _getContainerSize() {
         return this.horizontal ? this.container.offsetHeight : this.container.offsetWidth;
@@ -234,8 +243,16 @@ window.mudSplitPanel_update = function (id, horizontal, resetOnDoubleClick, minP
     window.splitPanels[id].update(horizontal, resetOnDoubleClick, minPanelSize, panelGap);
 };
 
-window.mudSplitPanel_resetSizes = function (id) {
+window.mudSplitPanel_resetDividerPosition = function (id) {
     window.splitPanels[id].resetSizes();
+};
+
+window.mudSplitPanel_getDividerPosition = function (id) {
+    return window.splitPanels[id].getDividerPosition();
+};
+
+window.mudSplitPanel_setDividerPosition = function (id, offset) {
+    window.splitPanels[id].setDividerPosition(offset);
 };
 
 window.mudSplitPanel_destroy = function (id) {


### PR DESCRIPTION
This PR adds 2 functions to the `MudSplitPanel`:
* `GetDividerPositionAsync`
* `SetDividerPositionAsync`
and renames one:
* `ResetSizesAsync` => `ResetDividerPositionAsync`
