### PR TITLE
Tests: Fix reliance on particular regional settings

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -446,7 +446,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Font size should be calculated based on cell dimensions
             fontSize.Should().NotBeNull();
-            double.Parse(fontSize).Should().BeGreaterThan(0);
+            double.Parse(fontSize.Replace(',', '.'), CultureInfo.InvariantCulture).Should().BeGreaterThan(0);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -833,7 +833,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DataGridPaginationShouldFormatNumbersWithCommas()
+        public void DataGridPaginationShouldFormatNumbersGroupSeparator()
         {
             var comp = Context.Render<DataGridPaginationFormattingTest>();
             var groupSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -836,16 +836,16 @@ namespace MudBlazor.UnitTests.Components
         public void DataGridPaginationShouldFormatNumbersWithCommas()
         {
             var comp = Context.Render<DataGridPaginationFormattingTest>();
-
-            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("1-10 of 1,000");
+            var groupSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
+            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be($"1-10 of 1{groupSeparator}000");
         }
 
         [Test]
         public void DataGridPaginationShouldRespectCustomFormatWithSingleTag()
         {
             var comp = Context.Render<DataGridPaginationCustomFormatTest>();
-
-            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("Total: 1,000");
+            var groupSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator;
+            comp.FindAll(".mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be($"Total: 1{groupSeparator}000");
         }
 
         [Test]


### PR DESCRIPTION
Unit tests were relying on commas (,) and dots (.) which varies with the regional settings of the local computer. This PR fixes three tests that failed on my Win11-box with Swedish regional settings.

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
