### PR TITLE
MudCheckBox, MudSwitch, MudRadio: Respect user-defined TabIndex (case-insensitive)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/BooleanInputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BooleanInputTests.cs
@@ -11,23 +11,21 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("tabindex", "5")]
         [TestCase("tabIndex", "7")]
         [TestCase("TABINDEX", "9")]
-        public void ResolveTabIndexAndAttributes_RespectsCaseInsensitiveTabIndex(string key, string value)
+        public void InputTabIndex_RespectsCaseInsensitiveTabIndex(string key, string value)
         {
             var comp = Context.Render<TestBooleanInput>(p =>
                 p.AddUnmatched(key, value)
             );
 
-            var result = comp.Instance.Resolve();
-
-            result.TabIndex.Should().Be(int.Parse(value));
-            result.Attributes.Should().BeNull();
+            comp.Instance.TabIndex.Should().Be(int.Parse(value));
+            comp.Instance.Attributes.Should().BeNull();
         }
 
         [Test]
         [TestCase("tabindex")]
         [TestCase("tabIndex")]
         [TestCase("TABINDEX")]
-        public void ResolveTabIndexAndAttributes_RemovesAllTabIndexVariants(string key)
+        public void InputUserAttributes_RemovesAllTabIndexVariants(string key)
         {
             var comp = Context.Render<TestBooleanInput>(p =>
             {
@@ -35,28 +33,24 @@ namespace MudBlazor.UnitTests.Components
                 p.AddUnmatched("other", "value");
             });
 
-            var result = comp.Instance.Resolve();
-
-            result.TabIndex.Should().Be(5);
-            result.Attributes.Should().NotContainKey(key);
-            result.Attributes.Should().ContainKey("other");
+            comp.Instance.TabIndex.Should().Be(5);
+            comp.Instance.Attributes.Should().NotContainKey(key);
+            comp.Instance.Attributes.Should().ContainKey("other");
         }
 
         [Test]
-        public void ResolveTabIndexAndAttributes_DefaultsToZero_WhenNoUserTabIndex()
+        public void InputTabIndex_DefaultsToZero_WhenNoUserTabIndex()
         {
             var comp = Context.Render<TestBooleanInput>(p =>
                 p.AddUnmatched("other", "value")
             );
 
-            var result = comp.Instance.Resolve();
-
-            result.TabIndex.Should().Be(0);
-            result.Attributes.Should().ContainKey("other");
+            comp.Instance.TabIndex.Should().Be(0);
+            comp.Instance.Attributes.Should().ContainKey("other");
         }
 
         [Test]
-        public void ResolveTabIndexAndAttributes_Disabled_ForcesMinusOne()
+        public void InputTabIndex_Disabled_ForcesMinusOne()
         {
             var comp = Context.Render<TestBooleanInput>(p =>
             {
@@ -64,15 +58,13 @@ namespace MudBlazor.UnitTests.Components
                 p.AddUnmatched("tabindex", "5");
             });
 
-            var result = comp.Instance.Resolve();
-
-            result.TabIndex.Should().Be(-1);
+            comp.Instance.TabIndex.Should().Be(-1);
         }
 
         private class TestBooleanInput : MudBooleanInput<bool>
         {
-            public (int TabIndex, IReadOnlyDictionary<string, object> Attributes) Resolve()
-                => ResolveTabIndexAndAttributes();
+            public int TabIndex => InputTabIndex;
+            public IReadOnlyDictionary<string, object> Attributes => InputUserAttributes?.ToDictionary(x => x.Key, x => x.Value);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/BooleanInputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BooleanInputTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Bunit;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class BooleanInputTests : BunitTest
+    {
+        [Test]
+        [TestCase("tabindex", "5")]
+        [TestCase("tabIndex", "7")]
+        [TestCase("TABINDEX", "9")]
+        public void GetResolvedTabIndex_RespectsCaseInsensitiveTabIndex(string key, string value)
+        {
+            var input = new TestBooleanInput();
+            input.SetUserAttributes(new Dictionary<string, object> { { key, value } });
+            input.GetResolvedTabIndex().Should().Be(int.Parse(value));
+        }
+
+        [Test]
+        [TestCase("tabindex")]
+        [TestCase("tabIndex")]
+        [TestCase("TABINDEX")]
+        public void GetResolvedUserAttributes_RemovesAllTabIndexVariants(string key)
+        {
+            var input = new TestBooleanInput();
+            input.SetUserAttributes(new Dictionary<string, object>
+            {
+                { key, "5" },
+                { "other", "value" }
+            });
+            var attrs = input.GetResolvedUserAttributes();
+            attrs.Should().NotContainKey(key);
+            attrs.Should().ContainKey("other");
+        }
+
+        private class TestBooleanInput : MudBooleanInput<bool>
+        {
+            public void SetUserAttributes(Dictionary<string, object> attrs)
+            {
+                base.UserAttributes = attrs;
+            }
+        }            
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/BooleanInputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BooleanInputTests.cs
@@ -1,8 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
-// MudBlazor licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using AwesomeAssertions;
+﻿using AwesomeAssertions;
 using Bunit;
 using NUnit.Framework;
 
@@ -15,36 +11,68 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("tabindex", "5")]
         [TestCase("tabIndex", "7")]
         [TestCase("TABINDEX", "9")]
-        public void GetResolvedTabIndex_RespectsCaseInsensitiveTabIndex(string key, string value)
+        public void ResolveTabIndexAndAttributes_RespectsCaseInsensitiveTabIndex(string key, string value)
         {
-            var input = new TestBooleanInput();
-            input.SetUserAttributes(new Dictionary<string, object> { { key, value } });
-            input.GetResolvedTabIndex().Should().Be(int.Parse(value));
+            var comp = Context.Render<TestBooleanInput>(p =>
+                p.AddUnmatched(key, value)
+            );
+
+            var result = comp.Instance.Resolve();
+
+            result.TabIndex.Should().Be(int.Parse(value));
+            result.Attributes.Should().BeNull();
         }
 
         [Test]
         [TestCase("tabindex")]
         [TestCase("tabIndex")]
         [TestCase("TABINDEX")]
-        public void GetResolvedUserAttributes_RemovesAllTabIndexVariants(string key)
+        public void ResolveTabIndexAndAttributes_RemovesAllTabIndexVariants(string key)
         {
-            var input = new TestBooleanInput();
-            input.SetUserAttributes(new Dictionary<string, object>
+            var comp = Context.Render<TestBooleanInput>(p =>
             {
-                { key, "5" },
-                { "other", "value" }
+                p.AddUnmatched(key, "5");
+                p.AddUnmatched("other", "value");
             });
-            var attrs = input.GetResolvedUserAttributes();
-            attrs.Should().NotContainKey(key);
-            attrs.Should().ContainKey("other");
+
+            var result = comp.Instance.Resolve();
+
+            result.TabIndex.Should().Be(5);
+            result.Attributes.Should().NotContainKey(key);
+            result.Attributes.Should().ContainKey("other");
+        }
+
+        [Test]
+        public void ResolveTabIndexAndAttributes_DefaultsToZero_WhenNoUserTabIndex()
+        {
+            var comp = Context.Render<TestBooleanInput>(p =>
+                p.AddUnmatched("other", "value")
+            );
+
+            var result = comp.Instance.Resolve();
+
+            result.TabIndex.Should().Be(0);
+            result.Attributes.Should().ContainKey("other");
+        }
+
+        [Test]
+        public void ResolveTabIndexAndAttributes_Disabled_ForcesMinusOne()
+        {
+            var comp = Context.Render<TestBooleanInput>(p =>
+            {
+                p.Add(x => x.Disabled, true);
+                p.AddUnmatched("tabindex", "5");
+            });
+
+            var result = comp.Instance.Resolve();
+
+            result.TabIndex.Should().Be(-1);
         }
 
         private class TestBooleanInput : MudBooleanInput<bool>
         {
-            public void SetUserAttributes(Dictionary<string, object> attrs)
-            {
-                base.UserAttributes = attrs;
-            }
-        }            
+            public (int TabIndex, IReadOnlyDictionary<string, object> Attributes) Resolve()
+                => ResolveTabIndexAndAttributes();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -501,10 +501,10 @@ namespace MudBlazor.UnitTests.Components
             var input = comp.Find("input");
 
             // tabindex should NOT be on label
-            Assert.That(label.HasAttribute("tabindex"), Is.False);
+            label.HasAttribute("tabindex").Should().BeFalse();
 
             // tabindex should be on input and match user value
-            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo(userTabIndex));
+            input.GetAttribute("tabindex").Should().Be(userTabIndex);
         }
 
         [Test]
@@ -515,8 +515,8 @@ namespace MudBlazor.UnitTests.Components
             var label = comp.Find("label");
             var input = comp.Find("input");
 
-            Assert.That(label.HasAttribute("tabindex"), Is.False);
-            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo("0"));
+            label.HasAttribute("tabindex").Should().BeFalse();
+            input.GetAttribute("tabindex").Should().Be("0");
         }
 
         [TestCase("0")]
@@ -531,8 +531,8 @@ namespace MudBlazor.UnitTests.Components
 
             var input = comp.Find("input");
 
-            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo("-1"));
-            Assert.That(input.HasAttribute("disabled"), Is.True);
+            input.GetAttribute("tabindex").Should().Be("-1");
+            input.HasAttribute("disabled").Should().BeTrue();
         }
 
         [Test]
@@ -544,7 +544,7 @@ namespace MudBlazor.UnitTests.Components
 
             var input = comp.Find("input");
 
-            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo("-1"));
+            input.GetAttribute("tabindex").Should().Be("-1");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -488,5 +488,63 @@ namespace MudBlazor.UnitTests.Components
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".cb5 label.mud-checkbox #{input4ForId}").Should().NotBeNull();
         }
+
+        [TestCase("0")]
+        [TestCase("-1")]
+        public void CheckBox_RespectsUserTabIndex_WhenNotDisabled(string userTabIndex)
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(
+                p => p.AddUnmatched("tabindex", userTabIndex)
+            );
+
+            var label = comp.Find("label");
+            var input = comp.Find("input");
+
+            // tabindex should NOT be on label
+            Assert.That(label.HasAttribute("tabindex"), Is.False);
+
+            // tabindex should be on input and match user value
+            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo(userTabIndex));
+        }
+
+        [Test]
+        public void CheckBox_DefaultTabIndexIsZero_WhenNotProvided()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>();
+
+            var label = comp.Find("label");
+            var input = comp.Find("input");
+
+            Assert.That(label.HasAttribute("tabindex"), Is.False);
+            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo("0"));
+        }
+
+        [TestCase("0")]
+        [TestCase("5")]
+        [TestCase("-1")]
+        public void CheckBox_Disabled_ForcesTabIndexMinusOne(string userTabIndex)
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(
+                p => p.Add(x => x.Disabled, true)
+                      .AddUnmatched("tabindex", userTabIndex)
+            );
+
+            var input = comp.Find("input");
+
+            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo("-1"));
+            Assert.That(input.HasAttribute("disabled"), Is.True);
+        }
+
+        [Test]
+        public void CheckBox_Disabled_DefaultsToMinusOne()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(
+                p => p.Add(x => x.Disabled, true)
+            );
+
+            var input = comp.Find("input");
+
+            Assert.That(input.GetAttribute("tabindex"), Is.EqualTo("-1"));
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -447,5 +447,35 @@ namespace MudBlazor.UnitTests.Components
             var comp2 = Context.Render<MudRadio<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
+
+        [Test]
+        [TestCase("5")]
+        [TestCase("7")]
+        public void Radio_RespectsUserTabIndex_WhenNotDisabled(string userTabIndex)
+        {
+            var comp = Context.Render<MudRadio<bool>>(p => p.AddUnmatched("tabindex", userTabIndex));
+            var input = comp.Find("input");
+            input.GetAttribute("tabindex").Should().Be(userTabIndex);
+            input.Attributes.Count(a => string.Equals(a.Name, "tabindex", StringComparison.OrdinalIgnoreCase)).Should().Be(1);
+        }
+
+        [Test]
+        public void Radio_DefaultTabIndexIsZero_WhenNotProvided()
+        {
+            var comp = Context.Render<MudRadio<bool>>();
+            var input = comp.Find("input");
+            input.GetAttribute("tabindex").Should().Be("0");
+        }
+
+        [Test]
+        [TestCase("5")]
+        [TestCase("7")]
+        public void Radio_Disabled_ForcesTabIndexMinusOne(string userTabIndex)
+        {
+            var comp = Context.Render<MudRadio<bool>>(p => p.AddUnmatched("tabindex", userTabIndex).Add(x => x.Disabled, true));
+            var input = comp.Find("input");
+            input.GetAttribute("tabindex").Should().Be("-1");
+            input.Attributes.Count(a => string.Equals(a.Name, "tabindex", StringComparison.OrdinalIgnoreCase)).Should().Be(1);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -188,5 +188,35 @@ namespace MudBlazor.UnitTests.Components
             Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
             Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, true)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
         }
+
+        [Test]
+        [TestCase("5")]
+        [TestCase("7")]
+        public void Switch_RespectsUserTabIndex_WhenNotDisabled(string userTabIndex)
+        {
+            var comp = Context.Render<MudSwitch<bool>>(p => p.AddUnmatched("tabindex", userTabIndex));
+            var input = comp.Find("input");
+            input.GetAttribute("tabindex").Should().Be(userTabIndex);
+            input.Attributes.Count(a => string.Equals(a.Name, "tabindex", StringComparison.OrdinalIgnoreCase)).Should().Be(1);
+        }
+
+        [Test]
+        public void Switch_DefaultTabIndexIsZero_WhenNotProvided()
+        {
+            var comp = Context.Render<MudSwitch<bool>>();
+            var input = comp.Find("input");
+            input.GetAttribute("tabindex").Should().Be("0");
+        }
+
+        [Test]
+        [TestCase("5")]
+        [TestCase("7")]
+        public void Switch_Disabled_ForcesTabIndexMinusOne(string userTabIndex)
+        {
+            var comp = Context.Render<MudSwitch<bool>>(p => p.AddUnmatched("tabindex", userTabIndex).Add(x => x.Disabled, true));
+            var input = comp.Find("input");
+            input.GetAttribute("tabindex").Should().Be("-1");
+            input.Attributes.Count(a => string.Equals(a.Name, "tabindex", StringComparison.OrdinalIgnoreCase)).Should().Be(1);
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -43,42 +43,43 @@ namespace MudBlazor
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
         ///  <summary>
-        /// Returns the resolved tabindex for the input element.
+        /// Returns the resolved tabindex for the input element as well as user attributes splatted onto the input element. 
         /// </summary>
-        /// <returns>The first resolved tabindex value.</returns>
-        protected internal int GetResolvedTabIndex()
+        internal (int TabIndex, IReadOnlyDictionary<string, object>? Attributes) ResolveTabIndexAndAttributes()
         {
-            if (GetDisabledState())
+            if (UserAttributes == null || UserAttributes.Count == 0)
             {
-                return -1;
+                return (GetDisabledState() ? -1 : 0, null);
             }
 
-            if (UserAttributes != null)
+            int? userTabIndex = null;
+            Dictionary<string, object>? filtered = null;
+
+            foreach (var kvp in UserAttributes)
             {
-                foreach (var attribute in UserAttributes)
+                if (string.Equals(kvp.Key, "tabindex", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (string.Equals(attribute.Key, "tabindex", StringComparison.OrdinalIgnoreCase) &&
-                        int.TryParse(attribute.Value?.ToString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                    if (int.TryParse(
+                        kvp.Value?.ToString(),
+                        System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        out var parsed))
                     {
-                        return parsed;
+                        userTabIndex = parsed;
                     }
+
+                    continue;
                 }
+
+                filtered ??= new Dictionary<string, object>(UserAttributes.Count);
+                filtered[kvp.Key] = kvp.Value!;
             }
 
-            return 0;
-        }
+            var resolvedTabIndex = GetDisabledState()
+                ? -1
+                : userTabIndex ?? 0;
 
-        /// <summary>
-        /// Returns UserAttributes excluding any tabindex key (case-insensitive).
-        /// </summary>
-        protected internal IReadOnlyDictionary<string, object>? GetResolvedUserAttributes()
-        {
-            if (UserAttributes == null)
-                return null;
-
-            return UserAttributes
-                .Where(a => !string.Equals(a.Key, "tabindex", StringComparison.OrdinalIgnoreCase))
-                .ToDictionary(a => a.Key, a => (object)a.Value!);
+            return (resolvedTabIndex, filtered);
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -47,12 +47,12 @@ namespace MudBlazor
         /// <summary>
         /// The <c>tabindex</c> value resolved for the underlying input element.
         /// </summary>
-        protected int InputTabIndex => _inputTabIndex;
+        internal int InputTabIndex => _inputTabIndex;
 
         /// <summary>
         /// The user attributes for the underlying input element, excluding <c>tabindex</c>.
         /// </summary>
-        protected IReadOnlyDictionary<string, object?>? InputUserAttributes => _inputUserAttributes;
+        internal IReadOnlyDictionary<string, object?>? InputUserAttributes => _inputUserAttributes;
 
         /// <inheritdoc />
         protected override void OnParametersSet()

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -42,21 +42,43 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
-        protected int GetResolvedTabIndex()
+        ///  <summary>
+        /// Returns the resolved tabindex for the input element.
+        /// </summary>
+        /// <returns>The first resolved tabindex value.</returns>
+        protected internal int GetResolvedTabIndex()
         {
             if (GetDisabledState())
             {
                 return -1;
             }
 
-            if (UserAttributes != null &&
-                UserAttributes.TryGetValue("tabindex", out var value) &&
-                int.TryParse(value?.ToString(), out var parsed))
+            if (UserAttributes != null)
             {
-                return parsed;
+                foreach (var attribute in UserAttributes)
+                {
+                    if (string.Equals(attribute.Key, "tabindex", StringComparison.OrdinalIgnoreCase) &&
+                        int.TryParse(attribute.Value?.ToString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                    {
+                        return parsed;
+                    }
+                }
             }
 
             return 0;
+        }
+
+        /// <summary>
+        /// Returns UserAttributes excluding any tabindex key (case-insensitive).
+        /// </summary>
+        protected internal IReadOnlyDictionary<string, object>? GetResolvedUserAttributes()
+        {
+            if (UserAttributes == null)
+                return null;
+
+            return UserAttributes
+                .Where(a => !string.Equals(a.Key, "tabindex", StringComparison.OrdinalIgnoreCase))
+                .ToDictionary(a => a.Key, a => (object)a.Value!);
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -14,6 +14,8 @@ namespace MudBlazor
     public class MudBooleanInput<T> : MudFormComponent<T?, bool?>
     {
         private readonly ParameterState<T?> _valueState;
+        private int _inputTabIndex;
+        private IReadOnlyDictionary<string, object?>? _inputUserAttributes;
 
         public MudBooleanInput()
         {
@@ -42,18 +44,30 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
-        ///  <summary>
-        /// Returns the resolved tabindex for this input element as well as user attributes splatted onto this input element. 
+        /// <summary>
+        /// The <c>tabindex</c> value resolved for the underlying input element.
         /// </summary>
-        internal (int TabIndex, IReadOnlyDictionary<string, object>? Attributes) ResolveTabIndexAndAttributes()
+        protected int InputTabIndex => _inputTabIndex;
+
+        /// <summary>
+        /// The user attributes for the underlying input element, excluding <c>tabindex</c>.
+        /// </summary>
+        protected IReadOnlyDictionary<string, object?>? InputUserAttributes => _inputUserAttributes;
+
+        /// <inheritdoc />
+        protected override void OnParametersSet()
         {
+            base.OnParametersSet();
+
             if (UserAttributes == null || UserAttributes.Count == 0)
             {
-                return (GetDisabledState() ? -1 : 0, null);
+                _inputTabIndex = GetDisabledState() ? -1 : 0;
+                _inputUserAttributes = null;
+                return;
             }
 
             int? userTabIndex = null;
-            Dictionary<string, object>? filtered = null;
+            Dictionary<string, object?>? filtered = null;
 
             foreach (var kvp in UserAttributes)
             {
@@ -71,15 +85,15 @@ namespace MudBlazor
                     continue;
                 }
 
-                filtered ??= new Dictionary<string, object>(UserAttributes.Count);
-                filtered[kvp.Key] = kvp.Value!;
+                filtered ??= new Dictionary<string, object?>(UserAttributes.Count);
+                filtered[kvp.Key] = kvp.Value;
             }
 
-            var resolvedTabIndex = GetDisabledState()
+            _inputTabIndex = GetDisabledState()
                 ? -1
                 : userTabIndex ?? 0;
 
-            return (resolvedTabIndex, filtered);
+            _inputUserAttributes = filtered;
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -69,12 +69,12 @@ namespace MudBlazor
             int? userTabIndex = null;
             Dictionary<string, object?>? filtered = null;
 
-            foreach (var kvp in UserAttributes)
+            foreach (var (key, value) in UserAttributes)
             {
-                if (string.Equals(kvp.Key, "tabindex", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(key, "tabindex", StringComparison.OrdinalIgnoreCase))
                 {
                     if (int.TryParse(
-                        kvp.Value?.ToString(),
+                        value?.ToString(),
                         System.Globalization.NumberStyles.Integer,
                         System.Globalization.CultureInfo.InvariantCulture,
                         out var parsed))
@@ -85,14 +85,11 @@ namespace MudBlazor
                     continue;
                 }
 
-                filtered ??= new Dictionary<string, object?>(UserAttributes.Count);
-                filtered[kvp.Key] = kvp.Value;
+                filtered ??= new(UserAttributes.Count);
+                filtered[key] = value;
             }
 
-            _inputTabIndex = GetDisabledState()
-                ? -1
-                : userTabIndex ?? 0;
-
+            _inputTabIndex = GetDisabledState() ? -1 : userTabIndex ?? 0;
             _inputUserAttributes = filtered;
         }
 

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -43,7 +43,7 @@ namespace MudBlazor
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
         ///  <summary>
-        /// Returns the resolved tabindex for the input element as well as user attributes splatted onto the input element. 
+        /// Returns the resolved tabindex for this input element as well as user attributes splatted onto this input element. 
         /// </summary>
         internal (int TabIndex, IReadOnlyDictionary<string, object>? Attributes) ResolveTabIndexAndAttributes()
         {

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -42,6 +42,23 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
+        protected int GetResolvedTabIndex()
+        {
+            if (GetDisabledState())
+            {
+                return -1;
+            }
+
+            if (UserAttributes != null &&
+                UserAttributes.TryGetValue("tabindex", out var value) &&
+                int.TryParse(value?.ToString(), out var parsed))
+            {
+                return parsed;
+            }
+
+            return 0;
+        }
+
         /// <summary>
         /// Prevents the user from changing the input.
         /// </summary>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,7 +7,9 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes"
+                       tabindex="@GetResolvedTabIndex()" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange"
+                       disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,8 +7,11 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@GetResolvedUserAttributes()"
-                       tabindex="@GetResolvedTabIndex()" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange"
+                @{
+                    var (resolvedForTabIndex, resolvedUserAttributes) = ResolveTabIndexAndAttributes();
+                }
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@resolvedUserAttributes"
+                       tabindex="@resolvedForTabIndex" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange"
                        disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,7 +7,7 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes"
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@GetResolvedUserAttributes()"
                        tabindex="@GetResolvedTabIndex()" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange"
                        disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,11 +7,8 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                @{
-                    var (resolvedForTabIndex, resolvedUserAttributes) = ResolveTabIndexAndAttributes();
-                }
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@resolvedUserAttributes"
-                       tabindex="@resolvedForTabIndex" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange"
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@InputUserAttributes"
+                       tabindex="@InputTabIndex" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange"
                        disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -217,19 +217,6 @@ namespace MudBlazor
                 ? SetBoolValueAsync(null, true)
                 : Task.CompletedTask;
 
-        private int GetResolvedTabIndex()
-        {
-            if (GetDisabledState())
-                return -1;
-
-            if (UserAttributes != null &&
-                UserAttributes.TryGetValue("tabindex", out var value) &&
-                int.TryParse(value?.ToString(), out var parsed))
-                return parsed;
-
-            return 0;
-        }
-
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -217,6 +217,19 @@ namespace MudBlazor
                 ? SetBoolValueAsync(null, true)
                 : Task.CompletedTask;
 
+        private int GetResolvedTabIndex()
+        {
+            if (GetDisabledState())
+                return -1;
+
+            if (UserAttributes != null &&
+                UserAttributes.TryGetValue("tabindex", out var value) &&
+                int.TryParse(value?.ToString(), out var parsed))
+                return parsed;
+
+            return 0;
+        }
+
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,10 +6,13 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                  <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@GetResolvedUserAttributes()"
-                         tabindex="@GetResolvedTabIndex()" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" 
-                         checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" 
-                         @onclick="OnClickAsync" />
+                @{
+                    var (resolvedForTabIndex, resolvedUserAttributes) = ResolveTabIndexAndAttributes();
+                }
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@resolvedUserAttributes"
+                        tabindex="@resolvedForTabIndex" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" 
+                        checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" 
+                        @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,11 +6,8 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                @{
-                    var (resolvedForTabIndex, resolvedUserAttributes) = ResolveTabIndexAndAttributes();
-                }
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@resolvedUserAttributes"
-                        tabindex="@resolvedForTabIndex" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" 
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@InputUserAttributes"
+                        tabindex="@InputTabIndex" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" 
                         checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" 
                         @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,8 +6,10 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes"
-                       tabindex="@GetResolvedTabIndex()" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                  <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@GetResolvedUserAttributes()"
+                         tabindex="@GetResolvedTabIndex()" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" 
+                         checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" 
+                         @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,7 +6,8 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes"
+                       tabindex="@GetResolvedTabIndex()" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,8 +8,10 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" 
-                               tabindex="@GetResolvedTabIndex()" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                           <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetResolvedUserAttributes()" 
+                                  tabindex="@GetResolvedTabIndex()" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" 
+                                  class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" 
+                                  @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">
                             @if (!string.IsNullOrEmpty(ThumbIcon))
                             {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,7 +8,8 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" 
+                               tabindex="@GetResolvedTabIndex()" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">
                             @if (!string.IsNullOrEmpty(ThumbIcon))
                             {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,10 +8,13 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                           <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetResolvedUserAttributes()" 
-                                  tabindex="@GetResolvedTabIndex()" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" 
-                                  class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" 
-                                  @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                        @{
+                            var (resolvedForTabIndex, resolvedUserAttributes) = ResolveTabIndexAndAttributes();
+                        }
+                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@resolvedUserAttributes" 
+                                tabindex="@resolvedForTabIndex" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" 
+                                class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" 
+                                @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">
                             @if (!string.IsNullOrEmpty(ThumbIcon))
                             {

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,11 +8,8 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                        @{
-                            var (resolvedForTabIndex, resolvedUserAttributes) = ResolveTabIndexAndAttributes();
-                        }
-                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@resolvedUserAttributes" 
-                                tabindex="@resolvedForTabIndex" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" 
+                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="@InputUserAttributes" 
+                                tabindex="@InputTabIndex" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" 
                                 class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" 
                                 @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Resolves #7346 
This PR unifies and improves tabIndex handling for `MudCheckBox`, `MudSwitch`, and `MudRadio`:

TabIndex is now resolved in a case-insensitive manner from UserAttributes property (tabindex, TabIndex, etc.).
All casing variants of tabIndex are filtered out from splatted attributes, preventing duplicate attributes in the rendered HTML.
Parsing of TabIndex values uses culture-invariant logic for consistency.
The logic is centralized in MudBooleanInput, with all three components using the same approach.
Unit tests have been added for `MudSwitch` and `MudRadio` to match `MudCheckBox` coverage, verifying default, user-supplied, and disabled tabindex behavior as well as `MudBooleanInput` tests.
Additional tests ensure only one TabIndex attribute is rendered, regardless of casing.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
