### PR TITLE
MudBaseInput: Fix OnlyValidateIfDirty with non-default initial Value

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -949,6 +949,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TextField_OnlyValidateIfDirty_WithNonDefaultInitialValue_ShouldNotValidateOnBlur()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Value, string.Empty)
+                .Add(p => p.Required, true)
+                .Add(p => p.OnlyValidateIfDirty, true));
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+
+            // blur without user interaction should not trigger validation
+            await comp.Find("input").BlurAsync();
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+
+            // user types then clears — now dirty, validation should fire
+            await comp.Find("input").ChangeAsync("x");
+            await comp.Find("input").ChangeAsync("");
+            await comp.Find("input").BlurAsync();
+            comp.FindAll("div.mud-input-error").Count.Should().BeGreaterThan(0);
+            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Required");
+        }
+
+        [Test]
         public async Task TextField_OnlyValidateIfDirty_Is_False_Should_HaveInputErrorWhenFocusChanged()
         {
             var comp = Context.Render<MudTextField<int?>>(parameters => parameters

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -552,7 +552,6 @@ namespace MudBlazor
 
         private async Task OnValueParameterChangedAsync(ParameterChangedEventArgs<T?> arg)
         {
-            _isDirty = true;
             _validated = false;
 
             // When Value changes from parent, update Text from Value


### PR DESCRIPTION
# Fix OnlyValidateIfDirty with non-default initial Value

When a `MudBaseInput<T>` derivative has `OnlyValidateIfDirty="true"` and the initial bound `Value` differs from `default(T?)`, the field incorrectly shows validation errors on blur without any user interaction.

**Root cause:** The `ParameterState` change handler `OnValueParameterChangedAsync` unconditionally sets `_isDirty = true`. On the first `SetParametersAsync`, the parent passes (e.g.) `Value = ""` but the `ParameterState` internal value is `null` (`default(string?)`). The handler fires because `null != ""`, marking the field dirty before the user ever interacts with it.

**Fix:** Remove `_isDirty = true` from `OnValueParameterChangedAsync` since it represents a parent-originated parameter change, not a user edit. `_isDirty` is still set by `SetValueAndUpdateTextAsync` for actual user modifications.

Introduced in commit `2e3f97c66` — "MudBaseInput: ParameterState for Value (#12267)".

### Repro

https://try.mudblazor.com/snippet/cYcUYcGxGXqMiJDX

Click Name → click Other (blur) → "Name is required" error appears despite no user edit.

### Test coverage

- **New:** `TextField_OnlyValidateIfDirty_WithNonDefaultInitialValue_ShouldNotValidateOnBlur` — renders a `MudTextField<string>` with `Value = string.Empty` and `OnlyValidateIfDirty = true`, asserts no validation on blur without interaction, then asserts validation fires after the user types and clears the field.
- **Existing:** `TextField_OnlyValidateIfDirty_Is_True_Should_OnlyHaveInputErrorWhenValueChanged` already covers the default-value path (`int?` with `null`), including user edits, repeated blurs, reset, and re-edit cycles. This test continues to pass, confirming `_isDirty` is still correctly set via `SetValueAndUpdateTextAsync` on user interaction.

### Affects

Any `MudBaseInput<T>` derivative (`MudTextField`, `MudNumericField`, `MudSelect`, `MudAutocomplete`, etc.) where the initial bound value differs from `default(T?)`.