### PR TITLE
MudSplitPanel: Fix overlay not being clickthrough and add SecondPanelInitialSize

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/SplitPanel/Examples/SplitPanelOverlayExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/SplitPanel/Examples/SplitPanelOverlayExample.razor
@@ -3,7 +3,7 @@
 <MudPaper Class="mud-width-full mud-height-full relative">
     <MudSplitPanel Class="mud-height-full"
                    UseAsOverlay="true"
-                   Elevation="8"
+                   Elevation="4"
                    FirstPanelInitialSize="150"
                    MinPanelSize="150"
                    Padding="4"

--- a/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
@@ -52,6 +52,7 @@ public class SplitPanelTests : BunitTest
         Context.Render<SplitPanelTest>();
         var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel.build");
         invocation.Arguments.Count.Should().Be(7);
+        invocation.Arguments[5].Should().BeNull();
 
         await Context.DisposeComponentsAsync();
         invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_destroy");

--- a/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
@@ -51,7 +51,7 @@ public class SplitPanelTests : BunitTest
     {
         Context.Render<SplitPanelTest>();
         var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel.build");
-        invocation.Arguments.Count.Should().Be(6);
+        invocation.Arguments.Count.Should().Be(7);
 
         await Context.DisposeComponentsAsync();
         invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_destroy");

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -112,6 +112,16 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     public int? FirstPanelInitialSize { get; set; }
 
     /// <summary>
+    /// Sets the initial height or width of the second panel in pixels.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// If both <see cref="FirstPanelInitialSize"/> and <see cref="SecondPanelInitialSize"/> are set, only <see cref="FirstPanelInitialSize"/> will be used.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.SplitPanel.Behavior)]
+    public int? SecondPanelInitialSize { get; set; }
+
+    /// <summary>
     /// The height and width in pixel each panel can't be made smaller than.
     /// </summary>
     /// <remarks>
@@ -148,10 +158,10 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     public bool ResetOnDoubleClick { get; set; } = true;
 
     /// <summary>
-    /// Makes the panels backgrounds transparent.
+    /// Makes the panels backgrounds transparent and click through.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>false</c>.
+    /// Defaults to <c>false</c>. Transparency is automatically applied to panels without any contents.
     /// </remarks>
     [Parameter, Category(CategoryTypes.SplitPanel.Appearance)]
     public bool Transparent { get; set; }
@@ -185,7 +195,7 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
 
         if (firstRender)
         {
-            await JsRuntime.InvokeVoidAsync("mudSplitPanel.build", _containerId, Horizontal, ResetOnDoubleClick, MinPanelSize, FirstPanelInitialSize, PanelGap);
+            await JsRuntime.InvokeVoidAsync("mudSplitPanel.build", _containerId, Horizontal, ResetOnDoubleClick, MinPanelSize, FirstPanelInitialSize, SecondPanelInitialSize, PanelGap);
         }
     }
 

--- a/src/MudBlazor/Styles/components/_splitpanel.scss
+++ b/src/MudBlazor/Styles/components/_splitpanel.scss
@@ -1,5 +1,6 @@
 .mud-split-panel {
   display: flex;
+  pointer-events: none;
 
   &.absolute {
     position: absolute;
@@ -14,9 +15,11 @@
     flex: 1 1 auto;
     overflow: hidden;
     background-color: var(--mud-palette-surface);
+    pointer-events: auto;
 
     &.transparent {
       background: transparent;
+      pointer-events: none;
     }
   }
 
@@ -24,6 +27,7 @@
     cursor: ew-resize;
     position: relative;
     outline: none;
+    pointer-events: auto;
 
     &.horizontal {
       cursor: n-resize;

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -113,7 +113,9 @@ class MudSplitPanel {
         if (firstPanelSizeNew === null) {
             this.divider.ariaValueNow = "50";
         } else {
-            this._setPanelSizes(firstPanelSizeNew, containerSize);
+            const maxPanelSize = containerSize - this.panelGap - this.minPanelSize;
+            const clampedFirstPanelSize = Math.min(Math.max(firstPanelSizeNew, this.minPanelSize), maxPanelSize);
+            this._setPanelSizes(clampedFirstPanelSize, containerSize);
         }
     }
 
@@ -216,10 +218,10 @@ class MudSplitPanel {
             : this.container.offsetWidth;
 
         let firstPanelSize = this.firstPanelInitialSize;
-        if (!firstPanelSize && this.secondPanelInitialSize) {
+        if (firstPanelSize === null && this.secondPanelInitialSize !== null) {
             firstPanelSize = containerSize - this.secondPanelInitialSize - this.panelGap;
         }
-        if (!firstPanelSize) {
+        if (firstPanelSize === null) {
             firstPanelSize = containerSize / 2 - this.panelGap / 2;
         }
 

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -11,11 +11,11 @@ class MudSplitPanel {
     /**
      * Creates and stores a split panel runtime instance for a container ID.
      */
-    static build(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap) {
-        window.splitPanels[containerId] = new MudSplitPanel(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap);
+    static build(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, secondPanelInitialSize, panelGap) {
+        window.splitPanels[containerId] = new MudSplitPanel(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, secondPanelInitialSize, panelGap);
     }
 
-    constructor(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, panelGap) {
+    constructor(containerId, horizontal, resetOnDoubleClick, minPanelSize, firstPanelInitialSize, secondPanelInitialSize, panelGap) {
         this.container = document.getElementById(containerId);
         if (!this.container) {
             console.warn(`MudSplitPanel: Container with id '${containerId}' not found.`);
@@ -39,6 +39,7 @@ class MudSplitPanel {
         this.lastTap = 0;
         this.lastDragEndDate = 0;
         this.firstPanelInitialSize = firstPanelInitialSize;
+        this.secondPanelInitialSize = secondPanelInitialSize;
         this.keyboardStep = 10;
 
         this._onMouseDown = this._onMouseDown.bind(this);
@@ -103,11 +104,16 @@ class MudSplitPanel {
         this.firstPanel.style.height = "100%";
         this.secondPanel.style.height = "100%";
 
-        const firstPanelSizeNew = firstPanelSize !== null ? firstPanelSize : this.firstPanelInitialSize;
+        const containerSize = this._getContainerSize();
+        let firstPanelSizeNew = firstPanelSize !== null ? firstPanelSize : this.firstPanelInitialSize;
+        if (firstPanelSizeNew === null && this.secondPanelInitialSize !== null) {
+            firstPanelSizeNew = containerSize - this.secondPanelInitialSize - this.panelGap;
+        }
+
         if (firstPanelSizeNew === null) {
             this.divider.ariaValueNow = "50";
         } else {
-            this._setPanelSizes(firstPanelSizeNew, this._getContainerSize());
+            this._setPanelSizes(firstPanelSizeNew, containerSize);
         }
     }
 
@@ -210,6 +216,9 @@ class MudSplitPanel {
             : this.container.offsetWidth;
 
         let firstPanelSize = this.firstPanelInitialSize;
+        if (!firstPanelSize && this.secondPanelInitialSize) {
+            firstPanelSize = containerSize - this.secondPanelInitialSize - this.panelGap;
+        }
         if (!firstPanelSize) {
             firstPanelSize = containerSize / 2 - this.panelGap / 2;
         }


### PR DESCRIPTION
This PR:
- Fixes the overlay not beeing clickthrough
- Fixes a transparent panel not not beeing clickthrough
- Adds a needed `SecondPanelInitialSize` property, which is required to be able to fully use the second i.e. right or lower panel