### PR TITLE
MudSelect: Add two-way Open parameter

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest5.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectTest5.razor
@@ -1,12 +1,9 @@
-﻿@if (_posts is not null)
-{
-    <MudSelect Label="Roles" T="string" SelectedValues="_selectedValues" MultiSelection="true">
-        @foreach (var role in _posts)
-        {
-            <MudSelectItem T="string" Value="@role">@role</MudSelectItem>
-        }
-    </MudSelect>
-}
+﻿<MudSelect Label="Roles" T="string" SelectedValues="_selectedValues" MultiSelection="true">
+    @foreach (var role in _posts)
+    {
+        <MudSelectItem T="string" Value="@role">@role</MudSelectItem>
+    }
+</MudSelect>
 
 @code {
     private readonly IEnumerable<string> _selectedValues = new HashSet<string>
@@ -14,12 +11,5 @@
         "Programista", "test"
     };
 
-    private HashSet<string>? _posts;
-
-    protected override void OnInitialized()
-    {
-        _posts = ["Programista", "Programista 2", "test", "Technik", "Tester", "Tester tester"];
-
-        base.OnInitialized();
-    }
+    private readonly HashSet<string> _posts = ["Programista", "Programista 2", "test", "Technik", "Tester", "Tester tester"];
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectFocusAndTypeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectFocusAndTypeTest.razor
@@ -8,10 +8,10 @@
 </MudSelect>
 
 @code {
-    string? _value;
+    private string? _value;
 
-    private string[] _states =
-    {
+    private readonly string[] _states =
+    [
         "Alabama", "Alaska", "Arizona", "Arkansas", "California",
         "Colorado", "Connecticut", "Delaware", "Florida", "Georgia",
         "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas",
@@ -22,5 +22,5 @@
         "Oregon", "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota",
         "Tennessee", "Texas", "Utah", "Vermont", "Virginia",
         "Washington", "West Virginia", "Wisconsin", "Wyoming"
-    };
+    ];
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectOpenTwoBindTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectOpenTwoBindTest.razor
@@ -1,0 +1,17 @@
+﻿<MudPopoverProvider />
+
+<MudSelect T="string" @bind-Value="_value" @bind-Open="Open">
+    <MudSelectItem Value="@("1")">1</MudSelectItem>
+    <MudSelectItem Value="@("2")">2</MudSelectItem>
+    <MudSelectItem Value="@("3")">3</MudSelectItem>
+</MudSelect>
+
+<MudSwitch id="switch" Color="Color.Primary" @bind-Value="Open" Label="Open" />
+
+@code {
+    public static string __description__ = "Tests Open two-way bind.";
+
+    private string? _value = null;
+
+    public bool Open { get; private set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverRelativeWidthTest.razor
@@ -11,7 +11,7 @@
     </div>
 
     <div class="pa-4 d-inline-block" style="width:125px;">
-        <MudSelect @bind-Value=_selected Variant="Variant.Outlined" RelativeWidth="DropdownWidth.Adaptive" Dense id="expanded-select" PopoverClass="expanded">
+        <MudSelect @bind-Value="@_selected" Variant="Variant.Outlined" RelativeWidth="DropdownWidth.Adaptive" Dense id="expanded-select" PopoverClass="expanded">
             @foreach (var value in _values)
             {
                 <MudSelectItem T="string" Value="@value">@value</MudSelectItem>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<SelectRequiredTest>();
             var select = comp.FindComponent<MudSelect<string>>();
             await comp.InvokeAsync(() => select.Instance.HandleKeyDownAsync(new KeyboardEventArgs() { Key = "Enter" }));
-            await comp.InvokeAsync(async () => await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ListClass, "my-list-class")));
+            await select.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ListClass, "my-list-class"));
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("my-list-class"));
         }
 
@@ -28,9 +28,10 @@ namespace MudBlazor.UnitTests.Components
         public async Task Select_CheckLayerClass()
         {
             var comp = Context.Render<MudSelect<string>>();
-            await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.OuterClass, "my-outer-class")));
-            await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Class, "my-main-class")));
-            await comp.InvokeAsync(async () => await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.InputClass, "my-input-class")));
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.OuterClass, "my-outer-class")
+                .Add(x => x.Class, "my-main-class")
+                .Add(x => x.InputClass, "my-input-class"));
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("my-outer-class"));
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("my-main-class"));
             await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("my-input-class"));
@@ -1241,7 +1242,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
             var mudSelectElement = comp.Find(".mud-select");
             await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
-            select.Instance._open.Should().BeTrue();
+            select.Instance.GetState(x=> x.Open).Should().BeTrue();
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[0].ClickAsync();
             await items[2].ClickAsync();
@@ -1714,18 +1715,18 @@ namespace MudBlazor.UnitTests.Components
 
             var instance = comp.Instance;
 
-            instance._open.Should().BeFalse();
+            instance.GetState(x => x.Open).Should().BeFalse();
 
             await comp.InvokeAsync(async () => await instance.HandleMouseDown(args));
 
             switch (args.Button)
             {
                 case 0:
-                    instance._open.Should().BeTrue();
+                    instance.GetState(x => x.Open).Should().BeTrue();
                     break;
                 case 1:
                 case 2:
-                    instance._open.Should().BeFalse();
+                    instance.GetState(x => x.Open).Should().BeFalse();
                     break;
             }
         }
@@ -1763,10 +1764,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void PopoverSettings_OverridesDefaultValues()
         {
-            var select = Context.Render<MudSelect<string>>(p =>
+            var select = Context.Render<MudSelect<string>>(parameters =>
             {
-                p.Add(p => p.PopoverFixed, true);
-                p.Add(p => p.Modal, true);
+                parameters.Add(x => x.PopoverFixed, true);
+                parameters.Add(x => x.Modal, true);
             });
 
             select.Instance.PopoverFixed.Should().BeTrue();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -168,7 +168,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() =>
                 comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() =>
                 comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -211,12 +211,12 @@ namespace MudBlazor.UnitTests.Components
             var inputs = comp.FindAll("input");
             inputs.Count.Should().Be(3);
             inputs[1].GetAttribute("value").Should().Be("Value2");
-            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            await inputs[1].MouseDownAsync();
             await Task.Delay(500);
             var listItems = comp.FindAll(".mud-list-item");
             foreach (var listItem in listItems)
             {
-                await listItem.ClickAsync(new MouseEventArgs());
+                await listItem.ClickAsync();
             }
 
             inputs = comp.FindAll("input");
@@ -241,7 +241,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadText.Should().Be(default(MyEnum).ToString());
 
             comp.Find("input").Attributes["value"]?.Value.Should().Be("First");
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
@@ -261,7 +261,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().Be(17);
             select.Instance.ReadText.Should().Be("17");
             comp.Find("input").Attributes["value"]?.Value.Should().Be("17");
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
@@ -287,7 +287,7 @@ namespace MudBlazor.UnitTests.Components
             // BUT: we have a select with Strict="true" so the Text will not be shown because it is not in the list of selectable values
             comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be(null);
             comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
@@ -312,7 +312,7 @@ namespace MudBlazor.UnitTests.Components
             select.Markup.Should().Contain("mud-shrink");
 
             // Open menu and select a non-null value
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             await comp.FindAll("div.mud-list-item").ToArray()[1].ClickAsync(); // Select "One" (value = 1)
 
@@ -322,7 +322,7 @@ namespace MudBlazor.UnitTests.Components
             select.Markup.Should().Contain("mud-shrink");
 
             // Open menu again and select null value
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             await comp.FindAll("div.mud-list-item").ToArray()[0].ClickAsync(); // Select "None" (value = null)
 
@@ -406,7 +406,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadText.Should().Be("1");
             comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none");
 
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
@@ -429,7 +429,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
@@ -442,7 +442,7 @@ namespace MudBlazor.UnitTests.Components
             text.Should().Be("2");
 
             //open the menu again
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item");
 
@@ -483,7 +483,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
@@ -499,7 +499,7 @@ namespace MudBlazor.UnitTests.Components
             textChangedCount.Should().Be(0);
             string.Join(",", selectedValues).Should().Be("2");
 
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
 
@@ -540,7 +540,7 @@ namespace MudBlazor.UnitTests.Components
               })));
 
             var selectElement = comp.Find("div.mud-input-control");
-            await selectElement.MouseDownAsync(new MouseEventArgs());
+            await selectElement.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             // click list item
@@ -585,7 +585,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
 
             var selectElement = comp.Find("div.mud-input-control");
-            await selectElement.MouseDownAsync(new MouseEventArgs());
+            await selectElement.MouseDownAsync();
 
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item-disabled").Count.Should().Be(1));
             await comp.FindAll("div.mud-list-item-disabled")[0].ClickAsync();
@@ -606,7 +606,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() =>
                 comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             await comp.WaitForAssertionAsync(() =>
                 comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
@@ -641,7 +641,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click the first checkbox
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
@@ -659,7 +659,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
 
             // get the first (select all item) and check if it is selected
@@ -694,7 +694,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
             // Check that the icon corresponds to an unchecked checkbox
             var mudListItem = comp.FindComponent<MudListItem<string>>();
@@ -710,7 +710,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
             // Open the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click the first checkbox to select all
             var items = comp.FindAll("div.mud-list-item").ToArray();
@@ -744,7 +744,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().BeNullOrEmpty();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             // click and check if it has toggled the menu
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -756,7 +756,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadText.Should().Be("2");
             validatedValue.Should().Be("2");
 
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
 
@@ -867,7 +867,7 @@ namespace MudBlazor.UnitTests.Components
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
 
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             select.Instance.ReadValue.Should().Be("Apple");
 
@@ -881,7 +881,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ChangeCount.Should().Be(1);
 
             // now click an item and see the value change
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
@@ -955,7 +955,7 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().BeNullOrEmpty();
             comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
             // open the select
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // no option should be hilited
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(0));
@@ -964,7 +964,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("2"));
             // open again and check hilited option
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             // Nr 2 should be hilited
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
@@ -989,22 +989,22 @@ namespace MudBlazor.UnitTests.Components
             select.Instance.ReadValue.Should().Be("2");
             comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
             // open the select
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
-            // Nr 2 should be hilited
+            // Nr 2 should be highlighted
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
             comp.FindAll("div.mud-list-item")[1].ToMarkup().Should().Contain("mud-selected-item");
             // now click an item and see the value change
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
-            // open again and check hilited option
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            // open again and check highlighted option
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
-            // Nr 1 should be hilited
+            // Nr 1 should be highlighted
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-selected-item").Count.Should().Be(1));
             comp.FindAll("div.mud-list-item")[0].ToMarkup().Should().Contain("mud-selected-item");
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
         }
 
@@ -1014,17 +1014,17 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<ReloadSelectItemsTest>();
             var select = comp.FindComponent<MudSelect<string>>();
             // normal, without reloading
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("American Samoa"));
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Arizona"));
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.FindAll("div.mud-list-item")[2].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -1032,17 +1032,17 @@ namespace MudBlazor.UnitTests.Components
             // reloading!
             await comp.Find(".reload").ClickAsync();
             // check again, different values expected now
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Alabama"));
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.FindAll("div.mud-list-item")[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Alaska"));
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.FindAll("div.mud-list-item")[2].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -1242,7 +1242,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MultiSelectTest6>();
             var select = comp.FindComponent<MudSelect<string>>();
             var mudSelectElement = comp.Find(".mud-select");
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             select.Instance.GetState(x => x.Open).Should().BeTrue();
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[0].ClickAsync();
@@ -1280,7 +1280,7 @@ namespace MudBlazor.UnitTests.Components
             // Check input text
             comp.Find("input").GetAttribute("value").Should().Be("Selected Cafe Latte, Selected Espresso");
             // Click to render the menu
-            await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
+            await comp.Find("div.mud-input-control").MouseDownAsync();
             // Check check marks
             const string @unchecked =
                 "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
@@ -1300,7 +1300,7 @@ namespace MudBlazor.UnitTests.Components
             var sut = comp.FindComponent<MudSelect<string>>();
 
             var input = comp.Find("div.mud-input-control");
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
 
             sut.Instance.Items.Should().HaveCountGreaterThanOrEqualTo(4);
@@ -1328,14 +1328,14 @@ namespace MudBlazor.UnitTests.Components
 
             //2a. Now check when SelectedItems is greater than one - Validation Should Pass
             var inputs = comp.FindAll("div.mud-input-control");
-            await inputs[0].MouseDownAsync(new MouseEventArgs());//The 2nd one is the
+            await inputs[0].MouseDownAsync();//The 2nd one is the
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
             await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.Count.Should().Be(0);
 
             //2b.
-            await inputs[1].MouseDownAsync(new MouseEventArgs());//selectWithT
+            await inputs[1].MouseDownAsync();//selectWithT
             //wait for render and it will find 5 items from the component
             comp.WaitForState(() => comp.FindAll("div.mud-list-item").Count == 5);
             items = comp.FindAll("div.mud-list-item").ToArray();
@@ -1353,23 +1353,23 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => select.ValidateAsync());
             select.ValidationErrors.First().Should().Be("Required");
 
-            await comp.Find("#clear-string").ClickAsync(new MouseEventArgs());
+            await comp.Find("#clear-string").ClickAsync();
             select.ValidationErrors.First().Should().Be("Required");
 
-            await comp.Find("#reset-string").ClickAsync(new MouseEventArgs());
+            await comp.Find("#reset-string").ClickAsync();
             select.ValidationErrors.Should().BeEmpty();
 
             //test clearing string values
             var inputs = comp.FindAll("div.mud-input-control");
-            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            await inputs[0].MouseDownAsync();
 
             var items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
-            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            await items[1].ClickAsync();
+            await inputs[0].MouseDownAsync();
             select.Value.Should().Be("2");
             select.GetState(x => x.SelectedValues).Should().Contain("2");
 
-            await comp.Find("#clear-string").ClickAsync(new MouseEventArgs());
+            await comp.Find("#clear-string").ClickAsync();
 
             select.Value.Should().BeNullOrEmpty();
             select.GetState(x => x.SelectedValues).Should().BeEmpty();
@@ -1377,14 +1377,14 @@ namespace MudBlazor.UnitTests.Components
 
             //test resetting string values
             inputs = comp.FindAll("div.mud-input-control");
-            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            await inputs[0].MouseDownAsync();
             items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
-            await inputs[0].MouseDownAsync(new MouseEventArgs());
+            await items[1].ClickAsync();
+            await inputs[0].MouseDownAsync();
             select.Value.Should().Be("2");
             select.GetState(x => x.SelectedValues).Should().Contain("2");
 
-            await comp.Find("#reset-string").ClickAsync(new MouseEventArgs());
+            await comp.Find("#reset-string").ClickAsync();
 
             select.Value.Should().BeNullOrEmpty();
             select.GetState(x => x.SelectedValues).Should().BeEmpty();
@@ -1396,34 +1396,34 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => select2.ValidateAsync());
             select2.ValidationErrors.First().Should().Be("Required");
 
-            await comp.Find("#clear-object").ClickAsync(new MouseEventArgs());
+            await comp.Find("#clear-object").ClickAsync();
             select2.ValidationErrors.First().Should().Be("Required");
 
-            await comp.Find("#reset-object").ClickAsync(new MouseEventArgs());
+            await comp.Find("#reset-object").ClickAsync();
             select2.ValidationErrors.Should().BeEmpty();
 
             inputs = comp.FindAll("div.mud-input-control");
-            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            await inputs[1].MouseDownAsync();
 
             items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
-            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            await items[1].ClickAsync();
+            await inputs[1].MouseDownAsync();
             select2.SelectedValues.Select(x => x.Name).Should().Contain("Customer");
 
-            await comp.Find("#clear-object").ClickAsync(new MouseEventArgs());
+            await comp.Find("#clear-object").ClickAsync();
 
             select2.SelectedValues.Should().BeEmpty();
             select2.ValidationErrors.First().Should().Be("Required");
 
             //test resetting object values
             inputs = comp.FindAll("div.mud-input-control");
-            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            await inputs[1].MouseDownAsync();
             items = comp.FindAll("div.mud-list-item").ToArray();
-            await items[1].ClickAsync(new MouseEventArgs());
-            await inputs[1].MouseDownAsync(new MouseEventArgs());
+            await items[1].ClickAsync();
+            await inputs[1].MouseDownAsync();
             select2.SelectedValues.Select(x => x.Name).Should().Contain("Customer");
 
-            await comp.Find("#reset-object").ClickAsync(new MouseEventArgs());
+            await comp.Find("#reset-object").ClickAsync();
 
             select2.SelectedValues.Should().BeEmpty();
             select2.ValidationErrors.Should().BeEmpty();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -433,7 +433,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
-            var items = comp.FindAll("div.mud-list-item").ToArray();
+            var items = comp.FindAll("div.mud-list-item");
             await items[1].ClickAsync();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -444,7 +444,7 @@ namespace MudBlazor.UnitTests.Components
             //open the menu again
             await input.MouseDownAsync(new MouseEventArgs());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            items = comp.FindAll("div.mud-list-item").ToArray();
+            items = comp.FindAll("div.mud-list-item");
 
             await items[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("1"));
@@ -488,7 +488,7 @@ namespace MudBlazor.UnitTests.Components
             menu.ClassList.Should().Contain("mud-popover-open");
             // now click an item and see the value change
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
-            var items = comp.FindAll("div.mud-list-item").ToArray();
+            var items = comp.FindAll("div.mud-list-item");
             await items[1].ClickAsync();
             // menu should be closed now
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
@@ -700,6 +700,7 @@ namespace MudBlazor.UnitTests.Components
             var mudListItem = comp.FindComponent<MudListItem<string>>();
             mudListItem.Instance.Icon.Should().Be("<path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\"/>");
         }
+
         [Test]
         public async Task MultiSelect_SelectAll4()
         {
@@ -1652,18 +1653,18 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             //Open restricted popover
-            await comp.Find("#restricted-select").MouseDownAsync(new PointerEventArgs());
+            await comp.Find("#restricted-select").MouseDownAsync();
 
             //confirm relative width class
             comp.Find(".restricted").ClassList.Should().Contain("mud-popover-open").And.Contain("mud-popover-relative-width");
 
             //close popover
-            await comp.Find("#restricted-select").MouseDownAsync(new PointerEventArgs());
+            await comp.Find("#restricted-select").MouseDownAsync();
 
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
 
             //Open expanded popover
-            await comp.Find("#expanded-select").MouseDownAsync(new PointerEventArgs());
+            await comp.Find("#expanded-select").MouseDownAsync();
 
             //confirm relative width class not applied
             comp.Find(".expanded").ClassList.Should().Contain("mud-popover-open").And.NotContain("mud-popover-relative-width");
@@ -1741,7 +1742,7 @@ namespace MudBlazor.UnitTests.Components
 
             //open the popover
             var input = comp.Find("div.mud-input-control");
-            await input.MouseDownAsync(new MouseEventArgs());
+            await input.MouseDownAsync();
 
             //click an item and see the value change
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
@@ -1749,6 +1750,39 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() => comp.Instance.FormFieldChangedEventArgs.Should().NotBeNull());
             comp.Instance.FormFieldChangedEventArgs.NewValue.Should().BeEquivalentTo(comp.Instance.States.Take(2).Reverse());
+        }
+
+        [Test]
+        public async Task SelectOpenTwoWay()
+        {
+            var comp = Context.Render<SelectOpenTwoBindTest>();
+            IElement SwitchElement() => comp.Find("#switch");
+
+            var input = comp.Find("div.mud-input-control");
+            // Open the menu
+            await input.MouseDownAsync();
+
+            SwitchElement().HasAttribute("checked").Should().BeTrue();
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            comp.Instance.Open.Should().BeTrue();
+
+            // Close the menu
+            var items = comp.FindAll("div.mud-list-item");
+            await items[1].ClickAsync();
+
+            SwitchElement().HasAttribute("checked").Should().BeFalse();
+            comp.Instance.Open.Should().BeFalse();
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+
+            // Open the menu using the switch
+            await SwitchElement().ChangeAsync(true);
+            comp.Instance.Open.Should().BeTrue();
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            // Close the menu using the switch
+            await SwitchElement().ChangeAsync(false);
+            comp.Instance.Open.Should().BeFalse();
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
         }
 
         [Test]
@@ -1784,6 +1818,5 @@ namespace MudBlazor.UnitTests.Components
             // Modal should be null (using PopoverOptions defaults)
             select.Instance.Modal.Should().BeNull();
         }
-#nullable disable
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1756,6 +1756,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task SelectOpenTwoWay()
         {
             var comp = Context.Render<SelectOpenTwoBindTest>();
+            var selectComponentInsaInstance = comp.FindComponent<MudSelect<string>>().Instance;
             IElement SwitchElement() => comp.Find("#switch");
 
             var input = comp.Find("div.mud-input-control");
@@ -1765,24 +1766,28 @@ namespace MudBlazor.UnitTests.Components
             SwitchElement().HasAttribute("checked").Should().BeTrue();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             comp.Instance.Open.Should().BeTrue();
+            selectComponentInsaInstance.GetState(x => x.Open).Should().BeTrue();
 
             // Close the menu
             var items = comp.FindAll("div.mud-list-item");
             await items[1].ClickAsync();
 
             SwitchElement().HasAttribute("checked").Should().BeFalse();
-            comp.Instance.Open.Should().BeFalse();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+            comp.Instance.Open.Should().BeFalse();
+            selectComponentInsaInstance.GetState(x => x.Open).Should().BeFalse();
 
             // Open the menu using the switch
             await SwitchElement().ChangeAsync(true);
-            comp.Instance.Open.Should().BeTrue();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            comp.Instance.Open.Should().BeTrue();
+            selectComponentInsaInstance.GetState(x => x.Open).Should().BeTrue();
 
             // Close the menu using the switch
             await SwitchElement().ChangeAsync(false);
-            comp.Instance.Open.Should().BeFalse();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
+            comp.Instance.Open.Should().BeFalse();
+            selectComponentInsaInstance.GetState(x => x.Open).Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1242,7 +1242,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
             var mudSelectElement = comp.Find(".mud-select");
             await comp.Find("div.mud-input-control").MouseDownAsync(new MouseEventArgs());
-            select.Instance.GetState(x=> x.Open).Should().BeTrue();
+            select.Instance.GetState(x => x.Open).Should().BeTrue();
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[0].ClickAsync();
             await items[2].ClickAsync();

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -90,7 +90,7 @@
                         }
                     </MudStack>
                 }
-                <MudPopover Open="@_open"
+                <MudPopover Open="@_openState.Value"
                             MaxHeight="@MaxHeight"
                             Class="@PopoverClass"
                             AnchorOrigin="@AnchorOrigin"
@@ -134,7 +134,7 @@ When Modal is false the overlay does not receive pointer events so we activate
 the auto close feature and call CloseMenu in OnClosed. The modeless auto close
 feature relies on pointerdown event resulting in the same order of events.
 -->
-<MudOverlay Visible="_open"
+<MudOverlay Visible="_openState.Value"
             @onpointerdown="@(() => CloseMenu(false))"
             LockScroll="@LockScroll"
             AutoClose="@(!GetModal())"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -34,6 +34,7 @@ namespace MudBlazor
         private string _searchText = string.Empty;
         private string? _lastSelectedId = string.Empty;
         private DateTime _lastSearchTime = DateTime.MinValue;
+        private readonly ParameterState<bool> _openState;
         private readonly ParameterState<IEnumerable<T?>?> _selectedValuesState;
 
         public MudSelect()
@@ -49,6 +50,9 @@ namespace MudBlazor
             registerScope.RegisterParameter<IEqualityComparer<T?>?>(nameof(Comparer))
                 .WithParameter(() => Comparer)
                 .WithChangeHandler(OnComparerChangedAsync);
+            _openState = registerScope.RegisterParameter<bool>(nameof(Open))
+                .WithParameter(() => Open)
+                .WithEventCallback(() => OpenChanged);
             _selectedValuesState = registerScope.RegisterParameter<IEnumerable<T?>?>(nameof(SelectedValues))
                 .WithParameter(() => SelectedValues)
                 .WithEventCallback(() => SelectedValuesChanged)
@@ -146,7 +150,7 @@ namespace MudBlazor
         {
             var selectList = _items;
 
-            if (!_open)
+            if (!_openState.Value)
                 selectList = _shadowLookup.Values.ToList();
 
             if (selectList.Count == 0)
@@ -247,6 +251,13 @@ namespace MudBlazor
             await ScrollToItemAsync(item);
         }
 
+        [Parameter, ParameterState]
+        [Category(CategoryTypes.Popover.Behavior)]
+        public bool Open { get; set; }
+
+        [Parameter]
+        public EventCallback<bool> OpenChanged { get; set; }
+
         /// <summary>
         /// Displays the dropdown popover in a fixed position, even while scrolling.
         /// </summary>
@@ -298,20 +309,6 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Appearance)]
         [Parameter]
         public string? InputClass { get; set; }
-
-        /// <summary>
-        /// Occurs when this drop-down opens.
-        /// </summary>
-        [Category(CategoryTypes.FormComponent.Behavior)]
-        [Parameter]
-        public EventCallback OnOpen { get; set; }
-
-        /// <summary>
-        /// Occurs when this drop-down closes.
-        /// </summary>
-        [Category(CategoryTypes.FormComponent.Behavior)]
-        [Parameter]
-        public EventCallback OnClose { get; set; }
 
         /// <summary>
         /// Prevents interaction with background elements while this list is open.
@@ -707,8 +704,6 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.ListBehavior)]
         public bool SelectionOnEnter { get; set; }
 
-        internal bool _open;
-
         /// <summary>
         /// The current adornment icon to display.
         /// </summary>
@@ -849,7 +844,7 @@ namespace MudBlazor
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return;
-            if (_open)
+            if (_openState.Value)
                 await CloseMenu(true);
             else
                 await OpenMenu();
@@ -866,7 +861,7 @@ namespace MudBlazor
             if (GetDisabledState() || GetReadOnlyState())
                 return;
 
-            _open = true;
+            await _openState.SetValueAsync(true);
             _needsHighlightAfterRender = true;
             UpdateIcon();
             StateHasChanged();
@@ -883,8 +878,6 @@ namespace MudBlazor
             }
             //disable escape propagation: if selectmenu is open, only the select popover should close and underlying components should not handle escape key
             await KeyInterceptorService.UpdateKeyAsync(_elementId, new("Escape", stopDown: "key+none"));
-
-            await OnOpen.InvokeAsync();
         }
 
         /// <summary>
@@ -895,7 +888,7 @@ namespace MudBlazor
         /// </remarks>
         public async Task CloseMenu(bool focusAgain = true)
         {
-            _open = false;
+            await _openState.SetValueAsync(false);
             UpdateIcon();
             if (focusAgain)
             {
@@ -907,8 +900,6 @@ namespace MudBlazor
 
             //enable escape propagation: the select popover was closed, now underlying components are allowed to handle escape key
             await KeyInterceptorService.UpdateKeyAsync(_elementId, new("Escape", stopDown: "none"));
-
-            await OnClose.InvokeAsync();
         }
 
         private void OnFitContentChanged(ParameterChangedEventArgs<bool> args)
@@ -939,7 +930,7 @@ namespace MudBlazor
 
         private void UpdateIcon()
         {
-            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _open ? CloseIcon : OpenIcon;
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _openState.Value ? CloseIcon : OpenIcon;
         }
 
         protected override void OnInitialized()
@@ -1179,7 +1170,7 @@ namespace MudBlazor
                         break;
                     }
 
-                    if (_open == false)
+                    if (!_openState.Value)
                     {
                         await OpenMenu();
                         break;
@@ -1194,7 +1185,7 @@ namespace MudBlazor
                         break;
                     }
 
-                    if (_open == false)
+                    if (!_openState.Value)
                     {
                         await OpenMenu();
                         break;
@@ -1219,7 +1210,7 @@ namespace MudBlazor
                     var index = _items.FindIndex(x => x.ItemId == _activeItemId);
                     if (!MultiSelection)
                     {
-                        if (!_open)
+                        if (!_openState.Value)
                         {
                             await OpenMenu();
                             break;
@@ -1230,7 +1221,7 @@ namespace MudBlazor
                         break;
                     }
 
-                    if (!_open)
+                    if (!_openState.Value)
                     {
                         await OpenMenu();
                         break;
@@ -1355,7 +1346,7 @@ namespace MudBlazor
 
         private async Task OnFocusOutAsync(FocusEventArgs focusEventArgs)
         {
-            if (_open)
+            if (_openState.Value)
             {
                 // when the menu is open we immediately get back the focus if we lose it (i.e. because of checkboxes in multi-select)
                 // otherwise we can't receive key strokes any longer

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -251,11 +251,18 @@ namespace MudBlazor
             await ScrollToItemAsync(item);
         }
 
+        /// <summary>
+        /// Sets a value indicating whether the select dropdown is open.
+        /// </summary>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Popover.Behavior)]
         public bool Open { get; set; }
 
+        /// <summary>
+        /// Occurs when the <see cref="Open"/> state of the select dropdown changes.
+        /// </summary>
         [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
         public EventCallback<bool> OpenChanged { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -252,17 +252,20 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Sets a value indicating whether the select dropdown is open.
+        /// Whether this select dropdown is open and the options are visible.
         /// </summary>
+        /// <remarks>
+        /// When this property changes, <see cref="OpenChanged"/> occurs.
+        /// </remarks>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Popover.Behavior)]
         public bool Open { get; set; }
 
         /// <summary>
-        /// Occurs when the <see cref="Open"/> state of the select dropdown changes.
+        /// Occurs when <see cref="Open"/> has changed.
         /// </summary>
         [Parameter]
-        [Category(CategoryTypes.FormComponent.Behavior)]
+        [Category(CategoryTypes.Popover.Behavior)]
         public EventCallback<bool> OpenChanged { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -604,7 +604,7 @@ namespace MudBlazor
                     result = true;
             }
             UpdateSelectAllChecked();
-            if (result.HasValue == false)
+            if (!result.HasValue)
             {
                 result = item.Value?.Equals(ReadValue);
             }
@@ -685,7 +685,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public bool LockScroll { get; set; } = false;
+        public bool LockScroll { get; set; }
 
         /// <summary>
         /// Occurs when the clear button is clicked.


### PR DESCRIPTION
`Open` is now two-way like in `MudMenu`, the API is replaced with:
```diff
-[Parameter]
-public EventCallback OnOpen { get; set; }

-[Parameter]
-public EventCallback OnClose { get; set; }

-internal bool _open;


+[Parameter, ParameterState]
+public bool Open { get; set; }

+[Parameter]
+public EventCallback<bool> OpenChanged { get; set; }
```

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
