### PR TITLE
MudBaseDatePicker: Validate against parameters on edits and parameters changes

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerEditableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerEditableTest.razor
@@ -1,0 +1,12 @@
+﻿<MudDatePicker @bind-Date="Date" Editable MinDate="MinDate" />
+<MudText>Selected: @Date</MudText>
+
+@code {
+
+    [Parameter]
+    public DateTime? Date { get; set; }
+
+    [Parameter]
+    public DateTime? MinDate { get; set; } = DateTime.Today;
+
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1870,5 +1870,21 @@ namespace MudBlazor.UnitTests.Components
                 nextMonthDay.ClassList.Contains("mud-hidden").Should().BeTrue("Next month days should be hidden");
             }
         }
+
+        [Test]
+        public async Task DatePicker_Editable_ShouldRespectMinDateConstraint()
+        {
+            var minDate = DateTime.Today;
+            var component = Context.Render<DatePickerEditableTest>(p => p
+                .Add(x => x.MinDate, minDate)
+                .Add(x => x.Date, minDate));
+
+            var datePickerComponent = component.FindComponent<MudDatePicker>();
+            var datePicker = datePickerComponent.Instance;
+
+            var invalidDate = minDate.AddYears(-1);
+            await component.InvokeAsync(() => component.Find("input").Change(DateOnly.FromDateTime(invalidDate)));
+            await component.WaitForAssertionAsync(() => datePicker.HasErrors.Should().BeTrue());
+        }
     }
 }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -352,6 +352,7 @@ namespace MudBlazor
                     errors.Add(ConversionErrorMessage);
                 }
                 // validation errors
+                ValidateValueInternal(ReadValue, errors);
                 if (Validation is ValidationAttribute validationAttribute)
                 {
                     ValidateWithAttribute(validationAttribute, ReadValue, errors);
@@ -430,6 +431,10 @@ namespace MudBlazor
                     StateHasChanged();
                 }
             }
+        }
+
+        protected virtual void ValidateValueInternal(T? value, List<string> errors)
+        {
         }
 
         protected virtual bool HasValue(T? value)

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.Resources;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -776,27 +777,30 @@ namespace MudBlazor
 
             if (MinDate.HasValue && value < MinDate)
             {
-                errors.Add($"Value may not be before {MinDate}");
+                var minDate = GetDefaultConverter().Convert(MinDate.Value) ?? MinDate.Value.ToString("d");
+                errors.Add(Localizer[LanguageResource.MudBaseDatePicker_MinDateError, minDate]);
             }
 
             if (MaxDate.HasValue && value > MaxDate)
             {
-                errors.Add($"Value may not be after {MaxDate}");
+                var maxDate = GetDefaultConverter().Convert(MaxDate.Value) ?? MaxDate.Value.ToString("d");
+                errors.Add(Localizer[LanguageResource.MudBaseDatePicker_MaxDateError, maxDate]);
             }
 
             if (FixYear.HasValue && value.Value.Year != FixYear)
             {
-                errors.Add($"Year must be {FixYear}");
+                errors.Add(Localizer[LanguageResource.MudBaseDatePicker_FixYearError, FixYear.Value]);
             }
 
             if (FixMonth.HasValue && value.Value.Month != FixMonth)
             {
-                errors.Add($"Month must be {FixMonth}");
+                var fixMonth = GetCulture().DateTimeFormat.GetMonthName(FixMonth.Value);
+                errors.Add(Localizer[LanguageResource.MudBaseDatePicker_FixMonthError, fixMonth]);
             }
 
             if (FixDay.HasValue && value.Value.Day != FixDay)
             {
-                errors.Add($"Day must be {FixDay}");
+                errors.Add(Localizer[LanguageResource.MudBaseDatePicker_FixDayError, FixDay.Value]);
             }
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -742,6 +742,39 @@ namespace MudBlazor
             };
         }
 
+        protected override void ValidateValueInternal(DateTime? value, List<string> errors)
+        {
+            if (!value.HasValue)
+            {
+                return;
+            }
+
+            if (MinDate.HasValue && value < MinDate)
+            {
+                errors.Add($"Value may not be before {MinDate}");
+            }
+
+            if (MaxDate.HasValue && value > MaxDate)
+            {
+                errors.Add($"Value may not be after {MaxDate}");
+            }
+
+            if (FixYear.HasValue && value.Value.Year != FixYear)
+            {
+                errors.Add($"Year must be {FixYear}");
+            }
+
+            if (FixMonth.HasValue && value.Value.Month != FixMonth)
+            {
+                errors.Add($"Month must be {FixMonth}");
+            }
+
+            if (FixDay.HasValue && value.Value.Day != FixDay)
+            {
+                errors.Add($"Day must be {FixDay}");
+            }
+        }
+
         protected override string GetFormat()
         {
             if (!string.IsNullOrEmpty(_dateFormatState.Value))

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -14,6 +14,11 @@ namespace MudBlazor
     {
         private readonly string _mudPickerCalendarContentElementId;
         private readonly ParameterState<string?> _dateFormatState;
+        private readonly ParameterState<DateTime?> _maxDateState;
+        private readonly ParameterState<DateTime?> _minDateState;
+        private readonly ParameterState<int?> _fixYearState;
+        private readonly ParameterState<int?> _fixMonthState;
+        private readonly ParameterState<int?> _fixDayState;
 
         protected MudBaseDatePicker()
         {
@@ -24,6 +29,21 @@ namespace MudBlazor
             _dateFormatState = registerScope.RegisterParameter<string?>(nameof(DateFormat))
                 .WithParameter(() => DateFormat)
                 .WithChangeHandler(DateFormatChangedAsync);
+            _maxDateState = registerScope.RegisterParameter<DateTime?>(nameof(MaxDate))
+                .WithParameter(() => MaxDate)
+                .WithChangeHandler(RevalidateForParameterChangeAsync);
+            _minDateState = registerScope.RegisterParameter<DateTime?>(nameof(MinDate))
+                .WithParameter(() => MinDate)
+                .WithChangeHandler(RevalidateForParameterChangeAsync);
+            _fixYearState = registerScope.RegisterParameter<int?>(nameof(FixYear))
+                .WithParameter(() => FixYear)
+                .WithChangeHandler(RevalidateForParameterChangeAsync);
+            _fixMonthState = registerScope.RegisterParameter<int?>(nameof(FixMonth))
+                .WithParameter(() => FixMonth)
+                .WithChangeHandler(RevalidateForParameterChangeAsync);
+            _fixDayState = registerScope.RegisterParameter<int?>(nameof(FixDay))
+                .WithParameter(() => FixDay)
+                .WithChangeHandler(RevalidateForParameterChangeAsync);
         }
 
         [Inject]
@@ -740,6 +760,11 @@ namespace MudBlazor
                 Culture = GetCulture,
                 Format = GetFormat
             };
+        }
+
+        private Task RevalidateForParameterChangeAsync<T>(ParameterChangedEventArgs<T> args)
+        {
+            return ValidateAsync();
         }
 
         protected override void ValidateValueInternal(DateTime? value, List<string> errors)

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -471,4 +471,19 @@
   <data name="MudFileUpload_FileSizeError" xml:space="preserve">
     <value>File '{0}' exceeds the maximum allowed size of {1} bytes.</value>
   </data>
+  <data name="MudBaseDatePicker_MinDateError" xml:space="preserve">
+    <value>Value should not be before {0}</value>
+  </data>
+  <data name="MudBaseDatePicker_MaxDateError" xml:space="preserve">
+    <value>Value should not be after {0}</value>
+  </data>
+  <data name="MudBaseDatePicker_FixYearError" xml:space="preserve">
+    <value>Year should be {0}</value>
+  </data>
+  <data name="MudBaseDatePicker_FixMonthError" xml:space="preserve">
+    <value>Month should be {0}</value>
+  </data>
+  <data name="MudBaseDatePicker_FixDayError" xml:space="preserve">
+    <value>Day should be {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Suggestion to issue #3461 

Add virtual validation method on `MudFormComponent` that allows for parameter validation in derived components.
Add validation errors when `MudBaseDatePicker` value does not comply with `MinDate`/`MaxDate`/`FixYear`/`FixMonth`/`FixDay` constraints.

I am unsure as to what is desirable for the value. Currently, the invalid value is not replaced with `null` or a valid value, it only adds a validation error as the current value is invalid. In the situation below, `MudBaseDatePicker.Date` still is `2026-01-04`, which is invalid according to `MinDate`.

<img width="251" height="60" alt="image" src="https://github.com/user-attachments/assets/9f2737cf-07f6-4c8d-a093-0774abb1fd2a" />  

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests
  A test was added, but more tests are probably needed
