### PR TITLE
MudBaseDatePicker: Ensure GetMonthStart always returns the first day of the month

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1870,5 +1870,18 @@ namespace MudBlazor.UnitTests.Components
                 nextMonthDay.ClassList.Contains("mud-hidden").Should().BeTrue("Next month days should be hidden");
             }
         }
+
+        [Test]
+        public void GetMonthStart_Should_NormalizeToFirstDayOfMonth()
+        {
+            var comp = OpenPicker(parameters => parameters
+                .Add(x => x.PickerMonth, new DateTime(2026, 2, 15)));
+
+            var button = comp
+                .FindAll(".mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon.mud-picker-calendar-day.mud-day")
+                .Single(x => x.GetAttribute("style") == "--day-id: 1;");
+
+            button.TextContent.Should().Be("1");
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -310,7 +310,7 @@ namespace MudBlazor
             var monthStartDate = _picker_month ?? DateTime.Today.StartOfMonth(GetCulture());
             var correctYear = FixYear ?? GetCulture().Calendar.GetYear(monthStartDate);
             var correctMonth = FixMonth ?? GetCulture().Calendar.GetMonth(monthStartDate);
-            monthStartDate = new DateTime(correctYear, correctMonth, GetCulture().Calendar.GetDayOfMonth(monthStartDate), 0, 0, 0, 0, GetCulture().Calendar, DateTimeKind.Utc);
+            monthStartDate = new DateTime(correctYear, correctMonth, 1, 0, 0, 0, 0, GetCulture().Calendar, DateTimeKind.Utc);
 
             // Return the min supported datetime of the calendar when this is year 1 and first month!
             if (_picker_month is { Year: 1, Month: 1 })


### PR DESCRIPTION
**Description**
When `PickerMonth` was set to a date that was not the first day of the month (for example 2026-02-15), the calendar grid could render incorrectly, because the component treated that mid-month date as the “start” used to compute the month view. The result was a broken layout where only the trailing part of the month could appear (as shown in the screenshot).

<img width="1396" height="826" alt="image" src="https://github.com/user-attachments/assets/bd260f51-2142-4fcf-ae76-93421484715c" />

**Root cause**
`GetMonthStart` did not normalize the provided PickerMonth to the first day of the month. It preserved the day-of-month from the `PickerMonth`, which meant downstream calendar calculations were anchored to the wrong day.

**Fix**
`GetMonthStart` now always returns a DateTime on day 1 for the computed year and month (still respecting the active culture/calendar and using DateTimeKind.Utc). This ensures the month view is always computed from a proper month boundary, regardless of what day `PickerMonth` is set to.

Resolves: https://github.com/MudBlazor/MudBlazor/issues/11777

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
