### PR TITLE
MudDataGrid: Fix CellClass ordering to allow style overrides

### DIFF
--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -29,13 +29,13 @@ namespace MudBlazor
         }
 
         internal string ComputedClass =>
-            new CssBuilder(_column.CellClassFunc?.Invoke(_item))
-                .AddClass(_column.CellClass)
-                .AddClass("mud-table-cell")
+            new CssBuilder("mud-table-cell")
                 .AddClass("mud-table-cell-hide", _column.HideSmall)
                 .AddClass("sticky-left", _column.StickyLeft)
                 .AddClass("sticky-right", _column.StickyRight)
                 .AddClass($"edit-mode-cell", _dataGrid.EditMode == DataGridEditMode.Cell && _column.Editable)
+                .AddClass(_column.CellClassFunc?.Invoke(_item))
+                .AddClass(_column.CellClass)
                 .Build();
 
         internal string ComputedStyle =>

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -498,6 +498,7 @@ namespace MudBlazor
 
         internal string FooterClassname =>
             new CssBuilder("mud-table-cell")
+                .AddClass("footer-cell")
                 .AddClass("mud-table-cell-hide", HideSmall)
                 .AddClass(Class)
                 .Build();

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -40,10 +40,9 @@ namespace MudBlazor
         public IEnumerable<T>? CurrentItems { get; set; }
 
         private string Classname =>
-            new CssBuilder("footer-cell")
+            new CssBuilder(Column?.FooterClassname)
                 .AddClass(Column?.FooterClassFunc?.Invoke(items ?? Enumerable.Empty<T>()))
                 .AddClass(Column?.FooterClass)
-                .AddClass(Column?.FooterClassname)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -75,9 +75,9 @@ namespace MudBlazor
         public SortDirection SortDirection { get; set; }
 
         private string Classname =>
-            new CssBuilder(Column?.HeaderClass)
+            new CssBuilder(Column?.HeaderClassname)
                 .AddClass(Column?.HeaderClassFunc?.Invoke(DataGrid?.CurrentPageItems ?? Enumerable.Empty<T>()))
-                .AddClass(Column?.HeaderClassname)
+                .AddClass(Column?.HeaderClass)
                 .AddClass(Class)
                 .Build();
 


### PR DESCRIPTION
Reorders CSS classes in DataGrid Cell, HeaderCell, and FooterCell components to place base classes before user-provided classes. This allows CellClass, HeaderClass, and FooterClass to properly override default styles like padding, font-size, text-align, etc.

Previously, user classes were added before base classes, preventing proper CSS specificity and forcing users to rely on inline styles. This fix aligns the DataGrid with the pattern used in MudTd (regular Table component).

**Changes:**
- Cell.cs: Move base classes before CellClassFunc and CellClass
- HeaderCell.razor.cs: Move HeaderClassname before user classes  
- FooterCell.razor.cs: Move FooterClassname before user classes

Fixes #12530

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
