### PR TITLE
MudFileUpload: Remove mt-1 spacing when SelectedTemplate is set

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadActivatorContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/FileUpload/FileUploadActivatorContentTest.razor
@@ -12,6 +12,13 @@
     </MudPaper>
 
     <MudPaper Outlined="true" Class="pa-4">
+        <MudText>Blank FileUpload with empty SelectedTemplate</MudText>
+        <MudFileUpload T="IReadOnlyList<IBrowserFile>" AppendMultipleFiles="true">
+            <SelectedTemplate />
+        </MudFileUpload>
+    </MudPaper>
+
+    <MudPaper Outlined="true" Class="pa-4">
         <MudText>Blank FileUpload Drag True</MudText>
         <MudFileUpload T="IReadOnlyList<IBrowserFile>"
                        Style="height: 300px;width: 300px;"

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -572,6 +572,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Ensures that no mt-1 spacing is applied when SelectedTemplate is used,
+        /// even if files are present.
+        /// </summary>
+        [Test]
+        public void FileUpload_SelectedTemplate_Should_Not_Apply_Mt1_To_Wrapper()
+        {
+            // Arrange
+            IReadOnlyList<IBrowserFile> files =
+            [
+                new DummyBrowserFile("a.txt", DateTimeOffset.Now, 0, "text/plain", [])
+            ];
+
+            var comp = Context.Render<MudFileUpload<IReadOnlyList<IBrowserFile>>>(parameters => parameters
+                .Add(x => x.Files, files)
+                .Add(x => x.SelectedTemplate, context => builder =>
+                {
+                    builder.AddContent(0, $"Selected files: {context?.Count ?? 0}");
+                }));
+
+            // Act
+            var wrapper = comp.Find(".mud-file-upload-files");
+
+            // Assert
+            wrapper.ClassList.Should().NotContain("mt-1");
+        }
+
+        /// <summary>
         /// Tests the SuppressOnChangeWhenInvalid behavior in the FileUpload component
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -572,11 +572,15 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Ensures that no mt-1 spacing is applied when SelectedTemplate is used,
-        /// even if files are present.
+        /// The wrapper must apply spacing class "mt-1" 
+        /// if and only if no SelectedTemplate is provided.
         /// </summary>
         [Test]
-        public void FileUpload_SelectedTemplate_Should_Not_Apply_Mt1_To_Wrapper()
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void FileUpload_FilesContainer_TopSpacing_Should_Depend_On_SelectedTemplate(
+            bool hasSelectedTemplate,
+            bool expectedMt1)
         {
             // Arrange
             IReadOnlyList<IBrowserFile> files =
@@ -584,18 +588,25 @@ namespace MudBlazor.UnitTests.Components
                 new DummyBrowserFile("a.txt", DateTimeOffset.Now, 0, "text/plain", [])
             ];
 
-            var comp = Context.Render<MudFileUpload<IReadOnlyList<IBrowserFile>>>(parameters => parameters
-                .Add(x => x.Files, files)
-                .Add(x => x.SelectedTemplate, context => builder =>
+            var comp = Context.Render<MudFileUpload<IReadOnlyList<IBrowserFile>>>(parameters =>
+            {
+                parameters.Add(x => x.Files, files);
+
+                if (hasSelectedTemplate)
                 {
-                    builder.AddContent(0, $"Selected files: {context?.Count ?? 0}");
-                }));
+                    parameters.Add(x => x.SelectedTemplate, context => builder =>
+                    {
+                        builder.AddContent(0, $"Selected files: {context?.Count ?? 0}");
+                    });
+                }
+            });
 
             // Act
             var wrapper = comp.Find(".mud-file-upload-files");
+            var hasMt1 = wrapper.ClassList.Contains("mt-1");
 
             // Assert
-            wrapper.ClassList.Should().NotContain("mt-1");
+            hasMt1.Should().Be(expectedMt1);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
@@ -59,13 +59,16 @@
                 </div>
             </CascadingValue>
         }
-        <div class="mud-file-upload-files mt-1">
-            @if (SelectedTemplate != null)
-            {
+
+        @if (SelectedTemplate != null)
+        {
+            <div class="mud-file-upload-files">
                 @SelectedTemplate(_filesState.Value)
-            }
-            else
-            {
+            </div>
+        }
+        else
+        {
+            <div class="mud-file-upload-files mt-1">
                 <!-- Make sure there is at least one file -->
                 @if (!EqualityComparer<T>.Default.Equals(_filesState.Value, default))
                 {
@@ -81,7 +84,7 @@
                         }
                     </span>
                 }
-            }
-        </div>
+            </div>
+        }
     </InputContent>
 </MudInputControl>


### PR DESCRIPTION
### Description

Apply `mt-1` spacing only for the default file list rendering in `MudFileUpload`.

Previously, the wrapper `.mud-file-upload-files` always included `mt-1`, which caused unintended spacing even when `SelectedTemplate` was provided. This could lead to unexpected layout changes in custom templates.

This change ensures that:
- `mt-1` is applied only when rendering the default file list.
- No additional spacing is forced when `SelectedTemplate` is used.

A regression test was added to verify that `mt-1` is not applied when `SelectedTemplate` is set.

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests