### PR TITLE
ThrottleDispatcher: Fix not throttling fast-completing actions

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
@@ -401,4 +401,36 @@ public class ThrottleDispatcherTests
         // So we should only see 1 execution (or maybe 2 if timing is tight)
         counter.Should().BeLessThanOrEqualTo(2);
     }
+
+    [Test]
+    public async Task ThrottleAsync_RapidCallsWithFastAction_ThrottlesCorrectly()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        using var dispatcher = new ThrottleDispatcher(50, timeProvider);
+        var counter = 0;
+        Task Invoke()
+        {
+            Interlocked.Increment(ref counter);
+            return Task.CompletedTask;
+        }
+
+        // Act - First call executes immediately (leading edge)
+        await dispatcher.ThrottleAsync(Invoke);
+        counter.Should().Be(1);
+
+        // Rapid calls within the interval should be suppressed even though the task completed
+        timeProvider.Advance(TimeSpan.FromMilliseconds(10));
+        await dispatcher.ThrottleAsync(Invoke);
+        counter.Should().Be(1);
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(10));
+        await dispatcher.ThrottleAsync(Invoke);
+        counter.Should().Be(1);
+
+        // After the interval elapses, the next call should execute
+        timeProvider.Advance(TimeSpan.FromMilliseconds(50));
+        await dispatcher.ThrottleAsync(Invoke);
+        counter.Should().Be(2);
+    }
 }

--- a/src/MudBlazor/Utilities/Throttle/ThrottleDispatcher.cs
+++ b/src/MudBlazor/Utilities/Throttle/ThrottleDispatcher.cs
@@ -127,10 +127,10 @@ internal sealed class ThrottleDispatcher : IDisposable
             var now = _timeProvider.GetUtcNow();
             var timeSinceLastExecution = now - _lastExecutionStartTime;
 
-            // If we have a running task, and we're within the interval, return the same task
-            if (_currentTask is not null && !_currentTask.IsCompleted && timeSinceLastExecution < _interval)
+            // Within the throttle interval - suppress execution (allow retry after faults)
+            if (timeSinceLastExecution < _interval && _currentTask is not null && !_currentTask.IsFaulted)
             {
-                return _currentTask;
+                return _currentTask.IsCompleted ? Task.CompletedTask : _currentTask;
             }
 
             // Clear completed task if it exists


### PR DESCRIPTION
Regression introduced in #12296 (`1e9837ae`). The refactor replaced the original two-part guard:

```csharp
// OLD — checked busy OR time
if (_lastTask is not null && (_busy || ShouldWait()))
    return _lastTask;
```

with a single condition that only checks the interval when the task is still running:

```csharp
// NEW — only checks time when task is incomplete
if (_currentTask is not null &&
    !_currentTask.IsCompleted &&
    timeSinceLastExecution < _interval)
    return _currentTask;
```

### Problem

When the action completes **synchronously**, `IsCompleted` is already `true` on the next call.
The completed task gets cleared and a new execution starts unconditionally, the time check is never reached.

### Fix

Check the interval **regardless of task completion state**. Faulted tasks still allow immediate retry:

```csharp
if (timeSinceLastExecution < _interval &&
    _currentTask is not null &&
    !_currentTask.IsFaulted)
{
    return _currentTask.IsCompleted
        ? Task.CompletedTask
        : _currentTask;
}
```

### Why tests didn’t catch it

* slow async actions (`Task.Delay`) that keep the task running, or
* real delays between calls that exceed the interval.

No test covered the real `MudColorPicker` scenario: a **synchronous** action called rapidly within the interval.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
