### PR TITLE
MudSelect: Prevent default(T) preselection in MultiSelection

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithEnumTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithEnumTest.razor
@@ -1,0 +1,20 @@
+﻿<MudPopoverProvider />
+
+<MudSelect MultiSelection="true" @bind-SelectedValues="@_selected">
+    @foreach (MyEnum item in Enum.GetValues(typeof(MyEnum)))
+    {
+        <MudSelectItem Value="@item">@item</MudSelectItem>
+    }
+</MudSelect>
+
+@code {
+    public static string __description__ = "Multiselection with enums should not automatically show the default(T) as selected";
+
+    private IReadOnlyCollection<MyEnum> _selected = [];
+
+    public enum MyEnum
+    {
+        First,
+        Second,
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -267,7 +267,6 @@ namespace MudBlazor.UnitTests.Components
 
             select.Instance.GetState(x => x.SelectedValues).Should().BeEmpty();
 
-
             await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -250,6 +250,53 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("input").Attributes["value"]?.Value.Should().Be("Second"));
         }
 
+
+
+        /// <summary>
+        /// Initial Text should be enums default value
+        /// Initial render fragment in input should be the pre-selected value's items's render fragment.
+        /// After clicking the second item, the render fragment should update
+        /// </summary>
+        [Test]
+        public async Task MultiSelectWithEnum()
+        {
+            var comp = Context.Render<MultiSelectWithEnumTest>();
+            // select elements needed for the test
+            var select = comp.FindComponent<MudSelect<MultiSelectWithEnumTest.MyEnum>>();
+            var input = comp.Find("div.mud-input-control");
+
+            select.Instance.GetState(x => x.SelectedValues).Should().BeEmpty();
+
+
+            await input.MouseDownAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            var items = comp.FindAll("div.mud-list-item").ToArray();
+
+            const string @unchecked =
+                "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
+            const string @checked =
+                "M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
+            // Validate that none of the items are selected
+            comp.FindAll("div.mud-list-item path:not(:first-child)").Should().AllSatisfy(item =>
+                item.Attributes["d"]!.Value.Should().Be(@unchecked)
+            );
+            // Select the first item
+            await items[0].ClickAsync();
+            await comp.WaitForAssertionAsync(() => comp.Find("input").Attributes["value"]?.Value.Should().Be("First"));
+            await comp.WaitForAssertionAsync(() =>
+                select.Instance.GetState(x => x.SelectedValues).Should().OnlyContain(item => item == MultiSelectWithEnumTest.MyEnum.First)
+            );
+            await comp.WaitForAssertionAsync(() =>
+            {
+                // Assert that the first item is checked
+                comp.FindAll("div.mud-list-item path:not(:first-child)")[0].Attributes["d"]!.Value.Should().Be(@checked);
+                // Remaining items should be unchecked
+                comp.FindAll("div.mud-list-item:not(:first-child) path:not(:first-child)").Should().AllSatisfy(item =>
+                    item.Attributes["d"]!.Value.Should().Be(@unchecked)
+                );
+            });
+        }
+
         /// <summary>
         /// Initially we have a value of 17 which is not in the list. So we render it as text via MudInput
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -250,8 +250,6 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("input").Attributes["value"]?.Value.Should().Be("Second"));
         }
 
-
-
         /// <summary>
         /// Initial Text should be enums default value
         /// Initial render fragment in input should be the pre-selected value's items's render fragment.

--- a/src/MudBlazor/Components/Select/MudSelectContext.cs
+++ b/src/MudBlazor/Components/Select/MudSelectContext.cs
@@ -72,10 +72,11 @@ internal sealed class MudSelectContext<T>
         // Shadow items are registered separately via RegisterShadowItem
 
         // Check if this item's value is currently selected
-        var currentValue = _select.ReadValue;
-        var selectedValues = _select.GetSelectedValues();
-        return currentValue?.Equals(item.Value) == true ||
-               selectedValues?.Contains(item.Value) == true;
+        return _select.MultiSelection switch
+        {
+            true => _select.GetSelectedValues()?.Contains(item.Value) == true,
+            false => _select.ReadValue?.Equals(item.Value) == true
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #12734 

As mentioned in the PR. When using a MudSelect with multiselection and non-nullable enum (possibly other types aswell) the default(T) is shown as selected due to a match against the Value instead of the SelectedValues. This adds a check to make sure that we, when multiselection is active, only check if the value is part of the SelectedValues. 

Note: Not sure if the switch expression here follows the standard but this also saves a call to GetSelectedValues() in the case of non-multiselection (not sure it matters). Happy to change to a if/else or if + early return if so.

As for testing, it was kind of annoying to check if the item was selected via the HTML but just reused some of the code from another multiselection test.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
