### PR TITLE
MudImage: Add NoCache property for cache-busting

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ImageTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ImageTests.cs
@@ -129,6 +129,35 @@ namespace MudBlazor.UnitTests.Components
 
             img.GetAttribute("src").Should().Be(initialSrc);
         }
+
+        [Test]
+        public void Image_NoCache_AppendsCacheBustingQueryString()
+        {
+            var src = "https://myimgsource.com/image.png";
+
+            var comp = Context.Render<MudImage>(parameters => parameters
+                .Add(p => p.Src, src)
+                .Add(p => p.NoCache, true)
+            );
+
+            var img = comp.Find("img");
+            img.GetAttribute("src").Should().StartWith(src + "?v=");
+        }
+
+        [Test]
+        public void Image_NoCache_False_DoesNotAppendQueryString()
+        {
+            var src = "https://myimgsource.com/image.png";
+
+            var comp = Context.Render<MudImage>(parameters => parameters
+                .Add(p => p.Src, src)
+                .Add(p => p.NoCache, false)
+            );
+
+            var img = comp.Find("img");
+            img.GetAttribute("src").Should().Be(src);
+        }
+
     }
 }
 

--- a/src/MudBlazor/Components/Image/MudImage.razor
+++ b/src/MudBlazor/Components/Image/MudImage.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<img @attributes="UserAttributes" src="@_srcState.Value" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnErrorAsync">
+<img @attributes="UserAttributes" src="@ComputedSrc" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnErrorAsync">

--- a/src/MudBlazor/Components/Image/MudImage.razor.cs
+++ b/src/MudBlazor/Components/Image/MudImage.razor.cs
@@ -130,9 +130,9 @@ public partial class MudImage : MudComponentBase
     /// <summary>
     /// Gets the computed image source, appending a cache-busting timestamp when <see cref="NoCache"/> is enabled.
     /// </summary>
-    private string? ComputedSrc => NoCache && !string.IsNullOrEmpty(Src)
-    ? $"{Src}?v={DateTime.UtcNow.Ticks}"
-    : Src;
+    private string? ComputedSrc => NoCache && !string.IsNullOrEmpty(_srcState.Value)
+    ? $"{_srcState.Value}?v={DateTime.UtcNow.Ticks}"
+    : _srcState.Value;
 
     /// <summary>
     /// Handles the image error event and sets the fallback image source.

--- a/src/MudBlazor/Components/Image/MudImage.razor.cs
+++ b/src/MudBlazor/Components/Image/MudImage.razor.cs
@@ -60,6 +60,17 @@ public partial class MudImage : MudComponentBase
     public string? FallbackSrc { get; set; }
 
     /// <summary>
+    /// Prevents the browser from caching this image.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>. When <c>true</c>, appends a unique timestamp to the image URL.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Image.Behavior)]
+    public bool NoCache { get; set; }
+
+
+    /// <summary>
     /// The alternate text for this image.
     /// </summary>
     [Parameter]
@@ -115,6 +126,13 @@ public partial class MudImage : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Image.Appearance)]
     public ObjectPosition ObjectPosition { set; get; } = ObjectPosition.Center;
+
+    /// <summary>
+    /// Gets the computed image source, appending a cache-busting timestamp when <see cref="NoCache"/> is enabled.
+    /// </summary>
+    private string? ComputedSrc => NoCache && !string.IsNullOrEmpty(Src)
+    ? $"{Src}?v={DateTime.UtcNow.Ticks}"
+    : Src;
 
     /// <summary>
     /// Handles the image error event and sets the fallback image source.


### PR DESCRIPTION
## What does this PR do?
Adds a `NoCache` boolean parameter to the `MudImage` component. 
When `NoCache="true"`, a unique timestamp is automatically appended 
to the image URL to prevent browser caching.

## Usage
```razor
<MudImage Src="@_imagePath" NoCache="true" />
```

## Why?
Previously, developers had to manually append cache-busting strings:
`Src="@($"{myPath}?v={DateTime.Now.Ticks}")"`
This PR makes that automatic and more "Blazor-like".

Closes #12681