### PR TITLE
KeyInterceptorService: Allow omitting TargetClass to attach event handlers to element itself

### DIFF
--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -11,7 +11,8 @@ namespace MudBlazor.Services;
 public class KeyInterceptorOptions
 {
     /// <summary>
-    /// The CSS class of the target HTML element that should be observed for keyboard events.
+    /// The CSS class of the target HTML element that should be observed for keyboard events or <see langword="null" />
+    /// to observe the element for which the subscription is created.
     /// </summary>
     /// <remarks>
     /// Note: This must be a single class name.
@@ -33,6 +34,15 @@ public class KeyInterceptorOptions
     /// </summary>
     public KeyInterceptorOptions()
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeyInterceptorOptions"/> class with the specified key options.
+    /// </summary>
+    /// <param name="keys">The key options to intercept.</param>
+    public KeyInterceptorOptions(params KeyOptions[] keys)
+    {
+        Keys = keys;
     }
 
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorOptions.cs
@@ -8,7 +8,7 @@ namespace MudBlazor.Services;
 /// <summary>
 /// Configuration options for key interception.
 /// </summary>
-public class KeyInterceptorOptions
+public sealed class KeyInterceptorOptions
 {
     /// <summary>
     /// The CSS class of the target HTML element that should be observed for keyboard events or <see langword="null" />
@@ -41,8 +41,8 @@ public class KeyInterceptorOptions
     /// </summary>
     /// <param name="keys">The key options to intercept.</param>
     public KeyInterceptorOptions(params KeyOptions[] keys)
+        : this(null, keys)
     {
-        Keys = keys;
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public class KeyInterceptorOptions
     /// </summary>
     /// <param name="targetClass">The CSS class of the target HTML element.</param>
     /// <param name="keys">The key options to intercept.</param>
-    public KeyInterceptorOptions(string targetClass, params KeyOptions[] keys)
+    public KeyInterceptorOptions(string? targetClass, params KeyOptions[] keys)
     {
         TargetClass = targetClass;
         Keys = keys;
@@ -62,7 +62,7 @@ public class KeyInterceptorOptions
     /// <param name="targetClass">The CSS class of the target HTML element.</param>
     /// <param name="keys">The key options to intercept.</param>
     /// <param name="enableLogging">Specifies whether resize events should be logged in the browser's console.</param>
-    public KeyInterceptorOptions(string targetClass, bool enableLogging = false, params KeyOptions[] keys)
+    public KeyInterceptorOptions(string? targetClass, bool enableLogging = false, params KeyOptions[] keys)
         : this(targetClass, keys)
     {
         EnableLogging = enableLogging;

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -46,8 +46,6 @@ class MudKeyInterceptor {
             return;
         if (!this._options.keys) 
             throw "_options.keys: array of KeyOptions expected";
-        if (!this._options.targetClass)
-            throw "_options.targetClass: css class name expected";
         if (this._observer) {
             // don't do double registration
             return;
@@ -73,8 +71,12 @@ class MudKeyInterceptor {
         if (this._regexOptions.size > 0)
             this.logger('[MudBlazor | KeyInterceptor] regex options: ', this._regexOptions);
         // register handlers
-        for (const child of this._element.getElementsByClassName(targetClass)) {
-            this.attachHandlers(child);
+        if (targetClass) {
+            for (const child of this._element.getElementsByClassName(targetClass)) {
+                this.attachHandlers(child);
+            }
+        } else {
+            this.attachHandlers(this._element);
         }
     }
 


### PR DESCRIPTION
Accept `KeyInterceptorOptions.TargetClass` being `null` to allow for attaching the key event handlers to the subscribed element itself instead of having to attach it to child elements having some class. 

For context, I want to stop propagation for the keydowns that I'm interested in, but let events for other keys bubble up. As far as i know, this is not possible without JS interop. This service provides exactly that functionality, except for it not being possible to simply attach to the subscribed element itself.

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
