### PR TITLE
MudChart: Remove width adjustment

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Bunit;
+using MudBlazor.Charts;
+using MudBlazor.Interop;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Charts;
+
+public class ChartSizingTests : BunitTest
+{
+    [Test]
+    public async Task MudAxisChartBase_MatchBoundsToSize_ShouldMatchMeasuredSizeExactly()
+    {
+        var chartSeries = new List<ChartSeries<double>>()
+        {
+            new () { Name = "Series 1", Data = new double[] { 10, 20 } },
+        };
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Bar)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.ChartSeries, chartSeries));
+
+        // Find the internal Bar component
+        var barComponent = comp.FindComponent<Bar<double>>();
+        var axisChartBase = barComponent.Instance as MudAxisChartBase<double, BarChartOptions>;
+
+        // Manually invoke OnElementSizeChanged with a specific width
+        const double measuredWidth = 800.0;
+        const double measuredHeight = 400.0;
+
+        await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize
+        {
+            Width = measuredWidth,
+            Height = measuredHeight,
+            Timestamp = DateTime.Now.Ticks
+        }));
+
+        // The viewBox should match the measured size exactly
+        comp.WaitForAssertion(() =>
+        {
+            var svg = comp.Find("svg.mud-chart-bar");
+            svg.GetAttribute("viewBox").Should().Be($"0 0 {measuredWidth} {measuredHeight}");
+        });
+    }
+
+    [Test]
+    public async Task MudAxisChartBase_LineChart_MatchBoundsToSize_ShouldMatchMeasuredSizeExactly()
+    {
+        var chartSeries = new List<ChartSeries<double>>()
+        {
+            new () { Name = "Series 1", Data = new double[] { 10, 20 } },
+        };
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.ChartSeries, chartSeries));
+
+        // Find the internal Line component
+        var lineComponent = comp.FindComponent<Line<double>>();
+        var axisChartBase = lineComponent.Instance as MudAxisChartBase<double, LineChartOptions>;
+
+        // Manually invoke OnElementSizeChanged with a specific width
+        const double measuredWidth = 900.0;
+        const double measuredHeight = 500.0;
+
+        await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize
+        {
+            Width = measuredWidth,
+            Height = measuredHeight,
+            Timestamp = DateTime.Now.Ticks
+        }));
+
+        // The viewBox should match the measured size exactly
+        comp.WaitForAssertion(() =>
+        {
+            var svg = comp.Find("svg.mud-chart-line");
+            svg.GetAttribute("viewBox").Should().Be($"0 0 {measuredWidth} {measuredHeight}");
+        });
+    }
+
+    [Test]
+    public void MudAxisChartBase_YAxisTitle_ShouldAllocateSpaceAndPositionCorrectly()
+    {
+        var chartSeries = new List<ChartSeries<double>>()
+        {
+            new () { Name = "Series 1", Data = new double[] { 10, 20 } },
+        };
+
+        // Render without title
+        var compWithoutTitle = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Bar)
+            .Add(p => p.ChartSeries, chartSeries));
+
+        var gridWithoutTitle = compWithoutTitle.Find("g.mud-charts-gridlines-yaxis path");
+        var dWithoutTitle = gridWithoutTitle.GetAttribute("d");
+        // Extract the first X coordinate from "M X Y ..."
+        var xWithoutTitle = double.Parse(dWithoutTitle.Split(' ')[1]);
+
+        // Render with title
+        var compWithTitle = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Bar)
+            .Add(p => p.ChartSeries, chartSeries)
+            .Add(p => p.ChartOptions, new BarChartOptions { YAxisTitle = "Title" }));
+
+        var gridWithTitle = compWithTitle.Find("g.mud-charts-gridlines-yaxis path");
+        var dWithTitle = gridWithTitle.GetAttribute("d");
+        var xWithTitle = double.Parse(dWithTitle.Split(' ')[1]);
+
+        // xWithTitle should be larger than xWithoutTitle if space was allocated
+        // Note: Since labels might be small, they both might fall into the 30px minimum.
+        // But we added 20px, so it should definitely exceed 30px if the original was 30px.
+        xWithTitle.Should().BeGreaterThan(xWithoutTitle);
+
+        // Also check that the title is at X=10
+        var titleGroup = compWithTitle.Find("g[transform^='translate(10,']");
+        titleGroup.Should().NotBeNull();
+        titleGroup.InnerHtml.Should().Contain("Title");
+    }
+}

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -43,7 +43,7 @@
     </g>
     @if (YAxisTitle is not null)
     {
-        <g transform="translate(@(ToS(-1 * (_yAxisLabelSize?.Width ?? 2 / 2))), @(ToS(ViewBoxHeight / 2)))">
+        <g transform="translate(10, @(ToS(ViewBoxHeight / 2)))">
             <text class="mud-charts-yaxis axis-title" transform="rotate(-90)" font-size="14px" text-anchor="middle" dominant-baseline="hanging">@YAxisTitle</text>
         </g>
     }
@@ -65,17 +65,10 @@
 
     @CustomGraphics
 
-    @if (ChartOptions?.ShowToolTips is true) 
+    @if (ChartOptions?.ShowToolTips is true)
     {
         <g class="mud-charts-tooltip" style="@TooltipStylename">
             @TooltipContent
         </g>
     }
 </svg>
-
-@* @if (XAxisTitle is not null)
-{
-    <MudStack Class="mt-2" Row="true" Justify="Justify.Center">
-        <MudText Class="mud-charts-xaxis axis-title" Typo="Typo.body2">@XAxisTitle</MudText>
-    </MudStack>
-} *@

--- a/src/MudBlazor/Components/Chart/Base/IAxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IAxisChartOptions.cs
@@ -45,4 +45,14 @@ public interface IAxisChartOptions : IChartOptions
     /// Rotation angle to rotate the labels in degrees.
     /// </summary>
     public int XAxisLabelRotation { get; set; }
+
+    /// <summary>
+    /// The title of the X-axis.
+    /// </summary>
+    public string? XAxisTitle { get; set; }
+
+    /// <summary>
+    /// The title of the Y-axis.
+    /// </summary>
+    public string? YAxisTitle { get; set; }
 }

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -81,7 +81,6 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     /// </summary>
     protected readonly List<SvgLegend> Legends = [];
 
-    private const double WidthAdjustment = 50.0;
     protected const double Epsilon = 1e-6;
     /// <summary>
     /// The default width of the chart bounds.
@@ -99,7 +98,7 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     /// <summary>
     /// The horizontal start space for the chart.
     /// </summary>
-    protected double HorizontalStartSpace => Math.Max(HorizontalStartSpaceBuffer + Math.Ceiling(_yAxisLabelSize?.Width ?? 0), 30);
+    protected double HorizontalStartSpace => Math.Max(HorizontalStartSpaceBuffer + Math.Ceiling(_yAxisLabelSize?.Width ?? 0), 30) + (ChartOptions?.YAxisTitle != null ? 20 : 0);
     /// <summary>
     /// The horizontal end space for the chart.
     /// </summary>
@@ -355,12 +354,7 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
         if (elementSize is null || elementSize.Timestamp <= _elementSize?.Timestamp)
             return;
 
-        _elementSize = new ElementSize()
-        {
-            Height = elementSize.Height,
-            Width = Math.Max(0, elementSize.Width - WidthAdjustment),
-            Timestamp = elementSize.Timestamp
-        };
+        _elementSize = elementSize;
 
         if (!MatchBoundsToSize)
             return;


### PR DESCRIPTION
This PR fixes a bug where MudChart components (Bar, StackedBar, Line, TimeSeries) would continuously shrink horizontally when MatchBoundsToSize was set to true and the legend was positioned on the side (Left, Right, Start, or End).

The issue was caused by a constant WidthAdjustment = 50.0 in MudAxisChartBase.OnElementSizeChanged that was being subtracted from the measured width before setting the chart's viewBox, leading to a feedback loop. 

Addresses issue raised in #12669 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
