### PR TITLE
MudThemeProvider: Fix script and refactor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,3 +43,4 @@
 /src/MudBlazor/TScripts/entrypoint.js @meenzen
 /src/MudBlazor/TScripts/mudInputSizing.js @danielchalmers
 /src/MudBlazor/TScripts/mudPopover.js @versile2
+/src/MudBlazor/TScripts/mudThemeProvider.js @meenzen

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -407,52 +407,52 @@ namespace MudBlazor.UnitTests.Components
         public async Task ObserveSystemDarkModeChange()
         {
             // Arrange & Act
-            Context.JSInterop.SetupVoid("stopWatchingDarkThemeMedia");
-            Context.JSInterop.SetupVoid("watchDarkThemeMedia");
+            Context.JSInterop.SetupVoid("mudThemeProvider.stopWatchingDarkMode");
+            Context.JSInterop.SetupVoid("mudThemeProvider.watchDarkMode");
             var themeProvider = Context.Render<ThemeProviderObserveSystemDarkModeChangeTest>();
 
             // Assert
-            Context.JSInterop.VerifyNotInvoke("watchDarkThemeMedia");
-            Context.JSInterop.VerifyNotInvoke("stopWatchingDarkThemeMedia");
+            Context.JSInterop.VerifyNotInvoke("mudThemeProvider.watchDarkMode");
+            Context.JSInterop.VerifyNotInvoke("mudThemeProvider.stopWatchingDarkMode");
 
             // Act
             await themeProvider.InvokeAsync(themeProvider.Instance.EnableObserve);
 
             // Assert
-            Context.JSInterop.VerifyInvoke("watchDarkThemeMedia", 1);
-            Context.JSInterop.VerifyNotInvoke("stopWatchingDarkThemeMedia");
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1);
+            Context.JSInterop.VerifyNotInvoke("mudThemeProvider.stopWatchingDarkMode");
 
             // Act
             await themeProvider.InvokeAsync(themeProvider.Instance.DisableObserve);
 
             // Assert
-            Context.JSInterop.VerifyInvoke("watchDarkThemeMedia", 1);
-            Context.JSInterop.VerifyInvoke("stopWatchingDarkThemeMedia", 1);
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1);
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.stopWatchingDarkMode", 1);
         }
 
         [Test]
         public async Task Dispose_ShouldInvokeJs()
         {
             // Arrange
-            Context.JSInterop.SetupVoid("stopWatchingDarkThemeMedia");
+            Context.JSInterop.SetupVoid("mudThemeProvider.stopWatchingDarkMode");
             Context.Render<MudThemeProvider>();
 
             //Act
             await Context.DisposeComponentsAsync();
 
             // Assert
-            Context.JSInterop.VerifyInvoke("stopWatchingDarkThemeMedia");
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.stopWatchingDarkMode");
         }
 
         [Test]
         public void RenderComponent_ShouldInvokeJs()
         {
             // Act & Arrange
-            Context.JSInterop.SetupVoid("watchDarkThemeMedia");
+            Context.JSInterop.SetupVoid("mudThemeProvider.watchDarkMode");
             Context.Render<MudThemeProvider>();
 
             // Assert
-            Context.JSInterop.VerifyInvoke("watchDarkThemeMedia");
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode");
         }
 
         [Test]

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -32,7 +32,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     private readonly ParameterState<bool> _observeSystemDarkModeChangeState;
     private readonly Lazy<DotNetObjectReference<MudThemeProvider>> _lazyDotNetRef;
 
-    private event Func<bool, Task>? _darkLightModeChanged;
+    private event Func<bool, Task>? DarkModeChanged;
 
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = null!;
@@ -118,22 +118,20 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// </returns>
     public async Task<bool> GetSystemDarkModeAsync()
     {
-        var (_, value) = await JsRuntime.InvokeAsyncWithErrorHandling(false, "darkModeChange");
-
+        var (_, value) = await JsRuntime.InvokeAsyncWithErrorHandling(false, "mudThemeProvider.isDarkMode");
         return value;
     }
 
     /// <summary>
     /// Calls a function when the system's color has changed.
     /// </summary>
-    /// <param name="functionOnChange">The function to call when the system theme has changed.</param>
+    /// <param name="onChange">The function to call when the system theme has changed.</param>
     /// <remarks>
     /// A value of <c>true</c> is passed if the system is now in Dark Mode. Otherwise, the system is now in Light Mode.
     /// </remarks>
-    public Task WatchSystemDarkModeAsync(Func<bool, Task> functionOnChange)
+    public Task WatchSystemDarkModeAsync(Func<bool, Task> onChange)
     {
-        _darkLightModeChanged += functionOnChange;
-
+        DarkModeChanged += onChange;
         return Task.CompletedTask;
     }
 
@@ -145,7 +143,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     public async Task SystemDarkModeChangedAsync(bool isDarkMode)
     {
         await _isDarkModeState.SetValueAsync(isDarkMode);
-        var handler = _darkLightModeChanged;
+        var handler = DarkModeChanged;
         if (handler is not null)
         {
             await handler(isDarkMode);
@@ -160,7 +158,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
             if (_observeSystemDarkModeChangeState.Value && !_observing)
             {
                 _observing = true;
-                await WatchDarkThemeMedia();
+                await WatchDarkMode();
             }
         }
 
@@ -575,14 +573,14 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
 
         _disposed = true;
 
-        _darkLightModeChanged = null;
+        DarkModeChanged = null;
 
         if (_lazyDotNetRef.IsValueCreated)
         {
             _lazyDotNetRef.Value.Dispose();
         }
 
-        await StopWatchingDarkThemeMedia();
+        await StopWatchingDarkMode();
     }
 
     private Palette? GetCurrentPalette()
@@ -606,7 +604,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
             if (!_observing)
             {
                 _observing = true;
-                await WatchDarkThemeMedia();
+                await WatchDarkMode();
             }
         }
         else
@@ -614,14 +612,14 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
             if (_observing)
             {
                 _observing = false;
-                await StopWatchingDarkThemeMedia();
+                await StopWatchingDarkMode();
             }
         }
     }
 
-    private ValueTask WatchDarkThemeMedia() => JsRuntime.InvokeVoidAsyncIgnoreErrors("watchDarkThemeMedia", _lazyDotNetRef.Value);
+    private ValueTask WatchDarkMode() => JsRuntime.InvokeVoidAsyncIgnoreErrors("mudThemeProvider.watchDarkMode", _lazyDotNetRef.Value);
 
-    private ValueTask StopWatchingDarkThemeMedia() => JsRuntime.InvokeVoidAsyncIgnoreErrors("stopWatchingDarkThemeMedia");
+    private ValueTask StopWatchingDarkMode() => JsRuntime.InvokeVoidAsyncIgnoreErrors("mudThemeProvider.stopWatchingDarkMode");
 
     private DotNetObjectReference<MudThemeProvider> CreateDotNetObjectReference() => DotNetObjectReference.Create(this);
 

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -1,18 +1,20 @@
-﻿const darkThemeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+﻿const isDarkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+let themeProvider = null;
 
-window.darkModeChange = () => {
-    return darkThemeMediaQuery.matches;
-};
-
-function darkModeChangeListener(e) {
-    dotNetHelperTheme.invokeMethodAsync('SystemDarkModeChangedAsync', e.matches);
+function listener(e) {
+    console.assert(themeProvider != null, "themeProvider is null")
+    themeProvider.invokeMethodAsync('SystemDarkModeChangedAsync', e.matches);
 }
 
-function watchDarkThemeMedia(dotNetHelper) {
-    dotNetHelperTheme = dotNetHelper;
-    darkThemeMediaQuery.addEventListener('change', darkModeChangeListener);
-}
-
-function stopWatchingDarkThemeMedia() {
-    darkThemeMediaQuery.removeEventListener('change', darkModeChangeListener);
+window.mudThemeProvider = {
+    isDarkMode() {
+        return isDarkModeQuery.matches;
+    },
+    watchDarkMode(dotNetHelper) {
+        themeProvider = dotNetHelper;
+        isDarkModeQuery.addEventListener('change', listener);
+    },
+    stopWatchingDarkMode() {
+        isDarkModeQuery.removeEventListener('change', listener);
+    },
 }

--- a/src/MudBlazor/build.mjs
+++ b/src/MudBlazor/build.mjs
@@ -42,6 +42,7 @@ function printTimings() {
     for (const timing of timings) {
         console.log(`  ${timing.step}: ${timing.ms} ms`);
     }
+    timings.length = 0;
 }
 
 async function buildJS() {
@@ -112,15 +113,16 @@ function buildSCSS() {
 }
 
 async function buildAll() {
+    await eslint();
     await buildJS();
     buildSCSS();
+    printTimings();
 }
 
 if (process.argv.includes("watch")) {
     console.log("Initial build...");
     try {
         await buildAll();
-        printTimings();
     } catch (e) {
         console.error("Initial build failed:", e);
     }
@@ -128,11 +130,12 @@ if (process.argv.includes("watch")) {
     console.log("Watching for changes, press Ctrl+C to stop...");
 
     const jsWatcher = fs.watch(
-        jsEntrypoint,
+        jsDirectory,
         { recursive: true },
         async (eventType, filename) => {
             console.log(`JS file changed: ${eventType} ${filename}`);
             try {
+                await eslint();
                 await buildJS();
                 printTimings();
             } catch (e) {
@@ -164,7 +167,5 @@ if (process.argv.includes("watch")) {
         process.exit(0);
     });
 } else {
-    await eslint();
     await buildAll();
-    printTimings();
 }


### PR DESCRIPTION
I missed in #12518 that `mudThemeProvider.js` wasn't properly exporting its functions to `window`.  This broke the system dark mode detection logic. For some reason all the js functions were globally scoped so I've added them to `window.mudThemeProvider`.

I've also renamed a few functions to be more clear, as it was hard to understand what was actually happening. 

This introduces a tiny breaking change as i've changed the parameter name `functionOnChange` to `onChange`:

```cs
// Before
MudThemeProvider.WatchSystemDarkModeAsync(Func<bool, Task> functionOnChange)

// After
MudThemeProvider.WatchSystemDarkModeAsync(Func<bool, Task> onChange)
```


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
