### PR TITLE
MudSelect: Add enum option

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/EnumSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/EnumSelectExample.razor
@@ -3,16 +3,13 @@
 
 <MudSelect T="SomeEnum" Label="Enum Select"
            @bind-Value="@_selectedValue"
-           EnumValues="true"
            HelperText="@($"Selected {_selectedValue}")"/>
 <MudSelect T="SomeEnum?" Label="Enum Select Nullable"
            @bind-Value="@_selectedValueNullable"
-           EnumValues="true"
            Clearable="true"
            HelperText="@($"Selected {(_selectedValueNullable?.ToString() ?? "None")}")"/>
 <MudSelect T="SomeEnum" Label="Enum Select Custom Display"
            @bind-Value="@_selectedValueDisplay"
-           EnumValues="true"
            HelperText="@($"Selected {_selectedValueDisplay}")"
            ToStringFunc="@(e => $"{e} Modified")"/>
 

--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/EnumSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/EnumSelectExample.razor
@@ -1,0 +1,36 @@
+﻿@using System.ComponentModel.DataAnnotations
+@namespace MudBlazor.Docs.Examples
+
+<MudSelect T="SomeEnum" Label="Enum Select"
+           @bind-Value="@_selectedValue"
+           EnumValues="true"
+           HelperText="@($"Selected {_selectedValue}")"/>
+<MudSelect T="SomeEnum?" Label="Enum Select Nullable"
+           @bind-Value="@_selectedValueNullable"
+           EnumValues="true"
+           Clearable="true"
+           HelperText="@($"Selected {(_selectedValueNullable?.ToString() ?? "None")}")"/>
+<MudSelect T="SomeEnum" Label="Enum Select Custom Display"
+           @bind-Value="@_selectedValueDisplay"
+           EnumValues="true"
+           HelperText="@($"Selected {_selectedValueDisplay}")"
+           ToStringFunc="@(e => $"{e} Modified")"/>
+
+@code {
+    private SomeEnum _selectedValue;
+    private SomeEnum? _selectedValueNullable;
+    private SomeEnum _selectedValueDisplay;
+
+    private enum SomeEnum
+    {
+        [Display(Name = "First Item")]
+        FirstItem,
+
+        [Display(Name = "Second Item")]
+        SecondItem,
+
+        [Display(Name = "Third Item")]
+        ThirdItem
+    }
+
+}

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -67,6 +67,17 @@
                         <MultiSelectComplexExample />
                     </SectionContent>
                 </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="Direct Enum Usage">
+                        <Description>
+                            You can directly plug in an existing enum. 
+                            The displayed text for the item can be customised by either providing a <CodeInline>[Display(Name = "...")]</CodeInline> attribute or using the <CodeInline>ToStringFunc</CodeInline>.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent ShowCode="true" Code="@nameof(EnumSelectExample)">
+                        <EnumSelectExample />
+                    </SectionContent>
+                </DocsPageSection>
             </SectionSubGroups>
         </DocsPageSection>
 

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -70,8 +70,9 @@
                 <DocsPageSection>
                     <SectionHeader Title="Direct Enum Usage">
                         <Description>
-                            You can directly plug in an existing enum. 
+                            <CodeInline>MudSelect</CodeInline> can automatically generate select items for each value in an enum type.
                             The displayed text for the item can be customised by either providing a <CodeInline>[Display(Name = "...")]</CodeInline> attribute or using the <CodeInline>ToStringFunc</CodeInline>.
+                            Note that no items are automatically generated if a child content is provided.
                         </Description>
                     </SectionHeader>
                     <SectionContent ShowCode="true" Code="@nameof(EnumSelectExample)">

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor
+@namespace MudBlazor
 @typeparam T
 @inherits MudBaseInput<T>
 
@@ -113,6 +113,13 @@
                                              Class="mb-2" />
                                 <MudDivider />
                             }
+                            @if (EnumValues && IsEnumType())
+                            {
+                                @foreach (var enumValue in GetEnumValues())
+                                {
+                                    <MudSelectItem T="T" Value="@enumValue">@GetEnumDisplayString(enumValue)</MudSelectItem>
+                                }
+                            }
                             @ChildContent
                         </MudList>
                     </CascadingValue>
@@ -123,6 +130,13 @@
     @*Shadow select items for IsValueInList and CanRenderValue*@
     <CascadingValue Value="@((IMudShadowSelect)this)" IsFixed="true">
         <CascadingValue Name="HideContent" Value="true">
+            @if (EnumValues && IsEnumType())
+            {
+                @foreach (var enumValue in GetEnumValues())
+                {
+                    <MudSelectItem T="T" Value="@enumValue">@GetEnumDisplayString(enumValue)</MudSelectItem>
+                }
+            }
             @ChildContent
         </CascadingValue>
     </CascadingValue>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -113,9 +113,9 @@
                                              Class="mb-2" />
                                 <MudDivider />
                             }
-                            @if (EnumValues && IsEnumType())
+                            @if (ShouldUseEnumValues())
                             {
-                                @foreach (var enumValue in GetEnumValues())
+                                foreach (var enumValue in GetEnumValues())
                                 {
                                     <MudSelectItem T="T" Value="@enumValue">@GetEnumDisplayString(enumValue)</MudSelectItem>
                                 }
@@ -130,9 +130,9 @@
     @*Shadow select items for IsValueInList and CanRenderValue*@
     <CascadingValue Value="@((IMudShadowSelect)this)" IsFixed="true">
         <CascadingValue Name="HideContent" Value="true">
-            @if (EnumValues && IsEnumType())
+            @if (ShouldUseEnumValues())
             {
-                @foreach (var enumValue in GetEnumValues())
+                foreach (var enumValue in GetEnumValues())
                 {
                     <MudSelectItem T="T" Value="@enumValue">@GetEnumDisplayString(enumValue)</MudSelectItem>
                 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1432,7 +1432,7 @@ namespace MudBlazor
         private bool ShouldUseEnumValues()
         {
             if (ChildContent != null) return false;
-            
+
             var type = typeof(T);
             return type.IsEnum || Nullable.GetUnderlyingType(type)?.IsEnum == true;
         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -41,6 +41,7 @@ namespace MudBlazor
         {
             Adornment = Adornment.End;
             IconSize = Size.Medium;
+
             // Set default value to ensure ParameterState never holds null
             SelectedValues = new HashSet<T?>();
             using var registerScope = CreateRegisterScope();
@@ -106,6 +107,7 @@ namespace MudBlazor
             if (direction < 0 && index < 0)
                 index = 0;
             MudSelectItem<T>? item = null;
+
             // the loop allows us to jump over disabled items until we reach the next non-disabled one
             for (var i = 0; i < _items.Count; i++)
             {
@@ -137,6 +139,7 @@ namespace MudBlazor
                 HighlightItem(item);
                 break;
             }
+
             await _elementReference.SetText(ReadText);
             await ScrollToItemAsync(item);
         }
@@ -217,6 +220,7 @@ namespace MudBlazor
                 _selectedValues.Clear();
                 _selectedValues.Add(item.Value);
                 await SetValueAndUpdateTextAsync(item.Value, updateText: true);
+
                 // Update ParameterState to keep SelectedValues in sync
                 await _selectedValuesState.SetValueAsync(new HashSet<T?>(_selectedValues, Comparer));
             }
@@ -244,6 +248,7 @@ namespace MudBlazor
             {
                 HighlightItem(item);
             }
+
             await _elementReference.SetText(ReadText);
             await ScrollToItemAsync(item);
         }
@@ -498,6 +503,7 @@ namespace MudBlazor
             {
                 FieldChanged(_selectedValues);
             }
+
             if (MultiSelection && typeof(T) == typeof(string))
                 await SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false);
         }
@@ -532,6 +538,7 @@ namespace MudBlazor
                 // which supply the RenderFragment. So in this case, a second render is necessary
                 StateHasChanged();
             }
+
             UpdateSelectAllChecked();
             lock (this)
             {
@@ -553,6 +560,7 @@ namespace MudBlazor
                 _renderComplete = new TaskCompletionSource();
                 t = _renderComplete.Task;
             }
+
             StateHasChanged();
             return t;
         }
@@ -652,11 +660,13 @@ namespace MudBlazor
                 if (EqualityComparer<T?>.Default.Equals(item.Value, ReadValue) && !MultiSelection)
                     result = true;
             }
+
             UpdateSelectAllChecked();
             if (result.HasValue == false)
             {
                 result = item.Value?.Equals(ReadValue);
             }
+
             return result == true;
         }
 
@@ -775,6 +785,7 @@ namespace MudBlazor
                     await CloseMenu();
                 return;
             }
+
             await SelectOption(_items[index].Value);
         }
 
@@ -831,6 +842,7 @@ namespace MudBlazor
             }
 
             HighlightItemForValueAsync(value);
+
             // Create a new HashSet to ensure ParameterState detects the change
             await _selectedValuesState.SetValueAsync(new HashSet<T?>(_selectedValues, Comparer));
             FieldChanged(_selectedValues);
@@ -849,8 +861,10 @@ namespace MudBlazor
         private async void HighlightItem(MudSelectItem<T>? item)
         {
             _activeItemId = item?.ItemId;
+
             // we need to make sure we are just after a render here or else there will be race conditions
             await WaitForRender();
+
             // Note: this is a hack, but I found no other way to make the list highlight the currently highlighted item
             // without the delay it always shows the previously highlighted item because the popup items don't exist yet
             // they are only registered after they are rendered, so we need to render again!
@@ -923,6 +937,7 @@ namespace MudBlazor
             UpdateIcon();
             StateHasChanged();
             await HighlightSelectedValue();
+
             //Scroll the active item on each opening
             if (_activeItemId != null)
             {
@@ -933,6 +948,7 @@ namespace MudBlazor
                     await ScrollToItemAsync(item);
                 }
             }
+
             //disable escape propagation: if selectmenu is open, only the select popover should close and underlying components should not handle escape key
             await KeyInterceptorService.UpdateKeyAsync(_elementId, new("Escape", stopDown: "key+none"));
 
@@ -989,8 +1005,10 @@ namespace MudBlazor
                     [
                         // prevent scrolling page, toggle open/close
                         new(" ", preventDown: "key+none"),
+
                         // prevent scrolling page, instead highlight previous item
                         new("ArrowUp", preventDown: "key+none"),
+
                         // prevent scrolling page, instead highlight next item
                         new("ArrowDown", preventDown: "key+none"),
                         new("Home", preventDown: "key+none"),
@@ -998,10 +1016,13 @@ namespace MudBlazor
                         new("Escape"),
                         new("Enter", preventDown: "key+none"),
                         new("NumpadEnter", preventDown: "key+none"),
+
                         // select all items instead of all page text
                         new("a", preventDown: "key+ctrl"),
+
                         // select all items instead of all page text
                         new("A", preventDown: "key+ctrl"),
+
                         // for our users
                         new("/./", subscribeDown: true, subscribeUp: true)
                     ]);
@@ -1092,9 +1113,10 @@ namespace MudBlazor
             await OnClearButtonClick.InvokeAsync(e);
         }
 
-        protected async Task SetCustomizedTextAsync(string text, bool updateValue = true,
-            List<string?>? selectedConvertedValues = null,
-            Func<List<string?>?, string>? multiSelectionTextFunc = null)
+        protected async Task SetCustomizedTextAsync(string text,
+                                                    bool updateValue = true,
+                                                    List<string?>? selectedConvertedValues = null,
+                                                    Func<List<string?>?, string>? multiSelectionTextFunc = null)
         {
             // The Text property of the control is updated
             var customText = multiSelectionTextFunc?.Invoke(selectedConvertedValues);
@@ -1166,6 +1188,7 @@ namespace MudBlazor
                 await FocusAsync();
                 return;
             }
+
             switch (obj.Key)
             {
                 case "Tab":
@@ -1245,14 +1268,17 @@ namespace MudBlazor
                         if (MultiSelection)
                         {
                             await SelectAllClickAsync();
+
                             //If we didn't add delay, it won't work.
                             await WaitForRender();
                             await Task.Delay(1);
                             StateHasChanged();
+
                             //It only works when selecting all, not render unselect all.
                             //UpdateSelectAllChecked();
                         }
                     }
+
                     break;
             }
 
@@ -1302,6 +1328,7 @@ namespace MudBlazor
                 _selectAllChecked = false;
             else
                 _selectAllChecked = true;
+
             // Define the items selection
             if (_selectAllChecked.Value)
                 await SelectAllItems();
@@ -1325,6 +1352,7 @@ namespace MudBlazor
             {
                 await SetTextAndUpdateValueAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)), updateValue: false);
             }
+
             UpdateSelectAllChecked();
             _selectedValues = selectedValues; // need to force selected values because Blazor overwrites it under certain circumstances due to changes of Text or Value
             await BeginValidateAsync();
@@ -1442,7 +1470,7 @@ namespace MudBlazor
             {
                 return Localizer[enumValue];
             }
-            
+
             return value?.ToString();
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -90,6 +90,9 @@ namespace MudBlazor
 
         [Inject]
         private IPopoverService PopoverService { get; set; } = null!;
+
+        [Inject]
+        private InternalMudLocalizer Localizer { get; set; } = null!;
 
         private Task SelectNextItem() => SelectAdjacentItem(+1);
 
@@ -362,6 +365,17 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
         public bool Dense { get; set; }
+
+        /// <summary>
+        /// Automatically generates <see cref="MudSelectItem{T}"/> elements for each value in an enum type.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>. When <c>true</c> and <c>T</c> is an enum type (or nullable enum),
+        /// items are automatically created for each enum value. Use <see cref="ToStringFunc"/> to customize display text.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.ListBehavior)]
+        public bool EnumValues { get; set; }
 
         /// <summary>
         /// The icon for opening the popover of items.
@@ -1393,6 +1407,43 @@ namespace MudBlazor
             if (MultiSelection)
                 return _selectedValues?.Any() ?? false;
             return base.HasValue(value);
+        }
+
+        /// <summary>
+        /// Returns whether <typeparamref name="T"/> is an enum type.
+        /// </summary>
+        private static bool IsEnumType()
+        {
+            var type = typeof(T);
+            return type.IsEnum || Nullable.GetUnderlyingType(type)?.IsEnum == true;
+        }
+
+        /// <summary>
+        /// Gets the enum values for type <typeparamref name="T"/>.
+        /// </summary>
+        private static IEnumerable<T> GetEnumValues()
+        {
+            var type = typeof(T);
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            return Enum.GetValues(underlyingType).Cast<T>();
+        }
+
+        /// <summary>
+        /// Converts an enum value to its display string using either the <see cref="ToStringFunc"/> (if it's not null) or the localizer.
+        /// </summary>
+        private string? GetEnumDisplayString(T? value)
+        {
+            if (ToStringFunc != null)
+            {
+                return ToStringFunc(value);
+            }
+
+            if (value is Enum enumValue)
+            {
+                return Localizer[enumValue];
+            }
+            
+            return value?.ToString();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -372,17 +372,6 @@ namespace MudBlazor
         public bool Dense { get; set; }
 
         /// <summary>
-        /// Automatically generates <see cref="MudSelectItem{T}"/> elements for each value in an enum type.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>false</c>. When <c>true</c> and <c>T</c> is an enum type (or nullable enum),
-        /// items are automatically created for each enum value. Use <see cref="ToStringFunc"/> to customize display text.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool EnumValues { get; set; }
-
-        /// <summary>
         /// The icon for opening the popover of items.
         /// </summary>
         /// <remarks>
@@ -1438,10 +1427,12 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Returns whether <typeparamref name="T"/> is an enum type.
+        /// Returns whether <typeparamref name="T"/> is an enum type and <see cref="ChildContent"/> is null.
         /// </summary>
-        private static bool IsEnumType()
+        private bool ShouldUseEnumValues()
         {
+            if (ChildContent != null) return false;
+            
             var type = typeof(T);
             return type.IsEnum || Nullable.GetUnderlyingType(type)?.IsEnum == true;
         }


### PR DESCRIPTION
This PR adds functionality to the `MudSelect` to directly plugin an `enum` in:

<img width="1247" height="784" alt="image" src="https://github.com/user-attachments/assets/cf140c21-6ece-41a4-be86-9efd4a4e07d5" />
