### PR TITLE
MudCollapse: Hide content after collapse animation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -317,7 +317,7 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Tests that buttons and other interactive content within a collapsed expansion panel 
         /// are properly hidden from accessibility tools and keyboard navigation by being placed 
-        /// in a container with the hidden attribute.
+        /// in a container with the visibility:hidden attribute.
         /// </summary>
         [Test]
         public void MudExpansionPanel_Button_IsInHiddenContainer_When_Panel_Collapsed()
@@ -327,7 +327,7 @@ namespace MudBlazor.UnitTests.Components
             var hiddenParent = button
                 .GetAncestors()
                 .OfType<IElement>()
-                .FirstOrDefault(e => e.HasAttribute("hidden"));
+                .FirstOrDefault(e => e.ClassList.Contains("invisible"));
 
             hiddenParent.Should().NotBeNull("button should not be accessible when the panel is collapsed");
         }
@@ -368,8 +368,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-panel-expanded");
             comp.Find("button").Should().NotBeNull();
 
-            var contentDiv = comp.Find(".mud-expand-panel-content");
-            contentDiv.HasAttribute("hidden").Should().BeTrue();
+            var contentDiv = comp.Find(".mud-collapse-container");
+            contentDiv.ClassList.Contains("invisible").Should().BeTrue();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -21,9 +21,10 @@ namespace MudBlazor
         private CollapseState _state = CollapseState.Exited;
 
         protected string Classname => new CssBuilder("mud-collapse-container")
-            .AddClass($"mud-collapse-entering", _state == CollapseState.Entering)
-            .AddClass($"mud-collapse-entered", _state == CollapseState.Entered)
-            .AddClass($"mud-collapse-exiting", _state == CollapseState.Exiting)
+            .AddClass("mud-collapse-entering", _state == CollapseState.Entering)
+            .AddClass("mud-collapse-entered", _state == CollapseState.Entered)
+            .AddClass("mud-collapse-exiting", _state == CollapseState.Exiting)
+            .AddClass("invisible", _state == CollapseState.Exited)
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -21,7 +21,7 @@
     <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
         @if (KeepContentAlive || _expandedState.Value)
         {
-            <div class="@PanelContentClassname" hidden="@(!_expandedState.Value)">
+            <div class="@PanelContentClassname">
                 @ChildContent
             </div>
         }


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->
Closes #11617 

When `MudExtensionPanel`, and by extension `MudCollapse`, is collapsed, its content should not be exposed to screen readers. This is currently handled in `MudExtensionPanel` by applying the `hidden` attribute when collapsed. While effective for accessibility, this approach removes the content **_before_** the collapse animation completes. As a result, the panel first shrinks and then collapses, leading to a noticeable and undesirable visual jank.

This change introduces use of the `visibility` attribute within `MudCollapse`, addressing both concerns (since `MudExtensionPanel` utilizes `MudCollapse`):

- Ensures collapsed content is not accessible to screen readers.
- Defers hiding the content until after the collapse animation completes, allowing the animation on both components to close smoothly without layout shifts caused by prematurely removed content. 

Before 


https://github.com/user-attachments/assets/b6c0f85d-d661-4a48-b179-228dbafa1b5e



After


https://github.com/user-attachments/assets/e480e1fa-5962-4d50-8365-a8f109283681




**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
