### PR TITLE
MudFab: Add MudFabGroup component

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabGroup/ButtonFabGroupPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabGroup/ButtonFabGroupPage.razor
@@ -1,0 +1,16 @@
+﻿@page "/components/buttonfabgroup"
+
+<DocsPage>
+    <DocsPageHeader Title="Fab Group" Component="@nameof(MudFabGroup)">
+        <Description></Description>
+    </DocsPageHeader>
+    <DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader Title="Basic Usage">
+            </SectionHeader>
+            <SectionContent Code="@nameof(ButtonFabGroupBasicExample)">
+                <ButtonFabGroupBasicExample/>
+            </SectionContent>
+        </DocsPageSection>
+    </DocsPageContent>
+</DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/ButtonFabGroup/Examples/ButtonFabGroupBasicExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ButtonFabGroup/Examples/ButtonFabGroupBasicExample.razor
@@ -1,0 +1,7 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudFabGroup>
+    <MudFab StartIcon="@Icons.Material.Filled.ArrowBack" />
+    <MudFab Color="Color.Error" StartIcon="@Icons.Material.Filled.Add" />
+    <MudFab Color="Color.Success" StartIcon="@Icons.Material.Filled.Remove" />
+</MudFabGroup>

--- a/src/MudBlazor.Docs/Services/Menu/MenuService.cs
+++ b/src/MudBlazor.Docs/Services/Menu/MenuService.cs
@@ -113,6 +113,7 @@ namespace MudBlazor.Docs.Services
                 .AddItem("Icon Button", typeof(MudIconButton))
                 .AddItem("Toggle Icon Button", typeof(MudToggleIconButton))
                 .AddItem("Button FAB", typeof(MudFab))
+                .AddItem("Button FAB Group", typeof(MudFabGroup))
                 .AddItem("Button FAB Menu", typeof(MudFabMenu))
             )
 

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -16,12 +16,12 @@
     <span class="mud-fab-label">
         @if (!string.IsNullOrWhiteSpace(StartIcon))
         {
-            <MudIcon Disabled="@Disabled" Icon="@StartIcon" Color="@IconColor" Size="@IconSize" />
+            <MudIcon Disabled="@Disabled" Icon="@StartIcon" Color="@IconColor" Size="@IconSize"/>
         }
         @Label
         @if (!string.IsNullOrWhiteSpace(EndIcon))
         {
-            <MudIcon Disabled="@Disabled" Icon="@EndIcon" Color="@IconColor" Size="@IconSize" />
+            <MudIcon Disabled="@Disabled" Icon="@EndIcon" Color="@IconColor" Size="@IconSize"/>
         }
     </span>
 </MudElement>

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -16,12 +16,15 @@ namespace MudBlazor
     /// <seealso cref="MudToggleIconButton" />
     public partial class MudFab : MudBaseButton
     {
+        [CascadingParameter]
+        protected MudFabGroup? FabGroup { get; set; }
+
         protected string Classname => new CssBuilder("mud-button-root mud-fab")
-            .AddClass($"mud-fab-extended", !string.IsNullOrEmpty(Label))
+            .AddClass("mud-fab-extended", !string.IsNullOrEmpty(Label))
             .AddClass($"mud-fab-{Color.ToStringFast(true)}")
             .AddClass($"mud-fab-size-{Size.ToStringFast(true)}")
-            .AddClass($"mud-ripple", Ripple && !GetDisabledState())
-            .AddClass($"mud-fab-disable-elevation", !DropShadow)
+            .AddClass("mud-ripple", Ripple && !GetDisabledState())
+            .AddClass("mud-fab-disable-elevation", !DropShadow)
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor/Components/Button/MudFabGroup.razor
+++ b/src/MudBlazor/Components/Button/MudFabGroup.razor
@@ -1,0 +1,8 @@
+@namespace MudBlazor
+@inherits MudComponentBase
+
+<div class="@Classname" style="@Stylename" @attributes="UserAttributes">
+    <CascadingValue Value="this" IsFixed="true">
+        @ChildContent
+    </CascadingValue>
+</div>

--- a/src/MudBlazor/Components/Button/MudFabGroup.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabGroup.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/Button/MudFabGroup.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabGroup.razor.cs
@@ -1,0 +1,63 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
+
+namespace MudBlazor;
+
+/// <summary>
+/// A container that stacks multiple <see cref="MudFab"/> buttons vertically in a fixed position.
+/// </summary>
+/// <seealso cref="MudFab"/>
+public partial class MudFabGroup : MudComponentBase
+{
+    protected string Classname => new CssBuilder("mud-fab-group")
+        .AddClass(Class)
+        .AddClass($"gap-{Spacing}", Spacing >= 0)
+        .Build();
+
+    protected string Stylename => new StyleBuilder()
+        .AddStyle("bottom", Bottom)
+        .AddStyle("right", Right)
+        .AddStyle(Style)
+        .Build();
+
+    /// <summary>
+    /// The distance from the bottom of the viewport.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>16px</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public string Bottom { get; set; } = "16px";
+
+    /// <summary>
+    /// The distance from the right edge of the viewport.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>16px</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public string Right { get; set; } = "16px";
+
+    /// <summary>
+    /// The space between buttons.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>3</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Button.Appearance)]
+    public int Spacing { get; set; } = 3;
+
+    /// <summary>
+    /// The <see cref="MudFab"/> components within this group.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Button.Behavior)]
+    public RenderFragment? ChildContent { get; set; }
+}

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor;
 public partial class MudFabMenu : MudFab
 {
     private new string Classname => new CssBuilder("mud-fab-menu-container")
-        .AddClass("fixed", Fixed)
+        .AddClass("fixed", Fixed && FabGroup is null)
         .AddClass($"align-{AlignItems.ToStringFast(true)}")
         .AddClass(Class)
         .Build();

--- a/src/MudBlazor/Styles/MudBlazor.scss
+++ b/src/MudBlazor/Styles/MudBlazor.scss
@@ -41,6 +41,7 @@
 @import 'components/_expansionpanel';
 @import 'components/_fab';
 @import 'components/_fabmenu';
+@import 'components/_fabgroup';
 @import 'components/_form';
 @import 'components/_list';
 @import 'components/_layout';

--- a/src/MudBlazor/Styles/components/_fab.scss
+++ b/src/MudBlazor/Styles/components/_fab.scss
@@ -9,10 +9,10 @@
   letter-spacing: var(--mud-typography-button-letterspacing);
   text-transform: var(--mud-typography-button-text-transform);
   min-width: 0;
-  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.2), 0px 6px 10px 0px rgba(0, 0, 0, 0.14), 0px 1px 18px 0px rgba(0, 0, 0, 0.12);
   box-sizing: border-box;
   min-height: 36px;
-  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   border-radius: 50%;
   color: var(--mud-palette-text-primary);
   --mud-ripple-color: var(--mud-palette-text-primary);
@@ -20,20 +20,20 @@
 
   @media(hover: hover) and (pointer: fine) {
     &:hover {
-      box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0,0,0,.12);
+      box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, .12);
       text-decoration: none;
       background-color: var(--mud-palette-action-disabled-background);
     }
   }
 
   &:focus-visible {
-    box-shadow: 0px 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0,0,0,.12);
+    box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, .12);
     text-decoration: none;
     background-color: var(--mud-palette-action-disabled-background);
   }
 
   &:active {
-    box-shadow: 0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);
+    box-shadow: 0 7px 8px -4px rgba(0, 0, 0, 0.2), 0px 12px 17px 2px rgba(0, 0, 0, 0.14), 0px 5px 22px 4px rgba(0, 0, 0, 0.12);
     text-decoration: none;
     background-color: var(--mud-palette-action-disabled-background);
   }

--- a/src/MudBlazor/Styles/components/_fabgroup.scss
+++ b/src/MudBlazor/Styles/components/_fabgroup.scss
@@ -1,0 +1,7 @@
+.mud-fab-group {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  z-index: calc(var(--mud-zindex-appbar) + 1);
+}


### PR DESCRIPTION
This component enables the default use case for a `Fab`, fixed on the bottom right, and handles alignment between multiple `Fab`s.

<img width="1107" height="427" alt="image" src="https://github.com/user-attachments/assets/1d933ad4-1516-4758-bc1e-76a3740f34cd" />
