### PR TITLE
Components: SetTextAsync->SetTextCoreAsync, SetValueAsync->SetValueCoreAsync

### DIFF
--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -575,7 +575,7 @@ namespace MudBlazor
         /// <summary>
         /// Override to write Value to ParameterState instead of backing field.
         /// </summary>
-        protected override Task SetValueAsync(T? value) => _valueState.SetValueAsync(value);
+        protected override Task SetValueCoreAsync(T? value) => _valueState.SetValueAsync(value);
 
         /// <summary>
         /// Sets the value, values, and text, and calls validation.
@@ -771,7 +771,7 @@ namespace MudBlazor
 
         protected internal string? ReadText => _textState.Value;
 
-        protected Task SetTextAsync(string? text) => _textState.SetValueAsync(text);
+        protected Task SetTextCoreAsync(string? text) => _textState.SetValueAsync(text);
 
         protected virtual async Task SetTextAndUpdateValueAsync(string? text, bool updateValue = true)
         {

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -167,7 +167,7 @@ namespace MudBlazor
 
         protected internal override T? ReadValue => _valueState.Value;
 
-        protected override Task SetValueAsync(T? value) => _valueState.SetValueAsync(value);
+        protected override Task SetValueCoreAsync(T? value) => _valueState.SetValueAsync(value);
 
         /// <summary>
         /// A value is required, so if not checked we return ERROR.

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -656,7 +656,7 @@ namespace MudBlazor
         protected virtual async Task ResetValueAsync()
         {
             /* to be overridden */
-            await SetValueAsync(default);
+            await SetValueCoreAsync(default);
             Touched = false;
             await InvokeAsync(StateHasChanged);
         }
@@ -1051,7 +1051,7 @@ namespace MudBlazor
 
         protected internal virtual T? ReadValue => _value;
 
-        protected virtual Task SetValueAsync(T? value)
+        protected virtual Task SetValueCoreAsync(T? value)
         {
             _value = value;
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -582,7 +582,7 @@ namespace MudBlazor
             var text = GetItemString(ReadValue);
             if (!string.IsNullOrWhiteSpace(text))
             {
-                await SetTextAsync(text);
+                await SetTextCoreAsync(text);
             }
         }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -460,7 +460,7 @@ namespace MudBlazor
 
         protected internal override MudColor? ReadValue => _valueState.Value;
 
-        protected override Task SetValueAsync(MudColor? value) => SetColorAsync(value);
+        protected override Task SetValueCoreAsync(MudColor? value) => SetColorAsync(value);
 
         protected override Task StringValueChangedAsync(string? value) => SetInputStringAsync(value);
 

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -320,7 +320,7 @@ namespace MudBlazor
 
         protected internal override T? ReadValue => _filesState.Value;
 
-        protected override Task SetValueAsync(T? value) => _filesState.SetValueAsync(value);
+        protected override Task SetValueCoreAsync(T? value) => _filesState.SetValueAsync(value);
 
         protected override async Task ValidateValue()
         {

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -266,7 +266,7 @@ namespace MudBlazor
                 if (Clearable)
                     UpdateClearable();
                 var v = ConvertGet(cleanText);
-                await SetValueAsync(v);
+                await SetValueCoreAsync(v);
                 await ValueChanged.InvokeAsync(v);
                 await SetCaretPositionAsync(caret, selection);
             }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -738,7 +738,7 @@ namespace MudBlazor
                     if (args.CtrlKey && args.ShiftKey)
                     {
                         await ClearAsync();
-                        await SetValueAsync(default);
+                        await SetValueCoreAsync(default);
                         await ResetAsync();
                     }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1084,7 +1084,7 @@ namespace MudBlazor
         {
             // The Text property of the control is updated
             var customText = multiSelectionTextFunc?.Invoke(selectedConvertedValues);
-            await SetTextAsync(customText);
+            await SetTextCoreAsync(customText);
 
             // The comparison is made on the multiSelectionText variable
             if (_multiSelectionText != text)

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -180,7 +180,7 @@ namespace MudBlazor
         /// Sets the <see cref="MudBaseInput{T}.Text"/> to the specified value.
         /// </summary>
         /// <param name="text">The new text value to use.</param>
-        public new async Task SetTextAsync(string? text)
+        public async Task SetTextAsync(string? text)
         {
             if (!HasMask)
             {


### PR DESCRIPTION
Follow up: https://github.com/MudBlazor/MudBlazor/pull/12484

I think that naming is actually more clean and make sense for a protected methods, and now you can make own `SetValueAsync` `SetTextAsync` that might not even cross paths.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
