### PR TITLE
CssBuilder/StyleBuilder: declare as readonly struct

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/CssBuilderTests.cs
@@ -335,29 +335,5 @@ namespace UtilityTests
             // Assert
             classToRender.Should().Be("item-one");
         }
-
-        [Test]
-        public void AddClass_ShouldNotBeNullWithDefaultStruct()
-        {
-            // Arrange
-            var cssBuilder = default(CssBuilder);
-
-            // Act
-            cssBuilder.AddClass("test-class");
-            cssBuilder.AddClass("test-class-2");
-
-            // Assert
-            cssBuilder.Build().Should().Be("test-class test-class-2");
-        }
-
-        [Test]
-        public void Build_ShouldNotBeNullWithDefaultStruct()
-        {
-            // Arrange
-            var cssBuilder = default(CssBuilder);
-
-            // Assert
-            cssBuilder.Build().Should().Be("");
-        }
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/StyleBuilderTests.cs
@@ -314,29 +314,5 @@ namespace UtilityTests
             // Assert
             styleBuilder.Should().Be(string.Empty);
         }
-
-        [Test]
-        public void AddStyle_ShouldNotBeNullWithDefaultStruct()
-        {
-            // Arrange
-            var styleBuilder = default(StyleBuilder);
-
-            // Act
-            styleBuilder.AddStyle("background-color", "green");
-            styleBuilder.AddStyle("color", "red");
-
-            // Assert
-            styleBuilder.Build().Should().Be("background-color:green;color:red;");
-        }
-
-        [Test]
-        public void Build_ShouldNotBeNullWithDefaultStruct()
-        {
-            // Arrange
-            var styleBuilder = default(StyleBuilder);
-
-            // Assert
-            styleBuilder.Build().Should().Be("");
-        }
     }
 }

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -10,9 +10,9 @@ namespace MudBlazor.Utilities
     /// <summary>
     /// Represents a builder for creating CSS classes used in a component.
     /// </summary>
-    public struct CssBuilder
+    public readonly struct CssBuilder
     {
-        private StringBuilder? _stringBuilder;
+        private readonly StringBuilder _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of CssBuilder with the specified initial value.
@@ -42,7 +42,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder()
         {
-            _stringBuilder = EnsureCreated();
+            _stringBuilder = StringBuilderCache.Acquire();
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace MudBlazor.Utilities
         {
             if (value is not null)
             {
-                EnsureCreated().Append(value);
+                _stringBuilder.Append(value);
             }
         }
 
@@ -70,7 +70,7 @@ namespace MudBlazor.Utilities
         {
             if (value is not null)
             {
-                EnsureCreated().Append(value);
+                _stringBuilder.Append(value);
             }
             return this;
         }
@@ -162,13 +162,10 @@ namespace MudBlazor.Utilities
         /// Finalizes the completed CSS classes as a string.
         /// </summary>
         /// <returns>The string representation of the CSS classes.</returns>
-        public string Build() => StringBuilderCache.GetStringAndRelease(EnsureCreated()).Trim();
+        public string Build() => StringBuilderCache.GetStringAndRelease(_stringBuilder).Trim();
 
         // ToString should only and always call Build to finalize the rendered string.
         /// <inheritdoc />
         public override string ToString() => Build();
-
-        // TODO: v8, remove that and declare CssBuilder as readonly struct, improve documentation to avoid default(StringBuilder), add Breaking Change notes.
-        private StringBuilder EnsureCreated() => _stringBuilder ??= StringBuilderCache.Acquire();
     }
 }

--- a/src/MudBlazor/Utilities/StringBuilderCache.cs
+++ b/src/MudBlazor/Utilities/StringBuilderCache.cs
@@ -41,11 +41,12 @@ namespace System.Text
         // as little memory (per thread) as possible and still covering a large part of short-lived
         // StringBuilder creations on the startup path of VS designers.
         private const int MaxBuilderSize = 360;
+        private const int DefaultCapacity = 16; // == StringBuilder.DefaultCapacity
 
         [ThreadStatic]
         private static StringBuilder? _cachedInstance;
 
-        public static StringBuilder Acquire(int capacity = MaxBuilderSize)
+        public static StringBuilder Acquire(int capacity = DefaultCapacity)
         {
             if (capacity <= MaxBuilderSize)
             {

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -10,9 +10,9 @@ namespace MudBlazor.Utilities
     /// <summary>
     /// Represents a builder for creating in-line styles used in a component.
     /// </summary>
-    public struct StyleBuilder
+    public readonly struct StyleBuilder
     {
-        private StringBuilder? _stringBuilder;
+        private readonly StringBuilder _stringBuilder;
 
         /// <summary>
         /// Creates a new instance of StyleBuilder with the specified property and value.
@@ -53,7 +53,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder()
         {
-            _stringBuilder = EnsureCreated();
+            _stringBuilder = StringBuilderCache.Acquire();
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace MudBlazor.Utilities
         /// <param name="prop">The CSS property.</param>
         /// <param name="value">The value of the property.</param>
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder(string prop, string value) =>
-            EnsureCreated()
+        public StyleBuilder(string prop, string value) : this() =>
+            _stringBuilder
                 .Append(prop)
                 .Append(':')
                 .Append(value)
@@ -104,7 +104,7 @@ namespace MudBlazor.Utilities
         {
             if (style is not null)
             {
-                EnsureCreated().Append(style);
+                _stringBuilder.Append(style);
             }
             return this;
         }
@@ -116,7 +116,7 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         private StyleBuilder AddRaw(char c)
         {
-            EnsureCreated().Append(c);
+            _stringBuilder.Append(c);
             return this;
         }
 
@@ -224,13 +224,10 @@ namespace MudBlazor.Utilities
         /// Finalizes the completed style as a string.
         /// </summary>
         /// <returns>The string representation of the style.</returns>
-        public string Build() => StringBuilderCache.GetStringAndRelease(EnsureCreated()).Trim();
+        public string Build() => StringBuilderCache.GetStringAndRelease(_stringBuilder).Trim();
 
         // ToString should only and always call Build to finalize the rendered string.
         /// <inheritdoc />
         public override string ToString() => Build();
-
-        // TODO: v8, remove that and declare StyleBuilder as readonly struct, improve documentation to avoid default(StyleBuilder), add Breaking Change notes.
-        private StringBuilder EnsureCreated() => _stringBuilder ??= StringBuilderCache.Acquire();
     }
 }


### PR DESCRIPTION
Something we forgot to do.
The readonly struct increases performance as as it avoids hidden defensive copies.

trade off:
`default(CssBuilder)` / `default(StyleBuilder)` will throw `NullReferenceException` at runtime

We don't support it anymore.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
