### PR TITLE
MudPicker: Correct space key prevention logic when Editable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/EditableTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/EditableTimePickerTest.razor
@@ -1,0 +1,40 @@
+﻿<MudPopoverProvider />
+
+<MudTimePicker @ref="_picker"
+			   @bind-Time="@Time"
+			   OpenTo="@OpenTo"
+			   AmPm="true"
+               Editable="IsEditable"
+               TimeEditMode="TimeEditMode"
+			   MinuteSelectionStep="MinuteSelectionStep"
+			   InputId="@InputId" />
+
+<MudSwitch @bind-Value="@IsEditable" T="bool" Label="Test" />
+
+@code {
+	private MudTimePicker _picker = null!;
+
+    public bool IsEditable { get; set; } = false;
+
+	[Parameter]
+    public OpenTo OpenTo { get; set; } = OpenTo.Hours;
+
+	[Parameter]
+    public TimeEditMode TimeEditMode { get; set; } = TimeEditMode.Normal;
+
+	[Parameter]
+    public TimeSpan? Time { get; set; }
+
+	[Parameter]
+    public bool AmPm { get; set; }
+
+	[Parameter]
+    public int MinuteSelectionStep { get; set; } = 1;
+
+	[Parameter]
+	public string? InputId { get; set; }
+
+    public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
+
+    public async Task Close() => await InvokeAsync(() => _picker.CloseAsync());
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/EditableTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/EditableTimePickerTest.razor
@@ -9,7 +9,7 @@
 			   MinuteSelectionStep="MinuteSelectionStep"
 			   InputId="@InputId" />
 
-<MudSwitch @bind-Value="@IsEditable" T="bool" Label="Test" />
+<MudSwitch @bind-Value="@IsEditable" T="bool" Label="Is Editable" />
 
 @code {
 	private MudTimePicker _picker = null!;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -22,6 +22,7 @@ namespace MudBlazor
         private bool _pickerSquare;
         private ElementReference _pickerInlineRef;
         private bool _keyInterceptorObserving;
+        private bool _lastEditableSentToInterceptor;
 
         internal string ElementId { get; } = Identifier.Create("picker");
 
@@ -636,10 +637,11 @@ namespace MudBlazor
             }
 
             _keyInterceptorObserving = true;
+            _lastEditableSentToInterceptor = Editable;
             var options = new KeyInterceptorOptions(
-                "mud-input-slot",
-                [
-                    new(" ", preventDown: "key+none"),
+            "mud-input-slot",
+            [
+                new(" ", preventDown: "key+none"),
                     //Allow space (" ") when Editable == true so that the user can enter a space before "AM"/"PM".
                     new(" ", preventDown: Editable ? "none" : "key+none"),
                     new("ArrowUp", preventDown: "key+none"),
@@ -647,7 +649,7 @@ namespace MudBlazor
                     new("Enter", preventDown: "key+none"),
                     new("NumpadEnter", preventDown: "key+none"),
                     new("/./", subscribeDown: true, subscribeUp: true)
-                ]);
+            ]);
 
             await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
                 .HookKeyDown(OnHandleKeyDownAsync)
@@ -661,13 +663,18 @@ namespace MudBlazor
             if (!_keyInterceptorObserving)
                 return;
 
+            // Only if changed
+            if (_lastEditableSentToInterceptor == Editable)
+                return;
+
+            _lastEditableSentToInterceptor = Editable;
+
             //On the event that the Editable property is toggled, we need update the Key Interceptor
             //  for the space-character so that the user can enter a space before "AM"/"PM"
             var option = new KeyOptions(" ", preventDown: Editable ? "none" : "key+none");
 
             await KeyInterceptorService.UpdateKeyAsync(ElementId, option);
         }
-
 
         private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState();
 
@@ -706,8 +713,10 @@ namespace MudBlazor
             {
                 await EnsureKeyInterceptorAsync();
             }
-
-            await UpdateSpaceKeyOptionAsync();
+            else
+            {
+                await UpdateSpaceKeyOptionAsync();
+            }
 
             await base.OnAfterRenderAsync(firstRender);
         }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -639,6 +639,8 @@ namespace MudBlazor
             var options = new KeyInterceptorOptions(
                 "mud-input-slot",
                 [
+                    new(" ", preventDown: "key+none"),
+                    //Allow space (" ") when Editable == true so that the user can enter a space before "AM"/"PM".
                     new(" ", preventDown: Editable ? "none" : "key+none"),
                     new("ArrowUp", preventDown: "key+none"),
                     new("ArrowDown", preventDown: "key+none"),
@@ -653,6 +655,19 @@ namespace MudBlazor
                     .OnKeyDown("Backspace", HandleBackspaceAsync)
                     .OnKeyDownAny(["Escape", "Tab"], () => CloseAsync(false))));
         }
+
+        private async Task UpdateSpaceKeyOptionAsync()
+        {
+            if (!_keyInterceptorObserving)
+                return;
+
+            //On the event that the Editable property is toggled, we need update the Key Interceptor
+            //  for the space-character so that the user can enter a space before "AM"/"PM"
+            var option = new KeyOptions(" ", preventDown: Editable ? "none" : "key+none");
+
+            await KeyInterceptorService.UpdateKeyAsync(ElementId, option);
+        }
+
 
         private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState();
 
@@ -691,6 +706,8 @@ namespace MudBlazor
             {
                 await EnsureKeyInterceptorAsync();
             }
+
+            await UpdateSpaceKeyOptionAsync();
 
             await base.OnAfterRenderAsync(firstRender);
         }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -663,14 +663,13 @@ namespace MudBlazor
             if (!_keyInterceptorObserving)
                 return;
 
-            // Only if changed
             if (_lastEditableSentToInterceptor == Editable)
                 return;
 
             _lastEditableSentToInterceptor = Editable;
 
             //On the event that the Editable property is toggled, we need update the Key Interceptor
-            //  for the space-character so that the user can enter a space before "AM"/"PM"
+            //  for the space-character so that the user can enter a space before "AM"/"PM".
             var option = new KeyOptions(" ", preventDown: Editable ? "none" : "key+none");
 
             await KeyInterceptorService.UpdateKeyAsync(ElementId, option);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -639,7 +639,7 @@ namespace MudBlazor
             var options = new KeyInterceptorOptions(
                 "mud-input-slot",
                 [
-                    new(" ", preventDown: "key+none"),
+                    new(" ", preventDown: Editable ? "none" : "key+none"),
                     new("ArrowUp", preventDown: "key+none"),
                     new("ArrowDown", preventDown: "key+none"),
                     new("Enter", preventDown: "key+none"),


### PR DESCRIPTION
Changed space key prevention logic to only prevent the default action when the input is not editable.

This ensures that users can enter spaces when the input is editable allowing for manual entry of AM/PM

<!-- Describe your changes and what the purpose of them is. -->
From: https://github.com/MudBlazor/MudBlazor/issues/10131
```Setup MudTimePicker with Editable="true" TimeFormat="h:mm tt" and AmPm="true" . You cannot type in a space between the minutes and am/pm. You are unable to type in a valid date with the default time format. The base class MudPicker prevents a space from being entered.```

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [contribution guidelines](CONTRIBUTING.md)
- [X] My code follows the style of this project
- [X] I've added or updated relevant unit tests
