### PR TITLE
MudSelectItem: Use ParameterState for CascadingParameter

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -90,7 +90,7 @@
                         }
                     </MudStack>
                 }
-                <MudPopover Open=@(_open)
+                <MudPopover Open="@_open"
                             MaxHeight="@MaxHeight"
                             Class="@PopoverClass"
                             AnchorOrigin="@AnchorOrigin"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -920,8 +920,8 @@ namespace MudBlazor
                 {
                     var item = shadowItem.Value;
                     var value = item.Value;
-                    var str = ToStringFunc?.Invoke(value) ?? ConvertSet(value);
-                    var length = str?.Length ?? 0;
+                    var valueToString = ConvertSet(value);
+                    var length = valueToString?.Length ?? 0;
 
                     if (length > longestItemLength)
                     {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -25,7 +25,6 @@ namespace MudBlazor
         private string? _activeItemId;
         private bool? _selectAllChecked;
         private string? _multiSelectionText;
-        private int _longestItemLength;
         private MudSelectItem<T>? _longestItem;
         private bool _needsHighlightAfterRender;
         private MudInput<string> _elementReference = null!;
@@ -55,6 +54,9 @@ namespace MudBlazor
                 .WithEventCallback(() => SelectedValuesChanged)
                 .WithChangeHandler(OnSelectedValuesChangedAsync)
                 .WithComparer(() => new SequenceComparer<T?>(Comparer));
+            registerScope.RegisterParameter<bool>(nameof(FitContent))
+                .WithParameter(() => FitContent)
+                .WithChangeHandler(OnFitContentChanged);
         }
 
         protected string OuterClassname =>
@@ -273,7 +275,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>. Requires FullWidth to be <c>false</c>
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         [Category(CategoryTypes.FormComponent.Appearance)]
         public bool FitContent { get; set; }
 
@@ -909,6 +911,32 @@ namespace MudBlazor
             await OnClose.InvokeAsync();
         }
 
+        private void OnFitContentChanged(ParameterChangedEventArgs<bool> args)
+        {
+            if (args.Value)
+            {
+                var longestItemLength = 0;
+                foreach (var shadowItem in _shadowLookup)
+                {
+                    var item = shadowItem.Value;
+                    var value = item.Value;
+                    var str = ToStringFunc?.Invoke(value) ?? ConvertSet(value);
+                    var length = str?.Length ?? 0;
+
+                    if (length > longestItemLength)
+                    {
+                        _longestItem = item;
+                        longestItemLength = length;
+                    }
+                }
+                StateHasChanged();
+            }
+            else
+            {
+                _longestItem = null;
+            }
+        }
+
         private void UpdateIcon()
         {
             _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _open ? CloseIcon : OpenIcon;
@@ -1312,18 +1340,6 @@ namespace MudBlazor
                 return;
 
             _shadowLookup[item.Value] = item;
-
-            if (!FitContent) return;
-
-            var stringValue = ToStringFunc?.Invoke(item.Value) ?? ConvertSet(item.Value);
-
-            if (_longestItem is null || stringValue?.Length > _longestItemLength)
-            {
-                _longestItem = item;
-                _longestItemLength = stringValue?.Length ?? 0;
-
-                StateHasChanged();
-            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -12,53 +13,60 @@ namespace MudBlazor
     /// <seealso cref="MudSelect{T}"/>
     public partial class MudSelectItem<T> : MudComponentBase, IDisposable
     {
-        private IMudSelect? _parent;
-        private IMudShadowSelect? _shadowParent;
-
         private string GetCssClasses() => new CssBuilder()
             .AddClass(Class)
             .Build();
 
         internal string ItemId { get; } = Identifier.Create();
 
+        public MudSelectItem()
+        {
+            using var registerScope = CreateRegisterScope();
+            _ = registerScope.RegisterParameter<IMudSelect?>(nameof(IMudSelect))
+                .WithParameter(() => IMudSelect)
+                .WithChangeHandler(OnMudSelectChanged);
+            _ = registerScope.RegisterParameter<IMudShadowSelect?>(nameof(IMudShadowSelect))
+                .WithParameter(() => IMudShadowSelect)
+                .WithChangeHandler(OnMudShadowSelectChanged);
+        }
+
+        private void OnMudShadowSelectChanged(ParameterChangedEventArgs<IMudShadowSelect?> args)
+        {
+            ((MudSelect<T>?)args.LastValue)?.UnregisterShadowItem(this);
+            ((MudSelect<T>?)args.Value)?.RegisterShadowItem(this);
+        }
+
+        private async Task OnMudSelectChanged(ParameterChangedEventArgs<IMudSelect?> args)
+        {
+            if (args.LastValue is MudSelect<T> oldParent)
+            {
+                oldParent.Remove(this);
+            }
+            if (args.Value == null)
+                return;
+            args.Value.CheckGenericTypeMatch(this);
+            if (MudSelect == null)
+                return;
+            var selected = MudSelect.Add(this);
+            if (args.Value.MultiSelection)
+            {
+                MudSelect.SelectionChangedFromOutside += OnUpdateSelectionStateFromOutside;
+                await InvokeAsync(() => OnUpdateSelectionStateFromOutside(MudSelect.GetState(x => x.SelectedValues)));
+            }
+            else
+            {
+                Selected = selected;
+            }
+        }
+
         /// <summary>
         /// The <see cref="MudSelect{T}"/> hosting this item.
         /// </summary>
         [CascadingParameter]
-        internal IMudSelect? IMudSelect
-        {
-            get => _parent;
-            set
-            {
-                _parent = value;
-                if (_parent == null)
-                    return;
-                _parent.CheckGenericTypeMatch(this);
-                if (MudSelect == null)
-                    return;
-                var selected = MudSelect.Add(this);
-                if (_parent.MultiSelection)
-                {
-                    MudSelect.SelectionChangedFromOutside += OnUpdateSelectionStateFromOutside;
-                    InvokeAsync(() => OnUpdateSelectionStateFromOutside(MudSelect.GetState(x => x.SelectedValues)));
-                }
-                else
-                {
-                    Selected = selected;
-                }
-            }
-        }
+        internal IMudSelect? IMudSelect { get; set; }
 
         [CascadingParameter]
-        internal IMudShadowSelect? IMudShadowSelect
-        {
-            get => _shadowParent;
-            set
-            {
-                _shadowParent = value;
-                ((MudSelect<T>?)_shadowParent)?.RegisterShadowItem(this);
-            }
-        }
+        internal IMudShadowSelect? IMudShadowSelect { get; set; }
 
         /// <summary>
         /// Select items with HideContent==true are only there to register their RenderFragment with the select but
@@ -162,7 +170,7 @@ namespace MudBlazor
             try
             {
                 MudSelect?.Remove(this);
-                ((MudSelect<T>?)_shadowParent)?.UnregisterShadowItem(this);
+                ((MudSelect<T>?)IMudShadowSelect)?.UnregisterShadowItem(this);
             }
             catch (Exception)
             {

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -143,6 +143,7 @@ namespace MudBlazor
         {
             if (args.LastValue is MudSelect<T> oldParent)
             {
+                oldParent.SelectionChangedFromOutside -= OnUpdateSelectionStateFromOutside;
                 oldParent.Remove(this);
             }
             if (args.Value == null)
@@ -169,6 +170,7 @@ namespace MudBlazor
         {
             try
             {
+                MudSelect?.SelectionChangedFromOutside -= OnUpdateSelectionStateFromOutside;
                 MudSelect?.Remove(this);
                 ((MudSelect<T>?)IMudShadowSelect)?.UnregisterShadowItem(this);
             }

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor.cs
@@ -22,41 +22,12 @@ namespace MudBlazor
         public MudSelectItem()
         {
             using var registerScope = CreateRegisterScope();
-            _ = registerScope.RegisterParameter<IMudSelect?>(nameof(IMudSelect))
+            registerScope.RegisterParameter<IMudSelect?>(nameof(IMudSelect))
                 .WithParameter(() => IMudSelect)
-                .WithChangeHandler(OnMudSelectChanged);
-            _ = registerScope.RegisterParameter<IMudShadowSelect?>(nameof(IMudShadowSelect))
+                .WithChangeHandler(OnMudSelectChangedAsync);
+            registerScope.RegisterParameter<IMudShadowSelect?>(nameof(IMudShadowSelect))
                 .WithParameter(() => IMudShadowSelect)
                 .WithChangeHandler(OnMudShadowSelectChanged);
-        }
-
-        private void OnMudShadowSelectChanged(ParameterChangedEventArgs<IMudShadowSelect?> args)
-        {
-            ((MudSelect<T>?)args.LastValue)?.UnregisterShadowItem(this);
-            ((MudSelect<T>?)args.Value)?.RegisterShadowItem(this);
-        }
-
-        private async Task OnMudSelectChanged(ParameterChangedEventArgs<IMudSelect?> args)
-        {
-            if (args.LastValue is MudSelect<T> oldParent)
-            {
-                oldParent.Remove(this);
-            }
-            if (args.Value == null)
-                return;
-            args.Value.CheckGenericTypeMatch(this);
-            if (MudSelect == null)
-                return;
-            var selected = MudSelect.Add(this);
-            if (args.Value.MultiSelection)
-            {
-                MudSelect.SelectionChangedFromOutside += OnUpdateSelectionStateFromOutside;
-                await InvokeAsync(() => OnUpdateSelectionStateFromOutside(MudSelect.GetState(x => x.SelectedValues)));
-            }
-            else
-            {
-                Selected = selected;
-            }
         }
 
         /// <summary>
@@ -160,6 +131,35 @@ namespace MudBlazor
                 await MudSelect.SelectOption(Value);
 
             await InvokeAsync(StateHasChanged);
+        }
+
+        private void OnMudShadowSelectChanged(ParameterChangedEventArgs<IMudShadowSelect?> args)
+        {
+            ((MudSelect<T>?)args.LastValue)?.UnregisterShadowItem(this);
+            ((MudSelect<T>?)args.Value)?.RegisterShadowItem(this);
+        }
+
+        private async Task OnMudSelectChangedAsync(ParameterChangedEventArgs<IMudSelect?> args)
+        {
+            if (args.LastValue is MudSelect<T> oldParent)
+            {
+                oldParent.Remove(this);
+            }
+            if (args.Value == null)
+                return;
+            args.Value.CheckGenericTypeMatch(this);
+            if (MudSelect == null)
+                return;
+            var selected = MudSelect.Add(this);
+            if (args.Value.MultiSelection)
+            {
+                MudSelect.SelectionChangedFromOutside += OnUpdateSelectionStateFromOutside;
+                await InvokeAsync(() => OnUpdateSelectionStateFromOutside(MudSelect.GetState(x => x.SelectedValues)));
+            }
+            else
+            {
+                Selected = selected;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Not sure how many more parameters relied on that IMudSelect.set / IMudShadowSelect.set were invoked on each re-render
Mostly relying on our tests...

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
