### PR TITLE
MudTooltip: Fix Unnecessary Tooltip Content Re-render

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithComplexObject.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithComplexObject.razor
@@ -1,7 +1,7 @@
 ﻿<MudText Typo="Typo.h6">ParameterSet calls (for MyObject): @_parameterSet</MudText>
 
 @code {
-    int _parameterSet = 0;
+    private int _parameterSet;
 
     [Parameter]
     public MyObject MyValue { get; set; } = new();

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithComplexObject.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithComplexObject.razor
@@ -1,0 +1,15 @@
+﻿<MudText Typo="Typo.h6">ParameterSet calls (for MyObject): @_parameterSet</MudText>
+
+@code {
+    int _parameterSet = 0;
+
+    [Parameter]
+    public MyObject MyValue { get; set; } = new();
+
+    public override Task SetParametersAsync(ParameterView parameters)
+    {
+        _parameterSet++;
+
+        return base.SetParametersAsync(parameters);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithSimpleValue.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithSimpleValue.razor
@@ -1,0 +1,15 @@
+﻿<MudText Typo="Typo.h6">ParameterSet calls (for int): @_parameterSet</MudText>
+
+@code {
+    int _parameterSet = 0;
+
+    [Parameter]
+    public int MyValue { get; set; }
+
+    public override Task SetParametersAsync(ParameterView parameters)
+    {
+        _parameterSet++;
+
+        return base.SetParametersAsync(parameters);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithSimpleValue.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyAreaWithSimpleValue.razor
@@ -1,7 +1,7 @@
 ﻿<MudText Typo="Typo.h6">ParameterSet calls (for int): @_parameterSet</MudText>
 
 @code {
-    int _parameterSet = 0;
+    private int _parameterSet;
 
     [Parameter]
     public int MyValue { get; set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyObject.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyObject.cs
@@ -4,12 +4,4 @@
 
 namespace MudBlazor.UnitTests.TestComponents.Tooltip.RerenderTests;
 
-public class MyObject
-{
-    public DateTime Day;
-
-    public MyObject()
-    {
-        Day = DateTime.Now;
-    }
-}
+public class MyObject;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyObject.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/RerenderTests/MyObject.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.UnitTests.TestComponents.Tooltip.RerenderTests;
+
+public class MyObject
+{
+    public DateTime Day;
+
+    public MyObject()
+    {
+        Day = DateTime.Now;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipChildRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipChildRenderTest.razor
@@ -1,0 +1,20 @@
+﻿@using MudBlazor.UnitTests.TestComponents.Tooltip.RerenderTests
+
+<MudPopoverProvider />
+
+<MudTooltip Text="Tooltip with Object" Arrow="true" Placement="Placement.Top">
+    <MyAreaWithComplexObject MyValue="@ComplexValue" />
+</MudTooltip>
+
+<br/>
+<br/>
+<br/>
+
+<MudTooltip Text="Tooltip with integer" Arrow="true" Placement="Placement.Top">
+    <MyAreaWithSimpleValue MyValue="@SimpleValue" />
+</MudTooltip>
+
+@code {
+    public MyObject ComplexValue = new();
+    public int SimpleValue = 1;
+}

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -1,5 +1,5 @@
-using System.Threading.Tasks;
-﻿using AngleSharp.Html.Dom;
+﻿using System.Threading.Tasks;
+using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -395,21 +395,6 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
-        private class ComplexComponent : ComponentBase
-        {
-            [Parameter]
-            public object Data { get; set; }
-
-            public int RenderCount { get; private set; }
-
-            protected override void BuildRenderTree(RenderTreeBuilder builder)
-            {
-                base.BuildRenderTree(builder);
-                RenderCount++;
-                builder.AddContent(0, "Complex Component Content");
-            }
-        }
-
         [Test]
         public async Task Tooltip_ShouldNotRerenderChildContent_WhenVisibleChangesInternally()
         {
@@ -454,6 +439,21 @@ namespace MudBlazor.UnitTests.Components
 
             // Should re-render because it should behave as if not encapsulated
             complexComp.RenderCount.Should().Be(initialCount + 1);
+        }
+
+        private class ComplexComponent : ComponentBase
+        {
+            [Parameter]
+            public object Data { get; set; }
+
+            public int RenderCount { get; private set; }
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                base.BuildRenderTree(builder);
+                RenderCount++;
+                builder.AddContent(0, "Complex Component Content");
+            }
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -1,6 +1,9 @@
+using System.Threading.Tasks;
 ﻿using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.Tooltip;
@@ -390,6 +393,67 @@ namespace MudBlazor.UnitTests.Components
                 await div.PointerLeaveAsync(new PointerEventArgs());
                 tooltip.GetState(x => x.Visible).Should().Be(!showOnHover);
             }
+        }
+
+        private class ComplexComponent : ComponentBase
+        {
+            [Parameter]
+            public object Data { get; set; }
+
+            public int RenderCount { get; private set; }
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                base.BuildRenderTree(builder);
+                RenderCount++;
+                builder.AddContent(0, "Complex Component Content");
+            }
+        }
+
+        [Test]
+        public async Task Tooltip_ShouldNotRerenderChildContent_WhenVisibleChangesInternally()
+        {
+            var complexData = new object();
+            var comp = Context.Render<MudTooltip>(parameters => parameters
+                .Add(p => p.Text, "Tooltip")
+                .AddChildContent<ComplexComponent>(child => child.Add(c => c.Data, complexData))
+            );
+
+            var complexComp = comp.FindComponent<ComplexComponent>().Instance;
+            var initialCount = complexComp.RenderCount;
+            initialCount.Should().Be(1);
+
+            // Simulate hover via bUnit's event trigger
+            var div = comp.Find(".mud-tooltip-root");
+            await div.PointerEnterAsync(new PointerEventArgs());
+
+            // Verify that the tooltip is now visible
+            comp.Instance.GetState(x => x.Visible).Should().BeTrue();
+
+            // Check if ChildContent re-rendered
+            complexComp.RenderCount.Should().Be(initialCount);
+        }
+
+        [Test]
+        public async Task Tooltip_ShouldRerenderChildContent_WhenParentRerenders()
+        {
+            var complexData = new object();
+            var comp = Context.Render<MudTooltip>(parameters => parameters
+                .Add(p => p.Text, "Tooltip")
+                .AddChildContent<ComplexComponent>(child => child.Add(c => c.Data, complexData))
+            );
+
+            var complexComp = comp.FindComponent<ComplexComponent>().Instance;
+            var initialCount = complexComp.RenderCount;
+            initialCount.Should().Be(1);
+
+            // Simulate parent re-render by setting a parameter again
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.Text, "Updated Tooltip")
+            );
+
+            // Should re-render because it should behave as if not encapsulated
+            complexComp.RenderCount.Should().Be(initialCount + 1);
         }
     }
 }

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -2,14 +2,14 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@ContainerClass" style="@RootStyle" @onpointerenter="@HandlePointerEnterAsync" @onpointerleave="@HandlePointerLeaveAsync" @onpointerup="@HandlePointerUpAsync" @onfocusin="@HandleFocusInAsync" @onfocusout="@HandleFocusOutAsync">
-    @ChildContent
+    <MudTooltipChildContainer ChildContent="@ChildContent" UpdateCount="@_parentUpdateCount" />
     @if (ShowToolTip())
     {
         <MudPopover Open="@_visibleState.Value" Duration="@Duration" Delay="@Delay" AnchorOrigin="@_anchorOrigin" TransformOrigin="@_transformOrigin" Class="@Classname" Style="@Style" Paper="false">
             @if (TooltipContent is not null)
             {
                 <div class="d-block">
-                    @TooltipContent
+                    <MudTooltipChildContainer ChildContent="@TooltipContent" UpdateCount="@_parentUpdateCount" />
                 </div>
             }
             else if (!string.IsNullOrEmpty(Text))

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -10,9 +14,11 @@ namespace MudBlazor
     /// </summary>
     public partial class MudTooltip : MudComponentBase
     {
+        private int _parentUpdateCount;
         private readonly ParameterState<bool> _visibleState;
         private Origin _anchorOrigin;
         private Origin _transformOrigin;
+
         public MudTooltip()
         {
             using var registerScope = CreateRegisterScope();
@@ -212,6 +218,14 @@ namespace MudBlazor
         internal bool ShowToolTip()
         {
             return !Disabled && (TooltipContent is not null || !string.IsNullOrEmpty(Text));
+        }
+
+        /// <inheritdoc />
+        public override Task SetParametersAsync(ParameterView parameters)
+        {
+            _parentUpdateCount++;
+
+            return base.SetParametersAsync(parameters);
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -223,7 +223,7 @@ namespace MudBlazor
         /// <inheritdoc />
         public override Task SetParametersAsync(ParameterView parameters)
         {
-            _parentUpdateCount++;
+            unchecked { _parentUpdateCount++; }
 
             return base.SetParametersAsync(parameters);
         }

--- a/src/MudBlazor/Components/Tooltip/MudTooltipChildContainer.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltipChildContainer.cs
@@ -11,9 +11,10 @@ namespace MudBlazor;
 /// This component is used to prevent re-rendering of the child content when the tooltip's internal state changes.
 /// It only re-renders when the parent component of the tooltip re-renders (signaled by UpdateCount).
 /// </summary>
-public class MudTooltipChildContainer : ComponentBase
+public class MudTooltipChildContainer : IComponent
 {
     private int _lastUpdateCount;
+    private RenderHandle _renderHandle;
 
     /// <summary>
     /// The child content to render.
@@ -28,16 +29,23 @@ public class MudTooltipChildContainer : ComponentBase
     public int UpdateCount { get; set; }
 
     /// <inheritdoc />
-    protected override void OnInitialized() => _lastUpdateCount = UpdateCount;
+    void IComponent.Attach(RenderHandle renderHandle) => _renderHandle = renderHandle;
 
     /// <inheritdoc />
-    protected override bool ShouldRender()
+    Task IComponent.SetParametersAsync(ParameterView parameters)
     {
+        parameters.SetParameterProperties(this);
+
         var changed = UpdateCount != _lastUpdateCount;
         _lastUpdateCount = UpdateCount;
-        return changed;
+        // Only recalculate if changed
+        if (changed)
+        {
+            _renderHandle.Render(BuildRenderTree);
+        }
+
+        return Task.CompletedTask;
     }
 
-    /// <inheritdoc />
-    protected override void BuildRenderTree(RenderTreeBuilder builder) => builder.AddContent(0, ChildContent);
+    private void BuildRenderTree(RenderTreeBuilder builder) => builder.AddContent(0, ChildContent);
 }

--- a/src/MudBlazor/Components/Tooltip/MudTooltipChildContainer.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltipChildContainer.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace MudBlazor;
+
+/// <summary>
+/// This component is used to prevent re-rendering of the child content when the tooltip's internal state changes.
+/// It only re-renders when the parent component of the tooltip re-renders (signaled by UpdateCount).
+/// </summary>
+public class MudTooltipChildContainer : ComponentBase
+{
+    /// <summary>
+    /// The child content to render.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// The update count of the parent component.
+    /// </summary>
+    [Parameter]
+    public int UpdateCount { get; set; }
+
+    private int _lastUpdateCount;
+
+    protected override void OnInitialized()
+    {
+        _lastUpdateCount = UpdateCount;
+    }
+
+    protected override bool ShouldRender()
+    {
+        if (UpdateCount != _lastUpdateCount)
+        {
+            _lastUpdateCount = UpdateCount;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.AddContent(0, ChildContent);
+    }
+}

--- a/src/MudBlazor/Components/Tooltip/MudTooltipChildContainer.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltipChildContainer.cs
@@ -13,6 +13,8 @@ namespace MudBlazor;
 /// </summary>
 public class MudTooltipChildContainer : ComponentBase
 {
+    private int _lastUpdateCount;
+
     /// <summary>
     /// The child content to render.
     /// </summary>
@@ -22,30 +24,20 @@ public class MudTooltipChildContainer : ComponentBase
     /// <summary>
     /// The update count of the parent component.
     /// </summary>
-    [Parameter]
+    [Parameter, EditorRequired]
     public int UpdateCount { get; set; }
 
-    private int _lastUpdateCount;
+    /// <inheritdoc />
+    protected override void OnInitialized() => _lastUpdateCount = UpdateCount;
 
-    protected override void OnInitialized()
-    {
-        _lastUpdateCount = UpdateCount;
-    }
-
+    /// <inheritdoc />
     protected override bool ShouldRender()
     {
-        if (UpdateCount != _lastUpdateCount)
-        {
-            _lastUpdateCount = UpdateCount;
-
-            return true;
-        }
-
-        return false;
+        var changed = UpdateCount != _lastUpdateCount;
+        _lastUpdateCount = UpdateCount;
+        return changed;
     }
 
-    protected override void BuildRenderTree(RenderTreeBuilder builder)
-    {
-        builder.AddContent(0, ChildContent);
-    }
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder) => builder.AddContent(0, ChildContent);
 }


### PR DESCRIPTION
This pull request effectively addresses a performance issue in MudTooltip by preventing unnecessary re-renders of its child content. 

The fix involves:
- Adding a MudTooltipChildContainer internal component that implements ShouldRender based on an UpdateCount.
- Updating MudTooltip to increment _parentUpdateCount only in SetParametersAsync.
- Wrapping ChildContent and TooltipContent in MudTooltipChildContainer in MudTooltip.razor.

This ensures that internal StateHasChanged calls in MudTooltip do not propagate to the children unless the parent component has also updated the tooltip's parameters.

Closes #9484

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
