### PR TITLE
MudLink: Add StartIcon and EndIcon properties

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Link/Examples/LinkIconExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Link/Examples/LinkIconExample.razor
@@ -1,0 +1,5 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudLink Href="https://mudblazor.com/" StartIcon="@Icons.Material.Filled.Home">Home</MudLink>
+<MudLink Href="https://github.com/MudBlazor/MudBlazor" Target="_blank" EndIcon="@Icons.Custom.Brands.GitHub">GitHub</MudLink>
+<MudLink Href="/" StartIcon="@Icons.Material.Filled.Link" EndIcon="@Icons.Material.Filled.OpenInNew">Internal Link</MudLink>

--- a/src/MudBlazor.Docs/Pages/Components/Link/LinkPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Link/LinkPage.razor
@@ -32,6 +32,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Icons">
+                <Description>Links can have icons at the start or end using the <CodeInline>StartIcon</CodeInline> and <CodeInline>EndIcon</CodeInline> properties. The icon automatically inherits the size and color.</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(LinkIconExample)">
+                <LinkIconExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="OnClick">
                 <Description><CodeInline>OnClick</CodeInline> property provides a way to invoke an action instead of (or in conjunction with) <CodeInline>Href</CodeInline> navigation.</Description>
             </SectionHeader>

--- a/src/MudBlazor.Docs/Pages/Components/Link/LinkPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Link/LinkPage.razor
@@ -33,7 +33,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Icons">
-                <Description>Links can have icons at the start or end using the <CodeInline>StartIcon</CodeInline> and <CodeInline>EndIcon</CodeInline> properties. The icon automatically inherits the size and color.</Description>
+                <Description>Links can have icons at the start or end using the <CodeInline>StartIcon</CodeInline> and <CodeInline>EndIcon</CodeInline> properties.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(LinkIconExample)">
                 <LinkIconExample />

--- a/src/MudBlazor.UnitTests/Components/LinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/LinkTests.cs
@@ -93,6 +93,31 @@ public class LinkTests : BunitTest
     }
 
     [Test]
+    public void Icons_RenderInMarkup()
+    {
+        var comp = Context.Render<MudLink>(parameters => parameters
+            .Add(p => p.StartIcon, Icons.Material.Filled.Home)
+            .Add(p => p.EndIcon, Icons.Material.Filled.OpenInNew)
+            .AddChildContent("Link Text"));
+
+        comp.Find(".mud-link-icon-start").Should().NotBeNull();
+        comp.Find(".mud-link-icon-end").Should().NotBeNull();
+        comp.Markup.Should().Contain("Link Text");
+    }
+
+    [Test]
+    public void Icons_CustomClass()
+    {
+        var comp = Context.Render<MudLink>(parameters => parameters
+            .Add(p => p.StartIcon, Icons.Material.Filled.Home)
+            .Add(p => p.IconClass, "custom-icon-class"));
+
+        var icon = comp.FindComponent<MudIcon>();
+        icon.Instance.Class.Should().Contain("custom-icon-class");
+        icon.Instance.Class.Should().Contain("mud-link-icon-start");
+    }
+
+    [Test]
     public async Task OnClickErrorContentCaughtException()
     {
         var comp = Context.Render<LinkErrorContenCaughtException>();

--- a/src/MudBlazor/Components/Link/MudLink.razor
+++ b/src/MudBlazor/Components/Link/MudLink.razor
@@ -2,5 +2,13 @@
 @inherits MudComponentBase
 
 <a @attributes="Attributes" @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)" class="@Classname" style="@Style">
+    @if (!string.IsNullOrWhiteSpace(StartIcon))
+    {
+        <MudIcon Icon="@StartIcon" Class="@StartIconClassname" />
+    }
     @ChildContent
+    @if (!string.IsNullOrWhiteSpace(EndIcon))
+    {
+        <MudIcon Icon="@EndIcon" Class="@EndIconClassname" />
+    }
 </a>

--- a/src/MudBlazor/Components/Link/MudLink.razor.cs
+++ b/src/MudBlazor/Components/Link/MudLink.razor.cs
@@ -23,6 +23,16 @@ public partial class MudLink : MudComponentBase
             .AddClass(Class)
             .Build();
 
+    protected string StartIconClassname =>
+        new CssBuilder("mud-link-icon-start")
+            .AddClass(IconClass)
+            .Build();
+
+    protected string EndIconClassname =>
+        new CssBuilder("mud-link-icon-end")
+            .AddClass(IconClass)
+            .Build();
+
     private Dictionary<string, object?> Attributes
     {
         get
@@ -63,6 +73,36 @@ public partial class MudLink : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Link.Appearance)]
     public Color Color { get; set; } = Color.Primary;
+
+    /// <summary>
+    /// The icon displayed before the text.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Link.Appearance)]
+    public string? StartIcon { get; set; }
+
+    /// <summary>
+    /// The icon displayed after the text.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Link.Appearance)]
+    public string? EndIcon { get; set; }
+
+    /// <summary>
+    /// The CSS classes applied to the icons.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.  You can use spaces to separate multiple classes.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Link.Appearance)]
+    public string? IconClass { get; set; }
 
     /// <summary>
     /// The typography variant to use.

--- a/src/MudBlazor/Styles/components/_link.scss
+++ b/src/MudBlazor/Styles/components/_link.scss
@@ -30,4 +30,20 @@
       text-decoration: none;
     }
   }
+
+  .mud-link-icon-start,
+  .mud-link-icon-end {
+    &.mud-icon-root {
+      font-size: inherit;
+      vertical-align: middle;
+    }
+  }
+
+  .mud-link-icon-start {
+    margin-inline-end: 4px;
+  }
+
+  .mud-link-icon-end {
+    margin-inline-start: 4px;
+  }
 }


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Adds `MudLink.StartIcon` and `MudLink.EndIcon`, similar to the properties available on MudButton and other components.
The size and color of the icon are inherited, instead of adding `IconColor` and `IconSize`, in order to reduce the API surface.

**Context:**

In #12052 it was noted that inline icons with this syntax are poorly aligned:

```razor
<MudLink>
    <MudIcon Icon="@Icons.Material.Rounded.Link"/>
    Worksheet Title
</MudLink>
```

<img width="246" height="54" alt="image" src="https://github.com/user-attachments/assets/e9c24df9-b8e5-4cb6-abb2-e4d5fe48631c" />

A narrow patch was experimented with in #12360 to vertically align inlined icons in the middle, but this did not address the sizing. A change to MudIcon was tested in #12364 but the risk of breaking existing icon layouts was too great. Instead, we can add brand new API to make it even easier to apply the icons while not risking backwards compatability with older style inline icons.

Closes #12052, Closes #12360, Closes #12364

**Examples:**

Syntax:

```razor
<MudLink Href="/" StartIcon="@Icons.Material.Filled.Link" EndIcon="@Icons.Material.Filled.OpenInNew">
    Internal Link
</MudLink>
```

Demo from the docs:

<img width="1448" height="390" alt="image" src="https://github.com/user-attachments/assets/60a03540-d811-4100-90ce-4a98012b63cf" />

Different typographies:

<img width="687" height="90" alt="image" src="https://github.com/user-attachments/assets/1ced0611-c3d5-4886-a725-030154ed0f52" />

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
