### PR TITLE
Build: Revert recent `.editorconfig` rule changes, Run full format check when `.editorconfig` changes

### DIFF
--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -47,7 +47,13 @@ jobs:
 
       - name: dotnet format
         run: |
+          # Skip format check when nothing changed under src.
           if [ "${{ steps.changed-files.outputs.any_changed }}" != "true" ]; then
+            exit 0
+          fi
+          # .editorconfig changes can affect any file, so check all.
+          if ${{ contains(format(' {0} ', steps.changed-files.outputs.all_changed_files), ' src/.editorconfig ') }}; then
+            dotnet format src --no-restore --verify-no-changes
             exit 0
           fi
           dotnet format src --no-restore --verify-no-changes --include ${{ steps.changed-files.outputs.all_changed_files }}

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -35,18 +35,21 @@ indent_size = 2
 
 # Shell script files
 [*.sh]
+end_of_line = lf
 indent_size = 2
 
 # Sassy CSS - CSS preprocessor
 [*.scss]
 charset = utf-8
 indent_size = 2
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 # JavaScript / TypeScript files
 [*.{js,mjs,ts}]
 indent_size = 4
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -79,7 +82,7 @@ dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
-# Types: use keywords instead of BCL types, and prefer var everywhere
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
@@ -181,6 +184,11 @@ dotnet_diagnostic.IDE0043.severity = warning
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true
 
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:suggestion
 dotnet_sort_system_directives_first = true
@@ -211,9 +219,9 @@ csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none
 csharp_style_expression_bodied_operators = false:none
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = true:silent
 
@@ -227,8 +235,9 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
-csharp_style_prefer_index_operator = false
-csharp_style_prefer_range_operator = false
+csharp_style_prefer_index_operator = true:none
+csharp_style_prefer_range_operator = true:none
+csharp_style_pattern_local_over_anonymous_function = false:none
 
 # Space preferences
 csharp_space_after_cast = false
@@ -238,7 +247,7 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = false
+csharp_space_around_declaration_statements = do_not_ignore
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
@@ -272,6 +281,9 @@ dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
 dotnet_style_prefer_simplified_boolean_expressions = true
 dotnet_style_prefer_simplified_interpolation = true
 
+# Parameter preferences
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
 # New line preferences
 dotnet_style_allow_multiple_blank_lines_experimental = false:suggestion
 dotnet_style_allow_statement_immediately_after_block_experimental = false:suggestion
@@ -287,7 +299,7 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true
 csharp_style_prefer_method_group_conversion = true
 csharp_style_prefer_local_over_anonymous_function = true
 csharp_style_prefer_null_check_over_type_check = true
-csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_tuple_swap = true:silent
 csharp_style_prefer_utf8_string_literals = true
 csharp_style_unused_value_assignment_preference = discard_variable
 csharp_style_unused_value_expression_statement_preference = discard_variable
@@ -309,19 +321,17 @@ csharp_style_allow_embedded_statements_on_same_line_experimental = false:suggest
 
 [*.{cs,razor}]
 file_header_template = Copyright (c) MudBlazor 2021\nMudBlazor licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
-csharp_style_prefer_primary_constructors = false:none                       # IDE0290
-csharp_style_unused_value_assignment_preference = discard_variable:warning  # IDE0059
-dotnet_code_quality_unused_parameters = all:warning                         # IDE0060
-dotnet_style_prefer_compound_assignment = true:suggestion                   # IDE0054
-dotnet_style_prefer_simplified_boolean_expressions = true:warning           # IDE0075
+csharp_style_prefer_primary_constructors = true:none                    # IDE0290
+csharp_remove_unnecessary_imports = true:warning                        # IDE0005
+dotnet_style_remove_unnecessary_value_assignment = true:warning         # IDE0059
+dotnet_code_style_unused_parameters = all:warning                       # IDE0060
+dotnet_style_prefer_compound_assignment = true:suggestion               # IDE0054
+dotnet_style_prefer_simplified_conditional_expression = true:suggestion # IDE0075
+dotnet_style_remove_unnecessary_cast = true:error                       # IDE0090
 
 # Rules that must use diagnostic syntax
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = none
-# IDE0004: Remove unnecessary cast
-dotnet_diagnostic.IDE0004.severity = warning
-# IDE0005: Using directive is unnecessary
-dotnet_diagnostic.IDE0005.severity = warning
 # IDE0073: Require file header
 dotnet_diagnostic.IDE0073.severity = none
 # IDE0055: Fix formatting

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -321,7 +321,7 @@ dotnet_diagnostic.CS1591.severity = none
 # IDE0004: Remove unnecessary cast
 dotnet_diagnostic.IDE0004.severity = warning
 # IDE0005: Using directive is unnecessary
-dotnet_diagnostic.IDE0005.severity = suggestion
+dotnet_diagnostic.IDE0005.severity = warning
 # IDE0073: Require file header
 dotnet_diagnostic.IDE0073.severity = none
 # IDE0055: Fix formatting


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Rolls back two recent `.editorconfig` changes because they broke our build and hardens the `dotnet format` CI check so config changes are validated against the full `src` scope so that won't be undetected next time.

**Changes:**
1. Revert `Build: Fix unused using directives being considered warnings` (ca06f1462d5b57bb44af1f31c7758b93c5c583e7).
2. Revert `Build: Align analyzer rules with our style and current Roslyn options` (#12754).
3. Update `.github/workflows/build-test-mudblazor.yml`:
   - Keep scoped `dotnet format --include <changed files>` for normal PRs.
   - If `src/.editorconfig` is changed, run `dotnet format src --no-restore --verify-no-changes` on all files.
   - Add inline comments to document both `if` conditions.

`.editorconfig` updates can affect formatting/analyzer behavior across the entire codebase, not just touched files. Running full format validation in that case avoids missing repo-wide issues.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
