### PR TITLE
Docs: Fix typo in section header for Parameter State

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/ParameterState/ParameterStatePage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/ParameterState/ParameterStatePage.razor
@@ -60,7 +60,7 @@
 
 
         <DocsPageSection>
-            <SectionHeader Title="How Parameter State Rosolves These Issues">
+            <SectionHeader Title="How Parameter State Resolves These Issues">
                 <Description>
                     <CodeInline>ParameterState</CodeInline> tracks and manages parameter changes reliably. 
                     Instead of using traditional property setters, parameters are registered with handlers that:


### PR DESCRIPTION
fixes a small typo in the docs

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
