### PR TITLE
MudTable: Display numeric values in pager info with thousand separators

### DIFF
--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -121,12 +121,12 @@ namespace MudBlazor
 
                 if (string.IsNullOrEmpty(InfoFormat))
                 {
-                    return Localizer[LanguageResource.MudDataGridPager_InfoFormat, firstItem, lastItem, $"{filteredItemsCount:N0}"];
+                    return Localizer[LanguageResource.MudDataGridPager_InfoFormat, $"{firstItem:N0}", $"{lastItem:N0}", $"{filteredItemsCount:N0}"];
                 }
 
                 return InfoFormat
-                    .Replace("{first_item}", $"{firstItem}")
-                    .Replace("{last_item}", $"{lastItem}")
+                    .Replace("{first_item}", $"{firstItem:N0}")
+                    .Replace("{last_item}", $"{lastItem:N0}")
                     .Replace("{all_items}", $"{filteredItemsCount:N0}");
             }
         }


### PR DESCRIPTION
Related to #12605 (previous merge to dev). This aligns the MudTable pagination logic with the MudDataGrid thousand seperators 


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
