### PR TITLE
Build: Switch to `fast-actions/setup-dotnet`

### DIFF
--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -65,10 +65,10 @@ jobs:
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Setup .NET
-        uses: fast-actions/setup-dotnet@v1.0.0
+        uses: fast-actions/setup-dotnet@v1
         with:
-          dotnet-sdk: 10.x.x
-          dotnet-aspnetcore: |
+          sdk-version: 10.x.x
+          aspnetcore-version: |
             9.x.x
             8.x.x
 

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -65,13 +65,12 @@ jobs:
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: fast-actions/setup-dotnet@v1.0.0
         with:
-          # We need all runtimes for the tests
-          dotnet-version: |
-            10.x
-            9.x
-            8.x
+          dotnet-sdk: 10.x.x
+          dotnet-aspnetcore: |
+            9.x.x
+            8.x.x
 
       - name: Restore dependencies
         working-directory: src

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -68,6 +68,7 @@ jobs:
         uses: fast-actions/setup-dotnet@v1
         with:
           sdk-version: 10.x.x
+          # We need these runtimes for the tests
           aspnetcore-version: |
             9.x.x
             8.x.x

--- a/.github/workflows/deploy-mudblazor-nuget.yml
+++ b/.github/workflows/deploy-mudblazor-nuget.yml
@@ -33,10 +33,10 @@ jobs:
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: fast-actions/setup-dotnet@v1.0.0
         with:
           # We only need the latest SDK for publishing
-          dotnet-version: 10.x
+          dotnet-sdk: 10.x.x
 
       - name: Restore dependencies
         working-directory: src/MudBlazor

--- a/.github/workflows/deploy-mudblazor-nuget.yml
+++ b/.github/workflows/deploy-mudblazor-nuget.yml
@@ -33,10 +33,10 @@ jobs:
           path: ${{ env.NUGET_PACKAGES }}
 
       - name: Setup .NET
-        uses: fast-actions/setup-dotnet@v1.0.0
+        uses: fast-actions/setup-dotnet@v1
         with:
           # We only need the latest SDK for publishing
-          dotnet-sdk: 10.x.x
+          sdk-version: 10.x.x
 
       - name: Restore dependencies
         working-directory: src/MudBlazor


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

The official `action/setup-dotnet` never caches the installed .NET SDK and Runtimes. That's why the action always needs about 20-25 seconds for installing SDK 8, 9, and 10.

I rebuilt the [`fast-actions/setup-dotnet`](https://github.com/fast-actions/setup-dotnet) from scratch with a focus on performance. This action downloads the .NET 10 SDK and AspNetCore Runtime 8 & 9. Which fits perfectly to our needs. It also caches the installed runtimes for future workflows. So .NET is installed in 4 seconds instead of 25 👀 

It would be awesome if we could start using it. Obviously, if something doesn't work, I'm here to fix it and we can roll back anytime.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
