### PR TITLE
Tests: Improve async usage in MenuTests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -132,11 +132,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuTestMouseOver>();
 
             // Briefly hover over the button and wait for it to open.
-            comp.Find("div.mud-menu").PointerEnter();
+            await comp.Find("div.mud-menu").PointerEnterAsync();
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
 
             // Close it again and wait for that to happen.
-            comp.Find("div.mud-menu").PointerLeave();
+            await comp.Find("div.mud-menu").PointerLeaveAsync();
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().NotContain("mud-popover-open"));
         }
 
@@ -167,7 +167,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuTestMouseOver>();
 
             // Enter opens the menu (after a delay).
-            comp.Find("div.mud-menu").PointerEnter();
+            await comp.Find("div.mud-menu").PointerEnterAsync();
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
 
             // Clicking the button should close the menu.
@@ -180,7 +180,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
 
             // Leaving the menu should no longer close it.
-            comp.Find("div.mud-menu").PointerLeave();
+            await comp.Find("div.mud-menu").PointerLeaveAsync();
             await Task.Delay(MudGlobal.MenuDefaults.HoverDelay + 100);
             await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
 
@@ -268,10 +268,10 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
             await comp.FindAll("div.mud-menu-item")[0].ClickAsync();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
-            comp.FindAll("button.mud-button-root")[0].Click(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Standart button menu -- right click
-            comp.FindAll("button.mud-button-root")[1].Click(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("button.mud-button-root")[1].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -286,10 +286,10 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
             await comp.FindAll("div.mud-menu-item")[0].ClickAsync();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
-            comp.FindAll("button.mud-button-root")[2].Click(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("button.mud-button-root")[2].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Icon button menu -- right click
-            comp.FindAll("button.mud-button-root")[3].Click(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("button.mud-button-root")[3].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -304,7 +304,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
             await comp.FindAll("div.mud-menu-item")[0].ClickAsync();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
-            comp.FindAll("button.mud-button-root")[4].Click(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("button.mud-button-root")[4].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Activator content menu -- right click (must trigger contextmenu on the user's div inside ActivatorContent)
             // Find the div that wraps the button in the right-click ActivatorContent (it has the @oncontextmenu handler)
@@ -821,18 +821,11 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
 
             var last = comp.Instance.LastInvokedIndex;
             last.Should().Be(1);
@@ -843,26 +836,15 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
+
+            var allFocusableItems = comp.FindAll(".mud-menu-item[tabindex='0']");
+
+            if (allFocusableItems.Count > 0)
             {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
-
-            await comp.InvokeAsync(() => Task.CompletedTask);
-
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-
-                var allFocusableItems = comp.FindAll(".mud-menu-item[tabindex='0']");
-
-                if (allFocusableItems.Count > 0)
-                {
-                    var lastItem = allFocusableItems.Last();
-                    await lastItem.ClickAsync(new MouseEventArgs());
-                }
-            });
+                var lastItem = allFocusableItems.Last();
+                await lastItem.ClickAsync(new MouseEventArgs());
+            }
 
             comp.Instance.LastInvokedIndex.Should().Be(6);
         }
@@ -873,28 +855,17 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index -1)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Press ArrowDown x4 to move to index 3 with nested menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
 
             // Press ArrowRight opens submenu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Should now be 2 open menus: the root and the submenu
             comp.FindAll(".mud-popover-open").Count.Should().BeGreaterThan(1);
@@ -906,18 +877,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index 0)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Press ArrowRight to go back to close menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Ensure the menu hasn't closed
             comp.FindAll(".mud-popover-open").Count.Should().Be(1);
@@ -929,18 +893,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the menu (focus starts at index 0)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Press Arrow Left to close menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
 
             // Ensure all popovers are closed
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
@@ -952,33 +909,23 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Move focus to index 3 and open nested submenu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Ensure we now have more than one menu open
             var openBefore = comp.FindAll(".mud-popover-open");
             openBefore.Count.Should().BeGreaterThan(1);
 
             // Simulate ArrowLeft keypress inside the last opened (nested) menu
-            await comp.InvokeAsync(async () =>
-            {
-                var nestedMenu = comp.FindAll("div[data-testid='menu-wrapper']").Last();
-                await nestedMenu.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
-            });
+            var nestedMenu = comp.FindAll("div[data-testid='menu-wrapper']").Last();
+            await nestedMenu.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
 
             // Assert the submenu was closed (back to just one open popover)
             var openAfter = comp.FindAll(".mud-popover-open");
@@ -991,25 +938,14 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Arrow down to second item (index 1, a link)
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
 
             // Press Enter to enter menu item
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
-            });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
 
             // Assert: menu should be closed
             comp.FindAll(".mud-popover-open").Should().BeEmpty();
@@ -1021,28 +957,17 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Arrow into nested menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Press Tab to tab menu item
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Tab" });
-            });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Tab" });
 
             // Assert: menu should be closed
             comp.FindAll(".mud-popover-open").Should().BeEmpty();
@@ -1054,29 +979,19 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MenuKeydownTest>();
 
             // Open the root menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Arrow into nested menu
-            await comp.InvokeAsync(async () =>
-            {
-                var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-                await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
-            });
+            var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Press Escape to close submenu
-            await comp.InvokeAsync(async () =>
-            {
-                var nestedWrapper = comp.FindAll("[data-testid='menu-wrapper']").Last();
-                await nestedWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Escape" });
-            });
+            var nestedWrapper = comp.FindAll("[data-testid='menu-wrapper']").Last();
+            await nestedWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Escape" });
 
             // Only parent menu should remain
             comp.FindAll(".mud-popover-open").Count.Should().Be(1);
@@ -1087,31 +1002,24 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
-            await comp.InvokeAsync(async () =>
-            {
-                // Find the disabled item
-                var disabledItem = comp.Find(".mud-menu-item.mud-disabled");
+            // Find the disabled item
+            var disabledItem = comp.Find(".mud-menu-item.mud-disabled");
 
-                // Verify it has the right accessibility attributes
-                disabledItem.GetAttribute("aria-disabled").Should().Be("true");
-                disabledItem.GetAttribute("tabindex").Should().Be("-1"); // Focusable by script, not by tab
+            // Verify it has the right accessibility attributes
+            disabledItem.GetAttribute("aria-disabled").Should().Be("true");
+            disabledItem.GetAttribute("tabindex").Should().Be("-1"); // Focusable by script, not by tab
 
-                // Verify it's in the DOM and visible for screen readers
-                disabledItem.Should().NotBeNull();
-                disabledItem.TextContent.Should().Contain("5 Disabled");
+            // Verify it's in the DOM and visible for screen readers
+            disabledItem.Should().NotBeNull();
+            disabledItem.TextContent.Should().Contain("5 Disabled");
 
-                // Try to click it - it should NOT invoke the action
-                await disabledItem.ClickAsync(new MouseEventArgs());
+            // Try to click it - it should NOT invoke the action
+            await disabledItem.ClickAsync(new MouseEventArgs());
 
-                // LastInvokedIndex should still be null because disabled items shouldn't invoke
-                comp.Instance.LastInvokedIndex.Should().BeNull();
-            });
+            // LastInvokedIndex should still be null because disabled items shouldn't invoke
+            comp.Instance.LastInvokedIndex.Should().BeNull();
         }
 
         [Test]
@@ -1119,26 +1027,19 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MenuKeydownTest>();
 
-            await comp.InvokeAsync(async () =>
-            {
-                var menuButton = comp.Find(".mud-menu-button-activator");
-                await menuButton.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
-            await comp.InvokeAsync(() =>
-            {
-                var disabledItem = comp.Find(".mud-menu-item.mud-disabled");
+            var disabledItem = comp.Find(".mud-menu-item.mud-disabled");
 
-                // Test all the accessibility attributes
-                disabledItem.GetAttribute("aria-disabled").Should().Be("true");
-                disabledItem.GetAttribute("class").Should().Contain("mud-disabled");
+            // Test all the accessibility attributes
+            disabledItem.GetAttribute("aria-disabled").Should().Be("true");
+            disabledItem.GetAttribute("class").Should().Contain("mud-disabled");
 
-                // The item should have the preventDefault attribute to stop normal click behavior
-                disabledItem.GetAttribute("blazor:onclick:preventDefault").Should().NotBeNull();
+            // The item should have the preventDefault attribute to stop normal click behavior
+            disabledItem.GetAttribute("blazor:onclick:preventDefault").Should().NotBeNull();
 
-                // But it should still be present in the DOM for screen readers
-                disabledItem.TextContent.Should().Contain("5 Disabled");
-            });
+            // But it should still be present in the DOM for screen readers
+            disabledItem.TextContent.Should().Contain("5 Disabled");
         }
 
         [Test]
@@ -1169,11 +1070,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Open the menu through its activator
-            await comp.InvokeAsync(async () =>
-            {
-                var button = comp.Find(".mud-menu-button-activator");
-                await button.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Simulate ArrowDown to move focus to the first item
             await comp.InvokeAsync(() =>
@@ -1198,11 +1095,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Open the menu through its activator
-            await comp.InvokeAsync(async () =>
-            {
-                var button = comp.Find(".mud-menu-button-activator");
-                await button.ClickAsync(new MouseEventArgs());
-            });
+            await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             // Simulate ArrowUp to move focus to the last item
             await comp.InvokeAsync(() =>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -149,54 +149,57 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().NotContain("mud-popover-open");
 
             // Pointer over to menu to open popover
-            await Menu().TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await Menu().PointerEnterAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
 
             // Popover open, captures pointer
-            await Menu().TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            await Menu().PointerLeaveAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().NotContain("mud-popover-open"));
 
             // Pointer moves to menu, still need to open
-            await Menu().TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            await Menu().PointerEnterAsync(new PointerEventArgs());
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
         }
 
         [Test]
         public async Task MouseOver_Click_ShouldKeepMenuOpen()
         {
+            var hoverDelay = 200;
+            MudGlobal.MenuDefaults.HoverDelay = hoverDelay;
             var comp = Context.Render<MenuTestMouseOver>();
+            var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Enter opens the menu (after a delay).
             await comp.Find("div.mud-menu").PointerEnterAsync();
-            await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Clicking the button should close the menu.
             await comp.Find("button.mud-button-root").ClickAsync();
             // Check that the component is closed
-            await comp.WaitForAssertionAsync(() => comp.Markup.Should().NotContain("mud-popover-open"));
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeFalse());
 
             // Clicking the button again should open the menu indefinitely.
             await comp.Find("button.mud-button-root").ClickAsync();
-            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Leaving the menu should no longer close it.
             await comp.Find("div.mud-menu").PointerLeaveAsync();
-            await Task.Delay(MudGlobal.MenuDefaults.HoverDelay + 100);
-            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
+            await Task.Delay(hoverDelay + 100);
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Hover the list shouldn't change anything.
-            await comp.Find("[data-testid='menu-wrapper']").TriggerEventAsync("onpointerenter", new PointerEventArgs());
-            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
+            await comp.Find("[data-testid='menu-wrapper']").PointerEnterAsync(new PointerEventArgs());
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Leave the list shouldn't change anything.
-            await comp.Find("[data-testid='menu-wrapper']").TriggerEventAsync("onpointerleave", new PointerEventArgs());
-            await Task.Delay(MudGlobal.MenuDefaults.HoverDelay + 100);
-            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudPopover>().Instance.Open.Should().BeTrue());
+            await comp.Find("[data-testid='menu-wrapper']").PointerLeaveAsync(new PointerEventArgs());
+            await Task.Delay(hoverDelay + 100);
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Clicking the button should now close the menu.
             await comp.Find("button.mud-button-root").ClickAsync();
             // Check that the component is closed
-            await comp.WaitForAssertionAsync(() => comp.Markup.Should().NotContain("mud-popover-open"));
+            await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeFalse());
         }
 
         [Test]
@@ -312,7 +315,7 @@ namespace MudBlazor.UnitTests.Components
             var rightClickMenu = rightClickMenus.FirstOrDefault(m => m.QuerySelector("div[style*='inline-block']") != null);
             var userDiv = rightClickMenu?.QuerySelector("div[style*='inline-block']");
             userDiv.Should().NotBeNull("User's div with contextmenu handler should exist");
-            await userDiv!.TriggerEventAsync("oncontextmenu", new MouseEventArgs() { Button = 2 });
+            await userDiv!.ContextMenuAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -824,8 +827,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find(".mud-menu-button-activator").ClickAsync(new MouseEventArgs());
 
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
             var last = comp.Instance.LastInvokedIndex;
             last.Should().Be(1);
@@ -859,13 +862,13 @@ namespace MudBlazor.UnitTests.Components
 
             // Press ArrowDown x4 to move to index 3 with nested menu
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
 
             // Press ArrowRight opens submenu
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Should now be 2 open menus: the root and the submenu
             comp.FindAll(".mud-popover-open").Count.Should().BeGreaterThan(1);
@@ -881,7 +884,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Press ArrowRight to go back to close menu
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Ensure the menu hasn't closed
             comp.FindAll(".mud-popover-open").Count.Should().Be(1);
@@ -897,7 +900,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Press Arrow Left to close menu
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
 
             // Ensure all popovers are closed
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
@@ -913,11 +916,11 @@ namespace MudBlazor.UnitTests.Components
 
             // Move focus to index 3 and open nested submenu
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Ensure we now have more than one menu open
             var openBefore = comp.FindAll(".mud-popover-open");
@@ -925,7 +928,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Simulate ArrowLeft keypress inside the last opened (nested) menu
             var nestedMenu = comp.FindAll("div[data-testid='menu-wrapper']").Last();
-            await nestedMenu.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowLeft" });
+            await nestedMenu.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowLeft" });
 
             // Assert the submenu was closed (back to just one open popover)
             var openAfter = comp.FindAll(".mud-popover-open");
@@ -942,10 +945,10 @@ namespace MudBlazor.UnitTests.Components
 
             // Arrow down to second item (index 1, a link)
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
 
             // Press Enter to enter menu item
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Enter" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
 
             // Assert: menu should be closed
             comp.FindAll(".mud-popover-open").Should().BeEmpty();
@@ -961,13 +964,13 @@ namespace MudBlazor.UnitTests.Components
 
             // Arrow into nested menu
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Press Tab to tab menu item
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Tab" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Tab" });
 
             // Assert: menu should be closed
             comp.FindAll(".mud-popover-open").Should().BeEmpty();
@@ -983,15 +986,15 @@ namespace MudBlazor.UnitTests.Components
 
             // Arrow into nested menu
             var menuWrapper = comp.Find("[data-testid='menu-wrapper']");
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowDown" });
-            await menuWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "ArrowRight" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await menuWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "ArrowRight" });
 
             // Press Escape to close submenu
             var nestedWrapper = comp.FindAll("[data-testid='menu-wrapper']").Last();
-            await nestedWrapper.TriggerEventAsync("onkeydown", new KeyboardEventArgs { Key = "Escape" });
+            await nestedWrapper.KeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
 
             // Only parent menu should remain
             comp.FindAll(".mud-popover-open").Count.Should().Be(1);


### PR DESCRIPTION
Use more of the native bUnit async methods instead of the sync ones, and avoid unnecessarily wrapping in `InvokeAsync`. Triess to fix this flaky test:

```
\n2026-01-25T17:07:31: Report generation took 1.9 seconds\n  Skipped DisposeAsync_ShouldClearActivePopoversAndFireOnBatchTimerElapsedAsync [1 ms]\n  Failed MouseOver_Click_ShouldKeepMenuOpen [311 ms]\n  Error Message:\n   Bunit.Rendering.UnknownEventHandlerIdException : There is no event handler with ID '8' associated with the 'onclick' event in the current render tree.\n\nThis can happen, for example, when using `cut.FindAll()`, and calling event trigger methods on the found elements after a re-render of the render tree. The workaround is to use re-issue the `cut.FindAll()` call after each render of a component, this ensures you have the latest version of the render tree and DOM tree available in your test code.\n\nThis can happen with code like this, `cut.Find("button").Click()`, where the buttons event handler can be removed between the time button is found with the Find method and the Click method is triggered. The workaround is to use wrap the Find and Click method calls in InvokeAsync, i.e. `cut.InvokeAsync(() => cut.Find("button").Click());`. This ensures that there are no changes to the DOM between Find method and the Click method calls.\n  ----> System.ArgumentException : There is no event handler associated with this event. EventId: '8'. (Parameter 'eventHandlerId')\n  Stack Trace:\n     at Bunit.Rendering.BunitRenderer.DispatchEventAsync(UInt64 eventHandlerId, EventFieldInfo fieldInfo, EventArgs eventArgs, Boolean ignoreUnknownEventHandlers) in /_/src/bunit/Rendering/BunitRenderer.cs:line 201\n   at Bunit.TriggerEventDispatchExtensions.GetDispatchEventTasks(BunitRenderer renderer, IElement element, String eventName, EventArgs eventArgs) in /_/src/bunit/EventDispatchExtensions/TriggerEventDispatchExtensions.cs:line 135\n   at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContext.<>c.<<InvokeAsync>b__10_0>d.MoveNext()\n--- End of stack trace from previous location ---\n   at Bunit.TriggerEventDispatchExtensions.TriggerEventAsync(IElement element, String eventName, EventArgs eventArgs) in /_/src/bunit/EventDispatchExtensions/TriggerEventDispatchExtensions.cs:line 75\n   at Bunit.EventHandlerDispatchExtensions.ClickAsync(IElement element, MouseEventArgs eventArgs) in /_/src/bunit/obj/Release/net10.0/bunit.generators.internal/Bunit.Blazor.EventDispatcherExtensionGenerator/EventHandlerDispatchExtensions.g.cs:line 1209\n   at MudBlazor.UnitTests.Components.MenuTests.MouseOver_Click_ShouldKeepMenuOpen() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/MenuTests.cs:line 174\n   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()\n   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)\n   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)\n   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)\n   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)\n   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)\n   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()\n   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)\n--ArgumentException\n   at Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(UInt64 eventHandlerId, EventFieldInfo fieldInfo, EventArgs eventArgs, Boolean waitForQuiescence)\n   at Bunit.Rendering.BunitRenderer.<>c__DisplayClass32_0.<DispatchEventAsync>b__0() in /_/src/bunit/Rendering/BunitRenderer.cs:line 182\n1)    at Bunit.Rendering.BunitRenderer.DispatchEventAsync(UInt64 eventHandlerId, EventFieldInfo fieldInfo, EventArgs eventArgs, Boolean ignoreUnknownEventHandlers) in /_/src/bunit/Rendering/BunitRenderer.cs:line 201\n   at Bunit.TriggerEventDispatchExtensions.GetDispatchEventTasks(BunitRenderer renderer, IElement element, String eventName, EventArgs eventArgs) in /_/src/bunit/EventDispatchExtensions/TriggerEventDispatchExtensions.cs:line 135\n   at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContext.<>c.<<InvokeAsync>b__10_0>d.MoveNext()\n--- End of stack trace from previous location ---\n   at Bunit.TriggerEventDispatchExtensions.TriggerEventAsync(IElement element, String eventName, EventArgs eventArgs) in /_/src/bunit/EventDispatchExtensions/TriggerEventDispatchExtensions.cs:line 75\n   at Bunit.EventHandlerDispatchExtensions.ClickAsync(IElement element, MouseEventArgs eventArgs) in /_/src/bunit/obj/Release/net10.0/bunit.generators.internal/Bunit.Blazor.EventDispatcherExtensionGenerator/EventHandlerDispatchExtensions.g.cs:line 1209\n   at MudBlazor.UnitTests.Components.MenuTests.MouseOver_Click_ShouldKeepMenuOpen() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/MenuTests.cs:line 174\n   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()\n   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)\n   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)\n   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)\n   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)\n   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)\n   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()\n   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)\n--ArgumentException\n   at Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(UInt64 eventHandlerId, EventFieldInfo fieldInfo, EventArgs eventArgs, Boolean waitForQuiescence)\n   at Bunit.Rendering.BunitRenderer.<>c__DisplayClass32_0.<DispatchEventAsync>b__0() in /_/src/bunit/Rendering/BunitRenderer.cs:line 182\n\nData collector 'Blame' message: All tests finished running, Sequence file will not be generated.\nResults File: junit.xml
```

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
