### PR TITLE
Build: Use composite action for faster CI feedback

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,13 +1,13 @@
-name: 'Build .NET Project'
-description: 'Build a .NET project'
+name: "Build .NET Project"
+description: "Build a .NET project"
 
 inputs:
   project-path:
-    description: 'Path to the project file to build'
+    description: "Path to the project file to build"
     required: true
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
       #  aspnetcore-version: ${{ inputs.with-runtime == 'true' && '9.x,8.x' || '' }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,10 +5,6 @@ inputs:
   project-path:
     description: 'Path to the project file to build'
     required: true
-  # with-runtime:
-  #   description: 'Whether to install ASP.NET Core runtimes'
-  #   required: false
-  #   default: 'false'
 
 runs:
   using: 'composite'
@@ -17,7 +13,6 @@ runs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
-      #  aspnetcore-version: ${{ inputs.with-runtime == 'true' && '9.x,8.x' || '' }}
 
     # We restore from our 'format-check' job cache if available because it contains all dependencies
     - name: Cache NuGet packages

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,28 @@
+name: 'Build .NET Project'
+description: 'Build a .NET project'
+
+inputs:
+  project-path:
+    description: 'Path to the project file to build'
+    required: true
+  with-runtime:
+    description: 'Whether to install ASP.NET Core runtimes'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup .NET
+      uses: fast-actions/setup-dotnet@v1
+      with:
+        sdk-version: latest
+        aspnetcore-version: ${{ inputs.with-runtime == 'true' && '9.x,8.x' || '' }}
+
+    - name: Restore NuGet packages
+      shell: bash
+      run: dotnet restore "${{ inputs.project-path }}"
+
+    - name: Build project
+      shell: bash
+      run: dotnet build "${{ inputs.project-path }}" -c Release --no-restore

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,6 +19,13 @@ runs:
         sdk-version: latest
         aspnetcore-version: ${{ inputs.with-runtime == 'true' && '9.x,8.x' || '' }}
 
+    # We restore from our 'format-check' job cache if available because it contains all dependencies
+    - name: Cache NuGet packages
+      uses: actions/cache/restore@v5
+      with:
+        key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+        path: ${{ env.NUGET_PACKAGES }}
+
     - name: Restore NuGet packages
       shell: bash
       run: dotnet restore "${{ inputs.project-path }}"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         dotnet-version: 10.x
 
-    # We restore from our 'format-check' job cache if available because it contains all dependencies
+    # We try to restore from our 'format-check' job cache if available because it contains all dependencies
     - name: Cache NuGet packages
       uses: actions/cache/restore@v5
       with:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,19 +5,19 @@ inputs:
   project-path:
     description: 'Path to the project file to build'
     required: true
-  with-runtime:
-    description: 'Whether to install ASP.NET Core runtimes'
-    required: false
-    default: 'false'
+  # with-runtime:
+  #   description: 'Whether to install ASP.NET Core runtimes'
+  #   required: false
+  #   default: 'false'
 
 runs:
   using: 'composite'
   steps:
     - name: Setup .NET
-      uses: fast-actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1
       with:
-        sdk-version: latest
-        aspnetcore-version: ${{ inputs.with-runtime == 'true' && '9.x,8.x' || '' }}
+        dotnet-version: 10.x
+      #  aspnetcore-version: ${{ inputs.with-runtime == 'true' && '9.x,8.x' || '' }}
 
     # We restore from our 'format-check' job cache if available because it contains all dependencies
     - name: Cache NuGet packages
@@ -28,8 +28,8 @@ runs:
 
     - name: Restore NuGet packages
       shell: bash
-      run: dotnet restore "${{ inputs.project-path }}"
+      run: dotnet restore ${{ inputs.project-path }}
 
     - name: Build project
       shell: bash
-      run: dotnet build "${{ inputs.project-path }}" -c Release --no-restore
+      run: dotnet build ${{ inputs.project-path }} -c Release --no-restore

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -58,8 +58,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project-path: ["src/MudBlazor.UnitTests", "src/MudBlazor.UnitTests.Docs", "src/MudBlazor.UnitTests.Analyzers"]   
-        
+        project-path:
+          [
+            "src/MudBlazor.UnitTests",
+            "src/MudBlazor.UnitTests.Docs",
+            "src/MudBlazor.UnitTests.Analyzers",
+          ]
+
     steps:
       - uses: actions/checkout@v6
 
@@ -70,7 +75,7 @@ jobs:
 
       - name: Test ${{ matrix.project-path }}
         run: dotnet test ${{ matrix.project-path }} -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
-  
+
       - name: Publish docs coverage
         uses: codecov/codecov-action@v5
         with:
@@ -90,8 +95,8 @@ jobs:
       fail-fast: false
       matrix:
         # Project that are not covered by 'build-test' job
-        project-path: ["src/MudBlazor.Docs.WasmHost", "src/MudBlazor.Docs.Server"]   
-        
+        project-path: ["src/MudBlazor.Docs.WasmHost", "src/MudBlazor.Docs.Server"]
+
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -53,50 +53,85 @@ jobs:
           fi
           dotnet format src --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}
 
+
+
   build-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project-path: ["src/MudBlazor.UnitTests/MudBlazor.UnitTests", "src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs", "src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers"]   
+        
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v5
+      - name: Build .NET Project
+        uses: ./.github/actions/build
         with:
-          key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
-          path: ${{ env.NUGET_PACKAGES }}
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+          project-path: ${{ matrix.project-path }}
           # We need all runtimes for the tests
-          dotnet-version: |
-            10.x
-            9.x
-            8.x
+          with-runtime: true
 
-      - name: Restore dependencies
-        working-directory: src
-        run: dotnet restore
-
-      - name: Build solution
-        working-directory: src
-        run: dotnet build -c Release --no-restore
-
-      - name: Test solution
-        working-directory: src
-        run: dotnet test -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
-
-      - name: Publish coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+      - name: Test ${{ matrix.project-path }}
+        run: dotnet test ${{ matrix.project-path }} -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
+  
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          files: >
-            src/MudBlazor.UnitTests/junit.xml,
-            src/MudBlazor.UnitTests.Docs/junit.xml,
-            src/MudBlazor.UnitTests.Analyzers/junit.xml
+          files: ${{ matrix.project-path }}/junit.xml
+
+  # build-only:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       project-path:
+        # build-test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+
+  #     - name: Cache NuGet packages
+  #       uses: actions/cache@v5
+  #       with:
+  #         key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
+  #         path: ${{ env.NUGET_PACKAGES }}
+
+  #     - name: Setup .NET
+  #       uses: actions/setup-dotnet@v5
+  #       with:
+  #         # We need all runtimes for the tests
+  #         dotnet-version: |
+  #           10.x
+  #           9.x
+  #           8.x
+
+  #     - name: Restore dependencies
+  #       working-directory: src
+  #       run: dotnet restore
+
+  #     - name: Build solution
+  #       working-directory: src
+  #       run: dotnet build -c Release --no-restore
+
+  #     - name: Test solution
+  #       working-directory: src
+  #       run: dotnet test -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
+
+      # - name: Publish coverage
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+
+      # - name: Upload test results to Codecov
+      #   if: ${{ !cancelled() }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     report_type: test_results
+      #     files: >
+      #       src/MudBlazor.UnitTests/junit.xml,
+      #       src/MudBlazor.UnitTests.Docs/junit.xml,
+      #       src/MudBlazor.UnitTests.Analyzers/junit.xml

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project-path: ["src/MudBlazor.UnitTests/MudBlazor.UnitTests", "src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs", "src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers"]   
+        project-path: ["src/MudBlazor.UnitTests", "src/MudBlazor.UnitTests.Docs", "src/MudBlazor.UnitTests.Analyzers"]   
         
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -53,8 +53,6 @@ jobs:
           fi
           dotnet format src --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}
 
-
-
   build-test:
     runs-on: ubuntu-latest
     strategy:
@@ -69,12 +67,15 @@ jobs:
         uses: ./.github/actions/build
         with:
           project-path: ${{ matrix.project-path }}
-          # We need all runtimes for the tests
-          # with-runtime: true
 
       - name: Test ${{ matrix.project-path }}
         run: dotnet test ${{ matrix.project-path }} -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
   
+      - name: Publish docs coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
@@ -83,55 +84,17 @@ jobs:
           report_type: test_results
           files: ${{ matrix.project-path }}/junit.xml
 
-  # build-only:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       project-path:
-        # build-test:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v6
+  build-only:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project-path: ["src/MudBlazor.Docs.WasmHost", "src/MudBlazor.Docs.Server"]   
+        
+    steps:
+      - uses: actions/checkout@v6
 
-  #     - name: Cache NuGet packages
-  #       uses: actions/cache@v5
-  #       with:
-  #         key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
-  #         path: ${{ env.NUGET_PACKAGES }}
-
-  #     - name: Setup .NET
-  #       uses: actions/setup-dotnet@v5
-  #       with:
-  #         # We need all runtimes for the tests
-  #         dotnet-version: |
-  #           10.x
-  #           9.x
-  #           8.x
-
-  #     - name: Restore dependencies
-  #       working-directory: src
-  #       run: dotnet restore
-
-  #     - name: Build solution
-  #       working-directory: src
-  #       run: dotnet build -c Release --no-restore
-
-  #     - name: Test solution
-  #       working-directory: src
-  #       run: dotnet test -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
-
-      # - name: Publish coverage
-      #   uses: codecov/codecov-action@v5
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-
-      # - name: Upload test results to Codecov
-      #   if: ${{ !cancelled() }}
-      #   uses: codecov/codecov-action@v5
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     report_type: test_results
-      #     files: >
-      #       src/MudBlazor.UnitTests/junit.xml,
-      #       src/MudBlazor.UnitTests.Docs/junit.xml,
-      #       src/MudBlazor.UnitTests.Analyzers/junit.xml
+      - name: Build .NET Project
+        uses: ./.github/actions/build
+        with:
+          project-path: ${{ matrix.project-path }}

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -89,6 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Project that are not covered by 'build-test' job
         project-path: ["src/MudBlazor.Docs.WasmHost", "src/MudBlazor.Docs.Server"]   
         
     steps:

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Build .NET Project
+      - name: Build and Restore ${{ matrix.project-path }}
         uses: ./.github/actions/build
         with:
           project-path: ${{ matrix.project-path }}
@@ -76,7 +76,7 @@ jobs:
       - name: Test ${{ matrix.project-path }}
         run: dotnet test ${{ matrix.project-path }} -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"
 
-      - name: Publish docs coverage
+      - name: Publish coverage
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Build .NET Project
+      - name: Build and Restore ${{ matrix.project-path }}
         uses: ./.github/actions/build
         with:
           project-path: ${{ matrix.project-path }}

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           project-path: ${{ matrix.project-path }}
           # We need all runtimes for the tests
-          with-runtime: true
+          # with-runtime: true
 
       - name: Test ${{ matrix.project-path }}
         run: dotnet test ${{ matrix.project-path }} -c Release --no-build --blame-hang --blame-hang-timeout 60s /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ExcludeByAttribute='ExcludeFromCodeCoverageAttribute' /p:ExcludeByAttribute='CompilerGeneratedAttribute' /p:ExcludeByFile='**/*.g.cs' /p:Include='[MudBlazor]*' /p:SkipAutoProps=true /p:CoverletOutput='./TestResults/' --logger "junit;LogFilePath=junit.xml"


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Follow-up of https://github.com/MudBlazor/MudBlazor/pull/12553

This PR introduces a new composite `build` action, which is now used in the `build-test-mudblazor` workflow. It reduces the overall workflow execution time by ~ 2 minutes.

**Note:** Total CI minutes increase because multiple jobs now run in parallel.
**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
