### PR TITLE
Build: Update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,7 +83,7 @@
         {
             "customType": "regex",
             "managerFilePatterns": [
-                "/^Directory.Build.props$/"
+                "/(^|/)Directory\\.Build\\.props$/"
             ],
             "matchStrings": [
                 "<BunVersion>(?<currentValue>.*?)</BunVersion>"
@@ -94,7 +94,7 @@
         {
             "customType": "regex",
             "managerFilePatterns": [
-                "/^Directory.Build.props$/"
+                "/(^|/)Directory\\.Build\\.props$/"
             ],
             "matchStrings": [
                 "<BunDotNetVersion>(?<currentValue>.*?)</BunDotNetVersion>"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
     "labels": [
         "dependency"
     ],
+    "commitMessagePrefix": "Build: ",
     "minimumReleaseAge": "14 days",
     "vulnerabilityAlerts": {
         "enabled": true,
@@ -76,6 +77,30 @@
                 "minor"
             ],
             "automerge": true
+        }
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^Directory.Build.props$/"
+            ],
+            "matchStrings": [
+                "<BunVersion>(?<currentValue>.*?)</BunVersion>"
+            ],
+            "depNameTemplate": "bun",
+            "datasourceTemplate": "npm"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^Directory.Build.props$/"
+            ],
+            "matchStrings": [
+                "<BunDotNetVersion>(?<currentValue>.*?)</BunDotNetVersion>"
+            ],
+            "depNameTemplate": "BunDotNet.Cli",
+            "datasourceTemplate": "nuget"
         }
     ]
 }


### PR DESCRIPTION
- Renovate will now add `Build:` prefix to PR titles and commits
- Renovate can now update the `Bun` and `BunDotNet` versions

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
