### PR TITLE
Build: Reduce max runs and triages in AutoTriage backlog workflow

### DIFF
--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -48,10 +48,10 @@ jobs:
           enabled: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.enabled) }}
           model-fast: gemini-2.5-flash
           model-fast-temperature: 0.0
-          max-fast-runs: 40 # keep it low so we don't keep checking the same issues (for staleness, etc)
+          max-fast-runs: 20 # keep it low so we don't keep checking the same issues (for staleness, etc)
           model-pro: gemini-3-flash-preview # use a cheaper model since we've already scanned the issues before
           model-pro-temperature: 1.0
-          max-triages: 40
+          max-triages: 20
           db-path: triage-db.json
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Save on some billing charges by reducing the number of issues that are processed during the nightly backlog. We've already scanned a lot of issues and are down to 900 so it's easier to maintain that now.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
