### PR TITLE
Charts: Do not check floating point equality with exact values

### DIFF
--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -279,7 +279,9 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
         var data = AggregateSeriesData(ChartOptions!.AggregationOption);
         var total = double.CreateSaturating(data.SumGeneric());
 
-        return total == 0.0 ? (new double[data.Length]) : data.Select(x => double.CreateSaturating(T.Abs(x)) / total).ToArray();
+        return Math.Abs(total) < double.Epsilon
+            ? (new double[data.Length])
+            : data.Select(x => double.CreateSaturating(T.Abs(x)) / total).ToArray();
     }
 
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -38,7 +38,8 @@ namespace MudBlazor.Charts
 
             for (var i = 0; i < normalizedData.Length; i++)
             {
-                if (normalizedData[i] == 0.0) continue;
+                if (Math.Abs(normalizedData[i]) < double.Epsilon)
+                    continue;
 
                 var data = normalizedData[i];
                 var actualValue = T.Max(T.Zero, chartData[i]);

--- a/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Pie.razor.cs
@@ -36,7 +36,7 @@ namespace MudBlazor.Charts
 
             for (var i = 0; i < normalizedData.Length; i++)
             {
-                if (normalizedData[i] == 0.0)
+                if (Math.Abs(normalizedData[i]) < double.Epsilon)
                     continue;
 
                 var data = normalizedData[i];

--- a/src/MudBlazor/Components/Chart/Charts/Rose.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Rose.razor.cs
@@ -26,7 +26,7 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
 
         var chartData = AggregateSeriesData(ChartOptions!.AggregationOption);
         var normalizedData = GetNormalizedData();
-        var nonZeroCount = normalizedData.Count(d => d > 0.0);
+        var nonZeroCount = normalizedData.Count(d => d > double.Epsilon);
         if (nonZeroCount == 0) return;
 
         var angleStep = 2 * Math.PI / nonZeroCount;
@@ -37,7 +37,7 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
 
         for (var i = 0; i < normalizedData.Length; i++)
         {
-            if (normalizedData[i] == 0.0)
+            if (Math.Abs(normalizedData[i]) < double.Epsilon)
                 continue;
 
             var value = T.Max(T.Zero, chartData[i]);
@@ -72,7 +72,7 @@ public partial class Rose<T> : MudRadialChartBase<T, RoseChartOptions> where T :
 
     private double CalculateScaledRadius(double value, double max)
     {
-        return Math.Max(0, Radius * (max == 0.0 ? 0 : value / max) * ChartOptions!.ScaleFactor);
+        return Math.Max(0, Radius * (Math.Abs(max) < double.Epsilon ? 0 : value / max) * ChartOptions!.ScaleFactor);
     }
 
     private static SegmentCoordinates GetSegmentCoordinates(double angle, double step, int count) => new()

--- a/src/MudBlazor/Components/Chart/Interpolation/EndSlopeSpline.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/EndSlopeSpline.cs
@@ -53,7 +53,7 @@ namespace MudBlazor.Interpolation
                 if (i < n - 2)
                     _matrix.a[i + 1, i + 2] = h[i + 1];
 
-                if ((h[i] != 0.0) && (h[i + 1] != 0.0))
+                if (Math.Abs(h[i]) > double.Epsilon && Math.Abs(h[i + 1]) > double.Epsilon)
                     _matrix.y[i + 1] = (((a[i + 2] - a[i + 1]) / h[i + 1]) - ((a[i + 1] - a[i]) / h[i])) * 3.0;
                 else
                     _matrix.y[i + 1] = 0.0;
@@ -74,7 +74,7 @@ namespace MudBlazor.Interpolation
             }
             for (var i = 0; i < n; i++)
             {
-                if (h[i] != 0.0)
+                if (Math.Abs(h[i]) > double.Epsilon)
                 {
                     d[i] = 1.0 / 3.0 / h[i] * (c[i + 1] - c[i]);
                     b[i] = (1.0 / h[i] * (a[i + 1] - a[i])) - (h[i] / 3.0 * (c[i + 1] + (2 * c[i])));

--- a/src/MudBlazor/Components/Chart/Interpolation/MatrixSolver.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/MatrixSolver.cs
@@ -45,11 +45,11 @@ namespace MudBlazor.Interpolation
             {
                 for (i = k; i <= _maxOrder - 2; i++)
                 {
-                    if (Math.Abs(_matrix.a[i + 1, i]) < 1e-8)
+                    if (Math.Abs(_matrix.a[i + 1, i]) < double.Epsilon)
                     {
                         SwitchRows(i + 1);
                     }
-                    if (_matrix.a[i + 1, k] != 0.0)
+                    if (Math.Abs(_matrix.a[i + 1, k]) > double.Epsilon)
                     {
                         for (l = k + 1; l <= _maxOrder - 1; l++)
                         {
@@ -80,7 +80,7 @@ namespace MudBlazor.Interpolation
                 {
                     _matrix.y[k] = _matrix.y[k] - (_matrix.x[l] * _matrix.a[k, l]);
                 }
-                if (_matrix.a[k, k] != 0)
+                if (Math.Abs(_matrix.a[k, k]) > double.Epsilon)
                     _matrix.x[k] = _matrix.y[k] / _matrix.a[k, k];
                 else
                     _matrix.x[k] = 0;

--- a/src/MudBlazor/Components/Chart/Interpolation/NaturalSpline.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/NaturalSpline.cs
@@ -68,7 +68,7 @@ namespace MudBlazor.Interpolation
                         _matrix.a[i, i + 1] = h[i + 1];
                 }
 
-                if ((h[i] != 0.0) && (h[i + 1] != 0.0))
+                if (Math.Abs(h[i]) > double.Epsilon && Math.Abs(h[i + 1]) > double.Epsilon)
                     _matrix.y[i] = (((a[i + 2] - a[i + 1]) / h[i + 1]) - ((a[i + 1] - a[i]) / h[i])) * 3.0;
                 else
                     _matrix.y[i] = 0.0;
@@ -87,7 +87,7 @@ namespace MudBlazor.Interpolation
 
             for (var i = 0; i < n - 1; i++)
             {
-                if (h[i] != 0.0)
+                if (Math.Abs(h[i]) > double.Epsilon)
                 {
                     d[i] = 1.0 / 3.0 / h[i] * (c[i + 1] - c[i]);
                     b[i] = (1.0 / h[i] * (a[i + 1] - a[i])) - (h[i] / 3.0 * (c[i + 1] + (2 * c[i])));

--- a/src/MudBlazor/Components/Chart/Interpolation/PeriodicSpline.cs
+++ b/src/MudBlazor/Components/Chart/Interpolation/PeriodicSpline.cs
@@ -65,7 +65,7 @@ namespace MudBlazor.Interpolation
                     if (i < n - 2)
                         _matrix.a[i, i + 1] = h[i + 1];
                 }
-                if ((h[i] != 0.0) && (h[i + 1] != 0.0))
+                if (Math.Abs(h[i]) > double.Epsilon && Math.Abs(h[i + 1]) > double.Epsilon)
                     _matrix.y[i] = (((a[i + 2] - a[i + 1]) / h[i + 1]) - ((a[i + 1] - a[i]) / h[i])) * 3.0;
                 else
                     _matrix.y[i] = 0.0;
@@ -85,7 +85,7 @@ namespace MudBlazor.Interpolation
 
             for (var i = 0; i < n; i++)
             {
-                if (h[i] != 0.0)
+                if (Math.Abs(h[i]) > double.Epsilon)
                 {
                     d[i] = 1.0 / 3.0 / h[i] * (c[i + 1] - c[i]);
                     b[i] = (1.0 / h[i] * (a[i + 1] - a[i])) - (h[i] / 3.0 * (c[i + 1] + (2 * c[i])));

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -126,7 +126,12 @@ public partial class ChartTooltip : ComponentBase
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (firstRender || FontSize != _previousFontSize || Title != _previousTitle || Subtitle != _previousSubtitle || _previousX != X || _previousY != Y)
+        if (firstRender
+            || FontSize != _previousFontSize
+            || Title != _previousTitle
+            || Subtitle != _previousSubtitle
+            || Math.Abs(_previousX - X) > double.Epsilon
+            || Math.Abs(_previousY - Y) > double.Epsilon)
         {
             await RecalculateBoxWidthAsync();
         }


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Fixes all "Floating point numbers should not be tested for equality [csharpsquid:S1244](https://sonarcloud.io/organizations/mudblazor/rules?open=csharpsquid%3AS1244&rule_key=csharpsquid%3AS1244)" issues reported by Sonar.

This PR addresses SonarQube floating-point reliability issues by replacing exact `== 0.0` / `!= 0.0` comparisons with tolerance-style checks using built-in APIs only (`Math.Abs(...)` and `double.Epsilon`).

Changes
- Updated radial chart normalization and segment filtering logic:
  - `MudRadialChartBase`
  - `Donut`
  - `Pie`
  - `Rose`
- Updated spline/interpolation math guards to avoid exact zero comparisons:
  - `EndSlopeSpline`
  - `NaturalSpline`
  - `PeriodicSpline`
  - `MatrixSolver`
- Updated tooltip rerender condition for floating-point coordinate checks:
  - `ChartTooltip`

Notes
- Kept changes minimal and highly targeted to Sonar floating-point findings.
- Used built-in constants/methods only (no new custom tolerance constants).

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
