### PR TITLE
MudMenu: Automatize Custom Activator Toggle Behavior

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample1.razor
@@ -1,39 +1,52 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudMenu>
-    <ActivatorContent>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@context.ToggleAsync">Button</MudButton>
-    </ActivatorContent>
-    <ChildContent>
-        <MudMenuItem Label="Profile" />
-        <MudMenuItem Label="Theme" />
-        <MudMenuItem Label="Usage" />
-    </ChildContent>
-</MudMenu>
+<MudStack>
+    <MudStack Row="true">
+        <MudMenu ActivationEvent="_event">
+            <ActivatorContent>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" ClickPropagation="true">Button</MudButton>
+            </ActivatorContent>
+            <ChildContent>
+                <MudMenuItem Label="Profile" />
+                <MudMenuItem Label="Theme" />
+                <MudMenuItem Label="Usage" />
+            </ChildContent>
+        </MudMenu>
 
-<MudMenu>
-    <ActivatorContent>
-        <MudChip T="string" Icon="@Icons.Material.Filled.Person" Color="Color.Primary" OnClick="@(() => context.ToggleAsync())">Chip</MudChip>
-    </ActivatorContent>
-    <ChildContent>
-        <MudMenuItem Label="Profile" />
-        <MudMenuItem Label="Theme" />
-        <MudMenuItem Label="Usage" />
-    </ChildContent>
-</MudMenu>
+        <MudMenu ActivationEvent="_event">
+            <ActivatorContent>
+                <MudChip T="string" Icon="@Icons.Material.Filled.Person" Color="Color.Primary">Chip</MudChip>
+            </ActivatorContent>
+            <ChildContent>
+                <MudMenuItem Label="Profile" />
+                <MudMenuItem Label="Theme" />
+                <MudMenuItem Label="Usage" />
+            </ChildContent>
+        </MudMenu>
 
-<MudMenu>
-    <ActivatorContent>
-        <div @onclick="@context.ToggleAsync" style="cursor: pointer">
-            <MudAvatar>
-                <MudImage Src="images/toiletvisit.jpg" />
-            </MudAvatar>
-        </div>
-    </ActivatorContent>
-    <ChildContent>
-        <MudMenuItem Label="Profile" />
-        <MudMenuItem Label="Theme" />
-        <MudMenuItem Label="Usage" />
-    </ChildContent>
-</MudMenu>
+        <MudMenu ActivationEvent="_event">
+            <ActivatorContent>
+                <div style="cursor: pointer">
+                    <MudAvatar>
+                        <MudImage Src="images/toiletvisit.jpg" />
+                    </MudAvatar>
+                </div>
+            </ActivatorContent>
+            <ChildContent>
+                <MudMenuItem Label="Profile" />
+                <MudMenuItem Label="Theme" />
+                <MudMenuItem Label="Usage" />
+            </ChildContent>
+        </MudMenu>
+    </MudStack>
 
+    <MudSelect @bind-Value="@_event">
+        <MudSelectItem Value="MouseEvent.LeftClick">Left Click</MudSelectItem>
+        <MudSelectItem Value="MouseEvent.RightClick">Right Click</MudSelectItem>
+        <MudSelectItem Value="MouseEvent.MouseOver">Mouse Over</MudSelectItem>
+    </MudSelect>
+</MudStack>
+
+@code {
+    MouseEvent _event = MouseEvent.LeftClick;
+}

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample2.razor
@@ -3,7 +3,7 @@
 
 <MudMenu FullWidth="true" ActivationEvent="@MouseEvent.LeftClick">
     <ActivatorContent>
-        <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary" OnClick="@(() => context.ToggleAsync())">Left Click</MudChip>
+        <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Left Click</MudChip>
     </ActivatorContent>
     <ChildContent>
         <MudMenuItem Label="Profile" />
@@ -15,7 +15,7 @@
 
 <MudMenu ActivationEvent="@MouseEvent.RightClick">
     <ActivatorContent>
-        <div @oncontextmenu="@context.ToggleAsync" @oncontextmenu:preventDefault>
+        <div>
             <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Right Click</MudChip>
         </div>
     </ActivatorContent>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorOnMouseExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorOnMouseExample.razor
@@ -3,7 +3,7 @@
 
 <MudMenu PositionAtCursor="true">
     <ActivatorContent>
-        <div @onclick="@context.ToggleAsync" style="cursor: pointer">
+        <div style="cursor: pointer">
             <MudCard>
                 <MudCardMedia Image="images/door.jpg" Height="200" />
                 <MudCardContent>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -59,6 +59,7 @@
                             If the regular customization options are not enough, use the <CodeInline>ActivatorContent</CodeInline> render fragment to define a custom activator element for opening the menu.
                             In this example, a custom button, chip, and avatar are each used to open a menu. When generating activator elements inside a Blazor code block (<CodeInline>&#64;{ ... }</CodeInline>) or conditional markup, ensure that the element includes
 							<CodeInline>tabindex="0"</CodeInline> so it can receive focus and remain accessible via keyboard input.
+                            Be sure that inside elements allow click propagation to work MudMenu properly (for example set ClickPropagation to true on MudButtons).
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(MenuActivatorExample1)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestVariants.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Menu/MenuTestVariants.razor
@@ -26,7 +26,7 @@
 
 <MudMenu FullWidth="true" PopoverClass="menu-popover-class">
     <ActivatorContent>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@context.ToggleAsync">Activator Content Standard</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary">Activator Content Standard</MudButton>
     </ActivatorContent>
     <ChildContent>
         <MudMenuItem Class="test-class">1</MudMenuItem>
@@ -37,7 +37,7 @@
 
 <MudMenu ActivationEvent="MouseEvent.RightClick" FullWidth="true" PopoverClass="menu-popover-class">
     <ActivatorContent>
-        <div @oncontextmenu="@context.ToggleAsync" @oncontextmenu:preventDefault="true" style="display: inline-block">
+        <div style="display: inline-block">
             <MudButton Variant="Variant.Filled" Color="Color.Primary">Activator Content Right Click</MudButton>
         </div>
     </ActivatorContent>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -174,7 +174,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Clicking the button should close the menu.
-            await comp.Find("button.mud-button-root").ClickAsync();
+            await comp.Find("div.mud-menu").ClickAsync();
             // Check that the component is closed
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeFalse());
 
@@ -274,7 +274,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.FindAll("button.mud-button-root")[0].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Standart button menu -- right click
-            await comp.FindAll("button.mud-button-root")[1].ClickAsync(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("div.mud-menu")[1].ContextMenuAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -292,7 +292,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.FindAll("button.mud-button-root")[2].ClickAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Icon button menu -- right click
-            await comp.FindAll("button.mud-button-root")[3].ClickAsync(new MouseEventArgs() { Button = 2 });
+            await comp.FindAll("button.mud-button-root")[3].ContextMenuAsync(new MouseEventArgs() { Button = 2 });
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);
@@ -301,7 +301,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.FindAll("button.mud-button-root")[3].ClickAsync();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
             //Activator content menu -- left click
-            await comp.FindAll("button.mud-button-root")[4].ClickAsync();
+            await comp.FindAll("div.mud-menu")[4].ClickAsync();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
             comp.FindAll("div.mud-menu-item").Count.Should().Be(1);
             comp.FindAll("a.mud-menu-item").Count.Should().Be(2);

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -6,9 +6,10 @@
      style="@Style"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
-     @oncontextmenu="@((ActivationEvent == MouseEvent.RightClick && ActivatorContent is null ? ToggleMenuAsync : null)!)"
-     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null)"
-     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null)"
+     @onclick="HandleRootClick"
+     @oncontextmenu="@((ActivationEvent == MouseEvent.RightClick ? ToggleMenuAsync : null)!)"
+     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
+     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)"
      @onkeydown="TrackKeyboardInteraction">
     @if (GetActivatorHidden())
     {
@@ -58,7 +59,7 @@
                        Disabled="@Disabled"
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
-                       OnClick="@ToggleMenuAsync"
+                       ClickPropagation="true"
                        aria-label="@AriaLabel">
                 @Label
             </MudButton>
@@ -89,7 +90,7 @@
                        Disabled="@Disabled"
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
-                       OnClick="@ToggleMenuAsync"
+                       ClickPropagation="true"
                        aria-label="@AriaLabel" />
     }
 

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -1157,5 +1157,30 @@ namespace MudBlazor
                 await ToggleMenuAsync(e);
             }
         }
+
+        private async Task HandleRootClick(EventArgs args)
+        {
+            if (ActivationEvent == MouseEvent.RightClick)
+            {
+                return;
+            }
+
+            if (ActivationEvent == MouseEvent.LeftClick)
+            {
+                await ToggleMenuAsync(args);
+            }
+
+            if (ActivationEvent == MouseEvent.MouseOver)
+            {
+                if (_openState.Value)
+                {
+                    await CloseMenuAsync();
+                }
+                else
+                {
+                    await OpenMenuAsync(args);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
In current design, ActivatorContent ignores ActivationEvent completely. Users need to write own logic and call ToggleAsync manually, which is not a good approach.

Now we changed the click behavior. It only triggers on root container. Single layer has the toggle responsibility. So it works also for custom activator. We also removed inner toggle on click methods, just add ClickPropagation to true to be sure that root container can take click properly.

Also enhanced the docs example that we can test custom activator with all 3 mouse events.


https://github.com/user-attachments/assets/b7c5b5be-19f8-40c6-b6e5-63d10ec7af9a



**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
