### PR TITLE
Build: Add caching for Bun binary in GitHub Actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -21,6 +21,13 @@ runs:
         key: ${{ github.repository }}-nuget-${{ hashFiles('**/*.csproj') }}
         path: ${{ env.NUGET_PACKAGES }}
 
+    - name: Cache Bun binary
+      uses: actions/cache@v5
+      with:
+        # We use the hash of 'Directory.Build.props' because the version is defined there
+        key: ${{ github.repository }}-bun-binary-${{ hashFiles('**/Directory.Build.props') }}
+        path: ./tools/BunDotNet
+
     - name: Restore NuGet packages
       shell: bash
       run: dotnet restore ${{ inputs.project-path }}


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

This PR introduces a simple cache for the downloaded Bun binary. I'm not 100% sure how the BunDotNetCli works. But if it checks for an existing executable, it should work 🙂 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
