### PR TITLE
MudCheckBox, MudRadio, MudSwitch: Add or improve `aria-label` support

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Radio/RadioAriaLabelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Radio/RadioAriaLabelTest.razor
@@ -1,0 +1,16 @@
+
+<MudRadioGroup @bind-Value="SelectedValue" T="string">
+    <MudRadio Class="r1" Value="@("1")" Label="Radio One" />
+    <MudRadio Class="r2" Value="@("2")" Color="Color.Primary" AriaLabel="Option Two" Label="Radio Two" />
+    <MudRadio Class="r3" Value="@("3")" Color="Color.Secondary">
+        <span>Misc Content</span>
+    </MudRadio>
+    <MudRadio Class="r4" Value="@("4")" Color="Color.Secondary" AriaLabel="Option Four">
+        <span>Misc Content</span>
+    </MudRadio>
+    <MudRadio Class="r5" Value="@("5")" Disabled="true" AriaLabel="Option Five" />
+</MudRadioGroup>
+
+@code {
+    public string SelectedValue { get; set; } = "1";
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Switch/SwitchAriaLabelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Switch/SwitchAriaLabelTest.razor
@@ -1,0 +1,18 @@
+
+<MudSwitch Class="s1" @bind-Value="Val1" Label="Switch One" />
+<MudSwitch Class="s2" @bind-Value="Val2" Color="Color.Primary" AriaLabel="Option Two" Label="Switch Two" />
+<MudSwitch Class="s3" @bind-Value="Val3" Color="Color.Secondary">
+    <span>Misc Content</span>
+</MudSwitch>
+<MudSwitch Class="s4" @bind-Value="Val4" Color="Color.Secondary" AriaLabel="Option Four">
+    <span>Misc Content</span>
+</MudSwitch>
+<MudSwitch Class="s5" @bind-Value="Val5" Disabled="true" AriaLabel="Option Five" />
+
+@code {
+    public bool Val1 { get; set; } = true;
+    public bool Val2 { get; set; } = false;
+    public bool Val3 { get; set; } = false;
+    public bool Val4 { get; set; } = true;
+    public bool Val5 { get; set; } = false;
+}

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,6 +1,7 @@
 ﻿using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.UnitTests.TestComponents.Radio;
 using MudBlazor.UnitTests.TestComponents.RadioGroup;
 using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;
@@ -26,6 +27,50 @@ namespace MudBlazor.UnitTests.Components
             // Input content should not have main class (Classname), but should have input class (InputClass)
             comp.FindAll(".mud-radio-group.some-main-class").Should().BeEmpty();
             comp.FindAll(".mud-radio-group.some-input-class").Should().ContainSingle();
+        }
+
+        [Test]
+        public void Radio_AriaLabel()
+        {
+            var comp = Context.Render<RadioAriaLabelTest>();
+
+            // verify radio one maintains it's original structure, no aria class used, label with a span element
+            var r1 = comp.Find(".r1");
+            r1.GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            var element0 = comp.Find(".r1 label.mud-radio span.mud-typography");
+            element0.HasAttribute("aria-hidden").Should().BeFalse();
+
+            // radio two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
+            var r2 = comp.Find(".r2");
+            r2.GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            var element1 = comp.Find(".r2 label.mud-radio span.mud-typography");
+            element1.HasAttribute("aria-hidden").Should().BeTrue();
+            var input1 = comp.Find(".r2 label.mud-radio input");
+            var input1ForId = input1.GetAttribute("aria-labelledby");
+            comp.Find($".r2 label.mud-radio #{input1ForId}").Should().NotBeNull();
+
+            // radio three should have original structure intact, no aria class used, label with a span element for child content
+            var r3 = comp.Find(".r3");
+            r3.GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            var element2 = comp.Find(".r3 label.mud-radio span.mud-typography");
+            element2.HasAttribute("aria-hidden").Should().BeFalse();
+
+            // radio four should look identical to two except this time it's with ChildContent
+            var r4 = comp.Find(".r4");
+            r4.GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            var element3 = comp.Find(".r4 label.mud-radio span.mud-typography");
+            element3.HasAttribute("aria-hidden").Should().BeTrue();
+            var input3 = comp.Find(".r4 label.mud-radio input");
+            var input3ForId = input3.GetAttribute("aria-labelledby");
+            comp.Find($".r4 label.mud-radio #{input3ForId}").Should().NotBeNull();
+
+            // radio five has no label, no child content, just arialabel
+            var r5 = comp.Find(".r5");
+            r5.GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            comp.FindAll(".r5 label.mud-radio span.mud-typography").Count().Should().Be(0);
+            var input4 = comp.Find(".r5 label.mud-radio input");
+            var input4ForId = input4.GetAttribute("aria-labelledby");
+            comp.Find($".r5 label.mud-radio #{input4ForId}").Should().NotBeNull();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -45,6 +45,46 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Switch_AriaLabel()
+        {
+            var comp = Context.Render<SwitchAriaLabelTest>();
+            var switches = comp.FindAll(".mud-input-control-boolean-input");
+
+            // verify switch one maintains it's original structure, no aria class used, label with a span element
+            switches[0].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            var element0 = comp.Find(".s1 label.mud-switch span.mud-typography");
+            element0.HasAttribute("aria-hidden").Should().BeFalse();
+
+            // switch two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
+            switches[1].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            var element1 = comp.Find(".s2 label.mud-switch span.mud-typography");
+            element1.HasAttribute("aria-hidden").Should().BeTrue();
+            var input1 = comp.Find(".s2 label.mud-switch input");
+            var input1ForId = input1.GetAttribute("aria-labelledby");
+            comp.Find($".s2 label.mud-switch #{input1ForId}").Should().NotBeNull();
+
+            // switch three should have original structure intact, no aria class used, label with a span element for child content
+            switches[2].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            var element2 = comp.Find(".s3 label.mud-switch span.mud-typography");
+            element2.HasAttribute("aria-hidden").Should().BeFalse();
+
+            // switch four should look identical to two except this time it's with ChildContent
+            switches[3].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            var element3 = comp.Find(".s4 label.mud-switch span.mud-typography");
+            element3.HasAttribute("aria-hidden").Should().BeTrue();
+            var input3 = comp.Find(".s4 label.mud-switch input");
+            var input3ForId = input3.GetAttribute("aria-labelledby");
+            comp.Find($".s4 label.mud-switch #{input3ForId}").Should().NotBeNull();
+
+            // switch five has no label, no child content, just arialabel
+            switches[4].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            comp.FindAll(".s5 label.mud-switch span.mud-typography").Count().Should().Be(0);
+            var input4 = comp.Find(".s5 label.mud-switch input");
+            var input4ForId = input4.GetAttribute("aria-labelledby");
+            comp.Find($".s5 label.mud-switch #{input4ForId}").Should().NotBeNull();
+        }
+
+        [Test]
         [TestCase(Color.Default, Color.Primary)]
         [TestCase(Color.Primary, Color.Secondary)]
         [TestCase(Color.Secondary, Color.Info)]

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,7 +7,7 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                <input @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -157,18 +157,6 @@ namespace MudBlazor
 
         protected Task HandleKeyDownAsync(KeyboardEventArgs obj) => KeyInterceptorService.DispatchAsync(_elementId, KeyEventKind.Down, obj);
 
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-
-            // if Aria Label has a value add aria-labeled by
-            if (!string.IsNullOrWhiteSpace(AriaLabel))
-            {
-                // we use try add in case the user has already set an aria-labelledby attribute
-                UserAttributes.TryAdd("aria-labelledby", _ariaId);
-            }
-        }
-
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,18 +6,24 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText HtmlTag="span" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
+            }
+            @if (AriaLabel is not null)
+            {
+                <span id="@_ariaId" class="mud-sr-only">
+                    @AriaLabel
+                </span>
             }
         </label>
     </InputContent>

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -22,6 +22,7 @@ namespace MudBlazor
     {
         private IMudRadioGroup? _parent;
         private string _elementId = Identifier.Create("radio");
+        private readonly string _ariaId = Identifier.Create("radio-aria-");
 
         protected override string Classname => new CssBuilder("mud-input-control-boolean-input")
             .AddClass("mud-disabled", GetDisabledState())
@@ -73,6 +74,16 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public Color? UncheckedColor { get; set; } = null;
+
+        /// <summary>
+        /// The Aria Label to be assigned to the radio button.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. Used to improve accessibility for screen readers. Adds an <c>aria-labelledby</c> to the <c>input</c> element.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public string? AriaLabel { get; set; }
 
         /// <summary>
         /// Uses compact vertical padding.

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,7 +8,7 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                        <input @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">
                             @if (!string.IsNullOrEmpty(ThumbIcon))
                             {
@@ -21,15 +21,21 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" Class="@LabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" Class="@LabelClassname" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @Label
                 </MudText>
             }
             @if (ChildContent != null)
             {
-                <MudText HtmlTag="span" Class="@LabelClassname" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" Class="@LabelClassname" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
+            }
+            @if (AriaLabel is not null)
+            {
+                <span id="@_ariaId" class="mud-sr-only">
+                    @AriaLabel
+                </span>
             }
         </label>
     </InputContent>

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -15,6 +15,7 @@ namespace MudBlazor
     /// <seealso cref="MudRadio{T}"/>
     public partial class MudSwitch<T> : MudBooleanInput<T>
     {
+        private readonly string _ariaId = Identifier.Create("switch-aria-");
         internal string ElementId { get; } = Identifier.Create("switch");
 
         [Inject]
@@ -62,6 +63,16 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Radio.Appearance)]
         public Color UncheckedColor { get; set; } = Color.Default;
+
+        /// <summary>
+        /// The Aria Label to be assigned to the switch.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. Used to improve accessibility for screen readers. Adds an <c>aria-labelledby</c> to the <c>input</c> element.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Radio.Appearance)]
+        public string? AriaLabel { get; set; }
 
         /// <summary>
         /// The icon to display for the switch thumb.


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Refactored the `AriaLabel` handling in `MudCheckBox` and extended it to `MudRadio` and `MudSwitch` following ARIA best practices and MudBlazor code standards.

### Summary of Changes

1.  **`MudCheckBox` Refactor**:
    *   Removed manual `aria-labelledby` assignment from `OnInitialized` in MudCheckBox.razor.cs.
    *   Moved `aria-labelledby` attribute assignment directly to the `<input>` element in MudCheckBox.razor.
    *   Ensured visual labels and child content are hidden from screen readers via `aria-hidden` when a custom `AriaLabel` is provided, preventing redundant verbalization.

2.  **`MudRadio` Implementation**:
    *   Added `AriaLabel` parameter to MudRadio.razor.cs.
    *   Updated MudRadio.razor to include a screen-reader-only `<span>` for the label and linked it to the `input` via `aria-labelledby`.
    *   Applied `aria-hidden` to the visible label/content when `AriaLabel` is set.

3.  **`MudSwitch` Implementation**:
    *   Added `AriaLabel` parameter to MudSwitch.razor.cs.
    *   Updated MudSwitch.razor with the same `aria-labelledby` and `aria-hidden` pattern used in the other components.

4.  **Testing**:
    *   Verified existing CheckBox_AriaLabel_OverRides tests pass.
    *   Added `Radio_AriaLabel` test in RadioTests.cs and `Switch_AriaLabel` test in SwitchTests.cs.
    *   Created new test components: RadioAriaLabelTest.razor and SwitchAriaLabelTest.razor.

All three components now consistently handle ARIA labels by declaring them in the Razor file and correctly managing visibility for screen readers.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
