### PR TITLE
Build: Use PrepareForBuild for web assets

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -83,13 +83,12 @@
   <ItemGroup>
     <ScssAssetInputs Include="Styles/**/*.scss" />
   </ItemGroup>
-    <Target
-      Name="BuildWebAssets"
-      Inputs="@(ScssAssetInputs)"
-      Outputs="wwwroot/MudBlazorDocs.min.css"
-      BeforeTargets="BeforeBuild">
-      <Message Importance="High" Text="Building web assets SCSS for MudBlazor.Docs" />
-      <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  <Target Name="BuildWebAssets"
+          Inputs="@(ScssAssetInputs)"
+          Outputs="wwwroot/MudBlazorDocs.min.css"
+          BeforeTargets="PrepareForBuild">
+    <Message Importance="High" Text="Building web assets SCSS for MudBlazor.Docs" />
+    <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
 </Project>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -87,7 +87,7 @@
       Name="BuildWebAssets"
       Inputs="@(ScssAssetInputs)"
       Outputs="wwwroot/MudBlazorDocs.min.css"
-      BeforeTargets="PrepareForBuild">
+      BeforeTargets="BeforeBuild">
       <Message Importance="High" Text="Building web assets SCSS for MudBlazor.Docs" />
       <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -87,9 +87,9 @@
       Name="BuildWebAssets"
       Inputs="@(ScssAssetInputs)"
       Outputs="wwwroot/MudBlazorDocs.min.css"
-      BeforeTargets="BeforeBuild"
-    >
-    <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+      BeforeTargets="PrepareForBuild">
+      <Message Importance="High" Text="Building web assets SCSS for MudBlazor.Docs" />
+      <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
 </Project>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -104,7 +104,8 @@
   <Target Name="BuildWebAssets"
           Inputs="@(WebAssetInputs)"
           Outputs="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.css"
-          BeforeTargets="BeforeBuild">
+          BeforeTargets="BeforeBuild"
+          Condition=" '$(TargetFramework)' == 'net10.0' ">
     <Message Importance="High" Text="Building web assets JS/SCSS for MudBlazor" />
     <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -104,7 +104,7 @@
   <Target Name="BuildWebAssets"
           Inputs="@(WebAssetInputs)"
           Outputs="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.css"
-          BeforeTargets="BeforeBuild"
+          BeforeTargets="PrepareForBuild"
           Condition=" '$(TargetFramework)' == 'net10.0' ">
     <Message Importance="High" Text="Building web assets JS/SCSS for MudBlazor" />
     <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -100,12 +100,13 @@
     <ScssAssetInputs Include="Styles/**/*.scss" />
     <WebAssetInputs Include="@(JsAssetInputs);@(ScssAssetInputs)" />
   </ItemGroup>
-    <Target
-      Name="BuildWebAssets"
-      Inputs="@(WebAssetInputs)"
-      Outputs="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.css"
-      BeforeTargets="DispatchToInnerBuilds"
-    >
+
+  <Target Name="BuildWebAssets"
+          Inputs="@(WebAssetInputs)"
+          Outputs="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.css"
+          BeforeTargets="PrepareForBuild"
+          Condition="'$(IsCrossTargetingBuild)' != 'true'">
+    <Message Importance="High" Text="Building web assets JS/SCSS for MudBlazor" />
     <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
   

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -104,7 +104,7 @@
   <Target Name="BuildWebAssets"
           Inputs="@(WebAssetInputs)"
           Outputs="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.css"
-          BeforeTargets="PrepareForBuild">
+          BeforeTargets="BeforeBuild">
     <Message Importance="High" Text="Building web assets JS/SCSS for MudBlazor" />
     <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -104,8 +104,7 @@
   <Target Name="BuildWebAssets"
           Inputs="@(WebAssetInputs)"
           Outputs="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.css"
-          BeforeTargets="PrepareForBuild"
-          Condition="'$(IsCrossTargetingBuild)' != 'true'">
+          BeforeTargets="PrepareForBuild">
     <Message Importance="High" Text="Building web assets JS/SCSS for MudBlazor" />
     <Exec Command="$(BunWrapper) run build.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>


### PR DESCRIPTION
There is problem as the MudBlazor assets are missing on dev mudblazor.
There is one problem that `PrepareForBuild` \ `BeforeBuild` will run for each TFM.
I guess we have to live with this.
I haven't found any reliable way to avoid this, except using the `Build`, but then the assets will not be packed in nuget as the dll will compile before the assets are done.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
