### PR TITLE
MudChart: Fix Radial Chart Issues

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
@@ -277,7 +277,7 @@ public class RoseChartTests : BunitTest
 
         // Check legend items
         var legendItems = comp.FindAll(".mud-chart-legend-item");
-        legendItems.Count.Should().Be(3);
+        legendItems.Count.Should().Be(2);
     }
 
     [Test]

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -46,6 +46,8 @@
                 @ChartDataPoints(points)
             }
         }
+
+        @ChartAxisLabels
     </g>
 
     @CustomGraphics

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
@@ -134,6 +134,13 @@ public partial class BaseRadialChart<T, TChartOptions> : MudComponentBase
     public RenderFragment? ChartGrid { get; set; }
 
     /// <summary>
+    /// The labels overlaying the grid area.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Chart.Appearance)]
+    public RenderFragment? ChartAxisLabels { get; set; }
+
+    /// <summary>
     /// The data points for the chart.
     /// </summary>
     [Parameter]

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -197,6 +197,9 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
     /// <param name="chartLabels">The labels for the chart.</param>
     protected void BuildLegends(string[] chartLabels)
     {
+        var isGrouped = ChartOptions!.AggregationOption == AggregationOption.GroupByLabel;
+        var indicesWithPaths = _paths.Select(p => p.Index).ToHashSet();
+
         for (var i = 0; i < chartLabels.Length; i++)
         {
             var label = chartLabels[i];
@@ -204,13 +207,20 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
             if (string.IsNullOrWhiteSpace(label))
                 continue;
 
+            var hasPath = indicesWithPaths.Contains(i);
+
+            var visible = isGrouped
+                ? !HiddenIndices.Contains(i) && hasPath
+                : i < ChartSeries.Count && ChartSeries[i].Visible;
+
+            if (!CanHideSeries && !visible)
+                continue;
+
             _legends.Add(new SvgLegend
             {
                 Index = i,
                 Labels = label,
-                Visible = ChartOptions!.AggregationOption == AggregationOption.GroupByLabel
-                    ? !HiddenIndices.Contains(i)
-                    : ChartSeries[i].Visible,
+                Visible = visible,
                 OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
             });
         }

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor
@@ -15,6 +15,7 @@
                      ChartLabels="@ChartLabels"
                      ChartOptions="@ChartOptions"
                      ChartGrid="@RenderChartGrid()"
+                     ChartAxisLabels="@RenderAxisLabels()"
                      ChartDataPoints="@RenderChartDataPoints"
                      CustomGraphics="@CustomGraphics"
                      HoveredSegment="@_hoveredSegment"
@@ -32,24 +33,25 @@
 @code {
     private RenderFragment RenderChartGrid() => builder =>
     {
-        if (ChartOptions?.ShowGridLines is not true || _gridLines.Count == 0) return;
-
         var seq = 0;
 
-        // Grid lines group
-        builder.OpenElement(seq++, "g");
-        builder.AddAttribute(seq++, "class", "mud-chart-radar-grid");
-        foreach (var gridLine in _gridLines)
+        if (ChartOptions?.ShowGridLines is true && _gridLines.Count > 0) 
         {
-            builder.OpenElement(seq++, "path");
-            builder.AddAttribute(seq++, "class", "mud-chart-grid-line");
-            builder.AddAttribute(seq++, "d", gridLine.Data);
-            builder.AddAttribute(seq++, "fill", "none");
-            builder.AddAttribute(seq++, "stroke", ChartOptions.GridLineColor);
-            builder.AddAttribute(seq++, "stroke-width", ChartOptions.GridLineWidth);
-            builder.CloseElement();
+            // Grid lines group
+            builder.OpenElement(seq++, "g");
+            builder.AddAttribute(seq++, "class", "mud-chart-radar-grid");
+            foreach (var gridLine in _gridLines)
+            {
+                builder.OpenElement(seq++, "path");
+                builder.AddAttribute(seq++, "class", "mud-chart-grid-line");
+                builder.AddAttribute(seq++, "d", gridLine.Data);
+                builder.AddAttribute(seq++, "fill", "none");
+                builder.AddAttribute(seq++, "stroke", ChartOptions.GridLineColor);
+                builder.AddAttribute(seq++, "stroke-width", ChartOptions.GridLineWidth);
+                builder.CloseElement();
+            }
+            builder.CloseElement(); // </g>
         }
-        builder.CloseElement(); // </g>
 
         // Axis lines group
         builder.OpenElement(seq++, "g");
@@ -60,27 +62,41 @@
             builder.AddAttribute(seq++, "class", "mud-chart-axis-line");
             builder.AddAttribute(seq++, "d", axisLine.Data);
             builder.AddAttribute(seq++, "fill", "none");
-            builder.AddAttribute(seq++, "stroke", ChartOptions.AxisLineColor);
-            builder.AddAttribute(seq++, "stroke-width", ChartOptions.AxisLineWidth);
+            builder.AddAttribute(seq++, "stroke", ChartOptions?.AxisLineColor);
+            builder.AddAttribute(seq++, "stroke-width", ChartOptions?.AxisLineWidth);
             builder.CloseElement();
+        }
+        builder.CloseElement(); // </g>
+    };
 
-            if (ChartOptions.ShowAxisLabels)
+    private RenderFragment RenderAxisLabels() => builder =>
+    {
+        var seq = 0;
+
+        builder.OpenElement(seq++, "g");
+        builder.AddAttribute(seq++, "class", "mud-chart-radar-axis-labels");
+
+        if (ChartOptions?.ShowAxisLabels is true)
+        {
+            foreach (var axisLine in _axisLines)
             {
                 var anchor = Math.Abs(axisLine.LabelX) < 10 ? "middle" : (axisLine.LabelX < 0 ? "end" : "start");
                 var baseline = Math.Abs(axisLine.LabelY) < 10 ? "middle" : (axisLine.LabelY < 0 ? "auto" : "hanging");
+
                 builder.AddMarkupContent(seq++,
-                    $"<text class='mud-chart-axis-label' x='{axisLine.LabelX.ToStr()}' y='{axisLine.LabelY.ToStr()}' font-size='12px' text-anchor='{anchor}' dominant-baseline='{baseline}'>{axisLine.LabelYValue}</text>");
+                    $"<text class='mud-chart-axis-label' x='{axisLine.LabelX.ToStr()}' y='{axisLine.LabelY.ToStr()}' font-size='12px' text-anchor='{anchor}' dominant-baseline='{baseline}' fill='currentColor'>{axisLine.LabelYValue}</text>");
             }
         }
-        builder.CloseElement(); // </g>
+        builder.CloseElement();
 
-        // Axis value labels group 
         builder.OpenElement(seq++, "g");
         builder.AddAttribute(seq++, "class", "mud-chart-radar-axis-values");
+        builder.AddAttribute(seq++, "transform", "translate(0,5)");
+
         foreach (var axisValue in _axisValues)
         {
             builder.AddMarkupContent(seq++,
-                $"<text class='mud-chart-axis-value' x='{axisValue.LabelX.ToStr()}' y='{axisValue.LabelY.ToStr()}' font-size='10px' text-anchor='start' dominant-baseline='middle' fill='#666'>{axisValue.LabelYValue}</text>");
+                $"<text class='mud-chart-axis-value' x='{axisValue.LabelX.ToStr()}' y='{axisValue.LabelY.ToStr()}' font-size='10px' text-anchor='start' dominant-baseline='middle' fill='currentcolor'>{axisValue.LabelYValue}</text>");
         }
         builder.CloseElement(); // </g>
     };

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor
@@ -83,8 +83,16 @@
                 var anchor = Math.Abs(axisLine.LabelX) < 10 ? "middle" : (axisLine.LabelX < 0 ? "end" : "start");
                 var baseline = Math.Abs(axisLine.LabelY) < 10 ? "middle" : (axisLine.LabelY < 0 ? "auto" : "hanging");
 
-                builder.AddMarkupContent(seq++,
-                    $"<text class='mud-chart-axis-label' x='{axisLine.LabelX.ToStr()}' y='{axisLine.LabelY.ToStr()}' font-size='12px' text-anchor='{anchor}' dominant-baseline='{baseline}' fill='currentColor'>{axisLine.LabelYValue}</text>");
+                builder.OpenElement(seq++, "text");
+                builder.AddAttribute(seq++, "class", "mud-chart-axis-label");
+                builder.AddAttribute(seq++, "x", axisLine.LabelX.ToStr());
+                builder.AddAttribute(seq++, "y", axisLine.LabelY.ToStr());
+                builder.AddAttribute(seq++, "font-size", "12px");
+                builder.AddAttribute(seq++, "text-anchor", anchor);
+                builder.AddAttribute(seq++, "dominant-baseline", baseline);
+                builder.AddAttribute(seq++, "fill", "currentColor");
+                builder.AddContent(seq++, axisLine.LabelYValue);
+                builder.CloseElement();
             }
         }
         builder.CloseElement();
@@ -95,8 +103,16 @@
 
         foreach (var axisValue in _axisValues)
         {
-            builder.AddMarkupContent(seq++,
-                $"<text class='mud-chart-axis-value' x='{axisValue.LabelX.ToStr()}' y='{axisValue.LabelY.ToStr()}' font-size='10px' text-anchor='start' dominant-baseline='middle' fill='currentcolor'>{axisValue.LabelYValue}</text>");
+            builder.OpenElement(seq++, "text");
+            builder.AddAttribute(seq++, "class", "mud-chart-axis-value");
+            builder.AddAttribute(seq++, "x", axisValue.LabelX.ToStr());
+            builder.AddAttribute(seq++, "y", axisValue.LabelY.ToStr());
+            builder.AddAttribute(seq++, "font-size", "10px");
+            builder.AddAttribute(seq++, "text-anchor", "start");
+            builder.AddAttribute(seq++, "dominant-baseline", "middle");
+            builder.AddAttribute(seq++, "fill", "currentColor");
+            builder.AddContent(seq++, axisValue.LabelYValue);
+            builder.CloseElement();
         }
         builder.CloseElement(); // </g>
     };

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -151,7 +151,12 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     {
         Debug.Assert(ChartOptions is not null);
         var axisAngle = currentAngle;
-        var gridLevels = T.CreateSaturating(ChartOptions.GridLevels);
+        var gridLevelsOption = ChartOptions.GridLevels;
+
+        if (gridLevelsOption <= 0)
+            return;
+        
+        var gridLevels = T.CreateSaturating(gridLevelsOption);
         var stepValue = T.Max(T.CreateSaturating(1), axisMaxValue / gridLevels);
 
         for (var i = T.One; i <= gridLevels; i++)

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -152,7 +152,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         Debug.Assert(ChartOptions is not null);
         var axisAngle = currentAngle;
         var gridLevels = T.CreateSaturating(ChartOptions.GridLevels);
-        var stepValue = axisMaxValue / gridLevels;
+        var stepValue = T.Max(T.CreateSaturating(1), axisMaxValue / gridLevels);
 
         for (var i = T.One; i <= gridLevels; i++)
         {

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -155,7 +155,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
 
         if (gridLevelsOption <= 0)
             return;
-        
+
         var gridLevels = T.CreateSaturating(gridLevelsOption);
         var stepValue = T.Max(T.CreateSaturating(1), axisMaxValue / gridLevels);
 


### PR DESCRIPTION
## Fix radial chart legend logic
- Radial charts displayed all available legend items even if the data series item is not currently visible. This should only be the case when `CanHideSeries` is enabled to allow the user to show/hide.

## Fix radar label position
- Radar chart value labels were positions on top of the chart grid but behind the data paths. Depending on the opacity of the paths, the values could potentially be hidden.

Partially addresses #12669

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
