### PR TITLE
Build: Condense docs compiler logging

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -771,14 +771,12 @@ public class ApiDocumentationBuilder
         var fieldCoverage = wellDocumentedFields / (double)Fields.Count;
         var eventCoverage = wellDocumentedEvents / (double)Events.Count;
 
-        Console.WriteLine(@"XML Documentation Coverage for MudBlazor:");
-        Console.WriteLine();
-        Console.WriteLine(@$"Types:      {wellDocumentedTypes} of {Types.Count} ({typeCoverage:P0}) types");
-        Console.WriteLine(@$"Properties: {wellDocumentedProperties} of {Properties.Count} ({propertyCoverage:P0}) properties");
-        Console.WriteLine(@$"Methods:    {wellDocumentedMethods} of {Methods.Count} ({methodCoverage:P0}) methods");
-        Console.WriteLine(@$"Fields:     {wellDocumentedFields} of {Fields.Count} ({fieldCoverage:P0}) fields");
-        Console.WriteLine(@$"Events:     {wellDocumentedEvents} of {Events.Count} ({eventCoverage:P0}) events/EventCallback");
-        Console.WriteLine();
+        Console.WriteLine(
+            @$"XML Doc Coverage: T {wellDocumentedTypes}/{Types.Count} ({typeCoverage:P0}), " +
+            @$"P {wellDocumentedProperties}/{Properties.Count} ({propertyCoverage:P0}), " +
+            @$"M {wellDocumentedMethods}/{Methods.Count} ({methodCoverage:P0}), " +
+            @$"F {wellDocumentedFields}/{Fields.Count} ({fieldCoverage:P0}), " +
+            @$"E {wellDocumentedEvents}/{Events.Count} ({eventCoverage:P0})");
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs.Compiler/ExamplesMarkup.cs
+++ b/src/MudBlazor.Docs.Compiler/ExamplesMarkup.cs
@@ -99,8 +99,7 @@ namespace MudBlazor.Docs.Compiler
                 success = false;
             }
 
-            Console.WriteLine(@$"Docs.Compiler updated {noOfFilesUpdated} generated files");
-            Console.WriteLine(@$"Docs.Compiler generated {noOfFilesCreated} new files");
+            Console.WriteLine(@$"Docs.Compiler markup: updated {noOfFilesUpdated} files, generated {noOfFilesCreated} new files");
             return success;
         }
 


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Before:

```
2>  XML Documentation Coverage for MudBlazor:
2>
2>  Types:      416 of 467 (89%) types
2>  Properties: 2653 of 3095 (86%) properties
2>  Methods:    578 of 929 (62%) methods
2>  Fields:     349 of 561 (62%) fields
2>  Events:     207 of 222 (93%) events/EventCallback
2>
2>  Docs.Compiler updated 0 generated files
2>  Docs.Compiler generated 0 new files
2>  Docs.Compiler completed in 3251 milliseconds.
2>  Building MudBlazor.Docs web assets (inner build, TFM: net10.0)
```

After:

```
6>  XML Doc Coverage: T 416/467 (89%), P 2653/3095 (86%), M 578/929 (62%), F 349/561 (62%), E 207/222 (93%)
6>  Docs.Compiler markup: updated 0 files, generated 712 new files
6>  Docs.Compiler completed in 5368 milliseconds.
6>  Building MudBlazor.Docs web assets (inner build, TFM: net10.0)
```

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
