### PR TITLE
MudSelect: Add SelectionOnEnter, Improve Pager keyboard UX

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -170,6 +170,10 @@
                     <MudText><CodeInline>Enter</CodeInline> or <CodeInline>NumpadEnter</CodeInline> keys to select item (MultiSelect only)</MudText>
                     <MudText><CodeInline>Ctrl+A</CodeInline> key to toggle select all/clear all items (MultiSelect only)</MudText>
                     <MudText><CodeInline>Printable Characters</CodeInline> to highlight the first item in the list whose text starts with that character. Press again to move to the next item with the same starting character.</MudText>
+                    <MudText>
+                        Set <CodeInline>SelectionOnEnter="true"</CodeInline>to move the visual highlight with arrow keys, requiring an
+                        <CodeInline>Enter</CodeInline> press to confirm the selection.
+                    </MudText>
                     <br />
                     <MudText>*Disabled items cannot be selected by keys.</MudText>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -171,7 +171,7 @@
                     <MudText><CodeInline>Ctrl+A</CodeInline> key to toggle select all/clear all items (MultiSelect only)</MudText>
                     <MudText><CodeInline>Printable Characters</CodeInline> to highlight the first item in the list whose text starts with that character. Press again to move to the next item with the same starting character.</MudText>
                     <MudText>
-                        Set <CodeInline>SelectionOnEnter="true"</CodeInline>to move the visual highlight with arrow keys, requiring an
+                        Set <CodeInline>SelectionOnEnter="true"</CodeInline> to move the visual highlight with arrow keys, requiring an
                         <CodeInline>Enter</CodeInline> press to confirm the selection.
                     </MudText>
                     <br />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest3.razor
@@ -1,0 +1,27 @@
+﻿<MudPopoverProvider />
+
+<MudSelect @bind-Value="_value" PopoverClass="select-popover-class" @onfocus="Focused" OnBlur="Blurred" SelectionOnEnter="true">
+    <MudSelectItem Value="@("1")" />
+    <MudSelectItem Value="@("2")" />
+    <MudSelectItem Value="@("3")" />
+    <MudSelectItem Value="@("4")" Disabled="true" />
+</MudSelect>
+
+<MudSwitch id="switch" @bind-Value="@_focused" />
+
+@code {
+    public static string __description__ = "Click should open the Menu and selecting a value should update the bindable value.";
+
+    private string? _value = null;
+    private bool _focused;
+
+    private void Focused()
+    {
+        _focused = true;
+    }
+
+    private void Blurred()
+    {
+        _focused = false;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest3.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest3.razor
@@ -10,7 +10,7 @@
 <MudSwitch id="switch" @bind-Value="@_focused" />
 
 @code {
-    public static string __description__ = "Click should open the Menu and selecting a value should update the bindable value.";
+    public static string __description__ = "Click should open the Menu, Keyboard should not open the menu until Enter is pressed and selecting a value should update the bindable value.";
 
     private string? _value = null;
     private bool _focused;

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1167,6 +1167,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task SelectTest_SelectionOnEnter_ShouldOnlyChangeOnEnter()
+        {
+            var comp = Context.Render<SelectTest3>();
+            // print the generated html
+            // select elements needed for the test
+            var select = comp.FindComponent<MudSelect<string>>();
+
+            await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true, Type = "keydown" }));
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            // ArrowDown should move the highlight but NOT change the value
+            await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown" })); // Move to "1"
+            await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown" })); // Move to "2"
+            await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" })); // Move to "1"
+
+            // Value is still null/default even though we moved focus
+            await comp.WaitForAssertionAsync(() => select.Instance.Value.Should().BeNull());
+
+            // Confirm selection with Enter
+            await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown" }));
+
+            // Now the value should be "1" and popover should close
+            await comp.WaitForAssertionAsync(() => select.Instance.Value.Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+        }
+
+        [Test]
         public async Task SelectTest_KeyboardNavigation_MultiSelect()
         {
             var comp = Context.Render<MultiSelectTest3>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -11,7 +11,7 @@
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
             @RowsPerPageString
         </MudText>
-        <MudSelect T="int" ValueChanged="@SetRowsPerPageAsync" Value="@(DataGrid?.RowsPerPage ?? 0)" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled">
+        <MudSelect T="int" ValueChanged="@SetRowsPerPageAsync" Value="@(DataGrid?.RowsPerPage ?? 0)" Class="mud-table-pagination-select" Underline="false" Dense="true" Disabled="@Disabled" SelectionOnEnter="true">
             @foreach (int pageSize in PageSizeOptions)
             {
                 if (pageSize == int.MaxValue)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -115,9 +115,15 @@ namespace MudBlazor
                 item = _items[index];
                 if (!MultiSelection)
                 {
-                    _selectedValues.Clear();
-                    _selectedValues.Add(item.Value);
-                    await SetValueAndUpdateTextAsync(item.Value, updateText: true);
+                    // If SelectionOnEnter is false (default), it behaves as it always has.
+                    // If true, it skips this block and only executes HighlightItem(item) below.
+                    if (!SelectionOnEnter)
+                    {
+                        _selectedValues.Clear();
+                        _selectedValues.Add(item.Value);
+                        await SetValueAndUpdateTextAsync(item.Value, updateText: true);
+                    }
+
                     HighlightItem(item);
                     break;
                 }
@@ -725,6 +731,14 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
+
+        /// <summary>
+        /// If true, the selected value will not be updated when navigating with arrow keys. 
+        /// The user must press Enter or click to confirm the selection.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public bool SelectionOnEnter { get; set; }
 
         internal bool _open;
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -115,8 +115,8 @@ namespace MudBlazor
                 item = _items[index];
                 if (!MultiSelection)
                 {
-                    // If SelectionOnEnter is false (default), it behaves as it always has.
-                    // If true, it skips this block and only executes HighlightItem(item) below.
+                    // When SelectionOnEnter is true, we only update the visual highlight during navigation.
+                    // When false (default), the value is immediately updated as the user moves through the list.
                     if (!SelectionOnEnter)
                     {
                         _selectedValues.Clear();
@@ -733,8 +733,8 @@ namespace MudBlazor
         public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
         /// <summary>
-        /// If true, the selected value will not be updated when navigating with arrow keys. 
-        /// The user must press Enter or click to confirm the selection.
+        /// If <c>true</c>, navigating with arrow keys will only highlight items without updating the selected value.
+        /// The selection must be confirmed by pressing Enter or clicking the item.
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -18,7 +18,7 @@
                 <div class="mud-table-pagination-information">@RowsPerPageString</div>
             </div>
             <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed>
-                <MudSelect T="int" ValueChanged="SetRowsPerPage" Value="@(Table?.RowsPerPage ?? 0)" Class="mud-table-pagination-select" Underline="false" Dense="true">
+                <MudSelect T="int" ValueChanged="SetRowsPerPage" Value="@(Table?.RowsPerPage ?? 0)" Class="mud-table-pagination-select" Underline="false" Dense="true" SelectionOnEnter="true">
                     @foreach (int pageSize in PageSizeOptions)
                     {
                         if (pageSize == int.MaxValue)


### PR DESCRIPTION
### feat(`MudSelect`): add `SelectionOnEnter` and improve Pager keyboard UX

Related Issues
Fix #12404
Fix #9718

#### Summary
Introduces a new parameter `SelectionOnEnter` to `MudSelect` and enables it for `MudTablePager` and `MudDataGridPager`. This allows users to navigate dropdown options via keyboard without triggering an immediate value change, which is particularly beneficial for paginated components to prevent multiple expensive data reloads during navigation.

#### Key Changes
**MudSelect**
New Parameter: Added `SelectionOnEnter` (bool). When true, arrow key navigation only moves the visual highlight.
Logic Update: Refactored SelectAdjacentItem to skip SetValueAndUpdateTextAsync when SelectionOnEnter is enabled, requiring Enter or NumpadEnter to commit the selection.

**Documentation**
Updated the Keyboard Navigation section in the docs to explain the new behaviour and key bindings.

**Pagers**
`MudTablePager` & `MudDataGridPager`: Enabled `SelectionOnEnter="true"` by default. This fixes the "jumping" behaviour where the table would refresh for every arrow-key press when changing rows per page.

**Testing**
New Test Component: Created SelectTest3 specifically to verify the `SelectionOnEnter` state.
New Unit Test: Added S`electTest_SelectionOnEnter_ShouldOnlyChangeOnEnter` to ensure value binding only occurs after the Enter key is pressed.

How Has This Been Tested?
Manual Verification: Tested in the `MudBlazor.Docs` environment to ensure that `MudTable` and `MudDataGrid` pagers no longer refresh until the user explicitly selects a new page size with Enter and that `MudSelect` works as expected for all others. Testing in MudBlazor.UnitTests.Viewer and it outputs the same results.
Unit Tests: Ran all tests. Original tests pass (preserving backward compatibility), and the new test confirms the "selection-on-enter" logic.

Type of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (fix or improvement to the website or code docs)

Checklist
- [X] The PR is submitted to the correct branch (dev).
- [X] My code follows the code style of this project.
- [X] I've added relevant tests.

Remaining Issues / Clarifications
N/A