### PR TITLE
MudForm: Fix `IsValid` binding when required fields are empty on initial render

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerRequiredFormValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerRequiredFormValidationTest.razor
@@ -8,6 +8,9 @@
     public static string __description__ = "Form with required DatePicker should not be valid until date is selected.";
 
     public bool IsFormValid { get; set; }
+    
+    [Parameter]
     public string? Name { get; set; }
+    
     public DateTime? BirthDate { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerRequiredFormValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerRequiredFormValidationTest.razor
@@ -1,0 +1,13 @@
+<MudForm @bind-IsValid="@IsFormValid">
+    <MudTextField @bind-Value="@Name" Label="Name" Required="true" />
+    <MudDatePicker @bind-Date="@BirthDate" Label="Birth Date" Required="true" />
+</MudForm>
+
+@code
+{
+    public static string __description__ = "Form with required DatePicker should not be valid until date is selected.";
+
+    public bool IsFormValid { get; set; }
+    public string? Name { get; set; }
+    public DateTime? BirthDate { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2015,5 +2015,32 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.PickerMonth?.Month.Should().Be(12);
             return comp;
         }
+
+        [Test]
+        public void RequiredDatePicker_FormIsValid_ShouldBeFalseInitially()
+        {
+            var comp = Context.Render<DatePickerRequiredFormValidationTest>();
+            
+            comp.Instance.IsFormValid.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task RequiredDatePicker_FormIsValid_ShouldBeTrueAfterFillingAllFields()
+        {
+            var comp = Context.Render<DatePickerRequiredFormValidationTest>();
+            
+            comp.Instance.IsFormValid.Should().BeFalse();
+            
+            var textField = comp.FindComponents<MudTextField<string>>().First();
+            await comp.InvokeAsync(() => textField.Instance.SetTextAsync("John"));
+            await comp.InvokeAsync(() => textField.Instance.BlurAsync());
+            
+            comp.Instance.IsFormValid.Should().BeFalse();
+            
+            var datePicker = comp.FindComponent<MudDatePicker>();
+            await datePicker.InvokeAsync(() => datePicker.Instance.Date = new DateTime(2000, 1, 1));
+            
+            comp.Instance.IsFormValid.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -749,7 +749,8 @@ namespace MudBlazor.UnitTests.Components
                 .Select(button => ((IHtmlButtonElement)button).IsDisabled)
                 .Should()
                 // Only months with 31 days not disabled
-                .BeEquivalentTo(new[]
+                .BeEquivalentTo(
+                    new[]
                     {
                         false,
                         true,
@@ -2020,7 +2021,7 @@ namespace MudBlazor.UnitTests.Components
         public void RequiredDatePicker_FormIsValid_ShouldBeFalseInitially()
         {
             var comp = Context.Render<DatePickerRequiredFormValidationTest>();
-            
+
             comp.Instance.IsFormValid.Should().BeFalse();
         }
 
@@ -2028,17 +2029,17 @@ namespace MudBlazor.UnitTests.Components
         public async Task RequiredDatePicker_FormIsValid_ShouldBeTrueAfterFillingAllFields()
         {
             var comp = Context.Render<DatePickerRequiredFormValidationTest>();
-            
+
             comp.Instance.IsFormValid.Should().BeFalse();
-            
+
             var textField = comp.FindComponents<MudTextField<string>>().First();
             await comp.InvokeAsync(() => textField.Instance.SetTextAsync("John"));
             await comp.InvokeAsync(() => textField.Instance.BlurAsync());
-            
+
             comp.Instance.IsFormValid.Should().BeFalse();
-            
+
             await comp.InvokeAsync(() => comp.Instance.BirthDate = new DateTime(2000, 1, 1));
-            
+
             comp.Instance.IsFormValid.Should().BeTrue();
         }
     }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2037,8 +2037,7 @@ namespace MudBlazor.UnitTests.Components
             
             comp.Instance.IsFormValid.Should().BeFalse();
             
-            var datePicker = comp.FindComponent<MudDatePicker>();
-            await datePicker.InvokeAsync(() => datePicker.Instance.Date = new DateTime(2000, 1, 1));
+            await comp.InvokeAsync(() => comp.Instance.BirthDate = new DateTime(2000, 1, 1));
             
             comp.Instance.IsFormValid.Should().BeTrue();
         }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2038,7 +2038,8 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.IsFormValid.Should().BeFalse();
 
-            await comp.InvokeAsync(() => comp.Instance.BirthDate = new DateTime(2000, 1, 1));
+            var datePickerComp = comp.FindComponent<MudDatePicker>();
+            await datePickerComp.Find("input").ChangeAsync(new DateTime(2000, 1, 1).ToShortDateString());
 
             comp.Instance.IsFormValid.Should().BeTrue();
         }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2041,7 +2041,7 @@ namespace MudBlazor.UnitTests.Components
             var datePickerComp = comp.FindComponent<MudDatePicker>();
             await datePickerComp.Find("input").ChangeAsync(new DateTime(2000, 1, 1).ToShortDateString());
 
-            comp.Instance.IsFormValid.Should().BeTrue();
+            await comp.WaitForAssertionAsync(() => comp.Instance.IsFormValid.Should().BeTrue());
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2032,9 +2032,7 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.IsFormValid.Should().BeFalse();
 
-            var textField = comp.FindComponent<MudTextField<string>>();
-            await comp.InvokeAsync(() => textField.Instance.SetTextAsync("John"));
-            await comp.InvokeAsync(() => textField.Instance.BlurAsync());
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Name, "John"));
 
             comp.Instance.IsFormValid.Should().BeFalse();
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2032,14 +2032,17 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.IsFormValid.Should().BeFalse();
 
-            var textField = comp.FindComponents<MudTextField<string>>().First();
+            var textField = comp.FindComponent<MudTextField<string>>();
             await comp.InvokeAsync(() => textField.Instance.SetTextAsync("John"));
             await comp.InvokeAsync(() => textField.Instance.BlurAsync());
 
             comp.Instance.IsFormValid.Should().BeFalse();
 
             var datePickerComp = comp.FindComponent<MudDatePicker>();
-            await datePickerComp.Find("input").ChangeAsync(new DateTime(2000, 1, 1).ToShortDateString());
+            var date = new DateTime(2000, 1, 1);
+            var pickerCulture = datePickerComp.Instance.Culture ?? CultureInfo.CurrentCulture;
+            var input = date.ToString(pickerCulture.DateTimeFormat.ShortDatePattern, pickerCulture);
+            await datePickerComp.Find("input").ChangeAsync(input);
 
             await comp.WaitForAssertionAsync(() => comp.Instance.IsFormValid.Should().BeTrue());
         }

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -268,18 +268,21 @@ namespace MudBlazor
             return !SuppressRenderingOnValidation || _shouldRender;
         }
 
-        protected override Task OnAfterRenderAsync(bool firstRender)
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (firstRender)
             {
+                // If there are required fields, the form should start as invalid
+                // This ensures the IsValid binding is properly initialized even if the user
+                // bound IsValid to a variable that starts as true
                 var hasRequiredFields = _formControls.Any(x => x.Required);
-                var valid = !hasRequiredFields;
-                if (valid != IsValid)
+                if (hasRequiredFields && IsValid)
                 {
-                    SetIsValid(valid);
+                    IsValid = false;
+                    await IsValidChanged.InvokeAsync(IsValid);
                 }
             }
-            return base.OnAfterRenderAsync(firstRender);
+            await base.OnAfterRenderAsync(firstRender);
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -272,13 +272,14 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                // If there are required fields, the form should start as invalid
-                // This ensures the IsValid binding is properly initialized even if the user
-                // bound IsValid to a variable that starts as true
+                // Ensure IsValid binding is properly initialized based on whether there are required fields
+                // This handles cases where the user's bound variable conflicts with the form's internal state
                 var hasRequiredFields = _formControls.Any(x => x.Required);
-                if (hasRequiredFields && IsValid)
+                var expectedValid = !hasRequiredFields;
+                
+                if (expectedValid != IsValid)
                 {
-                    IsValid = false;
+                    IsValid = expectedValid;
                     await IsValidChanged.InvokeAsync(IsValid);
                 }
             }

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -276,7 +276,7 @@ namespace MudBlazor
                 // This handles cases where the user's bound variable conflicts with the form's internal state
                 var hasRequiredFields = _formControls.Any(x => x.Required);
                 var expectedValid = !hasRequiredFields;
-                
+
                 if (expectedValid != IsValid)
                 {
                     IsValid = expectedValid;

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -272,14 +272,12 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                var valid = _formControls.All(x => x.Required == false);
+                var hasRequiredFields = _formControls.Any(x => x.Required);
+                var valid = !hasRequiredFields;
                 if (valid != IsValid)
                 {
-                    // the user probably bound a variable to IsValid, and it conflicts with our state.
-                    // let's set this right
                     SetIsValid(valid);
                 }
-
             }
             return base.OnAfterRenderAsync(firstRender);
         }


### PR DESCRIPTION
Fixes #12400

## Description
Fixed MudForm's `IsValid` binding to correctly report `false` when required fields (including MudDatePicker) are empty on initial render.

## Problem
When a form contained required fields, `IsValid` would incorrectly be `true` on first render, allowing submit buttons to be enabled even when required fields were empty.

## Solution
Updated `MudForm.OnAfterRenderAsync` to properly check for the presence of required fields and set `IsValid = false` when any required fields exist, regardless of whether they've been touched yet.

## Changes
- Modified `MudForm.razor.cs` initial validation logic
- Added test component `DatePickerRequiredFormValidationTest.razor`
- Added two unit tests to verify the fix

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
