### PR TITLE
MudDateRangePicker: Fix initialization when using `DateTime.MinValue`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -554,6 +554,60 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task InitializeDateRange_WithMinValue_ShouldTreatAsNull()
+        {
+            var range = new DateRange(DateTime.MinValue, DateTime.MinValue);
+            
+            var comp = await OpenPicker(parameters => parameters
+                .Add(x => x.DateRange, range));
+            
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var picker = comp.FindComponent<MudDateRangePicker>();
+                
+                picker.Instance.DateRange.Should().NotBeNull();
+                picker.Instance.DateRange.Start.Should().BeNull();
+                picker.Instance.DateRange.End.Should().BeNull();
+            });
+        }
+        
+        [Test]
+        public async Task InitializeDateRange_WithMinValueStartOnly_ShouldNormalizeStart()
+        {
+            var range = new DateRange(DateTime.MinValue, DateTime.Today);
+            
+            var comp = await OpenPicker(parameters => parameters
+                .Add(x => x.DateRange, range));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var picker = comp.FindComponent<MudDateRangePicker>();
+                
+                picker.Instance.DateRange.Should().NotBeNull();
+                picker.Instance.DateRange.Start.Should().BeNull();
+                picker.Instance.DateRange.End.Should().Be(DateTime.Today);
+            });
+        }
+        
+        [Test]
+        public async Task InitializeDateRange_WithMinValueEndOnly_ShouldNormalizeEnd()
+        {
+            var range = new DateRange(DateTime.Today, DateTime.MinValue);
+            
+            var comp = await OpenPicker(parameters => parameters
+                .Add(x => x.DateRange, range));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var picker = comp.FindComponent<MudDateRangePicker>();
+                
+                picker.Instance.DateRange.Should().NotBeNull();
+                picker.Instance.DateRange.Start.Should().Be(DateTime.Today);
+                picker.Instance.DateRange.End.Should().BeNull();
+            });
+        }
+        
+        [Test]
         public async Task InitializeDateRange_AllNullValues()
         {
             var range = new DateRange(null, null);

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -557,56 +557,56 @@ namespace MudBlazor.UnitTests.Components
         public async Task InitializeDateRange_WithMinValue_ShouldTreatAsNull()
         {
             var range = new DateRange(DateTime.MinValue, DateTime.MinValue);
-            
-            var comp = await OpenPicker(parameters => parameters
-                .Add(x => x.DateRange, range));
-            
-            await comp.WaitForAssertionAsync(() =>
-            {
-                var picker = comp.FindComponent<MudDateRangePicker>();
-                
-                picker.Instance.DateRange.Should().NotBeNull();
-                picker.Instance.DateRange.Start.Should().BeNull();
-                picker.Instance.DateRange.End.Should().BeNull();
-            });
-        }
-        
-        [Test]
-        public async Task InitializeDateRange_WithMinValueStartOnly_ShouldNormalizeStart()
-        {
-            var range = new DateRange(DateTime.MinValue, DateTime.Today);
-            
+
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.DateRange, range));
 
             await comp.WaitForAssertionAsync(() =>
             {
                 var picker = comp.FindComponent<MudDateRangePicker>();
-                
+
+                picker.Instance.DateRange.Should().NotBeNull();
+                picker.Instance.DateRange.Start.Should().BeNull();
+                picker.Instance.DateRange.End.Should().BeNull();
+            });
+        }
+
+        [Test]
+        public async Task InitializeDateRange_WithMinValueStartOnly_ShouldNormalizeStart()
+        {
+            var range = new DateRange(DateTime.MinValue, DateTime.Today);
+
+            var comp = await OpenPicker(parameters => parameters
+                .Add(x => x.DateRange, range));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var picker = comp.FindComponent<MudDateRangePicker>();
+
                 picker.Instance.DateRange.Should().NotBeNull();
                 picker.Instance.DateRange.Start.Should().BeNull();
                 picker.Instance.DateRange.End.Should().Be(DateTime.Today);
             });
         }
-        
+
         [Test]
         public async Task InitializeDateRange_WithMinValueEndOnly_ShouldNormalizeEnd()
         {
             var range = new DateRange(DateTime.Today, DateTime.MinValue);
-            
+
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.DateRange, range));
 
             await comp.WaitForAssertionAsync(() =>
             {
                 var picker = comp.FindComponent<MudDateRangePicker>();
-                
+
                 picker.Instance.DateRange.Should().NotBeNull();
                 picker.Instance.DateRange.Start.Should().Be(DateTime.Today);
                 picker.Instance.DateRange.End.Should().BeNull();
             });
         }
-        
+
         [Test]
         public async Task InitializeDateRange_AllNullValues()
         {

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -119,6 +119,9 @@ namespace MudBlazor
 
         protected async Task SetDateRangeAsync(DateRange? range, bool updateValue)
         {
+            // Normalize the DateRange before exception is thrown
+            range = NormalizeDateRange(range);
+            
             if (_dateRange != range)
             {
                 var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
@@ -508,5 +511,42 @@ namespace MudBlazor
             var calenderYear = GetCulture().Calendar.GetYear(date);
             return calenderYear - diff;
         }
+        
+        /// <summary>
+        /// Normalize a date by treating DateTime.MinValue as null
+        /// This prevents an ArgumentOutOfRangeException from happening when performing date arithmetic
+        /// </summary>
+        /// <param name="date">The date to normalize</param>
+        /// <returns>Normalized date or null</returns>
+        private static DateTime? NormalizeDate(DateTime? date)
+        {
+            if (date is null)
+                return null;
+            
+            // Treat DateTime.MinValue as null
+            if (date.Value == DateTime.MinValue)
+                return null;
+            
+            return date;
+        }
+
+        /// <summary>
+        /// Normalize a date range by checking the start date and end date for DateRange.MinValue
+        /// This prevents an ArgumentOutOfRangeException from happening when performing date arithmetic
+        /// </summary>
+        /// <see cref="NormalizeDate"/>
+        /// <param name="range">The date range to normalize</param>
+        /// <returns>Normalized date range or null</returns>
+        private static DateRange? NormalizeDateRange(DateRange? range)
+        {
+            if (range is null)
+                return null;
+
+            var start = NormalizeDate(range.Start);
+            var end = NormalizeDate(range.End);
+
+            return new DateRange(start, end);
+        }
+        
     }
 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -531,7 +531,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Normalize a date range by checking the start date and end date for DateRange.MinValue
+        /// Normalize a date range by checking the start date and end date for DateTime.MinValue
         /// This prevents an ArgumentOutOfRangeException from happening when performing date arithmetic
         /// </summary>
         /// <see cref="NormalizeDate"/>

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -121,7 +121,7 @@ namespace MudBlazor
         {
             // Normalize the DateRange before exception is thrown
             range = NormalizeDateRange(range);
-            
+
             if (_dateRange != range)
             {
                 var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
@@ -511,7 +511,7 @@ namespace MudBlazor
             var calenderYear = GetCulture().Calendar.GetYear(date);
             return calenderYear - diff;
         }
-        
+
         /// <summary>
         /// Normalize a date by treating DateTime.MinValue as null
         /// This prevents an ArgumentOutOfRangeException from happening when performing date arithmetic
@@ -522,11 +522,11 @@ namespace MudBlazor
         {
             if (date is null)
                 return null;
-            
+
             // Treat DateTime.MinValue as null
             if (date.Value == DateTime.MinValue)
                 return null;
-            
+
             return date;
         }
 
@@ -547,6 +547,6 @@ namespace MudBlazor
 
             return new DateRange(start, end);
         }
-        
+
     }
 }


### PR DESCRIPTION
## Problem
MudDateRangePicker throws an error when initialized with DateTime.MinValue
(commonly coming from default database values or uninitialized DateTime fields).

## Solution
Add NormalizeDate and NormalizeDateRange to the MudDateRangePicker.razor.cs. These methods check for DateTime.MinValue and treat it as null if found.

## Tests
Added unit tests in DateRangePickerTests.cs covering :

- Initialization with DateTime.MinValue
- Normalization of DateRange where Start and/or End are DateTime.MinValue

All tests related to MudDateRangePicker are passing.

## Notes
Some unrelated failing tests were already failing on upstream `dev` before this change and are not introduced by this PR.

Fixes #11246