### PR TITLE
Refactor: Minor analyzer fixes

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -804,7 +804,11 @@ public class ApiDocumentationBuilder
             {
                 // Yes.   Move up to the type  (i.e. "MudBlazor.___")
                 start += 13;
-                var end = start == -1 ? -1 : globalProperty.Value.Summary.IndexOf('\"', start);
+                var end = globalProperty.Value.Summary.IndexOf('\"', start);
+                if (end == -1)
+                {
+                    continue;
+                }
                 var typeName = globalProperty.Value.Summary.Substring(start, end - start);
 
                 // Does the mentioned type exist?

--- a/src/MudBlazor.Docs/Components/ApiText.cs
+++ b/src/MudBlazor.Docs/Components/ApiText.cs
@@ -77,6 +77,11 @@ public sealed partial class ApiText : ComponentBase
                             switch (reader.Name)
                             {
                                 case "cref":
+                                    if (string.IsNullOrWhiteSpace(link) || link.Length < 3)
+                                    {
+                                        continue;
+                                    }
+
                                     // Get the link type
                                     var linkType = link.Substring(0, 1);
                                     var linkRef = link.Substring(2);

--- a/src/MudBlazor.Docs/Components/SectionContent.razor.cs
+++ b/src/MudBlazor.Docs/Components/SectionContent.razor.cs
@@ -160,7 +160,12 @@ public partial class SectionContent
         }
         else
         {
-            firstFile = Codes.FirstOrDefault().code;
+            firstFile = Codes.FirstOrDefault()?.code ?? Code;
+        }
+
+        if (string.IsNullOrWhiteSpace(firstFile))
+        {
+            return;
         }
 
         // We use a separator that won't be in code so we can send 2 files later

--- a/src/MudBlazor.UnitTests.Shared/Mocks/MockResizeObserver.cs
+++ b/src/MudBlazor.UnitTests.Shared/Mocks/MockResizeObserver.cs
@@ -109,13 +109,13 @@ public class MockResizeObserver : IResizeObserver
     }
 
     // MudTabs added a fallback for using jsinterop to find a valid value if one is not returned
-    public BoundingClientRect? GetSizeInfo(ElementReference reference) =>
+    public BoundingClientRect GetSizeInfo(ElementReference reference) =>
         _cachedValues.GetValueOrDefault(reference) ??
         new BoundingClientRect() { Width = !IsVertical ? PanelSize : 0.0, Height = IsVertical ? PanelSize : 0.0 };
 
-    public double GetHeight(ElementReference reference) => GetSizeInfo(reference)?.Height ?? 0.0;
+    public double GetHeight(ElementReference reference) => GetSizeInfo(reference).Height;
 
-    public double GetWidth(ElementReference reference) => GetSizeInfo(reference)?.Width ?? 0.0;
+    public double GetWidth(ElementReference reference) => GetSizeInfo(reference).Width;
 
     public bool IsElementObserved(ElementReference reference) => _cachedValues.ContainsKey(reference);
 

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -459,7 +459,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var yAxisLabels = comp.FindAll("g.mud-charts-yaxis text").Select(e => e.TextContent).ToList();
             yAxisLabels.Should().Contain("0");
-            yAxisLabels.Should().Contain(l => l.StartsWith("-")); // Negative values
+            yAxisLabels.Should().Contain(l => l.StartsWith("-") || l.StartsWith("-$")); // Negative values
             yAxisLabels.Should().Contain(l => char.IsDigit(l[0])); // Positive values (simple check)
         }
 

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -459,7 +459,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var yAxisLabels = comp.FindAll("g.mud-charts-yaxis text").Select(e => e.TextContent).ToList();
             yAxisLabels.Should().Contain("0");
-            yAxisLabels.Should().Contain(l => l.StartsWith("-") || l.StartsWith("-$")); // Negative values
+            yAxisLabels.Should().Contain(l => l.StartsWith("-")); // Negative values
             yAxisLabels.Should().Contain(l => char.IsDigit(l[0])); // Positive values (simple check)
         }
 

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -27,8 +27,8 @@ namespace MudBlazor
             .AddClass("mud-carousel-transition-slide-prev-rtl-enter", !_disposed && Transition == Transition.Slide && RightToLeft && Parent?.SelectedContainer == this && !Parent._moveNext)
             .AddClass("mud-carousel-transition-slide-prev-rtl-exit", !_disposed && Transition == Transition.Slide && RightToLeft && Parent?.LastContainer == this && !Parent._moveNext)
             .AddClass("mud-carousel-transition-none", !_disposed && Transition == Transition.None && Parent?.SelectedContainer != this)
-            .AddClass(CustomTransitionEnter, !_disposed && Transition == Transition.Custom && Parent?.SelectedContainer == this && Parent.SelectedContainer == this)
-            .AddClass(CustomTransitionExit, !_disposed && Transition == Transition.Custom && Parent?.LastContainer == this && Parent.LastContainer == this)
+            .AddClass(CustomTransitionEnter, !_disposed && Transition == Transition.Custom && Parent?.SelectedContainer == this)
+            .AddClass(CustomTransitionExit, !_disposed && Transition == Transition.Custom && Parent?.LastContainer == this)
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
@@ -159,9 +159,6 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
             var chartDataCircles = new List<SvgCircle>();
             ChartDataPoints[i] = chartDataCircles;
 
-            var dataLength = series.Data.Points.Count;
-            if (dataLength == 0) continue;
-
             var overrideSettings = GetSeriesDisplayOverride(series);
             var interpolationOption = overrideSettings?.InterpolationOption ?? ChartOptions?.InterpolationOption;
 
@@ -329,7 +326,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
     protected virtual string GetDataValueAsString(int seriesIndex, int dataPointIndex)
     {
         var value = GetDataValue<double>(seriesIndex, dataPointIndex);
-        return value.ToString(Series[seriesIndex].TooltipYValueFormat) ?? string.Empty;
+        return value.ToString(Series[seriesIndex].TooltipYValueFormat);
     }
 
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -316,7 +316,7 @@ namespace MudBlazor.Charts
             _dynamicFontSize = CalculateFontSize(estimatedCellWidth, estimatedCellHeight, 8);
 
             // Calculate Y-axis label width based on dynamic font size
-            _yAxisLabelWidth = (_series.Count > 0 ? _series?.Max(x => x.Name.Length) ?? 1 : 1) * _dynamicFontSize * AverageCharWidthMultiplier;
+            _yAxisLabelWidth = (_series.Count > 0 ? _series.Max(x => x.Name.Length) : 1) * _dynamicFontSize * AverageCharWidthMultiplier;
 
             const double DefaultCharsWidth = 5 * LegendFontSize * AverageCharWidthMultiplier;
             _legendLabelsYAxis = (int)Math.Ceiling(_options is { ShowLegendLabels: true }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -441,7 +441,7 @@
                     <MudItem xs="4">
                         <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Column]" Dense="true" Margin="@Margin.Dense"
                                    Class="filter-field">
-                            @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false) ?? Enumerable.Empty<Column<T>>())
+                            @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false))
                             {
                                 <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>
                             }

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -101,7 +101,7 @@ namespace MudBlazor
                 Debug.Assert(DataGrid is not null);
                 var firstItem = DataGrid.GetFilteredItemsCount() == 0 ? 0 : (DataGrid.CurrentPage * DataGrid.RowsPerPage) + 1;
                 var lastItem = Math.Min((DataGrid.CurrentPage + 1) * DataGrid.RowsPerPage, DataGrid.GetFilteredItemsCount());
-                var allItems = DataGrid?.GetFilteredItemsCount() ?? 0;
+                var allItems = DataGrid.GetFilteredItemsCount();
 
                 if (string.IsNullOrEmpty(InfoFormat))
                 {

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -115,9 +115,9 @@ namespace MudBlazor
                 Debug.Assert(Table != null);
 
                 // fetch number of filtered items (once only)
-                var filteredItemsCount = Table?.GetFilteredItemsCount() ?? 0;
-                var firstItem = (filteredItemsCount == 0 ? 0 : (Table?.CurrentPage * Table?.RowsPerPage) + 1) ?? 0;
-                var lastItem = Math.Min(((Table?.CurrentPage + 1) * Table?.RowsPerPage) ?? 0, filteredItemsCount);
+                var filteredItemsCount = Table.GetFilteredItemsCount();
+                var firstItem = filteredItemsCount == 0 ? 0 : (Table.CurrentPage * Table.RowsPerPage) + 1;
+                var lastItem = Math.Min((Table.CurrentPage + 1) * Table.RowsPerPage, filteredItemsCount);
 
                 if (string.IsNullOrEmpty(InfoFormat))
                 {


### PR DESCRIPTION
MudAxisLineChartBase.cs
- Line 163: 'dataLength == 0' is always false
- Line 332: 'value.ToString(...)' is always not null; '??' is excessive

HeatMap.razor.cs
- Line 319: '_series?.Max(...)' is always not null; '??' is excessive
- Line 319: Possible NRE due to mixed '?.' and '.' usage on '_series'

ApiDocumentationBuilder.cs
- Line 807: 'start == -1' is always false

ApiText.cs
- Line 82: 'link' used before null check (see also line 149)

MudCarouselItem.razor.cs
- Line 30: Identical sub-expressions in '&&'
- Line 31: Identical sub-expressions in '&&'

Rest is obvious 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
