### PR TITLE
MudTable: Cursor pointer behaves like v8 again

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3086,5 +3086,64 @@ namespace MudBlazor.UnitTests.Components
             tableEl.GetAttribute("aria-label").Should().Be("My Accessible Table");
         }
 
+        [Test]
+        public void RowGetsClickableClass_WhenOnRowClickProvided()
+        {
+            var comp = Context.Render<MudTable<int>>(parameters => parameters
+                .Add(p => p.Items, new[] { 1 })
+                .Add(p => p.RowTemplate, item => builder =>
+                {
+                    builder.OpenComponent<MudTd>(0);
+                    builder.AddAttribute(1, "ChildContent",
+                        (RenderFragment)(b => b.AddContent(2, item)));
+                    builder.CloseComponent();
+                })
+                .Add(p => p.OnRowClick, _ => { })
+            );
+
+            var row = comp.Find("tr.mud-table-row");
+
+            row.ClassList.Should().Contain("mud-table-row-clickable");
+        }
+        [Test]
+        public void RowDoesNotGetClickableClass_WhenOnRowClickNotProvided()
+        {
+            var comp = Context.Render<MudTable<int>>(parameters => parameters
+                .Add(p => p.Items, new[] { 1 })
+                .Add(p => p.RowTemplate, item => builder =>
+                {
+                    builder.OpenComponent<MudTd>(0);
+                    builder.AddAttribute(1, "ChildContent",
+                        (RenderFragment)(b => b.AddContent(2, item)));
+                    builder.CloseComponent();
+                })
+            );
+
+            var row = comp.Find("tr.mud-table-row");
+
+            row.ClassList.Should().NotContain("mud-table-row-clickable");
+        }
+
+        [Test]
+        public void RowDoesNotGetClickableClass_WhenDisabled()
+        {
+            var comp = Context.Render<MudTable<int>>(parameters => parameters
+                .Add(p => p.Items, new[] { 1 })
+                .Add(p => p.RowTemplate, item => builder =>
+                {
+                    builder.OpenComponent<MudTd>(0);
+                    builder.AddAttribute(1, "ChildContent",
+                        (RenderFragment)(b => b.AddContent(2, item)));
+                    builder.CloseComponent();
+                })
+                .Add(p => p.OnRowClick, _ => { })
+                .Add(p => p.RowDisabledFunc, _ => true)
+            );
+
+            var row = comp.Find("tr.mud-table-row");
+
+            row.ClassList.Should().NotContain("mud-table-row-clickable");
+            row.ClassList.Should().Contain("mud-table-row-disabled");
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -216,7 +216,7 @@
                      var itemIndexForId = FilteredItems.ToList().IndexOf(item);
                      var generatedRowId = itemIndexForId != -1 ? $"{_tableId}_row_{itemIndexForId}" : null;
 
-                     var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, itemIndexForId)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).Build();
+                     var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, itemIndexForId)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).AddClass("mud-table-row-clickable", OnRowClick.HasDelegate && !IsRowDisabled(item)).Build();
                      var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, itemIndexForId)).Build();
                  }
                  <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" RowId="@generatedRowId" Checkable="MultiSelection" SelectionChangeable="SelectionChangeable"

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -1,4 +1,4 @@
-@namespace MudBlazor
+﻿@namespace MudBlazor
 @inherits MudTableBase
 @using MudBlazor.Utilities
 @using MudBlazor.Resources
@@ -98,7 +98,10 @@
                                     @{
                                         var itemIndex = FilteredItems.ToList().IndexOf(item);
                                         var generatedRowId = itemIndex != -1 ? $"{_tableId}_row_{itemIndex}" : null;
-                                        var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, itemIndex)).Build();
+                                        var rowClass = new CssBuilder(RowClass)
+                                            .AddClass(RowClassFunc?.Invoke(item, itemIndex))
+                                            .AddClass("mud-table-row-clickable", OnRowClick.HasDelegate && !IsRowDisabled(item))
+                                            .Build();
                                         var rowStyle = new StyleBuilder().AddStyle(RowStyle).AddStyle(RowStyleFunc?.Invoke(item, itemIndex)).Build();
                                     }
                                     <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" RowId="@generatedRowId"

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -361,9 +361,9 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   vertical-align: middle;
 }
 
-  .mud-table-row-clickable {
-    cursor: pointer;
-  }
+.mud-table-row-clickable {
+  cursor: pointer;
+}
 
 .mud-table-row-disabled {
   color: var(--mud-palette-text-disabled);

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -361,6 +361,10 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   vertical-align: middle;
 }
 
+  .mud-table-row-clickable {
+    cursor: pointer;
+  }
+
 .mud-table-row-disabled {
   color: var(--mud-palette-text-disabled);
   cursor: default;
@@ -373,10 +377,6 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 
 .mud-table-hover {
   & .mud-table-container .mud-table-root .mud-table-body {
-    & .mud-table-row {
-      cursor: pointer;
-    }
-
     @media(hover: hover) and (pointer: fine) {
       & .mud-table-row:hover {
         background-color: var(--mud-palette-table-hover);


### PR DESCRIPTION
Fixed the cursor pointer on clickable, disabled and non clickable table rows.
Added tests to make sure these are working.

Reason for this change was that in v9 RC1 the tables always rendered the 'cursor: pointer' for each row. This causes confusion on the user if a row is clickable or not.

this resolved issue: #12678 

_This is my first ever PR on a public project. Let me know if I did something wrong or could improve._