### PR TITLE
MudSplitPanel: Fix splitter reset on double click even if drag occurs

### DIFF
--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using MudBlazor.Utilities;
 

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -22,9 +22,11 @@ class MudSplitPanel {
         this.secondPanel = children[2];
 
         this.isDragging = false;
+        this.dividerHasMoved = false;
         this.startPos = 0;
         this.startFirstSize = 0;
         this.lastTap = 0;
+        this.lastDragEndDate = 0;
         this.firstPanelInitialSize = firstPanelInitialSize;
         this.keyboardStep = 10;
 
@@ -104,6 +106,7 @@ class MudSplitPanel {
     _onMouseDown(e) {
         e.preventDefault();
         this.isDragging = true;
+        this.dividerHasMoved = false;
 
         const clientX = e.touches ? e.touches[0].clientX : e.clientX;
         const clientY = e.touches ? e.touches[0].clientY : e.clientY;
@@ -138,6 +141,7 @@ class MudSplitPanel {
         const max = containerSize - this.panelGap - min;
 
         if (newFirstSize >= min && newFirstSize <= max) {
+            this.dividerHasMoved = true;
             this._setPanelSizes(newFirstSize, containerSize);
         }
     }
@@ -157,6 +161,10 @@ class MudSplitPanel {
         if (!this.isDragging) return;
         this.isDragging = false;
 
+        if (this.dividerHasMoved) {
+            this.lastDragEndDate = Date.now();
+        }
+
         document.body.style.userSelect = "";
         document.body.style.cursor = "";
         document.removeEventListener("mousemove", this._onMouseMove);
@@ -167,6 +175,9 @@ class MudSplitPanel {
 
     _onDoubleClick() {
         if (!this.resetOnDoubleClick) return;
+
+        // Fixes the edge case where the user first clicks and then clicks again and holds to drag
+        if (Date.now() - this.lastDragEndDate < 100) return;
 
         const containerSize = this.horizontal
             ? this.container.offsetHeight


### PR DESCRIPTION
This PR fixes https://github.com/MudBlazor/MudBlazor/issues/12583 (If you double click the splitter (with ResetOnDoubleClick=true) and drag the splitter during the second click, it'll snap back when you let go of the pointer.)