### PR TITLE
Charts: Fix radial rendering, alignment, and padding issues

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,4 +17,9 @@
     <BunToolRestore>dotnet tool restore --tool-manifest ../../.config/dotnet-tools.json</BunToolRestore>
     <BunWrapper>dotnet tool run bun -- wrapper --version $(BunVersion) --path ../../tools --silent --</BunWrapper>
   </PropertyGroup>
+
+  <!-- Currently required as Rider's bundled NUnit engine requires Microsoft.Extensions.DependencyModel 8.x, which is not included in the .net 10 -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0"/>
+  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,9 +17,4 @@
     <BunToolRestore>dotnet tool restore --tool-manifest ../../.config/dotnet-tools.json</BunToolRestore>
     <BunWrapper>dotnet tool run bun -- wrapper --version $(BunVersion) --path ../../tools --silent --</BunWrapper>
   </PropertyGroup>
-
-  <!-- Currently required as Rider's bundled NUnit engine requires Microsoft.Extensions.DependencyModel 8.x, which is not included in the .net 10 -->
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0"/>
-  </ItemGroup>
 </Project>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/DonutChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/DonutChartPage.razor
@@ -3,15 +3,14 @@
 @page "/components/chart-types/donutchart"
 
 <DocsPage>
-    <DocsPageHeader Title="Donut Chart" Component="@nameof(MudBlazor.Charts.Donut<T>)" />
+    <DocsPageHeader Title="Donut Chart" Component="@nameof(MudBlazor.Charts.Donut<>)"/>
     <DocsPageContent>
-
         <DocsPageSection>
             <SectionHeader Title="Basic Donut">
                 <Description></Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(DonutExample1)" ShowCode="false" Block="true">
-                <DonutExample1 />
+                <DonutExample1/>
             </SectionContent>
         </DocsPageSection>
 
@@ -20,16 +19,17 @@
                 <Description></Description>
             </SectionHeader>
             <SectionContent Code="@nameof(DonutExample2)" ShowCode="false" Block="true">
-                <DonutExample2 />
+                <DonutExample2/>
             </SectionContent>
         </DocsPageSection>
-		 <DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Custom SVG Content">
                 <Description></Description>
             </SectionHeader>
             <SectionContent Code="@nameof(DonutCustomGraphicsExample)" Block="true">
-                <DonutCustomGraphicsExample />
+                <DonutCustomGraphicsExample/>
             </SectionContent>
-         </DocsPageSection>
+        </DocsPageSection>
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
@@ -2,11 +2,11 @@
 
 <MudChart ChartType="ChartType.Donut" Width="100%" Height="300px" ChartSeries="@Data.AsChartDataSet()" ChartLabels="@Labels">
 	<CustomGraphics>
-		<text class="mud-donut-text mud-typography-h3" x="50%" y="50%">@Convert.ToInt32(Data.Sum())</text>
+		<text class="mud-donut-text mud-typography-h3" x="50%" y="50%">@Data.Sum()</text>
 	</CustomGraphics>
 </MudChart>
 
 @code {
-    private static readonly double[] Data = [25, 77, 28, 5];
+    private static readonly int[] Data = [25, 77, 28, 5];
     private static readonly string[] Labels = ["Oil", "Coal", "Gas", "Biomass"];
 }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
@@ -1,13 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudChart ChartType="ChartType.Donut" Width="100%" Height="300px" ChartSeries="@data.AsChartDataSet()" ChartLabels="@labels">
+<MudChart ChartType="ChartType.Donut" Width="100%" Height="300px" ChartSeries="@Data.AsChartDataSet()" ChartLabels="@Labels">
 	<CustomGraphics>
-		<text class="donut-inner-text" x="50%" y="35%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="20">Total</text>
-		<text class="donut-inner-text" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="50">@data.Sum().ToString()</text>
+		<text class="mud-donut-text mud-typography-h3" x="50%" y="50%">@Convert.ToInt32(Data.Sum())</text>
 	</CustomGraphics>
 </MudChart>
 
 @code {
-    public double[] data = { 25, 77, 28, 5 };
-    public string[] labels = { "Oil", "Coal", "Gas", "Biomass" };
+    private static readonly double[] Data = [25, 77, 28, 5];
+    private static readonly string[] Labels = ["Oil", "Coal", "Gas", "Biomass"];
 }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -13,29 +13,29 @@
 </MudStack>
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Sankey" ChartSeries="@_series" Width="@($"{_width}px")" Height="@($"{_height}px")" ChartOptions="@_options" />
+    <MudChart ChartType="ChartType.Sankey" ChartSeries="@_series" Width="@($"{_width}px")" Height="@($"{_height}px")" ChartOptions="@_options"/>
 </MudPaper>
 
 <MudGrid>
     <MudItem xs="12" Class="d-flex justify-center">
         <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined" Class="pt-4">
             <MudTooltip Text="Show edge values">
-                <MudToggleIconButton Icon="@Icons.Material.Filled.ShortText" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.ShowEdgeLabels" />
+                <MudToggleIconButton Icon="@Icons.Material.Filled.ShortText" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.ShowEdgeLabels"/>
             </MudTooltip>
             <MudTooltip Text="Show labels">
                 <MudToggleIconButton Icon="@Icons.Material.Filled.Textsms" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.ShowLabels"/>
             </MudTooltip>
             <MudTooltip Text="Show node values">
-                <MudToggleIconButton Icon="@Icons.Material.Filled.Money" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.ShowNodeValues" />
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Money" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.ShowNodeValues"/>
             </MudTooltip>
             <MudTooltip Text="Highlight on hover">
-                <MudToggleIconButton Icon="@Icons.Material.Filled.Highlight" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.HighlightOnHover" />
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Highlight" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.HighlightOnHover"/>
             </MudTooltip>
             <MudTooltip Text="Hide nodes with no edges">
-                <MudToggleIconButton Icon="@Icons.Material.Filled.DisabledVisible" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.HideNodesWithNoEdges" />
+                <MudToggleIconButton Icon="@Icons.Material.Filled.DisabledVisible" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.HideNodesWithNoEdges"/>
             </MudTooltip>
             <MudTooltip Text="Order nodes by value">
-                <MudToggleIconButton Icon="@Icons.Material.Filled.Sort" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.OrderNodesByValue" />
+                <MudToggleIconButton Icon="@Icons.Material.Filled.Sort" Color="@Color.Dark" ToggledColor="@Color.Primary" @bind-Toggled="_options.OrderNodesByValue"/>
             </MudTooltip>
         </MudButtonGroup>
     </MudItem>
@@ -55,10 +55,10 @@
         <MudSlider @bind-Value="_height" ValueLabel="true" Max="2000">Chart height</MudSlider>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudColorPicker Label="Highlighting color" @bind-Text="@_options.HighlightColor" />
+        <MudColorPicker Label="Highlighting color" @bind-Text="@_options.HighlightColor"/>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudNumericField @bind-Value="_options.HideNodesSmallerThan" Label="Hide nodes smaller than" />
+        <MudNumericField @bind-Value="_options.HideNodesSmallerThan" Label="Hide nodes smaller than"/>
     </MudItem>
     <MudItem xs="12" md="6">
         <MudSelect @bind-Value="_options.LabelFontSize" Label="Label font size">
@@ -72,7 +72,7 @@
         </MudSelect>
     </MudItem>
     <MudItem xs="12" md="6">
-        <MudNumericField @bind-Value="_options.LabelPadding" Label="Label padding" />
+        <MudNumericField @bind-Value="_options.LabelPadding" Label="Label padding"/>
     </MudItem>
 </MudGrid>
 
@@ -80,6 +80,7 @@
     private List<SankeyNode> _nodes = [];
     private List<SankeyEdge<double>> _edges = [];
     private List<ChartSeries<double>> _series = [];
+
     private readonly SankeyChartOptions _options = new()
     {
         NodeWidth = 5,
@@ -90,8 +91,8 @@
         HideNodesSmallerThan = 1
     };
 
-    private int _width = 650;
-    private int _height = 650;
+    private int _width = 1000;
+    private int _height = 550;
     private int _nodeCount = 50;
     private int _columnCount = 3;
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/ChartsWithCustomGraphicsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/ChartsWithCustomGraphicsTest.razor
@@ -2,22 +2,22 @@
 	<MudItem xs="12" md="6" lg="4">
         <MudChart ChartType="ChartType.Donut" Width="300px" Height="300px" ChartSeries="@([Data])" ChartLabels="@Labels">
 			<CustomGraphics>
-				<text class="donut-inner-text" x="47%" y="35%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="2">Chart</text>
-				<text class="donut-inner-text" x="47%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="5">DONUT</text>
+				<text class="mud-donut-text" x="47%" y="35%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="2">Chart</text>
+				<text class="mud-donut-text" x="47%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="5">DONUT</text>
 			</CustomGraphics>
 		</MudChart>
 	</MudItem>
 	<MudItem xs="12" md="6" lg="4">
 		<MudChart ChartType="ChartType.Pie" Width="300px" Height="300px" ChartSeries="@([Data])" ChartLabels="@Labels">
 			<CustomGraphics>
-				 <text class="donut-inner-text" style="transform:rotate(90deg)" x="0" y="0" dominant-baseline="middle" text-anchor="middle" fill="white" font-family="Helvetica" font-size="0.3">PIE</text>
+				 <text class="mud-donut-text" style="transform:rotate(90deg)" x="0" y="0" dominant-baseline="middle" text-anchor="middle" fill="white" font-family="Helvetica" font-size="0.3">PIE</text>
 			</CustomGraphics>
 		</MudChart>
 	</MudItem>
 	<MudItem xs="12" md="6" lg="4">
 		<MudChart ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
 			<CustomGraphics>
-				<text class="donut-inner-text" x="50%" y="40" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="35">Line Chart</text>
+				<text class="mud-donut-text" x="50%" y="40" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="35">Line Chart</text>
 			</CustomGraphics>
 		</MudChart>
 	</MudItem>

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -15,10 +15,7 @@ public class ChartSizingTests : BunitTest
     [Test]
     public async Task MudAxisChartBase_MatchBoundsToSize_ShouldMatchMeasuredSizeExactly()
     {
-        var chartSeries = new List<ChartSeries<double>>()
-        {
-            new () { Name = "Series 1", Data = new double[] { 10, 20 } },
-        };
+        var chartSeries = new List<ChartSeries<double>> { new() { Name = "Series 1", Data = new double[] { 10, 20 } }, };
         var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Bar)
             .Add(p => p.MatchBoundsToSize, true)
@@ -26,34 +23,26 @@ public class ChartSizingTests : BunitTest
 
         // Find the internal Bar component
         var barComponent = comp.FindComponent<Bar<double>>();
-        var axisChartBase = barComponent.Instance as MudAxisChartBase<double, BarChartOptions>;
+        MudAxisChartBase<double, BarChartOptions> axisChartBase = barComponent.Instance;
 
         // Manually invoke OnElementSizeChanged with a specific width
-        const double measuredWidth = 800.0;
-        const double measuredHeight = 400.0;
+        const double MeasuredWidth = 800.0;
+        const double MeasuredHeight = 400.0;
 
-        await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize
-        {
-            Width = measuredWidth,
-            Height = measuredHeight,
-            Timestamp = DateTime.Now.Ticks
-        }));
+        await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize { Width = MeasuredWidth, Height = MeasuredHeight, Timestamp = DateTime.Now.Ticks }));
 
         // The viewBox should match the measured size exactly
-        comp.WaitForAssertion(() =>
+        await comp.WaitForAssertionAsync(() =>
         {
             var svg = comp.Find("svg.mud-chart-bar");
-            svg.GetAttribute("viewBox").Should().Be($"0 0 {measuredWidth} {measuredHeight}");
+            svg.GetAttribute("viewBox").Should().Be($"0 0 {MeasuredWidth} {MeasuredHeight}");
         });
     }
 
     [Test]
     public async Task MudAxisChartBase_LineChart_MatchBoundsToSize_ShouldMatchMeasuredSizeExactly()
     {
-        var chartSeries = new List<ChartSeries<double>>()
-        {
-            new () { Name = "Series 1", Data = new double[] { 10, 20 } },
-        };
+        var chartSeries = new List<ChartSeries<double>> { new() { Name = "Series 1", Data = new double[] { 10, 20 } }, };
         var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Line)
             .Add(p => p.MatchBoundsToSize, true)
@@ -61,34 +50,26 @@ public class ChartSizingTests : BunitTest
 
         // Find the internal Line component
         var lineComponent = comp.FindComponent<Line<double>>();
-        var axisChartBase = lineComponent.Instance as MudAxisChartBase<double, LineChartOptions>;
+        MudAxisChartBase<double, LineChartOptions> axisChartBase = lineComponent.Instance;
 
         // Manually invoke OnElementSizeChanged with a specific width
-        const double measuredWidth = 900.0;
-        const double measuredHeight = 500.0;
+        const double MeasuredWidth = 900.0;
+        const double MeasuredHeight = 500.0;
 
-        await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize
-        {
-            Width = measuredWidth,
-            Height = measuredHeight,
-            Timestamp = DateTime.Now.Ticks
-        }));
+        await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize { Width = MeasuredWidth, Height = MeasuredHeight, Timestamp = DateTime.Now.Ticks }));
 
         // The viewBox should match the measured size exactly
-        comp.WaitForAssertion(() =>
+        await comp.WaitForAssertionAsync(() =>
         {
             var svg = comp.Find("svg.mud-chart-line");
-            svg.GetAttribute("viewBox").Should().Be($"0 0 {measuredWidth} {measuredHeight}");
+            svg.GetAttribute("viewBox").Should().Be($"0 0 {MeasuredWidth} {MeasuredHeight}");
         });
     }
 
     [Test]
     public void MudAxisChartBase_YAxisTitle_ShouldAllocateSpaceAndPositionCorrectly()
     {
-        var chartSeries = new List<ChartSeries<double>>()
-        {
-            new () { Name = "Series 1", Data = new double[] { 10, 20 } },
-        };
+        var chartSeries = new List<ChartSeries<double>> { new() { Name = "Series 1", Data = new double[] { 10, 20 } } };
 
         // Render without title
         var compWithoutTitle = Context.Render<MudChart<double>>(parameters => parameters
@@ -96,7 +77,7 @@ public class ChartSizingTests : BunitTest
             .Add(p => p.ChartSeries, chartSeries));
 
         var gridWithoutTitle = compWithoutTitle.Find("g.mud-charts-gridlines-yaxis path");
-        var dWithoutTitle = gridWithoutTitle.GetAttribute("d");
+        var dWithoutTitle = gridWithoutTitle.GetAttribute("d")!;
         // Extract the first X coordinate from "M X Y ..."
         var xWithoutTitle = double.Parse(dWithoutTitle.Split(' ')[1]);
 
@@ -107,7 +88,7 @@ public class ChartSizingTests : BunitTest
             .Add(p => p.ChartOptions, new BarChartOptions { YAxisTitle = "Title" }));
 
         var gridWithTitle = compWithTitle.Find("g.mud-charts-gridlines-yaxis path");
-        var dWithTitle = gridWithTitle.GetAttribute("d");
+        var dWithTitle = gridWithTitle.GetAttribute("d")!;
         var xWithTitle = double.Parse(dWithTitle.Split(' ')[1]);
 
         // xWithTitle should be larger than xWithoutTitle if space was allocated
@@ -115,8 +96,8 @@ public class ChartSizingTests : BunitTest
         // But we added 20px, so it should definitely exceed 30px if the original was 30px.
         xWithTitle.Should().BeGreaterThan(xWithoutTitle);
 
-        // Also check that the title is at X=10
-        var titleGroup = compWithTitle.Find("g[transform^='translate(10,']");
+        // Also check that the title is at X=0
+        var titleGroup = compWithTitle.Find("g[transform^='translate(0,']");
         titleGroup.Should().NotBeNull();
         titleGroup.InnerHtml.Should().Contain("Title");
     }

--- a/src/MudBlazor.UnitTests/Components/Charts/DonutChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/DonutChartTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using AngleSharp.Dom;
 using AwesomeAssertions;
 using Bunit;
 using MudBlazor.Charts;
-using MudBlazor.UnitTests.Components;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Charts
@@ -42,6 +42,24 @@ namespace MudBlazor.UnitTests.Charts
         {
             var comp = Context.Render<Donut<double>>();
             comp.Markup.Should().Contain("mud-chart-donut");
+        }
+
+        [Test]
+        public void DonutChartRendersWithIntData()
+        {
+            var data = new[] { 50, 25, 20, 5 };
+            string[] labels = ["Fossil", "Nuclear", "Solar", "Wind"];
+
+            var comp = Context.Render<MudChart<int>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Donut)
+                .Add(p => p.Height, "300px")
+                .Add(p => p.Width, "300px")
+                .Add(p => p.ChartSeries, [data])
+                .Add(p => p.ChartLabels, labels));
+
+            comp.Markup.Should().Contain("class=\"mud-chart-donut mud-ltr\"");
+            comp.Markup.Should().Contain("class=\"mud-chart-serie\"");
+            comp.Markup.Should().Contain("mud-chart-legend-item");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -1,5 +1,4 @@
 ﻿@namespace MudBlazor.Charts
-@using System.Globalization
 
 @inherits MudComponentBase
 

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -5,14 +5,15 @@
 @typeparam T
 @typeparam TChartOptions
 
-<svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" width="@Width" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()" style="@HoveredStylename">
-    <Filters />
+<svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" width="@Width" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
+     style="@HoveredStylename">
+    <Filters/>
 
     <g class="mud-charts-grid">
         @if (XAxisTitle is not null)
         {
-            <g transform="translate(@(ToS(ViewBoxWidth / 2)), 10)">
-                <text class="mud-charts-yaxis axis-title" font-size="14px" text-anchor="middle" dominant-baseline="hanging">@XAxisTitle</text>
+            <g transform="translate(@(ToS(ViewBoxWidth / 2)), @AxisTitleOffset)">
+                <text class="mud-charts-xaxis" font-size="14px" text-anchor="middle" dominant-baseline="hanging">@XAxisTitle</text>
             </g>
         }
         @if (ChartOptions?.YAxisLines is true)
@@ -42,8 +43,8 @@
     </g>
     @if (YAxisTitle is not null)
     {
-        <g transform="translate(10, @(ToS(ViewBoxHeight / 2)))">
-            <text class="mud-charts-yaxis axis-title" transform="rotate(-90)" font-size="14px" text-anchor="middle" dominant-baseline="hanging">@YAxisTitle</text>
+        <g transform="translate(@AxisTitleOffset, @(ToS(ViewBoxHeight / 2)))">
+            <text class="mud-charts-yaxis" transform="rotate(-90)" font-size="14px" text-anchor="middle" dominant-baseline="hanging">@YAxisTitle</text>
         </g>
     }
     <g @ref="_xAxisGroupElementReference" class="mud-charts-xaxis">

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
@@ -20,7 +20,7 @@ public partial class BaseAxisChart<T, TChartOptions> : MudComponentBase
     where TChartOptions : IAxisChartOptions, new()
 {
     private const int AxisTitleOffset = 0;
-    
+
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = null!;
 

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
@@ -19,6 +19,8 @@ public partial class BaseAxisChart<T, TChartOptions> : MudComponentBase
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TChartOptions : IAxisChartOptions, new()
 {
+    private const int AxisTitleOffset = 0;
+    
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = null!;
 

--- a/src/MudBlazor/Components/Chart/Base/DefaultAxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultAxisChartOptions.cs
@@ -2,8 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.AspNetCore.Components;
-
 namespace MudBlazor.Charts;
 
 /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.Charts;
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
-public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TOptions>, IMudAxisChart<T>
+public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TOptions>
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IAxisLineChartOptions
 {
@@ -113,7 +113,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
             if (x > _boundWidth - HorizontalEndSpace)
                 break; // we are out of bounds
 
-            var line = new SvgPath()
+            var line = new SvgPath
             {
                 Index = i,
                 Data = $"M {ToS(x)} {ToS(_boundHeight - VerticalStartSpace)} L {ToS(x)} {ToS(VerticalEndSpace)}"
@@ -122,7 +122,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
 
             var xLabels = GetVerticalGridLineLabel(i);
 
-            var lineValue = new SvgText()
+            var lineValue = new SvgText
             {
                 X = x,
                 Y = _boundHeight - XAxisLabelOffset,
@@ -162,20 +162,16 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
             var dataLength = series.Data.Points.Count;
             if (dataLength == 0) continue;
 
-            double firstPointX;
-            double firstPointY;
-            double lastPointX;
-
             var overrideSettings = GetSeriesDisplayOverride(series);
             var interpolationOption = overrideSettings?.InterpolationOption ?? ChartOptions?.InterpolationOption;
 
             var interpolationEnabled = ShouldInterpolate && interpolationOption is not InterpolationOption.Straight and not null;
 
-            (firstPointX, firstPointY, lastPointX) = interpolationEnabled
+            var (firstPointX, firstPointY, lastPointX) = interpolationEnabled
                 ? GenerateInterpolatedLines(i, chartLine, chartDataCircles, lowestHorizontalLine, gridYUnits, horizontalSpace, verticalSpace)
                 : GenerateStraightLines(i, chartLine, chartDataCircles, lowestHorizontalLine, gridYUnits, horizontalSpace, verticalSpace);
 
-            var line = new SvgPath()
+            var line = new SvgPath
             {
                 Index = i,
                 Data = chartLine.ToString()
@@ -239,7 +235,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
 
             if (ChartOptions?.ShowToolTips == true)
             {
-                chartDataCircles.Add(new SvgCircle()
+                chartDataCircles.Add(new SvgCircle
                 {
                     Index = seriesIndex,
                     CX = x,
@@ -276,7 +272,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
     {
         double firstPointX = 0, firstPointY = 0, lastPointX = 0;
 
-        var interpolationResolution = 10;
+        const int InterpolationResolution = 10;
         var interpolator = CreateInterpolator(seriesIndex, lowestHorizontalLine, gridYUnits, horizontalSpace, verticalSpace);
 
         for (var j = 0; j < interpolator.InterpolatedYs.Length; j++)
@@ -302,13 +298,13 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
             chartLine.Append(' ');
             chartLine.Append(ToS(y));
 
-            var originalIndex = j / interpolationResolution;
+            var originalIndex = j / InterpolationResolution;
             // Add tooltip points for interpolated data if needed
-            if (j % interpolationResolution == 0 && ChartOptions?.ShowToolTips == true &&
+            if (j % InterpolationResolution == 0 && ChartOptions?.ShowToolTips == true &&
                 Series[seriesIndex].Data != null && originalIndex < Series[seriesIndex].Data.Points.Count)
             {
 
-                chartDataCircles.Add(new SvgCircle()
+                chartDataCircles.Add(new SvgCircle
                 {
                     Index = seriesIndex,
                     CX = x,
@@ -343,7 +339,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
     /// <param name="series">The chart series.</param>
     protected void AddLegend(int seriesIndex, ChartSeries<T> series)
     {
-        var legend = new SvgLegend()
+        var legend = new SvgLegend
         {
             Index = seriesIndex,
             Labels = series.Name,
@@ -390,7 +386,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
         chartArea.Append(ToS(firstPointY));
         chartArea.Append(" Z");
 
-        var area = new SvgPath()
+        var area = new SvgPath
         {
             Index = seriesIndex,
             Data = chartArea.ToString()

--- a/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
@@ -160,7 +160,7 @@ public abstract class MudChartBase<T, TOptions> : MudComponentBase, IMudChart<T>
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Chart.Behavior)]
-    public bool CanHideSeries { get; set; } = false;
+    public bool CanHideSeries { get; set; }
 
     /// <summary>
     /// The palette of colors to be used for the legend.

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -255,18 +255,16 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
     /// <summary>
     /// Scales the input data to the range between 0 and 1
     /// </summary>
-    protected T[] GetNormalizedData()
+    protected double[] GetNormalizedData()
     {
-        if (ChartSeries is null || ChartSeries.Count == 0)
-            return [];
+        if (ChartSeries is null || ChartSeries.Count == 0) return [];
 
         var data = AggregateSeriesData(ChartOptions!.AggregationOption);
-        var total = data.SumGeneric();
+        var total = double.CreateSaturating(data.SumGeneric());
 
-        if (total == T.Zero)
-            return data;
+        if (total == 0.0) return new double[data.Length];
 
-        return data.Select(x => T.Abs(x) / total).ToArray();
+        return data.Select(x => double.CreateSaturating(T.Abs(x)) / total).ToArray();
     }
 
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -148,7 +148,7 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
         {
             AggregationOption.GroupByLabel => AggregateByLabel(aggregated),
             AggregationOption.GroupByDataSet => AggregateByDataSet(aggregated),
-            _ => throw new ArgumentOutOfRangeException(nameof(aggregation), $"Unsupported aggregation: {aggregation}")
+            _ => throw new ArgumentOutOfRangeException(nameof(aggregation), $@"Unsupported aggregation: {aggregation}")
         };
     }
 

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -48,7 +48,7 @@ namespace MudBlazor.Charts
             // shared plot points should be initialized before generating overlay charts
             if (IsOverlayChart && SharedData is null) return;
 
-            Series = (ChartContainer != null && ChartReference is MudChart<T>)
+            Series = ChartContainer != null && ChartReference is MudChart<T>
                 ? ChartContainer.ChartSeries
                 : ChartSeries;
 
@@ -95,14 +95,10 @@ namespace MudBlazor.Charts
         private void ComputeUnitsAndNumberOfLines(out T gridYUnits, out int numHorizontalLines, out int lowestHorizontalLine, out int numVerticalLines)
         {
             var yAxisTicks = ChartOptions?.YAxisTicks;
-            if (yAxisTicks.HasValue && yAxisTicks.Value > 0)
-                gridYUnits = T.CreateSaturating(yAxisTicks.Value);
-            else
-                gridYUnits = T.CreateSaturating(20);
+            gridYUnits = T.CreateSaturating(yAxisTicks is > 0 ? yAxisTicks.Value : 20);
 
-            var allValues = Series.SelectMany(series => series.Data.Values);
-
-            if (allValues.Any())
+            var allValues = Series.SelectMany(series => series.Data.Values).ToArray();
+            if (allValues.Length != 0)
             {
                 var minY = allValues.Min();
                 var maxY = ChartOptions?.YAxisSuggestedMax is null
@@ -153,20 +149,11 @@ namespace MudBlazor.Charts
             for (var i = 0; i < numVerticalLines; i++)
             {
                 var x = barGroupPositions.Length == 0 ? 0 : barGroupPositions[i];
-                var line = new SvgPath()
-                {
-                    Index = i,
-                    Data = $"M {ToS(x)} {ToS(_boundHeight - VerticalStartSpace)} L {ToS(x)} {ToS(VerticalEndSpace)}"
-                };
+                var line = new SvgPath { Index = i, Data = $"M {ToS(x)} {ToS(_boundHeight - VerticalStartSpace)} L {ToS(x)} {ToS(VerticalEndSpace)}" };
                 VerticalLines.Add(line);
 
                 var xLabels = i < ChartLabels.Length ? ChartLabels[i] : "";
-                var lineValue = new SvgText()
-                {
-                    X = x + (_barGroupWidth / 2) - ((_barGap * spaces) / 2) - leftShift,
-                    Y = _boundHeight - 10,
-                    Value = xLabels
-                };
+                var lineValue = new SvgText { X = x + (_barGroupWidth / 2) - (_barGap * spaces / 2) - leftShift, Y = _boundHeight - 10, Value = xLabels };
                 VerticalValues.Add(lineValue);
             }
         }
@@ -190,10 +177,10 @@ namespace MudBlazor.Charts
                     var gridValueX = groupStartX + (i * (_barWidth + _barGap)) + (_barWidth / 2);
 
                     var gridValueY = _boundHeight - VerticalStartSpace + (lowestHorizontalLine * verticalSpace);
-                    var barHeight = (double.CreateSaturating((dataValue / gridYUnits)) - lowestHorizontalLine) * verticalSpace;
+                    var barHeight = (double.CreateSaturating(dataValue / gridYUnits) - lowestHorizontalLine) * verticalSpace;
                     var gridValue = _boundHeight - VerticalStartSpace - double.CreateSaturating(barHeight);
 
-                    var bar = new SvgPath()
+                    var bar = new SvgPath
                     {
                         Index = i,
                         Data = $"M {ToS(gridValueX)} {ToS(gridValueY)} L {ToS(gridValueX)} {ToS(gridValue)}",
@@ -265,8 +252,9 @@ namespace MudBlazor.Charts
 
             _barWidth = Math.Max(MinBarWidth, groupWidthRelative * barWidthRelative);
             _barGap = seriesCount > 1 ? groupWidthRelative * barWidthRelative * ChartOptions!.BarSpacingRatio : 0;
-            _barGroupWidth = Math.Max(MinBarWidth * seriesCount - 2, groupWidthRelative - _barWidth);
+            _barGroupWidth = Math.Max((MinBarWidth * seriesCount) - 2, groupWidthRelative - _barWidth);
         }
+
         private void OnBarMouseOver(MouseEventArgs _, SvgPath bar)
         {
             _hoveredBar = bar;

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor
@@ -26,5 +26,5 @@
                      OnMouseOut="() => OnSegmentMouseOut()" />
 
     <Legend T="T" Data="@_legends" ShowLegend="@ChartOptions?.ShowLegend" CanHideSeries="@CanHideSeries"
-            ChartPalette="@ChartOptions?.ChartPalette" OnLegendSelected="async (i) => await SetSelectedIndexAsync(i)" />
+            ChartPalette="@ChartOptions?.ChartPalette" OnLegendSelected="async (i) => await SetSelectedIndexAsync(i)"/>
 </div>

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -91,13 +91,13 @@ namespace MudBlazor.Charts
 
             sb.Append($"M {ToS(ToR(g.Coords.StartX, g.OuterRadius))} {ToS(ToR(g.Coords.StartY, g.OuterRadius))} ");
 
-            if (g.Data >= 1.0) 
+            if (g.Data >= 1.0)
                 sb.Append($"A {ToS(g.OuterRadius)} {ToS(g.OuterRadius)} 0 {arcFlag} 1 {ToS(ToR(g.Coords.MidX, g.OuterRadius))} {ToS(ToR(g.Coords.MidY, g.OuterRadius))} ");
 
             sb.Append($"A {ToS(g.OuterRadius)} {ToS(g.OuterRadius)} 0 {arcFlag} 1 {ToS(ToR(g.Coords.EndX, g.OuterRadius))} {ToS(ToR(g.Coords.EndY, g.OuterRadius))} ");
             sb.Append($"L {ToS(ToR(g.Coords.EndX, g.InnerRadius))} {ToS(ToR(g.Coords.EndY, g.InnerRadius))} ");
 
-            if (g.Data >= 1.0) 
+            if (g.Data >= 1.0)
                 sb.Append($"A {ToS(g.InnerRadius)} {ToS(g.InnerRadius)} 0 {arcFlag} 0 {ToS(ToR(g.Coords.MidX, g.InnerRadius))} {ToS(ToR(g.Coords.MidY, g.InnerRadius))} ");
 
             sb.Append($"A {ToS(g.InnerRadius)} {ToS(g.InnerRadius)} 0 {arcFlag} 0 {ToS(ToR(g.Coords.StartX, g.InnerRadius))} {ToS(ToR(g.Coords.StartY, g.InnerRadius))} Z");
@@ -107,7 +107,7 @@ namespace MudBlazor.Charts
 
         private static (double X, double Y) GetLabelPosition(double angle, double outerRadius, double donutRatio, double data)
         {
-            if (donutRatio >= 1 && data >= 1.0) 
+            if (donutRatio >= 1 && data >= 1.0)
                 return (0, 0);
 
             var radius = outerRadius * (1 - (donutRatio / 2));

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.Numerics;
 using System.Text;
-using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
 
 namespace MudBlazor.Charts
@@ -39,26 +38,19 @@ namespace MudBlazor.Charts
 
             for (var i = 0; i < normalizedData.Length; i++)
             {
-                if (normalizedData[i] == T.Zero)
-                    continue;
+                if (normalizedData[i] == 0.0) continue;
 
                 var data = normalizedData[i];
                 var actualValue = T.Max(T.Zero, chartData[i]);
-                var radians = 2 * Math.PI * double.CreateSaturating(data);
-                var coords = Donut<T>.GetSegmentCoordinates(cumulativeRadians, radians);
+                var radians = 2 * Math.PI * data;
+                var coords = GetSegmentCoordinates(cumulativeRadians, radians);
                 cumulativeRadians += radians;
 
-                var geometry = new PathGeometry
-                {
-                    Coords = coords,
-                    OuterRadius = Radius,
-                    InnerRadius = Radius * (1 - donutRatio),
-                    Data = data
-                };
+                var geometry = new PathGeometry { Coords = coords, OuterRadius = Radius, InnerRadius = Radius * (1 - donutRatio), Data = data };
 
-                var pathData = Donut<T>.BuildSvgPath(geometry);
-                var midAngle = cumulativeRadians - radians / 2;
-                var (x, y) = Donut<T>.GetLabelPosition(midAngle, Radius, donutRatio, data);
+                var pathData = BuildSvgPath(geometry);
+                var midAngle = cumulativeRadians - (radians / 2);
+                var (x, y) = GetLabelPosition(midAngle, Radius, donutRatio, data);
 
                 _paths.Add(new SvgPath
                 {
@@ -67,7 +59,7 @@ namespace MudBlazor.Charts
                     LabelX = x,
                     LabelY = y,
                     LabelXValue = ChartOptions.ShowAsPercentage
-                        ? $"{Math.Round(double.CreateSaturating(data) * 100, 1).ToInvariantString()}%"
+                        ? $"{Math.Round(data * 100, 1).ToInvariantString()}%"
                         : actualValue.ToString(null, CultureInfo.InvariantCulture),
                     LabelYValue = chartLabels.Length > i ? chartLabels[i] : string.Empty
                 });
@@ -93,19 +85,19 @@ namespace MudBlazor.Charts
         private static string BuildSvgPath(PathGeometry g)
         {
             var sb = new StringBuilder();
-            var arcFlag = double.CreateSaturating(g.Data) > 0.5 ? 1 : 0;
+            var arcFlag = g.Data > 0.5 ? 1 : 0;
 
             static double ToR(double value, double radius) => value * radius;
 
             sb.Append($"M {ToS(ToR(g.Coords.StartX, g.OuterRadius))} {ToS(ToR(g.Coords.StartY, g.OuterRadius))} ");
 
-            if (g.Data >= T.One)
+            if (g.Data >= 1.0) 
                 sb.Append($"A {ToS(g.OuterRadius)} {ToS(g.OuterRadius)} 0 {arcFlag} 1 {ToS(ToR(g.Coords.MidX, g.OuterRadius))} {ToS(ToR(g.Coords.MidY, g.OuterRadius))} ");
 
             sb.Append($"A {ToS(g.OuterRadius)} {ToS(g.OuterRadius)} 0 {arcFlag} 1 {ToS(ToR(g.Coords.EndX, g.OuterRadius))} {ToS(ToR(g.Coords.EndY, g.OuterRadius))} ");
             sb.Append($"L {ToS(ToR(g.Coords.EndX, g.InnerRadius))} {ToS(ToR(g.Coords.EndY, g.InnerRadius))} ");
 
-            if (g.Data >= T.One)
+            if (g.Data >= 1.0) 
                 sb.Append($"A {ToS(g.InnerRadius)} {ToS(g.InnerRadius)} 0 {arcFlag} 0 {ToS(ToR(g.Coords.MidX, g.InnerRadius))} {ToS(ToR(g.Coords.MidY, g.InnerRadius))} ");
 
             sb.Append($"A {ToS(g.InnerRadius)} {ToS(g.InnerRadius)} 0 {arcFlag} 0 {ToS(ToR(g.Coords.StartX, g.InnerRadius))} {ToS(ToR(g.Coords.StartY, g.InnerRadius))} Z");
@@ -113,12 +105,12 @@ namespace MudBlazor.Charts
             return sb.ToString();
         }
 
-        private static (double X, double Y) GetLabelPosition(double angle, double outerRadius, double donutRatio, T data)
+        private static (double X, double Y) GetLabelPosition(double angle, double outerRadius, double donutRatio, double data)
         {
-            if (donutRatio >= 1 && data >= T.One)
+            if (donutRatio >= 1 && data >= 1.0) 
                 return (0, 0);
 
-            var radius = outerRadius * (1 - donutRatio / 2);
+            var radius = outerRadius * (1 - (donutRatio / 2));
             return (Math.Cos(angle) * radius, Math.Sin(angle) * radius);
         }
 
@@ -127,8 +119,7 @@ namespace MudBlazor.Charts
             public SegmentCoordinates Coords { get; init; }
             public double OuterRadius { get; init; }
             public double InnerRadius { get; init; }
-            public T Data { get; init; }
+            public double Data { get; init; }
         }
-
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -1,6 +1,4 @@
-﻿@using System.Globalization
-
-@namespace MudBlazor.Charts
+﻿@namespace MudBlazor.Charts
 
 @inherits MudChartBase<T, HeatMapChartOptions>
 
@@ -12,15 +10,16 @@
     var series = _series.Where(x => x.Visible).ToList();
 }
 
-<svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()" style="@HoveredStylename">
+<svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
+     style="@HoveredStylename">
     @if (_options is { EnableSmoothGradient: true })
     {
         <defs>
             @* 4-point gradients for each cell *@
-            @for (int row = 0; row < series.Count; row++)
+            @for (var row = 0; row < series.Count; row++)
             {
                 var dataLength = series[row].Data?.Values.Count ?? 0;
-                for (int col = 0; col < dataLength; col++)
+                for (var col = 0; col < dataLength; col++)
                 {
                     var cell = _heatMapCells.FirstOrDefault(c => c.Row == row && c.Column == col);
                     var color = GetColorForValue(cell?.Value);
@@ -28,43 +27,43 @@
                     // Define each gradient for 4 directions
 
                     <linearGradient id="gradient-topcenter-@row-@col" x1="50%" y1="0%" x2="50%" y2="50%">
-                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row - 1, col))" />
-                        <stop offset="100%" style="stop-color:@color" />
+                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row - 1, col))"/>
+                        <stop offset="100%" style="stop-color:@color"/>
                     </linearGradient>
 
                     <linearGradient id="gradient-right-@row-@col" x1="100%" y1="50%" x2="50%" y2="50%">
-                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row, col + 1))" />
-                        <stop offset="100%" style="stop-color:@color" />
+                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row, col + 1))"/>
+                        <stop offset="100%" style="stop-color:@color"/>
                     </linearGradient>
 
                     <linearGradient id="gradient-bottomcenter-@row-@col" x1="50%" y1="100%" x2="50%" y2="50%">
-                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row + 1, col))" />
-                        <stop offset="100%" style="stop-color:@color" />
+                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row + 1, col))"/>
+                        <stop offset="100%" style="stop-color:@color"/>
                     </linearGradient>
 
                     <linearGradient id="gradient-left-@row-@col" x1="0%" y1="50%" x2="50%" y2="50%">
-                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row, col - 1))" />
-                        <stop offset="100%" style="stop-color:@color" />
+                        <stop offset="0%" style="stop-color:@GetColorForValue(GetDataValue(row, col - 1))"/>
+                        <stop offset="100%" style="stop-color:@color"/>
                     </linearGradient>
                 }
             }
         </defs>
     }
 
-    @for (int row = 0; row < series.Count; row++)
+    @for (var row = 0; row < series.Count; row++)
     {
         var rowIndex = row;
         var rowLabel = series[row].Name;
 
         // how tall each cell should be
-        var y = (row * (_cellDimension.Height + _cellDimension.Padding)) + _verticalStartSpace;
+        var y = row * (_cellDimension.Height + _cellDimension.Padding) + _verticalStartSpace;
         var seriesLength = series[row].Data != null ? series[row].Data.Values.Count : 0;
 
-        @for (int col = 0; col < seriesLength; col++)
+        @for (var col = 0; col < seriesLength; col++)
         {
             var colIndex = col;
             var cell = _heatMapCells.FirstOrDefault(c => c.Row == row && c.Column == col);
-            var x = (col * (_cellDimension.Width + _cellDimension.Padding)) + _horizontalStartSpace;
+            var x = col * (_cellDimension.Width + _cellDimension.Padding) + _horizontalStartSpace;
 
             // Gradient Overlays
             @if (_options is { EnableSmoothGradient: true })
@@ -75,39 +74,37 @@
                       width="@_cellDimension.Width.ToStr()"
                       height="@_cellDimension.Height.ToStr()"
                       fill="url(#gradient-topcenter-@row-@col)"
-                      opacity="0.25" />
+                      opacity="0.25"/>
 
                 <rect x="@x.ToStr()"
                       y="@y.ToStr()"
                       width="@_cellDimension.Width.ToStr()"
                       height="@_cellDimension.Height.ToStr()"
                       fill="url(#gradient-right-@row-@col)"
-                      opacity="0.25" />
+                      opacity="0.25"/>
 
                 <rect x="@x.ToStr()"
                       y="@y.ToStr()"
                       width="@_cellDimension.Width.ToStr()"
                       height="@_cellDimension.Height.ToStr()"
                       fill="url(#gradient-bottomcenter-@row-@col)"
-                      opacity="0.25" />
+                      opacity="0.25"/>
 
                 <rect x="@x.ToStr()"
                       y="@y.ToStr()"
                       width="@_cellDimension.Width.ToStr()"
                       height="@_cellDimension.Height.ToStr()"
                       fill="url(#gradient-left-@row-@col)"
-                      opacity="0.25" />
+                      opacity="0.25"/>
             }
-
 
             <g class="mud-chart-cell">
                 <!-- Group containing both the rectangle and the text -->
                 <g>
                     @{
-
                         var cellColor = _options is { EnableSmoothGradient: true }
-                                ? "transparent"
-                                : cell?.MudColor?.ToString(Utilities.MudColorOutputFormats.RGBA) ?? GetColorForValue(cell?.Value);
+                            ? "transparent"
+                            : cell?.MudColor?.ToString(Utilities.MudColorOutputFormats.RGBA) ?? GetColorForValue(cell?.Value);
                     }
                     <rect x="@x.ToStr()"
                           y="@y.ToStr()"
@@ -116,7 +113,7 @@
                           @onclick="async () => await SetSelectedCellAsync(rowIndex, colIndex)"
                           @onmouseover="(e) => OnCellMouseOver(e, cell)"
                           @onmouseout="OnCellMouseOut"
-                          fill="@(cellColor)" />
+                          fill="@(cellColor)"/>
 
                     @if (_options is { ShowLabels: true } && cell is { Value: not null } && cell is { CustomFragment: null })
                     {
@@ -129,7 +126,7 @@
                                   y="@((y + _cellDimension.Height / 2).ToStr())"
                                   dominant-baseline="middle"
                                   text-anchor="middle">
-                                  @FormatValueForDisplay(cell?.Value)
+                                @FormatValueForDisplay(cell?.Value)
                             </text>
                         </g>
                     }
@@ -148,7 +145,7 @@
                                  height="@_cellDimension.Height.ToStr()"
                                  viewBox="0 0 @tempWidth.ToStr() @tempHeight.ToStr()"
                                  preserveAspectRatio="xMidYMid meet">
-                                 @cell.CustomFragment
+                                @cell.CustomFragment
                             </svg>
                         }
                         else
@@ -205,130 +202,129 @@
         @switch (_legendPosition)
         {
             case Position.Top or Position.Bottom:
-                {
-                    var legendPadding = _options is { ShowLegendLabels: true } ? CellPadding * 2 : CellPadding;
-                    var totalChars = 8;
-                    // width is horizontal, cellpadding between the word Less and the middle section and the last word
-                    var textWidth = (totalChars * LegendFontSize * AverageCharWidthMultiplier) + (CellPadding * 2);
-                    var totalWidth = (_legends.Count * (LegendBox + legendPadding)) - legendPadding + textWidth;
-                    var offsetX = -totalWidth / 2; // Center horizontally
-                    var offsetY = LegendBox / 2; // Center vertically
+            {
+                var legendPadding = _options is { ShowLegendLabels: true } ? CellPadding * 2 : CellPadding;
+                var totalChars = 8;
+                // width is horizontal, cellpadding between the word Less and the middle section and the last word
+                var textWidth = totalChars * LegendFontSize * AverageCharWidthMultiplier + CellPadding * 2;
+                var totalWidth = _legends.Count * (LegendBox + legendPadding) - legendPadding + textWidth;
+                var offsetX = -totalWidth / 2; // Center horizontally
+                var offsetY = LegendBox / 2; // Center vertically
 
-                    <g transform="translate(@((legendX + offsetX).ToStr()), @(legendY.ToStr()))">
-                        <!-- "Less" label -->
-                        <text class="mud-charts-xaxis" 
-                        x="0"
-                        y="0"
-                        dominant-baseline="middle"
-                        text-anchor="start"
-                        font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_Less]
-                        </text>
-                        @for (int i = 0; i < _legends.Count; i++)
-                        {
-                            var index = i;
-                            var x = (textWidth / 2) + (i * (LegendBox + legendPadding));
-                            var tooltipX = legendX + offsetX + x + (LegendBox / 2);
+                <g transform="translate(@((legendX + offsetX).ToStr()), @(legendY.ToStr()))">
+                    <!-- "Less" label -->
+                    <text class="mud-charts-xaxis"
+                          x="0"
+                          y="0"
+                          dominant-baseline="middle"
+                          text-anchor="start"
+                          font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_Less]
+                    </text>
+                    @for (var i = 0; i < _legends.Count; i++)
+                    {
+                        var index = i;
+                        var x = textWidth / 2 + i * (LegendBox + legendPadding);
+                        var tooltipX = legendX + offsetX + x + LegendBox / 2;
 
-                            <g transform="translate(@x.ToStr(), 0)" class="mud-chart-heatmap-legend">
-                                <rect @onmouseover="(e) => OnLegendMouseOver(e, _legends[index], new((float)tooltipX , (float)legendY))"
-                                @onmouseout="OnLegendMouseOut"
-                                x="0" 
-                                y="@((-LegendBox / 2).ToStr())" 
-                                width="@LegendBox.ToStr()" 
-                                height="@LegendBox.ToStr()" 
-                                fill="@_legends[i].color">
-                                </rect>
-                                @if (_options is { ShowLegendLabels: true })
-                                {
-                                    var x1 = LegendBox / 2;
-                                    var x2 = x1;
-                                    var y1 = _legendPosition == Position.Top ? -offsetY : offsetY;
-                                    var y2 = _legendPosition == Position.Top ? -offsetY - LegendLineLength : offsetY + LegendLineLength;
+                        <g transform="translate(@x.ToStr(), 0)" class="mud-chart-heatmap-legend">
+                            <rect @onmouseover="(e) => OnLegendMouseOver(e, _legends[index], new((float)tooltipX , (float)legendY))"
+                                  @onmouseout="OnLegendMouseOut"
+                                  x="0"
+                                  y="@((-LegendBox / 2).ToStr())"
+                                  width="@LegendBox.ToStr()"
+                                  height="@LegendBox.ToStr()"
+                                  fill="@_legends[i].color">
+                            </rect>
+                            @if (_options is { ShowLegendLabels: true })
+                            {
+                                var x1 = LegendBox / 2;
+                                var x2 = x1;
+                                var y1 = _legendPosition == Position.Top ? -offsetY : offsetY;
+                                var y2 = _legendPosition == Position.Top ? -offsetY - LegendLineLength : offsetY + LegendLineLength;
 
-                                    <line x1="@x1.ToStr()" 
-                                    y1="@y1.ToStr()" 
-                                    x2="@x2.ToStr()" 
-                                    y2="@y2.ToStr()" 
-                                    stroke-width="1" />
-                                    var y3 = y2 + (_legendPosition == Position.Top ? -LegendLineLength : LegendLineLength);
-                                    @((MarkupString)@$"<text x='0' y='{y3.ToStr()}' dominant-baseline='middle' text-anchor='start' font-size='{labelFontSize}'>{FormatValueForDisplay(_legends[i].value)}</text>")
-                                }
-                            </g>
-                        }
+                                <line x1="@x1.ToStr()"
+                                      y1="@y1.ToStr()"
+                                      x2="@x2.ToStr()"
+                                      y2="@y2.ToStr()"
+                                      stroke-width="1"/>
+                                var y3 = y2 + (_legendPosition == Position.Top ? -LegendLineLength : LegendLineLength);
+                                @((MarkupString)@$"<text x='0' y='{y3.ToStr()}' dominant-baseline='middle' text-anchor='start' font-size='{labelFontSize}'>{FormatValueForDisplay(_legends[i].value)}</text>")
+                            }
+                        </g>
+                    }
 
-                        <!-- "More" label -->
-                        <text class="mud-charts-xaxis"
-                        x="@(((textWidth / 2) + (_legends.Count * (LegendBox + legendPadding))).ToStr())"
-                        y="0"
-                        dominant-baseline="middle"
-                        text-anchor="start"
-                        font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_More]
-                        </text>
-                    </g>
-
-                }
+                    <!-- "More" label -->
+                    <text class="mud-charts-xaxis"
+                          x="@((textWidth / 2 + _legends.Count * (LegendBox + legendPadding)).ToStr())"
+                          y="0"
+                          dominant-baseline="middle"
+                          text-anchor="start"
+                          font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_More]
+                    </text>
+                </g>
+            }
                 break;
 
             case Position.Right or Position.Left:
-                {
-                    var textHeight = (8 * LegendFontSize) + (CellPadding * 2);
-                    var totalHeight = (_legends.Count * (LegendBox + CellPadding)) - CellPadding + textHeight;
+            {
+                const int textHeight = 8 * LegendFontSize + CellPadding * 2;
+                var totalHeight = _legends.Count * (LegendBox + CellPadding) - CellPadding + textHeight;
 
-                    var offsetX = -1.0; // Center horizontally
-                    var offsetY = -totalHeight / 2; // Center vertically
+                const double offsetX = -1.0; // Center horizontally
+                var offsetY = -totalHeight / 2; // Center vertically
 
-                    <g transform="translate(@legendX.ToStr(), @((legendY + offsetY).ToStr()))">
-                        <!-- "Less" label -->
-                        <text class="mud-charts-xaxis" 
-                        x="@offsetX.ToStr()" 
-                        y="@(((textHeight / 2) - CellPadding - LegendBox).ToStr())" 
-                        dominant-baseline="middle" 
-                        text-anchor="start" 
-                        font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_Less]
-                        </text>
+                <g transform="translate(@legendX.ToStr(), @((legendY + offsetY).ToStr()))">
+                    <!-- "Less" label -->
+                    <text class="mud-charts-xaxis"
+                          x="@offsetX.ToStr()"
+                          y="@((textHeight / 2.0 - CellPadding - LegendBox).ToStr())"
+                          dominant-baseline="middle"
+                          text-anchor="start"
+                          font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_Less]
+                    </text>
 
-                        @for (int i = 0; i < _legends.Count; i++)
-                        {
-                            var index = i;
-                            var y = (textHeight / 2) + (i * (LegendBox + CellPadding));
-                            var tooltipY = legendY + offsetY + y;
+                    @for (var i = 0; i < _legends.Count; i++)
+                    {
+                        var index = i;
+                        var y = textHeight / 2.0 + i * (LegendBox + CellPadding);
+                        var tooltipY = legendY + offsetY + y;
 
-                            <g transform="translate(0, @y.ToStr())" class="mud-chart-heatmap-legend">
-                                <rect @onmouseover="(e) => OnLegendMouseOver(e, _legends[index], new((float)(legendX + (LegendBox / 2)) , (float)tooltipY))"
-                                @onmouseout="OnLegendMouseOut"
-                                x="0" 
-                                y="@((-LegendBox / 2).ToStr())" 
-                                width="@LegendBox.ToStr()" 
-                                height="@LegendBox.ToStr()" 
-                                fill="@_legends[i].color">
-                                </rect>
-                                @if (_options is { ShowLegendLabels: true })
-                                {
-                                    double y1 = 0, y2 = 0, x1 = _legendPosition == Position.Right ? LegendBox : 0;
-                                    double x2 = _legendPosition == Position.Right ? LegendBox + LegendLineLength : -LegendLineLength;
-                                    var x3 = x2 + (_legendPosition == Position.Right ? CellPadding : -CellPadding);
+                        <g transform="translate(0, @y.ToStr())" class="mud-chart-heatmap-legend">
+                            <rect @onmouseover="(e) => OnLegendMouseOver(e, _legends[index], new((float)(legendX + LegendBox / 2) , (float)tooltipY))"
+                                  @onmouseout="OnLegendMouseOut"
+                                  x="0"
+                                  y="@((-LegendBox / 2).ToStr())"
+                                  width="@LegendBox.ToStr()"
+                                  height="@LegendBox.ToStr()"
+                                  fill="@_legends[i].color">
+                            </rect>
+                            @if (_options is { ShowLegendLabels: true })
+                            {
+                                double y1 = 0, y2 = 0, x1 = _legendPosition == Position.Right ? LegendBox : 0;
+                                var x2 = _legendPosition == Position.Right ? LegendBox + LegendLineLength : -LegendLineLength;
+                                var x3 = x2 + (_legendPosition == Position.Right ? CellPadding : -CellPadding);
 
-                                    <line x1="@x1.ToStr()" 
-                                    y1="@y1.ToStr()" 
-                                    x2="@x2.ToStr()" 
-                                    y2="@y2.ToStr()" 
-                                    stroke-width="1" />
+                                <line x1="@x1.ToStr()"
+                                      y1="@y1.ToStr()"
+                                      x2="@x2.ToStr()"
+                                      y2="@y2.ToStr()"
+                                      stroke-width="1"/>
 
-                                    @((MarkupString)@$"<text x='{x3.ToStr()}' y='0' dominant-baseline='middle' text-anchor='{(_legendPosition == Position.Right ? "start" : "end")}' font-size='{labelFontSize}'>{FormatValueForDisplay(_legends[i].value)}</text>")
-                                }
-                            </g>
-                        }
+                                @((MarkupString)@$"<text x='{x3.ToStr()}' y='0' dominant-baseline='middle' text-anchor='{(_legendPosition == Position.Right ? "start" : "end")}' font-size='{labelFontSize}'>{FormatValueForDisplay(_legends[i].value)}</text>")
+                            }
+                        </g>
+                    }
 
-                        <!-- "More" label -->
-                        <text class="mud-charts-xaxis"
-                        x="@offsetX.ToStr()"
-                        y="@(((textHeight / 2) + ((_legends.Count) * (LegendBox + CellPadding))).ToStr())" 
-                        dominant-baseline="middle" 
-                        text-anchor="start" 
-                        font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_More]
-                        </text>
-                    </g>
-                }
+                    <!-- "More" label -->
+                    <text class="mud-charts-xaxis"
+                          x="@offsetX.ToStr()"
+                          y="@((textHeight / 2 + _legends.Count * (LegendBox + CellPadding)).ToStr())"
+                          dominant-baseline="middle"
+                          text-anchor="start"
+                          font-size="@LegendFontSize">@Localizer[Resources.LanguageResource.HeatMap_More]
+                    </text>
+                </g>
+            }
                 break;
         }
     }
@@ -339,8 +335,8 @@
         var color = GetColorForValue(_hoveredCell.Value);
         var colOffset = _hoveredCell.Column * (_cellDimension.Width + _cellDimension.Padding);
         var rowOffset = _hoveredCell.Row * (_cellDimension.Height + _cellDimension.Padding);
-        var x = colOffset + _horizontalStartSpace + (_cellDimension.Width / 2);
-        var y = rowOffset + _verticalStartSpace + (_cellDimension.Height / 2);
+        var x = colOffset + _horizontalStartSpace + _cellDimension.Width / 2;
+        var y = rowOffset + _verticalStartSpace + _cellDimension.Height / 2;
 
         var path = new SvgPath()
         {
@@ -352,8 +348,8 @@
         };
 
         var (tooltipX, tooltipY) = TooltipPositionFunc?.Invoke(path) is { } pos
-                ? (pos.X, pos.Y)
-                : (path.LabelX, path.LabelY);
+            ? (pos.X, pos.Y)
+            : (path.LabelX, path.LabelY);
 
         if (TooltipTemplate is not null)
         {
@@ -370,25 +366,26 @@
             if (!string.IsNullOrWhiteSpace(tooltipTitleFormat))
             {
                 var tooltipTitle = tooltipTitleFormat
-                .Replace("{{SERIES_NAME}}", hoveredSeries.Name)
-                .Replace("{{X_VALUE}}", ChartLabels.Length > _hoveredCell.Column ? ChartLabels[_hoveredCell.Column] : string.Empty)
-                .Replace("{{Y_VALUE}}", _hoveredCell.Value.ToString());
+                    .Replace("{{SERIES_NAME}}", hoveredSeries.Name)
+                    .Replace("{{X_VALUE}}", ChartLabels.Length > _hoveredCell.Column ? ChartLabels[_hoveredCell.Column] : string.Empty)
+                    .Replace("{{Y_VALUE}}", _hoveredCell.Value.ToString());
 
                 var tooltipSubtitle = tooltipSubtitleFormat?
-                .Replace("{{SERIES_NAME}}", hoveredSeries.Name)
-                .Replace("{{X_VALUE}}", ChartLabels.Length > _hoveredCell.Column ? ChartLabels[_hoveredCell.Column] : string.Empty)
-                .Replace("{{Y_VALUE}}", _hoveredCell.Value.ToString()) ?? string.Empty;
+                    .Replace("{{SERIES_NAME}}", hoveredSeries.Name)
+                    .Replace("{{X_VALUE}}", ChartLabels.Length > _hoveredCell.Column ? ChartLabels[_hoveredCell.Column] : string.Empty)
+                    .Replace("{{Y_VALUE}}", _hoveredCell.Value.ToString()) ?? string.Empty;
 
-                <ChartTooltip Title="@tooltipTitle" Subtitle="@tooltipSubtitle" Color="@color" X="@tooltipX" Y="@tooltipY" />
+                <ChartTooltip Title="@tooltipTitle" Subtitle="@tooltipSubtitle" Color="@color" X="@tooltipX" Y="@tooltipY"/>
             }
         }
     }
-    @if (_options is { ShowToolTips: true }  && _hoveredLegend is not null)
+    @if (_options is { ShowToolTips: true } && _hoveredLegend is not null)
     {
-        <ChartTooltip Title="@_hoveredLegend.Value.value.ToString()" Color="@_hoveredLegend.Value.color" X="@_hoveredLegendPosition.X" Y="@_hoveredLegendPosition.Y" />
+        <ChartTooltip Title="@_hoveredLegend.Value.value.ToString()" Color="@_hoveredLegend.Value.color" X="@_hoveredLegendPosition.X" Y="@_hoveredLegendPosition.Y"/>
     }
 </svg>
-@if (CanHideSeries is true)
+
+@if (CanHideSeries)
 {
-    <Legend T="T" Data="@_toggleLegend" />
+    <Legend T="T" Data="@_toggleLegend"></Legend>
 }

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -59,14 +59,14 @@
         var y = row * (_cellDimension.Height + _cellDimension.Padding) + _verticalStartSpace;
         var seriesLength = series[row].Data != null ? series[row].Data.Values.Count : 0;
 
-        @for (var col = 0; col < seriesLength; col++)
+        for (var col = 0; col < seriesLength; col++)
         {
             var colIndex = col;
             var cell = _heatMapCells.FirstOrDefault(c => c.Row == row && c.Column == col);
             var x = col * (_cellDimension.Width + _cellDimension.Padding) + _horizontalStartSpace;
 
             // Gradient Overlays
-            @if (_options is { EnableSmoothGradient: true })
+            if (_options is { EnableSmoothGradient: true })
             {
                 // Apply the 4 gradient overlays with partial opacity
                 <rect x="@x.ToStr()"
@@ -115,7 +115,7 @@
                           @onmouseout="OnCellMouseOut"
                           fill="@(cellColor)"/>
 
-                    @if (_options is { ShowLabels: true } && cell is { Value: not null } && cell is { CustomFragment: null })
+                    @if (_options is { ShowLabels: true } && cell is { Value: not null } and { CustomFragment: null })
                     {
                         <g>
                             <text @onclick="async () => await SetSelectedCellAsync(rowIndex, colIndex)"
@@ -132,7 +132,7 @@
                     }
                     else if (cell is { CustomFragment: not null })
                     {
-                        @if (cell.Width.HasValue || cell.Height.HasValue)
+                        if (cell.Width.HasValue || cell.Height.HasValue)
                         {
                             // If specific width/height are provided, scale to cell dimensions
                             var tempWidth = cell.Width ?? _cellDimension.Width;
@@ -167,31 +167,31 @@
 
             // XAxis Labels
             var xAxisLabels = ChartLabels;
-            @if (row == 0 && _options?.XAxisLabelPosition == XAxisLabelPosition.Top && col < xAxisLabels.Length)
+            if (row == 0 && _options?.XAxisLabelPosition == XAxisLabelPosition.Top && col < xAxisLabels.Length)
             {
                 <g transform="translate(@((x + _cellDimension.Width / 2).ToStr()), @((y - CellPadding).ToStr()))">
-                    <text class="mud-charts-xaxis" x="0" y="0" text-anchor="middle" font-size="@_dynamicFontSize.ToStr()">@xAxisLabels[col]</text>
+                    <text class="mud-charts-xaxis" x="0" y="@(-AxisLabelsPadding)" text-anchor="middle" font-size="@_dynamicFontSize.ToStr()">@xAxisLabels[col]</text>
                 </g>
             }
             else if (row == RowCount - 1 && _options?.XAxisLabelPosition == XAxisLabelPosition.Bottom && col < xAxisLabels.Length)
             {
                 <g transform="translate(@((x + _cellDimension.Width / 2).ToStr()), @((y + _cellDimension.Height + _dynamicFontSize).ToStr()))">
-                    <text class="mud-charts-xaxis" x="0" y="0" text-anchor="middle" fill="black" font-size="@_dynamicFontSize.ToStr()">@xAxisLabels[col]</text>
+                    <text class="mud-charts-xaxis" x="0" y="@AxisLabelsPadding" text-anchor="middle" fill="black" font-size="@_dynamicFontSize.ToStr()">@xAxisLabels[col]</text>
                 </g>
             }
         }
 
         // YAxis Labels
-        @if (_options?.YAxisLabelPosition == YAxisLabelPosition.Left)
+        if (_options?.YAxisLabelPosition == YAxisLabelPosition.Left)
         {
             <g transform="translate(@((_horizontalStartSpace - CellPadding).ToStr()), @((y + _cellDimension.Height / 2).ToStr()))">
-                @((MarkupString)$"<text class='mud-charts-yaxis' x='0' y='0' dominant-baseline='middle' text-anchor='end' font-size='{_dynamicFontSize.ToStr()}'>{rowLabel}</text>")
+                @((MarkupString)$"<text class='mud-charts-yaxis' x='{-AxisLabelsPadding}' y='0' dominant-baseline='middle' text-anchor='end' font-size='{_dynamicFontSize.ToStr()}'>{rowLabel}</text>")
             </g>
         }
         else if (_options?.YAxisLabelPosition == YAxisLabelPosition.Right)
         {
             <g transform="translate(@((_horizontalStartSpace + HeatmapWidth + CellPadding).ToStr()), @((y + _cellDimension.Height / 2).ToStr()))">
-                @((MarkupString)$"<text class='mud-charts-yaxis' x='0' y='0' dominant-baseline='middle' text-anchor='start' font-size='{_dynamicFontSize.ToStr()}'>{rowLabel}</text>")
+                @((MarkupString)$"<text class='mud-charts-yaxis' x='{AxisLabelsPadding}' y='0' dominant-baseline='middle' text-anchor='start' font-size='{_dynamicFontSize.ToStr()}'>{rowLabel}</text>")
             </g>
         }
     }
@@ -199,7 +199,7 @@
     {
         var (legendX, legendY) = GetLegendPosition();
         var labelFontSize = LegendFontSize - 2;
-        @switch (_legendPosition)
+        switch (_legendPosition)
         {
             case Position.Top or Position.Bottom:
             {
@@ -338,7 +338,7 @@
         var x = colOffset + _horizontalStartSpace + _cellDimension.Width / 2;
         var y = rowOffset + _verticalStartSpace + _cellDimension.Height / 2;
 
-        var path = new SvgPath()
+        var path = new SvgPath
         {
             Index = _hoveredCell.Row,
             LabelX = x,

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -279,9 +279,9 @@ namespace MudBlazor.Charts
                 {
                     var legend = new SvgLegend
                     {
-                        Index = row, 
-                        Labels = _series[row].Name, 
-                        Visible = _series[row].Visible, 
+                        Index = row,
+                        Labels = _series[row].Name,
+                        Visible = _series[row].Visible,
                         OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
                     };
                     _toggleLegend.Add(legend);

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -35,7 +35,7 @@ namespace MudBlazor.Charts
         private const double BoundWidth = 800.0;
 
         private const double BoundHeight = 350.0;
-        
+
         private const int AxisLabelsPadding = 5;
 
         internal Position _legendPosition = Position.Bottom;
@@ -66,7 +66,7 @@ namespace MudBlazor.Charts
 
         private double _dynamicFontSize = 8;
 
-        private double _yAxisLabelWidth = 0;
+        private double _yAxisLabelWidth;
 
         // padding or legend area for each side of the heatmap
         private double _horizontalStartSpace = HeatMapPadding;
@@ -92,10 +92,10 @@ namespace MudBlazor.Charts
         private int RowCount => _series.Count > 0 ? _series.Count(s => s.Visible) : 0;
 
         // the amount of pixels a legend extends horizontally when it's on left/right
-        private int _legendLabelsYAxis = 0;
+        private int _legendLabelsYAxis;
 
         // the amount of pixels a legend extends vertically when it's on the top/bottom
-        private int _legendLabelsXAxis = 0;
+        private int _legendLabelsXAxis;
 
         // Calculate the actual width of the heatmap cells area
         private double HeatmapWidth => _boundWidth - _horizontalStartSpace - _horizontalEndSpace;

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -35,6 +35,8 @@ namespace MudBlazor.Charts
         private const double BoundWidth = 800.0;
 
         private const double BoundHeight = 350.0;
+        
+        private const int AxisLabelsPadding = 5;
 
         internal Position _legendPosition = Position.Bottom;
 

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -277,9 +277,12 @@ namespace MudBlazor.Charts
 
                 if (CanHideSeries)
                 {
-                    var legend = new SvgLegend()
+                    var legend = new SvgLegend
                     {
-                        Index = row, Labels = _series[row].Name, Visible = _series[row].Visible, OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
+                        Index = row, 
+                        Labels = _series[row].Name, 
+                        Visible = _series[row].Visible, 
+                        OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
                     };
                     _toggleLegend.Add(legend);
                 }

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -13,7 +13,6 @@ using MudBlazor.Interop;
 using MudBlazor.Utilities;
 using MudBlazor.Utilities.Debounce;
 
-
 namespace MudBlazor.Charts
 {
     partial class HeatMap<T> : MudChartBase<T, HeatMapChartOptions>, IDisposable where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
@@ -278,10 +277,7 @@ namespace MudBlazor.Charts
                 {
                     var legend = new SvgLegend()
                     {
-                        Index = row,
-                        Labels = _series[row].Name,
-                        Visible = _series[row].Visible,
-                        OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
+                        Index = row, Labels = _series[row].Name, Visible = _series[row].Visible, OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
                     };
                     _toggleLegend.Add(legend);
                 }
@@ -317,11 +313,12 @@ namespace MudBlazor.Charts
             // Calculate Y-axis label width based on dynamic font size
             _yAxisLabelWidth = (_series.Count > 0 ? _series?.Max(x => x.Name.Length) ?? 1 : 1) * _dynamicFontSize * AverageCharWidthMultiplier;
 
-            var defaultCharsWidth = 5 * LegendFontSize * AverageCharWidthMultiplier;
+            const double DefaultCharsWidth = 5 * LegendFontSize * AverageCharWidthMultiplier;
             _legendLabelsYAxis = (int)Math.Ceiling(_options is { ShowLegendLabels: true }
-                ? (defaultCharsWidth + LegendLineLength) : 0);
+                ? DefaultCharsWidth + LegendLineLength
+                : 0);
             _legendLabelsXAxis = _options is { ShowLegendLabels: true }
-                ? (LegendFontSize + LegendLineLength)
+                ? LegendFontSize + LegendLineLength
                 : 0;
 
             // make room for X and Y Axis Labels
@@ -329,18 +326,22 @@ namespace MudBlazor.Charts
             {
                 _horizontalStartSpace += CellPadding + _yAxisLabelWidth + CellPadding;
             }
+
             if (_options?.YAxisLabelPosition == YAxisLabelPosition.Right)
             {
                 _horizontalEndSpace += CellPadding + _yAxisLabelWidth + CellPadding;
             }
+
             if (_options?.XAxisLabelPosition == XAxisLabelPosition.Top)
             {
                 _verticalStartSpace += CellPadding + _dynamicFontSize + CellPadding;
             }
+
             if (_options?.XAxisLabelPosition == XAxisLabelPosition.Bottom)
             {
                 _verticalEndSpace += CellPadding + _dynamicFontSize + CellPadding;
             }
+
             // Make Room for Legend (if Any)
             if (_options is { ShowLegend: true })
             {
@@ -349,12 +350,15 @@ namespace MudBlazor.Charts
                     case Position.Bottom:
                         _verticalEndSpace += CellPadding + _legendLabelsXAxis + LegendBox + CellPadding;
                         break;
+
                     case Position.Top:
                         _verticalStartSpace += CellPadding + _legendLabelsXAxis + LegendBox + CellPadding;
                         break;
+
                     case Position.Left:
                         _horizontalStartSpace += CellPadding + _legendLabelsYAxis + LegendBox + CellPadding;
                         break;
+
                     case Position.Right:
                         _horizontalEndSpace += CellPadding + _legendLabelsYAxis + LegendBox + CellPadding;
                         break;
@@ -382,11 +386,13 @@ namespace MudBlazor.Charts
             {
                 return null;
             }
+
             // need to ensure column index exists in case there is no data for a column in a series
             if (col < 0 || _series[row].Data == null || col >= _series[row].Data.Values.Count)
             {
                 return null;
             }
+
             return _series[row].Data[col].Y;
         }
 
@@ -415,14 +421,13 @@ namespace MudBlazor.Charts
             {
                 return MudColor.GenerateTintShadePalette(baseColors[0]).ToArray();
             }
-            else if (colorCount != 5)
+
+            if (colorCount != 5)
             {
                 return MudColor.GenerateMultiGradientPalette(baseColors, shadeCount).ToArray();
             }
-            else
-            {
-                return baseColors;
-            }
+
+            return baseColors;
         }
 
         private string FormatValueForDisplay(T? value)
@@ -434,7 +439,7 @@ namespace MudBlazor.Charts
             // Format the value and truncate to 5 characters or fewer
             var formattedValue = value.Value.ToString(formatString, CultureInfo.InvariantCulture);
 
-            return formattedValue.Length > 5 ? formattedValue.Substring(0, 5) : formattedValue;
+            return formattedValue.Length > 5 ? formattedValue[..5] : formattedValue;
         }
 
         private static double CalculateFontSize(double cellWidth, double cellHeight, int defaultSize)
@@ -509,9 +514,9 @@ namespace MudBlazor.Charts
                     _boundHeight = _elementSize.Height;
                 }
                 else if (Width.EndsWith("px")
-                    && Height.EndsWith("px")
-                    && double.TryParse(Width.AsSpan(0, Width.Length - 2), out var width)
-                    && double.TryParse(Height.AsSpan(0, Height.Length - 2), out var height))
+                         && Height.EndsWith("px")
+                         && double.TryParse(Width.AsSpan(0, Width.Length - 2), out var width)
+                         && double.TryParse(Height.AsSpan(0, Height.Length - 2), out var height))
                 {
                     _boundWidth = width;
                     _boundHeight = height;
@@ -543,10 +548,7 @@ namespace MudBlazor.Charts
         {
             _debouncer.DebounceAsync(async () =>
             {
-                await InvokeAsync(() =>
-                {
-                    RebuildChart();
-                });
+                await InvokeAsync(RebuildChart);
             }).CatchAndLog();
         }
 

--- a/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
@@ -36,21 +36,21 @@ namespace MudBlazor.Charts
 
             for (var i = 0; i < normalizedData.Length; i++)
             {
-                if (normalizedData[i] == T.Zero)
+                if (normalizedData[i] == 0.0)
                     continue;
 
                 var data = normalizedData[i];
                 var value = T.Max(T.Zero, chartData[i]);
-                var radians = 2 * Math.PI * double.CreateSaturating(data);
+                var radians = 2 * Math.PI * data;
                 var half = radians / 2;
 
-                var coords = Pie<T>.GetSegmentCoordinates(cumulativeRadians, half, radians);
+                var coords = GetSegmentCoordinates(cumulativeRadians, half, radians);
                 cumulativeRadians += radians;
 
-                var pathData = Pie<T>.BuildSvgPath(coords, Radius, data);
+                var pathData = BuildSvgPath(coords, Radius, data);
 
-                var midAngle = cumulativeRadians - Math.PI * double.CreateSaturating(data);
-                var (x, y) = Pie<T>.GetLabelPosition(midAngle, Radius, data);
+                var midAngle = cumulativeRadians - (Math.PI * data);
+                var (x, y) = GetLabelPosition(midAngle, Radius, data);
 
                 _paths.Add(new SvgPetal
                 {
@@ -59,7 +59,7 @@ namespace MudBlazor.Charts
                     LabelX = x,
                     LabelY = y,
                     LabelXValue = ChartOptions.ShowAsPercentage
-                        ? $"{Math.Round(double.CreateSaturating(data) * 100, 1).ToInvariantString()}%"
+                        ? $"{Math.Round(data * 100, 1).ToInvariantString()}%"
                         : value.ToString(null, CultureInfo.InvariantCulture),
                     LabelYValue = chartLabels.Length > i ? chartLabels[i] : string.Empty,
                     SegmentRadius = Radius,
@@ -85,12 +85,12 @@ namespace MudBlazor.Charts
             };
         }
 
-        private static string BuildSvgPath(SegmentCoordinates c, double radius, T data)
+        private static string BuildSvgPath(SegmentCoordinates c, double radius, double data)
         {
             var sb = new StringBuilder();
 
             sb.Append($"M {ToS(c.StartX * radius)} {ToS(c.StartY * radius)} ");
-            if (data >= T.One)
+            if (data >= 1.0)
                 sb.Append($"A {ToS(radius)} {ToS(radius)} 0 {c.LargeArcFlag} 1 {ToS(c.MidX * radius)} {ToS(c.MidY * radius)} ");
             sb.Append($"A {ToS(radius)} {ToS(radius)} 0 {c.LargeArcFlag} 1 {ToS(c.EndX * radius)} {ToS(c.EndY * radius)} ");
             sb.Append("L 0 0 Z");
@@ -98,9 +98,9 @@ namespace MudBlazor.Charts
             return sb.ToString();
         }
 
-        private static (double X, double Y) GetLabelPosition(double angle, double radius, T data)
+        private static (double X, double Y) GetLabelPosition(double angle, double radius, double data)
         {
-            if (data >= T.One)
+            if (data >= 1.0)
                 return (0, 0);
 
             var r = radius * 0.5;

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -69,9 +69,8 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     }
 
     private bool HasValidData() =>
-        ChartSeries != null &&
-        ChartSeries.Count > 0 &&
-        ChartSeries.Any(s => s.Data != null && s.Data.Count > 0);
+        ChartSeries is { Count: > 0 } &&
+        ChartSeries.Any(s => s.Data is { Count: > 0 });
 
     private double CalculateRadius()
     {
@@ -85,7 +84,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         return Math.Min(Radius, maxR);
     }
 
-    private void GenerateSvgPaths(List<ChartSeries<T>> seriesData, T[] normalizedData, int numAxes,
+    private void GenerateSvgPaths(List<ChartSeries<T>> seriesData, double[] normalizedData, int numAxes,
                                   double angleStep, double currentAngle, double radius, T axisMaxValue)
     {
         Debug.Assert(ChartOptions is not null);
@@ -104,7 +103,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
                 Data = pathString,
                 Points = points,
                 LabelXValue = ChartOptions.ShowAsPercentage
-                    ? ToS(Math.Round(double.CreateSaturating(normalizedData[seriesIndex]) * 100, 1)) + "%"
+                    ? ToS(Math.Round(normalizedData[seriesIndex] * 100, 1)) + "%"
                     : series.Data.Values.SumGeneric().ToString(null, CultureInfo.InvariantCulture),
                 LabelYValue = series.Name
             };

--- a/src/MudBlazor/Components/Chart/Charts/Rose.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Rose.razor.cs
@@ -5,7 +5,6 @@
 using System.Globalization;
 using System.Numerics;
 using System.Text;
-using MudBlazor.Extensions;
 
 namespace MudBlazor.Charts;
 

--- a/src/MudBlazor/Components/Chart/Charts/Rose.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Rose.razor.cs
@@ -27,18 +27,18 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
 
         var chartData = AggregateSeriesData(ChartOptions!.AggregationOption);
         var normalizedData = GetNormalizedData();
-        var nonZeroCount = normalizedData.Count(d => d > T.Zero);
+        var nonZeroCount = normalizedData.Count(d => d > 0.0);
         if (nonZeroCount == 0) return;
 
         var angleStep = 2 * Math.PI / nonZeroCount;
         var currentAngle = ChartOptions.AngleOffset * (Math.PI / 180);
         var chartLabels = GetChartLabels();
-        var maxValue = normalizedData.Length > 0 ? normalizedData.Max() : T.Zero;
-        var sum = normalizedData.SumGeneric();
+        var maxValue = normalizedData.Length > 0 ? normalizedData.Max() : 0.0;
+        var sum = normalizedData.Sum();
 
         for (var i = 0; i < normalizedData.Length; i++)
         {
-            if (normalizedData[i] == T.Zero)
+            if (normalizedData[i] == 0.0)
                 continue;
 
             var value = T.Max(T.Zero, chartData[i]);
@@ -60,7 +60,7 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
                 LabelX = x,
                 LabelY = y,
                 LabelXValue = ChartOptions.ShowAsPercentage
-                    ? $"{ToS(Math.Round(double.CreateSaturating(data / sum) * 100, 1))}%"
+                    ? $"{ToS(Math.Round(data / sum * 100, 1))}%"
                     : value.ToString(null, CultureInfo.InvariantCulture),
                 LabelYValue = chartLabels.Length > i ? chartLabels[i] : string.Empty
             });
@@ -71,9 +71,9 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
         BuildLegends(chartLabels);
     }
 
-    private double CalculateScaledRadius(T value, T max)
+    private double CalculateScaledRadius(double value, double max)
     {
-        return Math.Max(0, Radius * (max == T.Zero ? 0 : double.CreateSaturating(value / max)) * ChartOptions!.ScaleFactor);
+        return Math.Max(0, Radius * (max == 0.0 ? 0 : value / max) * ChartOptions!.ScaleFactor);
     }
 
     private static SegmentCoordinates GetSegmentCoordinates(double angle, double step, int count) => new()
@@ -82,7 +82,7 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
         StartY = Math.Sin(angle),
         EndX = Math.Cos(angle + step),
         EndY = Math.Sin(angle + step),
-        LargeArcFlag = (count == 1 || step > Math.PI) ? 1 : 0
+        LargeArcFlag = count == 1 || step > Math.PI ? 1 : 0
     };
 
     private static string BuildRadialPath(SegmentCoordinates coords, double radius, int count)

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -1,6 +1,4 @@
-﻿@using System.Globalization
-
-@namespace MudBlazor.Charts
+﻿@namespace MudBlazor.Charts
 
 @inherits MudChartBase<T, SankeyChartOptions>
 
@@ -93,7 +91,7 @@
     </svg>
 </div>
 
-@if (CanHideSeries is true)
+@if (CanHideSeries)
 {
     <Legend T="T" Data="@_legend" />
 }

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -50,7 +50,7 @@ namespace MudBlazor.Charts
         /// </summary>
         public HashSet<SankeyEdge<T>> Edges { get; set; } = [];
 
-        private Dictionary<string, NodeRect> NodeRects { get; set; } = [];
+        private Dictionary<string, NodeRect> NodeRects { get; } = [];
         private Dictionary<string, double> NodeValues { get; set; } = [];
         private List<EdgePath> EdgePaths { get; } = [];
         private string? ActiveNode { get; set; }
@@ -285,7 +285,6 @@ namespace MudBlazor.Charts
                     : ChartSeries.Count;
 
             var aggregated = new ChartSeries<T>[maxCategoryLength];
-
             return aggregation switch
             {
                 AggregationOption.GroupByLabel => AggregateByLabel(aggregated),
@@ -303,7 +302,7 @@ namespace MudBlazor.Charts
                               .Max(x => x?.Data?.Values.Count ?? 0);
         }
 
-        private List<ChartSeries<T>> AggregateByLabel(ChartSeries<T>[] aggregated)
+        private List<ChartSeries<T>> AggregateByLabel(ChartSeries<T>[] _)
         {
             var result = new List<ChartSeries<T>>();
             var visibleSeries = ChartSeries.Where(s => s.Visible).ToList();
@@ -432,17 +431,16 @@ namespace MudBlazor.Charts
             // Calculate grid sizes
             var maxRows = nodesPerColumn.Max(n => n.Count());
             var maxColumns = nodesPerColumn.Length - 1;
-            var boundWidthRelativeToNodeWidth = _boundWidth - ChartOptions!.NodeWidth * maxColumns - 2 * HorizontalPadding;
+            var boundWidthRelativeToNodeWidth = _boundWidth - (ChartOptions!.NodeWidth * maxColumns) - (2 * HorizontalPadding);
 
-            boundHeightRelativeToNodeHeight = _boundHeight - ChartOptions!.MinVerticalSpacing * maxRows;
+            boundHeightRelativeToNodeHeight = _boundHeight - (ChartOptions!.MinVerticalSpacing * maxRows);
 
             // Draw all nodes column per column
-            var nodeRects = new Dictionary<string, NodeRect>();
             foreach (var column in nodesPerColumn)
             {
-                var x = column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth + HorizontalPadding;
+                var x = (column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth) + HorizontalPadding;
                 var totalRelativeColumnValue = column.Sum(n => relativeNodesValuesMapping[n]);
-                var totalVerticalSpace = _boundHeight - double.CreateSaturating(totalRelativeColumnValue) * boundHeightRelativeToNodeHeight;
+                var totalVerticalSpace = _boundHeight - (double.CreateSaturating(totalRelativeColumnValue) * boundHeightRelativeToNodeHeight);
                 var verticalSpacing = Math.Max(totalVerticalSpace / (column.Count() + 1), ChartOptions!.MinVerticalSpacing);
 
                 double currentY = 0;
@@ -469,7 +467,7 @@ namespace MudBlazor.Charts
             }
         }
 
-        private SankeyNode[] NormaliseNodeColumnIndices(SankeyNode[] nodes)
+        private static SankeyNode[] NormaliseNodeColumnIndices(SankeyNode[] nodes)
         {
             // Normalise column indices
             var columnMap = nodes
@@ -546,8 +544,8 @@ namespace MudBlazor.Charts
                         ),
                         LabelXValue = rectSource.Name,
                         LabelYValue = rectTarget.Name,
-                        LabelX = startX + Math.Abs(startX - endX) / 2,
-                        LabelY = startY + (endY - startY) / 2 + height / 2
+                        LabelX = startX + (Math.Abs(startX - endX) / 2),
+                        LabelY = startY + ((endY - startY) / 2) + (height / 2)
                     });
 
                     startYOffset += height;
@@ -566,8 +564,8 @@ namespace MudBlazor.Charts
             var ty1 = targetY + targetHeight;
 
             // Control points for cubic Bezier curve
-            var cx0 = sourceX + (targetX - sourceX) * curvature;
-            var cx1 = targetX - (targetX - sourceX) * curvature;
+            var cx0 = sourceX + ((targetX - sourceX) * curvature);
+            var cx1 = targetX - ((targetX - sourceX) * curvature);
 
             return $"M{ToS(sourceX)},{ToS(sy0)} " + // Top-left of source
                    $"C{ToS(cx0)},{ToS(sy0)} " + // Control point 1

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
@@ -1,6 +1,4 @@
-﻿@using System.Globalization;
-
-@namespace MudBlazor.Charts
+﻿@namespace MudBlazor.Charts
 
 @inherits MudAxisChartBase<T, StackedBarChartOptions>
 

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor
@@ -1,6 +1,4 @@
-﻿@using System.Globalization;
-
-@namespace MudBlazor.Charts
+﻿@namespace MudBlazor.Charts
 
 @inherits MudAxisLineChartBase<T, TimeSeriesChartOptions>
 

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Numerics;
+﻿using System.Numerics;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Interpolation;
 

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -35,7 +35,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
 
     protected override void OnAfterRender(bool firstRender)
     {
-        if (firstRender && ChartReference is { })
+        if (firstRender && ChartReference is not null)
         {
             StateHasChanged();
         }

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -11,8 +11,8 @@
         {
             <div class="mud-chart-legend-item" 
                  @onclick:stopPropagation=@(ChartContainer!=null)
-                 @onclick=@(async ()=>{ if (OnLegendSelected.HasDelegate) { await OnLegendSelected.InvokeAsync(item.Index); }})>
-                @if(CanHideSeries == false)
+                 @onclick=@(async () => { if (OnLegendSelected.HasDelegate) { await OnLegendSelected.InvokeAsync(item.Index); }})>
+                @if(!CanHideSeries)
                 {
                     <span class="mud-chart-legend-marker" style="@($"background-color:{ChartPalette!.GetValue(item.Index % ChartPalette.Length)}")"></span>
                     <MudText Typo="Typo.body2" HtmlTag="span">@item.Labels</MudText>
@@ -20,7 +20,7 @@
                 else
                 {   
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
-                        <MudCheckBox Value="@item.Visible" ValueChanged="@((bool value) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense></MudCheckBox>
+                        <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense/>
                         <MudText Typo="Typo.body2" Class="ml-n2 align-self-end" HtmlTag="span">@item.Labels</MudText>
                     </div> 
                 }                 

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -35,6 +35,7 @@
       flex-direction: column;
       order: 3;
       min-width: fit-content;
+      margin-left: 10px;
     }
   }
 
@@ -45,18 +46,18 @@
       flex-direction: column;
       order: 1;
       min-width: fit-content;
+      margin-right: 10px;
     }
   }
 
-
-  & .mud-chart-donut, .mud-chart-pie, mud-chart-line, mud-chart-bar {
+  & .mud-chart-donut, .mud-chart-pie, .mud-chart-line, .mud-chart-bar {
     display: flex;
     margin: auto;
   }
 
   & .mud-chart-legend {
     display: flex;
-    padding: 10px 0px;
+    padding: 10px 0;
     margin: auto;
     flex-wrap: wrap;
 

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -121,6 +121,12 @@
     -o-transition: stroke .2s ease;
     transition: stroke .2s ease;
   }
+
+  & .mud-donut-text {
+    dominant-baseline: central;
+    text-anchor: middle;
+    fill: var(--mud-palette-primary-text);
+  }
 }
 
 .mud-chart-legend-marker {

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -127,7 +127,7 @@
   & .mud-donut-text {
     dominant-baseline: central;
     text-anchor: middle;
-    fill: var(mud-palette-text-primary);
+    fill: var(--mud-palette-text-primary);
   }
 }
 

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -53,6 +53,7 @@
   & .mud-chart-donut, .mud-chart-pie, .mud-chart-line, .mud-chart-bar {
     display: flex;
     margin: auto;
+    overflow: unset; // Workaround for clipped axis notations
   }
 
   & .mud-chart-legend {
@@ -126,7 +127,7 @@
   & .mud-donut-text {
     dominant-baseline: central;
     text-anchor: middle;
-    fill: var(--mud-palette-primary-text);
+    fill: var(mud-palette-text-primary);
   }
 }
 


### PR DESCRIPTION
## This PR fixes https://github.com/MudBlazor/MudBlazor/issues/12669:

* [Replace undefined donut text class and fix text alignment](https://github.com/MudBlazor/MudBlazor/commit/698c6260d3dbba135aa87b5a2e261857cc13f687)
<img width="1248" height="710" alt="image" src="https://github.com/user-attachments/assets/4a8be349-794a-4523-a49e-2b55dffb0dd7" />

* [Add heatmap axis label padding](https://github.com/MudBlazor/MudBlazor/commit/fa886a12416c366d52bd5b738494e64ec20e4db3)
<img width="794" height="345" alt="image" src="https://github.com/user-attachments/assets/e2a86746-4dcc-4fdb-b93d-51c81d4e925d" />

* [Fix axis chart axis title offset] (https://github.com/MudBlazor/MudBlazor/commit/f3c63711b0340c6876e5caf498885a1133a8f9d5)
<img width="711" height="411" alt="image" src="https://github.com/user-attachments/assets/f89f1e6c-860a-49ca-a724-7e0ec65167f3" />

* [Add missing horizontal legend padding](https://github.com/MudBlazor/MudBlazor/commit/82fc2ec56f27fd5a4c156614151684eb17972a02)
<img width="421" height="325" alt="image" src="https://github.com/user-attachments/assets/ca99bf55-88c4-496b-b3bd-ff61fd90d2a0" />

* [Fix sankey chart example 2 scaling](https://github.com/MudBlazor/MudBlazor/commit/3c5b0f53e480183c947b8ef33383ca3e9ba40560)
<img width="1186" height="765" alt="image" src="https://github.com/user-attachments/assets/c336b47c-3511-448c-a05c-e59db0bfd530" />

## This PR also fixes
* [Fix radial charts not rendering when using ints](https://github.com/MudBlazor/MudBlazor/commit/b3e922ae17caf9278eed81125610c33150166d57): Radial charts didn't render at all when using any non floating point data type
* Fix multiple non-existing or wrong declared css classes
* Remove dead code, fix code smells, increase code maintainability