### PR TITLE
MudSwitch, MudCheckBox, MudRadio: Render content inside `span`

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
@@ -55,7 +55,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
         // The "Classname" protected property should be visible
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"Classname\">");
     }
@@ -75,7 +75,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
         // The "Classname" protected property should NOT be visible
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">");
     }
@@ -95,7 +95,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
         // The "BeginValidateAsync" protected method should be visible
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"BeginValidateAsync\">");
     }
@@ -115,7 +115,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
         // The "BeginValidateAsync" protected method should NOT be visible
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">");
     }
@@ -135,7 +135,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should NOT be a message saying no members are found
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
         // The "CurrentView" protected field should be visible
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"CurrentView\">");
     }
@@ -155,7 +155,7 @@ public sealed class ApiMemberTableTests : BunitTest
         // There should be a message saying no members are found  (since the protected field was the ONLY field)
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
         // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<p class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</p>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
         // The "CurrentView" protected field should NOT be visible
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">");
     }

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -455,27 +455,27 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<CheckBoxAriaLabelTest>();
             var checkboxes = comp.FindAll(".mud-input-control.mud-input-control-boolean-input");
 
-            // verify checkbox one maintains it's original structure, no aria class used, label with a p element
+            // verify checkbox one maintains it's original structure, no aria class used, label with a span element
             checkboxes[0].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
-            var element0 = comp.Find(".cb1 label.mud-checkbox p");
+            var element0 = comp.Find(".cb1 label.mud-checkbox span");
             element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             checkboxes[1].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            var element1 = comp.Find(".cb2 label.mud-checkbox p");
+            var element1 = comp.Find(".cb2 label.mud-checkbox span");
             element1.HasAttribute("aria-hidden").Should().BeTrue();
             var input1 = comp.Find(".cb2 label.mud-checkbox input");
             var input1ForId = input1.GetAttribute("aria-labelledby");
             comp.Find($".cb2 label.mud-checkbox #{input1ForId}").Should().NotBeNull();
 
-            // checkbox three should have original structure intact, no aria class used, label with a p element for child content
+            // checkbox three should have original structure intact, no aria class used, label with a span element for child content
             checkboxes[2].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
-            var element2 = comp.Find(".cb3 label.mud-checkbox p");
+            var element2 = comp.Find(".cb3 label.mud-checkbox span");
             element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox four should look identical to two except this time it's with ChildContent
             checkboxes[3].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            var element3 = comp.Find(".cb4 label.mud-checkbox p");
+            var element3 = comp.Find(".cb4 label.mud-checkbox span");
             element3.HasAttribute("aria-hidden").Should().BeTrue();
             var input3 = comp.Find(".cb4 label.mud-checkbox input");
             var input3ForId = input3.GetAttribute("aria-labelledby");
@@ -483,7 +483,7 @@ namespace MudBlazor.UnitTests.Components
 
             // checkbox five has no label, no child content, just arialabel
             checkboxes[4].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            comp.FindAll(".cb5 label.mud-checkbox p").Count().Should().Be(0);
+            comp.FindAll(".cb5 label.mud-checkbox span").Count().Should().Be(0);
             var input4 = comp.Find(".cb5 label.mud-checkbox input");
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".cb5 label.mud-checkbox #{input4ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -457,12 +457,12 @@ namespace MudBlazor.UnitTests.Components
 
             // verify checkbox one maintains it's original structure, no aria class used, label with a span element
             checkboxes[0].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
-            var element0 = comp.Find(".cb1 label.mud-checkbox span");
+            var element0 = comp.Find(".cb1 label.mud-checkbox span.mud-typography");
             element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             checkboxes[1].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            var element1 = comp.Find(".cb2 label.mud-checkbox span");
+            var element1 = comp.Find(".cb2 label.mud-checkbox span.mud-typography");
             element1.HasAttribute("aria-hidden").Should().BeTrue();
             var input1 = comp.Find(".cb2 label.mud-checkbox input");
             var input1ForId = input1.GetAttribute("aria-labelledby");
@@ -470,12 +470,12 @@ namespace MudBlazor.UnitTests.Components
 
             // checkbox three should have original structure intact, no aria class used, label with a span element for child content
             checkboxes[2].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
-            var element2 = comp.Find(".cb3 label.mud-checkbox span");
+            var element2 = comp.Find(".cb3 label.mud-checkbox span.mud-typography");
             element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox four should look identical to two except this time it's with ChildContent
             checkboxes[3].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            var element3 = comp.Find(".cb4 label.mud-checkbox span");
+            var element3 = comp.Find(".cb4 label.mud-checkbox span.mud-typography");
             element3.HasAttribute("aria-hidden").Should().BeTrue();
             var input3 = comp.Find(".cb4 label.mud-checkbox input");
             var input3ForId = input3.GetAttribute("aria-labelledby");
@@ -483,7 +483,7 @@ namespace MudBlazor.UnitTests.Components
 
             // checkbox five has no label, no child content, just arialabel
             checkboxes[4].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            comp.FindAll(".cb5 label.mud-checkbox span").Count().Should().Be(0);
+            comp.FindAll(".cb5 label.mud-checkbox span.mud-typography").Count().Should().Be(0);
             var input4 = comp.Find(".cb5 label.mud-checkbox input");
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".cb5 label.mud-checkbox #{input4ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -426,32 +426,32 @@ namespace MudBlazor.UnitTests.Components
             // initial state
             comp.FindAll(".mud-chip")[0].ClassList.Should().NotContain("mud-chip-selected");
             comp.FindAll(".mud-chip")[2].ClassList.Should().NotContain("mud-chip-selected");
-            comp.FindAll(".mud-checkbox span")[0].ClassList.Should().Contain("mud-checkbox-false");
-            comp.FindAll(".mud-checkbox span")[2].ClassList.Should().Contain("mud-checkbox-false");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[0].ClassList.Should().Contain("mud-checkbox-false");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[2].ClassList.Should().Contain("mud-checkbox-false");
 
             // click Vodka chip
             await comp.FindAll("button.mud-chip")[0].ClickAsync();
             comp.Find("div.selection").TrimmedText().Should().Be("Vodka");
             comp.FindAll(".mud-chip")[0].ClassList.Should().Contain("mud-chip-selected");
             comp.FindAll(".mud-chip")[2].ClassList.Should().NotContain("mud-chip-selected");
-            comp.FindAll(".mud-checkbox span")[0].ClassList.Should().Contain("mud-checkbox-true");
-            comp.FindAll(".mud-checkbox span")[2].ClassList.Should().Contain("mud-checkbox-false");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[0].ClassList.Should().Contain("mud-checkbox-true");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[2].ClassList.Should().Contain("mud-checkbox-false");
 
             // click Olive checkbox
             await comp.FindAll("input.mud-checkbox-input")[2].ChangeAsync(true);
             comp.Find("div.selection").TrimmedText().Should().Be("Olive, Vodka");
             comp.FindAll(".mud-chip")[0].ClassList.Should().Contain("mud-chip-selected");
             comp.FindAll(".mud-chip")[2].ClassList.Should().Contain("mud-chip-selected");
-            comp.FindAll(".mud-checkbox span")[0].ClassList.Should().Contain("mud-checkbox-true");
-            comp.FindAll(".mud-checkbox span")[2].ClassList.Should().Contain("mud-checkbox-true");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[0].ClassList.Should().Contain("mud-checkbox-true");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[2].ClassList.Should().Contain("mud-checkbox-true");
 
             // click Vodka checkbox
             await comp.FindAll("input.mud-checkbox-input")[0].ChangeAsync(false);
             comp.Find("div.selection").TrimmedText().Should().Be("Olive");
             comp.FindAll(".mud-chip")[0].ClassList.Should().NotContain("mud-chip-selected");
             comp.FindAll(".mud-chip")[2].ClassList.Should().Contain("mud-chip-selected");
-            comp.FindAll(".mud-checkbox span")[0].ClassList.Should().Contain("mud-checkbox-false");
-            comp.FindAll(".mud-checkbox span")[2].ClassList.Should().Contain("mud-checkbox-true");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[0].ClassList.Should().Contain("mud-checkbox-false");
+            comp.FindAll(".mud-checkbox .mud-icon-button")[2].ClassList.Should().Contain("mud-checkbox-true");
         }
 
         [Test]

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -12,11 +12,11 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -11,11 +11,11 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -21,13 +21,13 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText Class="@LabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" Class="@LabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
                     @Label
                 </MudText>
             }
             @if (ChildContent != null)
             {
-                <MudText Class="@LabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" Class="@LabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }


### PR DESCRIPTION
Fix MudSwitch, MudCheckBox, and MudRadio WCAG 2.1 violations. A recent change to the component causes a WCAG 2.1 non-conformance: "The paragraph element is not expected inside the radiogroup role" (tested with ARC Toolkit). To fix this we can use the HtmlTag on MudText and set it to span.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Closes #11295, Closes #12585

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
