### PR TITLE
Docs: Parse markdown for Contribution & Release pages

### DIFF
--- a/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
+++ b/src/MudBlazor.Docs.Server/Pages/_Layout.cshtml
@@ -53,6 +53,7 @@
                                https://discord.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
+                               https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/CONTRIBUTING.md
                                https://*.google-analytics.com
                                http://localhost:*
                                wss://localhost:*

--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -50,6 +50,7 @@
                                https://discord.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
+                               https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/CONTRIBUTING.md
                                https://*.google-analytics.com
                                http://localhost:*
                                wss://localhost:*

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -59,6 +59,7 @@
                                https://discord.com
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/master/LICENSE
                                https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md
+                               https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/CONTRIBUTING.md
                                https://*.google-analytics.com
                                http://localhost:*
                                wss://localhost:*

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -62,6 +62,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
+    <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="NetEscapades.EnumGenerators.Generators" Version="1.0.0-beta20" PrivateAssets="all" />
   </ItemGroup>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
-    <PackageReference Include="Markdig" Version="0.37.0" />
+    <PackageReference Include="Markdig" Version="1.0.1" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="NetEscapades.EnumGenerators.Generators" Version="1.0.0-beta20" PrivateAssets="all" />
   </ItemGroup>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample4.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample4.razor
@@ -1,4 +1,5 @@
-﻿@namespace MudBlazor.Docs.Examples
+﻿@using MudBlazor.Utilities
+@namespace MudBlazor.Docs.Examples
 
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 
@@ -71,7 +72,7 @@
             <MudHeatMapCell Row="5" Column="0">
                 NO
             </MudHeatMapCell>
-            <MudHeatMapCell Row="6" Column="0" MudColor="@(new Utilities.MudColor("#FF5733"))" />
+            <MudHeatMapCell Row="6" Column="0" MudColor="@(new MudColor("#FF5733"))" />
         </MudChart>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample6.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample6.razor
@@ -1,4 +1,5 @@
-﻿@namespace MudBlazor.Docs.Examples
+﻿@using MudBlazor.Utilities
+@namespace MudBlazor.Docs.Examples
 
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 
@@ -15,7 +16,7 @@
         <MudHeatMapCell Row="0" Column="2" Value="1">
             <MudIcon Icon="material-symbols-outlined/foggy" Color="Color.Secondary" />
         </MudHeatMapCell>
-        <MudHeatMapCell Row="0" Column="3" Value="1" Width="24" MudColor="@(new Utilities.MudColor("#FF5733"))">
+        <MudHeatMapCell Row="0" Column="3" Value="1" Width="24" MudColor="@(new MudColor("#FF5733"))">
             <MudIcon Icon="@Icons.Material.Outlined.Thunderstorm" Color="Color.Dark" />
         </MudHeatMapCell>
         <MudHeatMapCell Row="0" Column="4" Value="1">

--- a/src/MudBlazor.Docs/Pages/Mud/Community/Contribution.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Community/Contribution.razor
@@ -12,7 +12,7 @@
         }
         else
         {
-            <MudStack Spacing="2" Class="mud-typography mud-typography-body1">
+            <MudStack Spacing="2" Class="mud-typography mud-typography-body1 docs-contribution-markdown">
                 @((MarkupString)GetBody(_contribution))
             </MudStack>
         }
@@ -36,7 +36,10 @@
 
     private string GetBody(string value)
     {
-        var html = MarkdownToHtml.Parse(value, new Uri(NavigationManager.Uri, UriKind.RelativeOrAbsolute));
+        var html = MarkdownToHtml.Parse(
+            value,
+            new Uri(NavigationManager.Uri, UriKind.RelativeOrAbsolute),
+            MarkdownToHtml.RenderMode.ContributionPageRender);
 
         return html;
     }

--- a/src/MudBlazor.Docs/Pages/Mud/Community/Contribution.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Community/Contribution.razor
@@ -1,33 +1,43 @@
 ﻿@page "/mud/community/contribution"
+@using MudBlazor.Docs.Utilities
+
+<PageTitle>Contribution - MudBlazor</PageTitle>
 
 <DocsPage DisplayFooter="true">
-    <DocsPageHeader Title="Contribution" SubTitle="" />
+    <DocsPageHeader Title="Contribution" />
     <DocsPageContent>
-        
-        <DocsPageSection>
-            <SectionHeader Title="Page under construction">
-                <Description>
-                    This page is under construction, for now check our guidelines for contributing on <MudLink Href="https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md" Target="_blank">GitHub.</MudLink>
-                </Description>
-            </SectionHeader>
-        </DocsPageSection>
-        
-
-        @*<DocsPageSection>
-            <SectionHeader Title="Help others">
-                <Description>
-
-                </Description>
-            </SectionHeader>
-        </DocsPageSection>*@
-
-        @*<DocsPageSection>
-            <SectionHeader Title="Fixing a bug">
-                <Description>
-
-                </Description>
-            </SectionHeader>
-        </DocsPageSection>*@
-
+        @if (string.IsNullOrEmpty(_contribution))
+        {
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        }
+        else
+        {
+            <MudStack Spacing="2" Class="mud-typography mud-typography-body1">
+                @((MarkupString)GetBody(_contribution))
+            </MudStack>
+        }
     </DocsPageContent>
 </DocsPage>
+
+@code {
+    private string _contribution;
+
+    [Inject]
+    private HttpClient HttpClient { get; set; }
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/CONTRIBUTING.md");
+        _contribution = await response.Content.ReadAsStringAsync();
+    }
+
+    private string GetBody(string value)
+    {
+        var html = MarkdownToHtml.Parse(value, new Uri(NavigationManager.Uri, UriKind.RelativeOrAbsolute));
+
+        return html;
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Releases.razor
@@ -1,5 +1,6 @@
 ﻿@page "/mud/project/releases"
 @using System.Text.RegularExpressions
+@using MudBlazor.Docs.Utilities
 
 @inject GitHubApiClient _gitHubApiClient;
 
@@ -28,7 +29,7 @@
                             @if (release.PublishedAt > _oldReleases)
                             {
                                 <div class="docs-github-release-body">
-                                    @((MarkupString)GetBody(release.Body))
+                                    @((MarkupString)NewBody(release.Body))
                                 </div>
                             }
                             else
@@ -48,10 +49,20 @@
     private GitHubReleases[] _githubReleases;
     private readonly DateTime _oldReleases = DateTime.Parse("2022-11-09");
 
+    [Inject]
+    private NavigationManager NavigationManager { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         _githubReleases = await _gitHubApiClient.GetReleasesAsync();
         StateHasChanged();
+    }
+
+    private string NewBody(string value)
+    {
+        var html = MarkdownToHtml.Parse(value, new Uri(NavigationManager.Uri, UriKind.RelativeOrAbsolute), MarkdownToHtml.RenderMode.ReleasePageRender);
+
+        return html;
     }
 
     private static string GetBody(string value)

--- a/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
+++ b/src/MudBlazor.Docs/Pages/Mud/Project/Roadmap.razor
@@ -1,5 +1,5 @@
 ﻿@page "/mud/project/roadmap"
-@using System.Text.RegularExpressions
+@using MudBlazor.Docs.Utilities
 
 <PageTitle>Roadmap - MudBlazor</PageTitle>
 
@@ -25,20 +25,19 @@
     [Inject]
     private HttpClient HttpClient { get; set; }
 
+    [Inject]
+    private NavigationManager NavigationManager { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         var response = await HttpClient.GetAsync("https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/ROADMAP.md");
         _roadMap = await response.Content.ReadAsStringAsync();
     }
 
-    private static string GetBody(string value)
+    private string GetBody(string value)
     {
-        // Wrap paragraphs in <p> tags before titles are converted to HTML headers
-        value = Regex.Replace(value, @"(^|\n\n)(?!#)([^\n]+(\n(?!#)[^\n]+)*)", "$1<p>$2</p>", RegexOptions.Multiline);
-        value = Regex.Replace(value, @"(##\s)(?<title>.+)", "<h5 class=\"mud-typography mud-typography-h5 mt-3\"><b>${title}</b></h5><hr class=\"mud-divider mud-divider-fullwidth\">");
-        value = Regex.Replace(value, @"(#\s)(?<title>.+)", "<h4 class=\"mud-typography mud-typography-h4\"><b>${title}</b></h4><hr class=\"mud-divider mud-divider-fullwidth\">");
-        value = Regex.Replace(value, @"\[(.*?)\]\((.*?)\)", "<a target=\"_blank\" href=\"$2\" class=\"mud-link mud-primary-text mud-link-underline-hover\">$1</a>");
+        var html = MarkdownToHtml.Parse(value, new Uri(NavigationManager.Uri, UriKind.RelativeOrAbsolute));
 
-        return value;
+        return html;
     }
 }

--- a/src/MudBlazor.Docs/Styles/MudBlazorDocs.scss
+++ b/src/MudBlazor.Docs/Styles/MudBlazorDocs.scss
@@ -10,6 +10,7 @@
 @import 'pages/_roadmap';
 @import 'pages/_overview';
 @import 'pages/_announcement';
+@import 'pages/_contribution';
 @import 'pages/_extensions.scss';
 
 @import 'components/_docspage';

--- a/src/MudBlazor.Docs/Styles/pages/_contribution.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_contribution.scss
@@ -1,0 +1,50 @@
+.docs-contribution-markdown {
+  ul {
+    list-style: disc;
+    padding-inline-start: 24px;
+    margin: 0 0 12px;
+  }
+
+  ol {
+    list-style: decimal;
+    padding-inline-start: 24px;
+    margin: 0 0 12px;
+  }
+
+  li {
+    margin: 4px 0;
+  }
+
+  pre {
+    margin: 12px 0 20px;
+    padding: 16px;
+    overflow: auto;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background-color: var(--mud-palette-background-grey);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  pre code {
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    color: inherit;
+    font-size: inherit;
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  }
+
+  :not(pre) > code {
+    display: inline-block;
+    padding: 0 5px;
+    direction: ltr;
+    font-size: 0.85em;
+    font-weight: 900;
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    line-height: 1.4;
+    border-radius: 2px;
+    color: var(--mud-palette-primary);
+    background-color: var(--mud-palette-primary-hover);
+  }
+}

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -33,6 +33,44 @@
         border-radius: var(--mud-default-borderradius);
         background-color: var(--mud-palette-background-grey);
       }
+
+      .docs-release-callout {
+        margin: 0 0 16px;
+        padding: 12px 16px;
+        border: 1px solid var(--mud-palette-lines-default);
+        border-left-width: 4px;
+        border-radius: var(--mud-default-borderradius);
+        background-color: var(--mud-palette-background-grey);
+
+        p {
+          margin: 0;
+        }
+      }
+
+      .docs-release-callout-title {
+        font-weight: var(--mud-typography-subtitle2-weight);
+        margin-bottom: 6px;
+      }
+
+      .docs-release-callout-note {
+        border-left-color: var(--mud-palette-info);
+      }
+
+      .docs-release-callout-tip {
+        border-left-color: var(--mud-palette-success);
+      }
+
+      .docs-release-callout-important {
+        border-left-color: var(--mud-palette-primary);
+      }
+
+      .docs-release-callout-warning {
+        border-left-color: var(--mud-palette-warning);
+      }
+
+      .docs-release-callout-caution {
+        border-left-color: var(--mud-palette-error);
+      }
     }
 
     h5 {

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -66,41 +66,57 @@
         line-height: 1.5;
       }
 
-      .docs-release-callout {
+      .markdown-alert,
+      .alert,
+      blockquote.alert {
         margin: 0 0 16px;
         padding: 12px 16px;
         border: 1px solid var(--mud-palette-lines-default);
         border-left-width: 4px;
         border-radius: var(--mud-default-borderradius);
         background-color: var(--mud-palette-background-grey);
-
-        p {
-          margin: 0;
-        }
       }
 
-      .docs-release-callout-title {
+      .markdown-alert p,
+      .alert p,
+      blockquote.alert p {
+        margin: 0;
+      }
+
+      .markdown-alert-title,
+      .alert-title,
+      blockquote.alert > p:first-child {
         font-weight: var(--mud-typography-subtitle2-weight);
         margin-bottom: 6px;
       }
 
-      .docs-release-callout-note {
+      .markdown-alert-note,
+      .alert-note,
+      blockquote.alert.alert-note {
         border-left-color: var(--mud-palette-info);
       }
 
-      .docs-release-callout-tip {
+      .markdown-alert-tip,
+      .alert-tip,
+      blockquote.alert.alert-tip {
         border-left-color: var(--mud-palette-success);
       }
 
-      .docs-release-callout-important {
+      .markdown-alert-important,
+      .alert-important,
+      blockquote.alert.alert-important {
         border-left-color: var(--mud-palette-primary);
       }
 
-      .docs-release-callout-warning {
+      .markdown-alert-warning,
+      .alert-warning,
+      blockquote.alert.alert-warning {
         border-left-color: var(--mud-palette-warning);
       }
 
-      .docs-release-callout-caution {
+      .markdown-alert-caution,
+      .alert-caution,
+      blockquote.alert.alert-caution {
         border-left-color: var(--mud-palette-error);
       }
     }

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -17,6 +17,24 @@
       }
     }
 
+    &:not(.old-releases) {
+      h6 {
+        margin-top: 24px;
+      }
+
+      p {
+        margin: 0 0 16px;
+        font-size: var(--mud-typography-body1-size);
+      }
+
+      .release-full-changelog {
+        padding: 12px 16px;
+        border: 1px solid var(--mud-palette-lines-default);
+        border-radius: var(--mud-default-borderradius);
+        background-color: var(--mud-palette-background-grey);
+      }
+    }
+
     h5 {
       &:first-child {
         padding: 12px 0;
@@ -31,11 +49,23 @@
     ul {
       list-style: disc;
       font-size: var(--mud-typography-body1-size);
+
+      li {
+        margin-bottom: 6px;
+      }
+
+      li:last-child {
+        margin-bottom: 0;
+      }
     }
 
     .github-user {
       font-weight: 700;
       color: var(--mud-palette-text-primary);
+    }
+
+    a {
+      overflow-wrap: anywhere;
     }
   }
 }

--- a/src/MudBlazor.Docs/Styles/pages/_releases.scss
+++ b/src/MudBlazor.Docs/Styles/pages/_releases.scss
@@ -34,6 +34,38 @@
         background-color: var(--mud-palette-background-grey);
       }
 
+      :not(pre) > code {
+        display: inline-block;
+        padding: 0 5px;
+        direction: ltr;
+        font-size: 0.85em;
+        font-weight: 900;
+        font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+        line-height: 1.4;
+        border-radius: 2px;
+        color: var(--mud-palette-primary);
+        background-color: var(--mud-palette-primary-hover);
+      }
+
+      pre {
+        margin: 12px 0 20px;
+        padding: 16px;
+        overflow: auto;
+        border: 1px solid var(--mud-palette-lines-default);
+        border-radius: var(--mud-default-borderradius);
+        background-color: var(--mud-palette-background-grey);
+      }
+
+      pre code {
+        padding: 0;
+        border: none;
+        background-color: transparent;
+        color: var(--mud-palette-text-primary);
+        font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+        font-size: 0.9rem;
+        line-height: 1.5;
+      }
+
       .docs-release-callout {
         margin: 0 0 16px;
         padding: 12px 16px;

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -95,9 +95,27 @@ public partial class MarkdownToHtml
 
     private static string PostProcessReleaseHtml(string html)
     {
+        html = ReleaseCalloutRegex().Replace(html, ReleaseCalloutReplacer);
         return FullChangelogParagraphRegex().Replace(
             html,
             "<p class=\"release-full-changelog\"><strong>Full Changelog</strong>:");
+    }
+
+    private static string ReleaseCalloutReplacer(Match match)
+    {
+        var type = match.Groups["type"].Value.ToLowerInvariant();
+        var content = match.Groups["content"].Value.Trim();
+        var title = type switch
+        {
+            "note" => "Note",
+            "tip" => "Tip",
+            "important" => "Important",
+            "warning" => "Warning",
+            "caution" => "Caution",
+            _ => "Note"
+        };
+
+        return $"<div class=\"docs-release-callout docs-release-callout-{type}\"><p class=\"docs-release-callout-title\">{title}</p><p>{content}</p></div>";
     }
 
     private static string PreprocessContributionMarkdown(string markdownBody)
@@ -352,6 +370,9 @@ public partial class MarkdownToHtml
 
     [GeneratedRegex(@"<p>\s*<strong>Full Changelog</strong>\s*:", RegexOptions.CultureInvariant)]
     private static partial Regex FullChangelogParagraphRegex();
+
+    [GeneratedRegex(@"<blockquote>\s*<p>\s*\[!(?<type>NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(?<content>[\s\S]*?)</p>\s*</blockquote>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ReleaseCalloutRegex();
 
     [GeneratedRegex(@"^https://github\.com/[A-Za-z0-9-]+/?$", RegexOptions.CultureInvariant)]
     private static partial Regex GitHubUserUrlRegex();

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -19,6 +19,27 @@ public partial class MarkdownToHtml
     private const string GitHubBlobDevBaseUrl = "https://github.com/MudBlazor/MudBlazor/blob/dev/";
     private const string GitHubRawDevBaseUrl = "https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/";
 
+    private static readonly RenderProfile _defaultProfile = new(
+        static value => value,
+        null,
+        new HeadingRenderOptions(true, true, true, true),
+        new ListRenderOptions(null),
+        new LinkRenderOptions(true, true));
+
+    private static readonly RenderProfile _releaseProfile = new(
+        PreprocessReleaseMarkdown,
+        PostProcessReleaseHtml,
+        new HeadingRenderOptions(false, false, false, false),
+        new ListRenderOptions("mt-3 mb-6 px-6"),
+        new LinkRenderOptions(true, true));
+
+    private static readonly RenderProfile _contributionProfile = new(
+        PreprocessContributionMarkdown,
+        null,
+        new HeadingRenderOptions(true, true, true, true),
+        new ListRenderOptions(null),
+        new LinkRenderOptions(true, true));
+
     public enum RenderMode
     {
         Default = 0,
@@ -30,12 +51,8 @@ public partial class MarkdownToHtml
     {
         ArgumentNullException.ThrowIfNull(markdownBody);
 
-        var body = renderMode switch
-        {
-            RenderMode.ReleasePageRender => PreprocessReleaseMarkdown(markdownBody),
-            RenderMode.ContributionPageRender => PreprocessContributionMarkdown(markdownBody),
-            _ => markdownBody
-        };
+        var profile = GetProfile(renderMode);
+        var body = profile.PreprocessMarkdown(markdownBody);
 
         var pipeline = new MarkdownPipelineBuilder()
             .UseAutoIdentifiers()
@@ -43,17 +60,27 @@ public partial class MarkdownToHtml
         var builder = new StringBuilder();
         using var textWriter = new StringWriter(builder);
         var renderer = new HtmlRenderer(textWriter) { BaseUrl = baseUrl };
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<HeadingBlock>>(new MudHeadingRenderer(renderMode));
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<LinkInline>>(new MudLinkRenderer());
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListBlock>>(new MudListRenderer(renderMode));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<HeadingBlock>>(new MudHeadingRenderer(profile.HeadingOptions));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<LinkInline>>(new MudLinkRenderer(profile.LinkOptions));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListBlock>>(new MudListRenderer(profile.ListOptions));
 
         var document = Markdown.Parse(body, pipeline);
         renderer.Render(document);
 
         var html = builder.ToString();
-        return renderMode == RenderMode.ReleasePageRender
-            ? PostProcessReleaseHtml(html)
-            : html;
+        return profile.PostprocessHtml is null
+            ? html
+            : profile.PostprocessHtml(html);
+    }
+
+    private static RenderProfile GetProfile(RenderMode renderMode)
+    {
+        return renderMode switch
+        {
+            RenderMode.ReleasePageRender => _releaseProfile,
+            RenderMode.ContributionPageRender => _contributionProfile,
+            _ => _defaultProfile
+        };
     }
 
     private static string PreprocessReleaseMarkdown(string markdownBody)
@@ -77,7 +104,7 @@ public partial class MarkdownToHtml
     {
         var body = ContributionImageSourceRegex().Replace(markdownBody, "$1=\"" + GitHubRawDevBaseUrl + "$2\"");
         body = ContributionImageSourceSetRegex().Replace(body, "$1=\"" + GitHubRawDevBaseUrl + "$2\"");
-        body = ContributionTocBlockRegex().Replace(body, match =>
+        body = ContributionTocBlockRegex().Replace(body, static match =>
         {
             var tocContent = match.Groups["toc"].Value.Trim();
             return $"## Table of Contents{Environment.NewLine}{Environment.NewLine}{tocContent}{Environment.NewLine}{Environment.NewLine}";
@@ -130,31 +157,31 @@ public partial class MarkdownToHtml
         return extensionEndIndex == url.Length || url[extensionEndIndex] == '#';
     }
 
-    public class MudListRenderer : HtmlObjectRenderer<ListBlock>
+    private class MudListRenderer : HtmlObjectRenderer<ListBlock>
     {
-        private readonly RenderMode _renderMode;
+        private readonly ListRenderOptions _options;
 
-        public MudListRenderer(RenderMode renderMode)
+        public MudListRenderer(ListRenderOptions options)
         {
-            _renderMode = renderMode;
+            _options = options;
         }
 
         protected override void Write(HtmlRenderer renderer, ListBlock obj)
         {
             var listRenderer = new ListRenderer();
-            if (_renderMode == RenderMode.ReleasePageRender)
+            if (!string.IsNullOrWhiteSpace(_options.AdditionalCssClass))
             {
                 var attributes = obj.GetAttributes();
-                attributes.AddClass("mt-3 mb-6 px-6");
+                attributes.AddClass(_options.AdditionalCssClass);
             }
 
             listRenderer.Write(renderer, obj);
         }
     }
 
-    public class MudHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
+    private class MudHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
     {
-        private readonly RenderMode _renderMode;
+        private readonly HeadingRenderOptions _options;
         private readonly Dictionary<int, string> _heading = new()
         {
             { 1, "h4" },
@@ -165,35 +192,44 @@ public partial class MarkdownToHtml
             { 6, "h6" }
         };
 
-        public MudHeadingRenderer(RenderMode renderMode)
+        public MudHeadingRenderer(HeadingRenderOptions options)
         {
-            _renderMode = renderMode;
+            _options = options;
         }
 
         protected override void Write(HtmlRenderer renderer, HeadingBlock obj)
         {
             renderer.EnsureLine();
+
             var heading = _heading[obj.Level];
             var headingId = obj.GetAttributes().Id;
+            var className = _options.IncludeTopMargin
+                ? $"mud-typography mud-typography-{heading} mt-3"
+                : $"mud-typography mud-typography-{heading}";
 
-            if (_renderMode == RenderMode.ReleasePageRender)
+            if (_options.IncludeIds && !string.IsNullOrWhiteSpace(headingId))
             {
-                renderer.Write($"<{heading} class=\"mud-typography mud-typography-{heading}\">");
+                renderer.Write($"<{heading} id=\"{headingId}\" class=\"{className}\">");
             }
             else
             {
-                renderer.Write($"<{heading} id=\"{headingId}\" class=\"mud-typography mud-typography-{heading} mt-3\">");
+                renderer.Write($"<{heading} class=\"{className}\">");
+            }
+
+            if (_options.BoldText)
+            {
                 renderer.Write("<b>");
             }
 
             renderer.WriteLeafInline(obj);
-            if (_renderMode != RenderMode.ReleasePageRender)
+
+            if (_options.BoldText)
             {
                 renderer.Write("</b>");
             }
 
             renderer.Write($"</{heading}>");
-            if (obj.Level < 3 && _renderMode != RenderMode.ReleasePageRender)
+            if (_options.DividerForTopHeadings && obj.Level < 3)
             {
                 renderer.Write("<hr class=\"mud-divider mud-divider-fullwidth\">");
             }
@@ -202,8 +238,15 @@ public partial class MarkdownToHtml
         }
     }
 
-    public class MudLinkRenderer : HtmlObjectRenderer<LinkInline>
+    private class MudLinkRenderer : HtmlObjectRenderer<LinkInline>
     {
+        private readonly LinkRenderOptions _options;
+
+        public MudLinkRenderer(LinkRenderOptions options)
+        {
+            _options = options;
+        }
+
         protected override void Write(HtmlRenderer renderer, LinkInline obj)
         {
             if (obj.IsImage)
@@ -214,7 +257,7 @@ public partial class MarkdownToHtml
 
             var defaultRenderer = new LinkInlineRenderer();
             var attributes = obj.GetAttributes();
-            if (IsGitHubUserLink(obj))
+            if (_options.HighlightGitHubMentions && IsGitHubUserLink(obj))
             {
                 attributes.AddClass("mud-link mud-default-text mud-link-underline-hover github-user");
             }
@@ -223,7 +266,7 @@ public partial class MarkdownToHtml
                 attributes.AddClass("mud-link mud-primary-text mud-link-underline-hover");
             }
 
-            if (IsCompareLink(obj.Url))
+            if (_options.HighlightCompareLinks && IsCompareLink(obj.Url))
             {
                 attributes.AddClass("docs-code docs-code-primary");
             }
@@ -281,6 +324,19 @@ public partial class MarkdownToHtml
             return text.ToString();
         }
     }
+
+    private sealed record RenderProfile(
+        Func<string, string> PreprocessMarkdown,
+        Func<string, string>? PostprocessHtml,
+        HeadingRenderOptions HeadingOptions,
+        ListRenderOptions ListOptions,
+        LinkRenderOptions LinkOptions);
+
+    private sealed record HeadingRenderOptions(bool IncludeIds, bool IncludeTopMargin, bool BoldText, bool DividerForTopHeadings);
+
+    private sealed record ListRenderOptions(string? AdditionalCssClass);
+
+    private sealed record LinkRenderOptions(bool HighlightGitHubMentions, bool HighlightCompareLinks);
 
     [GeneratedRegex(@"^\s*<!--.*?-->\s*", RegexOptions.Singleline)]
     private static partial Regex LeadingReleaseCommentRegex();

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -19,29 +19,18 @@ public partial class MarkdownToHtml
     private const string GitHubBlobDevBaseUrl = "https://github.com/MudBlazor/MudBlazor/blob/dev/";
     private const string GitHubRawDevBaseUrl = "https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/";
 
-    private static readonly RenderProfile _defaultProfile = new(
-        static value => value,
-        null,
-        false,
-        new HeadingRenderOptions(true, true, true, true),
-        new ListRenderOptions(null),
-        new LinkRenderOptions(true, true, false));
+    private static readonly HeadingRenderOptions _defaultHeadingOptions = new(true, true, true, true);
+    private static readonly HeadingRenderOptions _releaseHeadingOptions = new(false, false, false, false);
 
-    private static readonly RenderProfile _releaseProfile = new(
-        PreprocessReleaseMarkdown,
-        PostProcessReleaseHtml,
-        true,
-        new HeadingRenderOptions(false, false, false, false),
-        new ListRenderOptions("mt-3 mb-6 px-6"),
-        new LinkRenderOptions(true, true, false));
+    private static readonly ListRenderOptions _defaultListOptions = new(null);
+    private static readonly ListRenderOptions _releaseListOptions = new("mt-3 mb-6 px-6");
 
-    private static readonly RenderProfile _contributionProfile = new(
-        PreprocessContributionMarkdown,
-        null,
-        false,
-        new HeadingRenderOptions(true, true, true, true),
-        new ListRenderOptions(null),
-        new LinkRenderOptions(true, true, true));
+    private static readonly LinkRenderOptions _defaultLinkOptions = new(true, true, false);
+    private static readonly LinkRenderOptions _contributionLinkOptions = new(true, true, true);
+
+    private static readonly MarkdownPipeline _defaultPipeline = BuildDefaultPipeline();
+    private static readonly MarkdownPipeline _releasePipeline = BuildReleasePipeline();
+    private static readonly MarkdownPipeline _contributionPipeline = BuildContributionPipeline();
 
     public enum RenderMode
     {
@@ -54,41 +43,91 @@ public partial class MarkdownToHtml
     {
         ArgumentNullException.ThrowIfNull(markdownBody);
 
-        var profile = GetProfile(renderMode);
-        var body = profile.PreprocessMarkdown(markdownBody);
-
-        var pipelineBuilder = new MarkdownPipelineBuilder()
-            .UseAutoIdentifiers();
-        if (profile.EnableAlertBlocks)
+        return renderMode switch
         {
-            pipelineBuilder.UseAlertBlocks();
-        }
+            RenderMode.ReleasePageRender => ParseReleaseMarkdown(markdownBody, baseUrl),
+            RenderMode.ContributionPageRender => ParseContributionMarkdown(markdownBody, baseUrl),
+            _ => ParseDefaultMarkdown(markdownBody, baseUrl),
+        };
+    }
 
-        var pipeline = pipelineBuilder.Build();
+    private static string ParseDefaultMarkdown(string markdownBody, Uri? baseUrl)
+    {
+        return RenderMarkdown(
+            markdownBody,
+            baseUrl,
+            _defaultPipeline,
+            _defaultHeadingOptions,
+            _defaultListOptions,
+            _defaultLinkOptions);
+    }
+
+    private static string ParseReleaseMarkdown(string markdownBody, Uri? baseUrl)
+    {
+        var preprocessedBody = PreprocessReleaseMarkdown(markdownBody);
+        var html = RenderMarkdown(
+            preprocessedBody,
+            baseUrl,
+            _releasePipeline,
+            _releaseHeadingOptions,
+            _releaseListOptions,
+            _defaultLinkOptions);
+
+        return PostProcessReleaseHtml(html);
+    }
+
+    private static string ParseContributionMarkdown(string markdownBody, Uri? baseUrl)
+    {
+        var preprocessedBody = PreprocessContributionMarkdown(markdownBody);
+        return RenderMarkdown(
+            preprocessedBody,
+            baseUrl,
+            _contributionPipeline,
+            _defaultHeadingOptions,
+            _defaultListOptions,
+            _contributionLinkOptions);
+    }
+
+    private static string RenderMarkdown(
+        string markdownBody,
+        Uri? baseUrl,
+        MarkdownPipeline pipeline,
+        HeadingRenderOptions headingOptions,
+        ListRenderOptions listOptions,
+        LinkRenderOptions linkOptions)
+    {
         var builder = new StringBuilder();
         using var textWriter = new StringWriter(builder);
         var renderer = new HtmlRenderer(textWriter) { BaseUrl = baseUrl };
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<HeadingBlock>>(new MudHeadingRenderer(profile.HeadingOptions));
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<LinkInline>>(new MudLinkRenderer(profile.LinkOptions));
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListBlock>>(new MudListRenderer(profile.ListOptions));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<HeadingBlock>>(new MudHeadingRenderer(headingOptions));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<LinkInline>>(new MudLinkRenderer(linkOptions));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListBlock>>(new MudListRenderer(listOptions));
 
-        var document = Markdown.Parse(body, pipeline);
+        var document = Markdown.Parse(markdownBody, pipeline);
         renderer.Render(document);
-
-        var html = builder.ToString();
-        return profile.PostprocessHtml is null
-            ? html
-            : profile.PostprocessHtml(html);
+        return builder.ToString();
     }
 
-    private static RenderProfile GetProfile(RenderMode renderMode)
+    private static MarkdownPipeline BuildDefaultPipeline()
     {
-        return renderMode switch
-        {
-            RenderMode.ReleasePageRender => _releaseProfile,
-            RenderMode.ContributionPageRender => _contributionProfile,
-            _ => _defaultProfile
-        };
+        return new MarkdownPipelineBuilder()
+            .UseAutoIdentifiers()
+            .Build();
+    }
+
+    private static MarkdownPipeline BuildReleasePipeline()
+    {
+        return new MarkdownPipelineBuilder()
+            .UseAutoIdentifiers()
+            .UseAlertBlocks()
+            .Build();
+    }
+
+    private static MarkdownPipeline BuildContributionPipeline()
+    {
+        return new MarkdownPipelineBuilder()
+            .UseAutoIdentifiers()
+            .Build();
     }
 
     private static string PreprocessReleaseMarkdown(string markdownBody)
@@ -332,14 +371,6 @@ public partial class MarkdownToHtml
             return text.ToString();
         }
     }
-
-    private sealed record RenderProfile(
-        Func<string, string> PreprocessMarkdown,
-        Func<string, string>? PostprocessHtml,
-        bool EnableAlertBlocks,
-        HeadingRenderOptions HeadingOptions,
-        ListRenderOptions ListOptions,
-        LinkRenderOptions LinkOptions);
 
     private sealed record HeadingRenderOptions(bool IncludeIds, bool IncludeTopMargin, bool BoldText, bool DividerForTopHeadings);
 

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -2,10 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
@@ -16,7 +14,7 @@ using Markdig.Syntax.Inlines;
 namespace MudBlazor.Docs.Utilities;
 
 #nullable enable
-public class MarkdownToHtml
+public partial class MarkdownToHtml
 {
     public enum RenderMode
     {
@@ -28,6 +26,10 @@ public class MarkdownToHtml
     {
         ArgumentNullException.ThrowIfNull(markdownBody);
 
+        var body = renderMode == RenderMode.ReleasePageRender
+            ? PreprocessReleaseMarkdown(markdownBody)
+            : markdownBody;
+
         var pipeline = new MarkdownPipelineBuilder()
             .UseAutoIdentifiers()
             .Build();
@@ -37,20 +39,31 @@ public class MarkdownToHtml
         renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<HeadingBlock>>(new MudHeadingRenderer(renderMode));
         renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<LinkInline>>(new MudLinkRenderer());
         renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListBlock>>(new MudListRenderer(renderMode));
-        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListItemBlock>>(new B());
-        var document = Markdown.Parse(markdownBody, pipeline);
+
+        var document = Markdown.Parse(body, pipeline);
         renderer.Render(document);
 
-        return builder.ToString();
-
+        var html = builder.ToString();
+        return renderMode == RenderMode.ReleasePageRender
+            ? PostProcessReleaseHtml(html)
+            : html;
     }
 
-    public class B : HtmlObjectRenderer<ListItemBlock>
+    private static string PreprocessReleaseMarkdown(string markdownBody)
     {
-        protected override void Write(HtmlRenderer renderer, ListItemBlock obj)
-        {
-            throw new NotImplementedException();
-        }
+        var body = LeadingReleaseCommentRegex().Replace(markdownBody, string.Empty);
+        body = PullRequestUrlRegex().Replace(body, "[#$1]($0)");
+        body = CompareUrlRegex().Replace(body, "[${range}]($0)");
+        body = GitHubMentionRegex().Replace(body, "[@$1](https://github.com/$1)");
+
+        return body;
+    }
+
+    private static string PostProcessReleaseHtml(string html)
+    {
+        return FullChangelogParagraphRegex().Replace(
+            html,
+            "<p class=\"release-full-changelog\"><strong>Full Changelog</strong>:");
     }
 
     public class MudListRenderer : HtmlObjectRenderer<ListBlock>
@@ -70,10 +83,10 @@ public class MarkdownToHtml
                 var attributes = obj.GetAttributes();
                 attributes.AddClass("mt-3 mb-6 px-6");
             }
+
             listRenderer.Write(renderer, obj);
         }
     }
-
 
     public class MudHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
     {
@@ -88,7 +101,8 @@ public class MarkdownToHtml
             { 6, "h6" }
         };
 
-        public MudHeadingRenderer(RenderMode renderMode) {
+        public MudHeadingRenderer(RenderMode renderMode)
+        {
             _renderMode = renderMode;
         }
 
@@ -96,7 +110,7 @@ public class MarkdownToHtml
         {
             renderer.EnsureLine();
             var heading = _heading[obj.Level];
-            
+
             if (_renderMode == RenderMode.Default)
             {
                 renderer.Write($"<{heading} id=\"{obj.GetAttributes().Id}\" class=\"mud-typography mud-typography-{heading} mt-3\">");
@@ -105,7 +119,6 @@ public class MarkdownToHtml
             else
             {
                 renderer.Write($"<{heading} class=\"mud-typography mud-typography-{heading}\">");
-                //renderer.Write("<ul class=\"mt-3 mb-6 px-6\">");
             }
 
             renderer.WriteLeafInline(obj);
@@ -113,18 +126,11 @@ public class MarkdownToHtml
             {
                 renderer.Write("</b>");
             }
-            else
-            {
-                //renderer.Write("</ul>");
-            }
 
             renderer.Write($"</{heading}>");
-            if (obj.Level < 3)
+            if (obj.Level < 3 && _renderMode == RenderMode.Default)
             {
-                if (_renderMode == RenderMode.Default)
-                {
-                    renderer.Write("<hr class=\"mud-divider mud-divider-fullwidth\">");
-                }
+                renderer.Write("<hr class=\"mud-divider mud-divider-fullwidth\">");
             }
 
             renderer.EnsureLine();
@@ -135,21 +141,35 @@ public class MarkdownToHtml
     {
         protected override void Write(HtmlRenderer renderer, LinkInline obj)
         {
-            var defaultRenderer = new LinkInlineRenderer();
             if (obj.IsImage)
             {
                 // Ignore images
                 return;
             }
-           
+
+            var defaultRenderer = new LinkInlineRenderer();
             var attributes = obj.GetAttributes();
-            attributes.AddClass("mud-link mud-primary-text mud-link-underline-hover");
+            if (IsGitHubUserLink(obj))
+            {
+                attributes.AddClass("mud-link mud-default-text mud-link-underline-hover github-user");
+            }
+            else
+            {
+                attributes.AddClass("mud-link mud-primary-text mud-link-underline-hover");
+            }
+
+            if (IsCompareLink(obj.Url))
+            {
+                attributes.AddClass("docs-code docs-code-primary");
+            }
+
             if (obj.Url is not null)
             {
                 if (obj.Url.StartsWith("http://") || obj.Url.StartsWith("https://"))
                 {
                     // External url
                     attributes.AddProperty("target", "_blank");
+                    attributes.AddProperty("rel", "noopener noreferrer");
                 }
                 else
                 {
@@ -160,5 +180,58 @@ public class MarkdownToHtml
 
             defaultRenderer.Write(renderer, obj);
         }
+
+        private static bool IsCompareLink(string? url)
+        {
+            return url is not null
+                && url.Contains("/compare/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsGitHubUserLink(LinkInline obj)
+        {
+            if (obj.Url is null
+                || !GitHubUserUrlRegex().IsMatch(obj.Url))
+            {
+                return false;
+            }
+
+            return GetInlineText(obj).StartsWith("@", StringComparison.Ordinal);
+        }
+
+        private static string GetInlineText(LinkInline obj)
+        {
+            var text = new StringBuilder();
+            var child = obj.FirstChild;
+
+            while (child is not null)
+            {
+                if (child is LiteralInline literal)
+                {
+                    text.Append(literal.Content.ToString());
+                }
+
+                child = child.NextSibling;
+            }
+
+            return text.ToString();
+        }
     }
+
+    [GeneratedRegex(@"^\s*<!--.*?-->\s*", RegexOptions.Singleline)]
+    private static partial Regex LeadingReleaseCommentRegex();
+
+    [GeneratedRegex(@"https://github\.com/MudBlazor/MudBlazor/pull/(?<id>\d{3,6})")]
+    private static partial Regex PullRequestUrlRegex();
+
+    [GeneratedRegex(@"https://github\.com/MudBlazor/MudBlazor/compare/(?<range>[^\s)]+)")]
+    private static partial Regex CompareUrlRegex();
+
+    [GeneratedRegex(@"(?<![\w/\[(`])@(?<user>[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))\b")]
+    private static partial Regex GitHubMentionRegex();
+
+    [GeneratedRegex(@"<p>\s*<strong>Full Changelog</strong>\s*:", RegexOptions.CultureInvariant)]
+    private static partial Regex FullChangelogParagraphRegex();
+
+    [GeneratedRegex(@"^https://github\.com/[A-Za-z0-9-]+/?$", RegexOptions.CultureInvariant)]
+    private static partial Regex GitHubUserUrlRegex();
 }

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -22,6 +22,7 @@ public partial class MarkdownToHtml
     private static readonly RenderProfile _defaultProfile = new(
         static value => value,
         null,
+        false,
         new HeadingRenderOptions(true, true, true, true),
         new ListRenderOptions(null),
         new LinkRenderOptions(true, true, false));
@@ -29,6 +30,7 @@ public partial class MarkdownToHtml
     private static readonly RenderProfile _releaseProfile = new(
         PreprocessReleaseMarkdown,
         PostProcessReleaseHtml,
+        true,
         new HeadingRenderOptions(false, false, false, false),
         new ListRenderOptions("mt-3 mb-6 px-6"),
         new LinkRenderOptions(true, true, false));
@@ -36,6 +38,7 @@ public partial class MarkdownToHtml
     private static readonly RenderProfile _contributionProfile = new(
         PreprocessContributionMarkdown,
         null,
+        false,
         new HeadingRenderOptions(true, true, true, true),
         new ListRenderOptions(null),
         new LinkRenderOptions(true, true, true));
@@ -54,9 +57,14 @@ public partial class MarkdownToHtml
         var profile = GetProfile(renderMode);
         var body = profile.PreprocessMarkdown(markdownBody);
 
-        var pipeline = new MarkdownPipelineBuilder()
-            .UseAutoIdentifiers()
-            .Build();
+        var pipelineBuilder = new MarkdownPipelineBuilder()
+            .UseAutoIdentifiers();
+        if (profile.EnableAlertBlocks)
+        {
+            pipelineBuilder.UseAlertBlocks();
+        }
+
+        var pipeline = pipelineBuilder.Build();
         var builder = new StringBuilder();
         using var textWriter = new StringWriter(builder);
         var renderer = new HtmlRenderer(textWriter) { BaseUrl = baseUrl };
@@ -95,27 +103,9 @@ public partial class MarkdownToHtml
 
     private static string PostProcessReleaseHtml(string html)
     {
-        html = ReleaseCalloutRegex().Replace(html, ReleaseCalloutReplacer);
         return FullChangelogParagraphRegex().Replace(
             html,
             "<p class=\"release-full-changelog\"><strong>Full Changelog</strong>:");
-    }
-
-    private static string ReleaseCalloutReplacer(Match match)
-    {
-        var type = match.Groups["type"].Value.ToLowerInvariant();
-        var content = match.Groups["content"].Value.Trim();
-        var title = type switch
-        {
-            "note" => "Note",
-            "tip" => "Tip",
-            "important" => "Important",
-            "warning" => "Warning",
-            "caution" => "Caution",
-            _ => "Note"
-        };
-
-        return $"<div class=\"docs-release-callout docs-release-callout-{type}\"><p class=\"docs-release-callout-title\">{title}</p><p>{content}</p></div>";
     }
 
     private static string PreprocessContributionMarkdown(string markdownBody)
@@ -346,6 +336,7 @@ public partial class MarkdownToHtml
     private sealed record RenderProfile(
         Func<string, string> PreprocessMarkdown,
         Func<string, string>? PostprocessHtml,
+        bool EnableAlertBlocks,
         HeadingRenderOptions HeadingOptions,
         ListRenderOptions ListOptions,
         LinkRenderOptions LinkOptions);
@@ -370,9 +361,6 @@ public partial class MarkdownToHtml
 
     [GeneratedRegex(@"<p>\s*<strong>Full Changelog</strong>\s*:", RegexOptions.CultureInvariant)]
     private static partial Regex FullChangelogParagraphRegex();
-
-    [GeneratedRegex(@"<blockquote>\s*<p>\s*\[!(?<type>NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(?<content>[\s\S]*?)</p>\s*</blockquote>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
-    private static partial Regex ReleaseCalloutRegex();
 
     [GeneratedRegex(@"^https://github\.com/[A-Za-z0-9-]+/?$", RegexOptions.CultureInvariant)]
     private static partial Regex GitHubUserUrlRegex();

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Markdig;
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Markdig.Renderers.Html.Inlines;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace MudBlazor.Docs.Utilities;
+
+#nullable enable
+public class MarkdownToHtml
+{
+    public enum RenderMode
+    {
+        Default = 0,
+        ReleasePageRender = 1,
+    }
+
+    public static string Parse(string markdownBody, Uri? baseUrl = null, RenderMode renderMode = RenderMode.Default)
+    {
+        ArgumentNullException.ThrowIfNull(markdownBody);
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAutoIdentifiers()
+            .Build();
+        var builder = new StringBuilder();
+        using var textWriter = new StringWriter(builder);
+        var renderer = new HtmlRenderer(textWriter) { BaseUrl = baseUrl };
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<HeadingBlock>>(new MudHeadingRenderer(renderMode));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<LinkInline>>(new MudLinkRenderer());
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListBlock>>(new MudListRenderer(renderMode));
+        renderer.ObjectRenderers.ReplaceOrAdd<HtmlObjectRenderer<ListItemBlock>>(new B());
+        var document = Markdown.Parse(markdownBody, pipeline);
+        renderer.Render(document);
+
+        return builder.ToString();
+
+    }
+
+    public class B : HtmlObjectRenderer<ListItemBlock>
+    {
+        protected override void Write(HtmlRenderer renderer, ListItemBlock obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class MudListRenderer : HtmlObjectRenderer<ListBlock>
+    {
+        private readonly RenderMode _renderMode;
+
+        public MudListRenderer(RenderMode renderMode)
+        {
+            _renderMode = renderMode;
+        }
+
+        protected override void Write(HtmlRenderer renderer, ListBlock obj)
+        {
+            var listRenderer = new ListRenderer();
+            if (_renderMode == RenderMode.ReleasePageRender)
+            {
+                var attributes = obj.GetAttributes();
+                attributes.AddClass("mt-3 mb-6 px-6");
+            }
+            listRenderer.Write(renderer, obj);
+        }
+    }
+
+
+    public class MudHeadingRenderer : HtmlObjectRenderer<HeadingBlock>
+    {
+        private readonly RenderMode _renderMode;
+        private readonly Dictionary<int, string> _heading = new()
+        {
+            { 1, "h4" },
+            { 2, "h5" },
+            { 3, "h6" },
+            { 4, "h6" },
+            { 5, "h6" },
+            { 6, "h6" }
+        };
+
+        public MudHeadingRenderer(RenderMode renderMode) {
+            _renderMode = renderMode;
+        }
+
+        protected override void Write(HtmlRenderer renderer, HeadingBlock obj)
+        {
+            renderer.EnsureLine();
+            var heading = _heading[obj.Level];
+            
+            if (_renderMode == RenderMode.Default)
+            {
+                renderer.Write($"<{heading} id=\"{obj.GetAttributes().Id}\" class=\"mud-typography mud-typography-{heading} mt-3\">");
+                renderer.Write("<b>");
+            }
+            else
+            {
+                renderer.Write($"<{heading} class=\"mud-typography mud-typography-{heading}\">");
+                //renderer.Write("<ul class=\"mt-3 mb-6 px-6\">");
+            }
+
+            renderer.WriteLeafInline(obj);
+            if (_renderMode == RenderMode.Default)
+            {
+                renderer.Write("</b>");
+            }
+            else
+            {
+                //renderer.Write("</ul>");
+            }
+
+            renderer.Write($"</{heading}>");
+            if (obj.Level < 3)
+            {
+                if (_renderMode == RenderMode.Default)
+                {
+                    renderer.Write("<hr class=\"mud-divider mud-divider-fullwidth\">");
+                }
+            }
+
+            renderer.EnsureLine();
+        }
+    }
+
+    public class MudLinkRenderer : HtmlObjectRenderer<LinkInline>
+    {
+        protected override void Write(HtmlRenderer renderer, LinkInline obj)
+        {
+            var defaultRenderer = new LinkInlineRenderer();
+            if (obj.IsImage)
+            {
+                // Ignore images
+                return;
+            }
+           
+            var attributes = obj.GetAttributes();
+            attributes.AddClass("mud-link mud-primary-text mud-link-underline-hover");
+            if (obj.Url is not null)
+            {
+                if (obj.Url.StartsWith("http://") || obj.Url.StartsWith("https://"))
+                {
+                    // External url
+                    attributes.AddProperty("target", "_blank");
+                }
+                else
+                {
+                    // Internal url
+                    attributes.AddProperty("target", "_self");
+                }
+            }
+
+            defaultRenderer.Write(renderer, obj);
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -24,21 +24,21 @@ public partial class MarkdownToHtml
         null,
         new HeadingRenderOptions(true, true, true, true),
         new ListRenderOptions(null),
-        new LinkRenderOptions(true, true));
+        new LinkRenderOptions(true, true, false));
 
     private static readonly RenderProfile _releaseProfile = new(
         PreprocessReleaseMarkdown,
         PostProcessReleaseHtml,
         new HeadingRenderOptions(false, false, false, false),
         new ListRenderOptions("mt-3 mb-6 px-6"),
-        new LinkRenderOptions(true, true));
+        new LinkRenderOptions(true, true, false));
 
     private static readonly RenderProfile _contributionProfile = new(
         PreprocessContributionMarkdown,
         null,
         new HeadingRenderOptions(true, true, true, true),
         new ListRenderOptions(null),
-        new LinkRenderOptions(true, true));
+        new LinkRenderOptions(true, true, true));
 
     public enum RenderMode
     {
@@ -128,39 +128,7 @@ public partial class MarkdownToHtml
             return $"## Table of Contents{Environment.NewLine}{Environment.NewLine}{tocContent}{Environment.NewLine}{Environment.NewLine}";
         });
 
-        return MarkdownLinkRegex().Replace(body, RewriteContributionMarkdownLink);
-    }
-
-    private static string RewriteContributionMarkdownLink(Match match)
-    {
-        var text = match.Groups["text"].Value;
-        var url = match.Groups["url"].Value;
-        var suffix = match.Groups["suffix"].Value;
-
-        if (url.StartsWith('#')
-            || url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-            || url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
-        {
-            return match.Value;
-        }
-
-        if (url.StartsWith('/'))
-        {
-            var normalizedPath = url.TrimStart('/');
-            return $"[{text}]({GitHubBlobDevBaseUrl}{normalizedPath}{suffix})";
-        }
-
-        if (!IsMarkdownFileLink(url))
-        {
-            return match.Value;
-        }
-
-        var relativePath = url.StartsWith("./", StringComparison.Ordinal)
-            ? url[2..]
-            : url;
-
-        return $"[{text}]({GitHubBlobDevBaseUrl}{relativePath}{suffix})";
+        return body;
     }
 
     private static bool IsMarkdownFileLink(string url)
@@ -273,6 +241,11 @@ public partial class MarkdownToHtml
                 return;
             }
 
+            if (_options.RewriteContributionLinks && obj.Url is not null)
+            {
+                obj.Url = RewriteContributionLink(obj.Url);
+            }
+
             var defaultRenderer = new LinkInlineRenderer();
             var attributes = obj.GetAttributes();
             if (_options.HighlightGitHubMentions && IsGitHubUserLink(obj))
@@ -324,6 +297,33 @@ public partial class MarkdownToHtml
             return GetInlineText(obj).StartsWith("@", StringComparison.Ordinal);
         }
 
+        private static string RewriteContributionLink(string url)
+        {
+            if (url.StartsWith('#')
+                || url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return url;
+            }
+
+            if (url.StartsWith('/'))
+            {
+                return $"{GitHubBlobDevBaseUrl}{url.TrimStart('/')}";
+            }
+
+            if (!IsMarkdownFileLink(url))
+            {
+                return url;
+            }
+
+            var relativePath = url.StartsWith("./", StringComparison.Ordinal)
+                ? url[2..]
+                : url;
+
+            return $"{GitHubBlobDevBaseUrl}{relativePath}";
+        }
+
         private static string GetInlineText(LinkInline obj)
         {
             var text = new StringBuilder();
@@ -354,7 +354,7 @@ public partial class MarkdownToHtml
 
     private sealed record ListRenderOptions(string? AdditionalCssClass);
 
-    private sealed record LinkRenderOptions(bool HighlightGitHubMentions, bool HighlightCompareLinks);
+    private sealed record LinkRenderOptions(bool HighlightGitHubMentions, bool HighlightCompareLinks, bool RewriteContributionLinks);
 
     [GeneratedRegex(@"^\s*<!--.*?-->\s*", RegexOptions.Singleline)]
     private static partial Regex LeadingReleaseCommentRegex();
@@ -376,9 +376,6 @@ public partial class MarkdownToHtml
 
     [GeneratedRegex(@"^https://github\.com/[A-Za-z0-9-]+/?$", RegexOptions.CultureInvariant)]
     private static partial Regex GitHubUserUrlRegex();
-
-    [GeneratedRegex(@"\[(?<text>[^\]]+)\]\((?<url>[^)\s]+)(?<suffix>\s+""[^""]*"")?\)", RegexOptions.CultureInvariant)]
-    private static partial Regex MarkdownLinkRegex();
 
     [GeneratedRegex(@"<!--\s*TOC start.*?-->\s*(?<toc>[\s\S]*?)\s*<!--\s*TOC end\s*-->", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex ContributionTocBlockRegex();

--- a/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
+++ b/src/MudBlazor.Docs/Utilities/MarkdownToHtml.cs
@@ -16,19 +16,26 @@ namespace MudBlazor.Docs.Utilities;
 #nullable enable
 public partial class MarkdownToHtml
 {
+    private const string GitHubBlobDevBaseUrl = "https://github.com/MudBlazor/MudBlazor/blob/dev/";
+    private const string GitHubRawDevBaseUrl = "https://raw.githubusercontent.com/MudBlazor/MudBlazor/dev/";
+
     public enum RenderMode
     {
         Default = 0,
         ReleasePageRender = 1,
+        ContributionPageRender = 2,
     }
 
     public static string Parse(string markdownBody, Uri? baseUrl = null, RenderMode renderMode = RenderMode.Default)
     {
         ArgumentNullException.ThrowIfNull(markdownBody);
 
-        var body = renderMode == RenderMode.ReleasePageRender
-            ? PreprocessReleaseMarkdown(markdownBody)
-            : markdownBody;
+        var body = renderMode switch
+        {
+            RenderMode.ReleasePageRender => PreprocessReleaseMarkdown(markdownBody),
+            RenderMode.ContributionPageRender => PreprocessContributionMarkdown(markdownBody),
+            _ => markdownBody
+        };
 
         var pipeline = new MarkdownPipelineBuilder()
             .UseAutoIdentifiers()
@@ -64,6 +71,63 @@ public partial class MarkdownToHtml
         return FullChangelogParagraphRegex().Replace(
             html,
             "<p class=\"release-full-changelog\"><strong>Full Changelog</strong>:");
+    }
+
+    private static string PreprocessContributionMarkdown(string markdownBody)
+    {
+        var body = ContributionImageSourceRegex().Replace(markdownBody, "$1=\"" + GitHubRawDevBaseUrl + "$2\"");
+        body = ContributionImageSourceSetRegex().Replace(body, "$1=\"" + GitHubRawDevBaseUrl + "$2\"");
+        body = ContributionTocBlockRegex().Replace(body, match =>
+        {
+            var tocContent = match.Groups["toc"].Value.Trim();
+            return $"## Table of Contents{Environment.NewLine}{Environment.NewLine}{tocContent}{Environment.NewLine}{Environment.NewLine}";
+        });
+
+        return MarkdownLinkRegex().Replace(body, RewriteContributionMarkdownLink);
+    }
+
+    private static string RewriteContributionMarkdownLink(Match match)
+    {
+        var text = match.Groups["text"].Value;
+        var url = match.Groups["url"].Value;
+        var suffix = match.Groups["suffix"].Value;
+
+        if (url.StartsWith('#')
+            || url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
+        {
+            return match.Value;
+        }
+
+        if (url.StartsWith('/'))
+        {
+            var normalizedPath = url.TrimStart('/');
+            return $"[{text}]({GitHubBlobDevBaseUrl}{normalizedPath}{suffix})";
+        }
+
+        if (!IsMarkdownFileLink(url))
+        {
+            return match.Value;
+        }
+
+        var relativePath = url.StartsWith("./", StringComparison.Ordinal)
+            ? url[2..]
+            : url;
+
+        return $"[{text}]({GitHubBlobDevBaseUrl}{relativePath}{suffix})";
+    }
+
+    private static bool IsMarkdownFileLink(string url)
+    {
+        var markdownExtensionIndex = url.IndexOf(".md", StringComparison.OrdinalIgnoreCase);
+        if (markdownExtensionIndex < 0)
+        {
+            return false;
+        }
+
+        var extensionEndIndex = markdownExtensionIndex + 3;
+        return extensionEndIndex == url.Length || url[extensionEndIndex] == '#';
     }
 
     public class MudListRenderer : HtmlObjectRenderer<ListBlock>
@@ -110,25 +174,26 @@ public partial class MarkdownToHtml
         {
             renderer.EnsureLine();
             var heading = _heading[obj.Level];
+            var headingId = obj.GetAttributes().Id;
 
-            if (_renderMode == RenderMode.Default)
-            {
-                renderer.Write($"<{heading} id=\"{obj.GetAttributes().Id}\" class=\"mud-typography mud-typography-{heading} mt-3\">");
-                renderer.Write("<b>");
-            }
-            else
+            if (_renderMode == RenderMode.ReleasePageRender)
             {
                 renderer.Write($"<{heading} class=\"mud-typography mud-typography-{heading}\">");
             }
+            else
+            {
+                renderer.Write($"<{heading} id=\"{headingId}\" class=\"mud-typography mud-typography-{heading} mt-3\">");
+                renderer.Write("<b>");
+            }
 
             renderer.WriteLeafInline(obj);
-            if (_renderMode == RenderMode.Default)
+            if (_renderMode != RenderMode.ReleasePageRender)
             {
                 renderer.Write("</b>");
             }
 
             renderer.Write($"</{heading}>");
-            if (obj.Level < 3 && _renderMode == RenderMode.Default)
+            if (obj.Level < 3 && _renderMode != RenderMode.ReleasePageRender)
             {
                 renderer.Write("<hr class=\"mud-divider mud-divider-fullwidth\">");
             }
@@ -234,4 +299,16 @@ public partial class MarkdownToHtml
 
     [GeneratedRegex(@"^https://github\.com/[A-Za-z0-9-]+/?$", RegexOptions.CultureInvariant)]
     private static partial Regex GitHubUserUrlRegex();
+
+    [GeneratedRegex(@"\[(?<text>[^\]]+)\]\((?<url>[^)\s]+)(?<suffix>\s+""[^""]*"")?\)", RegexOptions.CultureInvariant)]
+    private static partial Regex MarkdownLinkRegex();
+
+    [GeneratedRegex(@"<!--\s*TOC start.*?-->\s*(?<toc>[\s\S]*?)\s*<!--\s*TOC end\s*-->", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ContributionTocBlockRegex();
+
+    [GeneratedRegex(@"(src)\s*=\s*""(content/[^""]+)""", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ContributionImageSourceRegex();
+
+    [GeneratedRegex(@"(srcset)\s*=\s*""(content/[^""]+)""", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ContributionImageSourceSetRegex();
 }


### PR DESCRIPTION
This work was on my disk laying for two years, but was lazy to finish it, thanks to AI i could polish it.
Contribution page is not into construction anymore, it's using Markdig for some parse and regex where there is no markdown tags.
Made release pages to use it too.
Release page didn't change much visually, but got some features like warning, info, caution etc:
<img width="1395" height="421" alt="Screenshot 2026-03-01 022412" src="https://github.com/user-attachments/assets/88e174e6-b00f-40bb-9890-6623e1e93909" />

Contribution page:

<img width="1450" height="1069" alt="Screenshot 2026-03-01 022549" src="https://github.com/user-attachments/assets/9468177b-3a82-43b3-b771-38f3bcf169dc" />
supports anchors as well

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
