### PR TITLE
MudPicker & MudRangeInput: add customizable ClearIcon parameter

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1463,5 +1463,17 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input[id='primary-color']").Should().NotBeNull();
         }
+
+        [Test]
+        public void ColorPicker_CustomClearIcon_Should_BeRenderedInMarkup()
+        {
+            var comp = Context.Render<MudColorPicker>(parameters => parameters
+                .Add(p => p.Value, new MudColor("#180f6fff"))
+                .Add(p => p.Editable, true)
+                .Add(p => p.Clearable, true)
+                .Add(p => p.ClearIcon, Icons.Custom.Brands.MudBlazor));
+
+            comp.Markup.Should().Contain(comp.Instance.ClearIcon);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1985,6 +1985,18 @@ namespace MudBlazor.UnitTests.Components
             button.TextContent.Should().Be("1");
         }
 
+        [Test]
+        public void DatePicker_CustomClearIcon_Should_BeRenderedInMarkup()
+        {
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(p => p.Date, new DateTime(2026, 2, 15))
+                .Add(p => p.Editable, true)
+                .Add(p => p.Clearable, true)
+                .Add(p => p.ClearIcon, Icons.Custom.Brands.MudBlazor));
+
+            comp.Markup.Should().Contain(comp.Instance.ClearIcon);
+        }
+
         private IRenderedComponent<SimpleMudDatePickerTest> OpenPicker(Action<ComponentParameterCollectionBuilder<SimpleMudDatePickerTest>>? parameterBuilder = null)
         {
             IRenderedComponent<SimpleMudDatePickerTest> comp;

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1331,6 +1331,18 @@ namespace MudBlazor.UnitTests.Components
             pickers[1].Markup.Should().NotContain("filter:grayscale(1)");
         }
 
+        [Test]
+        public void DateRangePicker_CustomClearIcon_Should_BeRenderedInMarkup()
+        {
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
+                .Add(p => p.DateRange, new DateRange(new DateTime(2020, 12, 26), new DateTime(2021, 02, 01)))
+                .Add(p => p.Editable, true)
+                .Add(p => p.Clearable, true)
+                .Add(p => p.ClearIcon, Icons.Custom.Brands.MudBlazor));
+
+            comp.Markup.Should().Contain(comp.Instance.ClearIcon);
+        }
+
         private sealed class DateRangePickerImpl : MudDateRangePicker
         {
             public DateTime StartOfMonth() => GetCalendarStartOfMonth();

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -354,5 +354,17 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input[id='start-time']").Should().NotBeNull();
         }
+
+        [Test]
+        public void TimePicker_CustomClearIcon_Should_BeRenderedInMarkup()
+        {
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(p => p.Time, new TimeSpan(10, 30, 0))
+                .Add(p => p.Editable, true)
+                .Add(p => p.Clearable, true)
+                .Add(p => p.ClearIcon, Icons.Custom.Brands.MudBlazor));
+
+            comp.Markup.Should().Contain(comp.Instance.ClearIcon);
+        }
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -36,7 +36,7 @@
                                   PlaceholderEnd="@PlaceholderEnd"
                                   SeparatorIcon="@SeparatorIcon"
                                   Clearable="@(Clearable && !GetReadOnlyState())"
-						          ClearIcon="@ClearIcon"
+                                  ClearIcon="@ClearIcon"
                                   Underline="@Underline"
                                   ShrinkLabel="@ShrinkLabel"
                                   InputId="@InputId" />

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -36,6 +36,7 @@
                                   PlaceholderEnd="@PlaceholderEnd"
                                   SeparatorIcon="@SeparatorIcon"
                                   Clearable="@(Clearable && !GetReadOnlyState())"
+						          ClearIcon="@ClearIcon"
                                   Underline="@Underline"
                                   ShrinkLabel="@ShrinkLabel"
                                   InputId="@InputId" />

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -65,7 +65,7 @@
     {
         <MudIconButton Class="@ClearButtonClassname" Style="z-index: 2"
                        Color="@Color.Default"
-                       Icon="@Icons.Material.Filled.Clear"
+                       Icon="@ClearIcon"
                        Size="@Size.Small"
                        OnClick="@ClearButtonClickHandlerAsync"
                        aria-label="@Localizer[LanguageResource.MudInput_Clear]"

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -77,9 +77,20 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
+        /// When <c>true</c>, an icon is displayed which, when clicked, clears the Text and Value.  Use the <see cref="ClearIcon"/> property to control the Clear button icon.
         /// </remarks>
         [Parameter]
         public bool Clearable { get; set; }
+
+        /// <summary>
+        /// Custom clear icon when <see cref="Clearable"/> is enabled.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.Clear"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string ClearIcon { get; set; } = Icons.Material.Filled.Clear;
 
         /// <summary>
         /// The content within this input component.

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -35,7 +35,7 @@
                        Error="@ErrorState.Value"
                        ErrorText="@ErrorTextState.Value"
                        Clearable="@(Clearable && !GetReadOnlyState())"
-					   ClearIcon="@ClearIcon"
+                       ClearIcon="@ClearIcon"
                        OnClearButtonClick="@(async () => await ClearAsync())"
                        ShrinkLabel="@ShrinkLabel"
                        KeyDownPreventDefault="Open"

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -35,6 +35,7 @@
                        Error="@ErrorState.Value"
                        ErrorText="@ErrorTextState.Value"
                        Clearable="@(Clearable && !GetReadOnlyState())"
+					   ClearIcon="@ClearIcon"
                        OnClearButtonClick="@(async () => await ClearAsync())"
                        ShrinkLabel="@ShrinkLabel"
                        KeyDownPreventDefault="Open"

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -213,11 +213,21 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.<br />
-        /// When <c>true</c>, an icon is displayed which, when clicked, clears the Text and Value.  Use the <c>ClearIcon</c> property to control the Clear button icon.
+        /// When <c>true</c>, an icon is displayed which, when clicked, clears the Text and Value.  Use the <see cref="ClearIcon"/> property to control the Clear button icon.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public bool Clearable { get; set; } = false;
+
+        /// <summary>
+        /// Custom clear icon when <see cref="Clearable"/> is enabled.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.Clear"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public string ClearIcon { get; set; } = Icons.Material.Filled.Clear;
 
         /// <summary>
         /// Prevents the user from interacting with this button.


### PR DESCRIPTION
**Description**
The documentation for several components related to `MudPicker` and `MudRangeInput` mentions a `ClearIcon` parameter that can be used to customize the clear icon. However, this parameter was not available on the components themselves.

This PR adds support for `ClearIcon` to the affected components so the documented behavior is now supported.

**Fix**
Add `ClearIcon` support to `MudPicker` and derived components:
- `MudTimePicker`
- `MudDatePicker`
- `MudColorPicker`

Add `ClearIcon` support to `MudRangeInput` and derived components:
- `MudDateRangePicker`

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests


**Documentation**
<img width="1329" height="595" alt="image" src="https://github.com/user-attachments/assets/9482f105-62f4-42a9-ae96-455faacacb79" />
<img width="1289" height="718" alt="image" src="https://github.com/user-attachments/assets/8570cb29-b064-4ac1-8950-cfed2919cf0d" />

