### PR TITLE
MudTimePicker: Fix AmPm and TimeFormat not reflected in text field

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -103,6 +103,54 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void TimePicker_WithTimeFormat_DisplaysFormattedText()
+        {
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(x => x.Culture, CultureInfo.InvariantCulture)
+                .Add(x => x.TimeFormat, "H:mm")
+                .Add(x => x.Time, new TimeSpan(17, 45, 0)));
+
+            comp.Find("input").GetAttribute("value").Should().Be("17:45");
+        }
+
+        [Test]
+        public async Task TimePicker_WhenAmPmChanges_UpdatesTextFieldFormat()
+        {
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(x => x.Culture, CultureInfo.InvariantCulture)
+                .Add(x => x.AmPm, false)
+                .Add(x => x.Time, new TimeSpan(17, 45, 0)));
+
+            comp.Find("input").GetAttribute("value").Should().Be("17:45");
+
+            await comp.InvokeAsync(() => comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.AmPm, true)));
+
+            comp.Find("input").GetAttribute("value").Should().Be("05:45 PM");
+        }
+
+        [Test]
+        public async Task TimePicker_WhenTimeFormatChanges_UpdatesTextFieldFormat()
+        {
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(x => x.Culture, CultureInfo.InvariantCulture)
+                .Add(x => x.TimeFormat, "HH:mm")
+                .Add(x => x.Time, new TimeSpan(17, 45, 0)));
+
+            comp.Find("input").GetAttribute("value").Should().Be("17:45");
+
+            await comp.InvokeAsync(() => comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.TimeFormat, "H:mm")));
+
+            comp.Find("input").GetAttribute("value").Should().Be("17:45");
+
+            await comp.InvokeAsync(() => comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.TimeFormat, "hh:mm tt")));
+
+            comp.Find("input").GetAttribute("value").Should().Be("05:45 PM");
+        }
+
+        [Test]
         public async Task OpenToHours_CheckMinutesHidden()
         {
             var comp = await OpenPicker(parameters => parameters.Add(x => x.OpenTo, OpenTo.Hours));

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -20,7 +20,7 @@
                     <MudText Typo="Typo.h2" Class="mud-timepicker-separator">@GetHourString():@GetMinuteString()</MudText>
                 }
             </div>
-            @if (AmPm)
+            @if (_amPmState.Value)
             {
                 <div class="mud-timepicker-ampm">
                     <MudButton Variant="@Variant.Text" Color="@Color.Inherit" Class="@AmButtonClassname" OnClick="OnAmClickedAsync">AM</MudButton>
@@ -37,7 +37,7 @@
                             <div class="@GetClockPointerThumbColor()"></div>
                         </div>
                         <div class="@HourDialClassname">
-                            @if (AmPm)
+                            @if (_amPmState.Value)
                             {
                                 @*Hours from 1 to 12*@
                                 for (int i = 1; i <= 12; ++i)

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using MudBlazor.Resources;
+using MudBlazor.State;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -19,11 +20,11 @@ namespace MudBlazor
     /// <seealso cref="MudDateRangePicker"/>
     public partial class MudTimePicker : MudPicker<TimeSpan?>
     {
-        private bool _amPm = false;
+        private readonly ParameterState<bool> _amPmState;
         private OpenTo _currentView;
         private string? _clockElementReferenceId;
         private readonly SetTime _timeSet = new();
-        private string _timeFormat = string.Empty;
+        private readonly ParameterState<string?> _timeFormatState;
         private readonly Lazy<DotNetObjectReference<MudTimePicker>> _dotNetReferenceLazy;
 
         [Inject]
@@ -38,6 +39,14 @@ namespace MudBlazor
         {
             AdornmentIcon = Icons.Material.Filled.AccessTime;
             _dotNetReferenceLazy = new Lazy<DotNetObjectReference<MudTimePicker>>(CreateDotNetObjectReference);
+
+            using var registerScope = CreateRegisterScope();
+            _amPmState = registerScope.RegisterParameter<bool>(nameof(AmPm))
+                .WithParameter(() => AmPm)
+                .WithChangeHandler(FormatChangedAsync);
+            _timeFormatState = registerScope.RegisterParameter<string?>(nameof(TimeFormat))
+                .WithParameter(() => TimeFormat)
+                .WithChangeHandler(FormatChangedAsync);
         }
 
         internal TimeSpan? TimeIntermediate { get; private set; }
@@ -103,24 +112,9 @@ namespace MudBlazor
         /// When <c>true</c>, hours 1-12 are displayed with an AM or PM marker.<br />
         /// When <c>false</c>, hours 0-23 are displayed.<br />
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public bool AmPm
-        {
-            get => _amPm;
-            set
-            {
-                if (value == _amPm)
-                {
-                    return;
-                }
-
-                _amPm = value;
-
-                Touched = true;
-                SetTextAsync(ConvertSet(_value), false).CatchAndLog();
-            }
-        }
+        public bool AmPm { get; set; }
 
         /// <summary>
         /// The format applied to time values.
@@ -134,24 +128,9 @@ namespace MudBlazor
         /// * <c>tt</c> for AM/PM markers.<br />
         /// For example: <c>h:mm tt</c> would display <c>6:32 PM</c>, and <c>HH:mm</c> would display <c>18:32</c>.
         /// </remarks>
-        [Parameter]
+        [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Behavior)]
-        public string TimeFormat
-        {
-            get => _timeFormat;
-            set
-            {
-                if (_timeFormat == value)
-                {
-                    return;
-                }
-
-                _timeFormat = value;
-
-                Touched = true;
-                SetTextAsync(ConvertSet(_value), false).CatchAndLog();
-            }
-        }
+        public string? TimeFormat { get; set; }
 
         /// <summary>
         /// The currently selected time.
@@ -256,7 +235,7 @@ namespace MudBlazor
                 return "--";
             }
 
-            var h = AmPm ? TimeIntermediate.Value.ToAmPmHour() : TimeIntermediate.Value.Hours;
+            var h = _amPmState.Value ? TimeIntermediate.Value.ToAmPmHour() : TimeIntermediate.Value.Hours;
             return $"{Math.Min(23, Math.Max(0, h)):D2}";
         }
 
@@ -385,7 +364,7 @@ namespace MudBlazor
             {
                 var h = _timeSet.Hour;
 
-                if (AmPm)
+                if (_amPmState.Value)
                 {
                     h = _timeSet.Hour % 12;
                     if (_timeSet.Hour % 12 == 0)
@@ -460,7 +439,7 @@ namespace MudBlazor
 
             if (_currentView == OpenTo.Hours)
             {
-                if (!AmPm && _timeSet.Hour > 0 && _timeSet.Hour < 13)
+                if (!_amPmState.Value && _timeSet.Hour > 0 && _timeSet.Hour < 13)
                 {
                     height = 26;
                 }
@@ -590,7 +569,7 @@ namespace MudBlazor
 
         private int HourAmPm(int hour)
         {
-            if (AmPm)
+            if (_amPmState.Value)
             {
                 if (IsAm && hour == 12)
                 {
@@ -778,12 +757,18 @@ namespace MudBlazor
 
         protected override string GetFormat()
         {
-            if (!string.IsNullOrEmpty(TimeFormat))
+            if (!string.IsNullOrEmpty(_timeFormatState.Value))
             {
-                return TimeFormat;
+                return _timeFormatState.Value;
             }
 
-            return AmPm ? TimeSpanConverter.Format12Hours : TimeSpanConverter.Format24Hours;
+            return _amPmState.Value ? TimeSpanConverter.Format12Hours : TimeSpanConverter.Format24Hours;
+        }
+
+        private Task FormatChangedAsync()
+        {
+            Touched = true;
+            return SetTextAsync(ConvertSet(_value), false);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary

`AmPm` and `TimeFormat` parameters had no effect on the text field displayed when the picker is closed — only the picker dialog reflected them.

### Root Cause

Both parameters were implemented as `[Parameter]` properties with logic in their setters (manually calling `SetTextAsync` on change), violating the codebase's auto-property rule and creating unreliable update behavior when multiple parameters change in the same render cycle.

### Changes

- **`AmPm` / `TimeFormat`** — converted from custom-setter `[Parameter]` properties to `[Parameter, ParameterState]` auto-properties backed by `ParameterState<bool>` and `ParameterState<string?>` respectively, following the `MudBaseDatePicker.DateFormat` pattern
- **`FormatChangedAsync()`** — shared change handler registered for both states; sets `Touched = true` and refreshes the text field via `SetTextAsync(ConvertSet(_value), false)`
- **`GetFormat()`** — updated to read from `_amPmState.Value` / `_timeFormatState.Value`
- All internal reads of `AmPm` replaced with `_amPmState.Value` (required by MUD0010 analyzer)

### Before / After

**Before** — text field ignores `AmPm` and `TimeFormat`:

<img width="968" height="314" alt="Before fix" src="https://github.com/user-attachments/assets/497692e5-e9bc-4627-acbe-544c015d0c51" />

**After** — text field correctly reflects both parameters:

<img width="973" height="457" alt="After fix" src="https://github.com/user-attachments/assets/a2b4539c-ca87-4194-9669-ac1ba95d0a7f" />

## Test Plan

- [x] Added unit tests verifying `AmPm` and `TimeFormat` are reflected in the text field
- [ ] Existing TimePicker tests pass
- [ ] Docs site TimePicker page displays correct formatting