### PR TITLE
MudBaseInput: Remove ForceUpdate

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1307,32 +1307,6 @@ namespace MudBlazor.UnitTests.Components
             sut.Instance.Items.Should().HaveCountGreaterThanOrEqualTo(4);
         }
 
-        [Test]
-        public async Task Select_ValueChangeEventCount()
-        {
-            var comp = Context.Render<SelectEventCountTest>(x =>
-            {
-                x.Add(c => c.MultiSelection, false);
-            });
-            var select = comp.FindComponent<MudSelect<string>>();
-
-            comp.Instance.ValueChangeCount.Should().Be(0);
-            comp.Instance.ValuesChangeCount.Should().Be(0);
-
-            await comp.InvokeAsync(async () => await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "1")));
-            await comp.InvokeAsync(() => select.Instance.ForceUpdate());
-            await comp.WaitForAssertionAsync(() => comp.Instance.ValueChangeCount.Should().Be(1));
-            comp.Instance.ValuesChangeCount.Should().Be(1);
-            select.Instance.ReadValue.Should().Be("1");
-
-            // Changing value programmatically without ForceUpdate should change value, but should not fire change events
-            // Its by design, so this part can be change if design changes
-            await comp.InvokeAsync(async () => await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "2")));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ValueChangeCount.Should().Be(1));
-            comp.Instance.ValuesChangeCount.Should().Be(1);
-            select.Instance.ReadValue.Should().Be("2");
-        }
-
         /// <summary>
         /// When MultiSelection and Required are True with no selected values, required validation should fail.
         /// </summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -578,20 +578,6 @@ namespace MudBlazor
         protected override Task SetValueCoreAsync(T? value) => _valueState.SetValueAsync(value);
 
         /// <summary>
-        /// Sets the value, values, and text, and calls validation.
-        /// </summary>
-        /// <remarks>
-        /// This method is typically called when the user has changed the <see cref="Value"/> or <see cref="Text"/> programmatically.
-        /// </remarks>
-        /// <returns>
-        /// A <see cref="Task"/> object.
-        /// </returns>
-        public virtual Task ForceUpdate()
-        {
-            return SetValueAndUpdateTextAsync(ReadValue, force: true);
-        }
-
-        /// <summary>
         /// Occurs when the value has changed internally.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1376,23 +1376,5 @@ namespace MudBlazor
                 return _selectedValues?.Any() ?? false;
             return base.HasValue(value);
         }
-
-        /// <summary>
-        /// Forces the <see cref="SelectedValuesChanged"/> event to occur.
-        /// </summary>
-        public override async Task ForceUpdate()
-        {
-            await base.ForceUpdate();
-            if (MultiSelection == false)
-            {
-                await _selectedValuesState.SetValueAsync(new HashSet<T?>(Comparer) { ReadValue });
-            }
-            else
-            {
-                var newValues = new HashSet<T?>(_selectedValues, Comparer);
-                await _selectedValuesState.SetValueAsync(newValues);
-                FieldChanged(newValues);
-            }
-        }
     }
 }


### PR DESCRIPTION
Test `Select_ValueChangeEventCount` makes no sense btw.
`ValueChange` should not be called when parent updates the child, and `ForceUpdate` enforces it. Without `ForceUpdate`, there is no need of such test.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
