### PR TITLE
Refactor: Fix several Sonar violations

### DIFF
--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -200,7 +200,7 @@ namespace MudBlazor
                     Severity.Success => Icons.Custom.Uncategorized.AlertSuccess,
                     Severity.Warning => Icons.Material.Outlined.ReportProblem,
                     Severity.Error => Icons.Material.Filled.ErrorOutline,
-                    _ => throw new ArgumentOutOfRangeException(nameof(Severity)),
+                    _ => throw new InvalidOperationException($"Unsupported {nameof(Severity)} value: {Severity}."),
                 };
             }
         }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
         private bool _isClearing;
         private bool _isProcessingValue;
         private int _selectedListItemIndex;
-        private int _elementKey = 0;
+        private readonly int _elementKey = 0;
         private int _returnedItemsCount;
         private bool _open;
         private bool _opening;

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -521,7 +521,18 @@ namespace MudBlazor
 
         private bool IsLoading => _currentSearchTask is { IsCompleted: false };
 
-        private string CurrentIcon => !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _open ? CloseIcon : OpenIcon;
+        private string CurrentIcon
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(AdornmentIcon))
+                {
+                    return AdornmentIcon;
+                }
+
+                return _open ? CloseIcon : OpenIcon;
+            }
+        }
 
         /// <summary>
         /// Returns a value for the <c>autocomplete</c> attribute, either supplied by default or the one specified in the attribute overrides.

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor
@@ -59,7 +59,7 @@
             builder.AddAttribute(seq++, "stroke", color);
             builder.AddAttribute(seq++, "stroke-width", _barWidth.ToStr());
             builder.AddAttribute(seq++, "d", bar.Data);
-            builder.AddAttribute(seq++, "onmouseover", EventCallback.Factory.Create<MouseEventArgs>(this, e => OnBarMouseOver(e, bar)));
+            builder.AddAttribute(seq++, "onmouseover", EventCallback.Factory.Create(this, () => OnBarMouseOver(bar)));
             builder.AddAttribute(seq++, "onmouseout", EventCallback.Factory.Create(this, OnBarMouseOut));
             builder.CloseElement();
         }

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -255,7 +255,7 @@ namespace MudBlazor.Charts
             _barGroupWidth = Math.Max((MinBarWidth * seriesCount) - 2, groupWidthRelative - _barWidth);
         }
 
-        private void OnBarMouseOver(MouseEventArgs _, SvgPath bar)
+        private void OnBarMouseOver(SvgPath bar)
         {
             _hoveredBar = bar;
 

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -111,7 +111,7 @@
                           width="@_cellDimension.Width.ToStr()"
                           height="@_cellDimension.Height.ToStr()"
                           @onclick="async () => await SetSelectedCellAsync(rowIndex, colIndex)"
-                          @onmouseover="(e) => OnCellMouseOver(e, cell)"
+                          @onmouseover="@(() => OnCellMouseOver(cell))"
                           @onmouseout="OnCellMouseOut"
                           fill="@(cellColor)"/>
 
@@ -119,7 +119,7 @@
                     {
                         <g>
                             <text @onclick="async () => await SetSelectedCellAsync(rowIndex, colIndex)"
-                                  @onmouseover="(e) => OnCellMouseOver(e, cell)"
+                                  @onmouseover="@(() => OnCellMouseOver(cell))"
                                   @onmouseout="OnCellMouseOut"
                                   font-size="@_dynamicFontSize.ToStr()"
                                   x="@((x + _cellDimension.Width / 2).ToStr())"
@@ -227,7 +227,7 @@
                         var tooltipX = legendX + offsetX + x + LegendBox / 2;
 
                         <g transform="translate(@x.ToStr(), 0)" class="mud-chart-heatmap-legend">
-                            <rect @onmouseover="(e) => OnLegendMouseOver(e, _legends[index], new((float)tooltipX , (float)legendY))"
+                            <rect @onmouseover="@(() => OnLegendMouseOver(_legends[index], new((float)tooltipX , (float)legendY)))"
                                   @onmouseout="OnLegendMouseOut"
                                   x="0"
                                   y="@((-LegendBox / 2).ToStr())"
@@ -290,7 +290,7 @@
                         var tooltipY = legendY + offsetY + y;
 
                         <g transform="translate(0, @y.ToStr())" class="mud-chart-heatmap-legend">
-                            <rect @onmouseover="(e) => OnLegendMouseOver(e, _legends[index], new((float)(legendX + LegendBox / 2) , (float)tooltipY))"
+                            <rect @onmouseover="@(() => OnLegendMouseOver(_legends[index], new((float)(legendX + LegendBox / 2) , (float)tooltipY)))"
                                   @onmouseout="OnLegendMouseOut"
                                   x="0"
                                   y="@((-LegendBox / 2).ToStr())"

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -557,17 +557,17 @@ namespace MudBlazor.Charts
             }).CatchAndLog();
         }
 
-        private void OnCellMouseOver(MouseEventArgs _, HeatMapCell<T>? cell)
+        private void OnCellMouseOver(HeatMapCell<T>? cell)
         {
             _hoveredCell = cell;
         }
 
-        private void OnCellMouseOut(MouseEventArgs _)
+        private void OnCellMouseOut()
         {
             _hoveredCell = null;
         }
 
-        private void OnLegendMouseOver(MouseEventArgs _, (T value, string color) legend, PointF position)
+        private void OnLegendMouseOver((T value, string color) legend, PointF position)
         {
             _hoveredLegend = legend;
             _hoveredLegendPosition = position;

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -34,7 +34,7 @@
                   fill="@($"url(#gradient_{NodeRects[edge.Source.Name].Hash}_{NodeRects[edge.Target.Name].Hash})")"
                   opacity="@ToS(ChartOptions?.EdgeOpacity ?? 0.5)"
                   filter="@(ActiveNode == edge.Source.Name || ActiveNode == edge.Target.Name || edge.Name == ActiveEdge ? $"url(#{glowName})" : "")"
-                  @onmouseover="@((e) => OnEdgeMouseOver(e, edge))"
+                  @onmouseover="@(() => OnEdgeMouseOver(edge))"
                   @onmouseout="@OnEdgeMouseOut" />
         }
         @foreach (var kv in NodeRects)
@@ -45,9 +45,9 @@
                   height="@ToS(kv.Value.Height)"
                   fill="@kv.Value.Color"
                   filter="@(ActiveNode == kv.Key ? $"url(#{glowName})" : "")"
-                  @onmouseover="@((e) => OnNodeMouseOver(e, kv.Value))"
+                  @onmouseover="@(() => OnNodeMouseOver(kv.Value))"
                   @onmouseout="@OnNodeMouseOut"
-                  @onclick="@(e => OnNodeClick(e, kv.Value))" />
+                  @onclick="@(() => OnNodeClick(kv.Value))" />
 
             if (ChartOptions?.ShowLabels is true || kv.Key == ActiveNode)
             {

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -287,7 +287,7 @@ namespace MudBlazor.Charts
             var aggregated = new ChartSeries<T>[maxCategoryLength];
             return aggregation switch
             {
-                AggregationOption.GroupByLabel => AggregateByLabel(aggregated),
+                AggregationOption.GroupByLabel => AggregateByLabel(),
                 AggregationOption.GroupByDataSet => AggregateByDataSet(aggregated),
                 _ => throw new ArgumentOutOfRangeException(nameof(aggregation), $"Unsupported aggregation: {aggregation}")
             };
@@ -302,7 +302,7 @@ namespace MudBlazor.Charts
                               .Max(x => x?.Data?.Values.Count ?? 0);
         }
 
-        private List<ChartSeries<T>> AggregateByLabel(ChartSeries<T>[] _)
+        private List<ChartSeries<T>> AggregateByLabel()
         {
             var result = new List<ChartSeries<T>>();
             var visibleSeries = ChartSeries.Where(s => s.Visible).ToList();
@@ -512,7 +512,7 @@ namespace MudBlazor.Charts
             EdgePaths.Clear();
 
             var index = 0;
-            var edgesPerSources = Edges.GroupBy(e => e.Source).ToList();
+            var edgesPerSources = edges.GroupBy(e => e.Source).ToList();
             foreach (var sourceGrp in edgesPerSources)
             {
                 if (!NodeRects.TryGetValue(sourceGrp.Key, out var rectSource)) continue;
@@ -610,29 +610,29 @@ namespace MudBlazor.Charts
             RebuildChart();
         }
 
-        private void OnNodeMouseOver(MouseEventArgs _, NodeRect rect)
+        private void OnNodeMouseOver(NodeRect rect)
         {
             if (ChartOptions!.HighlightOnHover) ActiveNode = rect.Name;
         }
 
-        private void OnNodeMouseOut(MouseEventArgs _)
+        private void OnNodeMouseOut()
         {
             ActiveNode = null;
         }
 
-        private async Task OnNodeClick(MouseEventArgs _, NodeRect rect)
+        private async Task OnNodeClick(NodeRect rect)
         {
             var index = Nodes.ToList().IndexOf(Nodes.First(n => n.Name == rect.Name));
 
             await SetSelectedIndexAsync(index);
         }
 
-        private void OnEdgeMouseOver(MouseEventArgs _, EdgePath edge)
+        private void OnEdgeMouseOver(EdgePath edge)
         {
             if (ChartOptions!.HighlightOnHover) ActiveEdge = edge.Name;
         }
 
-        private void OnEdgeMouseOut(MouseEventArgs _)
+        private void OnEdgeMouseOut()
         {
             ActiveEdge = null;
         }

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
@@ -60,7 +60,7 @@
             builder.AddAttribute(seq++, "stroke-width", _barWidthStroke.ToStr());
             builder.AddAttribute(seq++, "fill", "none");
             builder.AddAttribute(seq++, "d", bar.Data);
-            builder.AddAttribute(seq++, "onmouseover", EventCallback.Factory.Create<MouseEventArgs>(this, e => OnBarMouseOver(e, bar)));
+            builder.AddAttribute(seq++, "onmouseover", EventCallback.Factory.Create(this, () => OnBarMouseOver(bar)));
             builder.AddAttribute(seq++, "onmouseout", EventCallback.Factory.Create(this, OnBarMouseOut));
             builder.CloseElement();
         }

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -312,7 +312,7 @@ namespace MudBlazor.Charts
             return (int)Math.Max(0, spaceBetweenBars);
         }
 
-        private void OnBarMouseOver(MouseEventArgs _, SvgPath bar)
+        private void OnBarMouseOver(SvgPath bar)
         {
             _hoveredBar = bar;
 

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -147,10 +147,18 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
     {
         var now = TimeProvider.GetLocalNow().DateTime;
         _minDateTime = now;
-        _maxDateTime =
-            spacing.Days > 0 ? now.AddDays(1) :
-            spacing.Minutes > 0 ? now.AddHours(1) :
-            now.AddMinutes(1);
+        if (spacing.Days > 0)
+        {
+            _maxDateTime = now.AddDays(1);
+        }
+        else if (spacing.Minutes > 0)
+        {
+            _maxDateTime = now.AddHours(1);
+        }
+        else
+        {
+            _maxDateTime = now.AddMinutes(1);
+        }
     }
 
     private void ApplyLabelRounding(TimeSpan spacing)

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -7,7 +7,7 @@ namespace MudBlazor.Charts;
 
 public partial class ChartTooltip : ComponentBase
 {
-    private record BBox(double X = 0, double Y = 0, double Width = 0, double Height = 0);
+    private sealed record BBox(double X = 0, double Y = 0, double Width = 0, double Height = 0);
 
     private const double TriangleWidth = 16;
     private const double TriangleHeight = 8;

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -17,7 +17,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
     [Inject]
     private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
 
-    private string _chipContainerId = $"chip-container-{Guid.NewGuid()}";
+    private readonly string _chipContainerId = $"chip-container-{Guid.NewGuid()}";
 
     internal readonly ParameterState<bool> SelectedState;
 

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -42,7 +42,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
     private readonly ParameterState<IReadOnlyCollection<T>?> _selectedValues;
 
     private HashSet<T> _selection = new();
-    private HashSet<MudChip<T>> _chips = new();
+    private readonly HashSet<MudChip<T>> _chips = new();
     private bool MultiSelection => SelectionMode == SelectionMode.MultiSelection;
     private bool Mandatory => SelectionMode == SelectionMode.SingleSelection;
 

--- a/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
+++ b/src/MudBlazor/Components/ChipSet/MudChipSet.razor.cs
@@ -351,11 +351,7 @@ public partial class MudChipSet<T> : MudComponentBase, IDisposable
         if (_disposed)
             return; // don't raise any events if we are already disposed
         var value = chip.GetValue();
-        //if (chip.IsSelectedState.Value && value is not null)
-        //{
         await UpdateSelectedValuesAsync(_selection.Where(x => !Comparer.Equals(x, value)).ToList());
-        //}
-        // return Task.CompletedTask;
         StateHasChanged();
     }
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -32,8 +32,6 @@ namespace MudBlazor
         [CascadingParameter]
         public MudDataGrid<T> DataGrid { get; set; } = null!;
 
-        //[CascadingParameter(Name = "HeaderCell")] public HeaderCell<T> HeaderCell { get; set; }
-
         /// <summary>
         /// The value stored in this column.
         /// </summary>
@@ -44,12 +42,6 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         public EventCallback<T> ValueChanged { get; set; }
-
-        //[Parameter] public bool Visible { get; set; } = true;
-
-        //[Parameter] public string Field { get; set; }
-
-        //[Parameter] public Type FieldType { get; set; }
 
         /// <summary>
         /// The display text for this column.
@@ -655,21 +647,6 @@ namespace MudBlazor
 
             // Add the HeaderContext
             headerContext = new HeaderContext<T>(DataGrid);
-
-            // Add the FilterContext
-            //if (filterable)
-            //{
-            //    filterContext = new FilterContext<T>(DataGrid);
-            //    var operators = FilterOperator.GetOperatorByDataType(dataType);
-            //    filterContext.FilterDefinition = new FilterDefinition<T>()
-            //    {
-            //        DataGrid = this.DataGrid,
-            //        Field = PropertyName,
-            //        FieldType = dataType,
-            //        Title = Title,
-            //        Operator = operators.FirstOrDefault()
-            //    };
-            //}
 
             // Add the FilterContext
             filterContext = new FilterContext<T>(DataGrid);

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -60,7 +60,6 @@ namespace MudBlazor
 
         void IForm.Update(IFormComponent formControl)
         {
-            //Validate(formControl);
         }
 
         protected HashSet<IFormComponent> _formControls = new HashSet<IFormComponent>();

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -24,7 +24,7 @@ namespace MudBlazor
         private bool _filtersMenuVisible;
         private ElementReference _headerElement;
         private ElementReference _resizerElement;
-        private string _id = Identifier.Create();
+        private readonly string _id = Identifier.Create();
 
         // Resize state
         private double _resizeStartX;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -252,7 +252,6 @@ namespace MudBlazor
 
         internal T? _editingItem;
 
-        //internal int editingItemHash;
         internal T? _editingSourceItem;
 
         internal T? _previousEditingItem;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         private string _columnsPanelSearch = string.Empty;
         private MudDropContainer<Column<T>>? _dropContainer;
         private MudDropContainer<Column<T>>? _columnsPanelDropContainer;
-        private PropertyInfo[] _properties = typeof(T).GetProperties();
+        private readonly PropertyInfo[] _properties = typeof(T).GetProperties();
         private CancellationTokenSource? _serverDataCancellationTokenSource;
         private IEnumerable<T>? _currentRenderFilteredItemsCache = null;
         internal GroupDefinition<T>? _groupDefinition;

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -400,7 +400,7 @@ namespace MudBlazor
         {
             OpenTo? nextView = CurrentView switch
             {
-                OpenTo.Year => !FixMonth.HasValue ? OpenTo.Month : !FixDay.HasValue ? OpenTo.Date : null,
+                OpenTo.Year => GetNextViewFromYear(),
                 OpenTo.Month => !FixDay.HasValue ? OpenTo.Date : null,
                 _ => null,
             };
@@ -411,11 +411,41 @@ namespace MudBlazor
         {
             OpenTo? previousView = CurrentView switch
             {
-                OpenTo.Date => !FixMonth.HasValue ? OpenTo.Month : !FixYear.HasValue ? OpenTo.Year : null,
+                OpenTo.Date => GetPreviousViewFromDate(),
                 OpenTo.Month => !FixYear.HasValue ? OpenTo.Year : null,
                 _ => null,
             };
             return previousView;
+        }
+
+        private OpenTo? GetNextViewFromYear()
+        {
+            if (!FixMonth.HasValue)
+            {
+                return OpenTo.Month;
+            }
+
+            if (!FixDay.HasValue)
+            {
+                return OpenTo.Date;
+            }
+
+            return null;
+        }
+
+        private OpenTo? GetPreviousViewFromDate()
+        {
+            if (!FixMonth.HasValue)
+            {
+                return OpenTo.Month;
+            }
+
+            if (!FixYear.HasValue)
+            {
+                return OpenTo.Year;
+            }
+
+            return null;
         }
 
         protected virtual async Task SubmitAndCloseAsync()

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -25,7 +25,7 @@ namespace MudBlazor
     {
         private IDialogReference? _reference;
         private readonly ParameterState<bool> _visibleState;
-        private SemaphoreSlim _showLock = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _showLock = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// Creates a new instance.

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor.cs
@@ -22,7 +22,7 @@ namespace MudBlazor
     public partial class MudDropContainer<T> : MudComponentBase where T : notnull
     {
         private MudDragAndDropItemTransaction<T>? _transaction;
-        private Dictionary<string, MudDropZone<T>> _mudDropZones = new();
+        private readonly Dictionary<string, MudDropZone<T>> _mudDropZones = new();
 
         protected string Classname =>
             new CssBuilder("mud-drop-container")

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -25,9 +25,9 @@ namespace MudBlazor
         private bool _canDrop = false;
         private bool _dragInProgress = false;
         private bool _disposedValue = false;
-        private string _id = MudBlazor.Identifier.Create();
+        private readonly string _id = MudBlazor.Identifier.Create();
 
-        private Dictionary<T, int> _indices = new();
+        private readonly Dictionary<T, int> _indices = new();
 
         [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
 

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -186,7 +186,6 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
             }
         }
 
-        //JS.InvokeVoidAsync("draggableTouch");
     }
 
     private async Task TouchEndedAsync(TouchEventArgs e)
@@ -225,7 +224,6 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
                 StateHasChanged();
             }
         }
-        //await JsRuntime.InvokeVoidAsync("mudDragAndDrop.makeDropZonesRelative");
     }
 
     /// <summary>

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -147,7 +147,7 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
         StateHasChanged();
     }
 
-    private async Task DragEndedAsync(DragEventArgs e)
+    private async Task DragEndedAsync()
     {
         if (_dragOperationIsInProgress)
         {

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor;
 public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
 {
     private bool _dragOperationIsInProgress = false;
-    private string _id = Identifier.Create();
+    private readonly string _id = Identifier.Create();
     private double _onTouchStartX;
     private double _onTouchStartY;
     private double _onTouchLastX;

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanels.razor.cs
@@ -10,7 +10,7 @@ namespace MudBlazor
     /// <seealso cref="MudCollapse"/>
     public partial class MudExpansionPanels : MudComponentBase
     {
-        private List<MudExpansionPanel> _panels = new();
+        private readonly List<MudExpansionPanel> _panels = new();
 
         protected string Classname =>
             new CssBuilder("mud-expansion-panels")

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -262,7 +262,7 @@ namespace MudBlazor
             await _draggingState.SetValueAsync(false);
         }
 
-        private Task OnDragAreaClickAsync(MouseEventArgs _)
+        private Task OnDragAreaClickAsync()
         {
             if (GetDisabledState())
             {
@@ -272,7 +272,7 @@ namespace MudBlazor
             return OpenFilePickerAsync();
         }
 
-        private Task OnDragEnterAsync(DragEventArgs _)
+        private Task OnDragEnterAsync()
         {
             if (GetDisabledState())
             {

--- a/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
+++ b/src/MudBlazor/Components/FocusTrap/MudFocusTrap.razor.cs
@@ -92,17 +92,17 @@ namespace MudBlazor
             }
         }
 
-        private Task OnBottomFocusAsync(FocusEventArgs args)
+        private Task OnBottomFocusAsync()
         {
             return FocusLastAsync();
         }
 
-        private Task OnBumperFocusAsync(FocusEventArgs args)
+        private Task OnBumperFocusAsync()
         {
             return _shiftDown ? FocusLastAsync() : FocusFirstAsync();
         }
 
-        private Task OnRootFocusAsync(FocusEventArgs args)
+        private Task OnRootFocusAsync()
         {
             return FocusFallbackAsync();
         }
@@ -117,7 +117,7 @@ namespace MudBlazor
             HandleKeyEvent(args);
         }
 
-        private Task OnTopFocusAsync(FocusEventArgs args)
+        private Task OnTopFocusAsync()
         {
             return FocusFirstAsync();
         }

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -52,11 +52,11 @@ namespace MudBlazor
                 .WithChangeHandler(Update);
         }
 
-        private ParameterState<T?> _selectedValueState;
-        private ParameterState<IReadOnlyCollection<T>?> _selectedValuesState;
+        private readonly ParameterState<T?> _selectedValueState;
+        private readonly ParameterState<IReadOnlyCollection<T>?> _selectedValuesState;
 
-        private HashSet<MudListItem<T>> _items = new();
-        private HashSet<MudList<T>> _childLists = new();
+        private readonly HashSet<MudListItem<T>> _items = new();
+        private readonly HashSet<MudList<T>> _childLists = new();
         private HashSet<T> _selection = new();
         internal MudList<T> TopLevelList { get; private set; }
 

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -17,7 +17,7 @@ namespace MudBlazor
         private bool _selected;
         private bool MultiSelection => MudList?.SelectionMode == SelectionMode.MultiSelection;
 
-        private ParameterState<bool> _expandedState;
+        private readonly ParameterState<bool> _expandedState;
 
         public MudListItem()
         {

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -186,7 +186,7 @@ namespace MudBlazor
             }
 
             if (_isFocused && Mask.Selection == null)
-                await SetCaretPositionAsync(Mask.CaretPos, _selection, render: false);
+                await SetCaretPositionAsync(Mask.CaretPos, _selection);
             await base.OnAfterRenderAsync(firstRender);
         }
 
@@ -404,7 +404,7 @@ namespace MudBlazor
             _isFocused = false;
         }
 
-        private async Task SetCaretPositionAsync(int caret, (int, int)? selection = null, bool render = true)
+        private async Task SetCaretPositionAsync(int caret, (int, int)? selection = null)
         {
             if (!_isFocused)
                 return;
@@ -462,7 +462,7 @@ namespace MudBlazor
             _mask = other;
         }
 
-        private async Task OnCutAsync(ClipboardEventArgs obj)
+        private async Task OnCutAsync()
         {
             if (GetReadOnlyState())
                 return;

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -21,9 +21,9 @@ namespace MudBlazor
         private T? _step;
         private T? _max;
         private T? _min;
-        private T? _minDefault;
-        private T? _maxDefault;
-        private T? _stepDefault;
+        private readonly T? _minDefault;
+        private readonly T? _maxDefault;
+        private readonly T? _stepDefault;
         private bool _maxHasValue = false;
         private bool _minHasValue = false;
         private bool _stepHasValue = false;

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -14,7 +14,7 @@ namespace MudBlazor
     /// </summary>
     public partial class MudPageContentNavigation : IAsyncDisposable, IMudStateHasChanged
     {
-        private List<MudPageContentSection> _sections = new();
+        private readonly List<MudPageContentSection> _sections = new();
         private IScrollSpy? _scrollSpy;
 
         [Inject]
@@ -123,7 +123,7 @@ namespace MudBlazor
         /// <param name="forceUpdate">If true, StateHasChanged is called, forcing a re-render of the component</param>
         public void AddSection(string sectionName, string sectionId, bool forceUpdate) => AddSection(new MudPageContentSection(sectionName, sectionId), forceUpdate);
 
-        private Dictionary<MudPageContentSection, MudPageContentSection> _parentMapper = new();
+        private readonly Dictionary<MudPageContentSection, MudPageContentSection> _parentMapper = new();
 
         /// <summary>
         /// Add a section to the content navigation

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -13,10 +13,10 @@ namespace MudBlazor
     /// </summary>
     public partial class MudPagination : MudComponentBase
     {
-        private ParameterState<int> _countState;
-        private ParameterState<int> _selectedState;
-        private ParameterState<int> _middleCountState;
-        private ParameterState<int> _boundaryCountState;
+        private readonly ParameterState<int> _countState;
+        private readonly ParameterState<int> _selectedState;
+        private readonly ParameterState<int> _middleCountState;
+        private readonly ParameterState<int> _boundaryCountState;
 
         private string Classname =>
             new CssBuilder("mud-pagination")

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -20,7 +20,7 @@ namespace MudBlazor
     public partial class MudRadio<T> : MudBooleanInput<T>
     {
         private IMudRadioGroup? _parent;
-        private string _elementId = Identifier.Create("radio");
+        private readonly string _elementId = Identifier.Create("radio");
         private readonly string _ariaId = Identifier.Create("radio-aria-");
 
         protected override string Classname => new CssBuilder("mud-input-control-boolean-input")

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -856,7 +856,7 @@ namespace MudBlazor
                 SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false).CatchAndLog();
         }
 
-        private async Task OnFocusOutAsync(FocusEventArgs focusEventArgs)
+        private async Task OnFocusOutAsync()
         {
             if (_openState.Value)
             {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -494,11 +494,18 @@ namespace MudBlazor
         /// If no items are selected, <see cref="UncheckedIcon"/> is returned.
         /// Otherwise, <see cref="IndeterminateIcon"/> is returned.
         /// </remarks>
-        protected string SelectAllCheckBoxIcon => _selectAllChecked.HasValue
-            ? _selectAllChecked.Value
-                ? CheckedIcon
-                : UncheckedIcon
-            : IndeterminateIcon;
+        protected string SelectAllCheckBoxIcon
+        {
+            get
+            {
+                if (!_selectAllChecked.HasValue)
+                {
+                    return IndeterminateIcon;
+                }
+
+                return _selectAllChecked.Value ? CheckedIcon : UncheckedIcon;
+            }
+        }
 
         /// <summary>
         /// Selects the item at the specified index.
@@ -781,7 +788,13 @@ namespace MudBlazor
 
         private void UpdateIcon()
         {
-            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _openState.Value ? CloseIcon : OpenIcon;
+            if (!string.IsNullOrWhiteSpace(AdornmentIcon))
+            {
+                _currentIcon = AdornmentIcon;
+                return;
+            }
+
+            _currentIcon = _openState.Value ? CloseIcon : OpenIcon;
         }
 
         private Task HighlightItemForValueAsync(T? value)

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -303,12 +303,12 @@ public partial class MudStepper : MudComponentBase
     /// <remarks>
     /// Typically used to enable or disable a custom <c>Next</c> button.
     /// </remarks>
-    public bool CanGoToNextStep => _steps.Any() && _steps.SkipWhile(x => _steps.IndexOf(x) <= _activeIndex).Count(x => !x.DisabledState.Value) > 0;
+    public bool CanGoToNextStep => _steps.Any() && _steps.SkipWhile(x => _steps.IndexOf(x) <= _activeIndex).Any(x => !x.DisabledState.Value);
 
     /// <summary>
     /// Whether the <c>Previous</c> button is enabled.
     /// </summary>
-    public bool PreviousStepEnabled => _steps.Any() && _steps.TakeWhile(x => _steps.IndexOf(x) < _activeIndex).Count(x => !x.DisabledState.Value) > 0;
+    public bool PreviousStepEnabled => _steps.Any() && _steps.TakeWhile(x => _steps.IndexOf(x) < _activeIndex).Any(x => !x.DisabledState.Value);
 
     /// <summary>
     /// Whether all steps have been completed.

--- a/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
+++ b/src/MudBlazor/Components/SwipeArea/MudSwipeArea.razor.cs
@@ -170,9 +170,15 @@ namespace MudBlazor
                 return;
             }
 
-            var swipeDirection = Math.Abs(xDiff) > Math.Abs(yDiff) ?
-                xDiff > 0 ? SwipeDirection.RightToLeft : SwipeDirection.LeftToRight :
-                yDiff > 0 ? SwipeDirection.BottomToTop : SwipeDirection.TopToBottom;
+            SwipeDirection swipeDirection;
+            if (Math.Abs(xDiff) > Math.Abs(yDiff))
+            {
+                swipeDirection = xDiff > 0 ? SwipeDirection.RightToLeft : SwipeDirection.LeftToRight;
+            }
+            else
+            {
+                swipeDirection = yDiff > 0 ? SwipeDirection.BottomToTop : SwipeDirection.TopToBottom;
+            }
 
             if (Math.Abs(xDiff) > Math.Abs(yDiff))
             {

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -600,7 +600,11 @@ namespace MudBlazor
                     var filteredItemCount = GetFilteredItemsCount();
                     var lastPageNo = filteredItemCount == 0
                         ? 0
-                        : (filteredItemCount / RowsPerPage) - (filteredItemCount % RowsPerPage == 0 ? 1 : 0);
+                        : (filteredItemCount / RowsPerPage);
+                    if (filteredItemCount > 0 && filteredItemCount % RowsPerPage == 0)
+                    {
+                        lastPageNo -= 1;
+                    }
                     CurrentPage = lastPageNo < CurrentPage ? lastPageNo : CurrentPage;
                 }
 

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -51,7 +51,6 @@ namespace MudBlazor
 
         void IForm.Update(IFormComponent formControl)
         {
-            //Validate(formControl);
         }
 
         protected HashSet<IFormComponent> _formControls = new();

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -919,9 +919,17 @@ namespace MudBlazor
 
         private Color GetPanelIconColor(MudTabPanel panel)
         {
-            var iconColor = panel.Disabled ? Color.Inherit : panel.IconColor != default ? panel.IconColor : IconColor;
+            if (panel.Disabled)
+            {
+                return Color.Inherit;
+            }
 
-            return iconColor;
+            if (panel.IconColor != default)
+            {
+                return panel.IconColor;
+            }
+
+            return IconColor;
         }
 
         #endregion

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -15,7 +15,6 @@ namespace MudBlazor;
 /// <seealso cref="MudTheme"/>
 partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
 {
-    // private const string Breakpoint = "mud-breakpoint";
     private bool _disposed;
     private bool _observing;
     private const string Palette = "mud-palette";
@@ -388,14 +387,6 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
         themeStringBuilder.AppendLine(
             $"--{LayoutProperties}-drawer-width-mini-right: {theme.LayoutProperties.DrawerMiniWidthRight};");
         themeStringBuilder.AppendLine($"--{LayoutProperties}-appbar-height: {theme.LayoutProperties.AppbarHeight};");
-
-        //Breakpoint
-        //theme.AppendLine($"--{Breakpoint}-xs: {Theme.Breakpoints.xs};");
-        //theme.AppendLine($"--{Breakpoint}-sm: {Theme.Breakpoints.sm};");
-        //theme.AppendLine($"--{Breakpoint}-md: {Theme.Breakpoints.md};");
-        //theme.AppendLine($"--{Breakpoint}-lg: {Theme.Breakpoints.lg};");
-        //theme.AppendLine($"--{Breakpoint}-xl: {Theme.Breakpoints.xl};");
-        //theme.AppendLine($"--{Breakpoint}-xxl: {Theme.Breakpoints.xxl};");
 
         //Typography
         themeStringBuilder.AppendLine(

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -843,7 +843,7 @@ namespace MudBlazor
             }
         }
 
-        private record SetTime
+        private sealed record SetTime
         {
             public int Hour { get; set; }
 

--- a/src/MudBlazor/Extensions/ExpressionExtensions.cs
+++ b/src/MudBlazor/Extensions/ExpressionExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -12,18 +13,20 @@ namespace MudBlazor
     {
         public static string GetFullPathOfMember<T>(this Expression<Func<T>> property)
         {
-            var resultingString = string.Empty;
+            var pathSegments = new List<string>();
             var p = property.Body as MemberExpression;
 
             while (p is not null)
             {
                 if (p.Expression is MemberExpression)
                 {
-                    resultingString = p.Member.Name + (resultingString != string.Empty ? "." : string.Empty) + resultingString;
+                    pathSegments.Add(p.Member.Name);
                 }
                 p = p.Expression as MemberExpression;
             }
-            return resultingString;
+
+            pathSegments.Reverse();
+            return string.Join(".", pathSegments);
         }
 
         /// <summary>

--- a/src/MudBlazor/Extensions/ExpressionExtensions.cs
+++ b/src/MudBlazor/Extensions/ExpressionExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -13,20 +12,18 @@ namespace MudBlazor
     {
         public static string GetFullPathOfMember<T>(this Expression<Func<T>> property)
         {
-            var pathSegments = new List<string>();
+            var resultingString = string.Empty;
             var p = property.Body as MemberExpression;
 
             while (p is not null)
             {
                 if (p.Expression is MemberExpression)
                 {
-                    pathSegments.Add(p.Member.Name);
+                    resultingString = p.Member.Name + (resultingString != string.Empty ? "." : string.Empty) + resultingString;
                 }
                 p = p.Expression as MemberExpression;
             }
-
-            pathSegments.Reverse();
-            return string.Join(".", pathSegments);
+            return resultingString;
         }
 
         /// <summary>

--- a/src/MudBlazor/Services/Dialog/DialogService.cs
+++ b/src/MudBlazor/Services/Dialog/DialogService.cs
@@ -29,7 +29,7 @@ namespace MudBlazor
         /// This keeps dialog content stable while the parent fragment re-renders.
         /// See: https://github.com/MudBlazor/MudBlazor/issues/10659#issuecomment-2602911059
         /// </remarks>
-        private class DialogHelperComponent : IComponent
+        private sealed class DialogHelperComponent : IComponent
         {
             private const string ChildContent = nameof(ChildContent);
             private RenderFragment? _renderFragment;

--- a/src/MudBlazor/Services/KeyInterceptor/KeyObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyObserver.cs
@@ -103,7 +103,7 @@ public class KeyObserver : IKeyInterceptorObserver, IEquatable<KeyObserver>
     /// <inheritdoc />
     public override int GetHashCode() => _elementId.GetHashCode();
 
-    private class KeyDownLambdaObserver : IKeyDownObserver
+    private sealed class KeyDownLambdaObserver : IKeyDownObserver
     {
         private readonly Action<KeyboardEventArgs>? _lambda;
 
@@ -118,7 +118,7 @@ public class KeyObserver : IKeyInterceptorObserver, IEquatable<KeyObserver>
         }
     }
 
-    private class KeyDownLambdaTaskObserver : IKeyDownObserver
+    private sealed class KeyDownLambdaTaskObserver : IKeyDownObserver
     {
         private readonly Func<KeyboardEventArgs, Task>? _lambda;
 
@@ -128,7 +128,7 @@ public class KeyObserver : IKeyInterceptorObserver, IEquatable<KeyObserver>
         public Task NotifyOnKeyDownAsync(KeyboardEventArgs args) => _lambda is null ? Task.CompletedTask : _lambda(args);
     }
 
-    private class KeyUpLambdaObserver : IKeyUpObserver
+    private sealed class KeyUpLambdaObserver : IKeyUpObserver
     {
         private readonly Action<KeyboardEventArgs>? _lambda;
 
@@ -143,7 +143,7 @@ public class KeyObserver : IKeyInterceptorObserver, IEquatable<KeyObserver>
         }
     }
 
-    private class KeyUpLambdaTaskObserver : IKeyUpObserver
+    private sealed class KeyUpLambdaTaskObserver : IKeyUpObserver
     {
         private readonly Func<KeyboardEventArgs, Task>? _lambda;
 
@@ -153,5 +153,5 @@ public class KeyObserver : IKeyInterceptorObserver, IEquatable<KeyObserver>
         public Task NotifyOnKeyUpAsync(KeyboardEventArgs args) => _lambda is null ? Task.CompletedTask : _lambda(args);
     }
 
-    private class KeyObserverIgnore : IKeyDownObserver, IKeyUpObserver;
+    private sealed class KeyObserverIgnore : IKeyDownObserver, IKeyUpObserver;
 }

--- a/src/MudBlazor/State/Builder/ParameterAttachBuilderOfT.cs
+++ b/src/MudBlazor/State/Builder/ParameterAttachBuilderOfT.cs
@@ -185,9 +185,12 @@ internal class ParameterAttachBuilder<T>
     /// <exception cref="ArgumentNullException">Thrown when required parameters are not provided.</exception>
     public ParameterStateInternal<T> Attach()
     {
+        ArgumentNullException.ThrowIfNull(_metadata);
+        ArgumentNullException.ThrowIfNull(_getParameterValueFunc);
+
         return ParameterStateInternal<T>.Attach(
-            _metadata ?? throw new ArgumentNullException(nameof(_metadata)),
-            _getParameterValueFunc ?? throw new ArgumentNullException(nameof(_getParameterValueFunc)),
+            _metadata,
+            _getParameterValueFunc,
             _eventCallbackFunc,
             _parameterChangedHandler,
             _comparer

--- a/src/MudBlazor/State/Builder/RegisterParameterBuilderOfT.cs
+++ b/src/MudBlazor/State/Builder/RegisterParameterBuilderOfT.cs
@@ -200,10 +200,11 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
     private ParameterStateInternal<T> CreateParameterState()
     {
         ArgumentNullException.ThrowIfNull(_parameterName);
+        ArgumentNullException.ThrowIfNull(_getParameterValueFunc);
 
         var parameterState = ParameterStateInternal<T>.Attach(
             new ParameterMetadata(_parameterName, _handlerName, _comparerParameterName),
-            _getParameterValueFunc ?? throw new ArgumentNullException(nameof(_getParameterValueFunc)),
+            _getParameterValueFunc,
             _eventCallbackFunc,
             _parameterChangedHandler,
             _comparer);

--- a/src/MudBlazor/State/ParameterScopeContainer.cs
+++ b/src/MudBlazor/State/ParameterScopeContainer.cs
@@ -198,7 +198,7 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// <summary>
     /// Represents an enumerable reader for parameter states.
     /// </summary>
-    private class ParameterScopeContainerReadonlyEnumerable : IParameterStatesReader
+    private sealed class ParameterScopeContainerReadonlyEnumerable : IParameterStatesReader
     {
         private readonly IEnumerable<IParameterComponentLifeCycle> _parameters;
 

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -79,8 +79,8 @@ window.mudDragAndDrop = {
         const elem = document.getElementById(id);
 
         // Persist offsets on the element so each pointer move can stay incremental.
-        const tx = (parseFloat(elem.getAttribute('data-x')) || 0) + dx;
-        const ty = (parseFloat(elem.getAttribute('data-y')) || 0) + dy;
+        const tx = (Number.parseFloat(elem.getAttribute('data-x')) || 0) + dx;
+        const ty = (Number.parseFloat(elem.getAttribute('data-y')) || 0) + dy;
 
         // translate3d keeps drag movement smooth and avoids forcing layout recalculation.
         elem.style.webkitTransform =

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -66,7 +66,8 @@ function serializeParameter(data, spec) {
         if (typeof currentMember === 'object') {
             if (Array.isArray(currentMember) || currentMember.length) {
                 res[i] = [];
-                for (const arrayItem of Array.from(currentMember)) {
+                for (let j = 0; j < currentMember.length; j++) {
+                    const arrayItem = currentMember[j];
                     if (typeof arrayItem === 'object') {
                         res[i].push(serializeParameter(arrayItem, currentMemberSpec));
                     } else {

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -54,13 +54,13 @@ function serializeParameter(data, spec) {
         }
 
         let currentMemberSpec;
-        if (spec != "*") {
+        if (spec === "*") {
+            currentMemberSpec = "*";
+        } else {
             currentMemberSpec = Array.isArray(data) ? spec : spec[i];
             if (!currentMemberSpec) {
                 continue;
             }
-        } else {
-            currentMemberSpec = "*";
         }
 
         if (typeof currentMember === 'object') {

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -73,13 +73,11 @@ function serializeParameter(data, spec) {
                         res[i].push(arrayItem);
                     }
                 }
-            } else {
+            } else if (currentMember.length === 0) {
                 //the browser provides some member (like plugins) as hash with index as key, if length == 0 we shall not convert it
-                if (currentMember.length === 0) {
-                    res[i] = [];
-                } else {
-                    res[i] = serializeParameter(currentMember, currentMemberSpec);
-                }
+                res[i] = [];
+            } else {
+                res[i] = serializeParameter(currentMember, currentMemberSpec);
             }
         } else {
             // string, number or boolean

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -66,8 +66,7 @@ function serializeParameter(data, spec) {
         if (typeof currentMember === 'object') {
             if (Array.isArray(currentMember) || currentMember.length) {
                 res[i] = [];
-                for (let j = 0; j < currentMember.length; j++) {
-                    const arrayItem = currentMember[j];
+                for (const arrayItem of Array.from(currentMember)) {
                     if (typeof arrayItem === 'object') {
                         res[i].push(serializeParameter(arrayItem, currentMemberSpec));
                     } else {

--- a/src/MudBlazor/TScripts/mudInput.js
+++ b/src/MudBlazor/TScripts/mudInput.js
@@ -66,7 +66,7 @@ class MudInput {
 
     _clampPosition(position, max) {
         const pos = Number(position);
-        return isNaN(pos)
+        return Number.isNaN(pos)
             ? max
             : Math.max(0, Math.min(pos, max));
     }

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -32,7 +32,7 @@ window.mudInputSizing = {
             // Save scroll positions https://github.com/MudBlazor/MudBlazor/issues/8152.
             const scrollTops = [];
             let curElem = elem;
-            while (curElem && curElem.parentNode && curElem.parentNode instanceof Element) {
+            while (curElem?.parentNode instanceof Element) {
                 if (curElem.parentNode.scrollTop) {
                     scrollTops.push([curElem.parentNode, curElem.parentNode.scrollTop]);
                 }

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -12,8 +12,8 @@ window.mudInputSizing = {
      */
     init: (elem, maxLines) => {
         const compStyle = getComputedStyle(elem);
-        const lineHeight = parseFloat(compStyle.getPropertyValue('line-height'));
-        const paddingTop = parseFloat(compStyle.getPropertyValue('padding-top'));
+        const lineHeight = Number.parseFloat(compStyle.getPropertyValue('line-height'));
+        const paddingTop = Number.parseFloat(compStyle.getPropertyValue('padding-top'));
 
         let maxHeight = 0;
 

--- a/src/MudBlazor/TScripts/mudJsEvent.js
+++ b/src/MudBlazor/TScripts/mudJsEvent.js
@@ -27,7 +27,7 @@ class MudJsEventFactory {
      */
     disconnect(elementId) {
         const element = document.getElementById(elementId);
-        if (!element || !element.mudJsEvent)
+        if (!element?.mudJsEvent)
             return;
         element.mudJsEvent.disconnect();
     }
@@ -52,7 +52,7 @@ class MudJsEventFactory {
      */
     unsubscribe(elementId, eventName) {
         const element = document.getElementById(elementId);
-        if (!element || !element.mudJsEvent)
+        if (!element?.mudJsEvent)
             return;
         element.mudJsEvent.unsubscribe(element, eventName);
     }
@@ -190,13 +190,13 @@ class MudJsEvent {
         for (const mutation of mutationsList) {
             //self.logger('[MudBlazor | JsEvent] Subtree mutation: ', { mutation });
             for (const element of mutation.addedNodes) {
-                if (element.classList && element.classList.contains(targetClass)) {
+                if (element.classList?.contains(targetClass)) {
                     if (!self._options.TagName || element.tagName == self._options.TagName)
                         self.attachHandlers(element);
                 }
             }
             for (const element of mutation.removedNodes) {
-                if (element.classList && element.classList.contains(targetClass)) {
+                if (element.classList?.contains(targetClass)) {
                     if (!self._options.tagName || element.tagName == self._options.tagName)
                          self.detachHandlers(element);
                 }

--- a/src/MudBlazor/TScripts/mudJsEvent.js
+++ b/src/MudBlazor/TScripts/mudJsEvent.js
@@ -155,7 +155,7 @@ class MudJsEvent {
             this.logger('[MudBlazor | JsEvent] attaching event ' + eventName, child);
             child.addEventListener(eventName, this.eventHandler);
         }
-        if(this._observedChildren.indexOf(child) < 0)
+        if (!this._observedChildren.includes(child))
             this._observedChildren.push(child);
     }
 

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -153,7 +153,7 @@ class MudKeyInterceptor {
      */
     attachHandlers(child) {
         this.logger('[MudBlazor | KeyInterceptor] attaching handlers ', { child });
-        if (this._observedChildren.indexOf(child) > -1) {
+        if (this._observedChildren.includes(child)) {
             //console.log("... already attached");
             return;
         }

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -27,7 +27,7 @@ class MudKeyInterceptorFactory {
      */
     updatekey(elementId, option) {
         const element = document.getElementById(elementId);
-        if (!element || !element.mudKeyInterceptor)
+        if (!element?.mudKeyInterceptor)
             return;
         element.mudKeyInterceptor.updatekey(option);
     }
@@ -37,7 +37,7 @@ class MudKeyInterceptorFactory {
      */
     disconnect(elementId) {
         const element = document.getElementById(elementId);
-        if (!element || !element.mudKeyInterceptor)
+        if (!element?.mudKeyInterceptor)
             return;
         element.mudKeyInterceptor.disconnect();
     }
@@ -83,7 +83,7 @@ class MudKeyInterceptor {
         this._keyOptions = {};
         this._regexOptions = [];
         for (const keyOption of this._options.keys) {
-            if (!keyOption || !keyOption.key) {
+            if (!keyOption?.key) {
                 this.logger('[MudBlazor | KeyInterceptor] got invalid key options: ', keyOption);
                 continue;
             }
@@ -183,11 +183,11 @@ class MudKeyInterceptor {
         for (const mutation of mutationsList) {
             //self.logger('[MudBlazor | KeyInterceptor] Subtree mutation: ', { mutation });
             for (const element of mutation.addedNodes) {
-                if (element.classList && element.classList.contains(targetClass))
+                if (element.classList?.contains(targetClass))
                     self.attachHandlers(element);
             }
             for (const element of mutation.removedNodes) {
-                if (element.classList && element.classList.contains(targetClass))
+                if (element.classList?.contains(targetClass))
                     self.detachHandlers(element);
             }
         }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -108,74 +108,74 @@ window.mudpopoverHelper = {
         let top = boundingRect.top;     // default for mud-popover-anchor-top-left
         let left = boundingRect.left;   // default for mud-popover-anchor-top-left
 
-        const isPositionOverride = list.indexOf('mud-popover-position-override') >= 0;
+        const isPositionOverride = list.includes('mud-popover-position-override');
 
         let offsetX = 0;
         let offsetY = 0;
         // transform origin
 
-        if (list.indexOf('mud-popover-top-left') >= 0) {
+        if (list.includes('mud-popover-top-left')) {
             offsetX = 0;
             offsetY = 0;
-        } else if (list.indexOf('mud-popover-top-center') >= 0) {
+        } else if (list.includes('mud-popover-top-center')) {
             offsetX = -selfRect.width / 2;
             offsetY = 0;
-        } else if (list.indexOf('mud-popover-top-right') >= 0) {
+        } else if (list.includes('mud-popover-top-right')) {
             offsetX = -selfRect.width;
             offsetY = 0;
         }
 
-        else if (list.indexOf('mud-popover-center-left') >= 0) {
+        else if (list.includes('mud-popover-center-left')) {
             offsetX = 0;
             offsetY = -selfRect.height / 2;
-        } else if (list.indexOf('mud-popover-center-center') >= 0) {
+        } else if (list.includes('mud-popover-center-center')) {
             offsetX = -selfRect.width / 2;
             offsetY = -selfRect.height / 2;
-        } else if (list.indexOf('mud-popover-center-right') >= 0) {
+        } else if (list.includes('mud-popover-center-right')) {
             offsetX = -selfRect.width;
             offsetY = -selfRect.height / 2;
         }
 
-        else if (list.indexOf('mud-popover-bottom-left') >= 0) {
+        else if (list.includes('mud-popover-bottom-left')) {
             offsetX = 0;
             offsetY = -selfRect.height;
-        } else if (list.indexOf('mud-popover-bottom-center') >= 0) {
+        } else if (list.includes('mud-popover-bottom-center')) {
             offsetX = -selfRect.width / 2;
             offsetY = -selfRect.height;
-        } else if (list.indexOf('mud-popover-bottom-right') >= 0) {
+        } else if (list.includes('mud-popover-bottom-right')) {
             offsetX = -selfRect.width;
             offsetY = -selfRect.height;
         }
 
         if (!isPositionOverride) {
             // anchor origin, don't flip anchors on position override
-            if (list.indexOf('mud-popover-anchor-top-left') >= 0) {
+            if (list.includes('mud-popover-anchor-top-left')) {
                 left = boundingRect.left;
                 top = boundingRect.top;
-            } else if (list.indexOf('mud-popover-anchor-top-center') >= 0) {
+            } else if (list.includes('mud-popover-anchor-top-center')) {
                 left = boundingRect.left + boundingRect.width / 2;
                 top = boundingRect.top;
-            } else if (list.indexOf('mud-popover-anchor-top-right') >= 0) {
+            } else if (list.includes('mud-popover-anchor-top-right')) {
                 left = boundingRect.left + boundingRect.width;
                 top = boundingRect.top;
 
-            } else if (list.indexOf('mud-popover-anchor-center-left') >= 0) {
+            } else if (list.includes('mud-popover-anchor-center-left')) {
                 left = boundingRect.left;
                 top = boundingRect.top + boundingRect.height / 2;
-            } else if (list.indexOf('mud-popover-anchor-center-center') >= 0) {
+            } else if (list.includes('mud-popover-anchor-center-center')) {
                 left = boundingRect.left + boundingRect.width / 2;
                 top = boundingRect.top + boundingRect.height / 2;
-            } else if (list.indexOf('mud-popover-anchor-center-right') >= 0) {
+            } else if (list.includes('mud-popover-anchor-center-right')) {
                 left = boundingRect.left + boundingRect.width;
                 top = boundingRect.top + boundingRect.height / 2;
 
-            } else if (list.indexOf('mud-popover-anchor-bottom-left') >= 0) {
+            } else if (list.includes('mud-popover-anchor-bottom-left')) {
                 left = boundingRect.left;
                 top = boundingRect.top + boundingRect.height;
-            } else if (list.indexOf('mud-popover-anchor-bottom-center') >= 0) {
+            } else if (list.includes('mud-popover-anchor-bottom-center')) {
                 left = boundingRect.left + boundingRect.width / 2;
                 top = boundingRect.top + boundingRect.height;
-            } else if (list.indexOf('mud-popover-anchor-bottom-right') >= 0) {
+            } else if (list.includes('mud-popover-anchor-bottom-right')) {
                 left = boundingRect.left + boundingRect.width;
                 top = boundingRect.top + boundingRect.height;
             }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -248,7 +248,7 @@ window.mudpopoverHelper = {
         // parentNode is the calling element, mudmenu/tooltip/etc not the parent popover if it's a child popover
         // this happens at page load unless it's popover inside a popover, then it happens when you activate the parent
 
-        if (popoverNode && popoverNode.parentNode) {
+        if (popoverNode?.parentNode) {
             const id = popoverNode.id.substr(8);
             const popoverContentNode = document.getElementById('popovercontent-' + id);
 
@@ -325,10 +325,7 @@ window.mudpopoverHelper = {
                 // Adjust .mud-list children if they would run off screen even after flipping
                 const firstChild = popoverContentNode.firstElementChild;
                 // Check if firstChild exists, has a classList, and is a mud-list
-                const isList =
-                    firstChild &&
-                    firstChild.classList &&
-                    firstChild.classList.contains("mud-list");
+                const isList = firstChild?.classList?.contains("mud-list");
                 // we do it here to ensure it flips properly if more space becomes available on the other side.
                 if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
                     popoverContentNode.style.maxHeight = null;
@@ -693,7 +690,7 @@ window.mudpopoverHelper = {
             popoverContentNode.style['z-index'] = newZIndex;
         }
         // tooltip container update, so the node it's being compared to is a tooltip
-        else if (parentNode && parentNode.classList.contains("mud-tooltip-root")) {
+        else if (parentNode?.classList?.contains("mud-tooltip-root")) {
             const computedStyle = window.getComputedStyle(parentNode);
             const tooltipZIndexValue = computedStyle.getPropertyValue('z-index');
             if (tooltipZIndexValue !== 'auto') {
@@ -702,7 +699,7 @@ window.mudpopoverHelper = {
             popoverContentNode.style['z-index'] = Math.max(newZIndex, window.mudpopoverHelper.baseTooltipZIndex + 1);
         }
         // specific appbar interference update
-        else if (parentNode && parentNode.classList.contains("mud-appbar")) {
+        else if (parentNode?.classList?.contains("mud-appbar")) {
             // adjust zindex to top of appbar if it's underneath
             const computedStyle = window.getComputedStyle(parentNode);
             const appBarZIndexValue = computedStyle.getPropertyValue('z-index');
@@ -763,7 +760,7 @@ window.mudpopoverHelper = {
         if (!parentNode || !parentNode.children) { return; }
         // Traverse children of target.parentNode that contain the class "mud-popover"
         for (const child of parentNode.children) {
-            if (child && child.classList && child.classList.contains("mud-popover-open")) {
+            if (child?.classList?.contains("mud-popover-open")) {
                 const tickValue = Number(child.getAttribute("data-ticks")) || 0;
 
                 if (tickValue > highestTickValue) {
@@ -833,13 +830,13 @@ class MudPopover {
         // this is the content node in the provider regardless of the RenderFragment that exists when the popover is active
         const popoverContentNode = document.getElementById('popovercontent-' + id);
 
-        if (popoverNode && popoverNode.parentNode && popoverContentNode) {
+        if (popoverNode?.parentNode && popoverContentNode) {
             // add a resize observer to catch resize events
             const resizeObserver = new ResizeObserver(entries => {
                 for (const entry of entries) {
                     const target = entry.target;
                     for (const childNode of target.childNodes) {
-                        if (childNode.id && childNode.id.startsWith('popover-')) {
+                        if (childNode.id?.startsWith('popover-')) {
                             this.onResize();
                         }
                     }
@@ -918,14 +915,14 @@ class MudPopover {
         if (mutation.type == 'attributes' && mutation.attributeName == 'class') {
             if (target.classList.contains('mud-popover-open')) {
                 // setup for an open popover and create observers
-                if (this.map[id] && !this.map[id].isOpened) {
+                if (this.map[id]?.isOpened === false) {
                     this.map[id].isOpened = true;
                 }
                 this.openPopover(target, id);
             }
             else {
                 // tell the map that this popover is closed
-                if (this.map[id] && this.map[id].isOpened) {
+                if (this.map[id]?.isOpened) {
                     this.map[id].isOpened = false;
                 }
                 // wait this long until we "move it off screen"
@@ -937,8 +934,8 @@ class MudPopover {
                 }
                 else {
                     setTimeout(() => {
-                        if (this.map[id] && this.map[id].isOpened) return; // in case it's reopened before the timeout is over
-                        if (target && !target.classList.contains('mud-popover-open')) {
+                        if (this.map[id]?.isOpened) return; // in case it's reopened before the timeout is over
+                        if (!target?.classList?.contains('mud-popover-open')) {
                             target.style.removeProperty('left');
                             target.style.removeProperty('top');
                         }
@@ -960,7 +957,7 @@ class MudPopover {
             // instead we use data-ticks since we know the newest data-ticks > 0 is the top most.
             const tickAttribute = target.getAttribute('data-ticks');
             // data ticks is not 0 so let's reposition the popover and overlay
-            if (tickAttribute > 0 && target.parentNode && this.map[id] && this.map[id].isOpened) {
+            if (tickAttribute > 0 && target?.parentNode && this.map[id]?.isOpened) {
                 // reposition popover individually
                 window.mudpopoverHelper.placePopoverByNode(target);
             }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -190,7 +190,8 @@ window.mudpopoverHelper = {
     getPositionForFlippedPopver: function (inputArray, selector, boundingRect, selfRect) {
         const classList = [];
         const replacementsList = {};
-        for (const item of inputArray) {
+        for (let i = 0; i < inputArray.length; i++) {
+            const item = inputArray[i];
             const replacements = window.mudpopoverHelper.flipClassReplacements[selector][item];
             if (replacements) {
                 replacementsList[item] = replacements;
@@ -627,8 +628,8 @@ window.mudpopoverHelper = {
     // cycles through popovers to reposition those that are open, classSelector is passed on
     placePopoverByClassSelector: function (classSelector = null) {
         const items = window.mudPopover.getAllObservedContainers();
-        for (const item of items) {
-            const popoverNode = document.getElementById('popover-' + item);
+        for (let i = 0; i < items.length; i++) {
+            const popoverNode = document.getElementById('popover-' + items[i]);
             window.mudpopoverHelper.placePopover(popoverNode, classSelector);
         }
     },

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -190,8 +190,7 @@ window.mudpopoverHelper = {
     getPositionForFlippedPopver: function (inputArray, selector, boundingRect, selfRect) {
         const classList = [];
         const replacementsList = {};
-        for (let i = 0; i < inputArray.length; i++) {
-            const item = inputArray[i];
+        for (const item of inputArray) {
             const replacements = window.mudpopoverHelper.flipClassReplacements[selector][item];
             if (replacements) {
                 replacementsList[item] = replacements;
@@ -631,8 +630,8 @@ window.mudpopoverHelper = {
     // cycles through popovers to reposition those that are open, classSelector is passed on
     placePopoverByClassSelector: function (classSelector = null) {
         const items = window.mudPopover.getAllObservedContainers();
-        for (let i = 0; i < items.length; i++) {
-            const popoverNode = document.getElementById('popover-' + items[i]);
+        for (const item of items) {
+            const popoverNode = document.getElementById('popover-' + item);
             window.mudpopoverHelper.placePopover(popoverNode, classSelector);
         }
     },

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -25,10 +25,10 @@ window.mudpopoverHelper = {
         };
     },
 
-    basePopoverZIndex: parseInt(getComputedStyle(document.documentElement)
+    basePopoverZIndex: Number.parseInt(getComputedStyle(document.documentElement)
         .getPropertyValue('--mud-zindex-popover')) || 1200,
 
-    baseTooltipZIndex: parseInt(getComputedStyle(document.documentElement)
+    baseTooltipZIndex: Number.parseInt(getComputedStyle(document.documentElement)
         .getPropertyValue('--mud-zindex-tooltip')) || 1600,
 
     // static set of replacement values
@@ -283,9 +283,9 @@ window.mudpopoverHelper = {
 
             if (isPositionOverride) {
                 const attrY = popoverContentNode.getAttribute('data-pc-y');
-                const positiontop = attrY == null ? boundingRect.top : parseInt(attrY, 10);
+                const positiontop = attrY == null ? boundingRect.top : Number.parseInt(attrY, 10);
                 const attrX = popoverContentNode.getAttribute('data-pc-x');
-                const positionleft = attrX == null ? boundingRect.left : parseInt(attrX, 10);
+                const positionleft = attrX == null ? boundingRect.left : Number.parseInt(attrX, 10);
                 const scrollLeft = window.scrollX;
                 const scrollTop = window.scrollY;
 
@@ -678,7 +678,7 @@ window.mudpopoverHelper = {
         const popoverNode = document.getElementById('popover-' + popoverContentNode.id.substr(15));
         // get --mud-zindex-popover from root
         let newZIndex = window.mudpopoverHelper.basePopoverZIndex + 1;
-        const origZIndex = parseInt(popoverContentNode.style['z-index']) || 1;
+        const origZIndex = Number.parseInt(popoverContentNode.style['z-index']) || 1;
         const contentZIndex = popoverContentNode.style['z-index'];
         // normal nested position update parentPopover is a parent with .mud-popover so nested for sure
         if (parentPopover) {
@@ -689,7 +689,7 @@ window.mudpopoverHelper = {
                 // parentpopovers will never be auto zindex due to css rules
                 // children are set "auto" z-index in css and therefore need updated
                 // set new z-index 1 above parent
-                newZIndex = parseInt(parentZIndexValue) + 1;
+                newZIndex = Number.parseInt(parentZIndexValue) + 1;
             }
             popoverContentNode.style['z-index'] = newZIndex;
         }
@@ -698,7 +698,7 @@ window.mudpopoverHelper = {
             const computedStyle = window.getComputedStyle(parentNode);
             const tooltipZIndexValue = computedStyle.getPropertyValue('z-index');
             if (tooltipZIndexValue !== 'auto') {
-                newZIndex = parseInt(tooltipZIndexValue) + 1;
+                newZIndex = Number.parseInt(tooltipZIndexValue) + 1;
             }
             popoverContentNode.style['z-index'] = Math.max(newZIndex, window.mudpopoverHelper.baseTooltipZIndex + 1);
         }
@@ -708,7 +708,7 @@ window.mudpopoverHelper = {
             const computedStyle = window.getComputedStyle(parentNode);
             const appBarZIndexValue = computedStyle.getPropertyValue('z-index');
             if (appBarZIndexValue !== 'auto') {
-                newZIndex = parseInt(appBarZIndexValue) + 1;
+                newZIndex = Number.parseInt(appBarZIndexValue) + 1;
             }
             popoverContentNode.style['z-index'] = newZIndex;
         }
@@ -719,7 +719,7 @@ window.mudpopoverHelper = {
             popoverContentNode.style['z-index'] = Math.max(newZIndex, window.mudpopoverHelper.basePopoverZIndex + 1, origZIndex);
         }
         // if popoverContentNode.style['z-index'] is not set or set lower than minimum set it to default popover zIndex
-        else if (!contentZIndex || parseInt(contentZIndex) < 1) {
+        else if (!contentZIndex || Number.parseInt(contentZIndex) < 1) {
             popoverContentNode.style['z-index'] = newZIndex;
         }
     },
@@ -743,10 +743,10 @@ window.mudpopoverHelper = {
             }
 
             const zIndex = style.getPropertyValue('z-index');
-            const zIndexValue = parseInt(zIndex, 10);
+            const zIndexValue = Number.parseInt(zIndex, 10);
 
             // update maxZIndex only if zIndexValue is defined and greater than current max
-            if (!isNaN(zIndexValue) && zIndexValue > maxZIndex) {
+            if (!Number.isNaN(zIndexValue) && zIndexValue > maxZIndex) {
                 maxZIndex = zIndexValue;
             }
 
@@ -930,7 +930,7 @@ class MudPopover {
                     this.map[id].isOpened = false;
                 }
                 // wait this long until we "move it off screen"
-                const delay = parseFloat(target.style['transition-duration']) || 0;
+                const delay = Number.parseFloat(target.style['transition-duration']) || 0;
                 if (delay == 0) {
                     // remove left and top styles
                     target.style.removeProperty('left');
@@ -1080,9 +1080,9 @@ class MudPopover {
         if (!timeStr) return 0;
         timeStr = timeStr.trim();
         if (timeStr.endsWith('ms')) {
-            return parseFloat(timeStr);
+            return Number.parseFloat(timeStr);
         } else if (timeStr.endsWith('s')) {
-            return parseFloat(timeStr) * 1000;
+            return Number.parseFloat(timeStr) * 1000;
         }
         return 0;
     }

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -165,8 +165,8 @@ window.mudResizeListenerFactory = {
      * Cancels and removes multiple listeners.
      */
     cancelListeners: (ids) => {
-        for (const id of ids) {
-            window.mudResizeListenerFactory.cancelListener(id);
+        for (let i = 0; i < ids.length; i++) {
+            window.mudResizeListenerFactory.cancelListener(ids[i]);
         }
     },
 

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -165,8 +165,8 @@ window.mudResizeListenerFactory = {
      * Cancels and removes multiple listeners.
      */
     cancelListeners: (ids) => {
-        for (let i = 0; i < ids.length; i++) {
-            window.mudResizeListenerFactory.cancelListener(ids[i]);
+        for (const id of ids) {
+            window.mudResizeListenerFactory.cancelListener(id);
         }
     },
 

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -62,7 +62,7 @@ class MudResizeObserver {
         this.options = options;
         this._dotNetRef = dotNetRef;
 
-        const delay = (this.options || {}).reportRate || 200;
+        const delay = this.options?.reportRate || 200;
 
         this.throttleResizeHandlerId = -1;
 

--- a/src/MudBlazor/TScripts/mudScrollSpy.js
+++ b/src/MudBlazor/TScripts/mudScrollSpy.js
@@ -49,7 +49,9 @@ class MudScrollSpy {
         let minDifference = Number.MAX_SAFE_INTEGER;
         let foundAbove = false;
         let elementId = '';
-        for (const element of Array.from(elements)) {
+        for (let i = 0; i < elements.length; i++) {
+            const element = elements[i];
+
             const rect = element.getBoundingClientRect();
             const diff = Math.abs(rect.top - center);
 

--- a/src/MudBlazor/TScripts/mudScrollSpy.js
+++ b/src/MudBlazor/TScripts/mudScrollSpy.js
@@ -49,9 +49,7 @@ class MudScrollSpy {
         let minDifference = Number.MAX_SAFE_INTEGER;
         let foundAbove = false;
         let elementId = '';
-        for (let i = 0; i < elements.length; i++) {
-            const element = elements[i];
-
+        for (const element of Array.from(elements)) {
             const rect = element.getBoundingClientRect();
             const diff = Math.abs(rect.top - center);
 

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -104,10 +104,10 @@ class MudSplitPanel {
         this.secondPanel.style.height = "100%";
 
         const firstPanelSizeNew = firstPanelSize !== null ? firstPanelSize : this.firstPanelInitialSize;
-        if (firstPanelSizeNew !== null) {
-            this._setPanelSizes(firstPanelSizeNew, this._getContainerSize());
-        } else {
+        if (firstPanelSizeNew === null) {
             this.divider.ariaValueNow = "50";
+        } else {
+            this._setPanelSizes(firstPanelSizeNew, this._getContainerSize());
         }
     }
 

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -244,16 +244,14 @@ class MudSplitPanel {
             } else if (key === "End") {
                 this._setPanelSizes(containerSize - this.panelGap - this.minPanelSize, containerSize);
             }
-        } else {
-            if (key === "ArrowLeft") {
-                delta = -this.keyboardStep;
-            } else if (key === "ArrowRight") {
-                delta = this.keyboardStep;
-            } else if (key === "Home") {
-                this._setPanelSizes(this.minPanelSize, containerSize);
-            } else if (key === "End") {
-                this._setPanelSizes(containerSize - this.panelGap - this.minPanelSize, containerSize);
-            }
+        } else if (key === "ArrowLeft") {
+            delta = -this.keyboardStep;
+        } else if (key === "ArrowRight") {
+            delta = this.keyboardStep;
+        } else if (key === "Home") {
+            this._setPanelSizes(this.minPanelSize, containerSize);
+        } else if (key === "End") {
+            this._setPanelSizes(containerSize - this.panelGap - this.minPanelSize, containerSize);
         }
 
         if (delta !== 0) {

--- a/src/MudBlazor/TScripts/mudTimePicker.js
+++ b/src/MudBlazor/TScripts/mudTimePicker.js
@@ -27,7 +27,7 @@ window.mudTimePicker = {
             // Set the selected value to the stick that the pointer went down on.
             if (event.target.classList.contains('mud-hour') || event.target.classList.contains('mud-minute')) {
                 const attributeValue = event.target.getAttribute('data-stick-value');
-                const stickValue = attributeValue ? parseInt(attributeValue) : -1; // Ensure an integer.
+                const stickValue = attributeValue ? Number.parseInt(attributeValue, 10) : -1; // Ensure an integer.
 
                 dotNetHelper.invokeMethodAsync('SelectTimeFromStick', stickValue, false);
             }
@@ -45,7 +45,7 @@ window.mudTimePicker = {
 
             if (event.target.classList.contains('mud-hour') || event.target.classList.contains('mud-minute')) {
                 const attributeValue = event.target.getAttribute('data-stick-value');
-                const stickValue = attributeValue ? parseInt(attributeValue) : -1; // Ensure an integer.
+                const stickValue = attributeValue ? Number.parseInt(attributeValue, 10) : -1; // Ensure an integer.
 
                 dotNetHelper.invokeMethodAsync('OnStickClick', stickValue);
             }
@@ -60,7 +60,7 @@ window.mudTimePicker = {
             }
 
             const attributeValue = event.target.getAttribute('data-stick-value');
-            const stickValue = attributeValue ? parseInt(attributeValue) : -1; // Ensure an integer.
+            const stickValue = attributeValue ? Number.parseInt(attributeValue, 10) : -1; // Ensure an integer.
 
             dotNetHelper.invokeMethodAsync('SelectTimeFromStick', stickValue, true);
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -51,7 +51,6 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
     /// </exception>
     public TIn ConvertBack(TOut input)
     {
-        //var runtimeType = input is null ? typeof(TIn) : input.GetType();
         var runtimeType = typeof(TIn);
 
         if (_backwards.TryGetValue(runtimeType, out var del))

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -46,7 +46,6 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
     /// </exception>
     public TOut Convert(TIn input)
     {
-        //var runtimeType = input is null ? typeof(TIn) : input.GetType();
         var runtimeType = typeof(TIn);
 
         if (_handlers.TryGetValue(runtimeType, out var del))

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -150,11 +150,17 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="CssBuilder"/> instance.</returns>
         public CssBuilder AddClassFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
         {
-            return additionalAttributes is null
-                ? this
-                : additionalAttributes.TryGetValue("class", out var result)
-                    ? AddClass(result.ToString())
-                    : this;
+            if (additionalAttributes is null)
+            {
+                return this;
+            }
+
+            if (additionalAttributes.TryGetValue("class", out var result))
+            {
+                return AddClass(result.ToString());
+            }
+
+            return this;
         }
 
         /// <summary>

--- a/src/MudBlazor/Utilities/Expressions/ExpressionNull.cs
+++ b/src/MudBlazor/Utilities/Expressions/ExpressionNull.cs
@@ -18,7 +18,6 @@ internal static class ExpressionNull
         var parameter = expression.Parameters[0];
         var body = AddNullChecks(expression.Body);
 
-        //return body;
         return Expression.Lambda<Func<T, TProperty>>(body, parameter);
     }
 

--- a/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
@@ -57,8 +57,8 @@ public partial class DateMask : PatternMask
         }
 
         _year = ExtractYear(mask, alignedText, maskOffset);
-        MonthLogic(mask, text, maskOffset, ref textIndex, ref maskIndex, ref alignedText);
-        DayLogic(mask, text, maskOffset, ref textIndex, ref maskIndex, ref alignedText);
+        MonthLogic(mask, maskOffset, ref maskIndex, ref alignedText);
+        DayLogic(mask, maskOffset, ref maskIndex, ref alignedText);
     }
 
     private int ExtractYear(string mask, string alignedText, int maskOffset)
@@ -84,7 +84,7 @@ public partial class DateMask : PatternMask
         return 0;
     }
 
-    private void MonthLogic(string mask, string text, int maskOffset, ref int textIndex, ref int maskIndex, ref string alignedText)
+    private void MonthLogic(string mask, int maskOffset, ref int maskIndex, ref string alignedText)
     {
         var monthPattern = new string(_monthChar, 2);
         var (monthString, index) = Extract(monthPattern, mask, maskOffset, alignedText);
@@ -110,7 +110,7 @@ public partial class DateMask : PatternMask
         }
     }
 
-    private void DayLogic(string mask, string text, int maskOffset, ref int textIndex, ref int maskIndex, ref string alignedText)
+    private void DayLogic(string mask, int maskOffset, ref int maskIndex, ref string alignedText)
     {
         var dayPattern = new string(_dayChar, 2);
         var (dayString, index) = Extract(dayPattern, mask, maskOffset, alignedText);
@@ -252,4 +252,3 @@ public partial class DateMask : PatternMask
     [GeneratedRegex(@"^\d+$")]
     private static partial Regex ValidDigitRegularExpression();
 }
-

--- a/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
@@ -167,8 +167,6 @@ public partial class DateMask : PatternMask
             var monthFound = monthIndex >= 0;
             var monthComplete = monthString?.Length == 2;
             var y = ExtractYear(Mask, text, 0);
-            //if (maskHasYear && y < 0 || maskHasMonth && (!monthFound || !monthComplete) || maskHasDay && (!dayFound || !dayComplete))
-            //    return text; // we have incomplete input, no final check necessary/possible
             int.TryParse(dayString ?? "", out var d);
             int.TryParse(monthString ?? "", out var m);
             if (!maskHasYear)

--- a/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace MudBlazor;
@@ -145,7 +146,7 @@ public class PatternMask : BaseMask
             return text;
         // fill the rest with placeholder
         // don't fill if text is still empty
-        var filledText = text;
+        var filledText = new StringBuilder(text);
         var len = text.Length;
         var mask = Mask ?? string.Empty;
         if (len == 0 || len >= mask.Length)
@@ -154,11 +155,11 @@ public class PatternMask : BaseMask
         {
             var maskChar = mask[maskIndex];
             if (IsDelimiter(maskChar))
-                filledText += maskChar;
+                filledText.Append(maskChar);
             else
-                filledText += Placeholder.Value;
+                filledText.Append(Placeholder.Value);
         }
-        return filledText;
+        return filledText.ToString();
     }
 
     /// <summary>
@@ -171,7 +172,7 @@ public class PatternMask : BaseMask
     {
         text ??= string.Empty;
         var mask = Mask ?? string.Empty;
-        var alignedText = string.Empty;
+        var alignedTextBuilder = new StringBuilder();
         var maskIndex = maskOffset; // index in mask
         var textIndex = 0; // index in text
         while (textIndex < text.Length)
@@ -182,20 +183,24 @@ public class PatternMask : BaseMask
             var textChar = text[textIndex];
             if (IsDelimiter(maskChar))
             {
-                alignedText += maskChar;
+                alignedTextBuilder.Append(maskChar);
                 maskIndex++;
+                var alignedText = alignedTextBuilder.ToString();
                 ModifyPartiallyAlignedMask(mask, text, maskOffset, ref textIndex, ref maskIndex, ref alignedText);
+                alignedTextBuilder = new StringBuilder(alignedText);
                 continue;
             }
             var isPlaceholder = textChar == Placeholder;
             if (IsMatch(maskChar, textChar) || isPlaceholder)
             {
                 var c = Transformation?.Invoke(textChar) ?? textChar;
-                alignedText += c;
+                alignedTextBuilder.Append(c);
                 maskIndex++;
             }
             textIndex++;
-            ModifyPartiallyAlignedMask(mask, text, maskOffset, ref textIndex, ref maskIndex, ref alignedText);
+            var currentAlignedText = alignedTextBuilder.ToString();
+            ModifyPartiallyAlignedMask(mask, text, maskOffset, ref textIndex, ref maskIndex, ref currentAlignedText);
+            alignedTextBuilder = new StringBuilder(currentAlignedText);
         }
         // fill any delimiters if possible
         for (var i = maskIndex; i < mask.Length; i++)
@@ -203,9 +208,9 @@ public class PatternMask : BaseMask
             var maskChar = mask[i];
             if (!IsDelimiter(maskChar))
                 break;
-            alignedText += maskChar;
+            alignedTextBuilder.Append(maskChar);
         }
-        return alignedText;
+        return alignedTextBuilder.ToString();
     }
 
     protected virtual void ModifyPartiallyAlignedMask(string mask, string text, int maskOffset, ref int textIndex, ref int maskIndex, ref string alignedText)

--- a/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace MudBlazor;
@@ -146,7 +145,7 @@ public class PatternMask : BaseMask
             return text;
         // fill the rest with placeholder
         // don't fill if text is still empty
-        var filledText = new StringBuilder(text);
+        var filledText = text;
         var len = text.Length;
         var mask = Mask ?? string.Empty;
         if (len == 0 || len >= mask.Length)
@@ -155,11 +154,11 @@ public class PatternMask : BaseMask
         {
             var maskChar = mask[maskIndex];
             if (IsDelimiter(maskChar))
-                filledText.Append(maskChar);
+                filledText += maskChar;
             else
-                filledText.Append(Placeholder.Value);
+                filledText += Placeholder.Value;
         }
-        return filledText.ToString();
+        return filledText;
     }
 
     /// <summary>
@@ -172,7 +171,7 @@ public class PatternMask : BaseMask
     {
         text ??= string.Empty;
         var mask = Mask ?? string.Empty;
-        var alignedTextBuilder = new StringBuilder();
+        var alignedText = string.Empty;
         var maskIndex = maskOffset; // index in mask
         var textIndex = 0; // index in text
         while (textIndex < text.Length)
@@ -183,24 +182,20 @@ public class PatternMask : BaseMask
             var textChar = text[textIndex];
             if (IsDelimiter(maskChar))
             {
-                alignedTextBuilder.Append(maskChar);
+                alignedText += maskChar;
                 maskIndex++;
-                var alignedText = alignedTextBuilder.ToString();
                 ModifyPartiallyAlignedMask(mask, text, maskOffset, ref textIndex, ref maskIndex, ref alignedText);
-                alignedTextBuilder = new StringBuilder(alignedText);
                 continue;
             }
             var isPlaceholder = textChar == Placeholder;
             if (IsMatch(maskChar, textChar) || isPlaceholder)
             {
                 var c = Transformation?.Invoke(textChar) ?? textChar;
-                alignedTextBuilder.Append(c);
+                alignedText += c;
                 maskIndex++;
             }
             textIndex++;
-            var currentAlignedText = alignedTextBuilder.ToString();
-            ModifyPartiallyAlignedMask(mask, text, maskOffset, ref textIndex, ref maskIndex, ref currentAlignedText);
-            alignedTextBuilder = new StringBuilder(currentAlignedText);
+            ModifyPartiallyAlignedMask(mask, text, maskOffset, ref textIndex, ref maskIndex, ref alignedText);
         }
         // fill any delimiters if possible
         for (var i = maskIndex; i < mask.Length; i++)
@@ -208,9 +203,9 @@ public class PatternMask : BaseMask
             var maskChar = mask[i];
             if (!IsDelimiter(maskChar))
                 break;
-            alignedTextBuilder.Append(maskChar);
+            alignedText += maskChar;
         }
-        return alignedTextBuilder.ToString();
+        return alignedText;
     }
 
     protected virtual void ModifyPartiallyAlignedMask(string mask, string text, int maskOffset, ref int textIndex, ref int maskIndex, ref string alignedText)

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -212,11 +212,17 @@ namespace MudBlazor.Utilities
         /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
         public StyleBuilder AddStyleFromAttributes(IReadOnlyDictionary<string, object>? additionalAttributes)
         {
-            return additionalAttributes is null
-                ? this
-                : additionalAttributes.TryGetValue("style", out var result)
-                    ? AddRaw(result.ToString())
-                    : this;
+            if (additionalAttributes is null)
+            {
+                return this;
+            }
+
+            if (additionalAttributes.TryGetValue("style", out var result))
+            {
+                return AddRaw(result.ToString());
+            }
+
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Fixes a broad set of [SonarQube issues](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=MudBlazor_MudBlazor) in C# and JavaScript that were causing noisy reports and failing quality checks.

**What changed:**
- Addressed multiple C# rules, including:
  - `S1172` unused parameters
  - `S3358` nested ternaries
  - `S3260` seal private non-derived types
  - `S2933` readonly constructor-assigned fields
  - `S125` commented-out code
  - `S3928` `ArgumentException` param name mismatch
  - `S1155` prefer `Any()` for emptiness checks
- Addressed multiple JS rules, including:
  - `S7773` prefer `Number.*` static APIs
  - `S6660` simplify else/if-only branches
  - `S6582` optional chaining
  - `S7765` prefer `.includes()`
  - `S7735` avoid negated conditions with `else`
- Reverted two earlier refactors (`S4138`, `S1643`) after review to keep safe/final behavior.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
