### PR TITLE
MudListItem: Fix disabled items not showing selected state in multi-selection mode

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListMultiSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListMultiSelectionTest.razor
@@ -18,6 +18,12 @@
             <MudListItem Text="Cafe Latte" />
         </NestedList>
     </MudListItem>
+    <MudListItem Text="Juices">
+        <NestedList>s
+            <MudListItem Text="Apple Juice" Disabled="true" />
+            <MudListItem Text="Orange Juice" Disabled="true" />
+        </NestedList>
+    </MudListItem>
 </MudList>
 
 <p class="selected-values">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListMultiSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListMultiSelectionTest.razor
@@ -19,7 +19,7 @@
         </NestedList>
     </MudListItem>
     <MudListItem Text="Juices">
-        <NestedList>s
+        <NestedList>
             <MudListItem Text="Apple Juice" Disabled="true" />
             <MudListItem Text="Orange Juice" Disabled="true" />
         </NestedList>

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -104,6 +104,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void ListMultiSelection_DisabledItems_ShouldDisplaySelectedState()
+        {
+            var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Apple Juice", "Orange Juice"]));
+            var list = comp.FindComponent<MudList<string>>().Instance;
+            var GetCheckBox = (string text) => comp.FindComponents<MudListItem<string>>().FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
+            comp.Find("p.selected-values").TrimmedText().Should().Be("Apple Juice, Orange Juice");
+            GetCheckBox("Apple Juice").ReadValue.Should().Be(true);
+            GetCheckBox("Orange Juice").ReadValue.Should().Be(true);
+        }
+
+        [Test]
         public async Task ListMultiSelectionBinding()
         {
             var comp = Context.Render<ListMultiSelectionBindingTest>();

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -104,11 +104,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void ListMultiSelection_DisabledItems_ShouldDisplaySelectedState()
+        public async Task ListMultiSelection_DisabledItems_ShouldDisplaySelectedStateAndNotBeClickable()
         {
             var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Apple Juice", "Orange Juice"]));
             var list = comp.FindComponent<MudList<string>>().Instance;
             var GetCheckBox = (string text) => comp.FindComponents<MudListItem<string>>().FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
+            comp.Find("p.selected-values").TrimmedText().Should().Be("Apple Juice, Orange Juice");
+            GetCheckBox("Apple Juice").ReadValue.Should().Be(true);
+            GetCheckBox("Orange Juice").ReadValue.Should().Be(true);
+            // attempt to click disabled items: selection state must not change
+            var appleItem = comp.FindComponents<MudListItem<string>>()
+                .FirstOrDefault(x => x.Instance.Text == "Apple Juice");
+            var orangeItem = comp.FindComponents<MudListItem<string>>()
+                .FirstOrDefault(x => x.Instance.Text == "Orange Juice");
+            await appleItem.Find("div.mud-list-item").ClickAsync();
+            await orangeItem.Find("div.mud-list-item").ClickAsync();
+            // after click attempts, disabled items should remain selected
             comp.Find("p.selected-values").TrimmedText().Should().Be("Apple Juice, Orange Juice");
             GetCheckBox("Apple Juice").ReadValue.Should().Be(true);
             GetCheckBox("Orange Juice").ReadValue.Should().Be(true);

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -338,7 +338,7 @@ namespace MudBlazor
 
         internal void SetSelected(bool selected)
         {
-            if (GetDisabled() || _selected == selected)
+            if (_selected == selected)
             {
                 return;
             }


### PR DESCRIPTION
## Description

This PR fixes a bug where disabled items in a `MudList` with `SelectionMode.MultiSelection` do not display their selected state (checkmark) when initialized with `SelectedValues` containing those disabled items.

## Changes

- Modified `SetSelected()` in `MudListItem<T>` to allow updating the visual selected state for disabled items
-  Added `Disabled="true"` to test items in `ListMultiSelectionTest.razor` to enable testing of disabled items
-  Added test `ListMultiSelectionInitialValues_WithDisabledItems()` to verify disabled items display checkmarks when pre-selected

## Root Cause

The `SetSelected()` method was returning early when `GetDisabled()` was true, preventing disabled items from ever being visually marked as selected (`_selected = true`). This meant that even when disabled items were in the `SelectedValues` collection, they would not display a checkmark.

## Solution

Removed the `GetDisabled()` check from `SetSelected()` to allow the visual state (`_selected`) to be updated for disabled items. User interaction is still properly prevented through existing guards in `OnCheckboxChangedAsync()` and `OnClickHandlerAsync()`, which both check `GetDisabled()` before allowing any changes.

Fixes #10291

## Testing

- Unit test added: `ListMultiSelection_DisabledItems_ShouldDisplaySelectedState()`
- All existing tests pass