### PR TITLE
KeyInterceptorService: Add option to ignore repeat events when holding down keys

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Services/KeyInterceptionIgnoreDownRepeatsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Services/KeyInterceptionIgnoreDownRepeatsTest.razor
@@ -1,0 +1,68 @@
+﻿@using MudBlazor.Services
+
+<MudStack id="@_elementId">
+    <MudButton Class="@_className" Variant="Variant.Outlined">Click Me</MudButton>
+    <MudText Class="d-flex">
+        <MudIcon Icon="@Icons.Material.Filled.ArrowCircleLeft" Class="mr-1" />
+        @_keyDownCountLeft
+    </MudText>
+    <MudText Class="d-flex">
+        <MudIcon Icon="@Icons.Material.Filled.ArrowCircleRight" Class="mr-1" />
+        @_keyDownCountRight
+    </MudText>
+</MudStack>
+
+@code {
+
+    public const string __description__ = @"
+Sample for demonstration of the KeyOptions.IgnoreDownRepeats option to prevent invocation of the .NET callback for repeated events 
+when holding down a key. Focus the button by clicking it and then press and hold either arrow left or arrow right and note the invocation
+counts below. For arrow right, only the initial keydown should be counted.";
+
+    private readonly string _elementId = Identifier.Create();
+    private readonly string _className = Identifier.Create();
+
+    private int _keyDownCountLeft = 0;
+    private int _keyDownCountRight = 0;
+
+    [Inject]
+    public IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        var options = new KeyInterceptorOptions()
+        {
+            TargetClass = _className,
+            EnableLogging = false,
+            Keys = [
+                new KeyOptions("ArrowLeft", subscribeDown: true),
+                new KeyOptions("ArrowRight", subscribeDown: true, ignoreDownRepeats: true),
+            ]
+        };
+
+        await KeyInterceptorService.SubscribeAsync(_elementId, options, HandleKeyDownAsync);
+    }
+
+    private Task HandleKeyDownAsync(KeyboardEventArgs args)
+    {
+        switch (args.Key)
+        {
+            case "ArrowLeft":
+                _keyDownCountLeft++;
+                StateHasChanged();
+                break;
+
+            case "ArrowRight":
+                _keyDownCountRight++;
+                StateHasChanged();
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyOptionsTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyOptionsTests.cs
@@ -27,5 +27,6 @@ public class KeyOptionsTests
         keyOptions1.PreventUp.Should().Be(keyOptions2.PreventUp);
         keyOptions1.StopDown.Should().Be(keyOptions2.StopDown);
         keyOptions1.StopUp.Should().Be(keyOptions2.StopUp);
+        keyOptions1.IgnoreDownRepeats.Should().Be(keyOptions2.IgnoreDownRepeats);
     }
 }

--- a/src/MudBlazor/Services/KeyInterceptor/KeyOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyOptions.cs
@@ -80,7 +80,7 @@ public class KeyOptions
     /// <summary>
     /// Invoke event KeyDown on C# side only for the initial keydown event and not for the repeats.
     /// </summary>
-    public bool IgnoreDownRepeats { get; init; } = false;
+    public bool IgnoreDownRepeats { get; init; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="KeyOptions"/> class.

--- a/src/MudBlazor/Services/KeyInterceptor/KeyOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyOptions.cs
@@ -78,6 +78,11 @@ public class KeyOptions
     public string StopUp { get; init; } = "none";
 
     /// <summary>
+    /// Invoke event KeyDown on C# side only for the initial keydown event and not for the repeats.
+    /// </summary>
+    public bool IgnoreDownRepeats { get; init; } = false;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="KeyOptions"/> class.
     /// </summary>
     public KeyOptions()
@@ -94,6 +99,7 @@ public class KeyOptions
     /// <param name="preventUp">Configuration for preventDefault() on key up events.</param>
     /// <param name="stopDown">Configuration for stopPropagation() on key down events.</param>
     /// <param name="stopUp">Configuration for stopPropagation() on key up events.</param>
+    /// <param name="ignoreDownRepeats">Ignore keydown repeat events.</param>
     public KeyOptions(
         string? key,
         bool subscribeDown = false,
@@ -101,7 +107,8 @@ public class KeyOptions
         string preventDown = "none",
         string preventUp = "none",
         string stopDown = "none",
-        string stopUp = "none")
+        string stopUp = "none",
+        bool ignoreDownRepeats = false)
     {
         Key = key;
         PreventDown = preventDown;
@@ -110,5 +117,6 @@ public class KeyOptions
         SubscribeUp = subscribeUp;
         StopDown = stopDown;
         StopUp = stopUp;
+        IgnoreDownRepeats = ignoreDownRepeats;
     }
 }

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -181,14 +181,14 @@ class MudKeyInterceptor {
             var keyOptions = self._keyOptions[key];
             self.logger('[MudBlazor | KeyInterceptor] options for "' + key + '"', keyOptions);
             self.processKeyDown(args, keyOptions);
-            if (keyOptions.subscribeDown)
+            if (self.shouldInvokeKeyDown(args, keyOptions))
                 invoke = true;
         }
         for (const keyOptions of self._regexOptions) {
             if (keyOptions.regex.test(key)) {
                 self.logger('[MudBlazor | KeyInterceptor] regex options for "' + key + '"', keyOptions);
                 self.processKeyDown(args, keyOptions);
-                if (keyOptions.subscribeDown)
+                if (self.shouldInvokeKeyDown(args, keyOptions))
                     invoke = true;
             }
         }
@@ -204,6 +204,10 @@ class MudKeyInterceptor {
             args.preventDefault();
         if (this.matchesKeyCombination(keyOptions.stopDown, args))
             args.stopPropagation();
+    }
+
+    shouldInvokeKeyDown(args, keyOptions) {
+        return keyOptions.subscribeDown && (!keyOptions.ignoreDownRepeats || !args.repeat);
     }
 
     onKeyUp(args) {


### PR DESCRIPTION
Add `KeyOptions.IgnoreDownRepeats` to prevent from invoking the .NET callback when the subscriber is only interested in the initial keydown event and not in the repeat stream from holding down the key. 

Usage example:
```razor
<MudStack id="@_elementId">
    <MudButton Class="@_className" Variant="Variant.Outlined">Click Me</MudButton>
    <MudText Class="d-flex">
        <MudIcon Icon="@Icons.Material.Filled.ArrowCircleLeft" Class="mr-1" />
        @_keyDownCountLeft
    </MudText>
    <MudText Class="d-flex">
        <MudIcon Icon="@Icons.Material.Filled.ArrowCircleRight" Class="mr-1" />
        @_keyDownCountRight
    </MudText>
</MudStack>

@code {
    private readonly string _elementId = Identifier.Create();
    private readonly string _className = Identifier.Create();

    private int _keyDownCountLeft = 0;
    private int _keyDownCountRight = 0;

    [Inject]
    public IKeyInterceptorService KeyInterceptorService { get; set; } = null!;

    protected override async Task OnAfterRenderAsync(bool firstRender)
    {
        if (!firstRender)
        {
            return;
        }

        var options = new KeyInterceptorOptions()
        {
            TargetClass = _className,
            EnableLogging = false,
            Keys = [
                new KeyOptions("ArrowLeft", subscribeDown: true),
                new KeyOptions("ArrowRight", subscribeDown: true, ignoreDownRepeats: true),
            ]
        };

        await KeyInterceptorService.SubscribeAsync(_elementId, options, HandleKeyDownAsync);
    }

    private Task HandleKeyDownAsync(KeyboardEventArgs args)
    {
        switch (args.Key)
        {
            case "ArrowLeft":
                _keyDownCountLeft++;
                StateHasChanged();
                break;

            case "ArrowRight":
                _keyDownCountRight++;
                StateHasChanged();
                break;
        }

        return Task.CompletedTask;
    }
```

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
  I could not find any JS testing, are those omitted? 
  Should a sample be created in `MudBlazor.UnitTests.Viewer` to at least be able to see it in action?
