### PR TITLE
Docs: Add notice to Masking page regarding use with Blazor Server

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
@@ -7,8 +7,7 @@
 
         <DocsPageSection>
             <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3 mb-0">
-                Note that masking is recommended for use in WASM projects only because it has known problems in Blazor Server,
-                especially with high network latency. See <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/8186">this issue</MudLink> on github.
+                Masking has known limitations in Blazor Server, particularly in high-latency environments. See <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/8186">issue #8186</MudLink> for details.
             </MudAlert>
             <SectionHeader Title="PatternMask">
                 <Description>

--- a/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
@@ -6,6 +6,10 @@
     <DocsPageContent>
 
         <DocsPageSection>
+            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3 mb-0">
+                Note that masking is recommended for use in WASM projects only because it has known problems in Blazor Server,
+                especially with high network latency. See <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/8186">this issue</MudLink> on github.
+            </MudAlert>
             <SectionHeader Title="PatternMask">
                 <Description>
                     <CodeInline Tag>MudTextField</CodeInline> can be configured to apply rules to the user input by setting 


### PR DESCRIPTION
**Description:**
Added notice to the Masking documentation page regarding problems when using Blazor Server. 

**Screenshot:**
<img width="1687" height="847" alt="2026-01-15 09_37_12-Masking - MudBlazor — Mozilla Firefox" src="https://github.com/user-attachments/assets/54027968-671b-4478-a5d1-b239ee07cca4" />

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
