### PR TITLE
MudBadge: Fix icon alignment under browser zoom

### DIFF
--- a/src/MudBlazor/Styles/components/_badge.scss
+++ b/src/MudBlazor/Styles/components/_badge.scss
@@ -101,10 +101,14 @@
   &.mud-badge-icon {
     width: 20px;
     height: 20px;
+    line-height: normal;
 
     & .mud-icon-badge {
       color: inherit;
       font-size: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
   }
 


### PR DESCRIPTION
### What
 Fixes #12507 icon misalignment in `MudBadge` when browser zoom is applied.

### Why
Icon badges rely on font/SVG rendering which is affected by line-height rounding under browser zoom (e.g. Chrome 125%).  
This causes the icon to appear slightly off-center vertically. The issue is reproducible on the official MudBlazor Badge documentation page.

### How
Centers the icon itself using layout-based (flex) alignment inside icon badges while preserving existing badge sizing, positioning, and behavior.

### Tested
- MudBlazor Docs (local)
- Chrome
- Multiple browser zoom levels 

### Screenshot

*Before*

<img width="1440" height="810" alt="Screenshot 2026-01-29 at 6 22 22 PM" src="https://github.com/user-attachments/assets/14372259-2fc3-4ee1-b121-0242710b565b" />


*After*

<img width="1439" height="812" alt="Screenshot 2026-01-29 at 6 24 22 PM" src="https://github.com/user-attachments/assets/c3df6a01-ebf9-469e-bbf9-8f57a0769099" />

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests

