### PR TITLE
MudBooleanInput: Move Automatic For Labels to Base Class

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -2,6 +2,7 @@
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.RadioGroup;
+using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -388,6 +389,18 @@ namespace MudBlazor.UnitTests.Components
             create(readOnly = true, disabled = false).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
             create(readOnly = false, disabled = true).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
             create(readOnly = true, disabled = true).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
+        }
+        
+        [Test]
+        public void RadioLabel()
+        {
+            var value = new DisplayNameLabelClass();
+
+            var comp = Context.Render<MudRadio<bool>>(x => x.Add(f => f.For, () => value.Boolean));
+            comp.Instance.Label.Should().Be("Boolean LabelAttribute"); //label should be set by the attribute
+
+            var comp2 = Context.Render<MudRadio<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
+            comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -390,7 +390,7 @@ namespace MudBlazor.UnitTests.Components
             create(readOnly = false, disabled = true).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
             create(readOnly = true, disabled = true).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
         }
-        
+
         [Test]
         public void RadioLabel()
         {

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -191,7 +191,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
-            
+
             if (Label is null && For is not null)
             {
                 Label = For.GetLabelString();

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -186,5 +186,16 @@ namespace MudBlazor
                 _ => placement
             };
         }
+
+        /// <inheritdoc />
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            
+            if (Label is null && For is not null)
+            {
+                Label = For.GetLabelString();
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -202,10 +202,6 @@ namespace MudBlazor
         {
             base.OnInitialized();
 
-            if (Label is null && For is not null)
-            {
-                Label = For.GetLabelString();
-            }
             // if Aria Label has a value add aria-labeled by
             if (!string.IsNullOrWhiteSpace(AriaLabel))
             {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -124,17 +124,6 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-
-            if (Label is null && For is not null)
-            {
-                Label = For.GetLabelString();
-            }
-        }
-
-        /// <inheritdoc />
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)


### PR DESCRIPTION
This change removes redundant code and makes the `MudRadio` consistent with the `MudCheckBox` and `MudSwitch`.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
