### PR TITLE
Revert "Tests: Use more async bUnit method variants"

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -435,7 +435,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act
 
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("input").KeyUp("Enter");
 
             // Assert : CoercedValue enabled, so value is set on key enter pressed
 
@@ -472,7 +472,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act
 
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("input").KeyUp("Enter");
 
             // Assert : CoercedValue disabled, so value is not set on key enter pressed
 
@@ -516,7 +516,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.ReadText.Should().Be("Austria");
 
             // now trigger the coercion by call MudInput.BlurAsync
-            await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
         }
@@ -540,7 +540,7 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.ReadText.Should().Be(null);
 
             // now trigger the coercion by call MudInput.BlurAsync
-            await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             autocomplete.ReadValue.Should().Be(null);
             autocomplete.ReadText.Should().Be(expected: null);
         }
@@ -774,7 +774,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
 
             // Let's call blur on the input and confirm that it closed
-            await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
 
             // Tab closes the drop-down and does not select the selected value (California)
@@ -799,7 +799,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
 
             // Lets call blur on the input and confirm that it closed
-            await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Tab" });
+            autocompleteComponent.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Tab" });
             await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
 
             // Tab closes the drop-down and selects the selected value (California)
@@ -1119,7 +1119,7 @@ namespace MudBlazor.UnitTests.Components
             await component.WaitForAssertionAsync(() => selectedItemIndexPropertyInfo.GetValue(autocompleteInstance).Should().Be(4));
 
             // select the highlighted value
-            await component.Find(TagNames.Input).KeyUpAsync(Key.Enter);
+            component.Find(TagNames.Input).KeyUp(Key.Enter);
 
             // Arkansas should be selected value
             autocompleteInstance.Value.Should().Be(arkansasString);
@@ -1599,8 +1599,8 @@ namespace MudBlazor.UnitTests.Components
 
             result.Should().BeEmpty();
             //Act
-            await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "a" });
-            await autocompleteComponent.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "a" });
+            autocompleteComponent.Find("input").KeyDown("a");
+            autocompleteComponent.Find("input").KeyUp("a");
             //Assert
             result.Count.Should().Be(2);
         }

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -258,40 +258,40 @@ namespace MudBlazor.UnitTests.Components
             var checkbox = comp.Instance;
             checkbox.ReadValue.Should().Be(null);
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(false));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(false));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
             //Backspace should not change state on non-tristate checkbox
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.TriState, false));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
             //Check tristate space key
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(false));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(true));
         }
         /// <summary>
@@ -309,40 +309,40 @@ namespace MudBlazor.UnitTests.Components
             var checkbox = comp.Instance;
             checkbox.ReadValue.Should().Be(null);
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Delete", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "NumpadEnter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             //Backspace should not change state on non-tristate checkbox
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.TriState, false));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
             //Check tristate space key
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = " ", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
         }
 

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -1,6 +1,5 @@
 ﻿using AwesomeAssertions;
 using Bunit;
-using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents.ChipSet;
 using NUnit.Framework;
@@ -471,34 +470,34 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudChip<string>>().Should().HaveCount(2);
 
             // pressing a chip using Space or Enter should toggle their state
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = " " });
-            // comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("#chip-1").KeyDown(" ");
+            //comp.Find("#chip-2").KeyDown("Enter");
             await comp.Find("#chip-2").ClickAsync(); // https://github.com/MudBlazor/MudBlazor/pull/10488#issuecomment-2558409773
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(2);
 
             // pressing the Delete or Backspace keys should have no impact when the chips are not closable
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = "Delete" });
-            await comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Backspace" });
+            comp.Find("#chip-1").KeyDown("Delete");
+            comp.Find("#chip-2").KeyDown("Backspace");
             onCloseCount.Should().Be(0);
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(2);
 
             // re-pressing a chip with Space or Enter should un-toggle their state
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = " " });
-            // comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("#chip-1").KeyDown(" ");
+            //comp.Find("#chip-2").KeyDown("Enter");
             await comp.Find("#chip-2").ClickAsync(); // https://github.com/MudBlazor/MudBlazor/pull/10488#issuecomment-2558409773
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().BeNullOrEmpty();
 
             // toggle the chips again, then delete them (the chipset should no longer consider them part of its group, and remove them from selected values)
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(p => p.AreChipsClosable, true));
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = " " });
-            // comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("#chip-1").KeyDown(" ");
+            //comp.Find("#chip-2").KeyDown("Enter");
             await comp.Find("#chip-2").ClickAsync(); // https://github.com/MudBlazor/MudBlazor/pull/10488#issuecomment-2558409773
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(2);
 
             // pressing the Delete or Backspace keys should remove the chips from the chipset now that they are closable
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = "Delete" });
-            await comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Backspace" });
+            comp.Find("#chip-1").KeyDown("Delete");
+            comp.Find("#chip-2").KeyDown("Backspace");
             onCloseCount.Should().Be(2);
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().BeNullOrEmpty();
         }
@@ -520,13 +519,13 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudChip<string>>().Should().HaveCount(2);
 
             // pressing a chip using Space or Enter shouldn't toggle their state because the set is disabled
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = " " });
-            await comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("#chip-1").KeyDown(" ");
+            comp.Find("#chip-2").KeyDown("Enter");
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(0);
 
             // pressing the Delete or Backspace keys should have no impact either
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = "Delete" });
-            await comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Backspace" });
+            comp.Find("#chip-1").KeyDown("Delete");
+            comp.Find("#chip-2").KeyDown("Backspace");
             onCloseCount.Should().Be(0);
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(0);
 
@@ -539,13 +538,13 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudChip<string>>().Should().HaveCount(2);
 
             // pressing a chip using Space or Enter shouldn't toggle their state because the set is readOnly
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = " " });
-            await comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            comp.Find("#chip-1").KeyDown(" ");
+            comp.Find("#chip-2").KeyDown("Enter");
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(0);
 
             // pressing the Delete or Backspace keys should have no impact either
-            await comp.Find("#chip-1").KeyDownAsync(new KeyboardEventArgs { Key = "Delete" });
-            await comp.Find("#chip-2").KeyDownAsync(new KeyboardEventArgs { Key = "Backspace" });
+            comp.Find("#chip-1").KeyDown("Delete");
+            comp.Find("#chip-2").KeyDown("Backspace");
             onCloseCount.Should().Be(0);
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(0);
         }

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1227,7 +1227,7 @@ namespace MudBlazor.UnitTests.Components
             await dataGrid.FindAll(".mud-table-body tr")[0].ClickAsync();
 
             // Fire RowContextMenuClick
-            await dataGrid.FindAll(".mud-table-body tr")[0].ContextMenuAsync();
+            dataGrid.FindAll(".mud-table-body tr")[0].ContextMenu();
 
             // Edit an item.
             await dataGrid.FindAll(".mud-table-body tr td input")[0].ChangeAsync("A test");
@@ -1272,7 +1272,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridOnContextMenuClickWhenIsGrouped()
+        public void DataGridOnContextMenuClickWhenIsGrouped()
         {
             var comp = Context.Render<DataGridGroupExpandedTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridGroupExpandedTest.Fruit>>();
@@ -1284,7 +1284,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.RowContextMenuClicked.Should().Be(false);
 
             // Fire RowContextMenuClick
-            await dataGrid.FindAll(".mud-table-body tr")[1].ContextMenuAsync();
+            dataGrid.FindAll(".mud-table-body tr")[1].ContextMenu();
 
             // Make sure that the callbacks have been fired.
             comp.Instance.RowContextMenuClicked.Should().Be(true);
@@ -3905,7 +3905,7 @@ namespace MudBlazor.UnitTests.Components
                 PageY = openPosition.Top,
                 PageX = openPosition.Left
             };
-            await comp.Find(".filter-button").ClickAsync(mouseArgs);
+            comp.Find(".filter-button").Click(mouseArgs);
             await comp.WaitForAssertionAsync(() => dataGrid.Instance._openPosition.Should().Be(openPosition));
         }
 

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -56,20 +56,20 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("p.mud-typography").TrimmedText().Should().Be("Wabalabadubdub!");
             // close by click outside the dialog
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
             comp.Markup.Trim().Should().BeEmpty();
             var result = await dialogReference.Result;
             result.Canceled.Should().BeTrue();
             // open simple test dialog
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>());
             // close by click on cancel button
-            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].Click();
             result = await dialogReference.Result;
             result.Canceled.Should().BeTrue();
             // open simple test dialog
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>());
             // close by click on ok button
-            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].Click();
             result = await dialogReference.Result;
             result.Canceled.Should().BeFalse();
 
@@ -84,7 +84,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Close by using default close method
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogOkCancel>());
-            await comp.FindAll("button")[2].ClickAsync();
+            comp.FindAll("button")[2].Click();
             result = await dialogReference.Result;
             result.Data.Should().BeNull();
             result.DataType.Should().BeNull();
@@ -106,17 +106,17 @@ namespace MudBlazor.UnitTests.Components
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var inlineDialog = Context.Render<TestInlineDialog>();
-            inlineDialog.FindComponents<MudButton>().Count.Should().Be(1);
+            var comp1 = Context.Render<TestInlineDialog>();
+            comp1.FindComponents<MudButton>().Count.Should().Be(1);
             // open the dialog
-            await inlineDialog.Find("button").ClickAsync();
-            await inlineDialog.WaitForAssertionAsync(() =>
+            comp1.Find("button").Click();
+            await comp1.WaitForAssertionAsync(() =>
                 comp.Find("div.mud-dialog-container").Should().NotBe(null)
             );
             comp.Find("p.mud-typography").TrimmedText().Should().Be("Wabalabadubdub!");
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Contain("mud-dialog-width-full");
             // close by click on ok button
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             comp.Markup.Trim().Should().BeEmpty();
         }
 
@@ -132,13 +132,13 @@ namespace MudBlazor.UnitTests.Components
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
 
-            var inlineDialog = Context.Render<InlineDialogShowMethod>();
+            var comp1 = Context.Render<InlineDialogShowMethod>();
 
             comp.Markup.Should().NotContain("Here be dragons");
 
             // open the dialog
-            inlineDialog.Find(".open-dialog-button").Click();
-            await inlineDialog.WaitForAssertionAsync(() => comp.Find("div.mud-dialog-container").Should().NotBe(null));
+            comp1.Find(".open-dialog-button").Click();
+            await comp1.WaitForAssertionAsync(() => comp.Find("div.mud-dialog-container").Should().NotBe(null));
 
             comp.Markup.Should().Contain("Here be dragons");
 
@@ -161,7 +161,7 @@ namespace MudBlazor.UnitTests.Components
         /// https://github.com/MudBlazor/MudBlazor/issues/11789
         /// </remarks>
         [Test]
-        public async Task InlineDialog_OpenCancelOpen()
+        public void InlineDialog_OpenCancelOpen()
         {
             // Arrange
 
@@ -174,7 +174,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act : Open the dialog
 
-            await sup.Find(".open-dialog-button").ClickAsync();
+            sup.Find(".open-dialog-button").Click();
 
             // Assert : Dialog should be open
 
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act : Cancel by click outside
 
-            await comp.Find("div.mud-overlay-dialog").ClickAsync();
+            comp.Find("div.mud-overlay-dialog").Click();
 
             // Assert : Dialog should be closed
 
@@ -190,7 +190,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act : Reopen the dialog
 
-            await sup.Find(".open-dialog-button").ClickAsync();
+            sup.Find(".open-dialog-button").Click();
 
             // Assert : Dialog should be open
 
@@ -211,14 +211,14 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<TestNestedInlineDialog>();
             comp.FindComponents<MudButton>().Count.Should().Be(1);
             // open the dialog
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             await comp.WaitForAssertionAsync(() =>
                 provider.Find("div.mud-dialog-container").Should().NotBe(null)
             );
             provider.Find("p.mud-typography").TrimmedText().Should().Be("Scorpiany!");
             provider.FindComponents<MudText>().Count.Should().Be(2); //counts both the dialog header and the text in our test component
 
-            await provider.Find("button").ClickAsync(); //open nested dialog
+            provider.Find("button").Click(); //open nested dialog
             await comp.WaitForAssertionAsync(() =>
                 provider.Find(".nested").Should().NotBe(null)
             );
@@ -238,26 +238,16 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Trim().Should().BeEmpty();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
-            var inlineDialog = Context.Render<InlineDialogIsVisibleStateTest>();
-
-            async Task OpenDialogAsync()
-            {
-                await inlineDialog.Find("button").ClickAsync();
-                await comp.WaitForAssertionAsync(
-                    () => comp.FindAll("div.mud-dialog-container").Count.Should().Be(1));
-            }
-
-            async Task CloseDialogAsync()
-            {
-                var overlay = await comp.WaitForElementAsync("div.mud-overlay");
-                await overlay.ClickAsync();
-                await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().BeEmpty());
-            }
-
-            await OpenDialogAsync();
-            await CloseDialogAsync();
-            await OpenDialogAsync();
-            await CloseDialogAsync();
+            var comp1 = Context.Render<InlineDialogIsVisibleStateTest>();
+            await comp1.InvokeAsync(() => comp1.Find("button").Click());
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-dialog-container").Count.Should().Be(1));
+            await comp.InvokeAsync(() => comp.WaitForElement("div.mud-overlay").Click());
+            await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().BeEmpty(), TimeSpan.FromSeconds(5));
+            await comp1.InvokeAsync(() => comp1.Find("button").Click());
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-dialog-container").Count.Should().Be(1),
+                TimeSpan.FromSeconds(5));
+            await comp.InvokeAsync(() => comp.WaitForElement("div.mud-overlay").Click());
+            await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().BeEmpty(), TimeSpan.FromSeconds(5));
         }
 
         /// <summary>
@@ -272,11 +262,11 @@ namespace MudBlazor.UnitTests.Components
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var inlineDialog = Context.Render<TestInlineDialog>();
+            var comp1 = Context.Render<TestInlineDialog>();
             // open the dialog
-            await inlineDialog.Find("button").ClickAsync();
+            comp1.Find("button").Click();
             // rate star
-            await comp.Find("span.mud-rating-item").FirstElementChild.ClickAsync();
+            comp.Find("span.mud-rating-item").FirstElementChild.Click();
             // check if is still opened
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-dialog-container").Should().NotBe(null), TimeSpan.FromSeconds(5));
         }
@@ -302,7 +292,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Be("Body:");
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title:");
             // click on ok button should set title and content
-            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].Click();
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Be("Body: Test123");
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title: Test123");
         }
@@ -331,11 +321,11 @@ namespace MudBlazor.UnitTests.Components
             var textField = comp.FindComponent<MudInput<string>>().Instance;
             textField.ReadText.Should().Be("test");
 
-            await comp.Find("input").ChangeAsync("new_test");
-            await comp.Find("input").BlurAsync();
+            comp.Find("input").Change("new_test");
+            comp.Find("input").Blur();
             textField.ReadText.Should().Be("new_test");
 
-            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].Click();
 
             ((DialogWithParameters)dialogReference.Dialog).TestValue.Should().Be("new_test");
             ((DialogWithParameters)dialogReference.Dialog).ParametersSetCounter.Should().Be(1);
@@ -352,10 +342,10 @@ namespace MudBlazor.UnitTests.Components
 
             var testComp = Context.Render<DialogWithEventCallbackTest>();
             // open dialog
-            await testComp.Find("button").ClickAsync();
+            testComp.Find("button").Click();
             // in the opened dialog find the text field
             var tf = comp.FindComponent<MudTextField<string>>();
-            await tf.Find("input").InputAsync("User input ...");
+            tf.Find("input").Input("User input ...");
             // the user input should be passed out of the dialog into the outer component and displayed there.
             await testComp.WaitForAssertionAsync(() =>
                 testComp.Find("p").TextContent.Trim().Should().Be("Search Text:  User input ...")
@@ -393,14 +383,14 @@ namespace MudBlazor.UnitTests.Components
             customDialogReference.AllowDismiss.Should().BeFalse();
 
             //Dialog should not be closable through backdrop click
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
             await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().NotBeEmpty(), TimeSpan.FromSeconds(5));
 
             //Allow dismiss
             customDialogReference.AllowDismiss = true;
 
             //Dialog should now be closable through backdrop click
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
             await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().BeEmpty(), TimeSpan.FromSeconds(5));
         }
 
@@ -419,13 +409,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogWithReturnValue>());
             dialogReference.Should().NotBe(null);
             // close by click on cancel button
-            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].Click();
             var rv = await dialogReference.GetReturnValueAsync<string>();
             rv.Should().BeNull();
             // open dialog
             await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogWithReturnValue>());
             // close by click on ok button
-            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].Click();
             rv = await dialogReference.GetReturnValueAsync<string>();
             rv.Should().Be("Closed via OK");
         }
@@ -494,7 +484,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title:");
 
             //Click on backdrop
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
 
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title: Backdrop clicked");
         }
@@ -512,11 +502,11 @@ namespace MudBlazor.UnitTests.Components
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
             // displaying the component with the inline dialog only renders the open button
-            var inlineDialog = Context.Render<TestInlineDialog>();
-            inlineDialog.FindComponents<MudButton>().Count.Should().Be(1);
+            var comp1 = Context.Render<TestInlineDialog>();
+            comp1.FindComponents<MudButton>().Count.Should().Be(1);
             // open the dialog
-            inlineDialog.Find("button").Click();
-            await inlineDialog.WaitForAssertionAsync(() =>
+            comp1.Find("button").Click();
+            await comp1.WaitForAssertionAsync(() =>
                 comp.Find("div.mud-dialog-container").Should().NotBe(null)
             );
             comp.Find("p.mud-typography").TrimmedText().Should().Be("Wabalabadubdub!");
@@ -543,9 +533,9 @@ namespace MudBlazor.UnitTests.Components
             dialogReference.Should().NotBe(null);
 
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
         }
 
@@ -609,7 +599,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-container").Should().NotBe(null);
             comp.Find("p.mud-typography").TrimmedText().Should().Be("Wabalabadubdub!");
             //close by click outside the dialog
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
             comp.Markup.Trim().Should().BeEmpty();
             var result = await dialogReference.Result;
             result.Canceled.Should().BeTrue();
@@ -618,7 +608,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dialogReferenceLazy.Value);
             dialogReference = await dialogReferenceLazy.Value;
             //close by click on cancel button
-            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].Click();
             result = await dialogReference.Result;
             result.Canceled.Should().BeTrue();
             //open simple test dialog
@@ -626,7 +616,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dialogReferenceLazy.Value);
             dialogReference = await dialogReferenceLazy.Value;
             //close by click on ok button
-            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].Click();
             result = result = await dialogReference.Result;
             result.Canceled.Should().BeFalse();
 
@@ -658,7 +648,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => dialogReferenceLazy.Value);
             var dialogReference = await dialogReferenceLazy.Value;
             await comp.WaitForAssertionAsync(() => dialogReference.Should().NotBe(null));
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-dialog").ClassList.Should().Contain("test-class"));
             comp.Find("div.mud-dialog-content").ClassList.Should().NotContain("test-class");
             comp.Find("div.mud-dialog-content").ClassList.Should().Contain("content-class");
@@ -689,7 +679,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Be("Body:");
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title:");
             // click on ok button should set title and content
-            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].Click();
             comp.Find("div.mud-dialog-content").TrimmedText().Should().Be("Body: Test123");
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title: Test123");
         }
@@ -719,11 +709,11 @@ namespace MudBlazor.UnitTests.Components
             var textField = comp.FindComponent<MudInput<string>>().Instance;
             textField.ReadText.Should().Be("test");
 
-            await comp.Find("input").ChangeAsync("new_test");
-            await comp.Find("input").BlurAsync();
+            comp.Find("input").Change("new_test");
+            comp.Find("input").Blur();
             textField.ReadText.Should().Be("new_test");
 
-            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].Click();
 
             ((DialogWithParameters)dialogReference.Dialog).TestValue.Should().Be("new_test");
             ((DialogWithParameters)dialogReference.Dialog).ParametersSetCounter.Should().Be(1);
@@ -783,14 +773,14 @@ namespace MudBlazor.UnitTests.Components
             customDialogReference.AllowDismiss.Should().BeFalse();
 
             //Dialog should not be closable through backdrop click
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
             await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().NotBeEmpty(), TimeSpan.FromSeconds(5));
 
             //Allow dismiss
             customDialogReference.AllowDismiss = true;
 
             //Dialog should now be closable through backdrop click
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
             await comp.WaitForAssertionAsync(() => comp.Markup.Trim().Should().BeEmpty(), TimeSpan.FromSeconds(5));
         }
 
@@ -810,14 +800,14 @@ namespace MudBlazor.UnitTests.Components
             var dialogReference = await dialogReferenceLazy.Value;
             dialogReference.Should().NotBe(null);
             // close by click on cancel button
-            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].Click();
             var rv = await dialogReference.GetReturnValueAsync<string>();
             rv.Should().BeNull();
             // open dialog
             dialogReferenceLazy = new Lazy<Task<IDialogReference>>(() => service.ShowAsync<DialogWithReturnValue>());
             await comp.InvokeAsync(() => dialogReferenceLazy.Value);
             // close by click on ok button
-            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].Click();
             dialogReference = await dialogReferenceLazy.Value;
             rv = await dialogReference.GetReturnValueAsync<string>();
             rv.Should().Be("Closed via OK");
@@ -869,7 +859,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title:");
 
             //Click on backdrop
-            await comp.Find("div.mud-overlay").ClickAsync();
+            comp.Find("div.mud-overlay").Click();
 
             comp.Find("div.mud-dialog-title").TrimmedText().Should().Be("Title: Backdrop clicked");
         }
@@ -889,9 +879,9 @@ namespace MudBlazor.UnitTests.Components
             dialogReference.Should().NotBe(null);
 
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-fullscreen");
-            await comp.Find("button").ClickAsync();
+            comp.Find("button").Click();
             comp.Find("div.mud-dialog").GetAttribute("class").Should().Be("mud-dialog mud-dialog-width-sm");
         }
 
@@ -1312,9 +1302,9 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudDialogProvider>();
             var service = Context.Services.GetRequiredService<IDialogService>();
             service.Should().NotBe(null);
-            var inlineDialog = Context.Render<InlineDialogDuplicateTest>();
+            var comp1 = Context.Render<InlineDialogDuplicateTest>();
             // open the dialog
-            await inlineDialog.Find("button").ClickAsync();
+            comp1.Find("button").Click();
             await Task.Delay(1000);
             comp.FindComponents<MudDialog>().Count.Should().Be(1);
         }
@@ -1327,9 +1317,9 @@ namespace MudBlazor.UnitTests.Components
 
             var service = Context.Services.GetRequiredService<IDialogService>();
 
-            var inlineDialog = Context.Render<InlineDialogTitleRefreshTest>();
+            var comp1 = Context.Render<InlineDialogTitleRefreshTest>();
 
-            inlineDialog.Find("button").Click();
+            comp1.Find("button").Click();
 
             var dialog = comp.Find("div.mud-dialog");
 
@@ -1383,7 +1373,7 @@ namespace MudBlazor.UnitTests.Components
                 Times.AtMost(1)); // Focus should be called once when dialog is opened (FocusTrap)
 
             comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog is open
-            await comp.Find("div.mud-overlay").ClickAsync(); // Simulate a click on the backdrop
+            comp.Find("div.mud-overlay").Click(); // Simulate a click on the backdrop
 
             //Assert
             comp.Find("div.mud-dialog-container").Should().NotBeNull(); // Dialog should still be open

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Components
             var sequence = new List<int> { 0, 2, 1 };
             foreach (var item in sequence)
             {
-                await comp.FindAll(".mud-expand-panel-header")[item].ClickAsync();
+                await comp.InvokeAsync(() => comp.FindAll(".mud-expand-panel-header")[item].Click());
 
                 var panels = comp.FindAll(".mud-expand-panel").ToList();
 
@@ -86,7 +86,7 @@ namespace MudBlazor.UnitTests.Components
             //click in the three headers
             foreach (var header in comp.FindAll(".mud-expand-panel-header"))
             {
-                await header.ClickAsync();
+                await comp.InvokeAsync(() => header.Click());
             }
 
             //the three panels must be expanded
@@ -129,7 +129,7 @@ namespace MudBlazor.UnitTests.Components
             //click in the three headers
             foreach (var header in comp.FindAll(".mud-expand-panel-header"))
             {
-                await header.ClickAsync();
+                await comp.InvokeAsync(() => header.Click());
             }
 
             //we could close them all

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -134,7 +134,7 @@ namespace MudBlazor.UnitTests.Components
             fileUploadInstance.Files.Should().NotBeNull();
             fileUploadInstance.Files!.Name.Should().Be(fileName);
 
-            await comp.Find("button#clear-button").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("button#clear-button").Click());
 
             fileUploadInstance.Files.Should().BeNull();
         }
@@ -151,7 +151,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<FileUploadWithDragAndDropActivatorTest>();
 
-            await comp.Find("button#open-file-picker-button").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("button#open-file-picker-button").Click());
 
             Context.JSInterop.Invocations.Should().ContainSingle(invocation => invocation.Identifier == "mudFileUpload.openFilePicker");
         }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -649,14 +649,14 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeFalse();
             form.IsValid.Should().BeFalse();
 
-            await comp.Find("input").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("input").Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
             // open color collection view
-            await comp.Find("div.mud-picker-color-dot-current").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("div.mud-picker-color-dot-current").Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(1));
 
             // set valid color
-            await comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").Skip(1).First().ClickAsync();
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").Skip(1).First().Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(0));
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeTrue();
@@ -664,11 +664,11 @@ namespace MudBlazor.UnitTests.Components
             colorPicker.GetState(x => x.Error).Should().BeFalse();
             colorPicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
-            await comp.Find("div.mud-picker-color-dot-current").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("div.mud-picker-color-dot-current").Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(1));
 
             // set invalid color
-            await comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").First().ClickAsync();
+            await comp.InvokeAsync(() => comp.FindAll("div.mud-picker-color-collection>div.mud-picker-color-dot").First().Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-color-collection").Count.Should().Be(0));
             form.IsTouched.Should().BeTrue();
             form.IsValid.Should().BeFalse();
@@ -781,8 +781,8 @@ namespace MudBlazor.UnitTests.Components
             dateRangePicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             await comp.Find("input").ClickAsync();
             // clicking day buttons to select a date range
-            await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).ClickAsync();
-            await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("11")).ClickAsync();
+            await comp.InvokeAsync(() => comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("10")).Click());
+            await comp.InvokeAsync(() => comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("11")).Click());
             // wait for picker to close
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
 
@@ -1004,7 +1004,7 @@ namespace MudBlazor.UnitTests.Components
             fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // clear files
-            await comp.Find("button#clear-button").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("button#clear-button").Click());
             fileUploadInstance.Files.Should().BeNull();
 
             // form should now be invalid because a file is required
@@ -1963,7 +1963,7 @@ namespace MudBlazor.UnitTests.Components
         /// CheckBox should be validated like every other form component when ticked using keyboard
         /// </summary>
         [Test]
-        public async Task FormWithCheckBox_When_CheckBoxTickedUsingKeyboard()
+        public void FormWithCheckBox_When_CheckBoxTickedUsingKeyboard()
         {
             var comp = Context.Render<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1975,7 +1975,7 @@ namespace MudBlazor.UnitTests.Components
             checkBox.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // tick checkBox with a key press
-            await comp.Find("input").KeyDownAsync(Key.Space);
+            comp.Find("input").KeyDown(Key.Space);
             form.IsTouched.Should().Be(true);
             form.IsValid.Should().Be(true);
             form.Errors.Length.Should().Be(0);
@@ -1983,7 +1983,7 @@ namespace MudBlazor.UnitTests.Components
             checkBox.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
 
             // untick checkBox with a key press
-            await comp.Find("input").KeyDownAsync(Key.Space);
+            comp.Find("input").KeyDown(Key.Space);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
             form.Errors[0].Should().Be("Required");
@@ -2032,3 +2032,4 @@ namespace MudBlazor.UnitTests.Components
         }
     }
 }
+

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -349,20 +349,20 @@ namespace MudBlazor.UnitTests.Components
             var numericField = comp.Instance;
             numericField.ReadValue.Should().Be(1234.56);
             numericField.ReadText.Should().Be("1234.56");
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1235.56));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "ArrowDown", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "c", Type = "keydown", CtrlKey = false });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "c", Type = "keyup", CtrlKey = false });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "9", Type = "keydown", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => numericField.ReadValue.Should().Be(1234.56));
         }
 
@@ -380,9 +380,9 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Disabled, true));
             comp.Instance.ReadValue.Should().Be(1234.56);
             comp.Instance.ReadText.Should().Be("1234.56");
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
         }
 
@@ -400,9 +400,9 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.ReadOnly, true));
             comp.Instance.ReadValue.Should().Be(1234.56);
             comp.Instance.ReadText.Should().Be("1234.56");
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "ArrowUp", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
+            comp.Find("input").KeyUp(new KeyboardEventArgs() { Key = "9", Type = "keyup", });
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234.56));
         }
 

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -226,10 +226,10 @@ namespace MudBlazor.UnitTests.Components
             var radio = comp.FindComponent<MudRadioGroup<string>>();
             radio.Instance.Value.Should().Be(null);
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be("1"));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be(null));
 
             //Can't tabbed around the radios in test.
@@ -248,7 +248,7 @@ namespace MudBlazor.UnitTests.Components
             await radio.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
             await comp.WaitForAssertionAsync(() => group.Instance.Value.Should().Be(null));
 
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => group.Instance.Value.Should().Be(null));
         }
 

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -719,12 +719,12 @@ namespace MudBlazor.UnitTests.Components
             // Force it out of the show transition.
 
             primary.State.SnackbarState.Should().Be(SnackbarState.Showing);
-            await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
+            _provider.Find(".mud-snackbar").PointerEnter(new PointerEventArgs());
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Ensure that leaving with the pointer does not trigger a hide transition by itself, like if the timer was not properly utilized.
 
-            await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
+            _provider.Find(".mud-snackbar").PointerLeave(new PointerEventArgs());
             await Task.Delay(primary.State.Options.VisibleStateDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -705,7 +705,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("input").ChangeAsync("Vat of acid");
 
             // this will make the input focused!
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+            comp.Find("input").KeyDown(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             textfield.ReadValue.Should().Be("Vat of acid");
             textfield.ReadText.Should().Be("Vat of acid");
 
@@ -1122,7 +1122,7 @@ namespace MudBlazor.UnitTests.Components
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
 
             // trigger delayed re-render
-            await comp.Find("#re-render-button").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("#re-render-button").Click());
 
             // imitate "typing in progress" by extending the debounce interval until component re-renders
             var elapsedTime = 0;

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -660,13 +660,13 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetCurrentPalette().Should().BeOfType<PaletteLight>();
 
             // Act - toggle to dark mode
-            await comp.Find("button").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("button").Click());
 
             // Assert - should be dark palette
             comp.Instance.GetCurrentPalette().Should().BeOfType<PaletteDark>();
 
             // Act - toggle back to light mode
-            await comp.Find("button").ClickAsync();
+            await comp.InvokeAsync(() => comp.Find("button").Click());
 
             // Assert - should be light palette again
             comp.Instance.GetCurrentPalette().Should().BeOfType<PaletteLight>();

--- a/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
@@ -29,7 +29,7 @@ public class ParameterStateUsageTests : BunitTest
     }
 
     [Test]
-    public async Task SharedHandlerIntegration()
+    public void SharedHandlerIntegration()
     {
         var comp = Context.Render<ParameterStateSharedHandlerTestComp>();
 
@@ -39,22 +39,22 @@ public class ParameterStateUsageTests : BunitTest
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("1");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("1");
-        await comp.Find("button.abc").ClickAsync();
+        comp.Find("button.abc").Click();
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("1");
-        await comp.Find("button.xyz").ClickAsync();
+        comp.Find("button.xyz").Click();
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("2");
-        await comp.Find("button.op").ClickAsync();
+        comp.Find("button.op").Click();
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("4");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("2");
     }
 
     [Test]
-    public async Task InheritanceIntegration()
+    public void InheritanceIntegration()
     {
         var comp = Context.Render<ParameterStateSharedInheritanceHandlerTestComp>();
 
@@ -64,29 +64,29 @@ public class ParameterStateUsageTests : BunitTest
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("1");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("1");
-        await comp.Find("button.abc").ClickAsync();
+        comp.Find("button.abc").Click();
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("1");
-        await comp.Find("button.xyz").ClickAsync();
+        comp.Find("button.xyz").Click();
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("2");
-        await comp.Find("button.op").ClickAsync();
+        comp.Find("button.op").Click();
         comp.Find("span.abc").InnerHtml.Trimmed().Should().Be("2");
         comp.Find("span.op").InnerHtml.Trimmed().Should().Be("4");
         comp.Find("span.xyz").InnerHtml.Trimmed().Should().Be("2");
     }
 
     [Test]
-    public async Task EventArgsIntegration()
+    public void EventArgsIntegration()
     {
         var comp = Context.Render<ParameterStateEventArgsTestComp>();
         comp.Find(".parameter-changes").Children.Length.Should().Be(0);
-        await comp.Find("button.increment-int-param").ClickAsync();
+        comp.Find("button.increment-int-param").Click();
         comp.Find(".parameter-changes").Children.Length.Should().Be(1);
         comp.Find(".parameter-changes").FirstChild?.TextContent.Trimmed().Should().Be("IntParam: 0=>1");
-        await comp.Find("button.increment-int-param").ClickAsync();
+        comp.Find("button.increment-int-param").Click();
         comp.Find(".parameter-changes").Children.Length.Should().Be(2);
         comp.Find(".parameter-changes").LastChild?.TextContent.Trimmed().Should().Be("IntParam: 1=>2");
     }
@@ -145,7 +145,7 @@ public class ParameterStateUsageTests : BunitTest
     }
 
     [Test]
-    public async Task GetStateTestIntegration()
+    public void GetStateTestIntegration()
     {
         var comp = Context.Render<ParameterStateEventArgsTestComp>();
         IElement IncrementButton() => comp.Find("button.increment-int-param");
@@ -154,12 +154,12 @@ public class ParameterStateUsageTests : BunitTest
         StateComponent().Instance.GetState(x => x.IntParam).Should().Be(0);
         StateComponent().Instance.GetState<int>(nameof(ParameterStateTestComp.IntParam)).Should().Be(0);
 
-        await IncrementButton().ClickAsync();
+        IncrementButton().Click();
 
         StateComponent().Instance.GetState(x => x.IntParam).Should().Be(1);
         StateComponent().Instance.GetState<int>(nameof(ParameterStateTestComp.IntParam)).Should().Be(1);
 
-        await IncrementButton().ClickAsync();
+        IncrementButton().Click();
 
         StateComponent().Instance.GetState(x => x.IntParam).Should().Be(2);
         StateComponent().Instance.GetState<int>(nameof(ParameterStateTestComp.IntParam)).Should().Be(2);

--- a/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
@@ -376,7 +376,7 @@ public class DebounceDispatcherTests
     }
 
     [Test]
-    public async Task DebounceAsync_NullAction_ThrowsArgumentNullException()
+    public void DebounceAsync_NullAction_ThrowsArgumentNullException()
     {
         // Arrange
         using var debounceDispatcher = new DebounceDispatcher(100);
@@ -527,7 +527,7 @@ public class DebounceDispatcherTests
     }
 
     [Test]
-    public async Task UpdateInterval_NegativeInterval_ThrowsArgumentOutOfRangeException()
+    public void UpdateInterval_NegativeInterval_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         using var debounceDispatcher = new DebounceDispatcher(100);

--- a/src/MudBlazor.UnitTests/Utilities/EventUtilTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/EventUtilTests.cs
@@ -14,13 +14,13 @@ namespace MudBlazor.UnitTests.Utilities
     public class EventUtilTests : BunitTest
     {
         [Test]
-        public async Task EventUtil_ShouldPreventRenderCycle()
+        public void EventUtil_ShouldPreventRenderCycle()
         {
             var comp = Context.Render<EventUtil1Test>();
             comp.Find("#clicks").TrimmedText().Should().Be("Clicks: 0/0/0");
             comp.RenderCount.Should().Be(1);
             // normal click handler causes a re-render automatically (normal Blazor behavior)
-            await comp.Find("#btn1").ClickAsync(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
+            comp.Find("#btn1").Click(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
             comp.RenderCount.Should().Be(2);
             comp.Find("#clicks").TrimmedText().Should().Be("Clicks: 1/0/0");
             comp.Instance.NumClicks1.Should().Be(1);
@@ -29,7 +29,7 @@ namespace MudBlazor.UnitTests.Utilities
             comp.Instance.ScreenX.Should().Be(0);
             comp.Instance.ScreenY.Should().Be(0);
             // now the EventUtil handler with render-suppression (no args)
-            await comp.Find("#btn2").ClickAsync(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
+            comp.Find("#btn2").Click(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
             comp.RenderCount.Should().Be(2);
             comp.Find("#clicks").TrimmedText().Should().Be("Clicks: 1/0/0"); // no update to the component due render suppression
             comp.Instance.NumClicks1.Should().Be(1);
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Utilities
             comp.Instance.ScreenX.Should().Be(0);
             comp.Instance.ScreenY.Should().Be(0);
             // now the EventUtil handler with render-suppression (with mouse args)
-            await comp.Find("#btn3").ClickAsync(new MouseEventArgs() { ScreenX = 17, ScreenY = 27 });
+            comp.Find("#btn3").Click(new MouseEventArgs() { ScreenX = 17, ScreenY = 27 });
             comp.RenderCount.Should().Be(2);
             comp.Find("#clicks").TrimmedText().Should().Be("Clicks: 1/0/0"); // no update to the component due render suppression
             comp.Instance.NumClicks1.Should().Be(1);
@@ -47,13 +47,13 @@ namespace MudBlazor.UnitTests.Utilities
             comp.Instance.ScreenX.Should().Be(17);
             comp.Instance.ScreenY.Should().Be(27);
             // click the first button to re-render
-            await comp.Find("#btn1").ClickAsync(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
+            comp.Find("#btn1").Click(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
             comp.RenderCount.Should().Be(3);
             comp.Find("#clicks").TrimmedText().Should().Be("Clicks: 2/1/1");
             comp.Instance.ScreenX.Should().Be(17);
             comp.Instance.ScreenY.Should().Be(27);
             // now test the async versions of the utility
-            await comp.Find("#btn4").ClickAsync(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
+            comp.Find("#btn4").Click(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
             comp.RenderCount.Should().Be(3);
             comp.Instance.NumClicks1.Should().Be(2);
             comp.Instance.NumClicks2.Should().Be(1);
@@ -62,7 +62,7 @@ namespace MudBlazor.UnitTests.Utilities
             comp.Instance.NumClicks5.Should().Be(0);
             comp.Instance.ScreenX.Should().Be(17);
             comp.Instance.ScreenY.Should().Be(27);
-            await comp.Find("#btn5").ClickAsync(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
+            comp.Find("#btn5").Click(new MouseEventArgs() { ScreenX = 66, ScreenY = 99 });
             comp.RenderCount.Should().Be(3);
             comp.Instance.NumClicks1.Should().Be(2);
             comp.Instance.NumClicks2.Should().Be(1);

--- a/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
@@ -252,7 +252,7 @@ public class ThrottleDispatcherTests
     }
 
     [Test]
-    public async Task ThrottleAsync_Dispose_DoesNotCancelRunningAction()
+    public void ThrottleAsync_Dispose_DoesNotCancelRunningAction()
     {
         // Arrange
         var dispatcher = new ThrottleDispatcher(100);
@@ -295,7 +295,7 @@ public class ThrottleDispatcherTests
     }
 
     [Test]
-    public async Task ThrottleAsync_DisposeDuringLock_HandlesGracefully()
+    public void ThrottleAsync_DisposeDuringLock_HandlesGracefully()
     {
         // Arrange
         using var dispatcher = new ThrottleDispatcher(100);
@@ -334,7 +334,7 @@ public class ThrottleDispatcherTests
     }
 
     [Test]
-    public async Task ThrottleAsync_NullAction_ThrowsArgumentNullException()
+    public void ThrottleAsync_NullAction_ThrowsArgumentNullException()
     {
         // Arrange
         using var dispatcher = new ThrottleDispatcher(100);


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#12545

Already had a lot of trouble getting it working and then it caused this on dev:

```
Run dotnet test -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
  [coverlet] _mapping file name: 'CoverletSourceRootsMapping_MudBlazor.UnitTests.Docs'
  [coverlet] _mapping file name: 'CoverletSourceRootsMapping_MudBlazor.UnitTests'
Test run for /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/bin/Release/net10.0/MudBlazor.UnitTests.dll (.NETCoreApp,Version=v10.0)
VSTest version 18.0.1 (x64)

Test run for /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests.Docs/bin/Release/net10.0/MudBlazor.UnitTests.Docs.dll (.NETCoreApp,Version=v10.0)
VSTest version 18.0.1 (x64)

Starting test execution, please wait...Starting test execution, please wait...

A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
  Failed DataGridGroupExpandedTrueServerData [1 s]
  Error Message:
   Bunit.Extensions.WaitForHelpers.WaitForFailedException : The assertion did not pass within the timeout period.

If this test does not fail consistently, the reason may be that
the wait timeout is too short, and the runtime did not have enough
time to complete the necessary number of renders of the component under test.
This can happen on highly utilized or slower hardware, for example.

To determine if this is the cause, compare the check and render count(s) below
and see if they match what is expected. If they do not,
consider increasing the timeout, either at the individual
method call level, e.g. WaitForElement("div", TimeSpan.FromSeconds(15)),
or via the static TestContext.DefaultWaitTimeout property.

Check count: 1.
Component render count: 14.
Total render count across all components: 0.
  ----> NUnit.Framework.AssertionException : Expected comp.FindAll("tbody .mud-table-row").Count to be 7, but found 0 (difference of -7).
  Stack Trace:
     at Bunit.RenderedComponentWaitForHelperExtensions.WaitForAssertionAsync[TComponent](IRenderedComponent`1 renderedComponent, Action assertion, Nullable`1 timeout) in /_/src/bunit/Extensions/WaitForHelpers/RenderedComponentWaitForHelperExtensions.WaitForState.cs:line 100
   at MudBlazor.UnitTests.Components.DataGridGroupingTests.DataGridGroupExpandedTrueServerData() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs:line 61
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
--AssertionException
   at AwesomeAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at AwesomeAssertions.Numeric.NumericAssertionsBase`3.Be(T expected, String because, Object[] becauseArgs)
   at MudBlazor.UnitTests.Components.DataGridGroupingTests.<>c__DisplayClass2_0.<DataGridGroupExpandedTrueServerData>b__0() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs:line 61
   at Bunit.Extensions.WaitForHelpers.WaitForAssertionHelper`1.<>c__DisplayClass6_0.<.ctor>b__0() in /_/src/bunit/Extensions/WaitForHelpers/WaitForAssertionHelper.cs:line 35
   at Bunit.Extensions.WaitForHelpers.WaitForHelper`2.OnAfterRender(Object sender, EventArgs args) in /_/src/bunit/Extensions/WaitForHelpers/WaitForHelper.cs:line 173
1)    at Bunit.RenderedComponentWaitForHelperExtensions.WaitForAssertionAsync[TComponent](IRenderedComponent`1 renderedComponent, Action assertion, Nullable`1 timeout) in /_/src/bunit/Extensions/WaitForHelpers/RenderedComponentWaitForHelperExtensions.WaitForState.cs:line 100
   at MudBlazor.UnitTests.Components.DataGridGroupingTests.DataGridGroupExpandedTrueServerData() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs:line 61
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
--AssertionException
   at AwesomeAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at AwesomeAssertions.Numeric.NumericAssertionsBase`3.Be(T expected, String because, Object[] becauseArgs)
   at MudBlazor.UnitTests.Components.DataGridGroupingTests.<>c__DisplayClass2_0.<DataGridGroupExpandedTrueServerData>b__0() in /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs:line 61
   at Bunit.Extensions.WaitForHelpers.WaitForAssertionHelper`1.<>c__DisplayClass6_0.<.ctor>b__0() in /_/src/bunit/Extensions/WaitForHelpers/WaitForAssertionHelper.cs:line 35
   at Bunit.Extensions.WaitForHelpers.WaitForHelper`2.OnAfterRender(Object sender, EventArgs args) in /_/src/bunit/Extensions/WaitForHelpers/WaitForHelper.cs:line 173

Data collector 'Blame' message: All tests finished running, Sequence file will not be generated.
Results File: junit.xml

Passed!  - Failed:     0, Passed:  1370, Skipped:     0, Total:  1370, Duration: 50 s - MudBlazor.UnitTests.Docs.dll (net10.0)
  [coverlet] 
  Calculating coverage result...
   Generating report '/home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests.Docs/TestResults/coverage.cobertura.xml'

+-----------+--------+--------+--------+
| Module    | Line   | Branch | Method |
+-----------+--------+--------+--------+
| MudBlazor | 66.25% | 46.61% | 60.2%  |
+-----------+--------+--------+--------+

+---------+--------+--------+--------+
|         | Line   | Branch | Method |
+---------+--------+--------+--------+
| Total   | 66.25% | 46.61% | 60.2%  |
+---------+--------+--------+--------+
| Average | 66.25% | 46.61% | 60.2%  |
+---------+--------+--------+--------+

2026-01-27T00:00:32: Reading historic reports
2026-01-27T00:00:33: File '/_/src/MudBlazor/obj/Release/net10.0/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/LanguageResource.Designer.cs' does not exist (any more).
2026-01-27T00:00:33: Writing report file './TestResults/Report/index.html'
2026-01-27T00:00:33: Creating history report
2026-01-27T00:00:33: Report generation took 1.9 seconds
  Skipped DisposeAsync_ShouldClearActivePopoversAndFireOnBatchTimerElapsedAsync [< 1 ms]
Data collector 'Blame' message: All tests finished running, Sequence file will not be generated.
Results File: junit.xml

Failed!  - Failed:     1, Passed:  4336, Skipped:     1, Total:  4338, Duration: 1 m 42 s - MudBlazor.UnitTests.dll (net10.0)
Error: Process completed with exit code 1.
```