### PR TITLE
Tests: Use TestCaseSource for generated example and API tests

### DIFF
--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -289,7 +289,6 @@ public partial class TestsForApiPages
     public void WritePublicTypeTest(CodeBuilder cb)
     {
         cb.AddLine("[Test]");
-        cb.AddLine("[Parallelizable(ParallelScope.All)]");
         cb.AddLine("[TestCaseSource(nameof(ApiCases))]");
         cb.AddLine("public async Task ApiPage_Renders(string typeName, bool hasExampleLink)");
         cb.AddLine("{");
@@ -316,7 +315,6 @@ public partial class TestsForApiPages
     public void WriteLegacyApiTest(CodeBuilder cb)
     {
         cb.AddLine("[Test]");
-        cb.AddLine("[Parallelizable(ParallelScope.All)]");
         cb.AddLine("[TestCaseSource(nameof(LegacyApiCases))]");
         cb.AddLine("public async Task LegacyApiPage_Renders(string component)");
         cb.AddLine("{");

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -293,9 +293,9 @@ public partial class TestsForApiPages
         cb.AddLine("public async Task ApiPage_Renders(string typeName, bool hasExampleLink)");
         cb.AddLine("{");
         cb.IndentLevel++;
-        cb.AddLine(@"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/components/{typeName}""));");
-        cb.AddLine(@"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, typeName));");
-        cb.AddLine(@"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        cb.AddLine(@"_ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/components/{typeName}""));");
+        cb.AddLine(@"var comp = _ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, typeName));");
+        cb.AddLine(@"await _ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
         cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {typeName} was not found"");");
         cb.AddLine("if (hasExampleLink)");
         cb.AddLine("{");
@@ -319,9 +319,9 @@ public partial class TestsForApiPages
         cb.AddLine("public async Task LegacyApiPage_Renders(string component)");
         cb.AddLine("{");
         cb.IndentLevel++;
-        cb.AddLine(@"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/components/api/{component}""));");
-        cb.AddLine(@"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, component));");
-        cb.AddLine(@"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        cb.AddLine(@"_ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/components/api/{component}""));");
+        cb.AddLine(@"var comp = _ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, component));");
+        cb.AddLine(@"await _ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
         cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {component} was not found"");");
         cb.IndentLevel--;
         cb.AddLine("}");

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForApiPages.cs
@@ -176,6 +176,7 @@ public partial class TestsForApiPages
             var cb = new CodeBuilder();
 
             cb.AddHeader();
+            cb.AddLine("using System.Collections.Generic;");
             cb.AddLine("using Bunit;");
             cb.AddLine("using AwesomeAssertions;");
             cb.AddLine("using Microsoft.AspNetCore.Components;");
@@ -193,8 +194,10 @@ public partial class TestsForApiPages
             cb.AddLine("{");
             cb.IndentLevel++;
 
-            WritePublicTypeTests(cb);
-            WriteLegacyApiLinkTests(cb);
+            WritePublicTypeCases(cb);
+            WriteLegacyApiCases(cb);
+            WritePublicTypeTest(cb);
+            WriteLegacyApiTest(cb);
 
             cb.IndentLevel--;
             cb.AddLine("}");
@@ -216,10 +219,14 @@ public partial class TestsForApiPages
     }
 
     /// <summary>
-    /// Creates tests for all public MudBlazor types.
+    /// Creates the ApiCases method that yields TestCaseData for all public MudBlazor types.
     /// </summary>
-    public void WritePublicTypeTests(CodeBuilder cb)
+    public void WritePublicTypeCases(CodeBuilder cb)
     {
+        cb.AddLine("public static IEnumerable<TestCaseData> ApiCases()");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+
         var mudBlazorAssembly = typeof(_Imports).Assembly;
         var mudBlazorComponents = mudBlazorAssembly.GetTypes()
             .Where(type =>
@@ -237,6 +244,7 @@ public partial class TestsForApiPages
                 // ... which aren't clone strategies
                 && !type.Name.Contains("SystemTextJson"))
             .ToList();
+
         foreach (var type in mudBlazorComponents)
         {
             // Skip MudBlazor.Color and MudBlazor.Input types
@@ -245,50 +253,81 @@ public partial class TestsForApiPages
                 continue;
             }
 
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {type.Name.Replace("`", "")}_API_TestAsync()");
-            cb.AddLine("{");
-            cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{type.Name}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{type.Name}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {type.Name} was not found"");");
-            // Should there be a link to the example page?
-            if (TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name))
-            {
-                // Yes.  Check for the example link
-                cb.AddLine(@$"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
-                cb.AddLine(@$"exampleLink.Should().NotBeNull();");
-            }
-            cb.IndentLevel--;
-            cb.AddLine("}");
+            var typeName = type.Name.Replace("`", "");
+            var hasExampleLink = TypesWithExamples.Exists(exampleType => exampleType.Name == type.Name);
+            cb.AddLine($"yield return new TestCaseData(\"{type.Name}\", {hasExampleLink.ToString().ToLowerInvariant()}).SetName(\"{typeName}_API\");");
         }
+
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
     }
 
     /// <summary>
-    /// Creates tests for existing API links (for backwards compatibility).
+    /// Creates the LegacyApiCases method that yields TestCaseData for legacy API links.
     /// </summary>
-    public void WriteLegacyApiLinkTests(CodeBuilder cb)
+    public void WriteLegacyApiCases(CodeBuilder cb)
     {
+        cb.AddLine("public static IEnumerable<TestCaseData> LegacyApiCases()");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+
         foreach (var url in _legacyApiAddresses)
         {
             var component = url.Replace("api/", "");
-
-            cb.AddLine("[Test]");
-            cb.AddLine($"public async Task {component.Replace("/", "_")}_Legacy_API_TestAsync()");
-            cb.AddLine("{");
-            cb.IndentLevel++;
-            // Create Api.razor with a type
-            cb.AddLine(@$"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", ""https://localhost:2112/components/{url}""));");
-            cb.AddLine(@$"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, ""{component}""));");
-            cb.AddLine(@$"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
-            // Make sure docs for the type were actually found
-            cb.AddLine(@$"comp.Markup.Should().NotContain(""Sorry, the type {component} was not found"");");
-            cb.IndentLevel--;
-            cb.AddLine("}");
+            cb.AddLine($"yield return new TestCaseData(\"{component}\").SetName(\"{component.Replace("/", "_")}_Legacy_API\");");
         }
+
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
+    }
+
+    /// <summary>
+    /// Creates the test method for public type API pages.
+    /// </summary>
+    public void WritePublicTypeTest(CodeBuilder cb)
+    {
+        cb.AddLine("[Test]");
+        cb.AddLine("[Parallelizable(ParallelScope.All)]");
+        cb.AddLine("[TestCaseSource(nameof(ApiCases))]");
+        cb.AddLine("public async Task ApiPage_Renders(string typeName, bool hasExampleLink)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine(@"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/components/{typeName}""));");
+        cb.AddLine(@"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, typeName));");
+        cb.AddLine(@"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {typeName} was not found"");");
+        cb.AddLine("if (hasExampleLink)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine(@"var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href != null && link.Instance.Href.StartsWith(""/component""));");
+        cb.AddLine(@"exampleLink.Should().NotBeNull();");
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
+    }
+
+    /// <summary>
+    /// Creates the test method for legacy API links.
+    /// </summary>
+    public void WriteLegacyApiTest(CodeBuilder cb)
+    {
+        cb.AddLine("[Test]");
+        cb.AddLine("[Parallelizable(ParallelScope.All)]");
+        cb.AddLine("[TestCaseSource(nameof(LegacyApiCases))]");
+        cb.AddLine("public async Task LegacyApiPage_Renders(string component)");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+        cb.AddLine(@"ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager(""https://localhost:2112/"", $""https://localhost:2112/components/api/{component}""));");
+        cb.AddLine(@"var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, component));");
+        cb.AddLine(@"await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();");
+        cb.AddLine(@"comp.Markup.Should().NotContain($""Sorry, the type {component} was not found"");");
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
     }
 
     /// <summary>

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -38,7 +38,6 @@ public class TestsForExamples
 
             // Generate single test method using TestCaseSource
             cb.AddLine("[Test]");
-            cb.AddLine("[Parallelizable(ParallelScope.All)]");
             cb.AddLine("[TestCaseSource(nameof(ExampleCases))]");
             cb.AddLine("public void Example_Renders(string componentName, System.Type componentType)");
             cb.AddLine("{");

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -18,6 +18,7 @@ public class TestsForExamples
             var cb = new CodeBuilder();
 
             cb.AddHeader();
+            cb.AddLine("using System.Collections.Generic;");
             cb.AddLine("using MudBlazor.Docs.Examples;");
             cb.AddLine("using MudBlazor.Docs.Wireframes;");
             cb.AddLine("using NUnit.Framework;");
@@ -32,26 +33,25 @@ public class TestsForExamples
             cb.AddLine("{");
             cb.IndentLevel++;
 
-            foreach (var entry in Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
-                .OrderBy(e => e.Replace("\\", "/"), StringComparer.Ordinal))
-            {
-                if (entry.EndsWith("Code.razor"))
-                    continue;
-                var filename = Path.GetFileName(entry);
-                var componentName = Path.GetFileNameWithoutExtension(filename);
-                if (!filename.Contains(Paths.ExampleDiscriminator))
-                    continue;
-                // skip over table/data grid virtualization since it takes too long.
-                if (filename == "TableVirtualizationExample.razor" || filename == "DataGridVirtualizationExample.razor")
-                    continue;
-                cb.AddLine("[Test]");
-                cb.AddLine($"public void {componentName}_Test()");
-                cb.AddLine("{");
-                cb.IndentLevel++;
-                cb.AddLine($"ctx.Render<{componentName}>();");
-                cb.IndentLevel--;
-                cb.AddLine("}");
-            }
+            // Generate static test case data
+            WriteExampleCases(cb);
+
+            // Generate single test method using TestCaseSource
+            cb.AddLine("[Test]");
+            cb.AddLine("[Parallelizable(ParallelScope.All)]");
+            cb.AddLine("[TestCaseSource(nameof(ExampleCases))]");
+            cb.AddLine("public void Example_Renders(string componentName, System.Type componentType)");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("ctx.Render(builder =>");
+            cb.AddLine("{");
+            cb.IndentLevel++;
+            cb.AddLine("builder.OpenComponent(0, componentType);");
+            cb.AddLine("builder.CloseComponent();");
+            cb.IndentLevel--;
+            cb.AddLine("});");
+            cb.IndentLevel--;
+            cb.AddLine("}");
 
             cb.IndentLevel--;
             cb.AddLine("}");
@@ -70,5 +70,35 @@ public class TestsForExamples
         }
 
         return success;
+    }
+
+    /// <summary>
+    /// Writes the ExampleCases method that yields TestCaseData for each example component.
+    /// </summary>
+    private void WriteExampleCases(CodeBuilder cb)
+    {
+        cb.AddLine("public static IEnumerable<TestCaseData> ExampleCases()");
+        cb.AddLine("{");
+        cb.IndentLevel++;
+
+        foreach (var entry in Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
+            .OrderBy(e => e.Replace("\\", "/"), StringComparer.Ordinal))
+        {
+            if (entry.EndsWith("Code.razor"))
+                continue;
+            var filename = Path.GetFileName(entry);
+            var componentName = Path.GetFileNameWithoutExtension(filename);
+            if (!filename.Contains(Paths.ExampleDiscriminator))
+                continue;
+            // skip over table/data grid virtualization since it takes too long.
+            if (filename == "TableVirtualizationExample.razor" || filename == "DataGridVirtualizationExample.razor")
+                continue;
+
+            cb.AddLine($"yield return new TestCaseData(\"{componentName}\", typeof({componentName})).SetName(\"{componentName}\");");
+        }
+
+        cb.IndentLevel--;
+        cb.AddLine("}");
+        cb.AddLine();
     }
 }

--- a/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
+++ b/src/MudBlazor.UnitTests.Docs.Generator/TestsForExamples.cs
@@ -42,7 +42,7 @@ public class TestsForExamples
             cb.AddLine("public void Example_Renders(string componentName, System.Type componentType)");
             cb.AddLine("{");
             cb.IndentLevel++;
-            cb.AddLine("ctx.Render(builder =>");
+            cb.AddLine("_ctx.Render(builder =>");
             cb.AddLine("{");
             cb.IndentLevel++;
             cb.AddLine("builder.OpenComponent(0, componentType);");

--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -13,36 +13,36 @@ namespace MudBlazor.UnitTests.Docs.Generated
     [TestFixture]
     public partial class ApiDocsTests
     {
-        private Bunit.BunitContext ctx;
+        private BunitContext _ctx;
 
         [SetUp]
         public void Setup()
         {
-            ctx = new Bunit.BunitContext();
-            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
-            ctx.Services.AddSingleton(TimeProvider.System);
-            ctx.Services.AddSingleton<IDialogService>(new DialogService());
-            ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
-            ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
-            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-            ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
-            ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
-            ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
-            ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
-            ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
-            ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
-            ctx.Services.AddTransient<IEventListener, MockEventListener>();
-            ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
-            ctx.Services.AddSingleton<IMenuService, MenuService>();
-            ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
-            ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
-            ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
-            ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
-            ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
-            ctx.Services.AddTransient<InternalMudLocalizer>();
-            ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
-            ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
-            ctx.Services.AddScoped(sp => new HttpClient());
+            _ctx = new BunitContext();
+            _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            _ctx.Services.AddSingleton(TimeProvider.System);
+            _ctx.Services.AddSingleton<IDialogService>(new DialogService());
+            _ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
+            _ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
+            _ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
+            _ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
+            _ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
+            _ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
+            _ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
+            _ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
+            _ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
+            _ctx.Services.AddTransient<IEventListener, MockEventListener>();
+            _ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();
+            _ctx.Services.AddSingleton<IMenuService, MenuService>();
+            _ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
+            _ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
+            _ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
+            _ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
+            _ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
+            _ctx.Services.AddTransient<InternalMudLocalizer>();
+            _ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
+            _ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
+            _ctx.Services.AddScoped(sp => new HttpClient());
         }
 
         // This shows how to test a docs page with incremental rendering.
@@ -50,9 +50,9 @@ namespace MudBlazor.UnitTests.Docs.Generated
         [Test]
         public async Task AlertPage_Test()
         {
-            ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/alert"));
-            var comp = ctx.Render<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
-            await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
+            _ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/alert"));
+            _ = _ctx.Render<MudBlazor.Docs.Pages.Components.Alert.AlertPage>();
+            await _ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
         }
 
         /// <summary>
@@ -61,15 +61,15 @@ namespace MudBlazor.UnitTests.Docs.Generated
         [Test]
         public async Task MudAlert_API_Test_Example()
         {
-            ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/MudAlert"));
-            var comp = ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, "MudAlert"));
-            await ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
+            _ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager("https://localhost:2112/", "https://localhost:2112/components/MudAlert"));
+            var comp = _ctx.Render<Api>(parameters => parameters.Add(x => x.TypeName, "MudAlert"));
+            await _ctx.Services.GetService<IRenderQueueService>().WaitUntilEmpty();
             comp.Markup.Should().NotContain("Sorry, the type").And.NotContain("could not be found");
             var exampleLink = comp.FindComponents<MudLink>().FirstOrDefault(link => link.Instance.Href.StartsWith("/component"));
             exampleLink.Should().NotBeNull();
         }
 
         [TearDown]
-        public async Task TearDown() => await ctx.DisposeAsync();
+        public async Task TearDown() => await _ctx.DisposeAsync();
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -12,37 +12,37 @@ namespace MudBlazor.UnitTests.Docs.Generated
     [TestFixture]
     public partial class ExampleDocsTests
     {
-        private BunitContext ctx;
+        private BunitContext _ctx;
 
         [SetUp]
         public void Setup()
         {
-            ctx = new BunitContext();
-            ctx.JSInterop.Mode = JSRuntimeMode.Loose;
-            ctx.Services.AddSingleton(TimeProvider.System);
-            ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
-            ctx.Services.AddSingleton<IDialogService>(new DialogService());
-            ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
-            ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
-            ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
-            ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
-            ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
-            ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
-            ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
-            ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
-            ctx.Services.AddTransient<IEventListener, MockEventListener>();
-            ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
-            ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
-            ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
-            ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
-            ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
-            ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
-            ctx.Services.AddTransient<InternalMudLocalizer>();
-            ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
-            ctx.Services.AddTransient<IScrollListener, ScrollListener>();
-            ctx.Services.AddTransient<IResizeObserver, ResizeObserver>();
-            ctx.Services.AddOptions();
-            ctx.Services.AddScoped(sp =>
+            _ctx = new BunitContext();
+            _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+            _ctx.Services.AddSingleton(TimeProvider.System);
+            _ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+            _ctx.Services.AddSingleton<IDialogService>(new DialogService());
+            _ctx.Services.AddSingleton<ISnackbar, SnackbarService>();
+            _ctx.Services.AddSingleton<IBrowserViewportService>(new MockBrowserViewportService());
+            _ctx.Services.AddTransient<IScrollManager, MockScrollManager>();
+            _ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
+            _ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
+            _ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
+            _ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
+            _ctx.Services.AddTransient<IEventListenerFactory, MockEventListenerFactory>();
+            _ctx.Services.AddTransient<IEventListener, MockEventListener>();
+            _ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
+            _ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
+            _ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
+            _ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
+            _ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
+            _ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
+            _ctx.Services.AddTransient<InternalMudLocalizer>();
+            _ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
+            _ctx.Services.AddTransient<IScrollListener, ScrollListener>();
+            _ctx.Services.AddTransient<IResizeObserver, ResizeObserver>();
+            _ctx.Services.AddOptions();
+            _ctx.Services.AddScoped(sp =>
                 new HttpClient(new MockDocsMessageHandler()) { BaseAddress = new Uri("https://localhost/") });
         }
 
@@ -51,7 +51,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
         {
             try
             {
-                ctx.Dispose();
+                _ctx.Dispose();
             }
             catch (Exception) { /*ignore, may fail because of dispose in the middle of a (second) render pass*/ }
         }


### PR DESCRIPTION
This PR refactors the docs test generators to utilize NUnit's `TestCaseSource` pattern. By moving away from generating individual test methods for every component and API page, we reduce metadata overhead and compilation time.

Closes #12470 (full parallelization requires a much deeper refactor that we'll skip for now)
Closes #12473

## Technical Rationale

The transition from individual `[Test]` methods to a `TestCaseSource` approach addresses two primary bottlenecks in the CI/CD and local development pipelines:

* **Test Discovery:** Instead of the NUnit runner and IDE Test Explorer indexing thousands of distinct metadata entities, they now identify a single data-yielding method.
* **JIT Compilation:** Previously, the runtime spent significant cycles JIT-compiling nearly identical method bodies for every example. Now, the test logic is compiled **once** and executed with different parameters.

## Changes

### 1. TestsForExamples.cs

Refactored to consolidate ~750 individual test methods into a single parameterized test.

**Before:**

```csharp
[Test]
public void BorderRadiusCornerExample_Test()
{
    ctx.Render<BorderRadiusCornerExample>();
}

```

**After:**

```csharp
public static IEnumerable<TestCaseData> ExampleCases()
{
    yield return new TestCaseData("BorderRadiusCornerExample", typeof(BorderRadiusCornerExample)).SetName("BorderRadiusCornerExample");
    // ...
}

[Test, TestCaseSource(nameof(ExampleCases))]
public void Example_Renders(string componentName, System.Type componentType)
{
    ctx.Render(builder =>
    {
        builder.OpenComponent(0, componentType);
        builder.CloseComponent();
    });
}

```

### 2. TestsForApiPages.cs

Consolidated hundreds of API and Legacy URL tests into two main test methods:

* `ApiCases()`: Yields data for all public MudBlazor types (~560 types).
* `LegacyApiCases()`: Yields data for legacy API URLs (~111 URLs).

**Checklist:**

* [x] I've read the [contribution guidelines](https://www.google.com/search?q=CONTRIBUTING.md)
* [x] My code follows the style of this project
* [x] I've added or updated relevant unit tests
