### PR TITLE
Build: Align analyzer rules with our style and current Roslyn options

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -309,7 +309,7 @@ csharp_style_allow_embedded_statements_on_same_line_experimental = false:suggest
 
 [*.{cs,razor}]
 file_header_template = Copyright (c) MudBlazor 2021\nMudBlazor licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
-csharp_style_prefer_primary_constructors = false:warning                    # IDE0290
+csharp_style_prefer_primary_constructors = false:none                       # IDE0290
 csharp_style_unused_value_assignment_preference = discard_variable:warning  # IDE0059
 dotnet_code_quality_unused_parameters = all:warning                         # IDE0060
 dotnet_style_prefer_compound_assignment = true:suggestion                   # IDE0054

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -35,21 +35,18 @@ indent_size = 2
 
 # Shell script files
 [*.sh]
-end_of_line = lf
 indent_size = 2
 
 # Sassy CSS - CSS preprocessor
 [*.scss]
 charset = utf-8
 indent_size = 2
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 # JavaScript / TypeScript files
 [*.{js,mjs,ts}]
 indent_size = 4
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -82,7 +79,7 @@ dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
-# Types: use keywords instead of BCL types, and permit var only when the type is clear
+# Types: use keywords instead of BCL types, and prefer var everywhere
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
@@ -184,11 +181,6 @@ dotnet_diagnostic.IDE0043.severity = warning
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true
 
-# Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
-
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:suggestion
 dotnet_sort_system_directives_first = true
@@ -237,7 +229,6 @@ csharp_style_conditional_delegate_call = true:suggestion
 # Other features
 csharp_style_prefer_index_operator = false:suggestion
 csharp_style_prefer_range_operator = false:suggestion
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
 
 # Space preferences
 csharp_space_after_cast = false
@@ -247,7 +238,7 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_around_declaration_statements = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
@@ -282,7 +273,6 @@ dotnet_style_prefer_simplified_boolean_expressions = true
 dotnet_style_prefer_simplified_interpolation = true
 
 # Parameter preferences
-dotnet_code_quality_unused_parameters = non_public:suggestion
 
 # New line preferences
 dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
@@ -297,7 +287,7 @@ csharp_style_prefer_pattern_matching = true:suggestion
 csharp_style_deconstructed_variable_declaration = true
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_prefer_method_group_conversion = true
-csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_null_check_over_type_check = true
 csharp_style_prefer_tuple_swap = false
 csharp_style_prefer_utf8_string_literals = true
@@ -322,16 +312,18 @@ csharp_style_allow_embedded_statements_on_same_line_experimental = false:suggest
 [*.{cs,razor}]
 file_header_template = Copyright (c) MudBlazor 2021\nMudBlazor licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
 csharp_style_prefer_primary_constructors = false:warning                # IDE0290
-csharp_remove_unnecessary_imports = true:warning                        # IDE0005
-dotnet_style_remove_unnecessary_value_assignment = true:warning         # IDE0059
-dotnet_code_style_unused_parameters = all:warning                       # IDE0060
+csharp_style_unused_value_assignment_preference = discard_variable:warning # IDE0059
+dotnet_code_quality_unused_parameters = all:warning                     # IDE0060
 dotnet_style_prefer_compound_assignment = true:suggestion               # IDE0054
-dotnet_style_prefer_simplified_conditional_expression = true:suggestion # IDE0075
-dotnet_style_remove_unnecessary_cast = true:warning                     # IDE0090
+dotnet_style_prefer_simplified_boolean_expressions = true:warning       # IDE0075
 
 # Rules that must use diagnostic syntax
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = none
+# IDE0004: Remove unnecessary cast
+dotnet_diagnostic.IDE0004.severity = warning
+# IDE0005: Using directive is unnecessary
+dotnet_diagnostic.IDE0005.severity = warning
 # IDE0073: Require file header
 dotnet_diagnostic.IDE0073.severity = none
 # IDE0055: Fix formatting

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -211,8 +211,8 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggesti
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:none
+dotnet_style_prefer_conditional_expression_over_return = true:none
 csharp_prefer_simple_default_expression = true:suggestion
 
 # Expression-bodied members
@@ -222,8 +222,8 @@ csharp_style_expression_bodied_operators = false:none
 csharp_style_expression_bodied_properties = true:none
 csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = true:silent
+csharp_style_expression_bodied_lambdas = true:none
+csharp_style_expression_bodied_local_functions = true:none
 
 # Pattern matching
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
@@ -235,9 +235,9 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
-csharp_style_prefer_index_operator = true:none
-csharp_style_prefer_range_operator = true:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+csharp_style_prefer_index_operator = false:suggestion
+csharp_style_prefer_range_operator = false:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
 
 # Space preferences
 csharp_space_after_cast = false
@@ -299,7 +299,7 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_prefer_method_group_conversion = true
 csharp_style_prefer_local_over_anonymous_function = true
 csharp_style_prefer_null_check_over_type_check = true
-csharp_style_prefer_tuple_swap = true:silent
+csharp_style_prefer_tuple_swap = false
 csharp_style_prefer_utf8_string_literals = true
 csharp_style_unused_value_assignment_preference = discard_variable
 csharp_style_unused_value_expression_statement_preference = discard_variable
@@ -321,13 +321,13 @@ csharp_style_allow_embedded_statements_on_same_line_experimental = false:suggest
 
 [*.{cs,razor}]
 file_header_template = Copyright (c) MudBlazor 2021\nMudBlazor licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
-csharp_style_prefer_primary_constructors = true:none                    # IDE0290
+csharp_style_prefer_primary_constructors = false:warning                # IDE0290
 csharp_remove_unnecessary_imports = true:warning                        # IDE0005
 dotnet_style_remove_unnecessary_value_assignment = true:warning         # IDE0059
 dotnet_code_style_unused_parameters = all:warning                       # IDE0060
 dotnet_style_prefer_compound_assignment = true:suggestion               # IDE0054
 dotnet_style_prefer_simplified_conditional_expression = true:suggestion # IDE0075
-dotnet_style_remove_unnecessary_cast = true:error                       # IDE0090
+dotnet_style_remove_unnecessary_cast = true:warning                     # IDE0090
 
 # Rules that must use diagnostic syntax
 # CS1591: Missing XML comment for publicly visible type or member

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -227,8 +227,8 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
-csharp_style_prefer_index_operator = false:suggestion
-csharp_style_prefer_range_operator = false:suggestion
+csharp_style_prefer_index_operator = false
+csharp_style_prefer_range_operator = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -285,7 +285,7 @@ csharp_style_prefer_pattern_matching = true:suggestion
 csharp_style_deconstructed_variable_declaration = true
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_prefer_method_group_conversion = true
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true
 csharp_style_prefer_null_check_over_type_check = true
 csharp_style_prefer_tuple_swap = true
 csharp_style_prefer_utf8_string_literals = true

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -272,8 +272,6 @@ dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
 dotnet_style_prefer_simplified_boolean_expressions = true
 dotnet_style_prefer_simplified_interpolation = true
 
-# Parameter preferences
-
 # New line preferences
 dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
 dotnet_style_allow_statement_immediately_after_block_experimental = false:suggestion
@@ -311,11 +309,11 @@ csharp_style_allow_embedded_statements_on_same_line_experimental = false:suggest
 
 [*.{cs,razor}]
 file_header_template = Copyright (c) MudBlazor 2021\nMudBlazor licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
-csharp_style_prefer_primary_constructors = false:warning                # IDE0290
-csharp_style_unused_value_assignment_preference = discard_variable:warning # IDE0059
-dotnet_code_quality_unused_parameters = all:warning                     # IDE0060
-dotnet_style_prefer_compound_assignment = true:suggestion               # IDE0054
-dotnet_style_prefer_simplified_boolean_expressions = true:warning       # IDE0075
+csharp_style_prefer_primary_constructors = false:warning                    # IDE0290
+csharp_style_unused_value_assignment_preference = discard_variable:warning  # IDE0059
+dotnet_code_quality_unused_parameters = all:warning                         # IDE0060
+dotnet_style_prefer_compound_assignment = true:suggestion                   # IDE0054
+dotnet_style_prefer_simplified_boolean_expressions = true:warning           # IDE0075
 
 # Rules that must use diagnostic syntax
 # CS1591: Missing XML comment for publicly visible type or member

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -203,19 +203,19 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggesti
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:none
-dotnet_style_prefer_conditional_expression_over_return = true:none
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
 csharp_prefer_simple_default_expression = true:suggestion
 
 # Expression-bodied members
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none
 csharp_style_expression_bodied_operators = false:none
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
-csharp_style_expression_bodied_lambdas = true:none
-csharp_style_expression_bodied_local_functions = true:none
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
 
 # Pattern matching
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
@@ -287,7 +287,7 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_prefer_method_group_conversion = true
 csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_null_check_over_type_check = true
-csharp_style_prefer_tuple_swap = false
+csharp_style_prefer_tuple_swap = true
 csharp_style_prefer_utf8_string_literals = true
 csharp_style_unused_value_assignment_preference = discard_variable
 csharp_style_unused_value_expression_statement_preference = discard_variable


### PR DESCRIPTION
This PR contains:
1. Manual rule updates from f53fa121bf106cc363f429fe706d91545ea41afe to try to align closer to our actual goals.
2. Remove invalid/obsolete keys, resolve conflicts, and drop redundant entries (see d6e14f631df368bda54a8232b66df08262aa020c description).

## What changed
- Updated style severities from `silent` to `none` where intended:
  - `dotnet_style_prefer_conditional_expression_over_assignment`
  - `dotnet_style_prefer_conditional_expression_over_return`
  - `csharp_style_expression_bodied_lambdas`
  - `csharp_style_expression_bodied_local_functions`
- Adjusted style preferences:
  - `csharp_style_prefer_index_operator = false:suggestion`
  - `csharp_style_prefer_range_operator = false:suggestion`
  - `csharp_style_prefer_tuple_swap = false`
  - `csharp_style_prefer_primary_constructors = false:warning`
- Corrected invalid/outdated options and analyzer mappings:
  - `csharp_space_around_declaration_statements = false` (replaces invalid `do_not_ignore`)
  - Removed `csharp_remove_unnecessary_imports`; added `dotnet_diagnostic.IDE0005.severity = warning`
  - Replaced `dotnet_style_remove_unnecessary_value_assignment` with `csharp_style_unused_value_assignment_preference = discard_variable:warning`
  - Replaced `dotnet_code_style_unused_parameters` with `dotnet_code_quality_unused_parameters = all:warning`
  - Replaced `dotnet_style_prefer_simplified_conditional_expression` with `dotnet_style_prefer_simplified_boolean_expressions = true:warning`
  - Removed `dotnet_style_remove_unnecessary_cast`; added `dotnet_diagnostic.IDE0004.severity = warning`
- Removed duplicate/redundant settings:
  - duplicate `var` preference block
  - legacy `csharp_style_pattern_local_over_anonymous_function`
  - redundant per-section `end_of_line = lf` (kept global `[*]` rule)
- Resolved conflicting unused-parameter configuration by removing the earlier `non_public:suggestion` entry and keeping `all:warning` in the override block.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
