### PR TITLE
Refactor: Use Length/Count property instead of Enumerable.Count method

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -676,35 +676,35 @@ namespace MudBlazor.UnitTests.Components
             seriesCheckboxes[2].IsChecked().Should().BeFalse("Sensor Gamma checkbox should be initially unchecked");
 
             // Initial state assertions for heatmap cells (rects)
-            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count()), "should equal count of visible cells");
+            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count), "should equal count of visible cells");
 
             // Hide Sensor Alpha series
             await seriesCheckboxes[0].ChangeAsync(false);
             seriesCheckboxes = comp.FindAll(".mud-checkbox-input"); // Re-find
             seriesCheckboxes[0].IsChecked().Should().BeFalse("Sensor Alpha checkbox should be unchecked after hiding");
             chartSeries[0].Visible.Should().BeFalse("Sensor Alpha Visible property should be false after hiding");
-            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count()), "should equal count of visible cells");
+            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count), "should equal count of visible cells");
 
             // Show Sensor Alpha series again
             await seriesCheckboxes[0].ChangeAsync(true);
             seriesCheckboxes = comp.FindAll(".mud-checkbox-input"); // Re-find
             seriesCheckboxes[0].IsChecked().Should().BeTrue("Sensor Alpha checkbox should be checked after re-showing");
             chartSeries[0].Visible.Should().BeTrue("Sensor Alpha Visible property should be true after re-showing");
-            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count()), "should equal count of visible cells");
+            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count), "should equal count of visible cells");
 
             // Show Sensor Gamma series (initially hidden)
             await seriesCheckboxes[2].ChangeAsync(true);
             seriesCheckboxes = comp.FindAll(".mud-checkbox-input"); // Re-find
             seriesCheckboxes[2].IsChecked().Should().BeTrue("Sensor Gamma checkbox should be checked after showing");
             chartSeries[2].Visible.Should().BeTrue("Sensor Gamma Visible property should be true after showing");
-            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count()), "should equal count of visible cells");
+            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count), "should equal count of visible cells");
 
             // Hide Sensor Gamma series again
             await seriesCheckboxes[2].ChangeAsync(false);
             seriesCheckboxes = comp.FindAll(".mud-checkbox-input"); // Re-find
             seriesCheckboxes[2].IsChecked().Should().BeFalse("Sensor Gamma checkbox should be unchecked after hiding again");
             chartSeries[2].Visible.Should().BeFalse("Sensor Gamma Visible property should be false after hiding again");
-            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count()), "should equal count of visible cells");
+            comp.FindAll(".mud-chart-cell").Count.Should().Be(chartSeries.Where(x => x.Visible).Sum(x => x.Data.Count), "should equal count of visible cells");
         }
 
         public record YAxisTestCase(Func<double, string> YAxisToStringFunc, string ExpectedValue);

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -456,12 +456,12 @@ namespace MudBlazor.UnitTests.Components
             var checkboxes = comp.FindAll(".mud-input-control.mud-input-control-boolean-input");
 
             // verify checkbox one maintains it's original structure, no aria class used, label with a span element
-            checkboxes[0].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            checkboxes[0].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".cb1 label.mud-checkbox span.mud-typography");
             element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
-            checkboxes[1].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            checkboxes[1].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element1 = comp.Find(".cb2 label.mud-checkbox span.mud-typography");
             element1.HasAttribute("aria-hidden").Should().BeTrue();
             var input1 = comp.Find(".cb2 label.mud-checkbox input");
@@ -469,12 +469,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find($".cb2 label.mud-checkbox #{input1ForId}").Should().NotBeNull();
 
             // checkbox three should have original structure intact, no aria class used, label with a span element for child content
-            checkboxes[2].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            checkboxes[2].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".cb3 label.mud-checkbox span.mud-typography");
             element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox four should look identical to two except this time it's with ChildContent
-            checkboxes[3].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            checkboxes[3].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element3 = comp.Find(".cb4 label.mud-checkbox span.mud-typography");
             element3.HasAttribute("aria-hidden").Should().BeTrue();
             var input3 = comp.Find(".cb4 label.mud-checkbox input");
@@ -482,8 +482,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Find($".cb4 label.mud-checkbox #{input3ForId}").Should().NotBeNull();
 
             // checkbox five has no label, no child content, just arialabel
-            checkboxes[4].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            comp.FindAll(".cb5 label.mud-checkbox span.mud-typography").Count().Should().Be(0);
+            checkboxes[4].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
+            comp.FindAll(".cb5 label.mud-checkbox span.mud-typography").Count.Should().Be(0);
             var input4 = comp.Find(".cb5 label.mud-checkbox input");
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".cb5 label.mud-checkbox #{input4ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -712,7 +712,7 @@ namespace MudBlazor.UnitTests.Components
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridEditableWithSelectColumnTest.Item>>();
 
             // test that all rows, header and footer have cell with a checkbox
-            dataGrid.FindAll("input.mud-checkbox-input").Count().Should().Be(dataGrid.Instance.Items.Count() + 2);
+            dataGrid.FindAll("input.mud-checkbox-input").Count.Should().Be(dataGrid.Instance.Items.Count() + 2);
 
             //test that changing header sets all items selected
             dataGrid.Instance.GetState(x => x.SelectedItems).Count.Should().Be(0);
@@ -5158,7 +5158,7 @@ namespace MudBlazor.UnitTests.Components
 
             // two way binding should have updated
             selectedItems.Should().Contain(5);
-            selectedItems.Count().Should().Be(1);
+            selectedItems.Count.Should().Be(1);
             selectedItem.Should().Be(5);
 
             // in multi selection toggle selection using row click method
@@ -5169,7 +5169,7 @@ namespace MudBlazor.UnitTests.Components
             // two way binding should have updated
             selectedItems.Should().Contain(4);
             selectedItems.Should().Contain(5);
-            selectedItems.Count().Should().Be(2);
+            selectedItems.Count.Should().Be(2);
             selectedItem.Should().Be(4);
         }
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -541,7 +541,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.FixMonth, 1));
-            comp.FindAll("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Count().Should().Be(0);
+            comp.FindAll("div.mud-picker-calendar-container > .mud-picker-calendar-header > .mud-picker-calendar-header-switch > .mud-button-month").Count.Should().Be(0);
             await comp.Find("div.mud-picker-datepicker-toolbar > button.mud-button-year").ClickAsync();
             comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container").Count.Should().Be(1);
             await comp.FindAll("div.mud-picker-calendar-container > div.mud-picker-year-container > div.mud-picker-year").First(x => x.TrimmedText().Contains("2022")).ClickAsync();

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -36,13 +36,13 @@ namespace MudBlazor.UnitTests.Components
 
             // verify radio one maintains it's original structure, no aria class used, label with a span element
             var r1 = comp.Find(".r1");
-            r1.GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            r1.GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".r1 label.mud-radio span.mud-typography");
             element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // radio two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             var r2 = comp.Find(".r2");
-            r2.GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            r2.GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element1 = comp.Find(".r2 label.mud-radio span.mud-typography");
             element1.HasAttribute("aria-hidden").Should().BeTrue();
             var input1 = comp.Find(".r2 label.mud-radio input");
@@ -51,13 +51,13 @@ namespace MudBlazor.UnitTests.Components
 
             // radio three should have original structure intact, no aria class used, label with a span element for child content
             var r3 = comp.Find(".r3");
-            r3.GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            r3.GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".r3 label.mud-radio span.mud-typography");
             element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // radio four should look identical to two except this time it's with ChildContent
             var r4 = comp.Find(".r4");
-            r4.GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            r4.GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element3 = comp.Find(".r4 label.mud-radio span.mud-typography");
             element3.HasAttribute("aria-hidden").Should().BeTrue();
             var input3 = comp.Find(".r4 label.mud-radio input");
@@ -66,8 +66,8 @@ namespace MudBlazor.UnitTests.Components
 
             // radio five has no label, no child content, just arialabel
             var r5 = comp.Find(".r5");
-            r5.GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            comp.FindAll(".r5 label.mud-radio span.mud-typography").Count().Should().Be(0);
+            r5.GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
+            comp.FindAll(".r5 label.mud-radio span.mud-typography").Count.Should().Be(0);
             var input4 = comp.Find(".r5 label.mud-radio input");
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".r5 label.mud-radio #{input4ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -184,7 +184,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => select.Instance.ReadText.Should().Be("2, 1, 3"));
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
             await comp.WaitForAssertionAsync(() => select.Instance.ReadText.Should().Be("2, 3"));
-            select.Instance.GetState(x => x.SelectedValues).Count().Should().Be(2);
+            select.Instance.GetState(x => x.SelectedValues).Count.Should().Be(2);
             select.Instance.GetState(x => x.SelectedValues).Should().Contain("2");
             select.Instance.GetState(x => x.SelectedValues).Should().Contain("3");
             const string @unchecked =
@@ -1494,10 +1494,10 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MultiSelectTest5>();
             var selectComponent = comp.FindComponent<MudSelect<string>>();
             var select = selectComponent.Instance;
-            select.GetState(x => x.SelectedValues).Count().Should().Be(2);
+            select.GetState(x => x.SelectedValues).Count.Should().Be(2);
             select.ReadText.Should().Be("Programista, test");
             await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.SelectedValues, new List<string> { "test" }));
-            select.GetState(x => x.SelectedValues).Count().Should().Be(1);
+            select.GetState(x => x.SelectedValues).Count.Should().Be(1);
             select.ReadText.Should().Be("test");
         }
 

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -51,12 +51,12 @@ namespace MudBlazor.UnitTests.Components
             var switches = comp.FindAll(".mud-input-control-boolean-input");
 
             // verify switch one maintains it's original structure, no aria class used, label with a span element
-            switches[0].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            switches[0].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".s1 label.mud-switch span.mud-typography");
             element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // switch two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
-            switches[1].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            switches[1].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element1 = comp.Find(".s2 label.mud-switch span.mud-typography");
             element1.HasAttribute("aria-hidden").Should().BeTrue();
             var input1 = comp.Find(".s2 label.mud-switch input");
@@ -64,12 +64,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Find($".s2 label.mud-switch #{input1ForId}").Should().NotBeNull();
 
             // switch three should have original structure intact, no aria class used, label with a span element for child content
-            switches[2].GetElementsByClassName("mud-sr-only").Count().Should().Be(0);
+            switches[2].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".s3 label.mud-switch span.mud-typography");
             element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // switch four should look identical to two except this time it's with ChildContent
-            switches[3].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
+            switches[3].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element3 = comp.Find(".s4 label.mud-switch span.mud-typography");
             element3.HasAttribute("aria-hidden").Should().BeTrue();
             var input3 = comp.Find(".s4 label.mud-switch input");
@@ -77,8 +77,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Find($".s4 label.mud-switch #{input3ForId}").Should().NotBeNull();
 
             // switch five has no label, no child content, just arialabel
-            switches[4].GetElementsByClassName("mud-sr-only").Count().Should().Be(1);
-            comp.FindAll(".s5 label.mud-switch span.mud-typography").Count().Should().Be(0);
+            switches[4].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
+            comp.FindAll(".s5 label.mud-switch span.mud-typography").Count.Should().Be(0);
             var input4 = comp.Find(".s5 label.mud-switch input");
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".s5 label.mud-switch #{input4ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1548,7 +1548,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<ActivatePanelDragAndDropTest>();
             var divs = comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab");
             // no drop container
-            comp.FindAll("div.mud-drop-container").Count().Should().Be(0);
+            comp.FindAll("div.mud-drop-container").Count.Should().Be(0);
             // all tabs should show
             divs.Count.Should().Be(4);
             divs[0].InnerHtml.Should().Be("One");
@@ -1584,7 +1584,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<ActivatePanelDragAndDropTest>();
             var divs = comp.FindAll("div.mud-tabs-tabbar-wrapper div.mud-tab");
             // no drop container
-            comp.FindAll("div.mud-drop-container").Count().Should().Be(0);
+            comp.FindAll("div.mud-drop-container").Count.Should().Be(0);
             // all tabs should show
             divs.Count.Should().Be(4);
             divs[0].InnerHtml.Should().Be("One");

--- a/src/MudBlazor.UnitTests/Services/ResizeObserverTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ResizeObserverTests.cs
@@ -219,7 +219,7 @@ namespace MudBlazor.UnitTests.Services
 
             Dictionary<ElementReference, BoundingClientRect> expectedRects = new(ElementReferenceComparer.Default);
 
-            for (var i = 0; i < resolvedElements.Count(); i++)
+            for (var i = 0; i < resolvedElements.Count; i++)
             {
                 var item = resolvedElements.ElementAt(i);
                 var correspondingId = ids[i];


### PR DESCRIPTION
Fixes all [`CA1829: Use Length/Count property instead of Enumerable.Count method`](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1829).

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
