### PR TITLE
Build: Upgrade AutoTriage workflows from v2 to v3

### DIFF
--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -2,14 +2,14 @@ name: AutoTriage (Backlog)
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       issues:
-        description: 'Space-separated issue numbers'
+        description: "Space-separated issue numbers"
         required: false
       dry-run:
-        description: 'Run in dry-run mode (true = no writes)'
+        description: "Run in dry-run mode (true = no writes)"
         type: boolean
         required: false
         default: true
@@ -48,9 +48,8 @@ jobs:
           prompt-path: .github/AutoTriage.prompt
           dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
           model-fast: gemini-2.5-flash
-          max-fast-runs: 20 # keep it low so we don't keep checking the same issues (for staleness, etc)
-          model-pro: gemini-3-flash-preview # use a cheaper model since we've already scanned the issues before
-          max-pro-runs: 20
+          max-fast-runs: 20
+          model-pro: gemini-3-flash-preview
           db-path: triage-db.json
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -47,6 +47,7 @@ jobs:
           issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt
           context-caching: true
+          extended: true
           dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
           model-fast: gemini-2.5-flash
           max-fast-runs: 20

--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -8,10 +8,11 @@ on:
       issues:
         description: 'Space-separated issue numbers'
         required: false
-      enabled:
-        description: 'Enable writes (false = dry-run)'
+      dry-run:
+        description: 'Run in dry-run mode (true = no writes)'
         type: boolean
         required: false
+        default: true
 
 concurrency:
   group: autotriage-backlog
@@ -41,17 +42,15 @@ jobs:
             ${{ runner.os }}-triage-db-
 
       - name: AutoTriage - triage backlog
-        uses: danielchalmers/AutoTriage@v2
+        uses: danielchalmers/AutoTriage@v3
         with:
-          issue-numbers: ${{ github.event.inputs.issues }}
+          issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt
-          enabled: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.enabled) }}
+          dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
           model-fast: gemini-2.5-flash
-          model-fast-temperature: 0.0
           max-fast-runs: 20 # keep it low so we don't keep checking the same issues (for staleness, etc)
           model-pro: gemini-3-flash-preview # use a cheaper model since we've already scanned the issues before
-          model-pro-temperature: 1.0
-          max-triages: 20
+          max-pro-runs: 20
           db-path: triage-db.json
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt
+          context-caching: true
           dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
           model-fast: gemini-2.5-flash
           max-fast-runs: 20

--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -7,12 +7,38 @@ on:
     inputs:
       issues:
         description: "Space-separated issue numbers"
+        type: string
         required: false
       dry-run:
         description: "Run in dry-run mode (true = no writes)"
         type: boolean
         required: false
         default: true
+      max-fast-runs:
+        description: "Max number of runs"
+        type: number
+        required: false
+        default: 20
+      context-caching:
+        description: "Enable context caching"
+        type: boolean
+        required: false
+        default: true
+      extended:
+        description: "Enable extended analysis"
+        type: boolean
+        required: false
+        default: true
+      model-fast:
+        description: "Fast model"
+        type: string
+        required: false
+        default: gemini-2.5-flash
+      model-pro:
+        description: "Pro model"
+        type: string
+        required: false
+        default: gemini-3-flash-preview
 
 concurrency:
   group: autotriage-backlog
@@ -46,12 +72,12 @@ jobs:
         with:
           issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt
-          context-caching: true
-          extended: true
           dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
-          model-fast: gemini-2.5-flash
-          max-fast-runs: 20
-          model-pro: gemini-3-flash-preview
+          max-fast-runs: ${{ github.event_name == 'workflow_dispatch' && inputs['max-fast-runs'] || 20 }}
+          context-caching: ${{ github.event_name == 'workflow_dispatch' && inputs['context-caching'] || true }}
+          extended: ${{ github.event_name == 'workflow_dispatch' && inputs['extended'] || true }}
+          model-fast: ${{ github.event_name == 'workflow_dispatch' && inputs['model-fast'] || 'gemini-2.5-flash' }}
+          model-pro: ${{ github.event_name == 'workflow_dispatch' && inputs['model-pro'] || 'gemini-3-flash-preview' }}
           db-path: triage-db.json
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/autotriage-issues.yml
+++ b/.github/workflows/autotriage-issues.yml
@@ -19,13 +19,12 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: AutoTriage - triage issue
-        uses: danielchalmers/AutoTriage@v2
+        uses: danielchalmers/AutoTriage@v3
         with:
-          issue-number: ${{ github.event.issue.number }}
+          issues: ${{ github.event.issue.number }}
           prompt-path: .github/AutoTriage.prompt
           model-fast: '' # skip fast pass
           model-pro: gemini-3.1-pro-preview
-          model-pro-temperature: 1.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/autotriage-issues.yml
+++ b/.github/workflows/autotriage-issues.yml
@@ -17,13 +17,13 @@ jobs:
           private-key: ${{ secrets.MUDBOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
-      
+
       - name: AutoTriage - triage issue
         uses: danielchalmers/AutoTriage@v3
         with:
           issues: ${{ github.event.issue.number }}
           prompt-path: .github/AutoTriage.prompt
-          model-fast: '' # skip fast pass
+          model-fast: "" # skip fast pass
           model-pro: gemini-3.1-pro-preview
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/autotriage-prs.yml
+++ b/.github/workflows/autotriage-prs.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           issues: ${{ github.event.pull_request.number }}
           prompt-path: .github/AutoTriage.prompt
-          model-fast: '' # skip fast pass
+          model-fast: "" # skip fast pass
           model-pro: gemini-3.1-pro-preview
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/autotriage-prs.yml
+++ b/.github/workflows/autotriage-prs.yml
@@ -19,13 +19,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: AutoTriage - triage pull request
-        uses: danielchalmers/AutoTriage@v2
+        uses: danielchalmers/AutoTriage@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issues: ${{ github.event.pull_request.number }}
           prompt-path: .github/AutoTriage.prompt
           model-fast: '' # skip fast pass
           model-pro: gemini-3.1-pro-preview
-          model-pro-temperature: 1.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Upgrade all AutoTriage workflows to `danielchalmers/AutoTriage@v3` and migrate deprecated v2 inputs to v3 equivalents.

**Changes:**
- Updated AutoTriage action version:
  - `.github/workflows/autotriage-prs.yml`
  - `.github/workflows/autotriage-issues.yml`
  - `.github/workflows/autotriage-backlog.yml`
- Migrated input names:
  - `issue-number` / `issue-numbers` -> `issues`
  - `max-triages` -> `max-pro-runs`
  - `enabled` -> `dry-run` (inverted behavior)
- Removed explicit temperature inputs now handled by v3:
  - `model-fast-temperature`
  - `model-pro-temperature`
- Updated backlog manual-dispatch input:
  - Replaced `enabled` with `dry-run` (default: `true`)
  - Updated `issues` description to comma-separated values

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
