### PR TITLE
MudDataGrid: Format pagination numbers with group separators and improve InfoFormat logic

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationCustomFormatTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationCustomFormatTest.razor
@@ -1,0 +1,19 @@
+﻿<MudDataGrid Items="@_items" RowsPerPage="10">
+    <Columns>
+        <PropertyColumn Property="x => x.Number" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Item" InfoFormat="Total: {all_items}" />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    private readonly List<Item> _items = Enumerable.Range(1, 1000)
+        .Select(i => new Item(i))
+        .ToList();
+    
+    private class Item(int number)
+    {
+        public int Number { get; set; } = number;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationFormattingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPaginationFormattingTest.razor
@@ -1,0 +1,19 @@
+﻿<MudDataGrid Items="@_items" RowsPerPage="10">
+    <Columns>
+        <PropertyColumn Property="x => x.Number" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Item" />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    private readonly List<Item> _items = Enumerable.Range(1, 1000)
+        .Select(i => new Item(i))
+        .ToList();
+    
+    private class Item(int number)
+    {
+        public int Number { get; set; } = number;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -397,7 +397,7 @@ namespace MudBlazor.UnitTests.Components
 
             await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Filterable, false));
         }
-
+        
         [Test]
         public async Task DataGridFilterable()
         {
@@ -870,7 +870,23 @@ namespace MudBlazor.UnitTests.Components
 
             comp.FindAll(".mud-table-pagination-select")[^1].TextContent.Trim().Should().Be("All");
         }
+        
+        [Test]
+        public void DataGridPagination_Should_FormatNumbersWithCommas()
+        {
+            var comp = Context.RenderComponent<DataGridPaginationFormattingTest>();
 
+            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 1,000");
+        }
+        
+        [Test]
+        public void DataGridPagination_Should_RespectCustomFormatWithSingleTag()
+        {
+            var comp = Context.RenderComponent<DataGridPaginationCustomFormatTest>();
+
+            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("Total: 1,000");
+        }
+        
         [Test]
         public void DataGridPaginationNoItems()
         {
@@ -881,7 +897,7 @@ namespace MudBlazor.UnitTests.Components
 
             dataGrid.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("0-0 of 0");
         }
-
+        
         [Test]
         public async Task DataGridHideNavigation()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -104,15 +104,15 @@ namespace MudBlazor
                 var lastItem = Math.Min((DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage, DataGrid.GetFilteredItemsCount());
                 var allItems = DataGrid?.GetFilteredItemsCount() ?? 0;
 
-                if (InfoFormat.Contains("{first_item}") || InfoFormat.Contains("{last_item}") || InfoFormat.Contains("{all_items}"))
+                if (string.IsNullOrEmpty(InfoFormat))
                 {
-                    return InfoFormat
-                        .Replace("{first_item}", $"{firstItem}")
-                        .Replace("{last_item}", $"{lastItem}")
-                        .Replace("{all_items}", $"{allItems}");
+                    return Localizer[LanguageResource.MudDataGridPager_InfoFormat, $"{firstItem:N0}", $"{lastItem:N0}", $"{allItems:N0}"];
                 }
 
-                return Localizer[LanguageResource.MudDataGridPager_InfoFormat, firstItem, lastItem, allItems];
+                return InfoFormat
+                    .Replace("{first_item}", $"{firstItem:N0}")
+                    .Replace("{last_item}", $"{lastItem:N0}")
+                    .Replace("{all_items}", $"{allItems:N0}");
             }
         }
 


### PR DESCRIPTION
This PR aligns the MudDataGridPager with the better implementation found in MudTablePager. It adds digit grouping (commas) to item counts and allows for more flexible custom formatting that can be found in the MudTablePager (matching functionality).