### PR TITLE
MudChart: Fix infinite expansion loop with MatchBoundsToSize and relative height

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartSelectionTest.razor
@@ -1,20 +1,18 @@
-﻿<MudChart T="double" ChartType="ChartType.Line" ChartOptions="@lineOptions"
-          ChartSeries="@series" ChartLabels="@labels" MatchBoundsToSize="true" />
+﻿<div>
+    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="_index" ChartLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
+    <MudText Typo="Typo.h6">Selected portion of the chart: @_index</MudText>
+</div>
 
 @code {
-    LineChartOptions lineOptions = new LineChartOptions
-    {
-        XAxisLabelRotation = 25,
-        ShowDataMarkers = true,
-        YAxisTicks = 2,
-        YAxisFormat = "C2",
-        ShowLegend = false
-    };
+    public static string __description__ = "Clicking the chart series or legend should update the index.";
+    
+    private int _index = -1; //default value cannot be 0 -> first selectedindex is 0.
 
-    List<ChartSeries<double>> series = new List<ChartSeries<double>>
-    {
-        new ChartSeries<double> { Data = new double[] { 12.2, 14.3, 11.5 } }
-    };
+    public List<ChartSeries<double>> Series =
+    [
+        new() { Name = "Series 1", Data = new([90, 79, 72, 69, 62, 62, 55, 65, 70]) },
+        new() { Name = "Series 2", Data = new([10, 41, 35, 51, 49, 62, 69, 91, 148]) }
+    ];
 
-    string[] labels = { "1/1/26", "2/1/26", "3/1/26" };
+    public string[] XAxisLabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"];
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/LineChartSelectionTest.razor
@@ -1,19 +1,20 @@
-﻿<div>
-    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" @bind-SelectedIndex="_index" ChartLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart>
-    <MudText Typo="Typo.h6">Selected portion of the chart: @_index</MudText>
-</div>
+﻿<MudChart T="double" ChartType="ChartType.Line" ChartOptions="@lineOptions"
+          ChartSeries="@series" ChartLabels="@labels" MatchBoundsToSize="true" />
 
 @code {
-    public static string __description__ = "Clicking the chart series or legend should update the index.";
-    
-    private int _index = -1; //default value cannot be 0 -> first selectedindex is 0.
+    LineChartOptions lineOptions = new LineChartOptions
+    {
+        XAxisLabelRotation = 25,
+        ShowDataMarkers = true,
+        YAxisTicks = 2,
+        YAxisFormat = "C2",
+        ShowLegend = false
+    };
 
-    public List<ChartSeries<double>> Series =
-    [
-        new() { Name = "Series 1", Data = new([90, 79, 72, 69, 62, 62, 55, 65, 70]) },
-        new() { Name = "Series 2", Data = new([10, 41, 35, 51, 49, 62, 69, 91, 148]) }
-    ];
+    List<ChartSeries<double>> series = new List<ChartSeries<double>>
+    {
+        new ChartSeries<double> { Data = new double[] { 12.2, 14.3, 11.5 } }
+    };
 
-    public string[] XAxisLabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep"];
+    string[] labels = { "1/1/26", "2/1/26", "3/1/26" };
 }
-

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -27,7 +27,7 @@ public class ChartSizingTests : BunitTest
 
         // Manually invoke OnElementSizeChanged with a specific width
         const double MeasuredWidth = 800.0;
-        const double MeasuredHeight = 400.0;
+        const double MeasuredHeight = 350.0;
 
         await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize { Width = MeasuredWidth, Height = MeasuredHeight, Timestamp = DateTime.Now.Ticks }));
 
@@ -54,7 +54,7 @@ public class ChartSizingTests : BunitTest
 
         // Manually invoke OnElementSizeChanged with a specific width
         const double MeasuredWidth = 900.0;
-        const double MeasuredHeight = 500.0;
+        const double MeasuredHeight = 350.0;
 
         await comp.InvokeAsync(() => axisChartBase.OnElementSizeChanged(new ElementSize { Width = MeasuredWidth, Height = MeasuredHeight, Timestamp = DateTime.Now.Ticks }));
 
@@ -91,14 +91,93 @@ public class ChartSizingTests : BunitTest
         var dWithTitle = gridWithTitle.GetAttribute("d")!;
         var xWithTitle = double.Parse(dWithTitle.Split(' ')[1]);
 
-        // xWithTitle should be larger than xWithoutTitle if space was allocated
-        // Note: Since labels might be small, they both might fall into the 30px minimum.
-        // But we added 20px, so it should definitely exceed 30px if the original was 30px.
         xWithTitle.Should().BeGreaterThan(xWithoutTitle);
 
         // Also check that the title is at X=0
         var titleGroup = compWithTitle.Find("g[transform^='translate(0,']");
         titleGroup.Should().NotBeNull();
         titleGroup.InnerHtml.Should().Contain("Title");
+    }
+
+    [Test]
+    public async Task MatchBoundsToSize_WithPercentageHeight_ShouldNotLoop()
+    {
+        var series = new List<ChartSeries<double>>
+            {
+                new() { Data = new double[] { 12.2, 14.3, 11.5 } }
+            };
+        var labels = new[] { "1/1/26", "2/1/26", "3/1/26" };
+
+        var initialSize = new ElementSize { Width = 700, Height = 350, Timestamp = 1 };
+
+        Context.JSInterop.Setup<ElementSize>("mudObserveElementSize", _ => true)
+            .SetResult(initialSize);
+
+        Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", _ => true)
+            .SetResult(new ElementSize { Width = 50, Height = 20 });
+
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.ChartSeries, series)
+            .Add(p => p.ChartLabels, labels)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Width, "100%")
+            .Add(p => p.Height, "80%")
+        );
+
+        var chartBase = comp.FindComponent<Line<double>>().Instance;
+
+        var svg = comp.Find("svg");
+        svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
+
+        var largerSize = new ElementSize { Width = 700, Height = 400, Timestamp = 2 };
+
+        await comp.InvokeAsync(() => chartBase.OnElementSizeChanged(largerSize));
+
+        await Task.Delay(300);
+
+        svg = comp.Find("svg");
+        svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
+    }
+
+    [Test]
+    public async Task MatchBoundsToSize_WithPixelHeight_ShouldUpdate()
+    {
+        var series = new List<ChartSeries<double>>
+            {
+                new() { Data = new double[] { 12.2, 14.3, 11.5 } }
+            };
+        var labels = new[] { "1/1/26", "2/1/26", "3/1/26" };
+
+        var initialSize = new ElementSize { Width = 700, Height = 350, Timestamp = 1 };
+
+        Context.JSInterop.Setup<ElementSize>("mudObserveElementSize", _ => true)
+            .SetResult(initialSize);
+
+        Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", _ => true)
+            .SetResult(new ElementSize { Width = 50, Height = 20 });
+
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.ChartSeries, series)
+            .Add(p => p.ChartLabels, labels)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Width, "700px")
+            .Add(p => p.Height, "350px")
+        );
+
+        var chartBase = comp.FindComponent<Line<double>>().Instance;
+
+        var svg = comp.Find("svg");
+        svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
+
+        var largerSize = new ElementSize { Width = 800, Height = 400, Timestamp = 2 };
+
+        await comp.InvokeAsync(() => chartBase.OnElementSizeChanged(largerSize));
+
+        await Task.Delay(300);
+
+        svg = comp.Find("svg");
+        svg.GetAttribute("viewBox").Should().Be("0 0 800 400");
     }
 }

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -227,18 +227,25 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
 
         if (MatchBoundsToSize)
         {
+
+            var isWidthFixed = Width.AsSpan().Trim().EndsWith("px");
+            var isHeightFixed = Height.AsSpan().Trim().EndsWith("px");
+
             if (_elementSize is not null)
             {
-                _boundWidth = _elementSize.Width;
-                _boundHeight = _elementSize.Height;
+                _boundWidth = _elementSize.Width > 0 ? _elementSize.Width : BoundWidthDefault;
+                _boundHeight = isHeightFixed ? _elementSize.Height : BoundHeightDefault;
             }
-            else if (Width.EndsWith("px")
-                && Height.EndsWith("px")
+            else if (isWidthFixed && isHeightFixed
                 && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var width)
                 && double.TryParse(Height.AsSpan(0, Height.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var height))
             {
                 _boundWidth = width;
                 _boundHeight = height;
+            }
+            else if (isWidthFixed && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var fixedWidth))
+            {
+                _boundWidth = fixedWidth;
             }
         }
     }

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -243,10 +243,6 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
                 _boundWidth = width;
                 _boundHeight = height;
             }
-            else if (isWidthFixed && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var fixedWidth))
-            {
-                _boundWidth = fixedWidth;
-            }
         }
     }
 


### PR DESCRIPTION
Prevent infinite expansion loop in `MudChart` when `MatchBoundsToSize` is `true` and `Height` is `relative` (not set). Fallback to default height

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
