### PR TITLE
Docs: Make featured search items searchable

### DIFF
--- a/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/ApiLinkService.cs
@@ -11,6 +11,78 @@ namespace MudBlazor.Docs.Services
     public class ApiLinkService : IApiLinkService
     {
         private readonly Dictionary<string, ApiLinkServiceEntry> _entries = [];
+        private readonly IReadOnlyCollection<ApiLinkServiceEntry> _featuredEntries =
+            [
+                new ApiLinkServiceEntry
+                {
+                    Title = "Installation",
+                    Link = "getting-started/installation",
+                    SubTitle = "Get started with MudBlazor fast and easy."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Wireframes",
+                    Link = "getting-started/wireframes",
+                    SubTitle = "These small templates can be copied directly or just be used for inspiration."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Table",
+                    Link = "components/table",
+                    ComponentType = typeof(MudTable<T>),
+                    SubTitle = "A sortable, filterable table with multiselection and pagination."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Grid",
+                    Link = "components/grid",
+                    ComponentType = typeof(MudGrid),
+                    SubTitle = "The grid component helps keeping layout consistent across various screen resolutions and sizes."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Button",
+                    Link = "components/button",
+                    ComponentType = typeof(MudGrid),
+                    SubTitle = "A Material Design button for triggering an action or navigating to a link."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Card",
+                    Link = "components/card",
+                    ComponentType = typeof(MudCard),
+                    SubTitle = "Cards can contain actions, text, or media like images or graphics."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Dialog",
+                    Link = "components/dialog",
+                    ComponentType = typeof(MudDialog),
+                    SubTitle = "A dialog will overlay your current app content, providing the user with either information, a choice, or other tasks."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "App Bar",
+                    Link = "components/appbar",
+                    ComponentType = typeof(MudAppBar),
+                    SubTitle = "App bar is used to display actions, branding, navigation and screen titles."
+                },
+
+                new ApiLinkServiceEntry
+                {
+                    Title = "Navigation Menu",
+                    Link = "components/navmenu",
+                    ComponentType = typeof(MudNavMenu),
+                    SubTitle = "Nav menu provides a tree-like menu linking to the content on your site."
+                }
+            ];
 
         public ApiLinkService(IMenuService menuService)
         {
@@ -19,6 +91,7 @@ namespace MudBlazor.Docs.Services
             Register(menuService.Customization);
             Register(menuService.Features);
             Register(menuService.Utilities);
+            RegisterFeaturedPages();
             RegisterAliases();
         }
 
@@ -65,6 +138,21 @@ namespace MudBlazor.Docs.Services
             );
         }
 
+        /// <inheritdoc />
+        public IReadOnlyCollection<ApiLinkServiceEntry> GetAllEntries()
+        {
+            return _entries.Values
+                .Distinct()
+                .OrderBy(entry => entry.Title, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<ApiLinkServiceEntry> GetFeaturedEntries()
+        {
+            return _featuredEntries;
+        }
+
         /// <summary>
         /// Returns a value representing the match ratio of the search input to the keyword.
         /// A higher ratio means a better match.
@@ -85,18 +173,18 @@ namespace MudBlazor.Docs.Services
         /// </summary>
         private void AddEntry(ApiLinkServiceEntry entry)
         {
-            void AddKeyword(string? k)
-            {
-                if (!string.IsNullOrWhiteSpace(k))
-                {
-                    _entries[k.ToLowerInvariant()] = entry;
-                }
-            }
+            AddKeyword(entry, entry.Title);
+            AddKeyword(entry, entry.SubTitle);
+            AddKeyword(entry, entry.ComponentName);
+            AddKeyword(entry, entry.Link);
+        }
 
-            AddKeyword(entry.Title);
-            AddKeyword(entry.SubTitle);
-            AddKeyword(entry.ComponentName);
-            AddKeyword(entry.Link);
+        private void AddKeyword(ApiLinkServiceEntry entry, string? keyword)
+        {
+            if (!string.IsNullOrWhiteSpace(keyword))
+            {
+                _entries[keyword.ToLowerInvariant()] = entry;
+            }
         }
 
         /// <inheritdoc />
@@ -136,6 +224,33 @@ namespace MudBlazor.Docs.Services
             RegisterPage("Side Panel", subtitle: "Go to Drawer", componentType: typeof(MudDrawer));
             RegisterPage("Toast", subtitle: "Go to Snackbar", componentType: typeof(MudSnackbarProvider));
             RegisterPage("Typeahead", subtitle: "Go to Autocomplete", componentType: typeof(MudAutocomplete<T>));
+            RegisterAliasKeyword("components/navmenu", "Navigation Menu");
+        }
+
+        private void RegisterFeaturedPages()
+        {
+            foreach (var entry in _featuredEntries)
+            {
+                if (entry.ComponentType is not null)
+                {
+                    continue;
+                }
+
+                RegisterPage(
+                    title: entry.Title,
+                    subtitle: entry.SubTitle,
+                    componentType: entry.ComponentType,
+                    link: entry.Link
+                );
+            }
+        }
+
+        private void RegisterAliasKeyword(string link, string alias)
+        {
+            if (_entries.TryGetValue(link.ToLowerInvariant(), out var entry))
+            {
+                AddKeyword(entry, alias);
+            }
         }
 
         /// <summary>

--- a/src/MudBlazor.Docs/Services/ApiLink/IApiLinkService.cs
+++ b/src/MudBlazor.Docs/Services/ApiLink/IApiLinkService.cs
@@ -21,4 +21,14 @@ public interface IApiLinkService
     /// </summary>
     /// <param name="text">The search query</param>
     Task<IReadOnlyCollection<ApiLinkServiceEntry>> Search(string text);
+
+    /// <summary>
+    /// Returns all entries registered in the search index.
+    /// </summary>
+    IReadOnlyCollection<ApiLinkServiceEntry> GetAllEntries();
+
+    /// <summary>
+    /// Returns the featured entries shown when the search is empty.
+    /// </summary>
+    IReadOnlyCollection<ApiLinkServiceEntry> GetFeaturedEntries();
 }

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -17,78 +17,6 @@ public partial class Appbar
     private int _searchDialogReturnedItemsCount;
     private MudAutocomplete<ApiLinkServiceEntry> _searchAutocomplete = null!;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true };
-    private readonly List<ApiLinkServiceEntry> _apiLinkServiceEntries =
-    [
-        new ApiLinkServiceEntry
-        {
-            Title = "Installation",
-            Link = "getting-started/installation",
-            SubTitle = "Get started with MudBlazor fast and easy."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Wireframes",
-            Link = "getting-started/wireframes",
-            SubTitle = "These small templates can be copied directly or just be used for inspiration."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Table",
-            Link = "components/table",
-            ComponentType = typeof(MudTable<T>),
-            SubTitle = "A sortable, filterable table with multiselection and pagination."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Grid",
-            Link = "components/grid",
-            ComponentType = typeof(MudGrid),
-            SubTitle = "The grid component helps keeping layout consistent across various screen resolutions and sizes."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Button",
-            Link = "components/button",
-            ComponentType = typeof(MudGrid),
-            SubTitle = "A Material Design button for triggering an action or navigating to a link."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Card",
-            Link = "components/card",
-            ComponentType = typeof(MudCard),
-            SubTitle = "Cards can contain actions, text, or media like images or graphics."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Dialog",
-            Link = "components/dialog",
-            ComponentType = typeof(MudDialog),
-            SubTitle = "A dialog will overlay your current app content, providing the user with either information, a choice, or other tasks."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "App Bar",
-            Link = "components/appbar",
-            ComponentType = typeof(MudAppBar),
-            SubTitle = "App bar is used to display actions, branding, navigation and screen titles."
-        },
-
-        new ApiLinkServiceEntry
-        {
-            Title = "Navigation Menu",
-            Link = "components/navmenu",
-            ComponentType = typeof(MudNavMenu),
-            SubTitle = "Nav menu provides a tree-like menu linking to the content on your site."
-        }
-    ];
 
     public bool IsSearchDialogOpen
     {
@@ -138,7 +66,7 @@ public partial class Appbar
         if (string.IsNullOrWhiteSpace(text))
         {
             // The user just opened the popover so show the most popular pages according to our analytics data as search results.
-            return Task.FromResult<IReadOnlyCollection<ApiLinkServiceEntry>>(_apiLinkServiceEntries);
+            return Task.FromResult(ApiLinkService.GetFeaturedEntries());
         }
 
         return ApiLinkService.Search(text);


### PR DESCRIPTION
the default items that show up in the search menu before you start typing (installation, wireframes, etc) should also be searchable themselves. right now if you search for "installation" nothing comes up

Register featured pages (Installation, Wireframes, Navigation Menu) in the docs search index so default items are searchable.

Unifiy the default search list with the full API link index by adding GetAllEntries to the API link service and using it when the search text is empty (no duplicate “featured” list).

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

After

<img width="370" height="556" alt="image" src="https://github.com/user-attachments/assets/6d6f65fd-2382-4b95-b4aa-bb567f341885" />


<img width="390" height="177" alt="image" src="https://github.com/user-attachments/assets/f41beec6-f987-4b85-b2ae-35e445884086" />


Before

<img width="547" height="162" alt="image" src="https://github.com/user-attachments/assets/69ade1b5-bb8c-4400-bf1d-f33e0d610931" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
