### PR TITLE
MudTextField: Add async postfixes

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1559,7 +1559,6 @@ namespace MudBlazor.UnitTests.Components
         public async Task FieldChangedEventShouldTrigger()
         {
             var comp = Context.Render<FormFieldChangedTest>();
-            var formsComp = comp.FindComponents<MudForm>();
 
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var numeric = comp.FindComponent<MudNumericField<int>>().Instance;
@@ -1569,8 +1568,8 @@ namespace MudBlazor.UnitTests.Components
 
             //in all below cases, the event args should switch to an instance of the field changed and contain the new value that was set
 
-            await comp.InvokeAsync(() => textField.SetText("new value"));
-            comp.Instance.FormFieldChangedEventArgs.NewValue.Should().Be("new value");
+            await comp.InvokeAsync(() => textField.SetTextAsync("new value"));
+            comp.Instance.FormFieldChangedEventArgs!.NewValue.Should().Be("new value");
             textField.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);
 
             numeric.Value.Should().Be(0);

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -728,11 +728,11 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await textField.FocusAsync());
             await comp.InvokeAsync(async () => await textField.SelectAsync());
             await comp.InvokeAsync(async () => await textField.SelectRangeAsync(0, 1));
-            await comp.InvokeAsync(() => textField.Clear());
+            await comp.InvokeAsync(() => textField.ClearAsync());
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(null));
 
             //This gives error
-            await comp.InvokeAsync(() => textField.SetText("123"));
+            await comp.InvokeAsync(() => textField.SetTextAsync("123"));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("(123) "));
 
             //ctrl+backspace

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -602,7 +602,7 @@ namespace MudBlazor.UnitTests.Components
             var textfield = comp.Instance;
             textfield.ReadValue.Should().Be(17);
             textfield.ReadText.Should().Be("17");
-            await comp.InvokeAsync(async () => await textfield.Clear());
+            await comp.InvokeAsync(async () => await textfield.ClearAsync());
             textfield.ReadValue.Should().Be(0);
             textfield.ReadText.Should().Be(null);
         }
@@ -615,7 +615,7 @@ namespace MudBlazor.UnitTests.Components
             var textfield = comp.Instance;
             textfield.ReadValue.Should().Be("Viva la ignorancia");
             textfield.ReadText.Should().Be("Viva la ignorancia");
-            await comp.InvokeAsync(async () => await textfield.Clear());
+            await comp.InvokeAsync(async () => await textfield.ClearAsync());
             textfield.ReadValue.Should().Be(null);
             textfield.ReadText.Should().Be(null);
         }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -771,7 +771,7 @@ namespace MudBlazor
 
         protected internal string? ReadText => _textState.Value;
 
-        protected Task SetTextAsync(string? text) => _textState.SetValueAsync(text);
+        public virtual Task SetTextAsync(string? text) => _textState.SetValueAsync(text);
 
         protected virtual async Task SetTextAndUpdateValueAsync(string? text, bool updateValue = true)
         {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -771,7 +771,7 @@ namespace MudBlazor
 
         protected internal string? ReadText => _textState.Value;
 
-        public virtual Task SetTextAsync(string? text) => _textState.SetValueAsync(text);
+        protected Task SetTextAsync(string? text) => _textState.SetValueAsync(text);
 
         protected virtual async Task SetTextAndUpdateValueAsync(string? text, bool updateValue = true)
         {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -453,7 +453,7 @@ namespace MudBlazor
                         {
                             await SubmitAsync();
                             await CloseAsync();
-                            _inputReference?.SetText(Text);
+                            _inputReference?.SetTextAsync(Text);
                         }
                     }
 
@@ -481,7 +481,7 @@ namespace MudBlazor
                     break;
                 default:
                     await SubmitAsync();
-                    _inputReference?.SetText(Text);
+                    _inputReference?.SetTextAsync(Text);
                     await CloseAsync();
                     break;
             }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -18,7 +18,7 @@
                      Margin="@Margin"
                      Required="@Required"
                      ForId="@InputElementId"
-                     @onclick="@HandleContainerClick">
+                     @onclick="@HandleContainerClickAsync">
         <InputContent>
             <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
                 @if (_mask == null)
@@ -82,7 +82,7 @@
                              Variant="@Variant"
                              Typo="Typo"
                              Value="@ReadText"
-                             ValueChanged="OnMaskedValueChanged"
+                             ValueChanged="OnMaskedValueChangedAsync"
                              Placeholder="@Placeholder"
                              Disabled=@GetDisabledState()
                              Underline="@Underline"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -12,14 +12,14 @@ namespace MudBlazor
     /// <typeparam name="T">The type of object managed by this input.</typeparam>
     public partial class MudTextField<T> : MudDebouncedInput<T>
     {
-        private IMask? _mask = null;
-        private MudMask? _maskReference = null;
+        private IMask? _mask;
+        private MudMask? _maskReference;
 
         protected string Classname =>
-           new CssBuilder("mud-input-input-control")
-               .AddClass($"mud-input-sizing-{Sizing.ToStringFast(true)}")
-               .AddClass(Class)
-               .Build();
+            new CssBuilder("mud-input-input-control")
+                .AddClass($"mud-input-sizing-{Sizing.ToStringFast(true)}")
+                .AddClass(Class)
+                .Build();
 
         /// <summary>
         /// The reference to the underlying <see cref="MudInput{T}"/> component.
@@ -44,7 +44,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public bool Clearable { get; set; } = false;
+        public bool Clearable { get; set; }
 
         /// <summary>
         /// The icon to display when <see cref="Clearable"/> is <c>true</c>.
@@ -166,7 +166,7 @@ namespace MudBlazor
         /// <summary>
         /// Clears the <see cref="MudBaseInput{T}.Text"/> and sets <see cref="MudBaseInput{T}.Value"/> to <c>default(T)</c>.
         /// </summary>
-        public Task Clear()
+        public Task ClearAsync()
         {
             if (!HasMask)
             {
@@ -180,7 +180,7 @@ namespace MudBlazor
         /// Sets the <see cref="MudBaseInput{T}.Text"/> to the specified value.
         /// </summary>
         /// <param name="text">The new text value to use.</param>
-        public async Task SetText(string? text)
+        public new async Task SetTextAsync(string? text)
         {
             if (!HasMask)
             {
@@ -225,7 +225,7 @@ namespace MudBlazor
             return Clearable && !GetDisabledState();
         }
 
-        private Task OnMaskedValueChanged(string s) => SetTextAndUpdateValueAsync(s);
+        private Task OnMaskedValueChangedAsync(string s) => SetTextAndUpdateValueAsync(s);
 
         private string GetCounterText() => Counter switch
         {
@@ -234,7 +234,7 @@ namespace MudBlazor
             _ => (string.IsNullOrEmpty(ReadText) ? "0" : $"{ReadText.Length}") + $" / {Counter}"
         };
 
-        protected async Task HandleContainerClick()
+        protected async Task HandleContainerClickAsync()
         {
             if (!_isFocused && IsJSRuntimeAvailable && InputReference != null)
             {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -180,7 +180,7 @@ namespace MudBlazor
         /// Sets the <see cref="MudBaseInput{T}.Text"/> to the specified value.
         /// </summary>
         /// <param name="text">The new text value to use.</param>
-        public override async Task SetTextAsync(string? text)
+        public new async Task SetTextAsync(string? text)
         {
             if (!HasMask)
             {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -180,7 +180,7 @@ namespace MudBlazor
         /// Sets the <see cref="MudBaseInput{T}.Text"/> to the specified value.
         /// </summary>
         /// <param name="text">The new text value to use.</param>
-        public new async Task SetTextAsync(string? text)
+        public override async Task SetTextAsync(string? text)
         {
             if (!HasMask)
             {

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -749,7 +749,7 @@ namespace MudBlazor
                     {
                         await SubmitAsync();
                         await CloseAsync();
-                        _inputReference?.SetText(Text);
+                        _inputReference?.SetTextAsync(Text);
                     }
 
                     break;
@@ -764,7 +764,7 @@ namespace MudBlazor
                         {
                             await SubmitAsync();
                             await CloseAsync();
-                            _inputReference?.SetText(Text);
+                            _inputReference?.SetTextAsync(Text);
                         }
                     }
 


### PR DESCRIPTION
* This PR adds the async postfix to all async functions of `MudTextField`
* This PR is breaking
* Note: `SetTextAsync` from `MudTextField` collides with `SetTextAsync` from `MudBaseInput`. The new definition of `SetTextAsync` in `MudTextField` is now `public override async Task SetTextAsync(string? text)` therefore overwriting the definition in `MudBaseInput` which should be the intended way if I am not mistaken but please take a look at it