### PR TITLE
Docs: Improve comment coverage for TScripts

### DIFF
--- a/src/MudBlazor/TScripts/entrypoint.js
+++ b/src/MudBlazor/TScripts/entrypoint.js
@@ -1,3 +1,6 @@
+// Bundle entrypoint for MudBlazor JS interop.
+// Why: every `window.mud*` API used from C# must be imported here so it lands in `wwwroot/MudBlazor.min.js`.
+// Keep this list in sync with the TScripts directory (excluding this file).
 import "./mudAAAlicense";
 import "./mudDragAndDrop";
 import "./mudElementReference";

--- a/src/MudBlazor/TScripts/entrypoint.js
+++ b/src/MudBlazor/TScripts/entrypoint.js
@@ -2,9 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Bundle entrypoint for MudBlazor JS interop.
-// Why: every `window.mud*` API used from C# must be imported here so it lands in `wwwroot/MudBlazor.min.js`.
-// Keep this list in sync with the TScripts directory (excluding this file).
+/**
+ * Bundles all JS interop modules exported as `window.mud*`.
+ * Keep this list in sync with the TScripts directory (excluding this file).
+ */
 import "./mudAAAlicense";
 import "./mudDragAndDrop";
 import "./mudElementReference";

--- a/src/MudBlazor/TScripts/entrypoint.js
+++ b/src/MudBlazor/TScripts/entrypoint.js
@@ -1,11 +1,3 @@
-// Copyright (c) MudBlazor 2021
-// MudBlazor licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-/**
- * Bundles all JS interop modules exported as `window.mud*`.
- * Keep this list in sync with the TScripts directory (excluding this file).
- */
 import "./mudAAAlicense";
 import "./mudDragAndDrop";
 import "./mudElementReference";

--- a/src/MudBlazor/TScripts/entrypoint.js
+++ b/src/MudBlazor/TScripts/entrypoint.js
@@ -1,3 +1,7 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 // Bundle entrypoint for MudBlazor JS interop.
 // Why: every `window.mud*` API used from C# must be imported here so it lands in `wwwroot/MudBlazor.min.js`.
 // Keep this list in sync with the TScripts directory (excluding this file).

--- a/src/MudBlazor/TScripts/mudAAAlicense.js
+++ b/src/MudBlazor/TScripts/mudAAAlicense.js
@@ -3,7 +3,12 @@
  * Copyright (c) 2021 MudBlazor
  * Licensed under MIT (https://github.com/MudBlazor/MudBlazor/blob/master/LICENSE)
  */
+
 // Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Imported first by `entrypoint.js` so distributed bundles keep the license banner at the top.
+
+/**
+ * License banner module imported first by `entrypoint.js`.
+ * Keeps the distributed bundle license notice at the top.
+ */

--- a/src/MudBlazor/TScripts/mudAAAlicense.js
+++ b/src/MudBlazor/TScripts/mudAAAlicense.js
@@ -3,3 +3,4 @@
  * Copyright (c) 2021 MudBlazor
  * Licensed under MIT (https://github.com/MudBlazor/MudBlazor/blob/master/LICENSE)
  */
+// Imported first by `entrypoint.js` so distributed bundles keep the license banner at the top.

--- a/src/MudBlazor/TScripts/mudAAAlicense.js
+++ b/src/MudBlazor/TScripts/mudAAAlicense.js
@@ -3,4 +3,7 @@
  * Copyright (c) 2021 MudBlazor
  * Licensed under MIT (https://github.com/MudBlazor/MudBlazor/blob/master/LICENSE)
  */
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Imported first by `entrypoint.js` so distributed bundles keep the license banner at the top.

--- a/src/MudBlazor/TScripts/mudAAAlicense.js
+++ b/src/MudBlazor/TScripts/mudAAAlicense.js
@@ -3,12 +3,3 @@
  * Copyright (c) 2021 MudBlazor
  * Licensed under MIT (https://github.com/MudBlazor/MudBlazor/blob/master/LICENSE)
  */
-
-// Copyright (c) MudBlazor 2021
-// MudBlazor licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-/**
- * License banner module imported first by `entrypoint.js`.
- * Keeps the distributed bundle license notice at the top.
- */

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -7,12 +7,18 @@
  * Uses transient transforms so .NET can finalize ordering and targets on drop.
  */
 window.mudDragAndDrop = {
-
+    /**
+     * Initializes native drag events for a drop-zone root element.
+     * Enables browser dragover/drop behavior needed by the DropZone workflow.
+     */
     initDropZone: (id) => {
         const elem = document.getElementById(id);
         elem.addEventListener('dragover', (event) => event.preventDefault());
         elem.addEventListener('dragstart', (event) => event.dataTransfer.setData('', event.target.id));
     },
+    /**
+     * Clears relative positioning during active dragging so hit-testing stays stable.
+     */
     makeDropZonesNotRelative: () => {
         const firstDropItems = Array.from(document.getElementsByClassName('mud-drop-item')).filter(x => x.getAttribute('index') == "-1");
         for (const dropItem of firstDropItems) {
@@ -24,8 +30,12 @@ window.mudDragAndDrop = {
             dropZone.style.position = 'unset';
         }
     },
+    /**
+     * Returns the first drop-zone identifier under a viewport coordinate.
+     */
     getDropZoneIdentifierOnPosition: (x, y) => {
         const elems = document.elementsFromPoint(x, y);
+        // Use top-to-bottom hit testing so nested layouts still resolve the visually closest zone.
         const dropZones = elems.filter(e => e.classList.contains('mud-drop-zone'));
         const dropZone = dropZones[0];
         if (dropZone) {
@@ -33,6 +43,9 @@ window.mudDragAndDrop = {
         }
         return "";
     },
+    /**
+     * Returns the target drop-item index under a viewport coordinate, excluding the dragged item.
+     */
     getDropIndexOnPosition: (x, y, id) => {
         //const selfItem = document.getElementById(id);
 
@@ -45,6 +58,9 @@ window.mudDragAndDrop = {
         }
         return "";
     },
+    /**
+     * Restores relative positioning after drag operations complete.
+     */
     makeDropZonesRelative: () => {
         const dropZones = document.getElementsByClassName('mud-drop-zone');
         for (const dropZone of dropZones) {
@@ -55,35 +71,37 @@ window.mudDragAndDrop = {
             dropItem.style.position = 'relative';
         }
     },
+    /**
+     * Applies incremental translation to the dragged element.
+     * Persists accumulated offsets in data attributes between pointer events.
+     */
     moveItemByDifference: (id, dx, dy) => {
         const elem = document.getElementById(id);
-        
 
-
-        // keep the ACCUMULATED dragged position in the data-x/data-y attributes
+        // Persist offsets on the element so each pointer move can stay incremental.
         const tx = (parseFloat(elem.getAttribute('data-x')) || 0) + dx;
         const ty = (parseFloat(elem.getAttribute('data-y')) || 0) + dy;
 
-
-        // translate the element
+        // translate3d keeps drag movement smooth and avoids forcing layout recalculation.
         elem.style.webkitTransform =
             elem.style.transform =
             'translate3d(' + tx + 'px, ' + ty + 'px, 10px)';
-        
-        // update the posiion attributes
+
+        // Update data attributes so subsequent move deltas accumulate correctly.
         elem.setAttribute('data-x', tx);
         elem.setAttribute('data-y', ty);
     },
+    /**
+     * Resets transform and accumulated drag offsets for an item.
+     */
     resetItem: (id) => {
         const elem = document.getElementById(id);
         if (elem) {
-            // translate the element
             elem.style.webkitTransform =
                 elem.style.transform = '';
-            // update the posiion attributes
+            // Reset stored offsets so the next drag starts from a clean origin.
             elem.setAttribute('data-x', 0);
             elem.setAttribute('data-y', 0);
         }
-        
     }
 };

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -2,6 +2,11 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Interop for DropZone drag state while the user is moving items.
+// Used from:
+// - DropZone container setup
+// - Drop item move/reset and target detection
+// The JS side keeps movement in transient CSS transforms so C# can decide final reorder/target on drop.
 window.mudDragAndDrop = {
 
     initDropZone: (id) => {

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -2,11 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Interop for DropZone drag state while the user is moving items.
-// Used from:
-// - DropZone container setup
-// - Drop item move/reset and target detection
-// The JS side keeps movement in transient CSS transforms so C# can decide final reorder/target on drop.
+/**
+ * Manages client-side drag state for DropZone interactions.
+ * Uses transient transforms so .NET can finalize ordering and targets on drop.
+ */
 window.mudDragAndDrop = {
 
     initDropZone: (id) => {

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -2,6 +2,11 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Shared ElementReference interop surface.
+// Used from:
+// - ElementReference extension helpers
+// - Input blur workaround hookup/cleanup
+// Keeping these helpers centralized avoids repeating browser-specific focus and selection quirks in components.
 class MudElementReference {
     constructor() {
         this.listenerId = 0;

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -2,11 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Shared ElementReference interop surface.
-// Used from:
-// - ElementReference extension helpers
-// - Input blur workaround hookup/cleanup
-// Keeping these helpers centralized avoids repeating browser-specific focus and selection quirks in components.
+/**
+ * Shared ElementReference interop surface for focus, selection, and DOM metrics.
+ * Centralizes browser-specific behavior used by components and extension helpers.
+ */
 class MudElementReference {
     constructor() {
         this.listenerId = 0;

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -12,6 +12,9 @@ class MudElementReference {
         this.eventListeners = {};
     }
 
+    /**
+     * Moves focus to the provided element.
+     */
     focus (element) {
         if (element)
         {
@@ -19,16 +22,24 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Removes focus from the provided element.
+     */
     blur(element) {
         if (element) {
             element.blur();
         }
     }
 
+    /**
+     * Focuses the first tabbable descendant, with optional skipping.
+     * Falls back to the container when not enough tabbable elements exist.
+     */
     focusFirst (element, skip = 0, min = 0) {
         if (element)
         {
             const tabbables = window.getTabbableElements(element);
+            // Fallback avoids trapping focus when a dialog/container has too few tabbable children.
             if (tabbables.length <= min)
                 element.focus();
             else
@@ -36,6 +47,10 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Focuses the last tabbable descendant, with optional reverse skipping.
+     * Falls back to the container when not enough tabbable elements exist.
+     */
     focusLast (element, skip = 0, min = 0) {
         if (element)
         {
@@ -47,13 +62,20 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Stores the currently active element on the container for later restoration.
+     */
     saveFocus (element) {
         if (element)
         {
+            // Store on the container instance so restoration survives intermediate re-renders.
             element['mudblazor_savedFocus'] = document.activeElement;
         }
     }
 
+    /**
+     * Restores focus previously captured by saveFocus.
+     */
     restoreFocus (element) {
         if (element)
         {
@@ -64,6 +86,10 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Selects a text range and focuses the element.
+     * Uses legacy-compatible APIs when needed.
+     */
     selectRange(element, pos1, pos2) {
         if (element)
         {
@@ -83,6 +109,9 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Selects the element's full text content.
+     */
     select(element) {
         if (element)
         {
@@ -90,6 +119,9 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Returns a serializable bounding rectangle enriched with scroll and viewport data.
+     */
     getBoundingClientRect(element) {
         if (!element) return;
 
@@ -103,6 +135,9 @@ class MudElementReference {
         return rect;
     }
 
+    /**
+     * Replaces the element className in one operation.
+     */
     changeCss (element, css) {
         if (element)
         {
@@ -110,11 +145,18 @@ class MudElementReference {
         }
     }
 
+    /**
+     * Removes a tracked event listener by event name and listener ID.
+     */
     removeEventListener (element, event, eventId) {
         element.removeEventListener(event, this.eventListeners[eventId]);
         delete this.eventListeners[eventId];
     }
 
+    /**
+     * Adds an event listener that always prevents default behavior.
+     * Returns a generated listener ID for later removal.
+     */
     addDefaultPreventingHandler(element, eventName) {
         const listener = function (e) {
             // Only prevent default if not already prevented
@@ -128,10 +170,17 @@ class MudElementReference {
         return this.listenerId;
     }
 
+    /**
+     * Removes a default-preventing listener by its generated listener ID.
+     */
     removeDefaultPreventingHandler(element, eventName, listenerId) {
         this.removeEventListener(element, eventName, listenerId);
     }
 
+    /**
+     * Adds default-preventing listeners for multiple event names.
+     * Returns listener IDs aligned with the provided event list.
+     */
     addDefaultPreventingHandlers(element, eventNames) {
         const listeners = [];
 
@@ -143,6 +192,9 @@ class MudElementReference {
         return listeners;
     }
 
+    /**
+     * Removes default-preventing listeners for multiple event names.
+     */
     removeDefaultPreventingHandlers(element, eventNames, listenerIds) {
         for (let index = 0; index < eventNames.length; ++index) {
             const eventName = eventNames[index];
@@ -151,19 +203,23 @@ class MudElementReference {
         }
     }
 
-    // ios doesn't trigger Blazor/React/Other dom style blur event so add a base event listener here 
+    // ios doesn't trigger Blazor/React/Other dom style blur event so add a base event listener here
     // that will trigger with IOS Done button and regular blur events
+    /**
+     * Attaches a blur bridge that calls back into .NET.
+     * Used to normalize blur behavior on iOS virtual keyboard flows.
+     */
     addOnBlurEvent(element, dotNetReference) {
         if (!element) return;
 
         element._mudBlurHandler = function (e) {
             if (!element || !document.contains(element)) {
-                // Element is no longer in the DOM, clean up
+                // iOS keyboard flows can blur after disposal; clean up to prevent stale callbacks.
                 window.mudElementRef.removeOnBlurEvent(element);
                 return;
             }
             e.preventDefault();
-            
+
             if (dotNetReference) {
                 dotNetReference.invokeMethodAsync('CallOnBlurredAsync').catch(err => {
                     console.warn("Error invoking CallOnBlurredAsync, possibly disposed:", err);
@@ -177,6 +233,9 @@ class MudElementReference {
         element.addEventListener('blur', element._mudBlurHandler);
     }
 
+    /**
+     * Detaches the blur bridge previously installed by addOnBlurEvent.
+     */
     removeOnBlurEvent(element) {
         if (!element) return;
         if (element._mudBlurHandler) {

--- a/src/MudBlazor/TScripts/mudFileUpload.js
+++ b/src/MudBlazor/TScripts/mudFileUpload.js
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 // noinspection JSUnusedGlobalSymbols
-
 /**
  * Programmatic file picker trigger for the file upload component.
  * Prefers `showPicker()` and falls back to `click()` for broader browser support.
  */
 class MudFileUpload {
+    /**
+     * Opens the file picker for the target input element.
+     */
     openFilePicker (id) {
         const element = document.getElementById(id);
 
@@ -17,17 +19,10 @@ class MudFileUpload {
         }
 
         try {
-            // only supported starting with Safari 16.4+
-            // // checking for user activation because browsers won't execute showPicker() without it
-            // if (!navigator.userActivation.isActive)
-            // {
-            //     return;
-            // }
-
-            // more reliable than click() and works in Safari
+            // Prefer showPicker when available because it follows native picker semantics more consistently.
             element.showPicker();
         } catch (_) {
-            // fallback
+            // click() keeps older engines working when showPicker is unavailable/restricted.
             element.click();
         }
     }

--- a/src/MudBlazor/TScripts/mudFileUpload.js
+++ b/src/MudBlazor/TScripts/mudFileUpload.js
@@ -1,3 +1,7 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 // noinspection JSUnusedGlobalSymbols
 
 // Programmatic file picker trigger for MudFileUpload.

--- a/src/MudBlazor/TScripts/mudFileUpload.js
+++ b/src/MudBlazor/TScripts/mudFileUpload.js
@@ -4,9 +4,10 @@
 
 // noinspection JSUnusedGlobalSymbols
 
-// Programmatic file picker trigger for MudFileUpload.
-// Used by the file upload component interop.
-// `showPicker()` is preferred to match native picker behavior in newer Safari; `click()` is the fallback.
+/**
+ * Programmatic file picker trigger for the file upload component.
+ * Prefers `showPicker()` and falls back to `click()` for broader browser support.
+ */
 class MudFileUpload {
     openFilePicker (id) {
         const element = document.getElementById(id);

--- a/src/MudBlazor/TScripts/mudFileUpload.js
+++ b/src/MudBlazor/TScripts/mudFileUpload.js
@@ -1,5 +1,8 @@
 // noinspection JSUnusedGlobalSymbols
 
+// Programmatic file picker trigger for MudFileUpload.
+// Used by the file upload component interop.
+// `showPicker()` is preferred to match native picker behavior in newer Safari; `click()` is the fallback.
 class MudFileUpload {
     openFilePicker (id) {
         const element = document.getElementById(id);

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -2,6 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Cross-cutting DOM helpers shared by multiple TScripts and chart components.
+// Primary consumers:
+// - Element reference focus navigation helpers (`getTabbableElements`)
+// - Chart sizing/measurement flows (`mudGetSvgBBox`, `mudObserveElementSize`)
 window.getTabbableElements = (element) => {
     return element.querySelectorAll(
         "a[href]:not([tabindex='-1'])," +
@@ -17,7 +21,8 @@ window.getTabbableElements = (element) => {
     );
 };
 
-//from: https://github.com/RemiBou/BrowserInterop
+// Legacy serializer kept on `window` for JS interop payload normalization in browser-only call paths.
+// Source inspiration: https://github.com/RemiBou/BrowserInterop
 function serializeParameter(data, spec) {
     if (typeof data == "undefined" ||
         data === null) {

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -2,10 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Cross-cutting DOM helpers shared by multiple TScripts and chart components.
-// Primary consumers:
-// - Element reference focus navigation helpers (`getTabbableElements`)
-// - Chart sizing/measurement flows (`mudGetSvgBBox`, `mudObserveElementSize`)
+/**
+ * Cross-cutting DOM helpers shared by interop modules and chart sizing flows.
+ * Exposes small global utilities consumed by other TScripts and component interop calls.
+ */
 window.getTabbableElements = (element) => {
     return element.querySelectorAll(
         "a[href]:not([tabindex='-1'])," +

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -6,6 +6,10 @@
  * Cross-cutting DOM helpers shared by interop modules and chart sizing flows.
  * Exposes small global utilities consumed by other TScripts and component interop calls.
  */
+
+/**
+ * Returns tabbable descendants used by focus-management helpers.
+ */
 window.getTabbableElements = (element) => {
     return element.querySelectorAll(
         "a[href]:not([tabindex='-1'])," +
@@ -21,6 +25,9 @@ window.getTabbableElements = (element) => {
     );
 };
 
+/**
+ * Serializes complex browser objects into interop-safe plain data.
+ */
 // Legacy serializer kept on `window` for JS interop payload normalization in browser-only call paths.
 // Source inspiration: https://github.com/RemiBou/BrowserInterop
 function serializeParameter(data, spec) {
@@ -75,8 +82,6 @@ function serializeParameter(data, spec) {
                     res[i] = serializeParameter(currentMember, currentMemberSpec);
                 }
             }
-
-
         } else {
             // string, number or boolean
             if (currentMember === Infinity) { //infinity is not serialized by JSON.stringify
@@ -93,7 +98,9 @@ function serializeParameter(data, spec) {
 
 window.serializeParameter = serializeParameter;
 
-// mudGetSvgBBox is a helper function to get the size of an svgElement
+/**
+ * Returns the SVG bounding box in a plain object for .NET interop.
+ */
 window.mudGetSvgBBox = (svgElement) => {
     if (svgElement == null) return null;
 
@@ -106,9 +113,10 @@ window.mudGetSvgBBox = (svgElement) => {
     };
 };
 
-// mudObserveElementSize is a helper function to observe the size of an element and notify a .NET reference.
-// It will automatically unobserve when the element is removed from the DOM.
-// The notification will be throttled to at most once every debounceMillis (defaults to 200ms).
+/**
+ * Observes element size changes and forwards throttled updates to a .NET callback.
+ * Automatically stops observing when the element is removed from the DOM.
+ */
 window.mudObserveElementSize = (dotNetReference, element, functionName = 'OnElementSizeChanged', debounceMillis = 200) => {
     if (!element) return;
 

--- a/src/MudBlazor/TScripts/mudHotkeyListener.js
+++ b/src/MudBlazor/TScripts/mudHotkeyListener.js
@@ -18,16 +18,25 @@ class MudHotkeyListener {
         document.addEventListener(this._EVENT_TYPE, this._handleKeyEventBound);
     }
 
+    /**
+     * Releases global keyboard listeners.
+     */
     dispose() {
         document.removeEventListener(this._EVENT_TYPE, this._handleKeyEventBound);
     }
 
+    /**
+     * Registers a hotkey, or replaces an existing definition with the same hotkey ID.
+     */
     registerOrUpdateHotkey(dotnetRef, dotnetMethodId, hotkeyId, key, modifiers, preventDefault) {
         modifiers = modifiers || [];
         const newHotkey = this._createHotkey(dotnetRef, dotnetMethodId, hotkeyId, key, modifiers, preventDefault);
         this._hotkeys.set(hotkeyId, newHotkey);
     }
 
+    /**
+     * Removes a previously registered hotkey by ID.
+     */
     unregisterHotkey(hotkeyId) {
         if (this._hotkeys.has(hotkeyId)) {
             this._hotkeys.delete(hotkeyId);
@@ -56,6 +65,7 @@ class MudHotkeyListener {
 
             const allModifiersPressed = [...hotkey.modifiers].every(m => pressedModifiers.has(m));
             const noExtraModifiersPressed = [...pressedModifiers].every(m => hotkey.modifiers.has(m));
+            // Require an exact modifier match so broader shortcuts do not shadow more specific ones.
             if (allModifiersPressed && noExtraModifiersPressed) {
                 if (hotkey.preventDefault) {
                     e.preventDefault();
@@ -72,6 +82,7 @@ class MudHotkeyListener {
                     });
                 }
 
+                // Stop at first match to preserve deterministic registration order.
                 break;
             }
         }

--- a/src/MudBlazor/TScripts/mudHotkeyListener.js
+++ b/src/MudBlazor/TScripts/mudHotkeyListener.js
@@ -1,3 +1,7 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 "use strict";
 
 // noinspection JSUnusedGlobalSymbols

--- a/src/MudBlazor/TScripts/mudHotkeyListener.js
+++ b/src/MudBlazor/TScripts/mudHotkeyListener.js
@@ -7,7 +7,7 @@
 // noinspection JSUnusedGlobalSymbols
 /**
  * Companion interop for the MudHotkey component.
- * Matching requires exact modifier sets so the same shortcut is not triggered by "extra key" combinations.
+ * Matches exact key-plus-modifier combinations to avoid accidental overlaps.
  */
 class MudHotkeyListener {
     constructor() {

--- a/src/MudBlazor/TScripts/mudHotkeyListener.js
+++ b/src/MudBlazor/TScripts/mudHotkeyListener.js
@@ -1,7 +1,10 @@
 "use strict";
 
 // noinspection JSUnusedGlobalSymbols
-/** This is the companion class for the MudBlazor.MudHotkey component. */
+/**
+ * Companion interop for the MudHotkey component.
+ * Matching requires exact modifier sets so the same shortcut is not triggered by "extra key" combinations.
+ */
 class MudHotkeyListener {
     constructor() {
         this._EVENT_TYPE = "keydown";

--- a/src/MudBlazor/TScripts/mudInput.js
+++ b/src/MudBlazor/TScripts/mudInput.js
@@ -8,6 +8,9 @@
  * Keeps updates caret-safe while still dispatching native `input` events.
  */
 class MudInput {
+    /**
+     * Clears the value of an input element by ID.
+     */
     resetValue(id) {
         const input = document.getElementById(id);
         if (input) {
@@ -15,10 +18,16 @@ class MudInput {
         }
     }
 
+    /**
+     * Returns the current caret start position.
+     */
     getCaretPosition(element) {
         return element.selectionStart;
     }
 
+    /**
+     * Inserts text at the current selection/caret position.
+     */
     insertAtCurrentCaretPosition(element, text) {
         const start = element.selectionStart !== null && element.selectionStart !== undefined ? element.selectionStart : 0;
         const end = element.selectionEnd !== null && element.selectionEnd !== undefined ? element.selectionEnd : start;
@@ -26,6 +35,9 @@ class MudInput {
         this._insertText(element, text, start, end);
     }
 
+    /**
+     * Inserts text at a specific character position.
+     */
     insertAtPosition(element, text, position) {
         const value = element.value !== null && element.value !== undefined ? element.value : '';
         const insertPos = this._clampPosition(position, value.length);
@@ -48,6 +60,7 @@ class MudInput {
             element.selectionStart = element.selectionEnd = newCaretPos;
         }
 
+        // Keep Blazor/input bindings in sync when value is mutated from JS.
         element.dispatchEvent(new Event('input', {bubbles: true}));
     }
 

--- a/src/MudBlazor/TScripts/mudInput.js
+++ b/src/MudBlazor/TScripts/mudInput.js
@@ -2,11 +2,11 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Text input editing interop for:
-// - text field caret APIs and insertion helpers
-// - file upload input reset (`resetValue`)
-// It centralizes caret-safe insertion logic so input updates still raise native `input` events.
 // noinspection JSUnusedGlobalSymbols
+/**
+ * Text input interop for caret APIs, insertion helpers, and value reset.
+ * Keeps updates caret-safe while still dispatching native `input` events.
+ */
 class MudInput {
     resetValue(id) {
         const input = document.getElementById(id);

--- a/src/MudBlazor/TScripts/mudInput.js
+++ b/src/MudBlazor/TScripts/mudInput.js
@@ -2,6 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Text input editing interop for:
+// - text field caret APIs and insertion helpers
+// - file upload input reset (`resetValue`)
+// It centralizes caret-safe insertion logic so input updates still raise native `input` events.
 // noinspection JSUnusedGlobalSymbols
 class MudInput {
     resetValue(id) {

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2023
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Auto-grow textarea behavior for the MudInput component.
-// Height adjustments run in JS to read live layout metrics and preserve ancestor scroll positions during reflow.
+/**
+ * Auto-grow textarea sizing logic for the MudInput component.
+ * Uses live layout metrics and restores ancestor scroll positions during reflow.
+ */
 window.mudInputSizing = {
     init: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Auto-grow textarea behavior for the MudInput component.
+// Height adjustments run in JS to read live layout metrics and preserve ancestor scroll positions during reflow.
 window.mudInputSizing = {
     init: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -7,6 +7,9 @@
  * Uses live layout metrics and restores ancestor scroll positions during reflow.
  */
 window.mudInputSizing = {
+    /**
+     * Initializes auto-sizing behavior for a textarea element.
+     */
     init: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);
         const lineHeight = parseFloat(compStyle.getPropertyValue('line-height'));
@@ -89,11 +92,17 @@ window.mudInputSizing = {
         elem.updateParameters(maxLines);
         elem.adjustSizingHeight();
     },
+    /**
+     * Recalculates the current textarea height.
+     */
     adjustHeight: (elem) => {
         if (typeof elem.adjustSizingHeight === 'function') {
             elem.adjustSizingHeight();
         }
     },
+    /**
+     * Updates auto-sizing parameters and reapplies sizing.
+     */
     updateParams: (elem, maxLines) => {
         if (typeof elem.updateParameters === 'function') {
             elem.updateParameters(maxLines);
@@ -102,6 +111,9 @@ window.mudInputSizing = {
             elem.adjustSizingHeight();
         }
     },
+    /**
+     * Removes auto-sizing listeners and restores the element's original sizing state.
+     */
     destroy: (elem) => {
         if (elem == null) {
             return;

--- a/src/MudBlazor/TScripts/mudJsEvent.js
+++ b/src/MudBlazor/TScripts/mudJsEvent.js
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Dynamic event bridge used by the JsEvent service.
+// It observes subtree mutations so handlers stay attached even when matching child nodes are re-rendered by Blazor.
 class MudJsEventFactory {
     connect(dotNetRef, elementId, options) {
         //console.log('[MudBlazor | MudJsEventFactory] connect ', { dotNetRef, elementId, options });
@@ -223,4 +225,3 @@ class MudJsEvent {
         }
     }
 }
-

--- a/src/MudBlazor/TScripts/mudJsEvent.js
+++ b/src/MudBlazor/TScripts/mudJsEvent.js
@@ -7,6 +7,9 @@
  * Provides connect/subscribe lifecycle entry points for .NET interop.
  */
 class MudJsEventFactory {
+    /**
+     * Creates (or reuses) a JsEvent observer for the element and starts observing it.
+     */
     connect(dotNetRef, elementId, options) {
         //console.log('[MudBlazor | MudJsEventFactory] connect ', { dotNetRef, elementId, options });
         if (!elementId)
@@ -19,6 +22,9 @@ class MudJsEventFactory {
         element.mudJsEvent.connect(element);
     }
 
+    /**
+     * Stops observing and detaches handlers for an element ID.
+     */
     disconnect(elementId) {
         const element = document.getElementById(elementId);
         if (!element || !element.mudJsEvent)
@@ -26,6 +32,9 @@ class MudJsEventFactory {
         element.mudJsEvent.disconnect();
     }
 
+    /**
+     * Subscribes a logical event name for matching child elements.
+     */
     subscribe(elementId, eventName) {
         //console.log('[MudBlazor | MudJsEventFactory] subscribe ', { elementId, eventName});
         if (!elementId)
@@ -38,6 +47,9 @@ class MudJsEventFactory {
         element.mudJsEvent.subscribe(eventName);
     }
 
+    /**
+     * Unsubscribes a logical event name for matching child elements.
+     */
     unsubscribe(elementId, eventName) {
         const element = document.getElementById(elementId);
         if (!element || !element.mudJsEvent)
@@ -52,7 +64,6 @@ window.mudJsEvent = new MudJsEventFactory();
  * Keeps subscriptions stable across dynamic DOM changes from re-rendering.
  */
 class MudJsEvent {
-
     constructor(dotNetRef, options) {
         this._dotNetRef = dotNetRef;
         this._options = options || {};
@@ -61,6 +72,9 @@ class MudJsEvent {
         this._subscribedEvents = {};
     }
 
+    /**
+     * Starts DOM observation for child nodes matching the configured target class.
+     */
     connect(element) {
         if (!this._options)
             return;
@@ -74,11 +88,15 @@ class MudJsEvent {
         this.logger('[MudBlazor | JsEvent] Start observing DOM of element for changes to child with class ', { element, targetClass });
         this._element = element;
         this._observer = new MutationObserver(this.onDomChanged);
+        // MutationObserver callbacks do not preserve class context, so keep an explicit back-reference.
         this._observer.mudJsEvent = this;
         this._observer.observe(this._element, { attributes: false, childList: true, subtree: true });
         this._observedChildren = [];
     }
 
+    /**
+     * Stops DOM observation and removes all active handlers.
+     */
     disconnect() {
         if (!this._observer)
             return;
@@ -89,6 +107,9 @@ class MudJsEvent {
             this.detachHandlers(child);
     }
 
+    /**
+     * Enables forwarding for one event name on matching child nodes.
+     */
     subscribe(eventName) {
         // register handlers
         if (this._subscribedEvents[eventName]) {
@@ -104,10 +125,14 @@ class MudJsEvent {
         }
     }
 
+    /**
+     * Disables forwarding for one event name on matching child nodes.
+     */
     unsubscribe(eventName) {
         if (!this._observer)
             return;
         this.logger('[MudBlazor | JsEvent] unsubscribe event handler ' + eventName );
+        // Pause observation while unsubscribing so removed handlers are not reattached by concurrent mutations.
         this._observer.disconnect();
         this._observer = null;
         this._subscribedEvents[eventName] = false;
@@ -116,7 +141,11 @@ class MudJsEvent {
         }
     }
 
+    /**
+     * Attaches currently subscribed event handlers to a matching child node.
+     */
     attachHandlers(child) {
+        // Event callbacks execute with `this === child`, so we stash the owning instance on the node.
         child.mudJsEvent = this;
         //this.logger('[MudBlazor | JsEvent] attachHandlers ', this._subscribedEvents, child);
         for (const eventName of Object.getOwnPropertyNames(this._subscribedEvents)) {
@@ -130,11 +159,17 @@ class MudJsEvent {
             this._observedChildren.push(child);
     }
 
+    /**
+     * Removes a single event handler from a child node.
+     */
     detachHandler(child, eventName) {
         this.logger('[MudBlazor | JsEvent] detaching handler ' + eventName, child);
         child.removeEventListener(eventName, this.eventHandler);
     }
 
+    /**
+     * Removes all subscribed event handlers from a child node.
+     */
     detachHandlers(child) {
         this.logger('[MudBlazor | JsEvent] detaching handlers ', child);
         for (const eventName of Object.getOwnPropertyNames(this._subscribedEvents)) {
@@ -145,6 +180,9 @@ class MudJsEvent {
         this._observedChildren = this._observedChildren.filter(x=>x!==child);
     }
 
+    /**
+     * Reacts to subtree mutations by attaching/removing handlers on matching nodes.
+     */
     onDomChanged(mutationsList, _) {
         const self = this.mudJsEvent; // func is invoked with this == _observer
         //self.logger('[MudBlazor | JsEvent] onDomChanged: ', { self });
@@ -166,14 +204,20 @@ class MudJsEvent {
         }
     }
 
+    /**
+     * Dispatches DOM events to the corresponding event-specific bridge method.
+     */
     eventHandler(e) {
         const self = this.mudJsEvent; // func is invoked with this == child
         const eventName = e.type;
         self.logger('[MudBlazor | JsEvent] "' + eventName + '"', e);
-        // call specific handler
+        // Dynamic dispatch keeps DOM event names aligned with their bridge methods (onkeyup, onpaste, ...).
         self["on" + eventName](self, e);
     }
 
+    /**
+     * Forwards caret changes from keyup to .NET.
+     */
     onkeyup(self, e) {
         const caretPosition = e.target.selectionStart;
         const invoke = self._subscribedEvents["keyup"];
@@ -183,6 +227,9 @@ class MudJsEvent {
         }
     }
 
+    /**
+     * Forwards caret changes from click events to .NET.
+     */
     onclick(self, e) {
         const caretPosition = e.target.selectionStart;
         const invoke = self._subscribedEvents["click"];
@@ -202,6 +249,9 @@ class MudJsEvent {
     //    }
     //}
 
+    /**
+     * Intercepts paste text and forwards plain text content to .NET.
+     */
     onpaste(self, e) {
         const invoke = self._subscribedEvents["paste"];
         if (invoke) {
@@ -218,6 +268,9 @@ class MudJsEvent {
         }
     }
 
+    /**
+     * Forwards selected text range changes to .NET.
+     */
     onselect(self, e) {
         const invoke = self._subscribedEvents["select"];
         if (invoke) {

--- a/src/MudBlazor/TScripts/mudJsEvent.js
+++ b/src/MudBlazor/TScripts/mudJsEvent.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Dynamic event bridge used by the JsEvent service.
-// It observes subtree mutations so handlers stay attached even when matching child nodes are re-rendered by Blazor.
+/**
+ * Factory that wires element IDs to MudJsEvent instances.
+ * Provides connect/subscribe lifecycle entry points for .NET interop.
+ */
 class MudJsEventFactory {
     connect(dotNetRef, elementId, options) {
         //console.log('[MudBlazor | MudJsEventFactory] connect ', { dotNetRef, elementId, options });
@@ -45,7 +47,10 @@ class MudJsEventFactory {
 }
 window.mudJsEvent = new MudJsEventFactory();
 
-
+/**
+ * Observes a container and attaches configured event handlers to matching children.
+ * Keeps subscriptions stable across dynamic DOM changes from re-rendering.
+ */
 class MudJsEvent {
 
     constructor(dotNetRef, options) {

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -2,10 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Key interception bridge used by:
-// - KeyInterceptor interop adapter
-// - KeyInterceptor service consumers
-// Options are applied in JS first so preventDefault/stopPropagation happen before Blazor handlers run.
+/**
+ * Factory that resolves elements and manages MudKeyInterceptor instances.
+ * Exposes connect/update/disconnect entry points for .NET interop.
+ */
 class MudKeyInterceptorFactory {
 
     connect(dotNetRef, elementId, options) {
@@ -36,6 +36,10 @@ class MudKeyInterceptorFactory {
 }
 window.mudKeyInterceptor = new MudKeyInterceptorFactory();
 
+/**
+ * Applies key options and raises keyboard callbacks to .NET.
+ * Handles preventDefault/stopPropagation in JS before component handlers run.
+ */
 class MudKeyInterceptor {
 
     constructor(dotNetRef, options) {

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -7,7 +7,9 @@
  * Exposes connect/update/disconnect entry points for .NET interop.
  */
 class MudKeyInterceptorFactory {
-
+    /**
+     * Creates (or reuses) a key interceptor for an element and attaches handlers.
+     */
     connect(dotNetRef, elementId, options) {
         //console.log('[MudBlazor | MudKeyInterceptorFactory] connect ', { dotNetRef, element, options });
         if (!elementId)
@@ -20,6 +22,9 @@ class MudKeyInterceptorFactory {
         element.mudKeyInterceptor.connect(element);
     }
 
+    /**
+     * Updates the key option for an existing interceptor registration.
+     */
     updatekey(elementId, option) {
         const element = document.getElementById(elementId);
         if (!element || !element.mudKeyInterceptor)
@@ -27,6 +32,9 @@ class MudKeyInterceptorFactory {
         element.mudKeyInterceptor.updatekey(option);
     }
 
+    /**
+     * Detaches a key interceptor from an element.
+     */
     disconnect(elementId) {
         const element = document.getElementById(elementId);
         if (!element || !element.mudKeyInterceptor)
@@ -41,7 +49,6 @@ window.mudKeyInterceptor = new MudKeyInterceptorFactory();
  * Handles preventDefault/stopPropagation in JS before component handlers run.
  */
 class MudKeyInterceptor {
-
     constructor(dotNetRef, options) {
         this._dotNetRef = dotNetRef;
         this._options = options;
@@ -49,6 +56,9 @@ class MudKeyInterceptor {
         this.logger('[MudBlazor | KeyInterceptor] Interceptor initialized', { options });
     }
 
+    /**
+     * Starts key interception on the target element (or matching child elements).
+     */
     connect(element) {
         if (!this._options)
             return;
@@ -92,6 +102,9 @@ class MudKeyInterceptor {
         }
     }
 
+    /**
+     * Normalizes and stores one key option definition.
+     */
     setKeyOption(keyOption) {
         if (keyOption.key.length > 2 && keyOption.key.startsWith('/') && keyOption.key.endsWith('/')) {
             // JS regex key options such as "/[a-z]/" or "/a|b/" but NOT "/[a-z]/g" or "/[a-z]/i"
@@ -99,6 +112,7 @@ class MudKeyInterceptor {
             this._regexOptions.push(keyOption);
         }
         else
+            // Normalize direct lookups to lowercase once so event handlers can stay allocation-light.
             this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
         // remove whitespace and enforce lowercase
         const whitespace = new RegExp("\\s", "g");
@@ -108,6 +122,9 @@ class MudKeyInterceptor {
         keyOption.stopUp = (keyOption.stopUp || "none").replace(whitespace, "").toLowerCase();
     }
 
+    /**
+     * Updates an existing key option definition.
+     */
     updatekey(updatedOption) {
         const option = this._keyOptions[updatedOption.key.toLowerCase()];
         option || this.logger('[MudBlazor | KeyInterceptor] updating option failed: key not registered');
@@ -115,6 +132,9 @@ class MudKeyInterceptor {
         this.logger('[MudBlazor | KeyInterceptor] updated option ', { option, updatedOption });
     }
 
+    /**
+     * Stops interception and detaches all listeners.
+     */
     disconnect() {
         if (!this._isConnected)
             return;
@@ -128,6 +148,9 @@ class MudKeyInterceptor {
         this._isConnected = false;
     }
 
+    /**
+     * Attaches keydown/keyup handlers to a target element.
+     */
     attachHandlers(child) {
         this.logger('[MudBlazor | KeyInterceptor] attaching handlers ', { child });
         if (this._observedChildren.indexOf(child) > -1) {
@@ -140,6 +163,9 @@ class MudKeyInterceptor {
         this._observedChildren.push(child);
     }
 
+    /**
+     * Detaches keydown/keyup handlers from a target element.
+     */
     detachHandlers(child) {
         this.logger('[MudBlazor | KeyInterceptor] detaching handlers ', { child });
         child.removeEventListener('keydown', this.onKeyDown);
@@ -147,6 +173,9 @@ class MudKeyInterceptor {
         this._observedChildren = this._observedChildren.filter(x=>x!==child);
     }
 
+    /**
+     * Applies handler attachment/detachment for added/removed matching DOM nodes.
+     */
     onDomChanged(mutationsList, _) {
         const self = this.mudKeyInterceptor; // func is invoked with this == _observer
         //self.logger('[MudBlazor | KeyInterceptor] onDomChanged: ', { self });
@@ -164,6 +193,9 @@ class MudKeyInterceptor {
         }
     }
 
+    /**
+     * Checks whether current modifier state matches an option expression.
+     */
     matchesKeyCombination(option, args) {
         if (!option || option === "none")
             return false;
@@ -184,6 +216,9 @@ class MudKeyInterceptor {
         return option.includes(combi);
     }
 
+    /**
+     * Processes keydown behavior and invokes .NET when configured.
+     */
     onKeyDown(args) {
         const self = this.mudKeyInterceptor; // func is invoked with this == child
         if (!args.key) {
@@ -202,6 +237,7 @@ class MudKeyInterceptor {
                 invoke = true;
         }
         for (const keyOptions of self._regexOptions) {
+            // Regex options allow wildcard key rules without precomputing every key in JS.
             if (keyOptions.regex.test(key)) {
                 self.logger('[MudBlazor | KeyInterceptor] regex options for "' + key + '"', keyOptions);
                 self.processKeyDown(args, keyOptions);
@@ -216,6 +252,9 @@ class MudKeyInterceptor {
         }
     }
 
+    /**
+     * Applies preventDefault/stopPropagation rules for keydown.
+     */
     processKeyDown(args, keyOptions) {
         if (this.matchesKeyCombination(keyOptions.preventDown, args))
             args.preventDefault();
@@ -223,10 +262,16 @@ class MudKeyInterceptor {
             args.stopPropagation();
     }
 
+    /**
+     * Returns whether keydown should be forwarded to .NET.
+     */
     shouldInvokeKeyDown(args, keyOptions) {
         return keyOptions.subscribeDown && (!keyOptions.ignoreDownRepeats || !args.repeat);
     }
 
+    /**
+     * Processes keyup behavior and invokes .NET when configured.
+     */
     onKeyUp(args) {
         const self = this.mudKeyInterceptor; // func is invoked with this == child
         if (!args.key) {
@@ -257,6 +302,9 @@ class MudKeyInterceptor {
         }
     }
 
+    /**
+     * Applies preventDefault/stopPropagation rules for keyup.
+     */
     processKeyUp(args, keyOptions) {
         if (this.matchesKeyCombination(keyOptions.preventUp, args))
             args.preventDefault();
@@ -264,6 +312,9 @@ class MudKeyInterceptor {
             args.stopPropagation();
     }
 
+    /**
+     * Converts a DOM keyboard event to the .NET keyboard event payload shape.
+     */
     toKeyboardEventArgs(args) {
         return {
             Key: args.key,

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -2,6 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Key interception bridge used by:
+// - KeyInterceptor interop adapter
+// - KeyInterceptor service consumers
+// Options are applied in JS first so preventDefault/stopPropagation happen before Blazor handlers run.
 class MudKeyInterceptorFactory {
 
     connect(dotNetRef, elementId, options) {
@@ -270,4 +274,3 @@ class MudKeyInterceptor {
     }
 
 }
-

--- a/src/MudBlazor/TScripts/mudPointerCapture.js
+++ b/src/MudBlazor/TScripts/mudPointerCapture.js
@@ -2,7 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Simple helper for pointer capture in DataGrid column resizing
+// Pointer capture helper for DataGrid column resizing.
+// Used during DataGrid header resize interactions.
+// Wrapping these calls keeps feature checks in one place for browsers with partial Pointer Events support.
 window.mudPointerCapture = {
     capture: function (element, pointerId) {
         if (element && typeof element.setPointerCapture === 'function') {

--- a/src/MudBlazor/TScripts/mudPointerCapture.js
+++ b/src/MudBlazor/TScripts/mudPointerCapture.js
@@ -7,12 +7,17 @@
  * Centralizes feature checks for browsers with partial Pointer Events support.
  */
 window.mudPointerCapture = {
+    /**
+     * Captures pointer events to the given element for the active pointer ID.
+     */
     capture: function (element, pointerId) {
         if (element && typeof element.setPointerCapture === 'function') {
             element.setPointerCapture(pointerId);
         }
     },
-    
+    /**
+     * Releases pointer capture for the given element and pointer ID.
+     */
     release: function (element, pointerId) {
         if (element && typeof element.releasePointerCapture === 'function') {
             element.releasePointerCapture(pointerId);

--- a/src/MudBlazor/TScripts/mudPointerCapture.js
+++ b/src/MudBlazor/TScripts/mudPointerCapture.js
@@ -2,9 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Pointer capture helper for DataGrid column resizing.
-// Used during DataGrid header resize interactions.
-// Wrapping these calls keeps feature checks in one place for browsers with partial Pointer Events support.
+/**
+ * Pointer capture helper used during DataGrid header resize interactions.
+ * Centralizes feature checks for browsers with partial Pointer Events support.
+ */
 window.mudPointerCapture = {
     capture: function (element, pointerId) {
         if (element && typeof element.setPointerCapture === 'function') {

--- a/src/MudBlazor/TScripts/mudPointerEventsNone.js
+++ b/src/MudBlazor/TScripts/mudPointerEventsNone.js
@@ -2,9 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Pointer event recovery for elements intentionally styled with `pointer-events: none`.
-// Used by the pointer-events-none interop/service layer.
-// It temporarily toggles candidate elements to `pointer-events: auto` only for hit-testing at event coordinates.
+/**
+ * Recovers pointer hits for elements intentionally styled with `pointer-events: none`.
+ * Temporarily enables pointer events to perform hit-testing and report matches to .NET.
+ */
 class MudPointerEventsNone {
     constructor() {
         this.dotnet = null;

--- a/src/MudBlazor/TScripts/mudPointerEventsNone.js
+++ b/src/MudBlazor/TScripts/mudPointerEventsNone.js
@@ -16,6 +16,9 @@ class MudPointerEventsNone {
         this.pointerUpMap = new Map();
     }
 
+    /**
+     * Starts global pointer listeners for an element configured with pointer-events-none behavior.
+     */
     listenForPointerEvents(dotNetReference, elementId, options) {
         if (!options) {
             this.logger("options object is required but was not provided");
@@ -72,10 +75,16 @@ class MudPointerEventsNone {
         }
     }
 
+    /**
+     * Handles global pointerdown and routes matching IDs to .NET.
+     */
     pointerDownHandler(event) {
         this._handlePointerEvent(event, this.pointerDownMap, "RaiseOnPointerDown");
     }
 
+    /**
+     * Handles global pointerup and routes matching IDs to .NET.
+     */
     pointerUpHandler(event) {
         this._handlePointerEvent(event, this.pointerUpMap, "RaiseOnPointerUp");
     }
@@ -132,6 +141,9 @@ class MudPointerEventsNone {
         this.dotnet.invokeMethodAsync(raiseMethod, matchingIds);
     }
 
+    /**
+     * Stops pointer listener participation for a specific element ID.
+     */
     cancelListener(elementId) {
         if (!elementId) {
             this.logger("cancelListener called with invalid elementId");
@@ -160,6 +172,9 @@ class MudPointerEventsNone {
         }
     }
 
+    /**
+     * Removes global listeners and clears all tracked element subscriptions.
+     */
     dispose() {
         if (!this.dotnet && !this.pointerDownHandlerRef && !this.pointerUpHandlerRef) {
             this.logger("dispose() called but instance was already cleaned up");

--- a/src/MudBlazor/TScripts/mudPointerEventsNone.js
+++ b/src/MudBlazor/TScripts/mudPointerEventsNone.js
@@ -2,6 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Pointer event recovery for elements intentionally styled with `pointer-events: none`.
+// Used by the pointer-events-none interop/service layer.
+// It temporarily toggles candidate elements to `pointer-events: auto` only for hit-testing at event coordinates.
 class MudPointerEventsNone {
     constructor() {
         this.dotnet = null;

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -2,9 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Core placement engine for all MudBlazor popovers/tooltips/menus.
-// Interop entry points are called from the popover interop adapter/service.
-// This file owns collision handling, flip logic, and observer lifecycle so C# only manages popover state.
+/**
+ * Core placement helpers for popovers, tooltips, and menus.
+ * Owns collision handling, flip logic, and shared repositioning behavior.
+ */
 window.mudpopoverHelper = {
     // set by the class MudPopover in initialize
     mainContainerClass: null,
@@ -781,6 +782,10 @@ window.mudpopoverHelper = {
     }
 };
 
+/**
+ * Manages popover lifecycle, observers, and event subscriptions.
+ * Coordinates helper-driven positioning with open/close state transitions.
+ */
 class MudPopover {
 
     constructor() {

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -787,7 +787,6 @@ window.mudpopoverHelper = {
  * Coordinates helper-driven positioning with open/close state transitions.
  */
 class MudPopover {
-
     constructor() {
         this.map = {};
         this.contentObserver = null;
@@ -796,7 +795,9 @@ class MudPopover {
         this.onScrollableNodes = (node) => window.mudpopoverHelper.handleScroll(node);
     }
 
-    // adds scroll listeners to node + parents up to body
+    /**
+     * Registers scroll listeners on scrollable ancestors up to the body element.
+     */
     popoverScrollListener(node) {
         let currentNode = node.parentNode;
         const scrollableElements = [];
@@ -818,6 +819,9 @@ class MudPopover {
         return scrollableElements;
     }
 
+    /**
+     * Creates resize/scroll observers required for one popover instance.
+     */
     createObservers(id) {
         // make sure observer lists are starting clear
         this.disposeObservers(id);
@@ -856,6 +860,9 @@ class MudPopover {
         }
     }
 
+    /**
+     * Disposes resize/scroll observers and listeners for one popover instance.
+     */
     disposeObservers(id) {
         // Get references to items that need cleanup
         const { scrollableElements, parentResizeObserver } = this.map[id];
@@ -879,6 +886,9 @@ class MudPopover {
         this.map[id].parentResizeObserver = null;
     }
 
+    /**
+     * Activates observers and performs transition-aware repositioning for an opened popover.
+     */
     openPopover(target, id) {
         // create observers for this popover (resizeObserver and scroll Listeners)
         this.createObservers(id);
@@ -896,6 +906,9 @@ class MudPopover {
         }, interval);
     }
 
+    /**
+     * Handles provider mutations that affect popover open state and placement.
+     */
     callbackPopover(mutation) {
         // good viewertests to check anytime you make a change
         // DrawerDialogSelectTest, OverlayNestedFreezeTest, OverlayDialogTest, PopoverDataGridFilterOptionsTest
@@ -955,6 +968,9 @@ class MudPopover {
         }
     }
 
+    /**
+     * Initializes the popover runtime and global observers for the provider container.
+     */
     initialize(containerClass, flipMargin, overflowPadding) {
         // only happens when the PopoverService is created which happens on application start and anytime the service might crash
         // "mud-popover-provider" is the default name of containerClass.
@@ -978,6 +994,9 @@ class MudPopover {
         window.addEventListener('scroll', this.onScroll, { passive: true });
     }
 
+    /**
+     * Ensures the main popover provider container is observed for relevant mutations.
+     */
     observeMainContainer() {
 
         const mainContent = document.body.getElementsByClassName(window.mudpopoverHelper.mainContainerClass);
@@ -1023,6 +1042,9 @@ class MudPopover {
         this.contentObserver = observer;
     }
 
+    /**
+     * Computes the maximum transition/animation time across a popover and its ancestors.
+     */
     getTransitionTimes(id) {
         let node = document.getElementById(`popover-${id}`);
         if (!node) {
@@ -1051,6 +1073,9 @@ class MudPopover {
         return maxTime;
     }
 
+    /**
+     * Parses CSS time values (`ms`/`s`) into milliseconds.
+     */
     parseTime(timeStr) {
         if (!timeStr) return 0;
         timeStr = timeStr.trim();
@@ -1154,6 +1179,9 @@ class MudPopover {
         }
     }
 
+    /**
+     * Returns all currently tracked popover IDs.
+     */
     getAllObservedContainers() {
         return Object.keys(this.map);
     }
@@ -1163,6 +1191,9 @@ window.mudpopoverHelper.debouncedResize = window.mudpopoverHelper.debounce(() =>
     window.mudpopoverHelper.placePopoverByClassSelector();
 }, 25);
 
+/**
+ * Repositions popovers after scroll events from body or nested scroll containers.
+ */
 window.mudpopoverHelper.handleScroll = function (node = null) {
     // node is a container scrollable element, doesn't need fixed position or flip always to fire
     // does need itself to be repositioned to stay anchored to where it's at

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -2,6 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Core placement engine for all MudBlazor popovers/tooltips/menus.
+// Interop entry points are called from the popover interop adapter/service.
+// This file owns collision handling, flip logic, and observer lifecycle so C# only manages popover state.
 window.mudpopoverHelper = {
     // set by the class MudPopover in initialize
     mainContainerClass: null,

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -7,7 +7,6 @@
  * Supports throttled callbacks and breakpoint-aware notifications.
  */
 class MudResizeListener {
-
     constructor(id) {
         this.logger = function () { };
         this.options = {};
@@ -18,6 +17,9 @@ class MudResizeListener {
         this.handleResize = this.throttleResizeHandler.bind(this);
     }
 
+    /**
+     * Starts listening for window resize events with the provided options.
+     */
     listenForResize(dotnetRef, options) {
         if (this.dotnet) {
             this.options = options;
@@ -35,6 +37,9 @@ class MudResizeListener {
         this.breakpoint = this.getBreakpoint(window.innerWidth);
     }
 
+    /**
+     * Debounces resize notifications according to reportRate.
+     */
     throttleResizeHandler() {
         clearTimeout(this.throttleResizeHandlerId);
         this.throttleResizeHandlerId = window.setTimeout(
@@ -43,6 +48,9 @@ class MudResizeListener {
         );
     }
 
+    /**
+     * Sends a resize notification to .NET, honoring breakpoint-only mode.
+     */
     resizeHandler() {
         if (this.options.notifyOnBreakpointOnly) {
             const bp = this.getBreakpoint(window.innerWidth);
@@ -76,16 +84,25 @@ class MudResizeListener {
         }
     }
 
+    /**
+     * Stops resize notifications for this listener instance.
+     */
     cancelListener() {
         this.dotnet = undefined;
         window.removeEventListener("resize", this.handleResize);
     }
 
+    /**
+     * Evaluates a media query and returns whether it currently matches.
+     */
     matchMedia(query) {
         const m = window.matchMedia(query).matches;
         return m;
     }
 
+    /**
+     * Returns the current viewport size.
+     */
     getBrowserWindowSize() {
         return {
             height: window.innerHeight,
@@ -93,6 +110,9 @@ class MudResizeListener {
         };
     }
 
+    /**
+     * Maps viewport width to MudBlazor breakpoint index.
+     */
     getBreakpoint(width) {
         if (width >= this.options.breakpointDefinitions["Xxl"])
             return 5;
@@ -112,6 +132,9 @@ class MudResizeListener {
 window.mudResizeListener = new MudResizeListener();
 window.mudResizeListenerFactory = {
     mapping: {},
+    /**
+     * Creates a resize listener for the provided ID when one does not already exist.
+     */
     listenForResize: (dotnetRef, options, id) => {
         const map = window.mudResizeListenerFactory.mapping;
         if (map[id]) {
@@ -123,6 +146,9 @@ window.mudResizeListenerFactory = {
         map[id] = listener;
     },
 
+    /**
+     * Cancels and removes a resize listener by ID.
+     */
     cancelListener: (id) => {
         const map = window.mudResizeListenerFactory.mapping;
 
@@ -135,12 +161,18 @@ window.mudResizeListenerFactory = {
         delete map[id];
     },
 
+    /**
+     * Cancels and removes multiple listeners.
+     */
     cancelListeners: (ids) => {
         for (let i = 0; i < ids.length; i++) {
             window.mudResizeListenerFactory.cancelListener(ids[i]);
         }
     },
 
+    /**
+     * Cancels and removes all listeners managed by the factory.
+     */
     dispose() {
         const map = window.mudResizeListenerFactory.mapping;
         for (const id in map) {

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -2,6 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Viewport resize notifications for BrowserViewportService/Hidden and related responsive components.
+// Called through the resize-listener interop adapter.
+// The factory keeps many logical subscriptions multiplexed over browser resize events.
 class MudResizeListener {
 
     constructor(id) {

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -2,9 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Viewport resize notifications for BrowserViewportService/Hidden and related responsive components.
-// Called through the resize-listener interop adapter.
-// The factory keeps many logical subscriptions multiplexed over browser resize events.
+/**
+ * Viewport resize listener used by responsive services and components.
+ * Supports throttled callbacks and breakpoint-aware notifications.
+ */
 class MudResizeListener {
 
     constructor(id) {

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Element resize observer bridge for the ResizeObserver service.
+// A factory map is used because one .NET service instance can observe many elements over time.
 class MudResizeObserverFactory {
     constructor() {
         this._maps = {};

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -11,6 +11,9 @@ class MudResizeObserverFactory {
         this._maps = {};
     }
 
+    /**
+     * Creates (or reuses) an observer instance for an ID and starts observing elements.
+     */
     connect(id, dotNetRef, elements, elementIds, options) {
         const existingEntry = this._maps[id];
         if (!existingEntry) {
@@ -22,6 +25,9 @@ class MudResizeObserverFactory {
         return result;
     }
 
+    /**
+     * Stops observing a specific element for an observer ID.
+     */
     disconnect(id, element) {
         //I can't think about a case, where this can be called, without observe has been called before
         //however, a check is not harmful either
@@ -31,6 +37,9 @@ class MudResizeObserverFactory {
         }
     }
 
+    /**
+     * Disposes and removes the observer instance for an ID.
+     */
     cancelListener(id) {
         //cancelListener is called during dispose of .net instance
         //in rare cases it could be possible, that no object has been connect so far
@@ -48,7 +57,6 @@ class MudResizeObserverFactory {
  * Aggregates observed element metadata needed for stable interop callbacks.
  */
 class MudResizeObserver {
-
     constructor(dotNetRef, options) {
         this.logger = options.enableLogging ? console.log : () => { };
         this.options = options;
@@ -93,6 +101,9 @@ class MudResizeObserver {
         });
     }
 
+    /**
+     * Forwards accumulated resize changes to .NET.
+     */
     resizeHandler(changes) {
         try {
             this.logger("[MudBlazor | ResizeObserver] OnSizeChanged handler invoked");
@@ -102,6 +113,9 @@ class MudResizeObserver {
         }
     }
 
+    /**
+     * Starts observing all provided elements and returns initial rect snapshots.
+     */
     connect(elements, ids) {
         const result = [];
         this.logger('[MudBlazor | ResizeObserver] Start observing elements...');
@@ -124,6 +138,9 @@ class MudResizeObserver {
         return result;
     }
 
+    /**
+     * Stops observing one element by observer element ID.
+     */
     disconnect(elementId) {
         this.logger('[MudBlazor | ResizeObserver] Try to unobserve element with id', { elementId });
 
@@ -139,6 +156,9 @@ class MudResizeObserver {
         }
     }
 
+    /**
+     * Disconnects the underlying ResizeObserver and clears .NET references.
+     */
     cancelListener() {
         this.logger('[MudBlazor | ResizeObserver] Closing ResizeObserver. Detaching all observed elements');
 
@@ -146,6 +166,4 @@ class MudResizeObserver {
         this._dotNetRef = undefined;
     }
 }
-
-
 window.mudResizeObserver = new MudResizeObserverFactory();

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Element resize observer bridge for the ResizeObserver service.
-// A factory map is used because one .NET service instance can observe many elements over time.
+/**
+ * Factory that maps .NET observer IDs to MudResizeObserver instances.
+ * Enables independent element-observer lifecycles per service instance.
+ */
 class MudResizeObserverFactory {
     constructor() {
         this._maps = {};
@@ -41,6 +43,10 @@ class MudResizeObserverFactory {
     }
 }
 
+/**
+ * Wraps the browser ResizeObserver and forwards size changes to .NET.
+ * Aggregates observed element metadata needed for stable interop callbacks.
+ */
 class MudResizeObserver {
 
     constructor(dotNetRef, options) {

--- a/src/MudBlazor/TScripts/mudRipple.js
+++ b/src/MudBlazor/TScripts/mudRipple.js
@@ -1,10 +1,10 @@
 // Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-//
-// Global ripple effect handler for elements rendered with the `.mud-ripple` CSS class.
-// Used indirectly by button/list/chip/radio/etc components that toggle ripple via their C# parameters.
-// This is event-delegated on `document` so no per-component JS interop registration is required.
+/**
+ * Global ripple effect handler for elements with the `.mud-ripple` class.
+ * Uses document-level event delegation so components do not need per-instance JS registration.
+ */
 
 (function () {
     // Minimum duration (ms) before ripple can start fading out

--- a/src/MudBlazor/TScripts/mudRipple.js
+++ b/src/MudBlazor/TScripts/mudRipple.js
@@ -1,6 +1,10 @@
 // Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+//
+// Global ripple effect handler for elements rendered with the `.mud-ripple` CSS class.
+// Used indirectly by button/list/chip/radio/etc components that toggle ripple via their C# parameters.
+// This is event-delegated on `document` so no per-component JS interop registration is required.
 
 (function () {
     // Minimum duration (ms) before ripple can start fading out

--- a/src/MudBlazor/TScripts/mudRipple.js
+++ b/src/MudBlazor/TScripts/mudRipple.js
@@ -1,6 +1,7 @@
 // Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 /**
  * Global ripple effect handler for elements with the `.mud-ripple` class.
  * Uses document-level event delegation so components do not need per-instance JS registration.

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -1,7 +1,10 @@
 ﻿"use strict";
 
 // noinspection JSUnusedGlobalSymbols
-/** This is the companion class for the MudBlazor.ScrollListener. */
+/**
+ * Companion interop for the ScrollListener service.
+ * It keeps one throttled handler per listener id so multiple components can subscribe independently.
+ */
 class MudScrollListener {
     constructor() {
         this.EVENT_TYPE = "scroll";

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -17,6 +17,9 @@ class MudScrollListener {
         this.targetElements = Object.create(null);
     }
 
+    /**
+     * Starts a throttled scroll subscription for a selector and listener ID.
+     */
     listenForScroll(dotnetReference, listenerId, selector, reportRateMs) {
         if (this.targetElements[listenerId]) {
             this.cancelListener(listenerId);
@@ -37,6 +40,9 @@ class MudScrollListener {
         return element;
     }
 
+    /**
+     * Debounces scroll callbacks according to report rate.
+     */
     throttleScrollHandler(dotnetReference, listenerId, reportRateMs) {
         clearTimeout(this.throttleScrollHandlerIds[listenerId]);
 
@@ -46,6 +52,9 @@ class MudScrollListener {
         );
     }
 
+    /**
+     * Captures current scroll state and forwards it to .NET.
+     */
     scrollHandler(dotnetReference, listenerId) {
         try {
             const scrollData = this._getCurrentScrollPosition(this.targetElements[listenerId]);
@@ -57,6 +66,9 @@ class MudScrollListener {
         }
     }
 
+    /**
+     * Returns current scroll metrics for the provided selector.
+     */
     getCurrentScrollPosition(selector) {
         const element = this._getElementBySelector(selector);
         return this._getCurrentScrollPosition(element);
@@ -82,6 +94,9 @@ class MudScrollListener {
         };
     }
 
+    /**
+     * Stops and removes a scroll subscription by listener ID.
+     */
     cancelListener(listenerId) {
         if (this.throttleScrollHandlerIds[listenerId]) {
             clearTimeout(this.throttleScrollHandlerIds[listenerId]);

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -1,4 +1,8 @@
-﻿"use strict";
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+"use strict";
 
 // noinspection JSUnusedGlobalSymbols
 /**

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -7,7 +7,7 @@
 // noinspection JSUnusedGlobalSymbols
 /**
  * Companion interop for the ScrollListener service.
- * It keeps one throttled handler per listener id so multiple components can subscribe independently.
+ * Keeps one throttled handler per listener ID for independent subscriptions.
  */
 class MudScrollListener {
     constructor() {

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Scroll utility interop used by the ScrollManager service.
-// Centralizing it here keeps DOM/container edge cases out of components (body vs element scrolling, lock nesting).
+/**
+ * Scroll utility interop surface used by the ScrollManager service.
+ * Centralizes DOM/container edge cases such as lock nesting and container fallbacks.
+ */
 class MudScrollManager {
     constructor() {
         this._lockCount = 0; // internal tracking for the # of overlay locks

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Scroll utility interop used by the ScrollManager service.
+// Centralizing it here keeps DOM/container edge cases out of components (body vs element scrolling, lock nesting).
 class MudScrollManager {
     constructor() {
         this._lockCount = 0; // internal tracking for the # of overlay locks

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -11,7 +11,9 @@ class MudScrollManager {
         this._lockCount = 0; // internal tracking for the # of overlay locks
     }
 
-    //scrolls to year in MudDatePicker
+    /**
+     * Scrolls the year list to center a selected year.
+     */
     scrollToYear(elementId) {
         const element = document.getElementById(elementId);
 
@@ -20,8 +22,9 @@ class MudScrollManager {
         }
     }
 
-    // sets the scroll position of the elements container,
-    // to the position of the element with the given element id
+    /**
+     * Scrolls a list container so the target item is aligned to the top.
+     */
     scrollToListItem(elementId) {
         const element = document.getElementById(elementId);
         if (element) {
@@ -32,19 +35,26 @@ class MudScrollManager {
         }
     }
 
-    //scrolls to the selected element. Default is documentElement (i.e., html element)
+    /**
+     * Scrolls the selected container, or the root document element when not found.
+     */
     scrollTo(selector, left, top, behavior) {
         const element = document.querySelector(selector) || document.documentElement;
         element.scrollTo({ left, top, behavior });
     }
 
-    //scrolls the provided selector into view
+    /**
+     * Scrolls the target element into view with centered vertical alignment.
+     */
     scrollIntoView(selector, behavior) {
         const element = document.querySelector(selector) || document.documentElement;
         if (element)
             element.scrollIntoView({ behavior, block: 'center', inline: 'start' });
     }
 
+    /**
+     * Scrolls a container (or page) to its bottom edge.
+     */
     scrollToBottom(selector, behavior) {
         const element = document.querySelector(selector);
         if (element) {
@@ -60,7 +70,9 @@ class MudScrollManager {
         }
     }
 
-    //locks the scroll of the selected element. Default is body
+    /**
+     * Adds a scroll-lock class with lock counting to support nested overlays.
+     */
     lockScroll(selector, lockclass) {
         if (this._lockCount === 0) {
             const element = document.querySelector(selector) || document.body;
@@ -74,7 +86,9 @@ class MudScrollManager {
         this._lockCount++;
     }
 
-    //unlocks the scroll. Default is body
+    /**
+     * Removes one scroll lock and unlocks when the lock count reaches zero.
+     */
     unlockScroll(selector, lockclass) {
         this._lockCount = Math.max(0, this._lockCount - 1); // subtract 1 or stop at 0
         if (this._lockCount === 0) {
@@ -85,6 +99,9 @@ class MudScrollManager {
         }
     }
 
+    /**
+     * Jumps near a virtualized item and then refines position once the target renders.
+     */
     scrollToVirtualizedItem(containerId, itemIndex, itemHeight, targetItemId, behaviorString) {
         const container = document.getElementById(containerId);
         if (!container) {

--- a/src/MudBlazor/TScripts/mudScrollSpy.js
+++ b/src/MudBlazor/TScripts/mudScrollSpy.js
@@ -7,14 +7,15 @@
  * Updates URL hash and section callbacks directly in JS to minimize interop churn.
  */
 class MudScrollSpy {
-
     constructor() {
         this.lastKnowElement = null;
         //needed as variable to remove the event listeners
         this.handlerRef = null;
     }
 
-    // subscribe to relevant events
+    /**
+     * Starts section tracking for a scroll container and section selector.
+     */
     spying(dotnetReference, containerSelector, sectionClassSelector) {
         this.lastKnowElement = null;
 
@@ -27,7 +28,9 @@ class MudScrollSpy {
         window.addEventListener('resize', this.handlerRef, true);
     }
 
-    // handle the document scroll event and if needed, fires the .NET event
+    /**
+     * Recomputes the active section and notifies .NET when it changes.
+     */
     handleScroll(dotnetReference, containerSelector, sectionClassSelector) {
         const container = document.querySelector(containerSelector);
         if (container === null) {
@@ -53,6 +56,7 @@ class MudScrollSpy {
             const diff = Math.abs(rect.top - center);
 
             if (!foundAbove && rect.top < center) {
+                // Prefer the most recent section above center so active state follows reading direction.
                 foundAbove = true;
                 minDifference = diff;
                 elementId = element.id;
@@ -71,11 +75,15 @@ class MudScrollSpy {
 
         if (elementId !== this.lastKnowElement) {
             this.lastKnowElement = elementId;
+            // replaceState updates deep-linking without polluting browser history while scrolling.
             history.replaceState(null, '', window.location.pathname + "#" + elementId);
             dotnetReference.invokeMethodAsync('SectionChangeOccured', elementId);
         }
     }
 
+    /**
+     * Marks a section as active and updates the URL hash without scrolling.
+     */
     activateSection(sectionId) {
         const element = document.getElementById(sectionId);
         if (element) {
@@ -84,6 +92,9 @@ class MudScrollSpy {
         }
     }
 
+    /**
+     * Scrolls to a section ID, or to the top when no section is provided.
+     */
     scrollToSection(sectionId) {
         if (sectionId) {
             const element = document.getElementById(sectionId);
@@ -96,7 +107,9 @@ class MudScrollSpy {
         }
     }
 
-    //remove event listeners
+    /**
+     * Stops section tracking and removes registered listeners.
+     */
     unspy() {
         document.removeEventListener('scroll', this.handlerRef, true);
         window.removeEventListener('resize', this.handlerRef, true);

--- a/src/MudBlazor/TScripts/mudScrollSpy.js
+++ b/src/MudBlazor/TScripts/mudScrollSpy.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Scroll section tracking for the ScrollSpy service.
-// Keeping URL hash updates in JS avoids round-tripping layout state through .NET on every scroll tick.
+/**
+ * Scroll section tracking for the ScrollSpy service.
+ * Updates URL hash and section callbacks directly in JS to minimize interop churn.
+ */
 class MudScrollSpy {
 
     constructor() {

--- a/src/MudBlazor/TScripts/mudScrollSpy.js
+++ b/src/MudBlazor/TScripts/mudScrollSpy.js
@@ -2,7 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//Functions related to the scroll spy
+// Scroll section tracking for the ScrollSpy service.
+// Keeping URL hash updates in JS avoids round-tripping layout state through .NET on every scroll tick.
 class MudScrollSpy {
 
     constructor() {

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -1,4 +1,8 @@
-﻿// SplitPanel resize behavior for the MudSplitPanel component.
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// SplitPanel resize behavior for the MudSplitPanel component.
 // This JS owns pointer/keyboard interaction and ARIA value updates to keep divider movement smooth.
 // noinspection JSUnusedGlobalSymbols
 class MudSplitPanel {

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-//
-// SplitPanel resize behavior for the MudSplitPanel component.
-// This JS owns pointer/keyboard interaction and ARIA value updates to keep divider movement smooth.
+
 // noinspection JSUnusedGlobalSymbols
+/**
+ * SplitPanel resize behavior for the MudSplitPanel component.
+ * Owns pointer/keyboard interaction and ARIA value updates for smooth resizing.
+ */
 class MudSplitPanel {
     static build(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap) {
         window.splitPanels[containerId] = new MudSplitPanel(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap);

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -1,4 +1,6 @@
-﻿// noinspection JSUnusedGlobalSymbols
+﻿// SplitPanel resize behavior for the MudSplitPanel component.
+// This JS owns pointer/keyboard interaction and ARIA value updates to keep divider movement smooth.
+// noinspection JSUnusedGlobalSymbols
 class MudSplitPanel {
     static build(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap) {
         window.splitPanels[containerId] = new MudSplitPanel(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap);

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -8,6 +8,9 @@
  * Owns pointer/keyboard interaction and ARIA value updates for smooth resizing.
  */
 class MudSplitPanel {
+    /**
+     * Creates and stores a split panel runtime instance for a container ID.
+     */
     static build(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap) {
         window.splitPanels[containerId] = new MudSplitPanel(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap);
     }
@@ -54,6 +57,9 @@ class MudSplitPanel {
         this.update(horizontal, resetOnDoubleClick, minPanelSize, panelGap, true);
     }
 
+    /**
+     * Removes listeners and disposes the split panel runtime instance.
+     */
     destroy() {
         this.divider.removeEventListener("mousedown", this._onMouseDown);
         this.divider.removeEventListener("touchstart", this._onMouseDown);
@@ -66,6 +72,9 @@ class MudSplitPanel {
     }
 
     // noinspection JSUnusedGlobalSymbols
+    /**
+     * Updates runtime options and recalculates panel sizes when needed.
+     */
     update(horizontal, resetOnDoubleClick, minPanelSize, panelGap, forceRecalculateSize = false) {
         const shouldRecalculateSize = horizontal !== this.horizontal || forceRecalculateSize;
         this.horizontal = horizontal;
@@ -85,6 +94,9 @@ class MudSplitPanel {
         }
     }
 
+    /**
+     * Resets both panel sizes using either the provided size or initial configuration.
+     */
     resetSizes(firstPanelSize = null) {
         this.firstPanel.style.width = "100%";
         this.secondPanel.style.width = "100%";
@@ -99,10 +111,16 @@ class MudSplitPanel {
         }
     }
 
+    /**
+     * Returns the current divider offset in pixels.
+     */
     getDividerPosition() {
         return this.horizontal ? this.firstPanel.clientHeight : this.firstPanel.clientWidth;
     }
 
+    /**
+     * Sets the divider offset in pixels.
+     */
     setDividerPosition(offset) {
         this.resetSizes(offset);
     }
@@ -258,22 +276,37 @@ if (!window.mudSplitPanel) {
     window.splitPanels = {};
 }
 
+/**
+ * Updates split panel options for an existing container ID.
+ */
 window.mudSplitPanel_update = function (id, horizontal, resetOnDoubleClick, minPanelSize, panelGap) {
     window.splitPanels[id].update(horizontal, resetOnDoubleClick, minPanelSize, panelGap);
 };
 
+/**
+ * Resets the divider position to the configured initial value.
+ */
 window.mudSplitPanel_resetDividerPosition = function (id) {
     window.splitPanels[id].resetSizes();
 };
 
+/**
+ * Returns the divider position for a split panel container ID.
+ */
 window.mudSplitPanel_getDividerPosition = function (id) {
     return window.splitPanels[id].getDividerPosition();
 };
 
+/**
+ * Sets the divider position for a split panel container ID.
+ */
 window.mudSplitPanel_setDividerPosition = function (id, offset) {
     window.splitPanels[id].setDividerPosition(offset);
 };
 
+/**
+ * Disposes the split panel runtime instance for a container ID.
+ */
 window.mudSplitPanel_destroy = function (id) {
     window.splitPanels[id].destroy();
 };

--- a/src/MudBlazor/TScripts/mudTableCell.js
+++ b/src/MudBlazor/TScripts/mudTableCell.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Table keyboard navigation helpers for the MudTable component.
-// Focus/click/select are coordinated in JS so the browser applies native focus semantics before .NET continues.
+/**
+ * Table keyboard navigation helpers for the MudTable component.
+ * Coordinates focus/click/select in JS so native focus behavior is preserved.
+ */
 window.mudTableCell = {
     focusCell(rowId, cellIndex) {
         const row = document.getElementById(rowId);

--- a/src/MudBlazor/TScripts/mudTableCell.js
+++ b/src/MudBlazor/TScripts/mudTableCell.js
@@ -7,6 +7,9 @@
  * Coordinates focus/click/select in JS so native focus behavior is preserved.
  */
 window.mudTableCell = {
+    /**
+     * Focuses a table cell by row ID and cell index, then triggers click behavior.
+     */
     focusCell(rowId, cellIndex) {
         const row = document.getElementById(rowId);
         if (!row) return;
@@ -14,12 +17,16 @@ window.mudTableCell = {
         const cells = row.querySelectorAll('td, th');
         if (cellIndex >= 0 && cellIndex < cells.length) {
             const cell = cells[cellIndex];
+            // tabindex keeps keyboard focusable behavior even for cells that are not natively tabbable.
             cell.setAttribute('tabindex', '-1');
             cell.focus();
             cell.click();
         }
     },
 
+    /**
+     * Focuses and selects text within an input/textarea inside the target cell.
+     */
     selectCell(rowId, cellIndex) {
         const row = document.getElementById(rowId);
         if (!row) return;

--- a/src/MudBlazor/TScripts/mudTableCell.js
+++ b/src/MudBlazor/TScripts/mudTableCell.js
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Table keyboard navigation helpers for the MudTable component.
+// Focus/click/select are coordinated in JS so the browser applies native focus semantics before .NET continues.
 window.mudTableCell = {
     focusCell(rowId, cellIndex) {
         const row = document.getElementById(rowId);

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -1,4 +1,6 @@
-﻿const isDarkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+﻿// System dark-mode bridge for the MudThemeProvider component.
+// MediaQuery listeners live in JS so updates fire even when no component currently triggers a render cycle.
+const isDarkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
 let themeProvider = null;
 
 function listener(e) {

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -1,4 +1,8 @@
-﻿// System dark-mode bridge for the MudThemeProvider component.
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// System dark-mode bridge for the MudThemeProvider component.
 // MediaQuery listeners live in JS so updates fire even when no component currently triggers a render cycle.
 const isDarkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
 let themeProvider = null;

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-//
-// System dark-mode bridge for the MudThemeProvider component.
-// MediaQuery listeners live in JS so updates fire even when no component currently triggers a render cycle.
+/**
+ * System dark-mode bridge for the MudThemeProvider component.
+ * Keeps media-query listeners in JS so OS theme changes are captured reliably.
+ */
 const isDarkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
 let themeProvider = null;
 

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 /**
  * System dark-mode bridge for the MudThemeProvider component.
  * Keeps media-query listeners in JS so OS theme changes are captured reliably.
  */
 const isDarkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+// Keep one shared callback target to avoid duplicate listeners across component re-renders.
 let themeProvider = null;
 
 function listener(e) {
@@ -14,13 +16,22 @@ function listener(e) {
 }
 
 window.mudThemeProvider = {
+    /**
+     * Returns whether the system currently prefers dark mode.
+     */
     isDarkMode() {
         return isDarkModeQuery.matches;
     },
+    /**
+     * Starts listening for system dark-mode changes and forwards updates to .NET.
+     */
     watchDarkMode(dotNetHelper) {
         themeProvider = dotNetHelper;
         isDarkModeQuery.addEventListener('change', listener);
     },
+    /**
+     * Stops listening for system dark-mode changes.
+     */
     stopWatchingDarkMode() {
         isDarkModeQuery.removeEventListener('change', listener);
     },

--- a/src/MudBlazor/TScripts/mudTimePicker.js
+++ b/src/MudBlazor/TScripts/mudTimePicker.js
@@ -2,9 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Pointer interaction model for the analog clock UI in `MudTimePicker`.
-// Used by the MudTimePicker component.
-// JS tracks pressed state so drag-over-stick selection feels continuous without flooding Blazor event plumbing.
+/**
+ * Pointer interaction model for the analog clock UI in MudTimePicker.
+ * Tracks pressed state so drag-over-stick selection remains continuous.
+ */
 window.mudTimePicker = {
     initPointerEvents: (clock, dotNetHelper) => {
         let isPointerDown = false;

--- a/src/MudBlazor/TScripts/mudTimePicker.js
+++ b/src/MudBlazor/TScripts/mudTimePicker.js
@@ -7,6 +7,9 @@
  * Tracks pressed state so drag-over-stick selection remains continuous.
  */
 window.mudTimePicker = {
+    /**
+     * Attaches pointer handlers for clock stick hover/select interactions.
+     */
     initPointerEvents: (clock, dotNetHelper) => {
         let isPointerDown = false;
 
@@ -77,6 +80,9 @@ window.mudTimePicker = {
         };
     },
 
+    /**
+     * Detaches pointer handlers previously registered on the clock container.
+     */
     destroyPointerEvents: (container) => {
         if (container == null) {
             return;

--- a/src/MudBlazor/TScripts/mudTimePicker.js
+++ b/src/MudBlazor/TScripts/mudTimePicker.js
@@ -2,6 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Pointer interaction model for the analog clock UI in `MudTimePicker`.
+// Used by the MudTimePicker component.
+// JS tracks pressed state so drag-over-stick selection feels continuous without flooding Blazor event plumbing.
 window.mudTimePicker = {
     initPointerEvents: (clock, dotNetHelper) => {
         let isPointerDown = false;

--- a/src/MudBlazor/TScripts/mudWindow.js
+++ b/src/MudBlazor/TScripts/mudWindow.js
@@ -7,11 +7,16 @@
  * Centralizes direct browser API dependencies behind one interop surface.
  */
 class MudWindow {
-
+    /**
+     * Copies text to the system clipboard.
+     */
     copyToClipboard (text) {
         navigator.clipboard.writeText(text);
     }
 
+    /**
+     * Replaces an element className by element ID.
+     */
     changeCssById (id, css) {
         const element = document.getElementById(id);
         if (element) {
@@ -19,6 +24,9 @@ class MudWindow {
         }
     }
 
+    /**
+     * Updates a CSS style property for an element by ID.
+     */
     updateStyleProperty (elementId, propertyName, value) {
         const element = document.getElementById(elementId);
         if (element) {
@@ -26,11 +34,16 @@ class MudWindow {
         }
     }
 
+    /**
+     * Updates a CSS variable on the document root.
+     */
     changeGlobalCssVariable (name, newValue) {
         document.documentElement.style.setProperty(name, newValue);
     }
 
-    // Needed as per https://stackoverflow.com/questions/62769031/how-can-i-open-a-new-window-without-using-js
+    /**
+     * Opens a new browser window/tab with the provided argument.
+     */
     open (args) {
         window.open(args);
     }

--- a/src/MudBlazor/TScripts/mudWindow.js
+++ b/src/MudBlazor/TScripts/mudWindow.js
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// Generic browser/window operations used by the JS API service.
+// Keeping these wrappers centralized constrains direct browser API dependencies to one interop surface.
 class MudWindow {
 
     copyToClipboard (text) {

--- a/src/MudBlazor/TScripts/mudWindow.js
+++ b/src/MudBlazor/TScripts/mudWindow.js
@@ -2,8 +2,10 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// Generic browser/window operations used by the JS API service.
-// Keeping these wrappers centralized constrains direct browser API dependencies to one interop surface.
+/**
+ * Generic browser/window operations exposed to the JS API service.
+ * Centralizes direct browser API dependencies behind one interop surface.
+ */
 class MudWindow {
 
     copyToClipboard (text) {


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

This PR standardizes the JavaScript interop layer in TScripts for readability and contributor onboarding, without changing intended behavior.

### What changed
- Unified copyright/license headers across TScripts files.
- Standardized class/file doc comments and public JS method JSDoc style.
- Added sparse, high-value inline comments focused on **why** (not restating obvious code).
- Normalized spacing/blank-line patterns so comments and sections are easier to scan.
- Enforced consistent control-flow style by adding braces for multi-line `if`/`else`/loop bodies (especially where comments are part of the block).

### Why
- Make interop code easier to understand quickly for new contributors.
- Reduce style drift across files and make future reviews simpler.
- Improve maintainability while keeping logic stable.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
