### PR TITLE
Docs: Remove Experimental Warning from Heat Map Component

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor
@@ -3,19 +3,7 @@
 @page "/components/chart-types/heatmapchart"
 
 <DocsPage>
-    <DocsPageHeader Title="HeatMap Chart" SubTitle="A chart that displays a HeatMap" Component="@nameof(MudBlazor.Charts.HeatMap<T>)">
-        <Description>
-            <DocsPageSection>
-                <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning:</b> This component is currently under development.
-                    <br />
-                    <br />
-                    Breaking changes such as updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
-                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute code.
-                </MudAlert>
-            </DocsPageSection>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="HeatMap Chart" SubTitle="A chart that displays a HeatMap" Component="@nameof(MudBlazor.Charts.HeatMap<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>


### PR DESCRIPTION
Removed the 'under development' warning alert from the Heat Map chart documentation page. 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
