### PR TITLE
Build: Update Bun for Windows ARM64 support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "bundotnet.cli": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "commands": [
         "bun"
       ],

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BunVersion>1.3.9</BunVersion>
+    <BunVersion>1.3.10</BunVersion>
     <BunToolRestore>dotnet tool restore --tool-manifest ../../.config/dotnet-tools.json</BunToolRestore>
     <BunWrapper>dotnet tool run bun -- wrapper --version $(BunVersion) --path ../../tools --silent --</BunWrapper>
   </PropertyGroup>


### PR DESCRIPTION
Updates Bun to `v1.3.10` to support Windows ARM64.

closes #12552
closes #12744
closes #12745

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
