### PR TITLE
Tests: Replace fixed delays with condition waits

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -132,11 +132,10 @@ namespace MudBlazor.UnitTests.Components
             var autocompleteContainerComp = comp.FindComponent<AutoCompleteContainer>();
             var autocompleteComp = autocompleteContainerComp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComp.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Text, "Alabama"));
-            await Task.Delay(500);
+            await comp.WaitForAssertionAsync(() => autocompleteComp.Instance.Text.Should().Be("Alabama"));
             comp.Instance.MustBeShown = false;
             comp.Render();
-            await Task.Delay(1000);
-            comp.Instance.HasBeenDisposed.Should().Be(true);
+            await comp.WaitForAssertionAsync(() => comp.Instance.HasBeenDisposed.Should().Be(true));
         }
 
         /// <summary>
@@ -1447,10 +1446,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Find("input").InputAsync("Foo");
 
-            await Task.Delay(20);
-
-            // Test
-
+            await comp.WaitForAssertionAsync(() => cancelToken.Should().NotBeNull());
             await comp.WaitForAssertionAsync(() => cancelToken?.IsCancellationRequested.Should().BeFalse());
 
             // Arrange second call
@@ -1463,10 +1459,6 @@ namespace MudBlazor.UnitTests.Components
             })));
 
             await comp.Find("input").InputAsync("Bar");
-
-            await Task.Delay(20);
-
-            // Test
 
             await comp.WaitForAssertionAsync(() => cancelToken?.IsCancellationRequested.Should().BeTrue());
 
@@ -1573,8 +1565,6 @@ namespace MudBlazor.UnitTests.Components
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SearchFunc, null));
 
             await comp.Find("input").InputAsync("Foo");
-
-            await Task.Delay(20);
 
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ToMarkup().Should().NotContain("Foo"));
         }

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -135,7 +135,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => autocompleteComp.Instance.Text.Should().Be("Alabama"));
             comp.Instance.MustBeShown = false;
             comp.Render();
-            await comp.WaitForAssertionAsync(() => comp.Instance.HasBeenDisposed.Should().Be(true));
+            await comp.WaitForAssertionAsync(
+                () => comp.Instance.HasBeenDisposed.Should().Be(true),
+                TimeSpan.FromSeconds(5));
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -927,24 +927,22 @@ namespace MudBlazor.UnitTests.Components
             openBtn.Count.Should().Be(1);
             var openBtnElement = openBtn[0].Find("button");
             await openBtnElement.TriggerEventAsync("onclick", new MouseEventArgs());
-            await Task.Delay(500);
             IElement DayButton(string dayNumber) =>
                 comp.FindAll("button")
                     .SingleOrDefault(x => x.GetStyle().GetPropertyValue("--day-id") == dayNumber);
+            await comp.WaitForAssertionAsync(() => DayButton("5").Should().NotBeNull());
             await DayButton("5").TriggerEventAsync("onclick", new MouseEventArgs());
-            await Task.Delay(200);
             await DayButton("7").TriggerEventAsync("onclick", new MouseEventArgs());
-            await Task.Delay(200);
 
             IReadOnlyList<IRenderedComponent<MudIconButton>> IconButtons(int index) =>
                 picker[index].FindComponents<MudIconButton>();
 
-            IconButtons(0).Count.Should().Be(2);
-            IconButtons(1).Count.Should().Be(2);
+            await comp.WaitForAssertionAsync(() => IconButtons(0).Count.Should().Be(2));
+            await comp.WaitForAssertionAsync(() => IconButtons(1).Count.Should().Be(2));
             await IconButtons(0)[0].Find("button").ClickAsync();
             await IconButtons(1)[0].Find("button").ClickAsync();
-            IconButtons(0).Count.Should().Be(1);
-            IconButtons(1).Count.Should().Be(1);
+            await comp.WaitForAssertionAsync(() => IconButtons(0).Count.Should().Be(1));
+            await comp.WaitForAssertionAsync(() => IconButtons(1).Count.Should().Be(1));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1340,7 +1340,9 @@ namespace MudBlazor.UnitTests.Components
             });
 
             // Wait for dialog to close and state reset
-            await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().NotContain("mud-dialog"));
+            await comp.WaitForAssertionAsync(
+                () => comp.Markup.Trim().Should().NotContain("mud-dialog"),
+                TimeSpan.FromSeconds(5));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1304,8 +1304,7 @@ namespace MudBlazor.UnitTests.Components
             var comp1 = Context.Render<InlineDialogDuplicateTest>();
             // open the dialog
             comp1.Find("button").Click();
-            await Task.Delay(1000);
-            comp.FindComponents<MudDialog>().Count.Should().Be(1);
+            await comp.WaitForAssertionAsync(() => comp.FindComponents<MudDialog>().Count.Should().Be(1));
         }
 
         [Test]
@@ -1327,22 +1326,21 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponent<MudProgressLinear>().Instance.Value.Should().Be(0); // Initial progress value - 0
 
             // Wait for mid-progress (simulate that loop is progressing)
-            await Task.Delay(1000);
-            //comp.Render();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                dialog = comp.Find("div.mud-dialog");
+                dialog.TextContent.Should().Contain("Progress"); //change from "Initial state" to "Progress"
+            });
 
-            dialog = comp.Find("div.mud-dialog");
-            dialog.TextContent.Should().Contain("Progress"); //change from "Initial state" to "Progress"
-
-            var progressComponent = comp.FindComponent<MudProgressLinear>();
-            var progressValue = progressComponent.Instance.Value;
-            progressValue.Should().BeGreaterThan(0).And.BeLessThan(100);
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var progressComponent = comp.FindComponent<MudProgressLinear>();
+                var progressValue = progressComponent.Instance.Value;
+                progressValue.Should().BeGreaterThan(0).And.BeLessThan(100);
+            });
 
             // Wait for dialog to close and state reset
-            await Task.Delay(3000); // Ensure loop finishes
-            comp.Render();
-
-            // Assert the dialog is now hidden
-            comp.Markup.Trim().Should().NotContain("mud-dialog");
+            await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().NotContain("mud-dialog"));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -157,8 +157,7 @@ namespace MudBlazor.UnitTests.Components
             var addButton = comp.Find(".my-add-icon-class");
             await addButton.ClickAsync();
 
-            await Task.Delay(5);
-            comp.Instance.AddClickCounter.Should().Be(1);
+            await comp.WaitForAssertionAsync(() => comp.Instance.AddClickCounter.Should().Be(1));
         }
 
         [Test]
@@ -171,9 +170,7 @@ namespace MudBlazor.UnitTests.Components
                 var closeButton = comp.FindAll(".my-close-icon-class")[i];
                 await closeButton.ClickAsync();
 
-                await Task.Delay(5);
-
-                comp.Instance.CloseClicked.Should().HaveCount(i + 1);
+                await comp.WaitForAssertionAsync(() => comp.Instance.CloseClicked.Should().HaveCount(i + 1));
             }
         }
     }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1190,9 +1190,11 @@ namespace MudBlazor.UnitTests.Components
         public async Task TablePaginationTest1()
         {
             var comp = Context.Render<TablePaginationTest1>();
-            await Task.Delay(200);
-            comp.FindAll("tr.mud-table-row").Count.Should().Be(11); // ten rows + header row
-            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.FindAll("tr.mud-table-row").Count.Should().Be(11); // ten rows + header row
+                comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 20");
+            });
         }
 
         /// <summary>
@@ -1461,11 +1463,7 @@ namespace MudBlazor.UnitTests.Components
                 return first.Task;
             })));
 
-            await Task.Delay(20);
-
-            // Test
-
-            // Make sure this first request was not canceled
+            await comp.WaitForAssertionAsync(() => cancelToken.Should().NotBeNull());
             await comp.WaitForAssertionAsync(() => cancelToken?.IsCancellationRequested.Should().BeFalse());
 
             // Arrange a table refresh
@@ -1477,11 +1475,6 @@ namespace MudBlazor.UnitTests.Components
                 return second.Task;
             })));
 
-            await Task.Delay(20);
-
-            // Test
-
-            // Make sure this second request DID cancel the first request's token
             await comp.WaitForAssertionAsync(() => cancelToken?.IsCancellationRequested.Should().BeTrue());
         }
 
@@ -3074,4 +3067,3 @@ namespace MudBlazor.UnitTests.Components
 
     }
 }
-

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1463,7 +1463,9 @@ namespace MudBlazor.UnitTests.Components
                 return first.Task;
             })));
 
-            await comp.WaitForAssertionAsync(() => cancelToken.Should().NotBeNull());
+            await comp.WaitForAssertionAsync(
+                () => cancelToken.Should().NotBeNull(),
+                TimeSpan.FromSeconds(5));
             await comp.WaitForAssertionAsync(() => cancelToken?.IsCancellationRequested.Should().BeFalse());
 
             // Arrange a table refresh


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Closes #12477

### Motivation
- Improve determinism and speed of bUnit tests by replacing fixed `Task.Delay` sleeps with condition-driven waits. 
- Avoid flaky timing-based assertions and adhere to the recommended bUnit patterns (`WaitForAssertionAsync`).
- Target several tests that relied on arbitrary sleeps to wait for UI updates or cancellation tokens.

### Description
- Replaced `Task.Delay(...)` calls with `comp.WaitForAssertionAsync(...)` assertions to wait for specific rendered conditions in `src/MudBlazor.UnitTests/Components/TableTests.cs`, `DialogTests.cs`, `DynamicTabsTests.cs`, `AutocompleteTests.cs`, and `DateRangePickerTests.cs`.
- Added an explicit `cancelToken` non-null assertion before checking `IsCancellationRequested` in `TableTests.cs`/`AutocompleteTests.cs` to ensure the token was observed before further assertions.
- Consolidated multiple sleep-based waits for progress/dialog lifecycle and disposal into `WaitForAssertionAsync` blocks that assert the expected DOM or component state.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
