### PR TITLE
Pickers: Use provider-based closing delays

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCompleteDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutoCompleteDatePickerTest.razor
@@ -1,4 +1,5 @@
-﻿<MudPopoverProvider />
+﻿@inject TimeProvider TimeProvider
+<MudPopoverProvider />
 
 <MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="_date">
     <PickerActions>
@@ -11,5 +12,10 @@
 @code {
     private MudDatePicker _picker = null!;
 
-    private DateTime? _date = DateTime.Today;
+    private DateTime? _date;
+
+    protected override void OnInitialized()
+    {
+        _date = TimeProvider.GetLocalNow().LocalDateTime.Date;
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerBindingTest.razor
@@ -1,13 +1,20 @@
-﻿<MudPopoverProvider />
+﻿@inject TimeProvider TimeProvider
+<MudPopoverProvider />
 
 <MudDatePicker Label="Date Picker" @bind-Date="ExpiresOn" />
 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ButtonOnClick">Set Date</MudButton>
 
 @code {
-    public DateTime? ExpiresOn { get; set; } = DateTime.Now.Date;
+    public DateTime? ExpiresOn { get; set; }
+
+    protected override void OnInitialized()
+    {
+        ExpiresOn = TimeProvider.GetLocalNow().LocalDateTime.Date;
+    }
 
     void ButtonOnClick()
     {
-        ExpiresOn = DateTime.Now.Date.AddMonths(10);
+        var today = TimeProvider.GetLocalNow().LocalDateTime.Date;
+        ExpiresOn = today.AddMonths(10);
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerStaticTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerStaticTest.razor
@@ -1,4 +1,5 @@
-﻿<MudPopoverProvider />
+﻿@inject TimeProvider TimeProvider
+<MudPopoverProvider />
 
 <MudDatePicker id="picker" @ref="PickerReference" Label="With action buttons" PickerVariant="PickerVariant.Static" @bind-Date="Date">
     <PickerActions>
@@ -10,7 +11,15 @@
 
 @code {
     [Parameter]
-    public DateTime? Date { get; set; } = DateTime.Today.Subtract(TimeSpan.FromDays(60));
+    public DateTime? Date { get; set; }
 
     public MudDatePicker PickerReference { get; set; } = null!;
+
+    protected override void OnInitialized()
+    {
+        if (Date is null)
+        {
+            Date = TimeProvider.GetLocalNow().LocalDateTime.Date.AddDays(-60);
+        }
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetRangeWithTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetRangeWithTimestampTest.razor
@@ -1,4 +1,5 @@
-﻿<MudDateRangePicker PickerVariant="PickerVariant.Static" @bind-DateRange="DateTimeRange" />
+﻿@inject TimeProvider TimeProvider
+<MudDateRangePicker PickerVariant="PickerVariant.Static" @bind-DateRange="DateTimeRange" />
 
 @code {
     public static string __description__ = "DateTime range with a timestamp";
@@ -7,7 +8,8 @@
 
     protected override Task OnInitializedAsync()
     {
-        DateTimeRange = new DateRange(DateTime.Now.AddDays(1), DateTime.Now.AddDays(5));
+        var now = TimeProvider.GetLocalNow().LocalDateTime;
+        DateTimeRange = new DateRange(now.AddDays(1), now.AddDays(5));
 
         return base.OnInitializedAsync();
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerPresetWithoutTimestampTest.razor
@@ -1,10 +1,20 @@
-﻿<MudDateRangePicker @ref="PickerReference" PickerVariant="PickerVariant.Static" @bind-DateRange="DateRange" />
+﻿@inject TimeProvider TimeProvider
+<MudDateRangePicker @ref="PickerReference" PickerVariant="PickerVariant.Static" @bind-DateRange="DateRange" />
 
 @code {
     public static string __description__ = "DateTime range without a timestamp";
 
     [Parameter]
-    public DateRange? DateRange { get; set; } = new DateRange(DateTime.Now.AddMonths(-1).Date, DateTime.Now.Date);
+    public DateRange? DateRange { get; set; }
 
     public MudDateRangePicker? PickerReference;
+
+    protected override void OnInitialized()
+    {
+        if (DateRange is null)
+        {
+            var today = TimeProvider.GetLocalNow().LocalDateTime.Date;
+            DateRange = new DateRange(today.AddMonths(-1), today);
+        }
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerValidationTest.razor
@@ -22,7 +22,7 @@
     private MudForm _form = null!;
     private MudDateRangePicker _picker = null!;
     private string? _submitStatus;
-    private DateRange? _dateRange; // = new(DateTime.Now, DateTime.Now.AddDays(2));
+    private DateRange? _dateRange;
 
     private void HandleFormValidChanged(bool isValid)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/VarientDatePickerRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/VarientDatePickerRenderTest.razor
@@ -1,4 +1,5 @@
-﻿<MudStack Row>
+﻿@inject TimeProvider TimeProvider
+<MudStack Row>
     <MudDatePicker Label="dd.MM.yyyy" @bind-Date="_date" Mask="@(new DateMask("dd.MM.yyyy"))" DateFormat="dd.MM.yyyy" Placeholder="de-AT Date" HelperText="Help Text" Variant="Variant.Text"/>
     <MudDatePicker Label="MM/dd/yyyy" @bind-Date="_date" Mask="@(new DateMask("MM/dd/yyyy"))" DateFormat="MM/dd/yyyy" Placeholder="en-US Date" HelperText="Help Text" Variant="Variant.Filled" />
     <MudDatePicker Label="yyyy-MM-dd" @bind-Date="_date" Mask="@(new DateMask("0000-00-00"))" DateFormat="yyyy-MM-dd" Placeholder="ISO Date" HelperText="Help Text" Variant="Variant.Outlined" />
@@ -21,6 +22,13 @@
 </MudStack>
 
 @code {
-    private DateTime? _date = DateTime.Today;
-    private DateRange _dateRange = new DateRange(DateTime.Today.AddDays(1), DateTime.Today.AddDays(5));
+    private DateTime? _date;
+    private DateRange _dateRange = null!;
+
+    protected override void OnInitialized()
+    {
+        var today = TimeProvider.GetLocalNow().LocalDateTime.Date;
+        _date = today;
+        _dateRange = new DateRange(today.AddDays(1), today.AddDays(5));
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -29,7 +29,9 @@ namespace MudBlazor.UnitTests.Components
             picker.MinDate.Should().Be(null);
             picker.OpenTo.Should().Be(OpenTo.Date);
             picker.FirstDayOfWeek.Should().Be(null);
-            picker.ClosingDelay.Should().Be(100);
+            picker.ClosingDelay.Should().BeNull();
+            Context.Services.GetRequiredService<IPopoverService>()
+                .PopoverOptions.DatePickerClosingDelay.Should().Be(TimeSpan.FromMilliseconds(100));
             picker.DisplayMonths.Should().Be(1);
             picker.MaxMonthColumns.Should().Be(null);
             picker.StartMonth.Should().Be(null);

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Globalization;
+﻿using System.Globalization;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AwesomeAssertions;
@@ -17,6 +16,18 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class DatePickerTests : BunitTest
     {
+        private static readonly DateTime DefaultUtcNow = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        [SetUp]
+        public void SetupTimeProvider()
+        {
+            var timeProvider = new FakeTimeProvider();
+            timeProvider.SetUtcNow(DefaultUtcNow);
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+        }
+
+        private DateTime GetToday() => Context.Services.GetRequiredService<TimeProvider>().GetLocalNow().LocalDateTime.Date;
+
         [Test]
         public void Default()
         {
@@ -70,19 +81,16 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_OpenClose_Performance()
         {
-            // warmup
             var comp = Context.Render<MudDatePicker>();
             var datepicker = comp.Instance;
-            // measure
-            var watch = Stopwatch.StartNew();
+
             for (var i = 0; i < 1000; i++)
             {
                 await comp.InvokeAsync(() => datepicker.OpenAsync());
                 await comp.InvokeAsync(() => datepicker.CloseAsync());
             }
 
-            watch.Stop();
-            watch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
         }
 
         [Test]
@@ -326,8 +334,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.Date.Should().NotBeNull();
             eventCount.Should().Be(1);
-            var now = DateTime.Now;
-            returnDate.Should().Be(new DateTime(now.Year, now.Month, 23));
+            var today = GetToday();
+            returnDate.Should().Be(new DateTime(today.Year, today.Month, 23));
         }
 
         [Test]
@@ -410,7 +418,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             await comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[2].ClickAsync();
             await comp.SelectDateAsync("2");
-            comp.Instance.Date?.Date.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
+            var today = GetToday();
+            comp.Instance.Date?.Date.Should().Be(new DateTime(today.Year, 3, 2));
         }
 
         [Test]
@@ -422,7 +431,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1);
             await comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-month-container > button.mud-picker-month")[3].ClickAsync();
             await comp.SelectDateAsync("23");
-            comp.Instance.Date?.Date.Should().Be(new DateTime(DateTime.Now.Year, 4, 23));
+            var today = GetToday();
+            comp.Instance.Date?.Date.Should().Be(new DateTime(today.Year, 4, 23));
         }
 
         [Test]
@@ -434,7 +444,7 @@ namespace MudBlazor.UnitTests.Components
             picker.Markup.Should().Contain("mud-selected"); //confirm selected date is shown
 
             // Calculate expected date before selection
-            var date = DateTime.Today.Subtract(TimeSpan.FromDays(60));
+            var date = GetToday().Subtract(TimeSpan.FromDays(60));
             var expectedDate = new DateTime(date.Year, date.Month, 23);
 
             // Select the date
@@ -483,7 +493,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             await comp.Find("div.mud-picker-calendar-header-switch > button:nth-child(1)").ClickAsync();
             picker.PickerMonth?.Month.Should().Be(11);
-            picker.PickerMonth?.Year.Should().Be(DateTime.Now.Year);
+            picker.PickerMonth?.Year.Should().Be(GetToday().Year);
         }
 
         [Test]
@@ -493,7 +503,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             await comp.Find("div.mud-picker-calendar-header-switch > button:nth-child(3)").ClickAsync();
             picker.PickerMonth?.Month.Should().Be(1);
-            picker.PickerMonth?.Year.Should().Be(DateTime.Now.Year + 1);
+            picker.PickerMonth?.Year.Should().Be(GetToday().Year + 1);
         }
 
         [Test]
@@ -692,7 +702,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SetPickerValue_CheckText()
         {
-            var date = DateTime.Now;
+            var date = GetToday();
             var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(x => x.Date, date));
             // select elements needed for the test
@@ -803,8 +813,8 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(10, 11, 2, 1)]
         public async Task MinDateEffectOnDisablingMonthsIfDayFixed(int minDatesDay, int fixedDay, int month, int disabledOnes)
         {
-            var currentDate = DateTime.Now;
-            var minDate = new DateTime(currentDate.Year, month, minDatesDay);
+            var currentYear = GetToday().Year;
+            var minDate = new DateTime(currentYear, month, minDatesDay);
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.MinDate, minDate)
                 .Add(x => x.OpenTo, OpenTo.Month)
@@ -825,8 +835,8 @@ namespace MudBlazor.UnitTests.Components
         public async Task MaxDateEffectOnDisablingMonthsIfDayFixed(int maxDatesDay, int fixedDay,
             int month, int disabledOnes)
         {
-            var currentDate = DateTime.Now;
-            var maxDate = new DateTime(currentDate.Year, month, maxDatesDay);
+            var currentYear = GetToday().Year;
+            var maxDate = new DateTime(currentYear, month, maxDatesDay);
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.MaxDate, maxDate)
                 .Add(x => x.OpenTo, OpenTo.Month)
@@ -846,7 +856,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(2, 4, 3)]
         public async Task MinDateEffectOnDisablingMonthsIfDayNotFixed(int minDatesDay, int month, int disabledOnes)
         {
-            var currentYear = DateTime.Now.Year;
+            var currentYear = GetToday().Year;
             var minDate = new DateTime(currentYear, month, minDatesDay);
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.MinDate, minDate)
@@ -866,7 +876,7 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(29, 9, 3)]
         public async Task MaxDateEffectOnDisablingMonthsIfDayNotFixed(int maxDatesDay, int month, int disabledOnes)
         {
-            var currentYear = DateTime.Now.Year;
+            var currentYear = GetToday().Year;
             var maxDate = new DateTime(currentYear, month, maxDatesDay);
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.MaxDate, maxDate)
@@ -889,7 +899,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
                 .Add(x => x.DateChanged, (DateTime? _) => wasEventCallbackCalled = true));
 
-            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.Date, DateTime.Now));
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.Date, GetToday()));
 
             comp.Instance.Date.Should().BeNull();
             wasEventCallbackCalled.Should().BeFalse();
@@ -899,7 +909,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task IsDateDisabledFunc_SettingDateToAnEnabledDateYieldsTheDate()
         {
             var wasEventCallbackCalled = false;
-            var today = DateTime.Today;
+            var today = GetToday();
             Func<DateTime, bool> isDisabledFunc = date => date < today;
             var comp = Context.Render<MudDatePicker>(parameters => parameters
                 .Add(x => x.IsDateDisabledFunc, isDisabledFunc)
@@ -950,7 +960,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CheckAutoCloseDatePickerTest()
         {
             // Define a date for comparison
-            var now = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
+            var now = GetToday();
 
             // Get access to the datepicker of the instance
             var comp = Context.Render<AutoCompleteDatePickerTest>();
@@ -1023,7 +1033,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task CheckReadOnly()
         {
             // Define a date for comparison
-            var now = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day);
+            var now = GetToday();
 
             // Get access to the datepicker of the instance
             var comp = Context.Render<SimpleMudDatePickerTest>();
@@ -1452,8 +1462,8 @@ namespace MudBlazor.UnitTests.Components
             var datePicker = datePickerComponent.Instance;
 
             await datePickerComponent.SetParametersAndRenderAsync(parameters => parameters
-                .Add(parameter => parameter.MinDate, DateTime.Now.AddDays(-1))
-                .Add(parameter => parameter.MaxDate, DateTime.Now.AddDays(1)));
+                .Add(parameter => parameter.MinDate, GetToday().AddDays(-1))
+                .Add(parameter => parameter.MaxDate, GetToday().AddDays(1)));
 
             // Open the datepicker
             await comp.InvokeAsync(datePicker.OpenAsync);
@@ -1544,7 +1554,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MudDatePicker>();
             var picker = comp.Instance;
-            var oldDate = DateTime.Now;
+            var oldDate = GetToday();
             var newDate = oldDate.AddDays(1);
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Date, oldDate));
 
@@ -1818,7 +1828,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_FixYear_Future()
         {
-            var futureYear = DateTime.Now.Year + 1;
+            var futureYear = GetToday().Year + 1;
             var component = Context.Render<DatePickerFixYearTest>(p => p.Add(x => x.FixYear, futureYear));
             var datePickerComponent = component.FindComponent<MudDatePicker>();
 
@@ -2005,8 +2015,9 @@ namespace MudBlazor.UnitTests.Components
 
         private async Task<IRenderedComponent<SimpleMudDatePickerTest>> OpenTo12ThMonth()
         {
+            var currentYear = GetToday().Year;
             var comp = await OpenPicker(parameters => parameters
-                .Add(x => x.PickerMonth, new DateTime(DateTime.Now.Year, 12, 01)));
+                .Add(x => x.PickerMonth, new DateTime(currentYear, 12, 1)));
             comp.Instance.PickerMonth?.Month.Should().Be(12);
             return comp;
         }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -7,6 +7,7 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using MudBlazor.Utilities;
@@ -29,7 +30,9 @@ namespace MudBlazor.UnitTests.Components
             picker.MinDate.Should().Be(null);
             picker.OpenTo.Should().Be(OpenTo.Date);
             picker.FirstDayOfWeek.Should().Be(null);
-            picker.ClosingDelay.Should().Be(100);
+            picker.ClosingDelay.Should().BeNull();
+            Context.Services.GetRequiredService<IPopoverService>()
+                .PopoverOptions.DatePickerClosingDelay.Should().Be(TimeSpan.FromMilliseconds(100));
             picker.DisplayMonths.Should().Be(2);
             picker.MaxMonthColumns.Should().Be(null);
             picker.StartMonth.Should().Be(null);

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Globalization;
+﻿using System.Globalization;
 using AngleSharp.Css.Dom;
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
@@ -8,6 +7,7 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using MudBlazor.Utilities;
@@ -18,6 +18,18 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class DateRangePickerTests : BunitTest
     {
+        private static readonly DateTime DefaultUtcNow = new DateTime(2024, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        [SetUp]
+        public void SetupTimeProvider()
+        {
+            var timeProvider = new FakeTimeProvider();
+            timeProvider.SetUtcNow(DefaultUtcNow);
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+        }
+
+        private DateTime GetToday() => Context.Services.GetRequiredService<TimeProvider>().GetLocalNow().LocalDateTime.Date;
+
         [Test]
         public void Default()
         {
@@ -162,7 +174,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OpenPickerWithCustomStartMonth_SetDateRange_CheckValue()
         {
-            var start = DateTime.Now.AddMonths(-1);
+            var start = GetToday().AddMonths(-1);
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.StartMonth, start));
             // clicking a day buttons to select a range and close
@@ -229,8 +241,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SelectDateAsync("8");
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0), TimeSpan.FromSeconds(5));
             comp.Instance.DateRange.Should().NotBeNull();
-            comp.Instance.DateRange.Start.Should().Be(new DateTime(DateTime.Now.Year, DateTime.Now.Month, 8));
-            comp.Instance.DateRange.End.Should().Be(new DateTime(DateTime.Now.Year, DateTime.Now.Month, 10));
+            var today = GetToday();
+            comp.Instance.DateRange.Start.Should().Be(new DateTime(today.Year, today.Month, 8));
+            comp.Instance.DateRange.End.Should().Be(new DateTime(today.Year, today.Month, 10));
         }
 
         [Test]
@@ -316,13 +329,15 @@ namespace MudBlazor.UnitTests.Components
                 .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("2")).ClickAsync();
             await comp
                 .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).ClickAsync();
-            comp.Instance.DateRange.Start.Should().Be(new DateTime(DateTime.Now.Year, 3, 2));
+            var today = GetToday();
+            comp.Instance.DateRange.Start.Should().Be(new DateTime(today.Year, 3, 2));
         }
 
         public async Task<IRenderedComponent<SimpleMudMudDateRangePickerTest>> OpenTo12thMonth()
         {
+            var currentYear = GetToday().Year;
             var comp = await OpenPicker(parameters => parameters
-                .Add(x => x.PickerMonth, new DateTime(DateTime.Now.Year, 12, 01)));
+                .Add(x => x.PickerMonth, new DateTime(currentYear, 12, 1)));
             comp.Instance.PickerMonth.Value.Month.Should().Be(12);
             return comp;
         }
@@ -341,7 +356,8 @@ namespace MudBlazor.UnitTests.Components
                 .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).ClickAsync();
             await comp
                 .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("12")).ClickAsync();
-            comp.Instance.DateRange.End.Should().Be(new DateTime(DateTime.Now.Year, 4, 12));
+            var today = GetToday();
+            comp.Instance.DateRange.End.Should().Be(new DateTime(today.Year, 4, 12));
         }
 
         [Test]
@@ -351,7 +367,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             await comp.Find("div.mud-picker-calendar-header-switch > button:nth-child(1)").ClickAsync();
             picker.PickerMonth.Value.Month.Should().Be(11);
-            picker.PickerMonth.Value.Year.Should().Be(DateTime.Now.Year);
+            picker.PickerMonth.Value.Year.Should().Be(GetToday().Year);
         }
 
         [Test]
@@ -361,7 +377,7 @@ namespace MudBlazor.UnitTests.Components
             var picker = comp.Instance;
             await comp.Find("div.mud-picker-calendar-header-switch > button:nth-child(3)").ClickAsync();
             picker.PickerMonth.Value.Month.Should().Be(1);
-            picker.PickerMonth.Value.Year.Should().Be(DateTime.Now.Year + 1);
+            picker.PickerMonth.Value.Year.Should().Be(GetToday().Year + 1);
         }
 
         [Test]
@@ -399,7 +415,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void SetPickerValue_CheckText()
         {
-            var date = DateTime.Now;
+            var date = GetToday();
             var comp = Context.Render<MudDateRangePicker>(parameters => parameters
                 .Add(x => x.DateRange, new DateRange(date, date.AddDays(5))));
             // select elements needed for the test
@@ -417,7 +433,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SetPickerToday_CheckSelected()
         {
-            var today = DateTime.Now.Date;
+            var today = GetToday();
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.DateRange, new DateRange(today, today)));
             comp.FindAll("button.mud-selected").Count.Should().Be(1);
@@ -438,9 +454,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task IsDateDisabledFunc_SettingRangeToIncludeADisabledDateYieldsNull()
         {
-            var today = DateTime.Today;
-            var yesterday = DateTime.Today.Subtract(TimeSpan.FromDays(1));
-            var twoDaysAgo = DateTime.Today.Subtract(TimeSpan.FromDays(2));
+            var today = GetToday();
+            var yesterday = today.AddDays(-1);
+            var twoDaysAgo = today.AddDays(-2);
             var wasEventCallbackCalled = false;
 
             Func<DateTime, bool> isDisabledFunc = date => date == yesterday;
@@ -457,9 +473,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task IsDateDisabledFunc_SettingRangeToExcludeADisabledDateYieldsTheRange()
         {
-            var today = DateTime.Today;
-            var yesterday = DateTime.Today.Subtract(TimeSpan.FromDays(1));
-            var twoDaysAgo = DateTime.Today.Subtract(TimeSpan.FromDays(2));
+            var today = GetToday();
+            var yesterday = today.AddDays(-1);
+            var twoDaysAgo = today.AddDays(-2);
             var wasEventCallbackCalled = false;
 
             Func<DateTime, bool> isDisabledFunc = date => date == twoDaysAgo;
@@ -576,8 +592,8 @@ namespace MudBlazor.UnitTests.Components
         {
             // define some "constant" values
             var errorMessage = "A valid date has to be picked";
-            var startDate = DateTime.Now.Date;
-            var endDate = DateTime.Now.Date.AddDays(2);
+            var startDate = GetToday();
+            var endDate = GetToday().AddDays(2);
 
             // create the component
             var dateRangePickerComponent = Context.Render<MudDateRangePicker>(parameters => parameters
@@ -625,9 +641,10 @@ namespace MudBlazor.UnitTests.Components
         public async Task CheckAutoCloseDateRangePicker_DoNotCloseWhenValueIsOff()
         {
             // Define a date range for comparison
+            var today = GetToday();
             var initialDateRange = new DateRange(
-               new DateTime(DateTime.Now.Year, DateTime.Now.Month, 01),
-                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
+               new DateTime(today.Year, today.Month, 1),
+                new DateTime(today.Year, today.Month, 2));
 
             // Get access to the date range picker of the instance
             var comp = Context.Render<AutoCloseDateRangePickerTest>(parameters => parameters
@@ -651,9 +668,10 @@ namespace MudBlazor.UnitTests.Components
         public async Task CheckAutoCloseDateRangePicker_CloseWhenValueIsOn()
         {
             // Define a date range for comparison
+            var today = GetToday();
             var initialDateRange = new DateRange(
-                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 01),
-                  new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
+                new DateTime(today.Year, today.Month, 1),
+                  new DateTime(today.Year, today.Month, 2));
 
             // Get access to the date range picker of the instance
             var comp = Context.Render<AutoCloseDateRangePickerTest>(parameters => parameters
@@ -674,15 +692,15 @@ namespace MudBlazor.UnitTests.Components
             // Check that the date range is changed because autoclose is true even when actions are defined
             comp.Instance.DateRange.Should().NotBe(initialDateRange);
             comp.Instance.DateRange.Should().Be(new DateRange(
-                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 10),
-                  new DateTime(DateTime.Now.Year, DateTime.Now.Month, 11)));
+                new DateTime(today.Year, today.Month, 10),
+                  new DateTime(today.Year, today.Month, 11)));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
         }
 
         [Test]
         public async Task CurrentDate_ShouldBeMarked()
         {
-            var currentDate = DateTime.Now.Date;
+            var currentDate = GetToday();
             var comp = await OpenPicker();
 
             // Check that only one date is marked
@@ -697,8 +715,8 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task SingleDayRange_Should_Render_Selected()
         {
-            var today = DateTime.Today;
-            var initialRange = new DateRange(new DateTime(today.Year, today.Month, 01), new DateTime(today.Year, today.Month, 05));
+            var today = GetToday();
+            var initialRange = new DateRange(new DateTime(today.Year, today.Month, 1), new DateTime(today.Year, today.Month, 5));
 
             var comp = Context.Render<AutoCloseDateRangePickerTest>(parameters => parameters
                 .Add(x => x.DateRange, initialRange));
@@ -857,9 +875,10 @@ namespace MudBlazor.UnitTests.Components
         public async Task CheckCloseOnClearDateRangePicker(bool closeOnClear)
         {
             // Define a date range for comparison
+            var today = GetToday();
             var initialDateRange = new DateRange(
-                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 01),
-                new DateTime(DateTime.Now.Year, DateTime.Now.Month, 02));
+                new DateTime(today.Year, today.Month, 1),
+                new DateTime(today.Year, today.Month, 2));
 
             // Get access to the date range picker of the instance
             var comp = Context.Render<DateRangePickerCloseOnClearTest>(parameters => parameters
@@ -902,9 +921,9 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task StrictCaptureRange_ShouldCaptureDisabledDates_WhenFalse()
         {
-            var today = DateTime.Today;
-            var yesterday = DateTime.Today.Subtract(TimeSpan.FromDays(1));
-            var twoDaysAgo = DateTime.Today.Subtract(TimeSpan.FromDays(2));
+            var today = GetToday();
+            var yesterday = today.AddDays(-1);
+            var twoDaysAgo = today.AddDays(-2);
             var wasEventCallbackCalled = false;
 
             var range = new DateRange(twoDaysAgo, today);
@@ -1177,11 +1196,10 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MudDateRangePicker>();
 
+            var today = GetToday();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.MaxDays, 30)
                                                                 .Add(picker => picker.PickerVariant, PickerVariant.Static)
-                                                                .Add(picker => picker.IsDateDisabledFunc, x => x.Date > DateTime.Today));
-
-            var today = DateTime.Today;
+                                                                .Add(picker => picker.IsDateDisabledFunc, x => x.Date > today));
 
             await comp
                 .FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals(today.Day.ToString())).ClickAsync(new MouseEventArgs());

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -530,6 +530,8 @@ public class ServiceCollectionExtensionsTests
             options.PopoverOptions.OverflowBehavior = OverflowBehavior.FlipNever;
             options.PopoverOptions.Delay = TimeSpan.FromSeconds(1);
             options.PopoverOptions.Duration = TimeSpan.FromSeconds(2);
+            options.PopoverOptions.DatePickerClosingDelay = TimeSpan.FromMilliseconds(150);
+            options.PopoverOptions.TimePickerClosingDelay = TimeSpan.FromMilliseconds(250);
 
             expectedOptions = options;
         });
@@ -598,6 +600,8 @@ public class ServiceCollectionExtensionsTests
         actualPopoverOptions.OverflowBehavior.Should().Be(expectedOptions.PopoverOptions.OverflowBehavior);
         actualPopoverOptions.Delay.Should().Be(expectedOptions.PopoverOptions.Delay);
         actualPopoverOptions.Duration.Should().Be(expectedOptions.PopoverOptions.Duration);
+        actualPopoverOptions.DatePickerClosingDelay.Should().Be(expectedOptions.PopoverOptions.DatePickerClosingDelay);
+        actualPopoverOptions.TimePickerClosingDelay.Should().Be(expectedOptions.PopoverOptions.TimePickerClosingDelay);
 
         actualResizeObserverOptions.EnableLogging.Should().Be(expectedOptions.ResizeObserverOptions.EnableLogging);
         actualResizeObserverOptions.ReportRate.Should().Be(expectedOptions.ResizeObserverOptions.ReportRate);

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor
@@ -45,7 +45,7 @@
                         }
                         else if (tempMonth == 0 && CurrentView == OpenTo.Month)
                         {
-                            var calendarYear = GetCalendarYear(PickerMonth ?? DateTime.Today);
+                            var calendarYear = GetCalendarYear(PickerMonth ?? GetToday());
 
                             <div class="mud-picker-calendar-header">
                                 <div class="mud-picker-calendar-header-switch">

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -137,7 +137,7 @@ namespace MudBlazor
 
         protected int GetClosingDelay() => ClosingDelay ?? (int)PopoverOptions.DatePickerClosingDelay.TotalMilliseconds;
 
-        protected DateTime GetToday() => TimeProvider.GetLocalNow().Date;
+        protected DateTime GetToday() => TimeProvider.GetLocalNow().LocalDateTime.Date;
 
         /// <summary>
         /// The number of months to display in the calendar.
@@ -763,7 +763,7 @@ namespace MudBlazor
 
             var culture = GetCulture();
             var calendar = culture.Calendar;
-            var today = TimeProvider.GetLocalNow().Date;
+            var today = GetToday();
 
             var year = FixYear ?? calendar.GetYear(today);
             var month = FixMonth ?? (year == calendar.GetYear(today) ? calendar.GetMonth(today) : 1);

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -128,12 +128,16 @@ namespace MudBlazor
         /// The delay, in milliseconds, before closing the picker after a value is selected.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>100</c>.<br />
+        /// Defaults to <see cref="PopoverOptions.DatePickerClosingDelay"/>.<br />
         /// This delay helps the user see that a date has been selected before the popover disappears.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
-        public int ClosingDelay { get; set; } = 100;
+        public int? ClosingDelay { get; set; }
+
+        protected int GetClosingDelay() => ClosingDelay ?? (int)PopoverOptions.DatePickerClosingDelay.TotalMilliseconds;
+
+        protected DateTime GetToday() => TimeProvider.GetLocalNow().Date;
 
         /// <summary>
         /// The number of months to display in the calendar.
@@ -307,7 +311,7 @@ namespace MudBlazor
                 return calendar.MinSupportedDateTime;
             }
 
-            var baseDate = _picker_month ?? DateTime.Today.StartOfMonth(culture);
+            var baseDate = _picker_month ?? GetToday().StartOfMonth(culture);
 
             var year = FixYear ?? calendar.GetYear(baseDate);
             var startMonth = FixMonth ?? calendar.GetMonth(baseDate);
@@ -334,7 +338,7 @@ namespace MudBlazor
         {
             var culture = GetCulture();
             var calendar = culture.Calendar;
-            var monthStartDate = _picker_month ?? DateTime.Today.StartOfMonth(culture);
+            var monthStartDate = _picker_month ?? GetToday().StartOfMonth(culture);
             return calendar.AddMonths(monthStartDate, month).EndOfMonth(culture);
         }
 
@@ -427,7 +431,7 @@ namespace MudBlazor
 
                 if (PickerVariant != PickerVariant.Static)
                 {
-                    await Task.Delay(ClosingDelay);
+                    await Task.Delay(GetClosingDelay());
                     await CloseAsync(false);
                 }
             }
@@ -646,7 +650,7 @@ namespace MudBlazor
             var calendar = culture.Calendar;
             if (MinDate.HasValue)
                 return calendar.GetYear(MinDate.Value);
-            return calendar.GetYear(DateTime.Today) - 100;
+            return calendar.GetYear(GetToday()) - 100;
         }
 
         protected int GetMaxYear()
@@ -655,7 +659,7 @@ namespace MudBlazor
             var calendar = culture.Calendar;
             if (MaxDate.HasValue)
                 return calendar.GetYear(MaxDate.Value);
-            return calendar.GetYear(DateTime.Today) + 100;
+            return calendar.GetYear(GetToday()) + 100;
         }
 
         private string? GetYearClasses(int year)

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
             set => SetDateAsync(value, true).CatchAndLog();
         }
 
-        private DateTime _lastSetTime = DateTime.MinValue;
+        private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
         private const int DebounceTimeoutMs = 100;
 
         protected async Task SetDateAsync(DateTime? date, bool updateValue)
@@ -41,7 +41,7 @@ namespace MudBlazor
                 date = DateTime.SpecifyKind(date.Value, _value.Value.Kind);
             }
 
-            var now = DateTime.UtcNow;
+            var now = TimeProvider.GetUtcNow();
 
             /* See #7866 for more details
              * When the date is set in the UI, this method gets called with the same value multiple time. This guard
@@ -128,7 +128,7 @@ namespace MudBlazor
 
                 if (PickerVariant != PickerVariant.Static)
                 {
-                    await Task.Delay(ClosingDelay);
+                    await Task.Delay(GetClosingDelay());
                     await CloseAsync(false);
                 }
             }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -110,7 +110,7 @@ namespace MudBlazor
                 return b.AddClass("mud-hidden").Build();
             if ((Date?.Date == day && _selectedDate == null) || _selectedDate?.Date == day)
                 return b.AddClass("mud-selected").AddClass($"mud-theme-{Color.ToStringFast(true)}").Build();
-            if (day == TimeProvider.GetLocalNow().Date)
+            if (day == TimeProvider.GetLocalNow().LocalDateTime.Date)
                 return b.AddClass("mud-current mud-button-outlined")
                         .AddClass(
                             $"mud-button-outlined-{Color.ToStringFast(true)} mud-{Color.ToStringFast(true)}-text")
@@ -261,7 +261,7 @@ namespace MudBlazor
 
         protected override DateTime GetCalendarStartOfMonth()
         {
-            var date = StartMonth ?? Date ?? HighlightedDate ?? TimeProvider.GetLocalNow().Date;
+            var date = StartMonth ?? Date ?? HighlightedDate ?? GetToday();
             return date.StartOfMonth(GetCulture());
         }
 
@@ -272,7 +272,7 @@ namespace MudBlazor
                 return FixYear.Value;
             }
 
-            var date = Date ?? TimeProvider.GetLocalNow().Date;
+            var date = Date ?? GetToday();
             var diff = GetCulture().Calendar.GetYear(date) - GetCulture().Calendar.GetYear(yearDate);
             var calenderYear = GetCulture().Calendar.GetYear(date);
             return calenderYear - diff;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -366,12 +366,13 @@ namespace MudBlazor
             static bool isEqualTo(DateTime date1, DateTime date2) => date1 == date2;
             static bool isNotEqualTo(DateTime date1, DateTime date2) => date1 != date2;
 
+            var today = GetToday();
             if ((_firstDate?.Date < day && _secondDate?.Date > day) || CheckDateRange(day, compareStart: isLessThan, compareEnd: isGreaterThan))
             {
                 return b
                     .AddClass("mud-range")
                     .AddClass("mud-range-between")
-                    .AddClass($"mud-current mud-{Color.ToStringFast(true)}-text mud-button-outlined mud-button-outlined-{Color.ToStringFast(true)}", day == DateTime.Today)
+                    .AddClass($"mud-current mud-{Color.ToStringFast(true)}-text mud-button-outlined mud-button-outlined-{Color.ToStringFast(true)}", day == today)
                     .Build();
             }
 
@@ -408,14 +409,14 @@ namespace MudBlazor
 
             if (_firstDate?.Date < day)
             {
-                return b.AddClass("mud-range", _secondDate is null && day != DateTime.Today)
+                return b.AddClass("mud-range", _secondDate is null && day != today)
                     .AddClass("mud-range-selection")
                     .AddClass($"mud-range-selection-{Color.ToStringFast(true)}", _firstDate is not null)
-                    .AddClass($"mud-current mud-{Color.ToStringFast(true)}-text mud-button-outlined mud-button-outlined-{Color.ToStringFast(true)}", day == DateTime.Today)
+                    .AddClass($"mud-current mud-{Color.ToStringFast(true)}-text mud-button-outlined mud-button-outlined-{Color.ToStringFast(true)}", day == today)
                     .Build();
             }
 
-            if (day == DateTime.Today)
+            if (day == today)
             {
                 return b.AddClass("mud-current")
                     .AddClass($"mud-button-outlined mud-button-outlined-{Color.ToStringFast(true)}")
@@ -452,7 +453,7 @@ namespace MudBlazor
 
                 if (PickerVariant != PickerVariant.Static)
                 {
-                    await Task.Delay(ClosingDelay);
+                    await Task.Delay(GetClosingDelay());
                     await CloseAsync(false);
                 }
             }
@@ -498,13 +499,13 @@ namespace MudBlazor
 
         protected override DateTime GetCalendarStartOfMonth()
         {
-            var date = StartMonth ?? DateRange?.Start ?? DateTime.Today;
+            var date = StartMonth ?? DateRange?.Start ?? GetToday();
             return date.StartOfMonth(GetCulture());
         }
 
         protected override int GetCalendarYear(DateTime yearDate)
         {
-            var date = DateRange?.Start ?? DateTime.Today;
+            var date = DateRange?.Start ?? GetToday();
             var diff = GetCulture().Calendar.GetYear(date) - GetCulture().Calendar.GetYear(yearDate);
             var calenderYear = GetCulture().Calendar.GetYear(date);
             return calenderYear - diff;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -30,6 +30,8 @@ namespace MudBlazor
         [Inject]
         private IPopoverService PopoverService { get; set; } = null!;
 
+        protected PopoverOptions PopoverOptions => PopoverService.PopoverOptions;
+
         protected string PickerClassname =>
             new CssBuilder("mud-picker")
                 .AddClass("mud-picker-inline", PickerVariant != PickerVariant.Static)

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -64,11 +64,11 @@ namespace MudBlazor
         /// The amount of time, in milliseconds, to wait before closing the picker.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>200</c>. The delay gives users a moment to see the selected time before the popover disappears.
+        /// Defaults to <see cref="PopoverOptions.TimePickerClosingDelay"/>. The delay gives users a moment to see the selected time before the popover disappears.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.PickerBehavior)]
-        public int ClosingDelay { get; set; } = 200;
+        public int? ClosingDelay { get; set; }
 
         /// <summary>
         /// Closes this picker when the value is set or cleared.
@@ -629,11 +629,13 @@ namespace MudBlazor
 
                 if (PickerVariant != PickerVariant.Static)
                 {
-                    await Task.Delay(ClosingDelay);
+                    await Task.Delay(GetClosingDelay());
                     await CloseAsync(false);
                 }
             }
         }
+
+        private int GetClosingDelay() => ClosingDelay ?? (int)PopoverOptions.TimePickerClosingDelay.TotalMilliseconds;
 
         protected internal override async Task OnHandleKeyDownAsync(KeyboardEventArgs obj)
         {

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -415,6 +415,8 @@ namespace MudBlazor.Services
                     popoverOptions.OverflowBehavior = options.PopoverOptions.OverflowBehavior;
                     popoverOptions.Delay = options.PopoverOptions.Delay;
                     popoverOptions.Duration = options.PopoverOptions.Duration;
+                    popoverOptions.DatePickerClosingDelay = options.PopoverOptions.DatePickerClosingDelay;
+                    popoverOptions.TimePickerClosingDelay = options.PopoverOptions.TimePickerClosingDelay;
                 })
                 .AddMudBlazorScrollSpy()
                 .AddMudEventManager()

--- a/src/MudBlazor/Services/Popover/PopoverOptions.cs
+++ b/src/MudBlazor/Services/Popover/PopoverOptions.cs
@@ -23,6 +23,18 @@ public class PopoverOptions
     public TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
 
     /// <summary>
+    /// Gets or sets the delay before closing a date picker after selection.
+    /// The default value is <c>100 milliseconds</c>.
+    /// </summary>
+    public TimeSpan DatePickerClosingDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets or sets the delay before closing a time picker after selection.
+    /// The default value is <c>200 milliseconds</c>.
+    /// </summary>
+    public TimeSpan TimePickerClosingDelay { get; set; } = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
     /// Gets or sets a value indicating whether to check for the presence of a popover provider <see cref="MudPopoverProvider"/>.
     /// The default value is <c>true</c>.
     /// </summary>


### PR DESCRIPTION
Hooked date/time picker close delays up to PopoverOptions defaults so pickers resolve delay from the provider when ClosingDelay isn’t set, and updated tests/config copying to match.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
