### PR TITLE
MudDatePicker: Fix FixYear

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerFixYearTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerFixYearTest.razor
@@ -1,0 +1,8 @@
+﻿<MudPopoverProvider></MudPopoverProvider>
+
+<MudDatePicker FixYear="@FixYear" />
+
+@code {
+    [Parameter]
+    public int? FixYear { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/PersianDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/PersianDatePickerTest.razor
@@ -14,6 +14,5 @@
     public DateTime? Date { get; set; } = new DateTime(2021, 02, 14); 
 
     [Parameter]
-    public int? FixDay { get; set; } = null;
-
+    public int? FixDay { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -1,4 +1,4 @@
-﻿﻿@using System.Globalization;
+﻿@using System.Globalization;
 
 <MudPopoverProvider></MudPopoverProvider>
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1742,22 +1742,22 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-picker-month").First(x => x.TrimmedText().Equals("Jan")).ToMarkup().Should().Contain("mud-picker-month-selected");
 
             //select new month (March)
-            await comp.FindAll("button.mud-picker-month").First(x => x.TrimmedText().Equals("Mar")).ClickAsync(new MouseEventArgs());
-            await comp.Find("button.mud-button-month").ClickAsync(new MouseEventArgs());
+            await comp.FindAll("button.mud-picker-month").First(x => x.TrimmedText().Equals("Mar")).ClickAsync();
+            await comp.Find("button.mud-button-month").ClickAsync();
 
             //confirm Jan is highlighted
             comp.FindAll("button.mud-picker-month").First(x => x.TrimmedText().Equals("Jan")).ToMarkup().Should().Contain("mud-picker-month-selected");
 
             //change year
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
 
             //confirm no month is highlighted
             comp.Find(".mud-picker-month-container").ToMarkup().Should().NotContain("mud-picker-month-selected");
 
             //back to present year
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Next year']").ClickAsync(new MouseEventArgs());
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Next year']").ClickAsync(new MouseEventArgs());
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Next year']").ClickAsync();
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Next year']").ClickAsync();
 
             //confirm Jan is highlighted
             comp.FindAll("button.mud-picker-month").First(x => x.TrimmedText().Equals("Jan")).ToMarkup().Should().Contain("mud-picker-month-selected");
@@ -1771,15 +1771,15 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
 
             //go to year view
-            await comp.Find("button.mud-button-month").ClickAsync(new MouseEventArgs());
-            await comp.Find("button.mud-picker-calendar-header-transition").ClickAsync(new MouseEventArgs());
+            await comp.Find("button.mud-button-month").ClickAsync();
+            await comp.Find("button.mud-picker-calendar-header-transition").ClickAsync();
 
             //2025 is highlighted
             comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2025")).ToMarkup().Should().Contain("mud-picker-year-selected");
 
             //select new year
-            await comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2020")).ClickAsync(new MouseEventArgs());
-            await comp.Find("button.mud-picker-calendar-header-transition").ClickAsync(new MouseEventArgs());
+            await comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2020")).ClickAsync();
+            await comp.Find("button.mud-picker-calendar-header-transition").ClickAsync();
 
             //2025 is still highlighted
             comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2025")).ToMarkup().Should().Contain("mud-picker-year-selected");
@@ -1793,26 +1793,83 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<DatePickerStaticTest>(p => p.Add(x => x.Date, selectedDate));
             var picker = comp.Instance;
 
-            await comp.Find("button.mud-button-month").ClickAsync(new MouseEventArgs());
+            await comp.Find("button.mud-button-month").ClickAsync();
 
             //back 5 years
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
-            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync(new MouseEventArgs());
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
+            await comp.Find(".mud-picker-calendar-header-switch button[aria-label^='Previous year']").ClickAsync();
 
             //Jump to 2020
-            await comp.Find("button.mud-picker-calendar-header-transition").ClickAsync(new MouseEventArgs());
+            await comp.Find("button.mud-picker-calendar-header-transition").ClickAsync();
 
             picker.PickerReference.PickerMonth!.Value.Year.Should().Be(2020);
             comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2025")).ToMarkup().Should().Contain("mud-picker-year-selected");
 
             //Jump to 2025
-            await comp.Find("button.mud-button-year").ClickAsync(new MouseEventArgs());
+            await comp.Find("button.mud-button-year").ClickAsync();
 
             picker.PickerReference.PickerMonth!.Value.Year.Should().Be(2025);
             comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2025")).ToMarkup().Should().Contain("mud-picker-year-selected");
+        }
+
+        [Test]
+        public async Task DatePicker_FixYear_Past()
+        {
+            var comp = Context.Render<DatePickerFixYearTest>(p => p.Add(x => x.FixYear, 1900));
+
+            // click to open menu
+            await comp.Find("input").ClickAsync();
+
+            await comp.Find("button.mud-button-month").ClickAsync();
+            var pickerHeader = comp.Find(".mud-picker-calendar-header-switch");
+            pickerHeader.TextContent.Trim().Should().Be("1900");
+        }
+
+        [Test]
+        public async Task DatePicker_FixYear_Future()
+        {
+            var futureYear = DateTime.Now.Year + 1;
+            var component = Context.Render<DatePickerFixYearTest>(p => p.Add(x => x.FixYear, futureYear));
+            var datePickerComponent = component.FindComponent<MudDatePicker>();
+
+            // Click to open date picker menu
+            await component.Find("input").ClickAsync();
+
+            var highlightedDate = datePickerComponent.Instance.HighlightedDate.GetValueOrDefault();
+            var firstDayOfMonth = new DateTime(highlightedDate.Year, highlightedDate.Month, 1);
+
+            // Calculate how many days from the previous month are shown at the start
+            var daysFromPreviousMonth = (int)firstDayOfMonth.DayOfWeek;
+
+            // Calculate total days in the current month
+            var totalDaysInMonth = DateTime.DaysInMonth(highlightedDate.Year, highlightedDate.Month);
+
+            // Get all the date buttons in the calendar
+            var dayButtons = component.FindAll(".mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-picker-calendar-day.mud-day");
+
+            // Split the buttons into previous, current, and next month days
+            var prevMonthDays = dayButtons.Take(daysFromPreviousMonth);
+            var currMonthDays = dayButtons.Skip(daysFromPreviousMonth).Take(totalDaysInMonth);
+            var nextMonthDays = dayButtons.Skip(daysFromPreviousMonth + totalDaysInMonth);
+
+            // Validate hidden and visible days
+            foreach (var prevMonthDay in prevMonthDays)
+            {
+                prevMonthDay.ClassList.Contains("mud-hidden").Should().BeTrue("Previous month days should be hidden");
+            }
+
+            foreach (var currMonthDay in currMonthDays)
+            {
+                currMonthDay.ClassList.Contains("mud-hidden").Should().BeFalse("Current month days should be visible");
+            }
+
+            foreach (var nextMonthDay in nextMonthDays)
+            {
+                nextMonthDay.ClassList.Contains("mud-hidden").Should().BeTrue("Next month days should be hidden");
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -116,7 +116,7 @@ namespace MudBlazor
         /// <remarks>
         /// This date is highlighted in the UI
         /// </remarks>
-        protected DateTime? HighlightedDate { get; set; }
+        protected internal DateTime? HighlightedDate { get; set; }
 
         /// <summary>
         /// Occurs when <see cref="PickerMonth"/> has changed.

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -254,12 +254,17 @@ namespace MudBlazor
 
         protected override DateTime GetCalendarStartOfMonth()
         {
-            var date = StartMonth ?? Date ?? TimeProvider.GetLocalNow().Date;
+            var date = StartMonth ?? Date ?? HighlightedDate ?? TimeProvider.GetLocalNow().Date;
             return date.StartOfMonth(GetCulture());
         }
 
         protected override int GetCalendarYear(DateTime yearDate)
         {
+            if (FixYear.HasValue)
+            {
+                return FixYear.Value;
+            }
+
             var date = Date ?? TimeProvider.GetLocalNow().Date;
             var diff = GetCulture().Calendar.GetYear(date) - GetCulture().Calendar.GetYear(yearDate);
             var calenderYear = GetCulture().Calendar.GetYear(date);


### PR DESCRIPTION
Fixes: #12368

The `FixYear` parameter was not being used when displaying the year header in month view or initializing the calendar, causing the picker to show the current year instead of the fixed year.

**Changes:**
- `GetCalendarYear()`: Return `FixYear.Value` when set, before falling back to date-based calculation
- `GetCalendarStartOfMonth()`: Include `HighlightedDate` in fallback chain (which respects `FixYear` during initialization)

**Example:**
```razor
<!-- Now correctly displays and constrains to year 1900 -->
<MudDatePicker FixYear="1900" />
```

The fix ensures that when `FixYear` is specified (past or future), the DatePicker consistently displays that year in the header and renders the correct month's days without hiding them incorrectly.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
