### PR TITLE
Docs: Update Google Fonts link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add to `MainLayout.razor` or `App.razor`:
 Add to HTML `head` section (`index.html`/`_Layout.cshtml`/`_Host.cshtml`/`App.razor`):
 
 ```razor
-<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
 <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 ```
 

--- a/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
@@ -65,7 +65,7 @@
     <link rel="mask-icon" href="_content/MudBlazor.Docs/safari-pinned-tab.svg" color="#7e6fff">
     <meta name="msapplication-TileColor" content="#110e2d">
     <meta name="theme-color" content="#ffffff">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
     <link href="_content/MudBlazor/MudBlazor.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />
     <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -62,7 +62,7 @@
     <link rel="mask-icon" href="_content/MudBlazor.Docs/safari-pinned-tab.svg" color="#7e6fff">
     <meta name="msapplication-TileColor" content="#110e2d">
     <meta name="theme-color" content="#ffffff">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
     <link href="_content/MudBlazor/MudBlazor.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />
     <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -71,7 +71,7 @@
     <link rel="mask-icon" href="_content/MudBlazor.Docs/safari-pinned-tab.svg" color="#7e6fff">
     <meta name="msapplication-TileColor" content="#110e2d">
     <meta name="theme-color" content="#ffffff">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
     <link href="_content/MudBlazor/MudBlazor.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />
     <link href="_content/MudBlazor.Docs/MudBlazorDocs.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExample.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
 <link href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" rel="stylesheet" />

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleNet8.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleNet8.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
 <link href="_content/MudBlazor/MudBlazor.min.css?v=@(MudBlazor.Metadata.Version)" rel="stylesheet" />

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleWasmStandalone.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Examples/InstallationManualCssFontsExampleWasmStandalone.razor
@@ -1,5 +1,5 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
 <!-- Important: Increment the version parameter whenever you update MudBlazor to prevent caching issues -->
 <link href="_content/MudBlazor/MudBlazor.min.css?v=1" rel="stylesheet" />

--- a/src/MudBlazor.UnitTests.Viewer/wwwroot/index.html
+++ b/src/MudBlazor.UnitTests.Viewer/wwwroot/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>MudBlazor Tests Viewer</title>
     <base href="/" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
 </head>
 


### PR DESCRIPTION
Updated Google Fonts link to use the new format. Google fonts use css2 api. And the old link doesn't include some font weights, such as 100 and 900.

<img width="1175" height="662" alt="Ekran görüntüsü 2025-12-31 183058" src="https://github.com/user-attachments/assets/573e5cb5-3a0f-42e7-8c33-f094b4e8b6d4" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
