### PR TITLE
MudCheckBox, MudSwitch, MudRadio: Respect user-defined `tabindex`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -439,6 +439,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void CheckBox_Respects_Custom_TabIndex()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters.AddUnmatched("tabindex", "-1"));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
             Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span").ClassList.Should().Contain("hover:mud-default-hover");

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -447,6 +447,30 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void CheckBox_Uses_Default_TabIndex_When_Enabled()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>();
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("0");
+        }
+
+        [Test]
+        public void CheckBox_Uses_Default_TabIndex_When_Disabled()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters.Add(x => x.Disabled, true));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
+        public void CheckBox_Respects_Custom_TabIndex_CaseInsensitive()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters.AddUnmatched("TabIndex", "-1"));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
             Context.Render<MudCheckBox<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span").ClassList.Should().Contain("hover:mud-default-hover");

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -405,6 +405,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Radio_Respects_Custom_TabIndex()
+        {
+            var comp = Context.Render<MudRadio<bool>>(parameters => parameters.AddUnmatched("tabindex", "-1"));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
         public void ReadOnlyDisabled_ShouldNot_Ripple()
         {
             var create = (bool readOnly, bool disabled) => Context.Render<MudRadioGroup<bool>>(self => self

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -413,6 +413,30 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Radio_Uses_Default_TabIndex_When_Enabled()
+        {
+            var comp = Context.Render<MudRadio<bool>>();
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("0");
+        }
+
+        [Test]
+        public void Radio_Uses_Default_TabIndex_When_Disabled()
+        {
+            var comp = Context.Render<MudRadio<bool>>(parameters => parameters.Add(x => x.Disabled, true));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
+        public void Radio_Respects_Custom_TabIndex_CaseInsensitive()
+        {
+            var comp = Context.Render<MudRadio<bool>>(parameters => parameters.AddUnmatched("TabIndex", "-1"));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
         public void ReadOnlyDisabled_ShouldNot_Ripple()
         {
             var create = (bool readOnly, bool disabled) => Context.Render<MudRadioGroup<bool>>(self => self

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -179,6 +179,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Switch_Respects_Custom_TabIndex()
+        {
+            var comp = Context.Render<MudSwitch<bool>>(parameters => parameters.AddUnmatched("tabindex", "-1"));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
             Context.Render<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().Contain("hover:mud-default-hover");

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -187,6 +187,30 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Switch_Uses_Default_TabIndex_When_Enabled()
+        {
+            var comp = Context.Render<MudSwitch<bool>>();
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("0");
+        }
+
+        [Test]
+        public void Switch_Uses_Default_TabIndex_When_Disabled()
+        {
+            var comp = Context.Render<MudSwitch<bool>>(parameters => parameters.Add(x => x.Disabled, true));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
+        public void Switch_Respects_Custom_TabIndex_CaseInsensitive()
+        {
+            var comp = Context.Render<MudSwitch<bool>>(parameters => parameters.AddUnmatched("TabIndex", "-1"));
+
+            comp.Find("input").GetAttribute("tabindex").Should().Be("-1");
+        }
+
+        [Test]
         public void ReadOnlyDisabled_ShouldNot_Hover()
         {
             Context.Render<MudSwitch<bool>>(self => self.Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().Contain("hover:mud-default-hover");

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -135,6 +135,21 @@ namespace MudBlazor
             return SetBoolValueAsync((bool?)args.Value, true);
         }
 
+        protected Dictionary<string, object?> GetInputAttributes()
+        {
+            var attributes = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["tabindex"] = GetDisabledState() ? -1 : 0
+            };
+
+            foreach (var userAttribute in UserAttributes)
+            {
+                attributes[userAttribute.Key] = userAttribute.Value;
+            }
+
+            return attributes;
+        }
+
         protected Task SetBoolValueAsync(bool? value, bool? markAsTouched = null)
         {
             if (markAsTouched is true)

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,7 +7,7 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,7 +6,7 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,7 +8,7 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="UserAttributes" tabindex="@(GetDisabledState() ? -1 : 0)" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">
                             @if (!string.IsNullOrEmpty(ThumbIcon))
                             {


### PR DESCRIPTION
This fixes a `tabindex` precedence issue on boolean inputs where user-supplied `tabindex` values could be ignored.

`MudCheckBox`, `MudSwitch`, and `MudRadio` were applying a default `tabindex` directly on the internal `<input>`, which could override user intent in some scenarios. Now, user-provided `tabindex` is respected.

**Changes:**
- Added shared input attribute resolution in `MudBooleanInput<T>`:
  - `GetInputAttributes()`
  - Sets default `tabindex` (`0` enabled / `-1` disabled)
  - Merges `UserAttributes` after defaults
  - Uses case-insensitive keys (`StringComparer.OrdinalIgnoreCase`) so `tabindex` overrides are reliable
- Updated:
  - `MudCheckBox` input markup to use `@attributes="GetInputAttributes()"`
  - `MudSwitch` input markup to use `@attributes="GetInputAttributes()"`
  - `MudRadio` input markup to use `@attributes="GetInputAttributes()"`

Closes #7346 and Closes #12800

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
