### PR TITLE
Docs: Fix MudMenu XML documentation

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -146,7 +146,7 @@ namespace MudBlazor
         public string? Icon { get; set; }
 
         /// <summary>
-        /// The color of the icon when <see cref="Icon"/> is set.
+        /// The color of the <see cref="StartIcon"/> and <see cref="EndIcon"/> icons.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Inherit"/>.
@@ -156,7 +156,7 @@ namespace MudBlazor
         public Color IconColor { get; set; } = Color.Inherit;
 
         /// <summary>
-        /// The icon displayed before the text.
+        /// The icon displayed before the text when <see cref="Icon"/> is not set. Also used for nested <see cref="MudMenu"/>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -166,7 +166,7 @@ namespace MudBlazor
         public string? StartIcon { get; set; }
 
         /// <summary>
-        /// The icon displayed after the text.
+        /// The icon displayed after the text when <see cref="Icon"/> is not set.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>null</c>.
@@ -176,7 +176,7 @@ namespace MudBlazor
         public string? EndIcon { get; set; }
 
         /// <summary>
-        /// The color of this menu's button when <see cref="Icon"/> is not set.
+        /// The color of this menu’s button when <see cref="Icon"/> is not set, or the color of the <see cref="MudIconButton" /> when <see cref="Icon"/> is set.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.
@@ -186,8 +186,11 @@ namespace MudBlazor
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
-        /// The size of this menu's button when <see cref="Icon" /> is not set.
+        /// The size of this menu's button when <see cref="Icon"/> is not set, or the size of the <see cref="MudIconButton" /> when <see cref="Icon"/> is set.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Size.Medium"/>.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.Appearance)]
         public Size Size { get; set; } = Size.Medium;

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -176,7 +176,7 @@ namespace MudBlazor
         public string? EndIcon { get; set; }
 
         /// <summary>
-        /// The color of this menu’s button when <see cref="Icon"/> is not set, or the color of the <see cref="MudIconButton" /> when <see cref="Icon"/> is set.
+        /// The color of this menu's button when <see cref="Icon"/> is not set, or the color of the <see cref="MudIconButton" /> when <see cref="Icon"/> is set.
         /// </summary>
         /// <remarks>
         /// Defaults to <see cref="Color.Default"/>.


### PR DESCRIPTION
**Description**
Some `MudMenu` parameters behave differently when `Icon` is set, because the menu activator is rendered as a `MudIconButton` instead of a standard button.
This PR updates the documentation to accurately describe the existing behavior and clarify which parameters apply depending on whether Icon is se

**Fix**
- Updated `StartIcon` and `EndIcon` documentation to indicate they only apply when `Icon` **is not set**.
- Updated `IconColor` documentation to reflect that it only affects `StartIcon` and `EndIcon`.
- Clarified that `Color` and `Size` apply to both the standard `MudButton` and the `MudIconButton`.

No functional changes.

Closes https://github.com/MudBlazor/MudBlazor/issues/11892

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
