### PR TITLE
MudDateRangePicker: Implement ResetValueAsync for MudForm reset

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormResetTest.razor
@@ -2,6 +2,7 @@
     <MudDatePicker Label="Date" Required @bind-Date="@_date" Editable></MudDatePicker>
     <MudTextField Label="Name" T="string" Required Immediate @bind-Value="@_name" />
     <MudNumericField Label="Age" T="int?" Required Immediate @bind-Value="@_age"></MudNumericField>
+	<MudDateRangePicker Label="Date Range" @bind-DateRange="@_dateRange" />
 </MudForm>
 <br><br>
 <span>Date: @_date</span>
@@ -16,6 +17,7 @@
     private int? _age;
     private string? _name;
     private DateTime? _date;
+	private DateRange? _dateRange;
     private MudForm _form = null!;
 
     private async Task ResetFormAsync()

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1444,6 +1444,40 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Calling form.Reset() should clear the DateRangePicker
+        /// </summary>
+        [Test]
+        public async Task FormReset_Should_ClearDateRangePicker()
+        {
+            var comp = Context.Render<FormResetTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var dateRangePickerComp = comp.FindComponent<MudDateRangePicker>();
+            var dateRangePicker = dateRangePickerComp.Instance;
+            // create test value and it's localized string representation
+            var testStartDate = new DateTime(2020, 05, 24);
+            var testEndDate = new DateTime(2020, 06, 24);
+
+            // input a date
+            dateRangePickerComp.FindAll("input")[0].Change(testStartDate.ToShortDateString());
+            dateRangePickerComp.FindAll("input")[1].Change(testEndDate.ToShortDateString());
+            dateRangePicker.DateRange.Start.Should().Be(testStartDate);
+            dateRangePicker.DateRange.End.Should().Be(testEndDate);
+
+            // call reset directly
+            await comp.InvokeAsync(() => form.ResetAsync());
+            dateRangePicker.DateRange.Should().BeNull();
+
+            // input a date
+            dateRangePickerComp.FindAll("input")[0].Change(testStartDate.ToShortDateString());
+            dateRangePickerComp.FindAll("input")[1].Change(testEndDate.ToShortDateString());
+            dateRangePicker.DateRange.Start.Should().Be(testStartDate);
+            dateRangePicker.DateRange.End.Should().Be(testEndDate);
+            // hit reset button
+            comp.Find("button.reset").Click();
+            dateRangePicker.DateRange.Should().BeNull();
+        }
+
+        /// <summary>
         /// Reset() should reset the form's state
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -479,6 +479,8 @@ namespace MudBlazor
             _secondDate = null;
         }
 
+        protected override Task ResetValueAsync() => ClearAsync();
+
         public override Task ClearAsync(bool close = true)
         {
             DateRange = null;


### PR DESCRIPTION
**Description**
`MudDateRangePicker` did not fully reset its value when used inside a form and the form was reset.
This was due to the component not overriding `ResetValueAsync`.

This PR adds an override for `ResetValueAsync` so the picker correctly clears its state when a form reset occurs.

**Fix**
- Override `ResetValueAsync` in `MudDateRangePicker` to call `ClearAsync`.
- Add a unit test to cover form reset behavior and prevent regressions.

Fixes https://github.com/MudBlazor/MudBlazor/issues/12113

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
