### PR TITLE
MudNumericField: Fix Format being broken

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -600,6 +600,66 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Instance.FieldNotImmediate.ReadValue.Should().Be(7000.99));
         }
 
+        [Test]
+        public async Task NumericField_Immediate_Should_Reformat_Repeated_Input_With_F3()
+        {
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "F3"));
+
+            var input = comp.Find("input");
+
+            await input.InputAsync("3.14514515415414515");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
+            input.GetAttribute("value").Should().Be("3.145");
+
+            await input.InputAsync("3.145145154154145159");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.145145154154145159d));
+            input.GetAttribute("value").Should().Be("3.145");
+        }
+
+        [Test]
+        public async Task NumericField_Should_Reformat_On_Blur_With_Custom_Format_When_Not_Immediate()
+        {
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, false)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "#.###"));
+
+            var input = comp.Find("input");
+
+            await input.ChangeAsync("3.14514515415414515");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
+            input.GetAttribute("value").Should().Be("3.145");
+
+            await input.BlurAsync();
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
+            input.GetAttribute("value").Should().Be("3.145");
+        }
+
+        [Test]
+        public async Task NumericField_NotImmediate_Should_Reformat_When_Blur_Fires_Before_Change()
+        {
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, false)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "#.###"));
+
+            var input = comp.Find("input");
+
+            await input.BlurAsync();
+            await input.ChangeAsync("3.14514515415414515");
+
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
+            input.GetAttribute("value").Should().Be("3.145");
+        }
+
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericField_Validation<T>(T value)
         {

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -660,6 +660,28 @@ namespace MudBlazor.UnitTests.Components
             input.GetAttribute("value").Should().Be("3.145");
         }
 
+        [Test]
+        public async Task NumericField_NotImmediate_Should_Reformat_Consistently_Across_Repeated_Blurs()
+        {
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, false)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "#.###"));
+
+            var input = comp.Find("input");
+            const string rawText = "3.14514515415414515";
+
+            for (var i = 0; i < 5; i++)
+            {
+                await input.ChangeAsync(rawText);
+                await input.BlurAsync();
+
+                await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
+                await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
+                input.GetAttribute("value").Should().Be("3.145");
+            }
+        }
+
         [TestCaseSource(nameof(TypeCases))]
         public async Task NumericField_Validation<T>(T value)
         {

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -348,8 +348,13 @@ namespace MudBlazor
         /// <param name="text">The new value.</param>
         public Task SetText(string? text)
         {
+            return SetText(text, updateValue: true);
+        }
+
+        internal Task SetText(string? text, bool updateValue)
+        {
             _internalText = text;
-            return SetTextAndUpdateValueAsync(text);
+            return SetTextAndUpdateValueAsync(text, updateValue);
         }
 
         // Certain HTML5 inputs (dates and color) have a native placeholder

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -181,13 +181,28 @@ namespace MudBlazor
         protected internal override async Task OnBlurredAsync(FocusEventArgs obj)
         {
             await base.OnBlurredAsync(obj);
-            // For non-immediate, non-debounced inputs the onchange path is responsible for value updates.
-            // Re-parsing here can conflict with already formatted text depending on blur/change event ordering.
+
             if (Immediate || DebounceInterval > 0)
             {
                 await UpdateValuePropertyAsync(true); //Required to set the value after a blur before the debounce period has elapsed
             }
+            else
+            {
+                // For non-immediate, non-debounced inputs, browser onchange timing can race with blur handlers.
+                // Parse current text only when it is not already the formatted representation of the current value.
+                var formattedValueText = ConvertSet(ReadValue);
+                if (!string.Equals(ReadText, formattedValueText, StringComparison.Ordinal))
+                {
+                    await UpdateValuePropertyAsync(true);
+                }
+            }
+
             await UpdateTextPropertyAsync(false); //Required to update the string formatting after a blur before the debounce period has elapsed
+
+            if (IsFormatted && DebounceInterval <= 0 && !ConversionError)
+            {
+                await _elementReference.SetText(ReadText, updateValue: false);
+            }
         }
 
         protected async Task<bool> ValidateInput(T? value)

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -181,7 +181,12 @@ namespace MudBlazor
         protected internal override async Task OnBlurredAsync(FocusEventArgs obj)
         {
             await base.OnBlurredAsync(obj);
-            await UpdateValuePropertyAsync(true); //Required to set the value after a blur before the debounce period has elapsed
+            // For non-immediate, non-debounced inputs the onchange path is responsible for value updates.
+            // Re-parsing here can conflict with already formatted text depending on blur/change event ordering.
+            if (Immediate || DebounceInterval > 0)
+            {
+                await UpdateValuePropertyAsync(true); //Required to set the value after a blur before the debounce period has elapsed
+            }
             await UpdateTextPropertyAsync(false); //Required to update the string formatting after a blur before the debounce period has elapsed
         }
 
@@ -466,9 +471,21 @@ namespace MudBlazor
             _ => (string.IsNullOrEmpty(ReadText) ? "0" : $"{ReadText.Length}") + $" / {Counter}"
         };
 
-        private Task OnInputValueChanged(string text)
+        private async Task OnInputValueChanged(string text)
         {
-            return SetTextAndUpdateValueAsync(text);
+            await SetTextAndUpdateValueAsync(text);
+
+            // Keep formatted text in sync when using formatted input mode.
+            // This also covers onchange updates that can occur around blur timing.
+            if (IsFormatted && DebounceInterval <= 0 && !ConversionError)
+            {
+                var formattedText = ConvertSet(ReadValue);
+                if (!string.Equals(ReadText, formattedText, StringComparison.Ordinal))
+                {
+                    await SetTextCoreAsync(formattedText);
+                    await _elementReference.SetText(formattedText, updateValue: false);
+                }
+            }
         }
 
         //avoids the format to use scientific notation for large or small number in floating points types, while covering all options


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/MudBlazor/issues/12677

Likely caused by https://github.com/MudBlazor/MudBlazor/pull/12272 as the timing is now different

Keep in mind, that when you use `Immidiate=true` with format, you'd like want to set `DebounceInterval` otherwise if you just hold button, funny thing can happen as the code won't be able to keep up.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
