### PR TITLE
Tests: Fix stale DebouncedNumericFieldRerenderTest

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -837,13 +837,14 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<DebouncedNumericFieldRerenderTest>();
             var numericField = comp.FindComponent<MudNumericField<int>>().Instance;
-            var delayedRerenderButton = comp.Find("button#re-render");
+            IElement DelayedRerenderButton() => comp.Find("button#re-render");
+            IElement Input() => comp.Find("input");
             var converter = new DefaultConverter<int>();
-            comp.Find("input").Input(new ChangeEventArgs { Value = "1" });
+            await Input().InputAsync("1");
             // trigger first value change
             await Task.Delay(comp.Instance.DebounceInterval);
             // trigger delayed re-render
-            delayedRerenderButton.Click();
+            await DelayedRerenderButton().ClickAsync();
             // imitate "typing in progress" by extending the debounce interval until component re-renders
             var elapsedTime = 0;
             var currentText = "1";
@@ -851,7 +852,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "2";
-                comp.Find("input").Input(new ChangeEventArgs { Value = currentText });
+                await Input().InputAsync(currentText);
                 await Task.Delay(delay);
                 elapsedTime += delay;
             }


### PR DESCRIPTION
Attempt to make `DebouncedNumericFieldRerenderTest` less flaky.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
