### PR TITLE
Build: Add internal incremental guards

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -186,6 +186,22 @@ public class ApiDocumentationBuilder
     /// </summary>
     public bool Execute()
     {
+        // Early exit: if ApiDocumentation.generated.cs exists and is newer than all input assemblies, skip generation
+        if (File.Exists(Paths.ApiDocumentationFilePath))
+        {
+            var outputLastWrite = File.GetLastWriteTimeUtc(Paths.ApiDocumentationFilePath);
+            var newestInputTime = Assemblies
+                .Select(a => File.GetLastWriteTimeUtc(a.Location))
+                .DefaultIfEmpty(DateTime.MinValue)
+                .Max();
+
+            if (outputLastWrite > newestInputTime)
+            {
+                Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs is up-to-date, skipping generation.");
+                return true;
+            }
+        }
+
         AddTypesToDocument();
         ResolveSeeAlsoLinks();
         FindDeclaringTypes();
@@ -727,6 +743,13 @@ public class ApiDocumentationBuilder
         if (currentCode != writer.ToString())
         {
             File.WriteAllText(Paths.ApiDocumentationFilePath, writer.ToString());
+            Console.WriteLine("ApiDocumentationBuilder: Updated ApiDocumentation.generated.cs");
+        }
+        else
+        {
+            // Touch the file to update its timestamp so future checks skip regeneration
+            File.SetLastWriteTimeUtc(Paths.ApiDocumentationFilePath, DateTime.UtcNow);
+            Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs content unchanged, touched timestamp.");
         }
     }
 

--- a/src/MudBlazor.Docs.Compiler/CodeSnippets.cs
+++ b/src/MudBlazor.Docs.Compiler/CodeSnippets.cs
@@ -10,6 +10,24 @@ namespace MudBlazor.Docs.Compiler
             var success = true;
             try
             {
+                // Early exit: if Snippets.generated.cs exists and is newer than all example files, skip generation
+                if (File.Exists(Paths.SnippetsFilePath))
+                {
+                    var snippetsLastWrite = File.GetLastWriteTimeUtc(Paths.SnippetsFilePath);
+                    var exampleFiles = Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
+                        .Where(f => Path.GetFileNameWithoutExtension(f).Contains(Paths.ExampleDiscriminator));
+                    var newestExampleTime = exampleFiles
+                        .Select(f => File.GetLastWriteTimeUtc(f))
+                        .DefaultIfEmpty(DateTime.MinValue)
+                        .Max();
+
+                    if (snippetsLastWrite > newestExampleTime)
+                    {
+                        Console.WriteLine("CodeSnippets: Snippets.generated.cs is up-to-date, skipping generation.");
+                        return true;
+                    }
+                }
+
                 var currentCode = string.Empty;
                 if (File.Exists(Paths.SnippetsFilePath))
                 {
@@ -44,6 +62,13 @@ namespace MudBlazor.Docs.Compiler
                 if (currentCode != cb.ToString())
                 {
                     File.WriteAllText(Paths.SnippetsFilePath, cb.ToString());
+                    Console.WriteLine("CodeSnippets: Updated Snippets.generated.cs");
+                }
+                else
+                {
+                    // Touch the file to update its timestamp so future checks skip regeneration
+                    File.SetLastWriteTimeUtc(Paths.SnippetsFilePath, DateTime.UtcNow);
+                    Console.WriteLine("CodeSnippets: Snippets.generated.cs content unchanged, touched timestamp.");
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
- Added early-exit check comparing Snippets.generated.cs and ApiDocumentation.generated.cs timestamp against all example files
- If output is newer than all inputs, skips the full file enumeration and parsing
- Added timestamp touch when content is unchanged to update the marker

Trims about 20% off the build time on my machine (15s->12s)

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
