### PR TITLE
Revert "Tests: Enable parallelization for TextFieldTests, NumericFieldTests"

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
+    [NonParallelizable]
     public class NumericFieldTests : BunitTest
     {
         // TestCaseSource does not know about "Nullable<T>" so having values as Nullable<T> does not make sense here
@@ -129,8 +130,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ShouldRespectDebounceIntervalPropertyInNumericField()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
             var comp = Context.Render<MudNumericField<int?>>(parameters => parameters
                 .Add(x => x.DebounceInterval, 200d));
             var numericField = comp.Instance;
@@ -144,12 +143,11 @@ namespace MudBlazor.UnitTests.Components
             numericField.ReadValue.Should().BeNull();
             numericField.ReadText.Should().Be("100");
             //DebounceInterval is 200 ms, so at 100 ms Value should not change in NumericField
-            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().NotBe(100), TimeSpan.FromMilliseconds(100));
             numericField.ReadValue.Should().BeNull();
             numericField.ReadText.Should().Be("100");
-            //More than 200 ms had elapsed, so Value should be updated
-            timeProvider.Advance(TimeSpan.FromMilliseconds(101));
-            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(100));
+            //More than 200 ms had elapsed, so Value should be updated (CPU time will likely take more than 200ms)
+            await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(100), TimeSpan.FromMilliseconds(300));
             numericField.ReadText.Should().Be("100");
         }
 
@@ -837,7 +835,9 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Validate that a re-render of a debounced numeric field does not cause a loss of uncommitted text.
         /// </summary>
+        // TODO: Re-enable parallel execution. This test intermittently causes test-host hangs under full parallel coverage runs.
         [Test]
+        [NonParallelizable]
         public async Task DebouncedNumericFieldRerender()
         {
             var timeProvider = new FakeTimeProvider();
@@ -866,7 +866,8 @@ namespace MudBlazor.UnitTests.Components
             }
             // after the final debounce, the value should be updated without swallowing any user input
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            await comp.WaitForAssertionAsync(() => comp.Instance.Value.Should().Be(converter.ConvertBack(currentText)));
+            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
+            comp.Instance.Value.Should().Be(converter.ConvertBack(currentText));
             numericField.ReadText.Should().Be(currentText);
         }
 
@@ -915,7 +916,8 @@ namespace MudBlazor.UnitTests.Components
             // once debounce occurs, both value and text are translated into the new culture
             // e.g. 1.00222222 (one comma something in en-US) turns into 100.222.222 (hundred million something in de-DE)
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval * 2));
-            await comp.WaitForAssertionAsync(() => numericField.ReadText.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture)));
+            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
+            numericField.ReadText.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture));
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -23,6 +23,7 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
+    [NonParallelizable]
     public class TextFieldTests : BunitTest
     {
         /// <summary>
@@ -151,8 +152,6 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ShouldRespectDebounceIntervalPropertyInTextField()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
             var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.DebounceInterval, 200d));
             var textField = comp.Instance;
             var input = comp.Find("input");
@@ -168,11 +167,10 @@ namespace MudBlazor.UnitTests.Components
             textField.ReadValue.Should().BeNull();
 
             //DebounceInterval is 200 ms, so at 100 ms Value should not change in TextField
-            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(100);
             textField.ReadValue.Should().BeNull();
 
             //More than 200 ms had elapsed, so Value should be updated
-            timeProvider.Advance(TimeSpan.FromMilliseconds(101));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Some Value"));
         }
 
@@ -183,8 +181,6 @@ namespace MudBlazor.UnitTests.Components
         public async Task DebounceInterval_EpsilonEquivalentValues_PreservesDebounce()
         {
             // Arrange
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
             var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.DebounceInterval, 200.0));
             var textField = comp.Instance;
             var input = comp.Find("input");
@@ -199,7 +195,6 @@ namespace MudBlazor.UnitTests.Components
             textField.ReadValue.Should().BeNull();
 
             // Wait for the debounce to complete
-            timeProvider.Advance(TimeSpan.FromMilliseconds(200));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Test Value"));
         }
 
@@ -1143,7 +1138,8 @@ namespace MudBlazor.UnitTests.Components
 
             // after the final debounce, the value should be updated without swallowing any user input
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(currentText));
+            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
+            textField.ReadValue.Should().Be(currentText);
             textField.ReadText.Should().Be(currentText);
         }
 
@@ -1194,7 +1190,8 @@ namespace MudBlazor.UnitTests.Components
             // once debounce occurs, both value and text are reset because they define an invalid DateTime,
             // now with the new Format
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be(expectedFinalDateTime));
+            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
+            textField.ReadValue.Should().Be(expectedFinalDateTime);
             textField.ReadText.Should().Be(expectedFinalDateTime.ToString(comp.Instance.Format, CultureInfo.InvariantCulture));
         }
 


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#12515 due to:

```
2026-01-25T16:16:20: Report generation took 1.7 seconds
  Failed DebouncedTextFieldFormatChangeRerender [2 s]
  Error Message:
   Expected textField.ReadText to be the same string, but they differ at index 0:
   ↓ (actual)
  "12/07/2023aaaaaaaa"
  "01/01/0001"
   ↑ (expected).
  Stack Trace:
     at AwesomeAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at AwesomeAssertions.Primitives.StringEqualityStrategy.ValidateAgainstMismatch(AssertionChain assertionChain, String subject, String expected)
   at AwesomeAssertions.Primitives.StringValidator.Validate(String subject, String expected)
   at AwesomeAssertions.Primitives.StringAssertions`1.Be(String expected, String because, Object[] becauseArgs)
   at MudBlazor.UnitTests.Components.TextFieldTests.DebouncedTextFieldFormatChangeRerender() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/TextFieldTests.cs:line 1198
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)


  Skipped DisposeAsync_ShouldClearActivePopoversAndFireOnBatchTimerElapsedAsync [< 1 ms]
Data collector 'Blame' message: All tests finished running, Sequence file will not be generated.
Results File: junit.xml
```