### PR TITLE
MudSnackbar: Use TimeProvider

### DIFF
--- a/src/MudBlazor.UnitTests.Shared/Extensions/TestContextExtensions.cs
+++ b/src/MudBlazor.UnitTests.Shared/Extensions/TestContextExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor.Services;
 using MudBlazor.UnitTests.Shared.Mocks;
 
@@ -12,6 +13,10 @@ namespace MudBlazor.UnitTests.Shared.Extensions
         {
             ctx.JSInterop.Mode = JSRuntimeMode.Loose;
             ctx.Services.AddSingleton<NavigationManager>(new MockNavigationManager());
+            var timeProvider = new FakeTimeProvider();
+            timeProvider.SetUtcNow(DateTime.UtcNow);
+            ctx.Services.AddSingleton(timeProvider);
+            ctx.Services.AddSingleton<TimeProvider>(sp => sp.GetRequiredService<FakeTimeProvider>());
             ctx.Services.AddMudServices(options =>
             {
                 options.SnackbarConfiguration.ShowTransitionDuration = 0;
@@ -20,6 +25,17 @@ namespace MudBlazor.UnitTests.Shared.Extensions
             });
             ctx.Services.AddScoped(sp => new HttpClient());
             ctx.Services.AddOptions();
+        }
+
+        public static void AdvanceTime(this BunitContext ctx, int milliseconds)
+        {
+            var timeProvider = ctx.Services.GetRequiredService<TimeProvider>();
+            if (timeProvider is not FakeTimeProvider fakeTimeProvider)
+            {
+                throw new InvalidOperationException("TimeProvider must be a FakeTimeProvider to advance time.");
+            }
+
+            fakeTimeProvider.Advance(TimeSpan.FromMilliseconds(milliseconds));
         }
     }
 }

--- a/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
+++ b/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
@@ -11,6 +11,7 @@
   
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.Extensions.Time.Testing" Version="10.2.0" />
     <PackageReference Include="nunit" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
+++ b/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
@@ -11,7 +11,7 @@
   
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.Extensions.Time.Testing" Version="10.2.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" />
     <PackageReference Include="nunit" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -3,6 +3,8 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor.UnitTests.TestComponents.Snackbar;
 using NUnit.Framework;
 
@@ -13,10 +15,13 @@ namespace MudBlazor.UnitTests.Components
     {
         private IRenderedComponent<MudSnackbarProvider> _provider;
         private ISnackbar _service;
+        private FakeTimeProvider _timeProvider;
 
         [SetUp]
         public void SnackbarSetUp()
         {
+            _timeProvider = new FakeTimeProvider();
+            Context.Services.AddSingleton<TimeProvider>(_timeProvider);
             _service = Context.Services.GetService<ISnackbar>();
             _provider = Context.Render<MudSnackbarProvider>();
             _provider.Find("#mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
@@ -27,6 +32,11 @@ namespace MudBlazor.UnitTests.Components
         {
             await _provider.InvokeAsync(() => _service.Clear());
             _service.ShownSnackbars.Should().BeEmpty();
+        }
+
+        private void AdvanceTime(int milliseconds)
+        {
+            _timeProvider.Advance(TimeSpan.FromMilliseconds(milliseconds));
         }
 
         [Test]
@@ -400,13 +410,14 @@ namespace MudBlazor.UnitTests.Components
 
             primary.PauseTransitions(true);
 
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Test resume.
 
             primary.PauseTransitions(false);
+            AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(
                 () => _provider.FindAll(".mud-snackbar").Count.Should().Be(0),
@@ -532,7 +543,7 @@ namespace MudBlazor.UnitTests.Components
             snackbar.Should().NotBeNull();
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
-            await Task.Delay(200);
+            AdvanceTime(200);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
@@ -567,8 +578,10 @@ namespace MudBlazor.UnitTests.Components
         public async Task CannotStopCloseTransition()
         {
             // Set up the snackbar.
+            Snackbar primary = null;
+
             await _provider.InvokeAsync(() =>
-                _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>
+                primary = _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>
                 {
                     c.ShowTransitionDuration = 0;
                     c.HideTransitionDuration = 100;
@@ -576,6 +589,7 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
+            primary.Should().NotBeNull();
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Test that the hide transition from clicking the close button cannot be stopped by hovering back over the snackbar.
@@ -583,6 +597,8 @@ namespace MudBlazor.UnitTests.Components
             await _provider.Find(".mud-snackbar-close-button").ClickAsync();
             _provider.Find(".mud-snackbar").TouchStart();
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+
+            AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -610,11 +626,13 @@ namespace MudBlazor.UnitTests.Components
 
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
 
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+
+            AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -642,12 +660,14 @@ namespace MudBlazor.UnitTests.Components
 
             _provider.Find(".mud-snackbar").TouchStart();
 
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
 
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             _provider.Find(".mud-snackbar").TouchEnd();
+
+            AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -678,13 +698,13 @@ namespace MudBlazor.UnitTests.Components
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Pointer is still over and the state should still be visible.
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Leave pointer and let the hide transition that's been pending start.
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            await Task.Delay(primary.State.Options.HideTransitionDuration / 2);
+            AdvanceTime(primary.State.Options.HideTransitionDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Hiding);
 
             // Re-enter halfway through hide transition.
@@ -693,6 +713,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Finally make the pointer leave and let it hide.
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            AdvanceTime(primary.State.Options.HideTransitionDuration);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
@@ -724,21 +745,23 @@ namespace MudBlazor.UnitTests.Components
             // Ensure that leaving with the pointer does not trigger a hide transition by itself, like if the timer was not properly utilized.
 
             _provider.Find(".mud-snackbar").TriggerEvent("onpointerleave", new PointerEventArgs());
-            await Task.Delay(primary.State.Options.VisibleStateDuration / 2);
+            AdvanceTime(primary.State.Options.VisibleStateDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // The snackbar should naturally leave the visibility state after the configured duration.
-            await Task.Delay(primary.State.Options.VisibleStateDuration);
-            _provider.FindAll(".mud-snackbar").Count.Should().Be(0);
+            AdvanceTime(primary.State.Options.VisibleStateDuration);
+            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
         [Test]
         public async Task PointerOverDoesNotRestartVisibleDuration()
         {
             // Set up the snackbar.
+            Snackbar primary = null;
+
             await _provider.InvokeAsync(() =>
-                _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>
+                primary = _service.Add("ah, ah, ah, ah, stayin' alive", Severity.Normal, c =>
                 {
                     c.ShowTransitionDuration = 0;
                     c.HideTransitionDuration = 0;
@@ -746,18 +769,21 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
+            primary.Should().NotBeNull();
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Prove that the pointer entering the snackbar does not restart the duration from zero.
 
-            await Task.Delay(60); // 60% through the visible duration.
+            var elapsed = primary.State.Options.VisibleStateDuration * 3 / 5; // 60% through the visible duration.
+            AdvanceTime(elapsed);
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
             _provider.Find(".mud-snackbar").TouchStart();
             _provider.Find(".mud-snackbar").TouchEnd();
 
-            // It should close within another 60ms if it's behaving correctly; If the duration was reset this assertion will fail.
-            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0), TimeSpan.FromMilliseconds(60));
+            // It should close within the remaining duration if it's behaving correctly; If the duration was reset this assertion will fail.
+            AdvanceTime(primary.State.Options.VisibleStateDuration - elapsed);
+            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -4,7 +4,7 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Time.Testing;
+using MudBlazor.UnitTests.Shared.Extensions;
 using MudBlazor.UnitTests.TestComponents.Snackbar;
 using NUnit.Framework;
 
@@ -15,13 +15,10 @@ namespace MudBlazor.UnitTests.Components
     {
         private IRenderedComponent<MudSnackbarProvider> _provider;
         private ISnackbar _service;
-        private FakeTimeProvider _timeProvider;
 
         [SetUp]
         public void SnackbarSetUp()
         {
-            _timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(_timeProvider);
             _service = Context.Services.GetService<ISnackbar>();
             _provider = Context.Render<MudSnackbarProvider>();
             _provider.Find("#mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
@@ -32,11 +29,6 @@ namespace MudBlazor.UnitTests.Components
         {
             await _provider.InvokeAsync(() => _service.Clear());
             _service.ShownSnackbars.Should().BeEmpty();
-        }
-
-        private void AdvanceTime(int milliseconds)
-        {
-            _timeProvider.Advance(TimeSpan.FromMilliseconds(milliseconds));
         }
 
         [Test]
@@ -410,14 +402,14 @@ namespace MudBlazor.UnitTests.Components
 
             primary.PauseTransitions(true);
 
-            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Test resume.
 
             primary.PauseTransitions(false);
-            AdvanceTime(primary.State.Options.HideTransitionDuration);
+            Context.AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(
                 () => _provider.FindAll(".mud-snackbar").Count.Should().Be(0),
@@ -543,7 +535,7 @@ namespace MudBlazor.UnitTests.Components
             snackbar.Should().NotBeNull();
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
-            AdvanceTime(200);
+            Context.AdvanceTime(200);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
@@ -598,7 +590,7 @@ namespace MudBlazor.UnitTests.Components
             _provider.Find(".mud-snackbar").TouchStart();
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
 
-            AdvanceTime(primary.State.Options.HideTransitionDuration);
+            Context.AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -626,13 +618,13 @@ namespace MudBlazor.UnitTests.Components
 
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
 
-            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
 
-            AdvanceTime(primary.State.Options.HideTransitionDuration);
+            Context.AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -660,14 +652,14 @@ namespace MudBlazor.UnitTests.Components
 
             _provider.Find(".mud-snackbar").TouchStart();
 
-            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
 
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             _provider.Find(".mud-snackbar").TouchEnd();
 
-            AdvanceTime(primary.State.Options.HideTransitionDuration);
+            Context.AdvanceTime(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -698,13 +690,13 @@ namespace MudBlazor.UnitTests.Components
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Pointer is still over and the state should still be visible.
-            AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration * 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Leave pointer and let the hide transition that's been pending start.
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            AdvanceTime(primary.State.Options.HideTransitionDuration / 2);
+            Context.AdvanceTime(primary.State.Options.HideTransitionDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Hiding);
 
             // Re-enter halfway through hide transition.
@@ -713,7 +705,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Finally make the pointer leave and let it hide.
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            AdvanceTime(primary.State.Options.HideTransitionDuration);
+            Context.AdvanceTime(primary.State.Options.HideTransitionDuration);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
@@ -745,12 +737,12 @@ namespace MudBlazor.UnitTests.Components
             // Ensure that leaving with the pointer does not trigger a hide transition by itself, like if the timer was not properly utilized.
 
             _provider.Find(".mud-snackbar").TriggerEvent("onpointerleave", new PointerEventArgs());
-            AdvanceTime(primary.State.Options.VisibleStateDuration / 2);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // The snackbar should naturally leave the visibility state after the configured duration.
-            AdvanceTime(primary.State.Options.VisibleStateDuration);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
@@ -775,14 +767,14 @@ namespace MudBlazor.UnitTests.Components
             // Prove that the pointer entering the snackbar does not restart the duration from zero.
 
             var elapsed = primary.State.Options.VisibleStateDuration * 3 / 5; // 60% through the visible duration.
-            AdvanceTime(elapsed);
+            Context.AdvanceTime(elapsed);
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerenter", new PointerEventArgs());
             await _provider.Find(".mud-snackbar").TriggerEventAsync("onpointerleave", new PointerEventArgs());
             _provider.Find(".mud-snackbar").TouchStart();
             _provider.Find(".mud-snackbar").TouchEnd();
 
             // It should close within the remaining duration if it's behaving correctly; If the duration was reset this assertion will fail.
-            AdvanceTime(primary.State.Options.VisibleStateDuration - elapsed);
+            Context.AdvanceTime(primary.State.Options.VisibleStateDuration - elapsed);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 

--- a/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
@@ -1,7 +1,6 @@
 ﻿//Copyright(c) Alessandro Ghidini.All rights reserved.
 //Changes and improvements Copyright (c) The MudBlazor Team.
 
-using System.Diagnostics;
 using static System.String;
 
 namespace MudBlazor
@@ -9,7 +8,10 @@ namespace MudBlazor
 #nullable enable
     internal class SnackBarMessageState
     {
-        private readonly Stopwatch _transitionStopwatch;
+        private readonly TimeProvider _timeProvider;
+        private TimeSpan _transitionElapsed;
+        private long _transitionStartTimestamp;
+        private bool _transitionRunning;
         private string AnimationId { get; }
         public bool UserHasInteracted { get; set; }
         public SnackbarOptions Options { get; }
@@ -21,7 +23,7 @@ namespace MudBlazor
             Options = options;
             AnimationId = Identifier.Create();
             SnackbarState = SnackbarState.Init;
-            _transitionStopwatch = timeProvider.CreateStopwatch();
+            _timeProvider = timeProvider;
         }
         private string Opacity => ((decimal)Options.MaximumOpacity / 100).ToPercentage();
 
@@ -105,19 +107,37 @@ namespace MudBlazor
 
         public void RestartTransitionTimer()
         {
-            _transitionStopwatch.Restart();
+            _transitionElapsed = TimeSpan.Zero;
+            _transitionStartTimestamp = _timeProvider.GetTimestamp();
+            _transitionRunning = true;
         }
 
         public void StopTransitionTimer()
         {
-            _transitionStopwatch.Stop();
+            if (!_transitionRunning)
+            {
+                return;
+            }
+
+            _transitionElapsed += GetElapsedSinceStart();
+            _transitionRunning = false;
         }
 
         private int RemainingTransitionMilliseconds(int transitionDuration)
         {
-            var duration = transitionDuration - (int)_transitionStopwatch.ElapsedMilliseconds;
+            var duration = transitionDuration - (int)ElapsedTransition.TotalMilliseconds;
 
             return duration >= 0 ? duration : 0;
+        }
+
+        private TimeSpan ElapsedTransition => _transitionRunning
+            ? _transitionElapsed + GetElapsedSinceStart()
+            : _transitionElapsed;
+
+        private TimeSpan GetElapsedSinceStart()
+        {
+            var delta = _timeProvider.GetTimestamp() - _transitionStartTimestamp;
+            return TimeSpan.FromSeconds((double)delta / _timeProvider.TimestampFrequency);
         }
     }
 }

--- a/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackBarMessageState.cs
@@ -9,17 +9,19 @@ namespace MudBlazor
 #nullable enable
     internal class SnackBarMessageState
     {
+        private readonly Stopwatch _transitionStopwatch;
         private string AnimationId { get; }
         public bool UserHasInteracted { get; set; }
         public SnackbarOptions Options { get; }
         public SnackbarState SnackbarState { get; set; }
-        public Stopwatch Stopwatch { get; } = new Stopwatch();
 
-        public SnackBarMessageState(SnackbarOptions options)
+        public SnackBarMessageState(SnackbarOptions options, TimeProvider timeProvider)
         {
+            ArgumentNullException.ThrowIfNull(timeProvider);
             Options = options;
             AnimationId = Identifier.Create();
             SnackbarState = SnackbarState.Init;
+            _transitionStopwatch = timeProvider.CreateStopwatch();
         }
         private string Opacity => ((decimal)Options.MaximumOpacity / 100).ToPercentage();
 
@@ -101,9 +103,19 @@ namespace MudBlazor
             }
         }
 
+        public void RestartTransitionTimer()
+        {
+            _transitionStopwatch.Restart();
+        }
+
+        public void StopTransitionTimer()
+        {
+            _transitionStopwatch.Stop();
+        }
+
         private int RemainingTransitionMilliseconds(int transitionDuration)
         {
-            var duration = transitionDuration - (int)Stopwatch.ElapsedMilliseconds;
+            var duration = transitionDuration - (int)_transitionStopwatch.ElapsedMilliseconds;
 
             return duration >= 0 ? duration : 0;
         }

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
         private bool _paused = false;
         private bool _transitionCancellable = true;
         private bool _hideOnResume = false;
-        private Timer Timer { get; }
+        private ITimer Timer { get; }
         internal SnackBarMessageState State { get; }
 
         /// <summary>
@@ -40,11 +40,12 @@ namespace MudBlazor
         /// </summary>
         public Severity Severity => State.Options.Severity;
 
-        internal Snackbar(SnackbarMessage message, SnackbarOptions options)
+        internal Snackbar(SnackbarMessage message, SnackbarOptions options, TimeProvider timeProvider)
         {
+            ArgumentNullException.ThrowIfNull(timeProvider);
             SnackbarMessage = message;
-            State = new SnackBarMessageState(options);
-            Timer = new Timer(TimerElapsed, null, Timeout.Infinite, Timeout.Infinite);
+            State = new SnackBarMessageState(options, timeProvider);
+            Timer = timeProvider.CreateTimer(TimerElapsed, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         }
 
         internal void Init() => TransitionTo(SnackbarState.Showing);
@@ -215,16 +216,16 @@ namespace MudBlazor
                 return false;
             }
 
-            State.Stopwatch.Restart();
-            Timer.Change(duration, Timeout.Infinite);
+            State.RestartTransitionTimer();
+            Timer.Change(TimeSpan.FromMilliseconds(duration), Timeout.InfiniteTimeSpan);
 
             return true;
         }
 
         private void StopTimer()
         {
-            State.Stopwatch.Stop();
-            Timer.Change(Timeout.Infinite, Timeout.Infinite);
+            State.StopTransitionTimer();
+            Timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         }
 
         public void Dispose()

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -20,14 +20,22 @@ namespace MudBlazor
         private readonly List<Snackbar> _snackBarList;
         private readonly ReaderWriterLockSlim _snackBarLock;
         private readonly NavigationManager _navigationManager;
+        private readonly TimeProvider _timeProvider;
 
         public SnackbarConfiguration Configuration { get; }
 
         public event Action? OnSnackbarsUpdated;
 
         public SnackbarService(NavigationManager navigationManager, IOptions<SnackbarConfiguration>? configuration = null)
+            : this(navigationManager, TimeProvider.System, configuration)
         {
+        }
+
+        public SnackbarService(NavigationManager navigationManager, TimeProvider timeProvider, IOptions<SnackbarConfiguration>? configuration = null)
+        {
+            ArgumentNullException.ThrowIfNull(timeProvider);
             _navigationManager = navigationManager;
+            _timeProvider = timeProvider;
             Configuration = configuration?.Value ?? new SnackbarConfiguration();
             Configuration.OnUpdate += ConfigurationUpdated;
             navigationManager.LocationChanged += NavigationManager_LocationChanged;
@@ -174,7 +182,7 @@ namespace MudBlazor
             var options = new SnackbarOptions(severity, Configuration);
             configure?.Invoke(options);
 
-            var snackbar = new Snackbar(message, options);
+            var snackbar = new Snackbar(message, options, _timeProvider);
 
             _snackBarLock.EnterWriteLock();
             try


### PR DESCRIPTION
Switched snackbar timing to a TimeProvider-backed timer/stopwatch flow and updated snackbar tests to drive time with a fake clock instead of real delays.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
