### PR TITLE
Docs: Improve and de-duplicate component descriptions

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/AppBar/AppBarPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/appbar"
 
 <DocsPage>
-    <DocsPageHeader Title="App Bar" Component="@nameof(MudAppBar)">
-        <Description>
-            Keeping the app bar persistent while browsing different pages will ease navigation and access to actions for your users.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="App Bar" Component="@nameof(MudAppBar)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/AutocompletePage.razor
@@ -1,12 +1,7 @@
 ﻿@page "/components/autocomplete"
 
 <DocsPage>
-    <DocsPageHeader Title="Autocomplete" Component="@nameof(MudAutocomplete<T>)">
-        <Description>
-            It is great for searching a value from a long list of options. In comparison to a Select, the Autocomplete doesn't need to know the complete item list,
-            it only calls a search function which will return matching items. The search function can even run asynchronously, i.e. for database queries.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Autocomplete" Component="@nameof(MudAutocomplete<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Badge/MudBadge.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Badge/MudBadge.razor
@@ -1,9 +1,7 @@
 ﻿@page "/components/badge"
 
 <DocsPage>
-    <DocsPageHeader Title="Badge" Component="@nameof(MudBadge)">
-        <Description>A badge is a useful way to wrap or overlay an action button or icon with a simple notification, making it easy to emphasize things like the number of notifications received.</Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Badge" Component="@nameof(MudBadge)" />
 
     <DocsPageContent>
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Breadcrumbs/BreadcrumbsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Breadcrumbs/BreadcrumbsPage.razor
@@ -1,8 +1,7 @@
 ﻿@page "/components/breadcrumbs"
 
 <DocsPage>
-    <DocsPageHeader Title="Breadcrumbs" Component="@nameof(MudBreadcrumbs)">
-    </DocsPageHeader>
+    <DocsPageHeader Title="Breadcrumbs" Component="@nameof(MudBreadcrumbs)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/breakpointprovider"
 
 <DocsPage>
-    <DocsPageHeader Title="Breakpoint Provider" Component="@nameof(MudBreakpointProvider)" SubTitle="Exposing the current breakpoint to multiple components" />
+    <DocsPageHeader Title="Breakpoint Provider" Component="@nameof(MudBreakpointProvider)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Button/ButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Button/ButtonPage.razor
@@ -1,9 +1,7 @@
 @page "/components/button"
 
 <DocsPage>
-    <DocsPageHeader Title="Button" Component="@nameof(MudButton)">
-        <Description>The <CodeInline>MudButton</CodeInline> component is a button with material design theme and comes with multiple functions.</Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Button" Component="@nameof(MudButton)" />
     <DocsPageContent>
         
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
@@ -1,12 +1,7 @@
 ﻿@page "/components/buttongroup"
 
 <DocsPage>
-    <DocsPageHeader Title="Button Group" Component="@nameof(MudButtonGroup)">
-        <Description>
-            The <ApiTypeLink TypeName="@nameof(MudButtonGroup)" /> component can be used to group related <ApiTypeLink TypeName="@nameof(MudButton)" /> components.
-            <MudText>See also: <MudLink Href="/components/togglegroup">Toggle Group</MudLink></MudText>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Button Group" Component="@nameof(MudButtonGroup)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonGroup/ButtonGroupPage.razor
@@ -1,7 +1,11 @@
 ﻿@page "/components/buttongroup"
 
 <DocsPage>
-    <DocsPageHeader Title="Button Group" Component="@nameof(MudButtonGroup)" />
+    <DocsPageHeader Title="Button Group" Component="@nameof(MudButtonGroup)">
+        <Description>
+            For selectable buttons, use <MudLink Href="/components/togglegroup">Toggle Group</MudLink>. For standalone actions, see <MudLink Href="/components/button">Button</MudLink>.
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Card/CardPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Card/CardPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/card"
 
 <DocsPage>
-    <DocsPageHeader Title="Card" Component="@nameof(MudCard)">
-        <Description>
-            Cards can contain actions, text, or media like images or graphics. Keeping a card to a single subject keeps the design clean.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Card" Component="@nameof(MudCard)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor
@@ -3,19 +3,7 @@
 @page "/components/chart-types/heatmapchart"
 
 <DocsPage>
-    <DocsPageHeader Title="HeatMap Chart" SubTitle="A chart that displays a HeatMap" Component="@nameof(MudBlazor.Charts.HeatMap<T>)">
-        <Description>
-            <DocsPageSection>
-                <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning:</b> This component is currently under development.
-                    <br />
-                    <br />
-                    Breaking changes such as updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
-                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute code.
-                </MudAlert>
-            </DocsPageSection>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="HeatMap Chart" Component="@nameof(MudBlazor.Charts.HeatMap<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/TimeSeriesChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/TimeSeriesChartPage.razor
@@ -2,8 +2,7 @@
 @page "/components/chart-types/timeserieschart"
 
 <DocsPage>
-    <DocsPageHeader Title="Time Series Chart" Component="@nameof(MudBlazor.Charts.TimeSeries<T>)">
-    </DocsPageHeader>
+    <DocsPageHeader Title="Time Series Chart" Component="@nameof(MudBlazor.Charts.TimeSeries<T>)"></DocsPageHeader>
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/TimeSeriesChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/TimeSeriesChartPage.razor
@@ -2,7 +2,7 @@
 @page "/components/chart-types/timeserieschart"
 
 <DocsPage>
-    <DocsPageHeader Title="Time Series Chart" Component="@nameof(MudBlazor.Charts.TimeSeries<T>)"></DocsPageHeader>
+    <DocsPageHeader Title="Time Series Chart" Component="@nameof(MudBlazor.Charts.TimeSeries<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ChatBubble/ChatPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChatBubble/ChatPage.razor
@@ -2,12 +2,15 @@
 @page "/components/MudChat"
 
 <DocsPage>
-    <DocsPageHeader Title="Chat" />
+    <DocsPageHeader Title="Chat">
+        <Description>
+            <MudAlert Severity="Severity.Info" Class="my-4">
+                <strong>Component Moved:</strong> The MudChat component family has been removed from MudBlazor and is now available in 
+                <MudLink Href="https://github.com/MudXtra/MudX" Target="_blank">MudX</MudLink>.
+            </MudAlert>
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
-        <MudAlert Severity="Severity.Info" Class="my-4">
-            <strong>Component Moved:</strong> The MudChat component family has been removed from MudBlazor and is now available in 
-            <MudLink Href="https://github.com/MudXtra/MudX" Target="_blank">MudX</MudLink>.
-        </MudAlert>
 
         <MudText Typo="Typo.h6" Class="mb-2">Migration Guide</MudText>
         <MudText Class="mb-4">

--- a/src/MudBlazor.Docs/Pages/Components/ChatBubble/ChatPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChatBubble/ChatPage.razor
@@ -2,7 +2,7 @@
 @page "/components/MudChat"
 
 <DocsPage>
-    <DocsPageHeader Title="Chat" SubTitle="Chat components have been moved to MudX" />
+    <DocsPageHeader Title="Chat" />
     <DocsPageContent>
         <MudAlert Severity="Severity.Info" Class="my-4">
             <strong>Component Moved:</strong> The MudChat component family has been removed from MudBlazor and is now available in 

--- a/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Checkbox/CheckboxPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/checkbox"
 
 <DocsPage>
-    <DocsPageHeader Title="Check Box" Component="@nameof(MudCheckBox<T>)">
-        <Description>
-            Use checkboxes (instead of switches or radio buttons) if multiple options can be selected from a list.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Check Box" Component="@nameof(MudCheckBox<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Chip/ChipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Chip/ChipPage.razor
@@ -1,12 +1,7 @@
 ﻿@page "/components/chips"
 
 <DocsPage>
-    <DocsPageHeader Title="Chips" Component="@nameof(MudChip<T>)">
-        <Description>
-            Use chips to show options for a specific context.
-            <br />See also: <MudLink Href="/components/chipset">ChipSet</MudLink>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Chips" Component="@nameof(MudChip<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Chip/ChipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Chip/ChipPage.razor
@@ -1,7 +1,11 @@
 ﻿@page "/components/chips"
 
 <DocsPage>
-    <DocsPageHeader Title="Chips" Component="@nameof(MudChip<T>)" />
+    <DocsPageHeader Title="Chips" Component="@nameof(MudChip<T>)">
+        <Description>
+            Looking for grouped selection? See <MudLink Href="/components/chipset">Chip Set</MudLink>. For inline count indicators, use <MudLink Href="/components/badge">Badge</MudLink>.
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ChipSet/ChipSetPage.razor
@@ -1,9 +1,7 @@
 ﻿@page "/components/chipset"
 
 <DocsPage>
-    <DocsPageHeader Title="Chip Set" Component="@nameof(MudChipSet<T>)">
-        <Description><br />See also: <MudLink Href="/components/chips">Chip</MudLink></Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Chip Set" Component="@nameof(MudChipSet<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Collapse/CollapsePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Collapse/CollapsePage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/collapse"
 
 <DocsPage>
-    <DocsPageHeader Title="Collapse" Component="@nameof(MudCollapse)" SubTitle="Simple wrapper that lets you collapse/expand some content" />
+    <DocsPageHeader Title="Collapse" Component="@nameof(MudCollapse)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Container/ContainerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Container/ContainerPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/container"
 
 <DocsPage>
-    <DocsPageHeader Title="Container" Component="@nameof(MudContainer)" SubTitle="A simple component to center content. Choose between fluid or fixed." />
+    <DocsPageHeader Title="Container" Component="@nameof(MudContainer)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/dialog"
 
 <DocsPage>
-    <DocsPageHeader Title="Dialog" Component="@nameof(MudDialog)">
-        <Description>
-            Use dialogs to make sure users act on information.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Dialog" Component="@nameof(MudDialog)" />
     <DocsPageContent>
 
         <MudAlert Severity="Severity.Info">

--- a/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/DialogPage.razor
@@ -1,13 +1,15 @@
 ﻿@page "/components/dialog"
 
 <DocsPage>
-    <DocsPageHeader Title="Dialog" Component="@nameof(MudDialog)" />
+    <DocsPageHeader Title="Dialog" Component="@nameof(MudDialog)">
+        <Description>
+            <MudAlert Severity="Severity.Info">
+                <MudText>The Dialog component relies on <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline> for its functionality.</MudText>
+                <MudText>See the <MudLink Href="/getting-started/installation">Installation</MudLink> page for setup instructions.</MudText>
+            </MudAlert>
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
-
-        <MudAlert Severity="Severity.Info">
-            <MudText>The Dialog component relies on <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline> for its functionality.</MudText>
-            <MudText>See the <MudLink Href="/getting-started/installation">Installation</MudLink> page for setup instructions.</MudText>
-        </MudAlert>
 
         <DocsPageSection>
             <SectionHeader Title="Usage">

--- a/src/MudBlazor.Docs/Pages/Components/Divider/DividerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Divider/DividerPage.razor
@@ -1,12 +1,7 @@
 ﻿@page "/components/divider"
 
 <DocsPage>
-    <DocsPageHeader Title="Divider" Component="@nameof(MudDivider)">
-        <Description>
-            Only use dividers if items can’t be grouped with open space.
-            Use dividers to group things, not separate individual items.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Divider" Component="@nameof(MudDivider)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -2,7 +2,12 @@
 @page "/components/fileuploader"
 
 <DocsPage>
-    <DocsPageHeader Title="File Upload" Component="@nameof(MudFileUpload<T>)" />
+    <DocsPageHeader Title="File Upload" Component="@nameof(MudFileUpload<T>)">
+        <Description>
+            Let users pick files or drag them onto a drop zone. For drag-and-drop lists and kanban boards, see
+            <MudLink Href="/components/dropzone">Drop Zone</MudLink>.
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FileUpload/FileUploadPage.razor
@@ -2,25 +2,7 @@
 @page "/components/fileuploader"
 
 <DocsPage>
-    <DocsPageHeader Title="File Upload" Component="@nameof(MudFileUpload<T>)">
-        <Description>
-            <MudText Typo="@Typo.body1" Class="mt-4">
-                To create a file upload button, two elements are needed: an activator (using the <CodeInline>ActivatorContent</CodeInline> parameter) and an <CodeInline>input</CodeInline>.
-            </MudText>
-            <br />
-            <MudText Typo="@Typo.body1">
-                The <CodeInline>MudFileUpload</CodeInline> component provides public <CodeInline>ClearAsync</CodeInline> and <CodeInline>OpenFilePickerAsync</CodeInline>
-                methods that can be used as <CodeInline>OnClick</CodeInline> events for buttons.
-            </MudText>
-            <br />
-            <MudText Typo="@Typo.body1">
-                After uploading the files, you will receive an <CodeInline>IReadOnlyList&#60IBrowserFile&#62</CodeInline> or <CodeInline>IBrowserFile</CodeInline> and you will need to manually handle the upload in <CodeInline>HandleFilesChanged</CodeInline>.
-                Instead of using <CodeInline>multiple</CodeInline> to allow multiple files, you set T to <CodeInline>IReadOnlyList&#60IBrowserFile&#62</CodeInline>. Using <CodeInline>IBrowserFile</CodeInline> restricts the component to a single file.
-            </MudText>
-            <br />
-            <br />
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="File Upload" Component="@nameof(MudFileUpload<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/FocusTrap/FocusTrapPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/FocusTrap/FocusTrapPage.razor
@@ -1,9 +1,7 @@
 ﻿@page "/components/focustrap"
 
 <DocsPage>
-    <DocsPageHeader Title="Focus Trap" Component="@nameof(MudFocusTrap)">
-        <Description>It is typically used when the user actions should be temporarily limited, for example within dropdown selectors and modal dialogs.</Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Focus Trap" Component="@nameof(MudFocusTrap)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Form/FormPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/FormPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/form"
 
 <DocsPage>
-    <DocsPageHeader Title="Form Validation" Component="@nameof(MudForm)" SubTitle="All about checking user input and visualization of errors" />
+    <DocsPageHeader Title="Form Validation" Component="@nameof(MudForm)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Grid/GridPage.razor
@@ -1,12 +1,7 @@
 ﻿@page "/components/grid"
 
 <DocsPage>
-    <DocsPageHeader Title="Grid" Component="@nameof(MudGrid)">
-        <Description>
-            MudBlazor comes with a 12-point grid system and contains 6 breakpoints that are used for specific screen sizes.<br /><br />
-            Read more about <MudLink Href="/features/breakpoints">MudBlazor's breakpoints here.</MudLink>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Grid" Component="@nameof(MudGrid)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Hotkey/HotkeyPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hotkey/HotkeyPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/hotkey"
 
 <DocsPage>
-    <DocsPageHeader Title="Hotkey" Component="@nameof(MudHotkey)" SubTitle="A simple way to implement hotkeys."/>
+    <DocsPageHeader Title="Hotkey" Component="@nameof(MudHotkey)"/>
     <DocsPageSection>
         <SectionHeader Title="Usage">
             <Description>

--- a/src/MudBlazor.Docs/Pages/Components/IconButton/IconButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/IconButton/IconButtonPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/iconbutton"
 
 <DocsPage>
-    <DocsPageHeader Title="Icon Button" Component="@nameof(MudIconButton)">
-        <Description>
-            Similar to <ApiTypeLink TypeName="MudButton" /> but with icons. For guidance and suggestions, go to <MudLink Href="/components/icons">Icons.</MudLink>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Icon Button" Component="@nameof(MudIconButton)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Icons/IconsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Icons/IconsPage.razor
@@ -3,8 +3,7 @@
 @using System.Reflection
 
 <DocsPage>
-    <DocsPageHeader Title="Icons" Component="@nameof(MudIcon)" SubTitle="Guidance and suggestions for using icons with MudBlazor.">
-    </DocsPageHeader>
+    <DocsPageHeader Title="Icons" Component="@nameof(MudIcon)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/List/ListPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/list"
 
 <DocsPage>
-    <DocsPageHeader Title="Lists" Component="@nameof(MudList<T>)">
-        <Description>
-            Use lists to help users find a specific item and act on it.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Lists" Component="@nameof(MudList<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -1,13 +1,7 @@
 ﻿@page "/components/menu"
 
 <DocsPage>
-    <DocsPageHeader Title="Menus" Component="@nameof(MudMenu)">
-        <Description>
-            Use menus to show items in a scannable way.
-            Make menus easy to open, close, and select.
-            Menus can open from a variety of components, including icon buttons and text fields.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Menus" Component="@nameof(MudMenu)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
@@ -1,14 +1,16 @@
 ﻿@page "/components/messagebox"
 
 <DocsPage>
-    <DocsPageHeader Title="Message Box" Component="@nameof(MudMessageBox)" />
+    <DocsPageHeader Title="Message Box" Component="@nameof(MudMessageBox)">
+        <Description>
+            <MudAlert Severity="Severity.Info">
+                <MudText>The MessageBox component uses <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline> for its functionality.</MudText>
+                <MudText>Global settings on MudDialogProvider affect all MessageBoxes in your app.</MudText>
+                <MudText>See the Dialog <MudLink Href="/components/dialog#configuration">Configuration</MudLink> section for details on global dialog setup.</MudText>
+            </MudAlert>
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
-        
-        <MudAlert Severity="Severity.Info">
-            <MudText>The MessageBox component uses <CodeInline Class="docs-code-tertiary">IDialogService</CodeInline> and <CodeInline>MudDialogProvider</CodeInline> for its functionality.</MudText>
-            <MudText>Global settings on MudDialogProvider affect all MessageBoxes in your app.</MudText>
-            <MudText>See the Dialog <MudLink Href="/components/dialog#configuration">Configuration</MudLink> section for details on global dialog setup.</MudText>
-        </MudAlert>
 
         <DocsPageSection>
             <SectionHeader Title="Message Box">
@@ -56,4 +58,3 @@
 
     </DocsPageContent>
 </DocsPage>
-

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
@@ -11,28 +11,7 @@
 </style>
 
 <DocsPage>
-    <DocsPageHeader Title="Overlay" Component="@nameof(MudOverlay)">
-        <Description>
-            <MudText Typo="Typo.h6" Class="mt-2">Default Behavior: </MudText>
-            <MudText Typo="Typo.body1">
-                <ul class="bullet-list">
-                    <li>
-                        <CodeInline>ZIndex</CodeInline> defaults to <CodeInline>5</CodeInline>.
-                    </li>
-                    <li>
-                        The <CodeInline Tag="true">MudOverlay</CodeInline> does not cover high-priority elements like the <CodeInline Tag="true">MudAppBar</CodeInline> 
-                        or <CodeInline Tag="true">MudDrawer</CodeInline> when used alone as they render above overlays due to 
-                        <MudLink Href="/customization/default-theme#mudtheme-zindex">theme-level defaults</MudLink>.
-                    </li>
-                    <li>
-                        Unless excluded, the <CodeInline Tag="true">MudOverlay</CodeInline> is scaffolded globally via the <CodeInline Tag="true">MudPopoverProvider</CodeInline>, 
-                        meaning only one overlay instance is active at a time. When scaffolded alongside a <CodeInline Tag="true">MudPopover</CodeInline> 
-                        the overlay is assigned a ZIndex exactly one less than the popover so the popover remains interactive and visually above the overlay. 
-                    </li>
-                </ul>
-            </MudText>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Overlay" Component="@nameof(MudOverlay)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
@@ -11,7 +11,13 @@
 </style>
 
 <DocsPage>
-    <DocsPageHeader Title="Overlay" Component="@nameof(MudOverlay)" />
+    <DocsPageHeader Title="Overlay" Component="@nameof(MudOverlay)">
+        <Description>
+            Overlays are scaffolded through <CodeInline>MudPopoverProvider</CodeInline> by default. Ensure the provider is in your layout, or
+            set <CodeInline>Absolute="true"</CodeInline> to keep an overlay scoped to its parent. See
+            <MudLink Href="/components/popover">Popover</MudLink> for provider setup details.
+        </Description>
+    </DocsPageHeader>
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Paper/PaperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Paper/PaperPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/paper"
 
 <DocsPage>
-    <DocsPageHeader Title="Paper" Component="@nameof(MudPaper)">
-        <Description>
-            It is generally used for foregrounds but can also be combined with <MudLink Href="/utilities/flex">Flex</MudLink> for layout.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Paper" Component="@nameof(MudPaper)" />
 
     <DocsPageContent>
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Progress/ProgressPage.razor
@@ -1,13 +1,7 @@
 ﻿@page "/components/progress"
 
 <DocsPage>
-    <DocsPageHeader Title="Progress" Component="@nameof(MudProgressCircular)" SubTitle="Progress indicators that either show the length of a process or unspecified wait time, also known as indeterminate state. The animation is done with SVGs and CSS.">
-        <Description>
-            <div class="mt-6">
-                Progress indicators inform users about the status of ongoing processes, such as loading an app, submitting a form, or saving updates. They communicate an app's state and indicate available actions, such as whether users can navigate away from the current screen.
-            </div>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Progress" Component="@nameof(MudProgressCircular)" />
 
     <DocsPageContent>
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/radio"
 
 <DocsPage>
-    <DocsPageHeader Title="Radio" Component="@nameof(MudRadio<T>)" SubTitle="Radio buttons allow the user to select a single choice from a group of options.">
-        <Description>
-            Use radio buttons (not switches) when only one item can be selected from a list.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Radio" Component="@nameof(MudRadio<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Rating/RatingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Rating/RatingPage.razor
@@ -1,9 +1,7 @@
 ﻿@page "/components/rating"
 
 <DocsPage>
-    <DocsPageHeader Title="Rating" Component="@nameof(MudRating)" SubTitle="Ratings provide insight regarding other's opinions and experiences with a product.">
-        <Description>Collecting user feedback via ratings is a simple analytic that can provide a lot of feedback to your product or application.</Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Rating" Component="@nameof(MudRating)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ScrollToTop/ScrollToTopPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ScrollToTop/ScrollToTopPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/scrolltotop"
 
 <DocsPage>
-    <DocsPageHeader Title="Scroll To Top" Component="@nameof(MudScrollToTop)" SubTitle="A ScrollToTop component is a component that allows the user to return to the top of the page easily." />    
+    <DocsPageHeader Title="Scroll To Top" Component="@nameof(MudScrollToTop)" />    
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -1,10 +1,7 @@
 ﻿@page "/components/select"
 
 <DocsPage>
-    <DocsPageHeader Title="Select" Component="@nameof(MudSelect<T>)" SubTitle="Select fields allow users to provide information from a list of options.">
-        <Description>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Select" Component="@nameof(MudSelect<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Skeleton/SkeletonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Skeleton/SkeletonPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/skeleton"
 
 <DocsPage>
-    <DocsPageHeader Title="Skeleton" Component="@nameof(MudSkeleton)" SubTitle="Display placeholder for your content while the data loads." />
+    <DocsPageHeader Title="Skeleton" Component="@nameof(MudSkeleton)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
@@ -1,12 +1,7 @@
 ﻿@page "/components/slider"
 
 <DocsPage>
-    <DocsPageHeader Title="Slider" Component="@nameof(MudSlider<T>)" SubTitle="A slider is a visual representation and action to let the user select from a range of values.">
-        <Description>
-            Sliders should present the full range of available values.
-            The slider value should take effect immediately.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Slider" Component="@nameof(MudSlider<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/SnackbarPage.razor
@@ -3,7 +3,7 @@
 @inject MudBlazor.ISnackbar Snackbar
 
 <DocsPage>
-    <DocsPageHeader Title="Snackbar" Component="@nameof(SnackbarService)" SubTitle="A Snackbar (also called Toast) is an Alert that pops up dynamically to notify the user about an important message." />    
+    <DocsPageHeader Title="Snackbar" Component="@nameof(SnackbarService)" />    
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Spacer/SpacerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Spacer/SpacerPage.razor
@@ -1,8 +1,7 @@
 ﻿@page "/components/spacer"
 
 <DocsPage>
-    <DocsPageHeader Title="Spacer" Component="@nameof(MudSpacer)" SubTitle="Expands and fills available space">
-    </DocsPageHeader>
+    <DocsPageHeader Title="Spacer" Component="@nameof(MudSpacer)" />
 
     <DocsPageContent>
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/SplitPanel/SplitPanelPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SplitPanel/SplitPanelPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/splitpanel"
 
 <DocsPage>
-    <DocsPageHeader Title="Split Panel" Component="@nameof(MudSplitPanel)">
-        <Description>
-            This component allows the user to dynamically resize content based on their current needs.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Split Panel" Component="@nameof(MudSplitPanel)" />
     <DocsPageContent>
         <DocsPageSection>
             <SectionHeader Title="Basic Usage" />

--- a/src/MudBlazor.Docs/Pages/Components/Stack/StackPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stack/StackPage.razor
@@ -1,8 +1,7 @@
 ﻿@page "/components/stack"
 
 <DocsPage>
-    <DocsPageHeader Title="Stack" Component="@nameof(MudStack)" SubTitle="Manages layout of its child items along the vertical or horizontal axis.">
-    </DocsPageHeader>
+    <DocsPageHeader Title="Stack" Component="@nameof(MudStack)" />
 
     <DocsPageContent>
 

--- a/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
@@ -1,19 +1,7 @@
 ﻿@page "/components/stepper"
 
 <DocsPage>
-    <DocsPageHeader Title="Stepper" Component="@nameof(MudStepper)" SubTitle="A wizard that guides the user through a series of steps to complete a transaction.">
-        <Description>
-            <DocsPageSection>
-                <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning:</b> This component is currently under development.
-                    <br />
-                    <br />
-                    Breaking changes such as updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
-                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute code.
-                </MudAlert>
-            </DocsPageSection>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Stepper" Component="@nameof(MudStepper)" />
 
     <DocsPageContent>
 

--- a/src/MudBlazor.Docs/Pages/Components/SwipeArea/SwipeAreaPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SwipeArea/SwipeAreaPage.razor
@@ -1,9 +1,7 @@
 ﻿@page "/components/swipearea"
 
 <DocsPage>
-    <DocsPageHeader Title="Swipe Area" Component="@nameof(MudSwipeArea)">
-        <Description>Controls the swipe movement of a determined area.</Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Swipe Area" Component="@nameof(MudSwipeArea)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Switch/SwitchPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/switch"
 
 <DocsPage>
-    <DocsPageHeader Title="Switch" Component="@nameof(MudSwitch<T>)" SubTitle="Similar to a checkbox but visually different, the switch lets the user switch between two values with the tap of a button.">
-        <Description>
-            Use switches (not radio buttons) if the items in a list can be independently controlled.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Switch" Component="@nameof(MudSwitch<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/tabs"
 
 <DocsPage>
-    <DocsPageHeader Title="Tabs" Component="@nameof(MudTabs)" SubTitle="Organizes content across multiple tab pages." />
+    <DocsPageHeader Title="Tabs" Component="@nameof(MudTabs)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/TemplateComponent/TemplatePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TemplateComponent/TemplatePage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/componentname"
 
 <DocsPage>
-    <DocsPageHeader Title="Component Name" SubTitle="A short description of the component." />
+    <DocsPageHeader Title="Component Name" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TimePicker/TimePickerPage.razor
@@ -1,9 +1,7 @@
 ﻿@page "/components/timepicker"
 
 <DocsPage>
-    <DocsPageHeader Title="Time Picker" Component="@nameof(MudTimePicker)">
-        <Description>Provides the user with a simple way to select time.</Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Time Picker" Component="@nameof(MudTimePicker)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/TimelinePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/TimelinePage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/timeline"
 
 <DocsPage>
-    <DocsPageHeader Title="Timeline" Component="@nameof(MudTimeline)" SubTitle="The timeline displays items in chronological order." />
+    <DocsPageHeader Title="Timeline" Component="@nameof(MudTimeline)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleGroup/ToggleGroupPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/togglegroup"
 
 <DocsPage>
-    <DocsPageHeader Title="Toggle Group" Component="@nameof(MudToggleGroup<T>)" SubTitle="Toggle buttons grouped to select one or multiple values." />
+    <DocsPageHeader Title="Toggle Group" Component="@nameof(MudToggleGroup<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/ToggleIconButtonPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToggleIconButton/ToggleIconButtonPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/toggleiconbutton"
 
 <DocsPage>
-    <DocsPageHeader Title="Toggle Icon Button" Component="@nameof(MudToggleIconButton)">
-        <Description>
-            A toggleable implementation of <CodeInline>MudIconButton</CodeInline> where you can use its familiar API to define two different states which you can toggle between. For available icons, go to <MudLink Href="/components/icons">Icons</MudLink>. Custom icons are passed as an SVG string.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Toggle Icon Button" Component="@nameof(MudToggleIconButton)" />
 
     <DocsPageContent>
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/ToolBar/ToolBarPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ToolBar/ToolBarPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/toolbar"
 
 <DocsPage>
-    <DocsPageHeader Title="Tool Bar" Component="@nameof(MudToolBar)" SubTitle="Guidance and suggestions for using toolbar with MudBlazor." />
+    <DocsPageHeader Title="Tool Bar" Component="@nameof(MudToolBar)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tooltip/TooltipPage.razor
@@ -1,11 +1,7 @@
 ﻿@page "/components/tooltip"
 
 <DocsPage>
-    <DocsPageHeader Title="Tooltip" Component="@nameof(MudTooltip)" SubTitle="A small popup which provides more information.">
-        <Description>
-            Use tooltips to add additional context to a button or other UI element.
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="Tooltip" Component="@nameof(MudTooltip)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor.Docs/Pages/Components/Typography/TypographyPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Typography/TypographyPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/components/typography"
 
 <DocsPage>
-    <DocsPageHeader Title="Typography" Component="@nameof(MudText)" SubTitle="Use MudText to present your design and content as clearly and efficiently as possible." />
+    <DocsPageHeader Title="Typography" Component="@nameof(MudText)" />
     <DocsPageContent>
 
         <DocsPageSection>

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
 #nullable enable
 
     /// <summary>
-    /// Represents an alert used to display an important message which is statically embedded in the page content.
+    /// Alerts highlight important messages inline within page content.
     /// </summary>
     /// <seealso cref="SnackbarService"/>
     public partial class MudAlert : MudComponentBase

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor;
 /// This component is often used to keep important information persistent while browsing different pages to ease navigation and access to actions for users.
 /// </remarks>
 /// <seealso cref="MudContextualActionBar"/>
-
 public partial class MudAppBar : MudComponentBase
 {
     internal static SectionOutlet ContextualActionBar { get; } = new();

--- a/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
+++ b/src/MudBlazor/Components/AppBar/MudAppBar.razor.cs
@@ -5,14 +5,14 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// Represents a bar used to display actions, branding, navigation and screen titles.
+/// App bar that keeps navigation, branding, and actions visible at the top or bottom of the page.
 /// </summary>
 /// <remarks>
 /// This component is often used to keep important information persistent while browsing different pages to ease navigation and access to actions for users.
 /// </remarks>
 /// <seealso cref="MudContextualActionBar"/>
+
 public partial class MudAppBar : MudComponentBase
 {
     internal static SectionOutlet ContextualActionBar { get; } = new();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -10,7 +10,6 @@ namespace MudBlazor
     /// Type-ahead input that searches large option sets by calling your search function, including async queries.
     /// </summary>
     /// <typeparam name="T">The type of item to search.</typeparam>
-
     public partial class MudAutocomplete<T> : MudBaseInput<T>
     {
         /// <summary>

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -7,9 +7,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a component with simple and flexible type-ahead functionality.
+    /// Type-ahead input that searches large option sets by calling your search function, including async queries.
     /// </summary>
     /// <typeparam name="T">The type of item to search.</typeparam>
+
     public partial class MudAutocomplete<T> : MudBaseInput<T>
     {
         /// <summary>

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -9,7 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Badge that overlays or wraps content to highlight counts, status, or notifications.
     /// </summary>
-
     public partial class MudBadge : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-badge-root")

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -7,8 +7,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents an overlay added to an icon or button to add information such as a number of new items.
+    /// Badge that overlays or wraps content to highlight counts, status, or notifications.
     /// </summary>
+
     public partial class MudBadge : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-badge-root")

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -7,7 +7,7 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Badge that overlays or wraps content to highlight counts, status, or notifications.
+    /// Badges show notifications, counts, or status information on navigation items and icons.
     /// </summary>
     public partial class MudBadge : MudComponentBase
     {

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -10,8 +10,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a cascading parameter which exposes the window's current breakpoint (xs, sm, md, lg, xl).
+    /// Provides the current responsive breakpoint to descendant components.
     /// </summary>
+
     public partial class MudBreakpointProvider : IBrowserViewportObserver, IAsyncDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor
     /// <summary>
     /// Provides the current responsive breakpoint to descendant components.
     /// </summary>
-
     public partial class MudBreakpointProvider : IBrowserViewportObserver, IAsyncDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -5,17 +5,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a button for actions, links, and commands.
+    /// Button component for triggering actions with filled, outlined, or text variants.
     /// </summary>
-    /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
-    /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
-    /// </remarks>
-    /// <seealso cref="MudButtonGroup" />
-    /// <seealso cref="MudFab" />
-    /// <seealso cref="MudIconButton" />
-    /// <seealso cref="MudToggleIconButton" />
+
     public partial class MudButton : MudBaseButton, IDisposable
     {
         protected string Classname => new CssBuilder("mud-button-root mud-button")

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -7,7 +7,6 @@ namespace MudBlazor
     /// <summary>
     /// Button component for triggering actions with filled, outlined, or text variants.
     /// </summary>
-
     public partial class MudButton : MudBaseButton, IDisposable
     {
         protected string Classname => new CssBuilder("mud-button-root mud-button")

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -6,17 +6,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a button consisting of an icon.
+    /// Icon-only button for compact actions.
     /// </summary>
-    /// <remarks>
-    /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
-    /// or <see href="https://developer.mozilla.org/docs/Web/HTML/Element/a">anchor</see> if <c>Href</c> is set.<br/>
-    /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
-    /// </remarks>
-    /// <seealso cref="MudButton" />
-    /// <seealso cref="MudFab" />
-    /// <seealso cref="MudToggleIconButton" />
-    /// <seealso cref="MudIcon"/>
+
     public partial class MudIconButton : MudBaseButton
     {
         protected string Classname => new CssBuilder("mud-button-root mud-icon-button")

--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Icon-only button for compact actions.
     /// </summary>
-
     public partial class MudIconButton : MudBaseButton
     {
         protected string Classname => new CssBuilder("mud-button-root mud-icon-button")

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -5,7 +5,7 @@ namespace MudBlazor;
 
 #nullable enable
 /// <summary>
-/// Represents a button consisting of an icon that can be toggled between two distinct states.
+/// Icon button that toggles between on and off states.
 /// </summary>
 /// <remarks>
 /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
@@ -15,6 +15,7 @@ namespace MudBlazor;
 /// <seealso cref="MudButton" />
 /// <seealso cref="MudFab" />
 /// <seealso cref="MudIconButton" />
+
 public partial class MudToggleIconButton : MudComponentBase
 {
     /// <summary>

--- a/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudToggleIconButton.razor.cs
@@ -15,7 +15,6 @@ namespace MudBlazor;
 /// <seealso cref="MudButton" />
 /// <seealso cref="MudFab" />
 /// <seealso cref="MudIconButton" />
-
 public partial class MudToggleIconButton : MudComponentBase
 {
     /// <summary>

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -7,7 +7,6 @@ namespace MudBlazor
     /// <summary>
     /// Group related buttons into a single segmented control.
     /// </summary>
-
     public partial class MudButtonGroup : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-button-group-root")

--- a/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
+++ b/src/MudBlazor/Components/ButtonGroup/MudButtonGroup.razor.cs
@@ -5,9 +5,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a group of connected <see cref="MudButton"/> components.
+    /// Group related buttons into a single segmented control.
     /// </summary>
-    /// <seealso cref="MudButton" />
+
     public partial class MudButtonGroup : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-button-group-root")

--- a/src/MudBlazor/Components/Card/MudCard.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCard.razor.cs
@@ -5,12 +5,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a block of content which can include a header, image, content, and actions.
+    /// Card surface for grouping related content and actions.
     /// </summary>
-    /// <seealso cref="MudCardActions" />
-    /// <seealso cref="MudCardContent" />
-    /// <seealso cref="MudCardHeader" />
-    /// <seealso cref="MudCardMedia" />
+
     public partial class MudCard : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-card")

--- a/src/MudBlazor/Components/Card/MudCard.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCard.razor.cs
@@ -7,7 +7,6 @@ namespace MudBlazor
     /// <summary>
     /// Card surface for grouping related content and actions.
     /// </summary>
-
     public partial class MudCard : MudComponentBase
     {
         protected string Classname => new CssBuilder("mud-card")

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -17,6 +17,11 @@ using MudBlazor.Utilities.Debounce;
 
 namespace MudBlazor.Charts
 {
+    /// <summary>
+    /// Heat map chart that visualizes values as colored cells.
+    /// </summary>
+    /// <typeparam name="T">The numeric value type for the heat map.</typeparam>
+
     partial class HeatMap<T> : MudChartBase<T, HeatMapChartOptions>, IDisposable where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         internal record CellDimension(double Width, double Height, int Padding);

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -7,10 +7,10 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a form input for boolean values or selecting multiple items in a list.
+    /// Checkbox control for toggling a boolean or tri-state value.
     /// </summary>
-    /// <typeparam name="T">The type of item managed by this checkbox.</typeparam>
-    /// <seealso cref="MudRadio{T}"/>
+    /// <typeparam name="T">The type of the bound value.</typeparam>
+
     public partial class MudCheckBox<T> : MudBooleanInput<T>
     {
         private readonly string _elementId = Identifier.Create("checkbox");

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -10,7 +10,6 @@ namespace MudBlazor
     /// Checkbox control for toggling a boolean or tri-state value.
     /// </summary>
     /// <typeparam name="T">The type of the bound value.</typeparam>
-
     public partial class MudCheckBox<T> : MudBooleanInput<T>
     {
         private readonly string _elementId = Identifier.Create("checkbox");

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor;
 /// </summary>
 /// <typeparam name="T">The type of item managed by this component.</typeparam>
 /// <seealso cref="MudChipSet{T}"/>
-
 public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
 {
     [Inject]

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -7,12 +7,12 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// Represents a compact element used to enter information, select a choice, filter content, or trigger an action.
+/// Compact chip for tags, filters, or input tokens.
 /// </summary>
 /// <typeparam name="T">The type of item managed by this component.</typeparam>
 /// <seealso cref="MudChipSet{T}"/>
+
 public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
 {
     [Inject]

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -15,7 +15,6 @@ namespace MudBlazor;
 /// </summary>
 /// <typeparam name="T">The type of item managed by this component.</typeparam>
 /// <seealso cref="MudChip{T}"/>
-
 public partial class MudChipSet<T> : MudComponentBase, IDisposable
 {
     public MudChipSet()

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -10,12 +10,12 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// Represents a set of multiple <see cref="MudChip{T}"/> components.
+/// Collection of chips that supports single or multiple selection.
 /// </summary>
 /// <typeparam name="T">The type of item managed by this component.</typeparam>
 /// <seealso cref="MudChip{T}"/>
+
 public partial class MudChipSet<T> : MudComponentBase, IDisposable
 {
     public MudChipSet()

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -6,10 +6,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// Represents a container for content which can be collapsed and expanded.
+    /// Smoothly collapse and expand content with animated height transitions.
     /// </summary>
-    /// <seealso cref="MudExpansionPanels"/>
-    /// <seealso cref="MudExpansionPanel"/>
+
     public partial class MudCollapse : MudComponentBase
     {
         private enum CollapseState

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Smoothly collapse and expand content with animated height transitions.
     /// </summary>
-
     public partial class MudCollapse : MudComponentBase
     {
         private enum CollapseState

--- a/src/MudBlazor/Components/Container/MudContainer.razor.cs
+++ b/src/MudBlazor/Components/Container/MudContainer.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/Container/MudContainer.razor.cs
+++ b/src/MudBlazor/Components/Container/MudContainer.razor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor
+{
+    /// <summary>
+    /// Responsive container that centers content with fluid or fixed widths.
+    /// </summary>
+    public partial class MudContainer
+    {
+    }
+}

--- a/src/MudBlazor/Components/Container/MudContainer.razor.cs
+++ b/src/MudBlazor/Components/Container/MudContainer.razor.cs
@@ -5,7 +5,7 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// Responsive container that centers content with fluid or fixed widths.
+    /// Containers keep content aligned and readable across breakpoints with fluid or fixed widths.
     /// </summary>
     public partial class MudContainer
     {

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -15,7 +15,6 @@ namespace MudBlazor
     /// <summary>
     /// Modal dialog container for focused content and actions.
     /// </summary>
-
     public partial class MudDialog : MudComponentBase
     {
         private IDialogReference? _reference;

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -13,15 +13,9 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// An overlay providing the user with information, a choice, or other input.
+    /// Modal dialog container for focused content and actions.
     /// </summary>
-    /// <seealso cref="MudDialogContainer"/>
-    /// <seealso cref="MudDialogProvider"/>
-    /// <seealso cref="DialogOptions"/>
-    /// <seealso cref="DialogParameters{T}"/>
-    /// <seealso cref="DialogReference"/>
-    /// <seealso cref="MudBlazor.DialogService"/>
-    /// <seealso cref="MudMessageBox" />
+
     public partial class MudDialog : MudComponentBase
     {
         private IDialogReference? _reference;

--- a/src/MudBlazor/Components/Divider/MudDivider.razor.cs
+++ b/src/MudBlazor/Components/Divider/MudDivider.razor.cs
@@ -8,9 +8,8 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// A thin line that groups content in lists and layouts.
+/// Divider line that separates content sections.
 /// </summary>
 public partial class MudDivider : MudComponentBase
 {

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -15,11 +15,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A form component for uploading one or more files.  For <c>T</c>, use either <c>IBrowserFile</c> for a single file or <c>IReadOnlyList&lt;IBrowserFile&gt;</c> for multiple files.
+    /// File upload control with drag-and-drop and customizable templates.
     /// </summary>
-    /// <typeparam name="T">Either <see cref="IBrowserFile"/> for a single file or <see cref="IReadOnlyList{IBrowserFile}">IReadOnlyList&lt;IBrowserFile&gt;</see> for multiple files.</typeparam>
+    /// <typeparam name="T">The type of the selected file value.</typeparam>
+
     public partial class MudFileUpload<T> : MudFormComponent<T, string>, IActivatable
     {
         private readonly ParameterState<T?> _filesState;

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -19,7 +19,6 @@ namespace MudBlazor
     /// File upload control with drag-and-drop and customizable templates.
     /// </summary>
     /// <typeparam name="T">The type of the selected file value.</typeparam>
-
     public partial class MudFileUpload<T> : MudFormComponent<T, string>, IActivatable
     {
         private readonly ParameterState<T?> _filesState;

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -16,7 +16,7 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// File upload control with drag-and-drop and customizable templates.
+    /// Let users pick or drag files into your app with customizable activators and templates.
     /// </summary>
     /// <typeparam name="T">The type of the selected file value.</typeparam>
     public partial class MudFileUpload<T> : MudFormComponent<T, string>, IActivatable

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -10,7 +10,6 @@ namespace MudBlazor
     /// <summary>
     /// Focus trap that keeps keyboard focus within its content.
     /// </summary>
-
     public partial class MudFocusTrap : IDisposable
     {
         private bool _shiftDown;

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -7,13 +7,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A component which prevents the keyboard focus from cycling out of its child content.
+    /// Focus trap that keeps keyboard focus within its content.
     /// </summary>
-    /// <remarks>
-    /// Typically used within dialogs and other overlays.
-    /// </remarks>
+
     public partial class MudFocusTrap : IDisposable
     {
         private bool _shiftDown;

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Form container that coordinates validation and error display for inputs.
     /// </summary>
-
     public partial class MudForm : MudComponentBase, IDisposable, IForm
     {
         // Note: w/o any children the form is automatically valid.

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -6,9 +6,9 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A component for collecting and validating user input. Every input derived from MudFormComponent 
-    /// within it is monitored and validated.
+    /// Form container that coordinates validation and error display for inputs.
     /// </summary>
+
     public partial class MudForm : MudComponentBase, IDisposable, IForm
     {
         // Note: w/o any children the form is automatically valid.

--- a/src/MudBlazor/Components/Grid/MudGrid.razor.cs
+++ b/src/MudBlazor/Components/Grid/MudGrid.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor;
 /// Responsive grid layout for rows and columns.
 /// </summary>
 /// <seealso cref="MudItem"/>
-
 public partial class MudGrid : MudComponentBase
 {
     protected string Classname =>

--- a/src/MudBlazor/Components/Grid/MudGrid.razor.cs
+++ b/src/MudBlazor/Components/Grid/MudGrid.razor.cs
@@ -8,11 +8,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// A component for organizing the layout of page content.
+/// Responsive grid layout for rows and columns.
 /// </summary>
 /// <seealso cref="MudItem"/>
+
 public partial class MudGrid : MudComponentBase
 {
     protected string Classname =>

--- a/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
+++ b/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor;
 
 #nullable enable
 /// <summary>
-/// Allows registering a hotkey.
+/// Hotkey listener that maps keyboard shortcuts to actions.
 /// </summary>
 public partial class MudHotkey : MudComponentBase, IAsyncDisposable
 {

--- a/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
+++ b/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
@@ -8,7 +8,7 @@ namespace MudBlazor;
 
 #nullable enable
 /// <summary>
-/// Hotkey listener that maps keyboard shortcuts to actions.
+/// Add keyboard shortcuts that trigger actions or toggle content.
 /// </summary>
 public partial class MudHotkey : MudComponentBase, IAsyncDisposable
 {

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -6,14 +6,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A picture displayed via an SVG path or font.
+    /// Icon component for Material or custom icon glyphs.
     /// </summary>
-    /// <remarks>
-    /// You can use the <see cref="Icons"/> class and <see href="https://mudblazor.com/features/icons#icons">Icons Reference</see> for SVG paths, or a <see href="https://fontawesome.com/icons">Font Awesome CSS Class</see>.
-    /// </remarks>
-    /// <seealso cref="MudIconButton"/>
+
     public partial class MudIcon : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -9,7 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Icon component for Material or custom icon glyphs.
     /// </summary>
-
     public partial class MudIcon : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -7,16 +7,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A scrollable list for displaying text, avatars, and icons.
+    /// List component for navigation, selection, or grouping items.
     /// </summary>
-    /// <remarks>
-    /// This component contains an optional <see cref="MudListSubheader"/> and one or more <see cref="MudListItem{T}"/>.
-    /// </remarks>
-    /// <typeparam name="T">The type of item being listed.</typeparam>
-    /// <seealso cref="MudListItem{T}"/>
-    /// <seealso cref="MudListSubheader"/>
+    /// <typeparam name="T">The type of item displayed by the list.</typeparam>
+
     public partial class MudList<T> : MudComponentBase, IDisposable
     {
         public MudList()

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -11,7 +11,6 @@ namespace MudBlazor
     /// List component for navigation, selection, or grouping items.
     /// </summary>
     /// <typeparam name="T">The type of item displayed by the list.</typeparam>
-
     public partial class MudList<T> : MudComponentBase, IDisposable
     {
         public MudList()

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -17,7 +17,6 @@ namespace MudBlazor
     /// <summary>
     /// Popup menu anchored to a trigger element.
     /// </summary>
-
     public partial class MudMenu : MudComponentBase, IDisposable
     {
         private readonly ParameterState<bool> _openState;

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -15,9 +15,9 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// An interactive menu that displays a list of options.
+    /// Popup menu anchored to a trigger element.
     /// </summary>
-    /// <seealso cref="MudMenuItem" />
+
     public partial class MudMenu : MudComponentBase, IDisposable
     {
         private readonly ParameterState<bool> _openState;

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -11,7 +11,7 @@ namespace MudBlazor;
 
 #nullable enable
 /// <summary>
-/// Overlay layer for blocking interactions or showing loading states.
+/// Overlays block interaction and focus attention during loading or modal states.
 /// </summary>
 public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, IAsyncDisposable
 {

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -10,9 +10,8 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// Renders a translucent layer over content, typically used for modals, popovers, progress bars, or blocking interactions.
+/// Overlay layer for blocking interactions or showing loading states.
 /// </summary>
 public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, IAsyncDisposable
 {

--- a/src/MudBlazor/Components/Paper/MudPaper.razor.cs
+++ b/src/MudBlazor/Components/Paper/MudPaper.razor.cs
@@ -8,9 +8,8 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// A surface for grouping other components.
+/// Paper surface with elevation or outlined styles.
 /// </summary>
 public partial class MudPaper : MudComponentBase
 {

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor
     /// <summary>
     /// Circular progress indicator for determinate or indeterminate progress.
     /// </summary>
-
     public partial class MudProgressCircular : MudComponentBase
     {
         private int _svgValue;

--- a/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
+++ b/src/MudBlazor/Components/Progress/MudProgressCircular.razor.cs
@@ -9,11 +9,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A circle-shaped indicator of progress for an ongoing operation.
+    /// Circular progress indicator for determinate or indeterminate progress.
     /// </summary>
-    /// <seealso cref="MudProgressLinear"/>
+
     public partial class MudProgressCircular : MudComponentBase
     {
         private int _svgValue;

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -10,13 +10,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// An option from a set of mutually exclusive options, often as part of a <see cref="MudRadioGroup{T}"/>.
+    /// Single-choice radio button used within a group.
     /// </summary>
-    /// <typeparam name="T">The type of value being selected, often a <c>bool</c>.</typeparam>
-    /// <seealso cref="MudCheckBox{T}" />
-    /// <seealso cref="MudRadioGroup{T}" />
+    /// <typeparam name="T">The type of the bound value.</typeparam>
+
     public partial class MudRadio<T> : MudBooleanInput<T>
     {
         private IMudRadioGroup? _parent;

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -14,7 +14,6 @@ namespace MudBlazor
     /// Single-choice radio button used within a group.
     /// </summary>
     /// <typeparam name="T">The type of the bound value.</typeparam>
-
     public partial class MudRadio<T> : MudBooleanInput<T>
     {
         private IMudRadioGroup? _parent;

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -9,7 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Rating control for collecting feedback with selectable icons.
     /// </summary>
-
     public partial class MudRating : MudComponentBase
     {
         private readonly ParameterState<int> _selectedValueState;

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -6,11 +6,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A component for collecting and displaying ratings.
+    /// Rating control for collecting feedback with selectable icons.
     /// </summary>
-    /// <seealso cref="MudRatingItem"/>
+
     public partial class MudRating : MudComponentBase
     {
         private readonly ParameterState<int> _selectedValueState;

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Trigger component that scrolls a target element back to the top.
     /// </summary>
-
     public partial class MudScrollToTop : IDisposable
     {
         private IScrollListener? _scrollListener;

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -5,10 +5,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A button which lets the user jump to the top of the page.
+    /// Trigger component that scrolls a target element back to the top.
     /// </summary>
+
     public partial class MudScrollToTop : IDisposable
     {
         private IScrollListener? _scrollListener;

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -17,7 +17,6 @@ namespace MudBlazor
     /// Dropdown select input for choosing from a list of options.
     /// </summary>
     /// <typeparam name="T">The type of value to select.</typeparam>
-
     public partial class MudSelect<T> : MudBaseInput<T>, IMudSelect, IMudShadowSelect
     {
         private string? _activeItemId;

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -13,12 +13,11 @@ using MudBlazor.Utilities.Exceptions;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A component for choosing an item from a list of options.
+    /// Dropdown select input for choosing from a list of options.
     /// </summary>
-    /// <typeparam name="T">The kind of object being selected.</typeparam>
-    /// <seealso cref="MudSelectItem{T}"/>
+    /// <typeparam name="T">The type of value to select.</typeparam>
+
     public partial class MudSelect<T> : MudBaseInput<T>, IMudSelect, IMudShadowSelect
     {
         private string? _activeItemId;

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
@@ -4,10 +4,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A temporary placeholder for content while data is loaded.
+    /// Skeleton placeholder that mimics content while data loads.
     /// </summary>
+
     public partial class MudSkeleton : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor.cs
@@ -7,7 +7,6 @@ namespace MudBlazor
     /// <summary>
     /// Skeleton placeholder that mimics content while data loads.
     /// </summary>
-
     public partial class MudSkeleton : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -11,7 +11,6 @@ namespace MudBlazor
     /// Slider for selecting a value within a defined range.
     /// </summary>
     /// <typeparam name="T">The numeric value type for the slider.</typeparam>
-
     public partial class MudSlider<T> : MudComponentBase where T : struct, INumber<T>
     {
         private int _tickMarkCount = 0;

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -8,9 +8,10 @@ namespace MudBlazor
 {
 #nullable enable
     /// <summary>
-    /// A component which allows users to select a value within a specified range.
+    /// Slider for selecting a value within a defined range.
     /// </summary>
-    /// <typeparam name="T">The type of the value the slider represents.</typeparam>
+    /// <typeparam name="T">The numeric value type for the slider.</typeparam>
+
     public partial class MudSlider<T> : MudComponentBase where T : struct, INumber<T>
     {
         private int _tickMarkCount = 0;

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -13,6 +13,9 @@ using MudBlazor.Components.Snackbar.InternalComponents;
 namespace MudBlazor
 {
     /// <summary>
+    /// Service that queues and displays snackbars (toast notifications).
+    /// </summary>
+    /// <summary>
     /// A service for managing snackbars.
     /// </summary>
     public class SnackbarService : ISnackbar

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -15,9 +15,6 @@ namespace MudBlazor
     /// <summary>
     /// Service that queues and displays snackbars (toast notifications).
     /// </summary>
-    /// <summary>
-    /// A service for managing snackbars.
-    /// </summary>
     public class SnackbarService : ISnackbar
     {
         private readonly List<Snackbar> _snackBarList;

--- a/src/MudBlazor/Components/Spacer/MudSpacer.razor.cs
+++ b/src/MudBlazor/Components/Spacer/MudSpacer.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/Spacer/MudSpacer.razor.cs
+++ b/src/MudBlazor/Components/Spacer/MudSpacer.razor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor
+{
+    /// <summary>
+    /// Flexible spacer that grows to fill available space.
+    /// </summary>
+    public partial class MudSpacer
+    {
+    }
+}

--- a/src/MudBlazor/Components/Spacer/MudSpacer.razor.cs
+++ b/src/MudBlazor/Components/Spacer/MudSpacer.razor.cs
@@ -5,7 +5,7 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// Flexible spacer that grows to fill available space.
+    /// Spacers create flexible gaps to push content apart in rows and stacks.
     /// </summary>
     public partial class MudSpacer
     {

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -5,9 +5,8 @@ using Microsoft.JSInterop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
-
 /// <summary>
-/// Two panels which are resizable.
+/// Resizable split panel for adjusting two panes.
 /// </summary>
 public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
 {

--- a/src/MudBlazor/Components/Stack/MudStack.razor.cs
+++ b/src/MudBlazor/Components/Stack/MudStack.razor.cs
@@ -8,9 +8,8 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// A component for aligning child items horizontally or vertically.
+/// Layout container that stacks children horizontally or vertically with spacing.
 /// </summary>
 public partial class MudStack : MudComponentBase
 {

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -9,9 +9,8 @@ using MudBlazor.State;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
-
 /// <summary>
-/// A wizard that guides the user through a series of steps to complete a transaction.
+/// Step-by-step wizard that guides users through a multi-step flow.
 /// </summary>
 public partial class MudStepper : MudComponentBase
 {

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
@@ -5,10 +5,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// An area which receives swipe events.
+    /// Gesture area that raises swipe events in multiple directions.
     /// </summary>
+
     public partial class MudSwipeArea : MudComponentBase
     {
         private static readonly string[] _preventDefaultEventNames = ["onpointerdown", "onpointerup", "onpointercancel", "onpointermove", "onpointerleave"];

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Gesture area that raises swipe events in multiple directions.
     /// </summary>
-
     public partial class MudSwipeArea : MudComponentBase
     {
         private static readonly string[] _preventDefaultEventNames = ["onpointerdown", "onpointerup", "onpointercancel", "onpointermove", "onpointerleave"];

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -10,7 +10,6 @@ namespace MudBlazor
     /// Switch-style toggle between two values.
     /// </summary>
     /// <typeparam name="T">The type of the bound value.</typeparam>
-
     public partial class MudSwitch<T> : MudBooleanInput<T>
     {
         private string _elementId = Identifier.Create("switch");

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -6,11 +6,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A component which switches between two values.
+    /// Switch-style toggle between two values.
     /// </summary>
-    /// <typeparam name="T">The kind of value being switched, typically a <see cref="bool"/>.</typeparam>
+    /// <typeparam name="T">The type of the bound value.</typeparam>
+
     public partial class MudSwitch<T> : MudBooleanInput<T>
     {
         private string _elementId = Identifier.Create("switch");

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -16,8 +16,9 @@ using MudBlazor.Utilities.Throttle;
 namespace MudBlazor
 {
     /// <summary>
-    /// A set of views organized into one or more <see cref="MudTabPanel" /> components.
+    /// Tabbed navigation that organizes content into pages.
     /// </summary>
+
     public partial class MudTabs : MudComponentBase, IAsyncDisposable
     {
         internal List<MudTabPanel> _panels;

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -18,7 +18,6 @@ namespace MudBlazor
     /// <summary>
     /// Tabbed navigation that organizes content into pages.
     /// </summary>
-
     public partial class MudTabs : MudComponentBase, IAsyncDisposable
     {
         internal List<MudTabPanel> _panels;

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -14,10 +14,9 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A component for selecting time values.
+    /// Time picker for selecting a time value.
     /// </summary>
-    /// <seealso cref="MudDatePicker"/>
-    /// <seealso cref="MudDateRangePicker"/>
+
     public partial class MudTimePicker : MudPicker<TimeSpan?>
     {
         private bool _amPm = false;

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -16,7 +16,6 @@ namespace MudBlazor
     /// <summary>
     /// Time picker for selecting a time value.
     /// </summary>
-
     public partial class MudTimePicker : MudPicker<TimeSpan?>
     {
         private bool _amPm = false;

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -11,7 +11,6 @@ namespace MudBlazor
     /// <summary>
     /// Timeline layout that presents items in chronological order.
     /// </summary>
-
     public partial class MudTimeline : MudBaseItemsControl<MudTimelineItem>
     {
         protected string Classnames =>

--- a/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimeline.razor.cs
@@ -8,11 +8,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// Displays items in chronological order.
+    /// Timeline layout that presents items in chronological order.
     /// </summary>
-    /// <seealso cref="MudTimelineItem"/>
+
     public partial class MudTimeline : MudBaseItemsControl<MudTimelineItem>
     {
         protected string Classnames =>

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -15,7 +15,6 @@ namespace MudBlazor
     /// Group of toggle buttons for single or multiple selection.
     /// </summary>
     /// <typeparam name="T">The type of value represented by each toggle.</typeparam>
-
     public partial class MudToggleGroup<T> : MudComponentBase
     {
         public MudToggleGroup()

--- a/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleGroup.razor.cs
@@ -11,14 +11,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// Maintains the selection of a group of <see cref="MudToggleItem{T}"/> components.
+    /// Group of toggle buttons for single or multiple selection.
     /// </summary>
-    /// <typeparam name="T">The type of item being toggled.</typeparam>
-    /// <seealso cref="MudToggleItem{T}"/>
-    /// <seealso cref="MudRadioGroup{T}"/>
-    /// <seealso cref="MudRadio{T}"/>
+    /// <typeparam name="T">The type of value represented by each toggle.</typeparam>
+
     public partial class MudToggleGroup<T> : MudComponentBase
     {
         public MudToggleGroup()

--- a/src/MudBlazor/Components/ToolBar/MudToolBar.razor.cs
+++ b/src/MudBlazor/Components/ToolBar/MudToolBar.razor.cs
@@ -8,11 +8,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// A set of action buttons.  
+/// Toolbar layout for grouping actions and content.
 /// </summary>
 /// <seealso cref="MudIconButton" />
+
 public partial class MudToolBar : MudComponentBase
 {
     protected string Classname =>

--- a/src/MudBlazor/Components/ToolBar/MudToolBar.razor.cs
+++ b/src/MudBlazor/Components/ToolBar/MudToolBar.razor.cs
@@ -12,7 +12,6 @@ namespace MudBlazor;
 /// Toolbar layout for grouping actions and content.
 /// </summary>
 /// <seealso cref="MudIconButton" />
-
 public partial class MudToolBar : MudComponentBase
 {
     protected string Classname =>

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -5,10 +5,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
 #nullable enable
-
     /// <summary>
-    /// A small popup which provides more information.
+    /// Small popup tooltip that provides extra context on hover or focus.
     /// </summary>
+
     public partial class MudTooltip : MudComponentBase
     {
         private readonly ParameterState<bool> _visibleState;

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Small popup tooltip that provides extra context on hover or focus.
     /// </summary>
-
     public partial class MudTooltip : MudComponentBase
     {
         private readonly ParameterState<bool> _visibleState;

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -4,9 +4,8 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 #nullable enable
-
 /// <summary>
-/// A customizable piece of text.
+/// Typography component for rendering text with Material styles.
 /// </summary>
 public partial class MudText : MudComponentBase
 {


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

- Docs pages had duplicated header descriptions and subtitles that are also provided verbatim from component XML documentation, resulting in redundant content. 
- Centralize the authoritative description in XML doc comments so the rendered docs use a single high-quality source of truth. 
- Ensure every component visible in the docs has a concise, enticing XML `summary` so removing the inline docs page descriptions does not reduce clarity.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
