### PR TITLE
MudIconButton: Fix focus state style when clicked

### DIFF
--- a/src/MudBlazor/Styles/components/_iconbutton.scss
+++ b/src/MudBlazor/Styles/components/_iconbutton.scss
@@ -29,6 +29,10 @@
     }
   }
 
+  &:focus:not(:focus-visible) {
+    background-color: transparent;
+  }
+
   &:disabled {
     color: var(--mud-palette-action-disabled);
     background-color: transparent;


### PR DESCRIPTION
There was a regression with #11858 that icon button always have a focus ring even when click with mouse.
Now we fixed the state that icon button only persist focus background only focused with keyboard, not mouse.

Before:

https://github.com/user-attachments/assets/ba083fbf-f57d-421d-9b3e-4c51e9deb5ee

After:

https://github.com/user-attachments/assets/61dc198e-b8f4-4649-82d0-6b491fc2c83f



**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
