### PR TITLE
MudSelect: Fix re-opening when clicked while already open

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1089,6 +1089,26 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task Select_ClickingSelectWhileOpen_ClosesWithoutReopening()
+        {
+            var comp = Context.Render<SelectTest1>();
+            var select = comp.FindComponent<MudSelect<string>>();
+
+            IElement Input() => comp.Find("div.mud-input-control");
+            IElement Menu() => comp.Find("div.mud-popover");
+
+            await Input().MouseDownAsync(new MouseEventArgs { Button = 0, ClientX = 10, ClientY = 10 });
+            await comp.WaitForAssertionAsync(() => Menu().ClassList.Should().Contain("mud-popover-open"));
+
+            var overlay = comp.Find("div.mud-overlay");
+            await overlay.PointerDownAsync(new PointerEventArgs { Button = 0, ClientX = 10, ClientY = 10 });
+            await Input().MouseDownAsync(new MouseEventArgs { Button = 0, ClientX = 10, ClientY = 10 });
+
+            await comp.WaitForAssertionAsync(() => Menu().ClassList.Should().NotContain("mud-popover-open"));
+            select.Instance.Open.Should().BeFalse();
+        }
+
+        [Test]
         public async Task Select_KeyboardNavigation_SingleSelect()
         {
             var keyInterceptorService = Context.AddKeyInterceptorService();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1101,6 +1101,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => Menu().ClassList.Should().Contain("mud-popover-open"));
 
             var overlay = comp.Find("div.mud-overlay");
+            await Input().PointerDownAsync(new PointerEventArgs { Button = 0, ClientX = 10, ClientY = 10 });
             await overlay.PointerDownAsync(new PointerEventArgs { Button = 0, ClientX = 10, ClientY = 10 });
             await Input().MouseDownAsync(new MouseEventArgs { Button = 0, ClientX = 10, ClientY = 10 });
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -135,8 +135,8 @@ the auto close feature and call CloseMenu in OnClosed. The modeless auto close
 feature relies on pointerdown event resulting in the same order of events.
 -->
 <MudOverlay Visible="_openState.Value"
-            @onpointerdown="@(() => CloseMenu(false))"
+            @onpointerdown="@CloseMenuFromOverlayAsync"
             LockScroll="@LockScroll"
             AutoClose="@(!GetModal())"
             Modal="@GetModal()"
-            OnClosed="@(() => CloseMenu(false))"/>
+            OnClosed="@CloseMenuFromOverlayAsync"/>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -3,7 +3,7 @@
 @inherits MudBaseInput<T>
 
 <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
-    <div class="@OuterClassname" id="@ElementId" @onfocusout="@OnFocusOutAsync" @onclick:stopPropagation @onmousedown:stopPropagation>
+    <div class="@OuterClassname" id="@ElementId" @onfocusout="@OnFocusOutAsync" @onclick:stopPropagation @onpointerdown="@HandlePointerDown" @onmousedown:stopPropagation>
         <MudInputControl Label="@Label"
                          Variant="@Variant"
                          HelperId="@GetHelperId()"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -708,16 +708,13 @@ namespace MudBlazor
             return _elementReference.SelectRangeAsync(pos1, pos2);
         }
 
-        private async Task CloseMenuFromOverlayAsync()
-        {
-            await CloseMenu(false);
-        }
+        private Task CloseMenuFromOverlayAsync() => CloseMenu(false);
 
-        private async Task OnComparerChangedAsync(ParameterChangedEventArgs<IEqualityComparer<T?>?> arg)
+        private Task OnComparerChangedAsync(ParameterChangedEventArgs<IEqualityComparer<T?>?> arg)
         {
             // Apply comparer and refresh selected values
             _selectedValues = new HashSet<T?>(_selectedValues, arg.Value);
-            await _selectedValuesState.SetValueAsync(new HashSet<T?>(_selectedValues, arg.Value));
+            return _selectedValuesState.SetValueAsync(new HashSet<T?>(_selectedValues, arg.Value));
         }
 
         private async Task OnSelectedValuesChangedAsync(ParameterChangedEventArgs<IReadOnlyCollection<T?>?> arg)
@@ -1084,10 +1081,12 @@ namespace MudBlazor
             await ScrollToItemAsync(item);
         }
 
-        internal Task HandlePointerDown(PointerEventArgs args)
+        private Task HandlePointerDown(PointerEventArgs args)
         {
             if (args.Button != 0)
+            {
                 return Task.CompletedTask;
+            }
 
             // In modeless mode, the overlay auto-close is triggered on pointerdown.
             // If the pointerdown started on this select while it was open, the follow-up

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -30,9 +30,11 @@ namespace MudBlazor
         private string _searchText = string.Empty;
         private string? _lastSelectedId = string.Empty;
         private DateTimeOffset _lastSearchTime = DateTimeOffset.MinValue;
+        private DateTimeOffset _suppressMouseDownToggleUntil = DateTimeOffset.MinValue;
         private readonly ParameterState<bool> _openState;
         private readonly ParameterState<IReadOnlyCollection<T?>?> _selectedValuesState;
         private readonly MudSelectContext<T> _context;
+        private static readonly TimeSpan _mouseDownToggleSuppressionDuration = TimeSpan.FromMilliseconds(75);
 
         internal string ElementId { get; } = Identifier.Create("select");
 
@@ -707,6 +709,12 @@ namespace MudBlazor
             return _elementReference.SelectRangeAsync(pos1, pos2);
         }
 
+        private async Task CloseMenuFromOverlayAsync()
+        {
+            _suppressMouseDownToggleUntil = TimeProvider.GetUtcNow().Add(_mouseDownToggleSuppressionDuration);
+            await CloseMenu(false);
+        }
+
         private async Task OnComparerChangedAsync(ParameterChangedEventArgs<IEqualityComparer<T?>?> arg)
         {
             // Apply comparer and refresh selected values
@@ -1082,6 +1090,19 @@ namespace MudBlazor
         {
             if (args.Button != 0) // if it wasn't left click drop out
                 return Task.CompletedTask;
+
+            var now = TimeProvider.GetUtcNow();
+            if (!_openState.Value && now <= _suppressMouseDownToggleUntil)
+            {
+                _suppressMouseDownToggleUntil = DateTimeOffset.MinValue;
+                return Task.CompletedTask;
+            }
+
+            if (now > _suppressMouseDownToggleUntil)
+            {
+                _suppressMouseDownToggleUntil = DateTimeOffset.MinValue;
+            }
+
             return ToggleMenu();
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -30,11 +30,10 @@ namespace MudBlazor
         private string _searchText = string.Empty;
         private string? _lastSelectedId = string.Empty;
         private DateTimeOffset _lastSearchTime = DateTimeOffset.MinValue;
-        private DateTimeOffset _suppressMouseDownToggleUntil = DateTimeOffset.MinValue;
+        private bool _suppressMouseDownToggleForCurrentPointerSequence;
         private readonly ParameterState<bool> _openState;
         private readonly ParameterState<IReadOnlyCollection<T?>?> _selectedValuesState;
         private readonly MudSelectContext<T> _context;
-        private static readonly TimeSpan _mouseDownToggleSuppressionDuration = TimeSpan.FromMilliseconds(75);
 
         internal string ElementId { get; } = Identifier.Create("select");
 
@@ -711,7 +710,6 @@ namespace MudBlazor
 
         private async Task CloseMenuFromOverlayAsync()
         {
-            _suppressMouseDownToggleUntil = TimeProvider.GetUtcNow().Add(_mouseDownToggleSuppressionDuration);
             await CloseMenu(false);
         }
 
@@ -1086,22 +1084,30 @@ namespace MudBlazor
             await ScrollToItemAsync(item);
         }
 
+        internal Task HandlePointerDown(PointerEventArgs args)
+        {
+            if (args.Button != 0)
+                return Task.CompletedTask;
+
+            // In modeless mode, the overlay auto-close is triggered on pointerdown.
+            // If the pointerdown started on this select while it was open, the follow-up
+            // mousedown on the select must not reopen the menu in the same click sequence.
+            _suppressMouseDownToggleForCurrentPointerSequence = _openState.Value;
+            return Task.CompletedTask;
+        }
+
         internal Task HandleMouseDown(MouseEventArgs args)
         {
             if (args.Button != 0) // if it wasn't left click drop out
                 return Task.CompletedTask;
 
-            var now = TimeProvider.GetUtcNow();
-            if (!_openState.Value && now <= _suppressMouseDownToggleUntil)
+            if (!_openState.Value && _suppressMouseDownToggleForCurrentPointerSequence)
             {
-                _suppressMouseDownToggleUntil = DateTimeOffset.MinValue;
+                _suppressMouseDownToggleForCurrentPointerSequence = false;
                 return Task.CompletedTask;
             }
 
-            if (now > _suppressMouseDownToggleUntil)
-            {
-                _suppressMouseDownToggleUntil = DateTimeOffset.MinValue;
-            }
+            _suppressMouseDownToggleForCurrentPointerSequence = false;
 
             return ToggleMenu();
         }


### PR DESCRIPTION
MudSelect could close and immediately reopen when clicking the select while its menu was already open.
Cause: in modeless overlay mode, the overlay auto-close runs on pointerdown, then the select’s mousedown toggle
runs in the same click sequence and reopens the menu.

Was working correctly in v6, can be checked here https://v6.mudblazor.mnzn.dev/

Probably a regression from:
- cd3ef0884 — MudOverlay: Add parameter Modal allowing click-through (#10893)

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
