### PR TITLE
MudDatePicker: Clear conversion error when editable field is manually erased

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -264,6 +264,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DatePicker_ShouldClearValidationError_WhenInvalidDateIsQuicklyErased()
+        {
+            var comp = Context.Render<MudDatePicker>();
+
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.Date.Should().Be(null);
+
+            var invalid = "INVALID_DATE";
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, "INVALID_DATE"));
+
+            picker.Date.Should().Be(null);
+            picker.Text.Should().Be(invalid);
+
+            picker.GetState(x => x.Error).Should().BeTrue();
+            picker.ConversionError.Should().BeTrue();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, ""));
+
+            picker.GetState(x => x.Error).Should().BeFalse();
+            picker.ConversionError.Should().BeFalse();
+            picker.Date.Should().Be(null);
+        }
+
+        [Test]
         public void Check_Initial_Date_Format()
         {
             DateTime? date = new DateTime(2021, 1, 13);

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -33,7 +33,10 @@ namespace MudBlazor
         private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
         private const int DebounceTimeoutMs = 100;
 
-        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate = false)
+        protected Task SetDateAsync(DateTime? date, bool updateValue)
+            => SetDateAsync(date, updateValue, false);
+        
+        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
             {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -35,7 +35,7 @@ namespace MudBlazor
 
         protected Task SetDateAsync(DateTime? date, bool updateValue)
             => SetDateAsync(date, updateValue, false);
-        
+
         protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
@@ -48,7 +48,7 @@ namespace MudBlazor
             /* See #7866 for more details
              * When the date is set in the UI, this method gets called with the same value multiple time. This guard
              * debounces the value to the same value in a short time frame is ignored. The debounce is ignored if
-             * foreceUpdate is true
+             * forceUpdate is true
              */
             if (_value == date && (now - _lastSetTime).TotalMilliseconds < DebounceTimeoutMs && !forceUpdate)
             {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -33,7 +33,7 @@ namespace MudBlazor
         private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
         private const int DebounceTimeoutMs = 100;
 
-        protected async Task SetDateAsync(DateTime? date, bool updateValue)
+        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate = false)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
             {
@@ -44,9 +44,10 @@ namespace MudBlazor
 
             /* See #7866 for more details
              * When the date is set in the UI, this method gets called with the same value multiple time. This guard
-             * debounces the value to the same value in a short time frame is ignored
+             * debounces the value to the same value in a short time frame is ignored. The debounce is ignored if
+             * foreceUpdate is true
              */
-            if (_value == date && (now - _lastSetTime).TotalMilliseconds < DebounceTimeoutMs)
+            if (_value == date && (now - _lastSetTime).TotalMilliseconds < DebounceTimeoutMs && !forceUpdate)
             {
                 return;
             }
@@ -86,6 +87,12 @@ namespace MudBlazor
                 await BeginValidateAsync();
                 FieldChanged(_value);
             }
+            else if (forceUpdate)
+            {
+                // If the field is quickly cleared after an error: just reset and resubmit.
+                ResetConverterErrors();
+                await BeginValidateAsync();
+            }
         }
 
         protected override Task DateFormatChangedAsync(string? newFormat)
@@ -97,8 +104,11 @@ namespace MudBlazor
         protected override Task StringValueChangedAsync(string? value)
         {
             Touched = true;
+            var hadConversionError = ConversionError;
+            var date = ConvertGet(value);
             // Update the date property (without updating back the Value property)
-            return SetDateAsync(ConvertGet(value), false);
+            // If the date had a conversion error and is now null or empty forceUpdate is true
+            return SetDateAsync(date, false, forceUpdate: string.IsNullOrEmpty(value) && hadConversionError);
         }
 
         protected override string GetDayClasses(int month, DateTime day)


### PR DESCRIPTION
## Problem
---

When using `MudDatePicker` with `Editable="true"`, typing an invalid date and then quickly erasing the field (e.g. hloding backspace) would leave the validation error visible even though the field  was empty. The error only cleared if the field was erased slowly.

## Root Cause
---

The debounce guard in `SetDateAsync` was blocking the call when  `_value == null` and `date == null` (both null after erasing), which prevented `BeginValidateAsync` from running and clearing the conversion error.

## Fix
---

- Added a `forceUpdate` optional parameter (default false) to `SetDateAsync` to bypass the debounce in specific cases.
- In `StringValueChangedAsync`, when the field is empty and a conversion error was previously active, `forceUpdate: true` is passed to force the revalidation regardless of the debounce timing.

## Test
---

Added `DatePicker_ShouldClearValidationError_WhenInvalidDateIsQuicklyErased` to reproduce the exact scenario.

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

Fixes #12336