### PR TITLE
KeyInterceptorService: Add KeyCommand concept

### DIFF
--- a/src/MudBlazor.UnitTests.Shared/Extensions/BunitContextExtensions.cs
+++ b/src/MudBlazor.UnitTests.Shared/Extensions/BunitContextExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.JSInterop;
+using Moq;
+
+namespace MudBlazor.UnitTests.Shared.Extensions;
+
+internal static class BunitContextExtensions
+{
+    private static KeyInterceptorService GetKeyInterceptorService()
+    {
+        var jsRuntimeMock = new Mock<IJSRuntime>();
+        var keyInterceptorService = new KeyInterceptorService(NullLogger<KeyInterceptorService>.Instance, jsRuntimeMock.Object);
+
+        return keyInterceptorService;
+    }
+
+    public static KeyInterceptorService AddKeyInterceptorService(this BunitContext context)
+    {
+        var service = GetKeyInterceptorService();
+
+        context.Services.AddScoped<IKeyInterceptorService>(_ => service);
+
+        return service;
+    }
+}

--- a/src/MudBlazor.UnitTests.Shared/Mocks/MockKeyInterceptorService.cs
+++ b/src/MudBlazor.UnitTests.Shared/Mocks/MockKeyInterceptorService.cs
@@ -9,11 +9,15 @@ public class MockKeyInterceptorService : IKeyInterceptorService
 
     public Task SubscribeAsync(IKeyInterceptorObserver observer, KeyInterceptorOptions options) => Task.CompletedTask;
 
+    public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Action<KeyMapBuilder> configure) => Task.CompletedTask;
+
     public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, IKeyDownObserver? keyDown = null, IKeyUpObserver? keyUp = null) => Task.CompletedTask;
 
     public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Action<KeyboardEventArgs>? keyDown = null, Action<KeyboardEventArgs>? keyUp = null) => Task.CompletedTask;
 
     public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Func<KeyboardEventArgs, Task>? keyDown = null, Func<KeyboardEventArgs, Task>? keyUp = null) => Task.CompletedTask;
+
+    public Task DispatchAsync(string elementId, KeyEventKind kind, KeyboardEventArgs args) => Task.CompletedTask;
 
     public Task UpdateKeyAsync(IKeyInterceptorObserver observer, KeyOptions option) => Task.CompletedTask;
 

--- a/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
+++ b/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
@@ -12,6 +12,15 @@
   <ItemGroup>
     <PackageReference Include="bunit" Version="2.5.3" />
     <PackageReference Include="nunit" Version="4.4.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="MudBlazor.UnitTests" />
+    <InternalsVisibleTo Include="MudBlazor.UnitTests.Docs" />
+    <InternalsVisibleTo Include="MudBlazor.UnitTests.Viewer" />
+    <!--We need to make internal types to be visible for mocking-->
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
 </Project>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/SimpleMudDatePickerTest.razor
@@ -2,43 +2,22 @@
 
 <MudPopoverProvider></MudPopoverProvider>
 
-@if (IsDateDisabledFunc != null)
-{
-    <MudDatePicker @ref="_picker"
-                   Date="@Date"
-                   DateChanged="HandleDateChanged"
-                   ReadOnly="Readonly"
-                   @bind-PickerMonth="PickerMonth"
-                   IsDateDisabledFunc="IsDateDisabledFunc"
-                   OpenTo="@OpenTo"
-                   FixDay="@FixDay"
-                   FixMonth="@FixMonth"
-                   FixYear="@FixYear"
-                   MinDate="@MinDate"
-                   MaxDate="@MaxDate"
-                   AdditionalDateClassesFunc="@AdditionalDateClassesFunc"
-                   Culture="@(new CultureInfo("en-US"))"
-                   InputId="@InputId"
-                   FirstDayOfWeek="@FirstDayOfWeek" />
-}
-else
-{
-    <MudDatePicker @ref="_picker"
-                   Date="@Date"
-                   DateChanged="HandleDateChanged"
-                   ReadOnly="Readonly"
-                   @bind-PickerMonth="PickerMonth"
-                   OpenTo="@OpenTo"
-                   FixDay="@FixDay"
-                   FixMonth="@FixMonth"
-                   FixYear="@FixYear"
-                   MinDate="@MinDate"
-                   MaxDate="@MaxDate"
-                   AdditionalDateClassesFunc="@AdditionalDateClassesFunc"
-                   Culture="@(new CultureInfo("en-US"))"
-                   InputId="@InputId"
-                   FirstDayOfWeek="@FirstDayOfWeek"/>
-}
+<MudDatePicker @ref="_picker"
+               Date="@Date"
+               DateChanged="HandleDateChanged"
+               ReadOnly="Readonly"
+               @bind-PickerMonth="PickerMonth"
+               IsDateDisabledFunc="IsDateDisabledFunc"
+               OpenTo="@OpenTo"
+               FixDay="@FixDay"
+               FixMonth="@FixMonth"
+               FixYear="@FixYear"
+               MinDate="@MinDate"
+               MaxDate="@MaxDate"
+               AdditionalDateClassesFunc="@AdditionalDateClassesFunc"
+               Culture="@(new CultureInfo("en-US"))"
+               InputId="@InputId"
+               FirstDayOfWeek="@FirstDayOfWeek" />
 
 @code {
     private MudDatePicker _picker = null!;
@@ -53,7 +32,7 @@ else
     public bool Readonly { get; set; }
 
     [Parameter]
-    public Func<DateTime, bool>? IsDateDisabledFunc { get; set; }
+    public Func<DateTime, bool>? IsDateDisabledFunc { get; set; } = _ => false;
 
     [Parameter]
     public OpenTo OpenTo { get; set; } = OpenTo.Date;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Switch/MudSwitchBasicTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Switch/MudSwitchBasicTest.razor
@@ -1,0 +1,7 @@
+﻿<MudSwitch id="switch" T="bool" Disabled="@Disabled" />
+
+@code
+{
+    [Parameter]
+    public bool Disabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1152,37 +1152,38 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SimpleMudDatePickerTest>();
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "Escape", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = " ", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = " ", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "ArrowDown", AltKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "NumpadEnter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Tab", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "Tab", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             await datePickerComponent.SetParametersAndRenderAsync(parameters => parameters.Add(parameter => parameter.Disabled, true));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             await comp.InvokeAsync(() => datePicker.ToggleOpenAsync());
@@ -1196,7 +1197,7 @@ namespace MudBlazor.UnitTests.Components
 
             await datePickerComponent.SetParametersAndRenderAsync(parameters => parameters.Add(parameter => parameter.Disabled, false));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs { Key = "NumpadEnter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
             await comp.InvokeAsync(datePicker.ToggleStateAsync);
@@ -1206,6 +1207,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation_SelectDate()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             var expectedDate1 = new DateTime(2021, 1, 23, new CultureInfo("en-US").Calendar);
@@ -1217,47 +1219,47 @@ namespace MudBlazor.UnitTests.Components
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
             //year
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             //month
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             //date
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(expectedDate1);
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
             //year
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             //month
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             //date
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
             // select month with shift key
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
             // select year with shift key
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(expectedDate2);
         }
@@ -1265,6 +1267,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation_SelectMonth()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             var expectedDate1 = new DateTime(2022, 1, 28, new CultureInfo("en-US").Calendar);
@@ -1276,31 +1279,31 @@ namespace MudBlazor.UnitTests.Components
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown" }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown" }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown" }));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(expectedDate1);
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             // select year with shift key
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(expectedDate2);
 
@@ -1309,6 +1312,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation_BackspacePreviousView()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             await comp.SetParametersAndRenderAsync(parameters => parameters
@@ -1317,23 +1321,23 @@ namespace MudBlazor.UnitTests.Components
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
             //year
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             //month
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             //date
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", }));
 
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             // no change to date should happen
@@ -1344,6 +1348,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation_MinMaxYearLimits()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SimpleMudDatePickerTest>();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             await comp.SetParametersAndRenderAsync(parameters => parameters
@@ -1355,25 +1360,25 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(parameter => parameter.MinDate, minDate));
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             //try to select year below min
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(minDate);
 
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             //try to select year above max
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(maxDate);
 
@@ -1382,6 +1387,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation_FixYear_CannotBeChanged()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             var comp = Context.Render<SimpleMudDatePickerTest>(parameters => parameters
                 .Add(x => x.Date, startDate)
@@ -1389,14 +1395,14 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.FixYear, 2022));
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             //try to select year outside fixed year in month view
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(startDate);
         }
@@ -1404,6 +1410,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_KeyboardNavigation_FixMonth_CannotBeChanged()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var startDate = new DateTime(2022, 12, 31, new CultureInfo("en-US").Calendar);
             var comp = Context.Render<SimpleMudDatePickerTest>(parameters => parameters
                 .Add(x => x.Date, startDate)
@@ -1411,13 +1418,13 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.FixMonth, 12));
             var datePickerComponent = comp.FindComponent<MudDatePicker>();
             var datePicker = datePickerComponent.Instance;
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             //try to select month outside fixed month in date view
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
-            await comp.InvokeAsync(() => datePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", ShiftKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(datePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             comp.WaitForAssertion(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
             datePicker.Date.Should().Be(startDate);
         }

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Components
     public class DialogTests : BunitTest
     {
         /// <summary>
-        /// Testing lifecycle of dialogs in dialogprovider
+        /// Testing lifecycle of dialogs in DialogProvider
         /// </summary>
         [Test]
         public async Task Lifecycle()
@@ -423,6 +423,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DialogKeyboardNavigation()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -434,7 +435,8 @@ namespace MudBlazor.UnitTests.Components
             var dialog1 = (DialogOkCancel)dialogReference.Dialog!;
             var dialogInstance1 = dialog1.MudDialog.GetDialogContainer();
             comp.Markup.Trim().Should().NotBeEmpty();
-            await comp.InvokeAsync(() => dialogInstance1.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance1.ElementId, new KeyboardEventArgs { Key = "Escape", Type = "keydown", }));
             comp.Markup.Trim().Should().BeEmpty();
             //dialog with disabled backdrop click
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = false }));
@@ -442,13 +444,14 @@ namespace MudBlazor.UnitTests.Components
             var dialog2 = (DialogOkCancel)dialogReference.Dialog!;
             var dialogInstance2 = dialog2.MudDialog.GetDialogContainer();
             comp.Markup.Trim().Should().NotBeEmpty();
-            await comp.InvokeAsync(() => dialogInstance2.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance2.ElementId, new KeyboardEventArgs { Key = "Escape", Type = "keydown", }));
             comp.Markup.Trim().Should().NotBeEmpty();
         }
 
         [Test]
         public async Task DialogKeyboardEvents()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -458,13 +461,14 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = true }));
             dialogReference.Should().NotBe(null);
             var dialog1 = ((DialogOkCancel)dialogReference.Dialog)!;
-            var dialogInstance1 = dialog1.MudDialog.GetDialogContainer();
+            var dialogInstance = dialog1.MudDialog.GetDialogContainer();
             dialog1.LastKeyDown.Should().Be(null);
             dialog1.LastKeyUp.Should().Be(null);
             comp.Markup.Trim().Should().NotBeEmpty();
-            await comp.InvokeAsync(() => dialogInstance1.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+
+            await comp.InvokeAsync(async () => await keyInterceptorService.OnKeyDown(dialogInstance.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keydown", }));
             dialog1.LastKeyDown.Key.Should().Be("Enter");
-            await comp.InvokeAsync(() => dialogInstance1.HandleKeyUpAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keyup", }));
+            await comp.InvokeAsync(async () => await keyInterceptorService.OnKeyUp(dialogInstance.ElementId, new KeyboardEventArgs { Key = "Backspace", Type = "keyup", }));
             dialog1.LastKeyUp.Key.Should().Be("Backspace");
             comp.Markup.Trim().Should().NotBeEmpty();
         }
@@ -816,6 +820,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AsyncDialogKeyboardNavigation()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
@@ -828,7 +833,7 @@ namespace MudBlazor.UnitTests.Components
             var dialog1 = (DialogOkCancel)dialogReference.Dialog!;
             var dialogInstance1 = dialog1.MudDialog.GetDialogContainer();
             comp.Markup.Trim().Should().NotBeEmpty();
-            await comp.InvokeAsync(() => dialogInstance1.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance1.ElementId, new KeyboardEventArgs { Key = "Escape", Type = "keydown", }));
             comp.Markup.Trim().Should().BeEmpty();
             //dialog with disabled backdrop click
             dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service.ShowAsync<DialogOkCancel>(string.Empty, new DialogOptions() { CloseOnEscapeKey = false }));
@@ -838,7 +843,7 @@ namespace MudBlazor.UnitTests.Components
             var dialog2 = (DialogOkCancel)dialogReference.Dialog!;
             var dialogInstance2 = dialog2.MudDialog.GetDialogContainer();
             comp.Markup.Trim().Should().NotBeEmpty();
-            await comp.InvokeAsync(() => dialogInstance2.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance2.ElementId, new KeyboardEventArgs { Key = "Escape", Type = "keydown", }));
             comp.Markup.Trim().Should().NotBeEmpty();
         }
 
@@ -905,7 +910,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void MockIDialogReferenceShouldWork()
         {
-            Func<IDialogReference> createMock = Moq.Mock.Of<IDialogReference>;
+            Func<IDialogReference> createMock = Mock.Of<IDialogReference>;
             createMock.Should().NotThrow();
         }
 

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -17,7 +17,7 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class DrawerTest : BunitTest
     {
-        private BrowserViewportService GetBrowserViewportService(BrowserWindowSize browserWindowSize)
+        private static BrowserViewportService GetBrowserViewportService(BrowserWindowSize browserWindowSize)
         {
             var jsRuntimeMock = new Mock<IJSRuntime>();
             var browserViewportService = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -4,7 +4,6 @@
 
 using AwesomeAssertions;
 using Bunit;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Mask;
 using NUnit.Framework;
@@ -60,134 +59,135 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_Fundamentals1()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().BeNullOrEmpty());
             //Unmatched keys should have no effect
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
             maskField.Instance.ReadValue.Should().BeNullOrEmpty();
             maskField.Instance.Mask.ToString().Should().Be("|");
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(a__) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(2));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             //Symbols should have no effect in letter
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "+" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "+" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             //Symbol as a mask character should have no effect in letter
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "*" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "*" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             //Check uppercase character
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "C" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "C" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(6));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "d" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "d" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC"));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
             //Symbols should have no effect in digit
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "+" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "+" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
             //Symbol as a mask character should have no effect in letter
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "*" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "*" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 12_-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC12"));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "0" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "0" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(10));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "A" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "A" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-A_"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120A"));
             //Check culture character
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "ı" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "ı" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-Aı"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120Aı"));
             //Keys should have no effect if the mask completed
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Z" }));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "0" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Z" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "0" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-Aı"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120Aı"));
 
             //Middle input should move the after characters
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(9));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-bA"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120bA"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(11));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "c" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "c" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-bc"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120bc"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(12));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-b_"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120b"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(11));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 120-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC120"));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 12_-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC12"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(8));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) 1__-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(abC) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("abC"));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(3));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(a__) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a"));
 
             //Backspace should have no effect on empty value
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(0));
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(0));
@@ -196,6 +196,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_Fundamentals2()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
@@ -205,7 +206,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(1));
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("(|abc) 120-ac"));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(bca) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("bca"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(1));
@@ -215,7 +216,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(6));
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("(abc) |120-ac"));
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("(ab|a) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(aba) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("aba"));
@@ -225,7 +226,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be(""));
 
             await comp.InvokeAsync(() => maskField.Instance.OnFocused(new FocusEventArgs()));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(a__) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.CaretPos.Should().Be(2));
@@ -234,6 +235,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_Int()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudTextField<int?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(0)0-0)") { Placeholder = '_', CleanDelimiters = true }));
             var tf = comp.Instance;
@@ -242,33 +244,33 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(1));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
             //Unmatched keys should have no effect
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)_-_)"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(1));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)2-_)"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(12));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "3" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "3" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)2-3)"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(123));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)2-_)"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(12));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(1)_-_)"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(1));
 
             await comp.InvokeAsync(
-                () => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                () => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be(""));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
         }
@@ -276,32 +278,33 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_InsertCharactersIntoMiddle()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
 
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("|"));
             // 1 is not accepted because first mask position wants a letter
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.InvokeAsync(() => maskField.Instance.Mask.ToString().Should().Be("|"));
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a|__) ___-__"));
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(6));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) |___-__"));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) 1|__-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a1"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(10));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) 1__-|__"));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a__) 1__-a|_"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("a1a"));
 
             await comp.InvokeAsync(() => maskField.Instance.OnCaretPositionChanged(1));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(|a__) 1__-a_"));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(b|a_) _1_-_a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ba_) _1_-_a"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ba1a"));
@@ -310,11 +313,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_ChangeMask1()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp;
 
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a|__) ___-__"));
             // change the mask
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask,
@@ -329,7 +333,7 @@ namespace MudBlazor.UnitTests.Components
                 }));
             // internal state is preserved!
             await comp.WaitForAssertionAsync(() => maskField.Instance.Mask.ToString().Should().Be("(a|__) ___-__"));
-            await comp.InvokeAsync(() => maskField.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.Instance.ElementId, new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadText.Should().Be("(ab_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.Instance.ReadValue.Should().Be("ab"));
         }
@@ -337,6 +341,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_ChangeMask2()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(LL) UU")
             {
@@ -350,19 +355,19 @@ namespace MudBlazor.UnitTests.Components
             }));
             var maskField = comp.Instance;
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(a_) __"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("a"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "A" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp.Instance.ElementId, new KeyboardEventArgs() { Key = "A" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(a_) __"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("a"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(aa) __"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("aa"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "A" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp.Instance.ElementId, new KeyboardEventArgs() { Key = "A" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(aa) A_"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("aaA"));
         }
@@ -374,44 +379,45 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_KeepInputBlockPositions()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             var maskField = comp.Instance;
 
             await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("(aaa) 000-aa") { Placeholder = '_', CleanDelimiters = true })));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(1));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(a__) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("a"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ab_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ab"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "c" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "c" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(abc) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("abc"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(3));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ac_) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ac"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(6));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ac_) 1__-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ac1"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "0" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "0" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(ac_) 10_-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("ac10"));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(1));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("(c__) ___-__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("c"));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be(""));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be(""));
         }
@@ -449,25 +455,26 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_Selection()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("0000 0000 000") { Placeholder = '_', CleanDelimiters = true }));
             var maskField = comp.Instance;
 
             await comp.InvokeAsync(() => maskField.OnPasteAsync("1234567899"));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234 5678 99|_"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "9" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "9" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234 5678 999|"));
             //Select and delete
             await comp.InvokeAsync(() => maskField.OnSelect(10, 12));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234 5678 [99]9"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234 5678 |9__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1234 5678 9__"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123456789"));
             //Select with a whitespace and test again
             await comp.InvokeAsync(() => maskField.OnSelect(4, 8));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234[ 567]8 9__"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1234| 89__ ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1234 89__ ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("123489"));
@@ -481,7 +488,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(0));
             await comp.InvokeAsync(() => maskField.OnSelect(0, 1));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("[1]234 8956 7__"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("|2348 9567 ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("2348 9567 ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("23489567"));
@@ -497,7 +504,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(1));
             await comp.InvokeAsync(() => maskField.OnSelect(1, 3));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("1[23]4 81__ _9_"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1481 ___9 ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("14819"));
 
@@ -511,26 +518,27 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_TwoWayBinding()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MaskTwoWayBindingTest>();
             var maskField1 = comp.FindComponents<MudMask>().First();
             var maskField2 = comp.FindComponents<MudMask>().Last();
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be(""));
 
-            await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "a" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "a" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(a"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("a"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(a"));
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("a"));
 
-            await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "b" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "b" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(ab"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("ab"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(ab"));
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("ab"));
 
-            await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "C" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "C" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) "));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.Mask.CaretPos.Should().Be(6));
@@ -538,14 +546,14 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) "));
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC"));
 
-            await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 1"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadText.Should().Be("(abC) 1"));
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC1"));
 
-            await comp.InvokeAsync(() => maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 12"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC12"));
 
@@ -553,7 +561,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC12"));
 
             await comp.InvokeAsync(() =>
-                maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) 1"));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC1"));
 
@@ -561,7 +569,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => maskField2.Instance.ReadValue.Should().Be("abC1"));
 
             await comp.InvokeAsync(() =>
-                maskField1.Instance.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+                keyInterceptorService.OnKeyDown(maskField1.Instance.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadText.Should().Be("(abC) "));
             await comp.WaitForAssertionAsync(() => maskField1.Instance.ReadValue.Should().Be("abC"));
 
@@ -578,34 +586,35 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_TimeSpan()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudTextField<TimeSpan?>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, new PatternMask("00:00") { CleanDelimiters = false, }));
             var tf = comp.Instance;
             var maskField = comp.FindComponent<MudMask>().Instance;
 
             await comp.InvokeAsync(() => maskField.OnFocused(new FocusEventArgs()));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(TimeSpan.FromDays(1)));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("12:"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "3" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "3" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("12:3"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(new TimeSpan(12, 3, 00)));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "4" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "4" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("12:34"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(new TimeSpan(12, 34, 00)));
 
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(2));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("13:4"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(new TimeSpan(13, 4, 00)));
 
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Delete" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Delete" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("14:"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be(null));
         }
@@ -613,6 +622,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_MoreCoverage()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             var maskField = comp.Instance;
             var impl = maskField.Mask;
@@ -625,7 +635,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(() => maskField.OnCopyAsync());
             await comp.InvokeAsync(async () => await maskField.FocusAsync());
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1__ ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("1"));
 
@@ -633,7 +643,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnCaretPositionChanged(0));
             await comp.InvokeAsync(async () => await maskField.SelectRangeAsync(0, 7));
             await comp.InvokeAsync(() => maskField.OnSelect(0, 7));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "2" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "2" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("2__ ___"));
             await comp.WaitForAssertionAsync(() => maskField.ReadValue.Should().Be("2"));
 
@@ -674,8 +684,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => maskField.OnPasteAsync(null));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("123 |"));
             // ctrl or alt doesn't do anything
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1", CtrlKey = true }));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1", AltKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "1", CtrlKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "1", AltKey = true }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("123 |"));
             // clear via clear button
             await comp.InvokeAsync(() => maskField.HandleClearButtonAsync(new MouseEventArgs()));
@@ -683,13 +693,14 @@ namespace MudBlazor.UnitTests.Components
             // ctrl + backspace clears input
             await comp.InvokeAsync(() => maskField.OnPasteAsync("123"));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("123 |"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
             await comp.WaitForAssertionAsync(() => maskField.Mask.ToString().Should().Be("|"));
         }
 
         [Test]
         public async Task Mask_MultipleTFsLinkedViaTwoWayBinding()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MaskedTextFieldTwoWayBindingTest>();
             var tfs = comp.FindComponents<MudTextField<string>>().Select(x => x.Instance).ToArray();
             var masks = comp.FindComponents<MudMask>().Select(x => x.Instance).ToArray();
@@ -698,7 +709,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => masks[1].Mask.ToString().Should().Be("12/34/56|"));
             tfs[0].ReadText.Should().Be("123-456");
             tfs[1].ReadText.Should().Be("12/34/56");
-            await comp.InvokeAsync(() => masks[1].HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(masks[0].ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             masks[1].Mask.ToString().Should().Be("12/34/5|");
             await comp.WaitForAssertionAsync(() => masks[0].Mask.ToString().Should().Be("123-45|"));
             tfs[0].ReadText.Should().Be("123-45");
@@ -711,6 +722,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormReset_Should_ClearMaskedField()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<FormResetMaskTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
@@ -741,7 +753,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => mask.Mask.ToString().Should().Be("(123) 456-7890|"));
             await comp.WaitForAssertionAsync(() => textField.ReadText.Should().Be("(123) 456-7890"));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("(123) 456-7890"));
-            await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(mask.ElementId, new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true }));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(""));
         }
 
@@ -751,6 +763,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Mask_Readonly()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<ReadonlyMaskedTextFieldTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var mask = comp.FindComponent<MudMask>().Instance;
@@ -766,7 +779,7 @@ namespace MudBlazor.UnitTests.Components
             });
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(originalValue));
             // backspace
-            await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(mask.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(originalValue));
             // cut
             await comp.InvokeAsync(() =>
@@ -785,7 +798,7 @@ namespace MudBlazor.UnitTests.Components
             });
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("2222 2222 2222 2222"));
             // backspace
-            await comp.InvokeAsync(() => mask.HandleKeyDown(new KeyboardEventArgs() { Key = "Backspace" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(mask.ElementId, new KeyboardEventArgs() { Key = "Backspace" }));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("2222 2222 2222 222"));
             // cut
             await comp.InvokeAsync(() =>
@@ -930,6 +943,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ClearableReadOnlyMask_Should_NotHaveClearButton()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudMask>();
             var maskField = comp.Instance;
             maskField.Clearable.Should().Be(false);
@@ -946,7 +960,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll(".mud-input-clear-button").Count.Should().Be(0);
 
             await comp.InvokeAsync(async () => await maskField.FocusAsync());
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs() { Key = "1" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs() { Key = "1" }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("1__ ___"));
 
             // mask is clearable and contains text so the clear button should show up
@@ -962,6 +976,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MetaKeyShortcuts_Should_NotIntroduceExtraCharacters()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudTextField<string>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, RegexMask.Email()));
             var tf = comp.Instance;
@@ -969,19 +984,19 @@ namespace MudBlazor.UnitTests.Components
 
             // prep field
             await comp.InvokeAsync(() => maskField.OnFocused(new FocusEventArgs()));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "a"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("a"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("a"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "b"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("ab"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("ab"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "c"
             }));
@@ -989,21 +1004,21 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
 
             // test common shortcuts
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "c",
                 MetaKey = true
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "v",
                 MetaKey = true
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("abc"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("abc"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "x",
                 MetaKey = true
@@ -1015,6 +1030,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CutShortcut_Should_ClearSelectionAndCopyItToClipboard()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudTextField<string>>();
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, RegexMask.Email()));
             var tf = comp.Instance;
@@ -1022,19 +1038,19 @@ namespace MudBlazor.UnitTests.Components
 
             // prep field
             await comp.InvokeAsync(() => maskField.OnFocused(new FocusEventArgs()));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "a"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("a"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("a"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "b"
             }));
             await comp.WaitForAssertionAsync(() => maskField.ReadText.Should().Be("ab"));
             await comp.WaitForAssertionAsync(() => tf.ReadValue.Should().Be("ab"));
-            await comp.InvokeAsync(() => maskField.HandleKeyDown(new KeyboardEventArgs()
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(maskField.ElementId, new KeyboardEventArgs()
             {
                 Key = "c"
             }));

--- a/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MessageBoxTests.cs
@@ -104,6 +104,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MessageBox_CloseOnEscapeKey_NoOptions_NoMudDefaults()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = (DialogService)Context.Services.GetService<IDialogService>()!;
@@ -166,7 +167,7 @@ namespace MudBlazor.UnitTests.Components
             buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
             buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
-            await comp.InvokeAsync(() => dialogInstance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "Escape" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance.ElementId, new KeyboardEventArgs { Key = "Escape" }));
 
             comp.FindAll("button").Count.Should().Be(3);
 
@@ -180,6 +181,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MessageBox_CloseOnEscapeKey_WithOptions_NoMudDefaults()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudDialogProvider>();
             comp.Markup.Trim().Should().BeEmpty();
             var service = (DialogService)Context.Services.GetService<IDialogService>();
@@ -240,7 +242,7 @@ namespace MudBlazor.UnitTests.Components
             buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
             buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
-            await comp.InvokeAsync(() => dialogInstance.HandleKeyDownAsync(new KeyboardEventArgs { Key = "Escape" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance.ElementId, new KeyboardEventArgs { Key = "Escape" }));
 
             comp.FindAll("button").Should().BeEmpty();
 
@@ -250,6 +252,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MessageBox_CloseOnEscapeKey_NoOptions_WithMudDefaults()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<MudDialogProvider>(builder =>
             {
                 builder.Add(p => p.CloseOnEscapeKey, true);
@@ -309,7 +312,7 @@ namespace MudBlazor.UnitTests.Components
             buttons[2].TrimmedText().Should().Be("Great");    // Third button (Yes)
             buttons[2].ClassList.Should().Contain("mud-message-box__yes-button");
 
-            await comp.InvokeAsync(() => dialogInstance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape" }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(dialogInstance.ElementId, new KeyboardEventArgs() { Key = "Escape" }));
 
             comp.FindAll("button").Should().BeEmpty();
 

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -349,20 +349,20 @@ namespace MudBlazor.UnitTests.Components
             var numericField = comp.Instance;
             numericField.ReadValue.Should().Be(1234.56);
             numericField.ReadText.Should().Be("1234.56");
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1235.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
         }
 
@@ -380,9 +380,9 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Disabled, true));
             comp.Instance.ReadValue.Should().Be(1234.56);
             comp.Instance.ReadText.Should().Be("1234.56");
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
         }
 
@@ -400,9 +400,9 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.ReadOnly, true));
             comp.Instance.ReadValue.Should().Be(1234.56);
             comp.Instance.ReadText.Should().Be("1234.56");
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
-            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
         }
 

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -226,10 +226,10 @@ namespace MudBlazor.UnitTests.Components
             var radio = comp.FindComponent<MudRadioGroup<string>>();
             radio.Instance.Value.Should().Be(null);
 
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be("1"));
 
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be(null));
 
             //Can't tabbed around the radios in test.
@@ -248,7 +248,7 @@ namespace MudBlazor.UnitTests.Components
             await radio.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             await comp.WaitForAssertionAsync(() => group.Instance.Value.Should().Be(null));
 
-            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => group.Instance.Value.Should().Be(null));
         }
 

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -1,4 +1,5 @@
-﻿using AwesomeAssertions;
+﻿using AngleSharp.Dom;
+using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Switch;
@@ -13,32 +14,34 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Switch_KeyboardNavigation()
         {
-            var comp = Context.Render<MudSwitch<bool>>();
+            var comp = Context.Render<MudSwitchBasicTest>();
+            var switchInstance = comp.FindComponent<MudSwitch<bool>>().Instance;
+            IElement MudSwitch() => comp.Find("#switch");
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = "Enter", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(true));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(false));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = "Delete", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(false));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(true));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(false));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(false));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = "NumpadEnter", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(true));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(false));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = " ", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(false));
 
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = " ", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(true));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
-            await comp.InvokeAsync(() => comp.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(true));
+            await comp.InvokeAsync(() => MudSwitch().KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => switchInstance.ReadValue.Should().Be(true));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -211,99 +211,100 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TimePicker_KeyboardNavigation()
         {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SimpleTimePickerTest>();
             var timePickerComponent = comp.FindComponent<MudTimePicker>();
             var timePicker = timePickerComponent.Instance;
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", AltKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Time, new TimeSpan(02, 00, 00)));
             await comp.WaitForAssertionAsync(() => comp.Instance.Time.Should().Be(new TimeSpan(02, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 59, 00)));
             //Enter keys submit, so time should only change with enter
             await comp.WaitForAssertionAsync(() => timePicker.ReadValue.Should().Be(new TimeSpan(02, 00, 00)));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.ReadValue.Should().Be(new TimeSpan(01, 59, 00)));
             //If Open is false, arrowkeys should now change TimeIntermediate
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.ReadValue.Should().Be(new TimeSpan(01, 59, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 00, 00)));
             //Escape key should turn last submitted time
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(01, 59, 00)));
             await comp.WaitForAssertionAsync(() => timePicker.ReadValue.Should().Be(new TimeSpan(01, 59, 00)));
             //Space key should also submit
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = " ", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 00, 00)));
             await comp.WaitForAssertionAsync(() => timePicker.ReadValue.Should().Be(new TimeSpan(02, 00, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = " ", CtrlKey = true, Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", CtrlKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = " ", CtrlKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", CtrlKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(03, 00, 00)));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Time, new TimeSpan(03, 56, 00)));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(04, 01, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(03, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", CtrlKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", CtrlKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowLeft", ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 51, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowRight", ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowUp", ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(07, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "ArrowDown", ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(new TimeSpan(02, 56, 00)));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true, Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Backspace", CtrlKey = true, ShiftKey = true, Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().Be(null));
             await comp.WaitForAssertionAsync(() => timePicker.ReadValue.Should().Be(null));
 
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
             //When its disabled, keys should not work
             await timePickerComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
 
             await timePicker.FocusAsync();
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
-            await comp.InvokeAsync(() => timePicker.OnHandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Escape", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs() { Key = "Enter", Type = "keydown", }));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
 
             await timePickerComponent.SetParametersAndRenderAsync(parameters => parameters

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="JunitXml.TestLogger" Version="7.1.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="ReportGenerator" Version="5.5.1" />

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyCommandObserverTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyCommandObserverTests.cs
@@ -1,0 +1,258 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services.KeyInterceptor;
+
+#nullable enable
+[TestFixture]
+public class KeyCommandObserverTests
+{
+    [Test]
+    public async Task NotifyOnKeyDownAsync_MatchingCommand_Executes()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task NotifyOnKeyDownAsync_NoMatchingCommand_DoesNothing()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Escape" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task NotifyOnKeyUpAsync_MatchingCommand_Executes()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(args);
+
+        // Assert
+        executed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task NotifyOnKeyDownAsync_MixedCommands_OnlyExecutesKeyDownCommands()
+    {
+        // Arrange
+        var downExecuted = false;
+        var upExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                downExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyUp("Enter", () =>
+            {
+                upExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        downExecuted.Should().BeTrue();
+        upExecuted.Should().BeFalse(); // Should not execute KeyUp command
+    }
+
+    [Test]
+    public async Task NotifyOnKeyUpAsync_MixedCommands_OnlyExecutesKeyUpCommands()
+    {
+        // Arrange
+        var downExecuted = false;
+        var upExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                downExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyUp("Enter", () =>
+            {
+                upExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(args);
+
+        // Assert
+        downExecuted.Should().BeFalse(); // Should not execute KeyDown command
+        upExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task NotifyOnKeyDownAsync_MultipleMatchingCommands_ExecutesOnlyFirst()
+    {
+        // Arrange
+        var firstExecuted = false;
+        var secondExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                firstExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                secondExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        firstExecuted.Should().BeTrue();
+        secondExecuted.Should().BeFalse(); // Early exit pattern - only first match executes
+    }
+
+    [Test]
+    public async Task NotifyOnKeyDownAsync_ConditionalCommands_RespectsConditions()
+    {
+        // Arrange
+        var condition1 = false;
+        var condition2 = true;
+        var firstExecuted = false;
+        var secondExecuted = false;
+
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                firstExecuted = true;
+                return Task.CompletedTask;
+            }, when: () => condition1)
+            .OnKeyDown("Enter", () =>
+            {
+                secondExecuted = true;
+                return Task.CompletedTask;
+            }, when: () => condition2);
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        firstExecuted.Should().BeFalse(); // Condition1 is false
+        secondExecuted.Should().BeTrue(); // Condition2 is true
+    }
+
+    [Test]
+    public async Task NotifyOnKeyDownAsync_EmptyCommandList_CompletesSuccessfully()
+    {
+        // Arrange
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Enter", () => Task.CompletedTask); // Only KeyUp command
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act & Assert - should not throw
+        await keyDown.NotifyOnKeyDownAsync(args);
+    }
+
+    [Test]
+    public async Task PerformanceOptimization_SeparatesCommandsByKindAtConstruction()
+    {
+        // This test verifies that the observer splits commands at construction time
+        // rather than checking Kind on every dispatch.
+
+        // Arrange
+        var downCount = 0;
+        var upCount = 0;
+        var builder = KeyMapBuilder.Create();
+
+        // Add many commands of both kinds
+        for (var i = 0; i < 100; i++)
+        {
+            var key = $"Key{i}";
+            builder.OnKeyDown(key, () =>
+            {
+                downCount++;
+                return Task.CompletedTask;
+            });
+            builder.OnKeyUp(key, () =>
+            {
+                upCount++;
+                return Task.CompletedTask;
+            });
+        }
+
+        var (keyDown, keyUp) = builder.Build();
+
+        // Act - trigger one down event
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Key50" });
+
+        // Assert - should only check down commands (not iterate through up commands)
+        downCount.Should().Be(1);
+        upCount.Should().Be(0);
+
+        // Act - trigger one up event
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Key50" });
+
+        // Assert
+        downCount.Should().Be(1); // Still 1
+        upCount.Should().Be(1);
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderHookTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderHookTests.cs
@@ -1,0 +1,515 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services.KeyInterceptor;
+
+#nullable enable
+[TestFixture]
+public class KeyMapBuilderHookTests
+{
+    [Test]
+    public async Task HookKeyDown_ExecutesForAnyKey()
+    {
+        // Arrange
+        var hookExecutedKeys = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                hookExecutedKeys.Add(args.Key);
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act - try different keys
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "a" });
+
+        // Assert
+        hookExecutedKeys.Should().HaveCount(3);
+        hookExecutedKeys.Should().Contain("Enter");
+        hookExecutedKeys.Should().Contain("Escape");
+        hookExecutedKeys.Should().Contain("a");
+    }
+
+    [Test]
+    public async Task HookKeyUp_ExecutesForAnyKey()
+    {
+        // Arrange
+        var hookExecutedKeys = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyUp(args =>
+            {
+                hookExecutedKeys.Add(args.Key);
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+
+        // Act - try different keys
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Escape" });
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "a" });
+
+        // Assert
+        hookExecutedKeys.Should().HaveCount(3);
+        hookExecutedKeys.Should().Contain("Enter");
+        hookExecutedKeys.Should().Contain("Escape");
+        hookExecutedKeys.Should().Contain("a");
+    }
+
+    [Test]
+    public async Task HookKeyDown_ExecutesBeforeOtherCommands()
+    {
+        // Arrange
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("Hook");
+        executionOrder[1].Should().Be("Command");
+    }
+
+    [Test]
+    public async Task HookKeyDown_AfterMatchingCommand_DoesNotExecute()
+    {
+        // Arrange
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command");
+                return Task.CompletedTask;
+            })
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Command executes and stops chain, Hook never reached
+        executionOrder.Should().HaveCount(1);
+        executionOrder[0].Should().Be("Command");
+    }
+
+    [Test]
+    public async Task HookKeyDown_MultipleHooks_ExecuteInOrder()
+    {
+        // Arrange
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook1");
+                return Task.CompletedTask;
+            })
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook2");
+                return Task.CompletedTask;
+            })
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook3");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        executionOrder.Should().HaveCount(3);
+        executionOrder[0].Should().Be("Hook1");
+        executionOrder[1].Should().Be("Hook2");
+        executionOrder[2].Should().Be("Hook3");
+    }
+
+    [Test]
+    public async Task HookKeyDown_DoesNotPreventOtherCommandsFromExecuting()
+    {
+        // Arrange
+        var hookExecuted = false;
+        var commandExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                hookExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                commandExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        hookExecuted.Should().BeTrue();
+        commandExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task HookKeyDown_ExecutesEvenWhenNoOtherCommandMatches()
+    {
+        // Arrange
+        var hookExecuted = false;
+        var commandExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                hookExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                commandExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act - press a key that doesn't match any command
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
+
+        // Assert
+        hookExecuted.Should().BeTrue();
+        commandExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task HookKeyDown_NotAffectedByWhenScope()
+    {
+        // Arrange
+        var condition = false; // Condition is false
+        var hookExecuted = false;
+        var commandExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                hookExecuted = true;
+                return Task.CompletedTask;
+            })
+            .When(() => condition, b => b
+                .OnKeyDown("Enter", () =>
+                {
+                    commandExecuted = true;
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - hook executes even though When condition is false
+        hookExecuted.Should().BeTrue();
+        commandExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task HookKeyDown_InsideWhenScope_ExecutesIfConditionTrue()
+    {
+        // Arrange
+        var condition = true; // Condition is true
+        var hookExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .When(() => condition, b => b
+                .HookKeyDown(args =>
+                {
+                    hookExecuted = true;
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - hook executes when condition is true
+        hookExecuted.Should().BeTrue();
+
+        // Reset and change condition
+        hookExecuted = false;
+        condition = false;
+
+        // Act again with false condition
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - hook doesn't execute when condition is false (wrapped in ConditionalCommand)
+        hookExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task HookKeyDown_ReceivesKeyboardEventArgs()
+    {
+        // Arrange
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var originalArgs = new KeyboardEventArgs
+        {
+            Key = "Enter",
+            CtrlKey = true,
+            ShiftKey = false,
+            AltKey = true
+        };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(originalArgs);
+
+        // Assert
+        receivedArgs.Should().NotBeNull();
+        receivedArgs!.Key.Should().Be("Enter");
+        receivedArgs.CtrlKey.Should().BeTrue();
+        receivedArgs.ShiftKey.Should().BeFalse();
+        receivedArgs.AltKey.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task HookKeyUp_ReceivesKeyboardEventArgs()
+    {
+        // Arrange
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyUp(args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+        var originalArgs = new KeyboardEventArgs
+        {
+            Key = "Escape",
+            CtrlKey = false,
+            ShiftKey = true,
+            AltKey = false
+        };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(originalArgs);
+
+        // Assert
+        receivedArgs.Should().NotBeNull();
+        receivedArgs!.Key.Should().Be("Escape");
+        receivedArgs.CtrlKey.Should().BeFalse();
+        receivedArgs.ShiftKey.Should().BeTrue();
+        receivedArgs.AltKey.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task HookKeyDown_AndHookKeyUp_IndependentExecution()
+    {
+        // Arrange
+        var downHookExecuted = false;
+        var upHookExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                downHookExecuted = true;
+                return Task.CompletedTask;
+            })
+            .HookKeyUp(args =>
+            {
+                upHookExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, keyUp) = builder.Build();
+
+        // Act - only trigger keydown
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - only down hook executed
+        downHookExecuted.Should().BeTrue();
+        upHookExecuted.Should().BeFalse();
+
+        // Reset
+        downHookExecuted = false;
+
+        // Act - only trigger keyup
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - only up hook executed
+        downHookExecuted.Should().BeFalse();
+        upHookExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task HookKeyDown_WithConditionalCommands_HookAlwaysExecutes()
+    {
+        // Arrange
+        var hookExecutionCount = 0;
+        var commandExecutionCount = 0;
+        var condition = true;
+
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                hookExecutionCount++;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                commandExecutionCount++;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+
+        // Act - condition is true
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert
+        hookExecutionCount.Should().Be(1);
+        commandExecutionCount.Should().Be(1);
+
+        // Change condition to false
+        condition = false;
+
+        // Act - condition is false
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - hook still executes, command doesn't
+        hookExecutionCount.Should().Be(2);
+        commandExecutionCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task HookKeyDown_WithMultipleCommands_OnlyFirstMatchingCommandExecutesAfterHooks()
+    {
+        // Arrange
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command1");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command2");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - hook executes, then only first matching command
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("Hook");
+        executionOrder[1].Should().Be("Command1");
+    }
+
+    [Test]
+    public async Task HookKeyDown_CanAccessAndModifySharedState()
+    {
+        // Arrange
+        var sharedCounter = 0;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                sharedCounter += 10; // Hook increments by 10
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                sharedCounter += 1; // Command increments by 1
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - both hook and command modified the shared state
+        sharedCounter.Should().Be(11);
+    }
+
+    [Test]
+    public async Task HookKeyDown_WithRegexPattern_StillExecutesForAllKeys()
+    {
+        // Arrange
+        var hookExecuted = false;
+        var regexCommandExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                hookExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("/[a-z]/", () =>
+            {
+                regexCommandExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act - press a key that matches the regex
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "a" });
+
+        // Assert
+        hookExecuted.Should().BeTrue();
+        regexCommandExecuted.Should().BeTrue();
+
+        // Reset
+        hookExecuted = false;
+        regexCommandExecuted = false;
+
+        // Act - press a key that doesn't match the regex
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "1" });
+
+        // Assert - hook still executes
+        hookExecuted.Should().BeTrue();
+        regexCommandExecuted.Should().BeFalse();
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderHookTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderHookTests.cs
@@ -94,7 +94,7 @@ public class KeyMapBuilderHookTests
     }
 
     [Test]
-    public async Task HookKeyDown_AfterMatchingCommand_DoesNotExecute()
+    public async Task HookKeyDown_AfterMatchingCommand_StillExecutes()
     {
         // Arrange
         var executionOrder = new List<string>();
@@ -115,9 +115,10 @@ public class KeyMapBuilderHookTests
         // Act
         await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
-        // Assert - Command executes and stops chain, Hook never reached
-        executionOrder.Should().HaveCount(1);
-        executionOrder[0].Should().Be("Command");
+        // Assert - Hook executes first (inserted at index 0), then Command
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("Hook");
+        executionOrder[1].Should().Be("Command");
     }
 
     [Test]
@@ -211,7 +212,7 @@ public class KeyMapBuilderHookTests
     }
 
     [Test]
-    public async Task HookKeyDown_NotAffectedByWhenScope()
+    public async Task HookKeyDown_OutsideWhenScope_ExecutesRegardlessOfCondition()
     {
         // Arrange
         var condition = false; // Condition is false
@@ -235,7 +236,7 @@ public class KeyMapBuilderHookTests
         // Act
         await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
-        // Assert - hook executes even though When condition is false
+        // Assert - hook executes even though When condition is false (hook is outside the When scope)
         hookExecuted.Should().BeTrue();
         commandExecuted.Should().BeFalse();
     }
@@ -511,5 +512,291 @@ public class KeyMapBuilderHookTests
         // Assert - hook still executes
         hookExecuted.Should().BeTrue();
         regexCommandExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task HookKeyDown_DeclaredAtEnd_StillExecutesFirst()
+    {
+        // Arrange
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command1");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Escape", () =>
+            {
+                executionOrder.Add("Command2");
+                return Task.CompletedTask;
+            })
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hook executes first even though declared last
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("Hook");
+        executionOrder[1].Should().Be("Command1");
+    }
+
+    [Test]
+    public async Task HookKeyDown_MultipleHooks_DeclaredInDifferentPositions_ExecuteInDeclarationOrder()
+    {
+        // Arrange - Hooks maintain their declaration order regardless of where they're declared
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook1");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command");
+                return Task.CompletedTask;
+            })
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook2");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hooks execute first in declaration order (Hook1, Hook2), then Command
+        executionOrder.Should().HaveCount(3);
+        executionOrder[0].Should().Be("Hook1");
+        executionOrder[1].Should().Be("Hook2");
+        executionOrder[2].Should().Be("Command");
+    }
+
+    [Test]
+    public async Task HookKeyDown_InsideWhenScope_ExecutesFirst()
+    {
+        // Arrange
+        var condition = true;
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("CommandOutside");
+                return Task.CompletedTask;
+            })
+            .When(() => condition, b => b
+                .OnKeyDown("Enter", () =>
+                {
+                    executionOrder.Add("CommandInside");
+                    return Task.CompletedTask;
+                })
+                .HookKeyDown(args =>
+                {
+                    executionOrder.Add("HookInside");
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hook inside When executes first, then CommandOutside (stops chain)
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("HookInside");
+        executionOrder[1].Should().Be("CommandOutside");
+    }
+
+    [Test]
+    public async Task HookKeyDown_InsideWhenScope_RespectsCondition()
+    {
+        // Arrange
+        var condition = false;
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command");
+                return Task.CompletedTask;
+            })
+            .When(() => condition, b => b
+                .HookKeyDown(args =>
+                {
+                    executionOrder.Add("HookInside");
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hook inside When doesn't execute because condition is false
+        executionOrder.Should().HaveCount(1);
+        executionOrder[0].Should().Be("Command");
+    }
+
+    [Test]
+    public async Task HookKeyUp_DeclaredAtEnd_StillExecutesFirst()
+    {
+        // Arrange
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Enter", () =>
+            {
+                executionOrder.Add("Command1");
+                return Task.CompletedTask;
+            })
+            .OnKeyUp("Escape", () =>
+            {
+                executionOrder.Add("Command2");
+                return Task.CompletedTask;
+            })
+            .HookKeyUp(args =>
+            {
+                executionOrder.Add("Hook");
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hook executes first even though declared last
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("Hook");
+        executionOrder[1].Should().Be("Command1");
+    }
+
+    [Test]
+    public async Task HookKeyDown_DeclaredAfterWhenScope_StillExecutesFirst()
+    {
+        // Arrange
+        var condition = true;
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .When(() => condition, b => b
+                .OnKeyDown("Enter", () =>
+                {
+                    executionOrder.Add("CommandInWhen");
+                    return Task.CompletedTask;
+                })
+                .OnKeyDownAny(["Escape", "Tab"], () =>
+                {
+                    executionOrder.Add("CommandAnyInWhen");
+                    return Task.CompletedTask;
+                }))
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("HookAfterWhen");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hook declared after When still executes first
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("HookAfterWhen");
+        executionOrder[1].Should().Be("CommandInWhen");
+    }
+
+    [Test]
+    public async Task HookKeyUp_DeclaredAfterWhenScope_StillExecutesFirst()
+    {
+        // Arrange
+        var condition = true;
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .When(() => condition, b => b
+                .OnKeyUp("Enter", () =>
+                {
+                    executionOrder.Add("CommandInWhen");
+                    return Task.CompletedTask;
+                })
+                .OnKeyUpAny(["Escape", "Tab"], () =>
+                {
+                    executionOrder.Add("CommandAnyInWhen");
+                    return Task.CompletedTask;
+                }))
+            .HookKeyUp(args =>
+            {
+                executionOrder.Add("HookAfterWhen");
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - Hook declared after When still executes first
+        executionOrder.Should().HaveCount(2);
+        executionOrder[0].Should().Be("HookAfterWhen");
+        executionOrder[1].Should().Be("CommandInWhen");
+    }
+
+    [Test]
+    public async Task HookKeyDown_MixedWithWhenScopes_MaintainsCorrectOrder()
+    {
+        // Arrange
+        var condition = true;
+        var executionOrder = new List<string>();
+        var builder = KeyMapBuilder.Create()
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook1");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command1");
+                return Task.CompletedTask;
+            })
+            .When(() => condition, b => b
+                .HookKeyDown(args =>
+                {
+                    executionOrder.Add("Hook2InWhen");
+                    return Task.CompletedTask;
+                })
+                .OnKeyDown("Enter", () =>
+                {
+                    executionOrder.Add("Command2InWhen");
+                    return Task.CompletedTask;
+                }))
+            .HookKeyDown(args =>
+            {
+                executionOrder.Add("Hook3");
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                executionOrder.Add("Command3");
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+        // Assert - All hooks execute first in declaration order, then first matching command
+        executionOrder.Should().HaveCount(4);
+        executionOrder[0].Should().Be("Hook1");
+        executionOrder[1].Should().Be("Hook2InWhen");
+        executionOrder[2].Should().Be("Hook3");
+        executionOrder[3].Should().Be("Command1");
     }
 }

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderRegexTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderRegexTests.cs
@@ -1,0 +1,235 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services.KeyInterceptor;
+
+#nullable enable
+
+[TestFixture]
+public class KeyMapBuilderRegexTests
+{
+    [Test]
+    public async Task OnKeyDown_WithRegexPattern_MatchesAnyKey()
+    {
+        // Arrange
+        var executionCount = 0;
+        var builder = KeyMapBuilder.Create();
+        builder.OnKeyDown("/./", () =>
+        {
+            executionCount++;
+            return Task.CompletedTask;
+        });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act & Assert - Test multiple different keys
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "A" });
+        executionCount.Should().Be(1);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "B" });
+        executionCount.Should().Be(2);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "1" });
+        executionCount.Should().Be(3);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        executionCount.Should().Be(4);
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithAlphaRegex_MatchesOnlyLetters()
+    {
+        // Arrange
+        var executionCount = 0;
+        var builder = KeyMapBuilder.Create();
+        builder.OnKeyDown("/[a-z]/", () =>
+        {
+            executionCount++;
+            return Task.CompletedTask;
+        });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act & Assert - Test letters (should match)
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "a" });
+        executionCount.Should().Be(1);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "z" });
+        executionCount.Should().Be(2);
+
+        // Test numbers (should not match)
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "1" });
+        executionCount.Should().Be(2); // unchanged
+
+        // Test uppercase (should not match)
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "A" });
+        executionCount.Should().Be(2); // unchanged
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithRegexOrPattern_MatchesMultipleKeys()
+    {
+        // Arrange
+        var executionCount = 0;
+        var builder = KeyMapBuilder.Create();
+        builder.OnKeyDown("/Enter|Escape|Tab/", () =>
+        {
+            executionCount++;
+            return Task.CompletedTask;
+        });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act & Assert
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        executionCount.Should().Be(1);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
+        executionCount.Should().Be(2);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Tab" });
+        executionCount.Should().Be(3);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "A" });
+        executionCount.Should().Be(3); // unchanged
+    }
+
+    [Test]
+    public async Task OnKeyDownAny_WithMixedRegexAndLiteral_MatchesBoth()
+    {
+        // Arrange
+        var executionCount = 0;
+        var builder = KeyMapBuilder.Create();
+        builder.OnKeyDownAny(["/[0-9]/", "Enter", "Escape"], () =>
+        {
+            executionCount++;
+            return Task.CompletedTask;
+        });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act & Assert - Test regex match (digits)
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "1" });
+        executionCount.Should().Be(1);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "9" });
+        executionCount.Should().Be(2);
+
+        // Test literal matches
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        executionCount.Should().Be(3);
+
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
+        executionCount.Should().Be(4);
+
+        // Test non-match
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "a" });
+        executionCount.Should().Be(4); // unchanged
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithRegexAndKeyboardEventArgs_PassesArgsCorrectly()
+    {
+        // Arrange
+        string? capturedKey = null;
+        var builder = KeyMapBuilder.Create();
+        builder.OnKeyDown("/./", (args) =>
+        {
+            capturedKey = args.Key;
+            return Task.CompletedTask;
+        });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "TestKey" });
+
+        // Assert
+        capturedKey.Should().Be("TestKey");
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithInvalidRegex_FallsBackToLiteralMatch()
+    {
+        // Arrange
+        var executionCount = 0;
+        var builder = KeyMapBuilder.Create();
+        // Invalid regex pattern (unclosed bracket)
+        builder.OnKeyDown("/[a-z/", () =>
+        {
+            executionCount++;
+            return Task.CompletedTask;
+        });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act & Assert - Should match literal string "/[a-z/"
+        await keyDown!.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "/[a-z/" });
+        executionCount.Should().Be(1);
+
+        // Should not match "a" as regex would
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "a" });
+        executionCount.Should().Be(1); // unchanged
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithRegexInConditionScope_WorksCorrectly()
+    {
+        // Arrange
+        var canHandle = true;
+        var executionCount = 0;
+        var builder = KeyMapBuilder.Create();
+        builder.When(() => canHandle, b => b
+            .OnKeyDown("/./", () =>
+            {
+                executionCount++;
+                return Task.CompletedTask;
+            }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act & Assert - When condition is true
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "A" });
+        executionCount.Should().Be(1);
+
+        // When condition is false
+        canHandle = false;
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "B" });
+        executionCount.Should().Be(1); // unchanged
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithMultipleRegexCommands_ExecutesFirstMatch()
+    {
+        // Arrange
+        var firstExecuted = false;
+        var secondExecuted = false;
+        var builder = KeyMapBuilder.Create();
+        builder
+            .OnKeyDown("/[a-z]/", () =>
+            {
+                firstExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("/./", () =>
+            {
+                secondExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "a" });
+
+        // Assert - Only first matching command should execute (early exit)
+        firstExecuted.Should().BeTrue();
+        secondExecuted.Should().BeFalse();
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderTests.cs
@@ -1,0 +1,399 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services.KeyInterceptor;
+
+#nullable enable
+[TestFixture]
+public class KeyMapBuilderTests
+{
+    [Test]
+    public void Build_EmptyBuilder_ReturnsEmptyObservers()
+    {
+        // Arrange
+        var builder = KeyMapBuilder.Create();
+
+        // Act
+        var (keyDown, keyUp) = builder.Build();
+
+        // Assert
+        var typeKeyUpIgnore = KeyObserver.KeyUpIgnore().GetType();
+        var typeKeyDownIgnore = KeyObserver.KeyDownIgnore().GetType();
+        keyDown.Should().BeOfType(typeKeyDownIgnore);
+        keyUp.Should().BeOfType(typeKeyUpIgnore);
+    }
+
+    [Test]
+    public async Task OnKeyDown_SimpleCommand_ExecutesAction()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyDown_WrongKey_DoesNotExecute()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Escape" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task OnKeyDown_ConditionalCommand_ExecutesWhenConditionTrue()
+    {
+        // Arrange
+        var condition = true;
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyDown_ConditionalCommand_DoesNotExecuteWhenConditionFalse()
+    {
+        // Arrange
+        var condition = false;
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task OnKeyDownAny_MultipleKeys_ExecutesForAnyKey()
+    {
+        // Arrange
+        var executedCount = 0;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDownAny(["Enter", "NumpadEnter", "Space"], () =>
+            {
+                executedCount++;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "NumpadEnter" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Space" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" }); // Should not execute
+
+        // Assert
+        executedCount.Should().Be(3);
+    }
+
+    [Test]
+    public async Task OnKeyDownAny_WithCondition_ExecutesWhenConditionTrue()
+    {
+        // Arrange
+        var condition = true;
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDownAny(["Enter", "NumpadEnter"], () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyDownAny_WithCondition_DoesNotExecuteWhenConditionFalse()
+    {
+        // Arrange
+        var condition = false;
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDownAny(["Enter", "NumpadEnter"], () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        executed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task When_ConditionalScope_AppliesConditionToAllCommands()
+    {
+        // Arrange
+        var condition = true;
+        var enterExecuted = false;
+        var spaceExecuted = false;
+        var escapeExecuted = false;
+
+        var builder = KeyMapBuilder.Create()
+            .When(() => condition, b => b
+                .OnKeyDown("Enter", () =>
+                {
+                    enterExecuted = true;
+                    return Task.CompletedTask;
+                })
+                .OnKeyDown("Space", () =>
+                {
+                    spaceExecuted = true;
+                    return Task.CompletedTask;
+                })
+                .OnKeyDown("Escape", () =>
+                {
+                    escapeExecuted = true;
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Space" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
+
+        // Assert
+        enterExecuted.Should().BeTrue();
+        spaceExecuted.Should().BeTrue();
+        escapeExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task When_ConditionalScope_DoesNotExecuteWhenConditionFalse()
+    {
+        // Arrange
+        var condition = false;
+        var enterExecuted = false;
+        var spaceExecuted = false;
+
+        var builder = KeyMapBuilder.Create()
+            .When(() => condition, b => b
+                .OnKeyDown("Enter", () =>
+                {
+                    enterExecuted = true;
+                    return Task.CompletedTask;
+                })
+                .OnKeyDown("Space", () =>
+                {
+                    spaceExecuted = true;
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Space" });
+
+        // Assert
+        enterExecuted.Should().BeFalse();
+        spaceExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task OnKeyUp_SimpleCommand_ExecutesAction()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(args);
+
+        // Assert
+        executed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Build_MixedDownAndUpCommands_ReturnsCorrectObservers()
+    {
+        // Arrange
+        var downExecuted = false;
+        var upExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                downExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyUp("Enter", () =>
+            {
+                upExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, keyUp) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+        await keyUp.NotifyOnKeyUpAsync(args);
+
+        // Assert
+        downExecuted.Should().BeTrue();
+        upExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Build_OnlyKeyDownCommands_KeyUpDoesNothing()
+    {
+        // Arrange
+        var executed = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(args); // Should not execute the keydown command
+
+        // Assert
+        executed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task MultipleCommands_ExecutesFirstMatchingCommand()
+    {
+        // Arrange
+        var firstExecuted = false;
+        var secondExecuted = false;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", () =>
+            {
+                firstExecuted = true;
+                return Task.CompletedTask;
+            })
+            .OnKeyDown("Enter", () =>
+            {
+                secondExecuted = true;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(args);
+
+        // Assert
+        firstExecuted.Should().BeTrue();
+        secondExecuted.Should().BeFalse(); // Only first matching command should execute
+    }
+
+    [Test]
+    public async Task When_NestedScopes_AppliesConditionsCorrectly()
+    {
+        // Arrange
+        var outerCondition = true;
+        var executed = false;
+
+        var builder = KeyMapBuilder.Create()
+            .When(() => outerCondition, b => b
+                .OnKeyDown("Enter", () =>
+                {
+                    executed = true;
+                    return Task.CompletedTask;
+                }));
+
+        var (keyDown, _) = builder.Build();
+        var args = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act - condition true
+        await keyDown.NotifyOnKeyDownAsync(args);
+        var executedWhenTrue = executed;
+
+        // Change condition
+        executed = false;
+        outerCondition = false;
+        await keyDown.NotifyOnKeyDownAsync(args);
+        var executedWhenFalse = executed;
+
+        // Assert
+        executedWhenTrue.Should().BeTrue();
+        executedWhenFalse.Should().BeFalse();
+    }
+}

--- a/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Services/KeyInterceptor/KeyMapBuilderTests.cs
@@ -396,4 +396,208 @@ public class KeyMapBuilderTests
         executedWhenTrue.Should().BeTrue();
         executedWhenFalse.Should().BeFalse();
     }
+
+    [Test]
+    public async Task OnKeyDown_WithKeyboardEventArgs_ExecutesActionWithArgs()
+    {
+        // Arrange
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+        var expectedArgs = new KeyboardEventArgs { Key = "Enter", CtrlKey = true, ShiftKey = true };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(expectedArgs);
+
+        // Assert
+        receivedArgs.Should().NotBeNull();
+        receivedArgs!.Key.Should().Be("Enter");
+        receivedArgs.CtrlKey.Should().BeTrue();
+        receivedArgs.ShiftKey.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithKeyboardEventArgsAndCondition_ExecutesWhenConditionTrue()
+    {
+        // Arrange
+        var condition = true;
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+        var expectedArgs = new KeyboardEventArgs { Key = "Enter", AltKey = true };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(expectedArgs);
+
+        // Assert
+        receivedArgs.Should().NotBeNull();
+        receivedArgs!.Key.Should().Be("Enter");
+        receivedArgs.AltKey.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyDown_WithKeyboardEventArgsAndCondition_DoesNotExecuteWhenConditionFalse()
+    {
+        // Arrange
+        var condition = false;
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDown("Enter", args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (keyDown, _) = builder.Build();
+        var expectedArgs = new KeyboardEventArgs { Key = "Enter" };
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(expectedArgs);
+
+        // Assert
+        receivedArgs.Should().BeNull();
+    }
+
+    [Test]
+    public async Task OnKeyDownAny_WithKeyboardEventArgs_ExecutesForAnyKey()
+    {
+        // Arrange
+        var executedCount = 0;
+        KeyboardEventArgs? lastReceivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyDownAny(["Enter", "NumpadEnter", "Space"], args =>
+            {
+                executedCount++;
+                lastReceivedArgs = args;
+                return Task.CompletedTask;
+            });
+
+        var (keyDown, _) = builder.Build();
+
+        // Act
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Enter", CtrlKey = true });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "NumpadEnter", ShiftKey = true });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Space", AltKey = true });
+        await keyDown.NotifyOnKeyDownAsync(new KeyboardEventArgs { Key = "Escape" }); // Should not execute
+
+        // Assert
+        executedCount.Should().Be(3);
+        lastReceivedArgs.Should().NotBeNull();
+        lastReceivedArgs!.Key.Should().Be("Space");
+        lastReceivedArgs.AltKey.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyUp_WithKeyboardEventArgs_ExecutesActionWithArgs()
+    {
+        // Arrange
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Enter", args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+        var expectedArgs = new KeyboardEventArgs { Key = "Enter", CtrlKey = true, MetaKey = true };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(expectedArgs);
+
+        // Assert
+        receivedArgs.Should().NotBeNull();
+        receivedArgs!.Key.Should().Be("Enter");
+        receivedArgs.CtrlKey.Should().BeTrue();
+        receivedArgs.MetaKey.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyUp_WithKeyboardEventArgsAndCondition_ExecutesWhenConditionTrue()
+    {
+        // Arrange
+        var condition = true;
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Escape", args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (_, keyUp) = builder.Build();
+        var expectedArgs = new KeyboardEventArgs { Key = "Escape", ShiftKey = true };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(expectedArgs);
+
+        // Assert
+        receivedArgs.Should().NotBeNull();
+        receivedArgs!.Key.Should().Be("Escape");
+        receivedArgs.ShiftKey.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OnKeyUp_WithKeyboardEventArgsAndCondition_DoesNotExecuteWhenConditionFalse()
+    {
+        // Arrange
+        var condition = false;
+        KeyboardEventArgs? receivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUp("Escape", args =>
+            {
+                receivedArgs = args;
+                return Task.CompletedTask;
+            }, when: () => condition);
+
+        var (_, keyUp) = builder.Build();
+        var expectedArgs = new KeyboardEventArgs { Key = "Escape" };
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(expectedArgs);
+
+        // Assert
+        receivedArgs.Should().BeNull();
+    }
+
+    [Test]
+    public async Task OnKeyUpAny_WithKeyboardEventArgs_ExecutesForAnyKey()
+    {
+        // Arrange
+        var executedCount = 0;
+        KeyboardEventArgs? lastReceivedArgs = null;
+        var builder = KeyMapBuilder.Create()
+            .OnKeyUpAny(["Escape", "Tab", "F1"], args =>
+            {
+                executedCount++;
+                lastReceivedArgs = args;
+                return Task.CompletedTask;
+            });
+
+        var (_, keyUp) = builder.Build();
+
+        // Act
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Escape", CtrlKey = true });
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Tab", ShiftKey = true });
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "F1", AltKey = true });
+        await keyUp.NotifyOnKeyUpAsync(new KeyboardEventArgs { Key = "Enter" }); // Should not execute
+
+        // Assert
+        executedCount.Should().Be(3);
+        lastReceivedArgs.Should().NotBeNull();
+        lastReceivedArgs!.Key.Should().Be("F1");
+        lastReceivedArgs.AltKey.Should().BeTrue();
+    }
 }

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -155,48 +155,7 @@ namespace MudBlazor
             return SetBoolValueAsync((bool?)args.Value, true);
         }
 
-        protected async Task HandleKeyDownAsync(KeyboardEventArgs obj)
-        {
-            if (GetDisabledState() || GetReadOnlyState() || !KeyboardEnabled)
-            {
-                return;
-            }
-
-            switch (obj.Key)
-            {
-                case "Delete":
-                    await SetBoolValueAsync(false, true);
-                    break;
-                case "Enter" or "NumpadEnter":
-                    await SetBoolValueAsync(true, true);
-                    break;
-                case "Backspace":
-                    if (TriState)
-                    {
-                        await SetBoolValueAsync(null, true);
-                    }
-
-                    break;
-                case " ":
-                    switch (BoolValue)
-                    {
-                        case null:
-                            await SetBoolValueAsync(true, true);
-                            break;
-                        case true:
-                            await SetBoolValueAsync(false, true);
-                            break;
-                        case false when TriState:
-                            await SetBoolValueAsync(null, true);
-                            break;
-                        case false:
-                            await SetBoolValueAsync(true, true);
-                            break;
-                    }
-
-                    break;
-            }
-        }
+        protected Task HandleKeyDownAsync(KeyboardEventArgs obj) => KeyInterceptorService.DispatchAsync(_elementId, KeyEventKind.Down, obj);
 
         protected override void OnInitialized()
         {
@@ -224,7 +183,12 @@ namespace MudBlazor
                         new("Backspace", preventDown: "key+none")
                     ]);
 
-                await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: HandleKeyDownAsync);
+                await KeyInterceptorService.SubscribeAsync(_elementId, options, keys => keys
+                    .When(CanHandleKeys, builder => builder
+                        .OnKeyDown("Delete", () => SetBoolValueAsync(false, true))
+                        .OnKeyDownAny(["Enter", "NumpadEnter"], () => SetBoolValueAsync(true, true))
+                        .OnKeyDown("Backspace", HandleBackspaceAsync)
+                        .OnKeyDown(" ", HandleSpaceAsync)));
             }
             await base.OnAfterRenderAsync(firstRender);
         }
@@ -243,11 +207,28 @@ namespace MudBlazor
             {
                 return BoolValue is not null;
             }
-            else
-            {
-                return base.HasValue(value);
-            }
+
+            return base.HasValue(value);
         }
+
+        private bool CanHandleKeys() => KeyboardEnabled && !GetDisabledState() && !GetReadOnlyState();
+
+        private Task HandleSpaceAsync()
+        {
+            bool? nextValue = BoolValue switch
+            {
+                null => true,
+                true => false,
+                false when TriState => null,
+                false => true
+            };
+
+            return SetBoolValueAsync(nextValue, true);
+        }
+
+        private Task HandleBackspaceAsync() => TriState
+                ? SetBoolValueAsync(null, true)
+                : Task.CompletedTask;
 
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -425,9 +425,16 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
                     new("Delete", preventDown: "key+none")
                 ]);
 
-            await KeyInterceptorService.SubscribeAsync(_chipContainerId, options, keyDown: HandleKeyDownAsync);
+            await KeyInterceptorService.SubscribeAsync(_chipContainerId, options, keys => keys
+                .When(CanHandleKeys, builder => builder
+                    .OnKeyDown(" ", () => OnClickAsync(new MouseEventArgs()))
+                    .OnKeyDownAny(["Backspace", "Delete"], () => OnCloseAsync(new MouseEventArgs()))));
         }
     }
+
+    private bool CanHandleKeys() => !GetDisabled() && !GetReadOnly();
+
+    protected Task HandleKeyDownAsync(KeyboardEventArgs obj) => KeyInterceptorService.DispatchAsync(_chipContainerId, KeyEventKind.Down, obj);
 
     protected internal async Task OnClickAsync(MouseEventArgs ev)
     {
@@ -457,24 +464,6 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         }
 
         StateHasChanged();
-    }
-
-    private async Task HandleKeyDownAsync(KeyboardEventArgs args)
-    {
-        if (GetDisabled() || GetReadOnly())
-        {
-            return;
-        }
-
-        switch (args.Key)
-        {
-            case " ":
-                await OnClickAsync(new MouseEventArgs());
-                break;
-            case "Backspace" or "Delete":
-                await OnCloseAsync(new MouseEventArgs());
-                break;
-        }
     }
 
     /// <summary>

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -7,7 +7,7 @@
 #nullable enable
 }
 
-<div @attributes="UserAttributes" id="@_elementId" class="mud-dialog-container @GetPosition()">
+<div @attributes="UserAttributes" id="@ElementId" class="mud-dialog-container @GetPosition()">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" @onmouseup="OnMouseUpAsync" />
     <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" class="@Classname" style="@Style" tabindex="-1">
         @if (!GetHideHeader())

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -29,7 +29,8 @@ namespace MudBlazor
         private ElementReference _dialogContainerReference;
         private readonly ParameterState<DialogOptions> _dialogOptionsState;
         private readonly ParameterState<string?> _titleState;
-        private readonly string _elementId = Identifier.Create("dialog");
+
+        internal string ElementId { get; } = Identifier.Create("dialog");
 
         public MudDialogContainer()
         {
@@ -135,22 +136,29 @@ namespace MudBlazor
                         new("/./", subscribeDown: true, subscribeUp: true)
                     ]);
 
-                await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: HandleKeyDownAsync, keyUp: HandleKeyUpAsync);
+                await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
+                    .OnKeyDown("Escape", HandleEscapeAsync)
+                    .OnKeyDown("/./", HandleAnyKeyDownAsync)
+                    .OnKeyUp("/./", HandleAnyKeyUpAsync));
             }
             await base.OnAfterRenderAsync(firstRender);
         }
 
-        internal async Task HandleKeyDownAsync(KeyboardEventArgs args)
+        private Task HandleEscapeAsync()
         {
-            switch (args.Key)
+            if (GetCloseOnEscapeKey())
             {
-                case "Escape":
-                    if (GetCloseOnEscapeKey())
-                    {
-                        ((IMudDialogInstance)this).Cancel();
-                    }
-                    break;
+                ((IMudDialogInstance)this).Cancel();
             }
+            return Task.CompletedTask;
+        }
+
+        private async Task HandleAnyKeyDownAsync(KeyboardEventArgs args)
+        {
+            // Don't invoke callback for Escape - it's handled separately
+            if (args.Key == "Escape")
+                return;
+
             if (_dialog is not null && _dialog.OnKeyDown.HasDelegate)
             {
                 await _dialog.OnKeyDown.InvokeAsync(args);
@@ -160,13 +168,7 @@ namespace MudBlazor
             }
         }
 
-        private async Task OnMouseUpAsync(MouseEventArgs args)
-        {
-            if (args.Button > 0)
-                await RefocusDialogAsync();
-        }
-
-        internal async Task HandleKeyUpAsync(KeyboardEventArgs args)
+        private async Task HandleAnyKeyUpAsync(KeyboardEventArgs args)
         {
             if (_dialog is not null && _dialog.OnKeyUp.HasDelegate)
             {
@@ -175,6 +177,12 @@ namespace MudBlazor
                 // Since the event originates from KeyInterceptor it will not cause a render automatically.
                 await InvokeAsync(StateHasChanged);
             }
+        }
+
+        private async Task OnMouseUpAsync(MouseEventArgs args)
+        {
+            if (args.Button > 0)
+                await RefocusDialogAsync();
         }
 
         private bool GetHideHeader()
@@ -302,7 +310,7 @@ namespace MudBlazor
             _disposed = true;
             if (IsJSRuntimeAvailable)
             {
-                await KeyInterceptorService.UnsubscribeAsync(_elementId);
+                await KeyInterceptorService.UnsubscribeAsync(ElementId);
             }
         }
 
@@ -314,7 +322,7 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        string IMudDialogInstance.ElementId => _elementId;
+        string IMudDialogInstance.ElementId => ElementId;
 
         /// <inheritdoc />
         string? IMudDialogInstance.Title => _titleState.Value;

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -4,7 +4,7 @@
 @inherits MudBaseInput<string>
 @inject InternalMudLocalizer Localizer
 
-<div id="@_elementId" class="@Classname" style="@Style">
+<div id="@ElementId" class="@Classname" style="@Style">
     @if (Adornment == Adornment.Start)
     {
         <MudInputAdornment Class="@AdornmentClassname"

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -28,7 +28,8 @@ namespace MudBlazor
         private ElementReference _elementReference;
         private ElementReference _elementReference1;
         private IMask _mask = new PatternMask("** **-** **");
-        private readonly string _elementId = Identifier.Create("mask");
+
+        internal string ElementId { get; } = Identifier.Create("mask");
 
         protected string Classname =>
             new CssBuilder("mud-input")
@@ -148,7 +149,7 @@ namespace MudBlazor
             {
                 _jsEvent = JsEventFactory.Create();
 
-                await _jsEvent.Connect(_elementId,
+                await _jsEvent.Connect(ElementId,
                     new JsEventOptions
                     {
                         //EnableLogging = true,
@@ -182,7 +183,7 @@ namespace MudBlazor
                         new("Delete", preventDown: "key+none")
                     ]);
 
-                await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: HandleKeyDown);
+                await KeyInterceptorService.SubscribeAsync(ElementId, options, keyDown: HandleKeyDown);
             }
 
             if (_isFocused && Mask.Selection == null)
@@ -480,7 +481,7 @@ namespace MudBlazor
 
             if (IsJSRuntimeAvailable)
             {
-                await KeyInterceptorService.UnsubscribeAsync(_elementId);
+                await KeyInterceptorService.UnsubscribeAsync(ElementId);
                 if (_jsEvent is not null)
                 {
                     _jsEvent.CaretPositionChanged -= OnCaretPositionChanged;

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -308,7 +308,10 @@ namespace MudBlazor
 
                 var options = new KeyInterceptorOptions("mud-input-slot", keyOptions.ToArray());
 
-                await KeyInterceptorService.SubscribeAsync(_elementId, options, KeyObserver.KeyDownIgnore(), KeyObserver.KeyUpIgnore());
+                await KeyInterceptorService.SubscribeAsync(_elementId, options, keys => keys
+                    .When(CanHandleKeys, builder => builder
+                        .OnKeyDown("ArrowUp", Increment)
+                        .OnKeyDown("ArrowDown", Decrement)));
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -327,21 +330,11 @@ namespace MudBlazor
             }
         }
 
+        private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState();
+
         protected async Task HandleKeyDownAsync(KeyboardEventArgs obj)
         {
-            if (GetDisabledState() || GetReadOnlyState())
-                return;
-
-            switch (obj.Key)
-            {
-                case "ArrowUp":
-                    await Increment();
-                    break;
-                case "ArrowDown":
-                    await Decrement();
-                    break;
-            }
-
+            await KeyInterceptorService.DispatchAsync(_elementId, KeyEventKind.Down, obj);
             await OnKeyDown.InvokeAsync(obj);
         }
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -52,7 +52,7 @@
 #nullable enable
     protected virtual RenderFragment? Render =>
         @<CascadingValue Value="@this" IsFixed="true">
-            <div class="@PickerClassname" id="@_elementId">
+            <div class="@PickerClassname" id="@ElementId">
                 @if (PickerVariant != PickerVariant.Static)
                 {
                     <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -21,8 +21,9 @@ namespace MudBlazor
         private string? _text;
         private bool _pickerSquare;
         private ElementReference _pickerInlineRef;
-        private bool _keyInterceptorObserving = false;
-        private readonly string _elementId = Identifier.Create("picker");
+        private bool _keyInterceptorObserving;
+
+        internal string ElementId { get; } = Identifier.Create("picker");
 
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
@@ -646,7 +647,29 @@ namespace MudBlazor
                     new("/./", subscribeDown: true, subscribeUp: true)
                 ]);
 
-            await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: OnHandleKeyDownAsync);
+            await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
+                .HookKeyDown(OnHandleKeyDownAsync)
+                .When(CanHandleKeys, builder => builder
+                    .OnKeyDown("Backspace", HandleBackspaceAsync)
+                    .OnKeyDownAny(["Escape", "Tab"], () => CloseAsync(false))));
+        }
+
+        private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState();
+
+        private async Task HandleBackspaceAsync(KeyboardEventArgs args)
+        {
+            // Ctrl+Shift+Backspace clears the value
+            if (args.CtrlKey && args.ShiftKey)
+            {
+                await ClearAsync();
+                await SetValueCoreAsync(default);
+                await ResetAsync();
+            }
+        }
+
+        protected internal virtual Task OnHandleKeyDownAsync(KeyboardEventArgs args)
+        {
+            return Task.CompletedTask;
         }
 
         private async Task OnClickAsync(MouseEventArgs args)
@@ -699,7 +722,7 @@ namespace MudBlazor
             }
 
             await EnsureKeyInterceptorAsync();
-            await KeyInterceptorService.UpdateKeyAsync(_elementId, new("Escape", stopDown: "key+none"));
+            await KeyInterceptorService.UpdateKeyAsync(ElementId, new("Escape", stopDown: "key+none"));
         }
 
         protected virtual async Task OnClosedAsync()
@@ -707,7 +730,7 @@ namespace MudBlazor
             await OnPickerClosedAsync();
 
             await EnsureKeyInterceptorAsync();
-            await KeyInterceptorService.UpdateKeyAsync(_elementId, new("Escape", stopDown: "none"));
+            await KeyInterceptorService.UpdateKeyAsync(ElementId, new("Escape", stopDown: "none"));
         }
 
         protected virtual Task OnPickerOpenedAsync() => PickerOpened.InvokeAsync(this);
@@ -728,28 +751,6 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
-        protected internal virtual async Task OnHandleKeyDownAsync(KeyboardEventArgs args)
-        {
-            if (GetDisabledState() || GetReadOnlyState())
-                return;
-            switch (args.Key)
-            {
-                case "Backspace":
-                    if (args.CtrlKey && args.ShiftKey)
-                    {
-                        await ClearAsync();
-                        await SetValueCoreAsync(default);
-                        await ResetAsync();
-                    }
-
-                    break;
-                case "Escape":
-                case "Tab":
-                    await CloseAsync(false);
-                    break;
-            }
-        }
-
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {
@@ -757,7 +758,7 @@ namespace MudBlazor
 
             if (IsJSRuntimeAvailable)
             {
-                await KeyInterceptorService.UnsubscribeAsync(_elementId);
+                await KeyInterceptorService.UnsubscribeAsync(ElementId);
             }
         }
     }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -167,27 +167,15 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
-        protected internal async Task HandleKeyDownAsync(KeyboardEventArgs keyboardEventArgs)
+        protected Task HandleKeyDownAsync(KeyboardEventArgs obj) => KeyInterceptorService.DispatchAsync(_elementId, KeyEventKind.Down, obj);
+
+        private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState() && !(MudRadioGroup?.GetReadOnlyState() ?? false);
+
+        private async Task HandleBackspaceAsync()
         {
-            if (GetDisabledState() || GetReadOnlyState() || (MudRadioGroup?.GetReadOnlyState() ?? false))
+            if (MudRadioGroup is not null)
             {
-                return;
-            }
-
-            switch (keyboardEventArgs.Key)
-            {
-                case "Enter" or "NumpadEnter" or " ":
-                    await SelectAsync();
-                    break;
-                case "Backspace":
-                    {
-                        if (MudRadioGroup is not null)
-                        {
-                            await MudRadioGroup.ResetAsync();
-                        }
-
-                        break;
-                    }
+                await MudRadioGroup.ResetAsync();
             }
         }
 
@@ -217,7 +205,10 @@ namespace MudBlazor
                         new("Backspace", preventDown: "key+none")
                     ]);
 
-                await KeyInterceptorService.SubscribeAsync(_elementId, options, KeyObserver.KeyDownIgnore(), KeyObserver.KeyUpIgnore());
+                await KeyInterceptorService.SubscribeAsync(_elementId, options, keys => keys
+                    .When(CanHandleKeys, builder => builder
+                        .OnKeyDownAny(["Enter", "NumpadEnter", " "], SelectAsync)
+                        .OnKeyDown("Backspace", HandleBackspaceAsync)));
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -4,7 +4,7 @@
 
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        <label class="@LabelClassname" style="@Style" @onkeydown="HandleKeyDownAsync" id="@_elementId">
+        <label class="@LabelClassname" style="@Style" @onkeydown="HandleKeyDownAsync" id="@ElementId">
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -15,7 +15,7 @@ namespace MudBlazor
     /// <seealso cref="MudRadio{T}"/>
     public partial class MudSwitch<T> : MudBooleanInput<T>
     {
-        private string _elementId = Identifier.Create("switch");
+        internal string ElementId { get; } = Identifier.Create("switch");
 
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
@@ -83,46 +83,6 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Appearance)]
         public Color ThumbIconColor { get; set; } = Color.Default;
 
-        /// <summary>
-        /// Occurs when a key is pressed.
-        /// </summary>
-        /// <param name="obj">Information about which key was pressed.</param>
-        /// <remarks>
-        /// Supported keys are:<br />
-        /// <c>ArrowLeft</c> or <c>Delete</c> to uncheck the switch.<br />
-        /// <c>ArrowRight</c>, <c>Enter</c>, or <c>NumpadEnter</c> to check the switch.<br />
-        /// <c>Space</c> to toggle the selected value.
-        /// </remarks>
-        protected internal async Task HandleKeyDownAsync(KeyboardEventArgs obj)
-        {
-            if (GetDisabledState() || GetReadOnlyState())
-            {
-                return;
-            }
-
-            switch (obj.Key)
-            {
-                case "ArrowLeft" or "Delete":
-                    await SetBoolValueAsync(false, true);
-                    break;
-                case "ArrowRight" or "Enter" or "NumpadEnter":
-                    await SetBoolValueAsync(true, true);
-                    break;
-                case " ":
-                    switch (BoolValue)
-                    {
-                        case true:
-                            await SetBoolValueAsync(false, true);
-                            break;
-                        default:
-                            await SetBoolValueAsync(true, true);
-                            break;
-                    }
-
-                    break;
-            }
-        }
-
         /// <inheritdoc />
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
@@ -138,11 +98,19 @@ namespace MudBlazor
                         new(" ", preventDown: "key+none", preventUp: "key+none")
                     ]);
 
-                await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: HandleKeyDownAsync);
+                await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
+                    .When(CanHandleKeys, builder => builder
+                        .OnKeyDownAny(["ArrowLeft", "Delete"], () => SetBoolValueAsync(false, true))
+                        .OnKeyDownAny(["ArrowRight", "Enter", "NumpadEnter"], () => SetBoolValueAsync(true, true))
+                        .OnKeyDown(" ", () => SetBoolValueAsync(!BoolValue, true))));
             }
 
             await base.OnAfterRenderAsync(firstRender);
         }
+
+        protected Task HandleKeyDownAsync(KeyboardEventArgs obj) => KeyInterceptorService.DispatchAsync(ElementId, KeyEventKind.Down, obj);
+
+        private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState();
 
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
@@ -151,7 +119,7 @@ namespace MudBlazor
 
             if (IsJSRuntimeAvailable)
             {
-                await KeyInterceptorService.UnsubscribeAsync(_elementId);
+                await KeyInterceptorService.UnsubscribeAsync(ElementId);
             }
         }
     }

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyCommand.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyCommand.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components.Web;
+
+namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// Represents a keyboard command that can be executed based on keyboard events.
+/// </summary>
+public interface IKeyCommand
+{
+    /// <summary>
+    /// Gets the kind of keyboard event this command handles (Down or Up).
+    /// </summary>
+    KeyEventKind Kind { get; }
+
+    /// <summary>
+    /// Gets whether this command is a hook that should always execute without stopping the command chain.
+    /// </summary>
+    bool IsHook { get; }
+
+    /// <summary>
+    /// Determines whether this command can be executed for the given keyboard event.
+    /// </summary>
+    /// <param name="args">The keyboard event arguments.</param>
+    /// <returns><c>true</c> if the command can execute; otherwise, <c>false</c>.</returns>
+    bool CanExecute(KeyboardEventArgs args);
+
+    /// <summary>
+    /// Executes the command asynchronously.
+    /// </summary>
+    /// <param name="args">The keyboard event arguments.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task ExecuteAsync(KeyboardEventArgs args);
+}

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyCommand.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyCommand.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Services;
 /// <summary>
 /// Represents a keyboard command that can be executed based on keyboard events.
 /// </summary>
-public interface IKeyCommand
+internal interface IKeyCommand
 {
     /// <summary>
     /// Gets the kind of keyboard event this command handles (Down or Up).

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorService.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorService.cs
@@ -24,6 +24,8 @@ public interface IKeyInterceptorService : IAsyncDisposable
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task SubscribeAsync(IKeyInterceptorObserver observer, KeyInterceptorOptions options);
 
+    Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Action<KeyMapBuilder> configure);
+
     /// <summary>
     /// Subscribes to key events for a specified element with the provided options.
     /// </summary>
@@ -62,6 +64,8 @@ public interface IKeyInterceptorService : IAsyncDisposable
     /// </remarks>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Func<KeyboardEventArgs, Task>? keyDown = null, Func<KeyboardEventArgs, Task>? keyUp = null);
+
+    Task DispatchAsync(string elementId, KeyEventKind kind, KeyboardEventArgs args);
 
     /// <summary>
     /// Updates the key options for a specified element.

--- a/src/MudBlazor/Services/KeyInterceptor/KeyCommandObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyCommandObserver.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components.Web;
+
+namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// Efficiently dispatches keyboard events to registered commands.
+/// Uses early-exit pattern for optimal performance.
+/// </summary>
+internal sealed class KeyCommandObserver :
+    IKeyDownObserver,
+    IKeyUpObserver
+{
+    private readonly IReadOnlyList<IKeyCommand> _downCommands;
+    private readonly IReadOnlyList<IKeyCommand> _upCommands;
+
+    public KeyCommandObserver(IReadOnlyList<IKeyCommand> commands)
+    {
+        // Split commands by kind at construction time for faster dispatch
+        var downCommands = new List<IKeyCommand>();
+        var upCommands = new List<IKeyCommand>();
+
+        foreach (var command in commands)
+        {
+            if (command.Kind == KeyEventKind.Down)
+            {
+                downCommands.Add(command);
+            }
+            else
+            {
+                upCommands.Add(command);
+            }
+        }
+
+        _downCommands = downCommands;
+        _upCommands = upCommands;
+    }
+
+    public Task NotifyOnKeyDownAsync(KeyboardEventArgs args)
+        => DispatchAsync(_downCommands, args);
+
+    public Task NotifyOnKeyUpAsync(KeyboardEventArgs args)
+        => DispatchAsync(_upCommands, args);
+
+    private static async Task DispatchAsync(IReadOnlyList<IKeyCommand> commands, KeyboardEventArgs args)
+    {
+        // Execute all hooks first (hooks always return true for CanExecute)
+        // Then find and execute the first non-hook command that matches
+        for (var i = 0; i < commands.Count; i++)
+        {
+            var command = commands[i];
+            if (command.CanExecute(args))
+            {
+                await command.ExecuteAsync(args);
+
+                // If this is not a hook, stop processing (early-exit pattern)
+                if (!command.IsHook)
+                {
+                    return;
+                }
+                // If it's a hook, continue to the next command
+            }
+        }
+    }
+}

--- a/src/MudBlazor/Services/KeyInterceptor/KeyCommandObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyCommandObserver.cs
@@ -48,9 +48,8 @@ internal sealed class KeyCommandObserver :
 
     private static async Task DispatchAsync(IReadOnlyList<IKeyCommand> commands, KeyboardEventArgs args)
     {
-        for (var i = 0; i < commands.Count; i++)
+        foreach (var command in commands)
         {
-            var command = commands[i];
             if (command.CanExecute(args))
             {
                 await command.ExecuteAsync(args);

--- a/src/MudBlazor/Services/KeyInterceptor/KeyCommandObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyCommandObserver.cs
@@ -48,8 +48,6 @@ internal sealed class KeyCommandObserver :
 
     private static async Task DispatchAsync(IReadOnlyList<IKeyCommand> commands, KeyboardEventArgs args)
     {
-        // Execute all hooks first (hooks always return true for CanExecute)
-        // Then find and execute the first non-hook command that matches
         for (var i = 0; i < commands.Count; i++)
         {
             var command = commands[i];

--- a/src/MudBlazor/Services/KeyInterceptor/KeyEventKind.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyEventKind.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// Specifies the type of keyboard event.
+/// </summary>
+public enum KeyEventKind
+{
+    /// <summary>
+    /// Represents a key down event.
+    /// </summary>
+    Down,
+
+    /// <summary>
+    /// Represents a key up event.
+    /// </summary>
+    Up
+}

--- a/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorService.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyInterceptorService.cs
@@ -60,6 +60,18 @@ internal sealed class KeyInterceptorService : IKeyInterceptorService
         }
     }
 
+    public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Action<KeyMapBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var builder = KeyMapBuilder.Create();
+        configure(builder);
+
+        var (keyDown, keyUp) = builder.Build();
+
+        return SubscribeAsync(elementId, options, keyDown, keyUp);
+    }
+
     /// <inheritdoc />
     public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, IKeyDownObserver? keyDown, IKeyUpObserver? keyUp)
     {
@@ -76,6 +88,16 @@ internal sealed class KeyInterceptorService : IKeyInterceptorService
     public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Func<KeyboardEventArgs, Task>? keyDown, Func<KeyboardEventArgs, Task>? keyUp)
     {
         return SubscribeAsync(new KeyObserver(elementId, KeyObserver.KeyDown(keyDown), KeyObserver.KeyUp(keyUp)), options);
+    }
+
+    public Task DispatchAsync(string elementId, KeyEventKind kind, KeyboardEventArgs args)
+    {
+        return kind switch
+        {
+            KeyEventKind.Down => OnKeyDown(elementId, args),
+            KeyEventKind.Up => OnKeyUp(elementId, args),
+            _ => Task.CompletedTask
+        };
     }
 
     /// <inheritdoc />

--- a/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
@@ -15,6 +15,7 @@ namespace MudBlazor.Services;
 public sealed class KeyMapBuilder
 {
     private readonly List<IKeyCommand> _commands = [];
+    private int _hookCount = 0;
 
     /// <summary>
     /// Helper to parse regex patterns from key strings.
@@ -166,13 +167,38 @@ public sealed class KeyMapBuilder
     /// <summary>
     /// Creates a conditional scope where all commands share the same condition.
     /// This is more efficient than adding the condition to each command individually.
+    /// Hooks within the scope are still inserted at the beginning to ensure they execute first.
     /// </summary>
     public KeyMapBuilder When(Func<bool> condition, Action<KeyMapBuilder> configure)
     {
         var scopedBuilder = new KeyMapBuilder();
         configure(scopedBuilder);
 
+        // Separate hooks from regular commands
+        var hooks = new List<IKeyCommand>();
+        var regularCommands = new List<IKeyCommand>();
+
         foreach (var command in scopedBuilder._commands)
+        {
+            if (command.IsHook)
+            {
+                hooks.Add(command);
+            }
+            else
+            {
+                regularCommands.Add(command);
+            }
+        }
+
+        // Insert hooks at the current hook position (maintaining declaration order)
+        foreach (var hook in hooks)
+        {
+            _commands.Insert(_hookCount, new ConditionalCommand(hook, condition));
+            _hookCount++;
+        }
+
+        // Add regular commands at the end
+        foreach (var command in regularCommands)
         {
             _commands.Add(new ConditionalCommand(command, condition));
         }
@@ -186,13 +212,13 @@ public sealed class KeyMapBuilder
     /// This is useful for maintaining virtual method override patterns while using the KeyCommand API.
     /// </summary>
     /// <remarks>
-    /// <para><strong>Important:</strong> Hooks execute in the order they are declared in the builder. For hooks to execute before specific key commands, declare them first using <c>.HookKeyDown()</c> before calling <c>.OnKeyDown()</c> or other command methods.</para>
+    /// <para><strong>Important:</strong> Hooks are always executed before regular commands, regardless of their declaration order. You can declare hooks anywhere in the builder chain and they will be automatically moved to execute first.</para>
     /// <para><strong>Example usage:</strong></para>
     /// <code>
     /// await KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
-    ///     .HookKeyDown(OnHandleKeyDownAsync)  // Hook executes first for ALL keys
+    ///     .OnKeyDown("Backspace", HandleBackspaceAsync)  // Regular commands
+    ///     .HookKeyDown(OnHandleKeyDownAsync)  // Hook still executes first for ALL keys
     ///     .When(CanHandleKeys, builder => builder
-    ///         .OnKeyDown("Backspace", HandleBackspaceAsync)  // Then specific key handlers
     ///         .OnKeyDownAny(["Escape", "Tab"], CloseAsync)));
     /// </code>
     /// <para>The hook receives the KeyboardEventArgs and can perform any necessary processing (e.g., calling a virtual method that derived classes can override). The hook will execute for every key down event, regardless of whether any specific key commands match.</para>
@@ -202,7 +228,8 @@ public sealed class KeyMapBuilder
     /// <returns>The builder for chaining.</returns>
     public KeyMapBuilder HookKeyDown(Func<KeyboardEventArgs, Task> hook)
     {
-        _commands.Add(new HookCommand(KeyEventKind.Down, hook));
+        _commands.Insert(_hookCount, new HookCommand(KeyEventKind.Down, hook));
+        _hookCount++;
         return this;
     }
 
@@ -212,13 +239,13 @@ public sealed class KeyMapBuilder
     /// This is useful for maintaining virtual method override patterns while using the KeyCommand API.
     /// </summary>
     /// <remarks>
-    /// <para><strong>Important:</strong> Hooks execute in the order they are declared in the builder. For hooks to execute before specific key commands, declare them first using <c>.HookKeyUp()</c> before calling <c>.OnKeyUp()</c> or other command methods.</para>
+    /// <para><strong>Important:</strong> Hooks are always executed before regular commands, regardless of their declaration order. You can declare hooks anywhere in the builder chain and they will be automatically moved to execute first.</para>
     /// <para><strong>Example usage:</strong></para>
     /// <code>
     /// await KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
-    ///     .HookKeyUp(OnHandleKeyUpAsync)  // Hook executes first for ALL keys
+    ///     .OnKeyUp("Enter", HandleEnterAsync)  // Regular commands
+    ///     .HookKeyUp(OnHandleKeyUpAsync)  // Hook still executes first for ALL keys
     ///     .When(CanHandleKeys, builder => builder
-    ///         .OnKeyUp("Enter", HandleEnterAsync)  // Then specific key handlers
     ///         .OnKeyUpAny(["Escape", "Tab"], CloseAsync)));
     /// </code>
     /// <para>The hook receives the KeyboardEventArgs and can perform any necessary processing (e.g., calling a virtual method that derived classes can override). The hook will execute for every key up event, regardless of whether any specific key commands match.</para>
@@ -228,7 +255,8 @@ public sealed class KeyMapBuilder
     /// <returns>The builder for chaining.</returns>
     public KeyMapBuilder HookKeyUp(Func<KeyboardEventArgs, Task> hook)
     {
-        _commands.Add(new HookCommand(KeyEventKind.Up, hook));
+        _commands.Insert(_hookCount, new HookCommand(KeyEventKind.Up, hook));
+        _hookCount++;
         return this;
     }
 
@@ -395,7 +423,8 @@ public sealed class KeyMapBuilder
     /// Used to maintain virtual method override patterns.
     /// Unlike regular commands, hooks do not stop the command chain after execution,
     /// allowing subsequent commands to also process the same key event.
-    /// Hooks execute in declaration order - declare them before other commands to ensure they run first.
+    /// Hooks are always inserted at index 0 to ensure they execute before regular commands,
+    /// regardless of their declaration order in the builder.
     /// </summary>
     private sealed class HookCommand(KeyEventKind kind, Func<KeyboardEventArgs, Task> hook) : IKeyCommand
     {

--- a/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
@@ -1,0 +1,413 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace MudBlazor.Services;
+
+#nullable enable
+/// <summary>
+/// A fluent builder for creating declarative key command mappings.
+/// Supports conditional execution and efficient command dispatching.
+/// </summary>
+public sealed class KeyMapBuilder
+{
+    private readonly List<IKeyCommand> _commands = [];
+
+    /// <summary>
+    /// Helper to parse regex patterns from key strings.
+    /// </summary>
+    private static Regex? ParseRegexPattern(string key)
+    {
+        // Check if key is a regex pattern like "/pattern/"
+        if (key.Length > 2 && key.StartsWith('/') && key.EndsWith('/'))
+        {
+            try
+            {
+                return new Regex(key.Substring(1, key.Length - 2));
+            }
+            catch
+            {
+                // Invalid regex, fall back to literal matching
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Maps multiple keys to a single action on key down.
+    /// </summary>
+    public KeyMapBuilder OnKeyDownAny(IEnumerable<string> keys, Func<Task> action)
+    {
+        _commands.Add(new MultiKeyCommand(KeyEventKind.Down, keys, action));
+        return this;
+    }
+
+    /// <summary>
+    /// Maps multiple keys to a single action on key down that receives the keyboard event args.
+    /// </summary>
+    public KeyMapBuilder OnKeyDownAny(IEnumerable<string> keys, Func<KeyboardEventArgs, Task> action)
+    {
+        _commands.Add(new MultiKeyCommandWithArgs(KeyEventKind.Down, keys, action));
+        return this;
+    }
+
+    /// <summary>
+    /// Maps multiple keys to a single action on key up.
+    /// </summary>
+    public KeyMapBuilder OnKeyUpAny(IEnumerable<string> keys, Func<Task> action)
+    {
+        _commands.Add(new MultiKeyCommand(KeyEventKind.Up, keys, action));
+        return this;
+    }
+
+    /// <summary>
+    /// Maps multiple keys to a single action on key up that receives the keyboard event args.
+    /// </summary>
+    public KeyMapBuilder OnKeyUpAny(IEnumerable<string> keys, Func<KeyboardEventArgs, Task> action)
+    {
+        _commands.Add(new MultiKeyCommandWithArgs(KeyEventKind.Up, keys, action));
+        return this;
+    }
+
+    /// <summary>
+    /// Maps a single key to an action on key down, with optional condition.
+    /// </summary>
+    /// <param name="key">The key to handle.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="when">Optional condition that must be true for the command to execute.</param>
+    public KeyMapBuilder OnKeyDown(string key, Func<Task> action, Func<bool>? when = null)
+    {
+        IKeyCommand command = new SimpleKeyCommand(KeyEventKind.Down, key, action);
+
+        if (when is not null)
+        {
+            command = new ConditionalCommand(command, when);
+        }
+
+        _commands.Add(command);
+        return this;
+    }
+
+    /// <summary>
+    /// Maps a single key to an action on key down that receives the keyboard event args.
+    /// Use this when you need access to modifier keys or other event details.
+    /// </summary>
+    /// <param name="key">The key to handle.</param>
+    /// <param name="action">The action to execute, receiving KeyboardEventArgs.</param>
+    /// <param name="when">Optional condition that must be true for the command to execute.</param>
+    public KeyMapBuilder OnKeyDown(string key, Func<KeyboardEventArgs, Task> action, Func<bool>? when = null)
+    {
+        IKeyCommand command = new KeyCommandWithArgs(KeyEventKind.Down, key, action);
+
+        if (when is not null)
+        {
+            command = new ConditionalCommand(command, when);
+        }
+
+        _commands.Add(command);
+        return this;
+    }
+
+    /// <summary>
+    /// Maps a single key to an action on key up, with optional condition.
+    /// </summary>
+    /// <param name="key">The key to handle.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="when">Optional condition that must be true for the command to execute.</param>
+    public KeyMapBuilder OnKeyUp(string key, Func<Task> action, Func<bool>? when = null)
+    {
+        IKeyCommand command = new SimpleKeyCommand(KeyEventKind.Up, key, action);
+
+        if (when is not null)
+        {
+            command = new ConditionalCommand(command, when);
+        }
+
+        _commands.Add(command);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Maps a single key to an action on key up that receives the keyboard event args.
+    /// Use this when you need access to modifier keys or other event details.
+    /// </summary>
+    /// <param name="key">The key to handle.</param>
+    /// <param name="action">The action to execute, receiving KeyboardEventArgs.</param>
+    /// <param name="when">Optional condition that must be true for the command to execute.</param>
+    public KeyMapBuilder OnKeyUp(string key, Func<KeyboardEventArgs, Task> action, Func<bool>? when = null)
+    {
+        IKeyCommand command = new KeyCommandWithArgs(KeyEventKind.Up, key, action);
+
+        if (when is not null)
+        {
+            command = new ConditionalCommand(command, when);
+        }
+
+        _commands.Add(command);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Maps multiple keys to an action on key down with a shared condition.
+    /// More efficient than calling OnKeyDown multiple times with the same condition.
+    /// </summary>
+    public KeyMapBuilder OnKeyDownAny(IEnumerable<string> keys, Func<Task> action, Func<bool> when)
+    {
+        _commands.Add(new ConditionalCommand(new MultiKeyCommand(KeyEventKind.Down, keys, action), when));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a conditional scope where all commands share the same condition.
+    /// This is more efficient than adding the condition to each command individually.
+    /// </summary>
+    public KeyMapBuilder When(Func<bool> condition, Action<KeyMapBuilder> configure)
+    {
+        var scopedBuilder = new KeyMapBuilder();
+        configure(scopedBuilder);
+
+        foreach (var command in scopedBuilder._commands)
+        {
+            _commands.Add(new ConditionalCommand(command, condition));
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a hook that will be called for every key down event, allowing subsequent commands to also execute.
+    /// Unlike regular commands which stop the command chain after execution, hooks do not stop the chain.
+    /// This is useful for maintaining virtual method override patterns while using the KeyCommand API.
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>Important:</strong> Hooks execute in the order they are declared in the builder. For hooks to execute before specific key commands, declare them first using <c>.HookKeyDown()</c> before calling <c>.OnKeyDown()</c> or other command methods.</para>
+    /// <para><strong>Example usage:</strong></para>
+    /// <code>
+    /// await KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
+    ///     .HookKeyDown(OnHandleKeyDownAsync)  // Hook executes first for ALL keys
+    ///     .When(CanHandleKeys, builder => builder
+    ///         .OnKeyDown("Backspace", HandleBackspaceAsync)  // Then specific key handlers
+    ///         .OnKeyDownAny(["Escape", "Tab"], CloseAsync)));
+    /// </code>
+    /// <para>The hook receives the KeyboardEventArgs and can perform any necessary processing (e.g., calling a virtual method that derived classes can override). The hook will execute for every key down event, regardless of whether any specific key commands match.</para>
+    /// <para>If a hook is placed inside a <c>When()</c> scope, it will still respect the condition - it won't execute unconditionally.</para>
+    /// </remarks>
+    /// <param name="hook">The method to call on every key down event.</param>
+    /// <returns>The builder for chaining.</returns>
+    public KeyMapBuilder HookKeyDown(Func<KeyboardEventArgs, Task> hook)
+    {
+        _commands.Add(new HookCommand(KeyEventKind.Down, hook));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a hook that will be called for every key up event, allowing subsequent commands to also execute.
+    /// Unlike regular commands which stop the command chain after execution, hooks do not stop the chain.
+    /// This is useful for maintaining virtual method override patterns while using the KeyCommand API.
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>Important:</strong> Hooks execute in the order they are declared in the builder. For hooks to execute before specific key commands, declare them first using <c>.HookKeyUp()</c> before calling <c>.OnKeyUp()</c> or other command methods.</para>
+    /// <para><strong>Example usage:</strong></para>
+    /// <code>
+    /// await KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
+    ///     .HookKeyUp(OnHandleKeyUpAsync)  // Hook executes first for ALL keys
+    ///     .When(CanHandleKeys, builder => builder
+    ///         .OnKeyUp("Enter", HandleEnterAsync)  // Then specific key handlers
+    ///         .OnKeyUpAny(["Escape", "Tab"], CloseAsync)));
+    /// </code>
+    /// <para>The hook receives the KeyboardEventArgs and can perform any necessary processing (e.g., calling a virtual method that derived classes can override). The hook will execute for every key up event, regardless of whether any specific key commands match.</para>
+    /// <para>If a hook is placed inside a <c>When()</c> scope, it will still respect the condition - it won't execute unconditionally.</para>
+    /// </remarks>
+    /// <param name="hook">The method to call on every key up event.</param>
+    /// <returns>The builder for chaining.</returns>
+    public KeyMapBuilder HookKeyUp(Func<KeyboardEventArgs, Task> hook)
+    {
+        _commands.Add(new HookCommand(KeyEventKind.Up, hook));
+        return this;
+    }
+
+    public (IKeyDownObserver, IKeyUpObserver) Build()
+    {
+        if (_commands.Count == 0)
+        {
+            return (KeyObserver.KeyDownIgnore(), KeyObserver.KeyUpIgnore());
+        }
+
+        var observer = new KeyCommandObserver(_commands);
+        return (observer, observer);
+    }
+
+    public static KeyMapBuilder Create() => new();
+
+    private sealed class SimpleKeyCommand(KeyEventKind kind, string key, Func<Task> action) : IKeyCommand
+    {
+        private readonly Regex? _regex = ParseRegexPattern(key);
+
+        public KeyEventKind Kind { get; } = kind;
+
+        public bool IsHook => false;
+
+        public bool CanExecute(KeyboardEventArgs args)
+            => _regex?.IsMatch(args.Key) ?? args.Key == key;
+
+        public Task ExecuteAsync(KeyboardEventArgs args)
+            => action();
+    }
+
+    private sealed class KeyCommandWithArgs(KeyEventKind kind, string key, Func<KeyboardEventArgs, Task> action) : IKeyCommand
+    {
+        private readonly Regex? _regex = ParseRegexPattern(key);
+
+        public KeyEventKind Kind { get; } = kind;
+
+        public bool IsHook => false;
+
+        public bool CanExecute(KeyboardEventArgs args)
+            => _regex?.IsMatch(args.Key) ?? args.Key == key;
+
+        public Task ExecuteAsync(KeyboardEventArgs args)
+            => action(args);
+    }
+
+    private sealed class MultiKeyCommand : IKeyCommand
+    {
+        private readonly HashSet<string> _keys = [];
+        private readonly List<Regex> _regexes = [];
+        private readonly Func<Task> _action;
+
+        public KeyEventKind Kind { get; }
+
+        public bool IsHook => false;
+
+        public MultiKeyCommand(KeyEventKind kind, IEnumerable<string> keys, Func<Task> action)
+        {
+            Kind = kind;
+            _action = action;
+
+            foreach (var key in keys)
+            {
+                var regex = ParseRegexPattern(key);
+                if (regex is not null)
+                {
+                    _regexes.Add(regex);
+                }
+                else
+                {
+                    _keys.Add(key);
+                }
+            }
+        }
+
+        public bool CanExecute(KeyboardEventArgs args)
+        {
+            if (_keys.Contains(args.Key))
+            {
+                return true;
+            }
+
+            foreach (var regex in _regexes)
+            {
+                if (regex.IsMatch(args.Key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public Task ExecuteAsync(KeyboardEventArgs args)
+            => _action();
+    }
+
+    private sealed class MultiKeyCommandWithArgs : IKeyCommand
+    {
+        private readonly HashSet<string> _keys = [];
+        private readonly List<Regex> _regexes = [];
+        private readonly Func<KeyboardEventArgs, Task> _action;
+
+        public KeyEventKind Kind { get; }
+
+        public bool IsHook => false;
+
+        public MultiKeyCommandWithArgs(KeyEventKind kind, IEnumerable<string> keys, Func<KeyboardEventArgs, Task> action)
+        {
+            Kind = kind;
+            _action = action;
+
+            foreach (var key in keys)
+            {
+                var regex = ParseRegexPattern(key);
+                if (regex != null)
+                {
+                    _regexes.Add(regex);
+                }
+                else
+                {
+                    _keys.Add(key);
+                }
+            }
+        }
+
+        public bool CanExecute(KeyboardEventArgs args)
+        {
+            if (_keys.Contains(args.Key))
+            {
+                return true;
+            }
+
+            foreach (var regex in _regexes)
+            {
+                if (regex.IsMatch(args.Key))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public Task ExecuteAsync(KeyboardEventArgs args)
+            => _action(args);
+    }
+
+    private sealed class ConditionalCommand(IKeyCommand inner, Func<bool> condition) : IKeyCommand
+    {
+        public KeyEventKind Kind => inner.Kind;
+
+        // Preserve hook status from inner command
+        public bool IsHook => inner.IsHook;
+
+        public bool CanExecute(KeyboardEventArgs args)
+            => condition() && inner.CanExecute(args);
+
+        public Task ExecuteAsync(KeyboardEventArgs args)
+            => inner.ExecuteAsync(args);
+    }
+
+    /// <summary>
+    /// A hook command that always executes for its Kind, regardless of the key pressed.
+    /// Used to maintain virtual method override patterns.
+    /// Unlike regular commands, hooks do not stop the command chain after execution,
+    /// allowing subsequent commands to also process the same key event.
+    /// Hooks execute in declaration order - declare them before other commands to ensure they run first.
+    /// </summary>
+    private sealed class HookCommand(KeyEventKind kind, Func<KeyboardEventArgs, Task> hook) : IKeyCommand
+    {
+        public KeyEventKind Kind { get; } = kind;
+
+        // Mark this as a hook so dispatcher knows not to stop the chain
+        public bool IsHook => true;
+
+        // Hook always executes for any key
+        public bool CanExecute(KeyboardEventArgs args) => true;
+
+        public Task ExecuteAsync(KeyboardEventArgs args) => hook(args);
+    }
+}

--- a/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
@@ -381,7 +381,6 @@ public sealed class KeyMapBuilder
     {
         public KeyEventKind Kind => inner.Kind;
 
-        // Preserve hook status from inner command
         public bool IsHook => inner.IsHook;
 
         public bool CanExecute(KeyboardEventArgs args)
@@ -402,7 +401,6 @@ public sealed class KeyMapBuilder
     {
         public KeyEventKind Kind { get; } = kind;
 
-        // Mark this as a hook so dispatcher knows not to stop the chain
         public bool IsHook => true;
 
         // Hook always executes for any key

--- a/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
@@ -14,8 +14,8 @@ namespace MudBlazor.Services;
 /// </summary>
 public sealed class KeyMapBuilder
 {
+    private int _hookCount;
     private readonly List<IKeyCommand> _commands = [];
-    private int _hookCount = 0;
 
     /// <summary>
     /// Helper to parse regex patterns from key strings.
@@ -27,7 +27,7 @@ public sealed class KeyMapBuilder
         {
             try
             {
-                return new Regex(key.Substring(1, key.Length - 2));
+                return new Regex(key.Substring(1, key.Length - 2), RegexOptions.None, TimeSpan.FromMilliseconds(250));
             }
             catch
             {
@@ -35,6 +35,7 @@ public sealed class KeyMapBuilder
                 return null;
             }
         }
+
         return null;
     }
 
@@ -212,7 +213,7 @@ public sealed class KeyMapBuilder
     /// This is useful for maintaining virtual method override patterns while using the KeyCommand API.
     /// </summary>
     /// <remarks>
-    /// <para><strong>Important:</strong> Hooks are always executed before regular commands, regardless of their declaration order. You can declare hooks anywhere in the builder chain and they will be automatically moved to execute first.</para>
+    /// <para><strong>Important:</strong> Hooks are always executed before regular commands, regardless of their declaration order. You can declare hooks anywhere in the builder chain, and they will be automatically moved to execute first.</para>
     /// <para><strong>Example usage:</strong></para>
     /// <code>
     /// await KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
@@ -239,7 +240,7 @@ public sealed class KeyMapBuilder
     /// This is useful for maintaining virtual method override patterns while using the KeyCommand API.
     /// </summary>
     /// <remarks>
-    /// <para><strong>Important:</strong> Hooks are always executed before regular commands, regardless of their declaration order. You can declare hooks anywhere in the builder chain and they will be automatically moved to execute first.</para>
+    /// <para><strong>Important:</strong> Hooks are always executed before regular commands, regardless of their declaration order. You can declare hooks anywhere in the builder chain, and they will be automatically moved to execute first.</para>
     /// <para><strong>Example usage:</strong></para>
     /// <code>
     /// await KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys


### PR DESCRIPTION
## New API Design:
```C#
await KeyInterceptorService.SubscribeAsync(_elementId, options, keys => keys
   .When(CanHandleKeys, builder => builder
       .OnKeyDown("Delete", () => SetBoolValueAsync(false, true))
       .OnKeyDownAny(["Enter", "NumpadEnter"], () => SetBoolValueAsync(true, true))
       .OnKeyDown("Backspace", HandleBackspaceAsync)
       .OnKeyDown(" ", HandleSpaceAsync)));
```
vs
```C#
await KeyInterceptorService.SubscribeAsync(_elementId, options, keyDown: HandleKeyDownAsync);

protected internal async Task HandleKeyDownAsync(KeyboardEventArgs obj)
{
	if (GetDisabledState() || GetReadOnlyState())
	{
		return;
	}

	switch (obj.Key)
	{
		case "ArrowLeft" or "Delete":
			await SetBoolValueAsync(false, true);
			break;
		case "ArrowRight" or "Enter" or "NumpadEnter":
			await SetBoolValueAsync(true, true);
			break;
		case " ":
			switch (BoolValue)
			{
				case true:
					await SetBoolValueAsync(false, true);
					break;
				default:
					await SetBoolValueAsync(true, true);
					break;
			}

			break;
	}
}
```
**NB!** New API is just an wrapper for existing KeyInterceptorService API, you still can use the old way.


## Migrated components:
- [x] MudSwitch
- [x] MudRadio
- [x] MudChip
- [x] MudNumericField
- [x] MudDialogContainer
- [x] MudPicker

## Not migrated due to complexity:
- [ ] MudSelect
- [ ] MudTabs
- [ ] MudMenu
- [ ] MudMask

## Tests improvements:

**SwitchTest:**
Instead of calling `MudSwitch.HandleKeyDownAsync` directly, it uses `bUnit.KeyDownAsync`, which triggers the `@onkeydown="HandleKeyDownAsync"`.

**DialogTests:**
Instead of calling `MudDialogContainer.HandleKeyDownAsync` directly, it uses `KeyInterceptorService.OnKeyDown`, because there is no `@onkeydown`.

**TimePickerTests:**
Instead of calling `MudTimePicker.HandleKeyDownAsync` directly, it uses `KeyInterceptorService.OnKeyDown`, because there is no `@onkeydown`.

**DatePickerTests:**
Instead of calling `MudDatePicker.HandleKeyDownAsync` directly, it uses `KeyInterceptorService.OnKeyDown`, because there is no `@onkeydown`.

**MaskTests:**
Instead of calling `MudMask.HandleKeyDownAsync` directly, it uses `KeyInterceptorService.OnKeyDown`, because there is no `@onkeydown`.

Components with improved tests:
- [x] MudSwitch
- [x] MudDialogContainer
- [x] MudTimePicker
- [x] MudTimePicker
- [x] MudMask
- [x] MudRadio - already used bUnit, rather than `MudRadio.HandleKeyDownAsync`, just switched to async version.
- [x] MudNumericField - already used bUnit, rather than `MudNumericField .HandleKeyDownAsync`, just switched to async version.
- [ ] MudChip - **missing Key Navigation tests**
- [ ] MudSelect - skipped, uses HandleKeyDownAsync directly
- [ ] MudTabs - unclear, uses bUnit but uses `TriggerEventAsync("onkeydown", ...)` for some reason?
- [ ] MudMenu - same as MudTabs, plus uses TrackKeyboardInteraction reflection?



**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
