### PR TITLE
DefaultConverter: Add IParsable support

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDragHandleTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropzoneDragHandleTest.razor
@@ -1,4 +1,4 @@
-@namespace MudBlazor.UnitTests.TestComponents.DropZone
+﻿@namespace MudBlazor.UnitTests.TestComponents.DropZone
 
 <MudDropContainer T="SimpleDropItem" Items="_items" ItemsSelector="@((item,dropzone) => item.Selector == dropzone)" ItemDropped="ItemUpdated">
     <ChildContent>
@@ -16,10 +16,7 @@
 </MudDropContainer>
 
 @code {
-    private List<SimpleDropItem> _items = new()
-    {
-        new SimpleDropItem { Name = "Item 1", Selector = "Zone 1" }
-    };
+    private readonly List<SimpleDropItem> _items = [new() { Name = "Item 1", Selector = "Zone 1" }];
 
     private void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropInfo)
     {

--- a/src/MudBlazor.UnitTests/Converters/BoolConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/BoolConverterTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
 using AwesomeAssertions;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Converters/BoolConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/BoolConverterTests.cs
@@ -516,8 +516,7 @@ public class BoolConverterTests
         Action act = () => conv.Convert(new object());
 
         act.Should()
-            .Throw<TargetInvocationException>()
-            .WithInnerException<InvalidOperationException>()
+            .Throw<InvalidOperationException>()
             .WithMessage("Cannot convert type System.Object to bool?");
     }
 }

--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -1121,4 +1121,80 @@ public class DefaultConverterTests
     }
 
     #endregion
+
+    #region IParsable
+
+    [Test]
+    public void DefaultConverter_IParsable_ConvertBack_ValidValue_UsesCulture()
+    {
+        var conv = new DefaultConverter<ParsableTemperature>
+        {
+            Culture = () => new CultureInfo("fr-FR")
+        };
+
+        var parsed = conv.ConvertBack("12,5");
+
+        parsed.Value.Should().Be(12.5m);
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableNullable_ConvertBack_NullOrEmpty_ReturnsNull()
+    {
+        var conv = new DefaultConverter<ParsableTemperature?>();
+
+        conv.ConvertBack(null).Should().BeNull();
+        conv.ConvertBack(string.Empty).Should().BeNull();
+    }
+
+    [Test]
+    public void DefaultConverter_IParsable_ConvertBack_NullOrEmpty_ReturnsDefault()
+    {
+        var conv = new DefaultConverter<ParsableTemperature>();
+
+        conv.ConvertBack(null).Should().Be(default(ParsableTemperature));
+        conv.ConvertBack(string.Empty).Should().Be(default(ParsableTemperature));
+    }
+
+    [Test]
+    public void DefaultConverter_IParsable_ConvertBack_Invalid_ThrowsConversionException_WithExpectedKeyAndTypeName()
+    {
+        var conv = new DefaultConverter<ParsableTemperature>();
+
+        Action act = () => conv.ConvertBack("not-a-temperature");
+
+        var exception = act.Should()
+            .Throw<ConversionException>()
+            .Which;
+
+        exception.ErrorMessageKey.Should().Be(LanguageResource.Converter_InvalidType);
+        exception.ErrorMessageArgs.Should().ContainSingle();
+        exception.ErrorMessageArgs[0].Should().Be(nameof(ParsableTemperature));
+    }
+
+    private readonly record struct ParsableTemperature(decimal Value) : IParsable<ParsableTemperature>
+    {
+        public static ParsableTemperature Parse(string s, IFormatProvider? provider)
+        {
+            if (!TryParse(s, provider, out var result))
+            {
+                throw new FormatException();
+            }
+
+            return result;
+        }
+
+        public static bool TryParse(string? s, IFormatProvider? provider, out ParsableTemperature result)
+        {
+            if (decimal.TryParse(s, NumberStyles.Any, provider, out var value))
+            {
+                result = new ParsableTemperature(value);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+    }
+
+    #endregion
 }

--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -1138,6 +1138,15 @@ public class DefaultConverterTests
     }
 
     [Test]
+    public void DefaultConverter_IParsable_Convert_ReturnsStringRepresentation()
+    {
+        var conv = new DefaultConverter<ParsableTemperature>();
+        var value = new ParsableTemperature(12.5m);
+
+        conv.Convert(value).Should().Be(value.ToString());
+    }
+
+    [Test]
     public void DefaultConverter_IParsableNullable_ConvertBack_NullOrEmpty_ReturnsNull()
     {
         var conv = new DefaultConverter<ParsableTemperature?>();
@@ -1147,12 +1156,51 @@ public class DefaultConverterTests
     }
 
     [Test]
+    public void DefaultConverter_IParsableNullable_Convert_ReturnsStringRepresentation()
+    {
+        var conv = new DefaultConverter<ParsableTemperature?>();
+        var value = new ParsableTemperature(7.25m);
+
+        conv.Convert(value).Should().Be(value.ToString());
+        conv.Convert(null).Should().BeNull();
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableNullable_ConvertBack_ValidValue_UsesCulture()
+    {
+        var conv = new DefaultConverter<ParsableTemperature?>
+        {
+            Culture = () => new CultureInfo("fr-FR")
+        };
+
+        var parsed = conv.ConvertBack("7,25");
+
+        parsed.Should().Be(new ParsableTemperature(7.25m));
+    }
+
+    [Test]
     public void DefaultConverter_IParsable_ConvertBack_NullOrEmpty_ReturnsDefault()
     {
         var conv = new DefaultConverter<ParsableTemperature>();
 
         conv.ConvertBack(null).Should().Be(default(ParsableTemperature));
         conv.ConvertBack(string.Empty).Should().Be(default(ParsableTemperature));
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableNullable_ConvertBack_Invalid_ThrowsConversionException_WithExpectedKeyAndTypeName()
+    {
+        var conv = new DefaultConverter<ParsableTemperature?>();
+
+        Action act = () => conv.ConvertBack("not-a-temperature");
+
+        var exception = act.Should()
+            .Throw<ConversionException>()
+            .Which;
+
+        exception.ErrorMessageKey.Should().Be(LanguageResource.Converter_InvalidType);
+        exception.ErrorMessageArgs.Should().ContainSingle();
+        exception.ErrorMessageArgs[0].Should().Be(nameof(ParsableTemperature));
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -1147,6 +1147,14 @@ public class DefaultConverterTests
     }
 
     [Test]
+    public void DefaultConverter_IParsableReference_Convert_Null_ReturnsNull()
+    {
+        var conv = new DefaultConverter<ParsableLabel>();
+
+        conv.Convert(null).Should().BeNull();
+    }
+
+    [Test]
     public void DefaultConverter_IParsableNullable_ConvertBack_NullOrEmpty_ReturnsNull()
     {
         var conv = new DefaultConverter<ParsableTemperature?>();
@@ -1240,6 +1248,35 @@ public class DefaultConverterTests
             }
 
             result = default;
+            return false;
+        }
+    }
+
+    private sealed class ParsableLabel(string value) : IParsable<ParsableLabel>
+    {
+        public string Value { get; } = value;
+
+        public override string ToString() => Value;
+
+        public static ParsableLabel Parse(string s, IFormatProvider? provider)
+        {
+            if (TryParse(s, provider, out var result))
+            {
+                return result;
+            }
+
+            throw new FormatException();
+        }
+
+        public static bool TryParse(string? s, IFormatProvider? provider, out ParsableLabel result)
+        {
+            if (!string.IsNullOrWhiteSpace(s))
+            {
+                result = new ParsableLabel(s);
+                return true;
+            }
+
+            result = null!;
             return false;
         }
     }

--- a/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
@@ -63,6 +63,30 @@ public class TypeDispatcherPolicyTests
     }
 
     [Test]
+    public void TypeDispatcher_AddDynamic_WhenConverterTypeDoesNotImplementTargetInterface_ThrowsInvalidOperationException()
+    {
+        var builder = TypeDispatcher.Create<int, string>();
+
+        Action act = () => builder.AddDynamic(typeof(int), new ForwardOnlyStringConverter());
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Converter type*does not implement Convert(System.Int32)");
+    }
+
+    [Test]
+    public void TypeDispatcher_UnsupportedRegistrationPolicy_ThrowsOnAdd()
+    {
+        var builder = TypeDispatcher.Create<int, string>((DispatcherRegistrationPolicy)999);
+
+        Action act = () => builder.Add(new ConstantConverter("A"));
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Unsupported registration policy:*");
+    }
+
+    [Test]
     public void ReversibleTypeDispatcher_DefaultPolicy_LastWins()
     {
         var dispatcher = ReversibleTypeDispatcher
@@ -111,6 +135,30 @@ public class TypeDispatcherPolicyTests
 
         dispatcher.Convert(3).Should().Be("A3");
         dispatcher.ConvertBack("A3").Should().Be(3);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddDynamic_WhenConverterTypeDoesNotImplementForwardInterface_ThrowsInvalidOperationException()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>();
+
+        Action act = () => builder.AddDynamic(typeof(int), new ForwardOnlyStringConverter());
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Converter type*does not implement Convert(System.Int32)");
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddDynamic_WhenConverterTypeDoesNotImplementReverseInterface_ThrowsInvalidOperationException()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>();
+
+        Action act = () => builder.AddDynamic(typeof(int), new ForwardOnlyIntConverter());
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Converter type*does not implement ConvertBack(System.String)");
     }
 
     [Test]
@@ -221,5 +269,15 @@ public class TypeDispatcherPolicyTests
         public string Convert(int input) => input.ToString();
 
         public int ConvertBack(string input) => throw new ConversionException(LanguageResource.Converter_InvalidType, [nameof(Int32)]);
+    }
+
+    private sealed class ForwardOnlyStringConverter : IConverter<string, string>
+    {
+        public string Convert(string input) => input;
+    }
+
+    private sealed class ForwardOnlyIntConverter : IConverter<int, string>
+    {
+        public string Convert(int input) => input.ToString();
     }
 }

--- a/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
@@ -114,6 +114,50 @@ public class TypeDispatcherPolicyTests
     }
 
     [Test]
+    public void ReversibleTypeDispatcher_ConvertBack_WhenNoConverterRegistered_ThrowsConversionException()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>()
+            .Build();
+
+        Action act = () => dispatcher.ConvertBack("x");
+
+        var exception = act.Should()
+            .Throw<ConversionException>()
+            .Which;
+
+        exception.ErrorMessageKey.Should().Be(LanguageResource.Converter_ConversionNotImplemented);
+        exception.ErrorMessageArgs.Should().ContainSingle().Which.Should().Be(typeof(int));
+        exception.InnerException.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddDynamic_NullSpecificType_ThrowsArgumentNullException()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>();
+
+        Action act = () => builder.AddDynamic(null!, new PrefixConverter("A"));
+
+        act.Should()
+            .Throw<ArgumentNullException>()
+            .Which.ParamName
+            .Should()
+            .Be("specificType");
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_UnsupportedRegistrationPolicy_ThrowsOnAdd()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>((DispatcherRegistrationPolicy)999);
+
+        Action act = () => builder.Add(new PrefixConverter("A"));
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Unsupported registration policy:*");
+    }
+
+    [Test]
     public void TypeDispatcher_Convert_WhenConverterThrowsConversionException_RethrowsInnerException()
     {
         var dispatcher = TypeDispatcher

--- a/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using MudBlazor.Resources;
+using MudBlazor.Utilities.Converter.Dispatcher;
+using MudBlazor.Utilities.Exceptions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Converters;
+
+#nullable enable
+[TestFixture]
+public class TypeDispatcherPolicyTests
+{
+    [Test]
+    public void TypeDispatcher_DefaultPolicy_LastWins()
+    {
+        var dispatcher = TypeDispatcher
+            .Create<int, string>()
+            .Add(new ConstantConverter("first"))
+            .Add(new ConstantConverter("second"))
+            .Build();
+
+        dispatcher.Convert(123).Should().Be("second");
+    }
+
+    [Test]
+    public void TypeDispatcher_FirstWinsPolicy_UsesFirstRegistration()
+    {
+        var dispatcher = TypeDispatcher
+            .Create<int, string>(DispatcherRegistrationPolicy.FirstWins)
+            .Add(new ConstantConverter("first"))
+            .Add(new ConstantConverter("second"))
+            .Build();
+
+        dispatcher.Convert(123).Should().Be("first");
+    }
+
+    [Test]
+    public void TypeDispatcher_ThrowPolicy_ThrowsOnDuplicateRegistration()
+    {
+        var builder = TypeDispatcher
+            .Create<int, string>(DispatcherRegistrationPolicy.Throw)
+            .Add(new ConstantConverter("first"));
+
+        Action act = () => builder.Add(new ConstantConverter("second"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public void TypeDispatcher_AddDynamic_FirstWinsPolicy_UsesFirstRegistration()
+    {
+        var builder = TypeDispatcher.Create<int, string>(DispatcherRegistrationPolicy.FirstWins);
+        builder.AddDynamic(typeof(int), new ConstantConverter("first"));
+        builder.AddDynamic(typeof(int), new ConstantConverter("second"));
+
+        var dispatcher = builder.Build();
+
+        dispatcher.Convert(5).Should().Be("first");
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_DefaultPolicy_LastWins()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>()
+            .Add(new PrefixConverter("A"))
+            .Add(new PrefixConverter("B"))
+            .Build();
+
+        dispatcher.Convert(7).Should().Be("B7");
+        dispatcher.ConvertBack("B7").Should().Be(7);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_FirstWinsPolicy_UsesFirstRegistration()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>(DispatcherRegistrationPolicy.FirstWins)
+            .Add(new PrefixConverter("A"))
+            .Add(new PrefixConverter("B"))
+            .Build();
+
+        dispatcher.Convert(7).Should().Be("A7");
+        dispatcher.ConvertBack("A7").Should().Be(7);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_ThrowPolicy_ThrowsOnDuplicateRegistration()
+    {
+        var builder = ReversibleTypeDispatcher
+            .Create<int, string>(DispatcherRegistrationPolicy.Throw)
+            .Add(new PrefixConverter("A"));
+
+        Action act = () => builder.Add(new PrefixConverter("B"));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddDynamic_FirstWinsPolicy_UsesFirstRegistration()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>(DispatcherRegistrationPolicy.FirstWins);
+        builder.AddDynamic(typeof(int), new PrefixConverter("A"));
+        builder.AddDynamic(typeof(int), new PrefixConverter("B"));
+
+        var dispatcher = builder.Build();
+
+        dispatcher.Convert(3).Should().Be("A3");
+        dispatcher.ConvertBack("A3").Should().Be(3);
+    }
+
+    [Test]
+    public void TypeDispatcher_Convert_WhenConverterThrowsConversionException_RethrowsInnerException()
+    {
+        var dispatcher = TypeDispatcher
+            .Create<int, string>()
+            .Add(new ThrowingForwardConverter())
+            .Build();
+
+        Action act = () => dispatcher.Convert(1);
+
+        act.Should()
+            .Throw<ConversionException>()
+            .Which.ErrorMessageKey
+            .Should()
+            .Be(LanguageResource.Converter_InvalidType);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_ConvertBack_WhenConverterThrowsConversionException_RethrowsInnerException()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>()
+            .Add(new ThrowingReverseConverter())
+            .Build();
+
+        Action act = () => dispatcher.ConvertBack("x");
+
+        act.Should()
+            .Throw<ConversionException>()
+            .Which.ErrorMessageKey
+            .Should()
+            .Be(LanguageResource.Converter_InvalidType);
+    }
+
+    private sealed class ConstantConverter(string output) : IConverter<int, string>
+    {
+        public string Convert(int input) => output;
+    }
+
+    private sealed class PrefixConverter(string prefix) : IReversibleConverter<int, string>
+    {
+        public string Convert(int input) => $"{prefix}{input}";
+
+        public int ConvertBack(string input)
+        {
+            if (!input.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                throw new FormatException($"Input must start with '{prefix}'.");
+            }
+
+            return int.Parse(input.AsSpan(prefix.Length));
+        }
+    }
+
+    private sealed class ThrowingForwardConverter : IConverter<int, string>
+    {
+        public string Convert(int input) => throw new ConversionException(LanguageResource.Converter_InvalidType, [nameof(Int32)]);
+    }
+
+    private sealed class ThrowingReverseConverter : IReversibleConverter<int, string>
+    {
+        public string Convert(int input) => input.ToString();
+
+        public int ConvertBack(string input) => throw new ConversionException(LanguageResource.Converter_InvalidType, [nameof(Int32)]);
+    }
+}

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -4,7 +4,6 @@ using MudBlazor.Extensions;
 using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities;
-using MudBlazor.Utilities.Converter;
 
 namespace MudBlazor
 {

--- a/src/MudBlazor/Converters/BoolConverter.cs
+++ b/src/MudBlazor/Converters/BoolConverter.cs
@@ -22,7 +22,7 @@ public sealed class BoolConverter<T> : IReversibleConverter<T?, bool?>
 
     private BoolConverter()
     {
-        var builder = ReversibleTypeDispatcher.Create<T?, bool?>()
+        var builder = ReversibleTypeDispatcher.Create<T?, bool?>(DispatcherRegistrationPolicy.FirstWins)
             .Add(StringConverter.Instance)      // string <-> bool?
             .Add<bool>(BoolIdentity.Instance)   // bool <-> bool?
             .Add<bool?>(BoolIdentity.Instance)  // bool? <-> bool?

--- a/src/MudBlazor/Converters/DefaultConverter.Parsable.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.Parsable.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using MudBlazor.Resources;
+using MudBlazor.Utilities.Exceptions;
+
+namespace MudBlazor;
+
+internal partial class DefaultConverter
+{
+    internal sealed class ParsableConverter<TParsable>(Func<CultureInfo> culture)
+        : IReversibleConverter<TParsable?, string?>
+        where TParsable : IParsable<TParsable>
+    {
+        public string? Convert(TParsable? input) => input is null ? null : input.ToString();
+
+        public TParsable? ConvertBack(string? input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return default;
+            }
+
+            if (TParsable.TryParse(input, culture.Invoke(), out var result))
+            {
+                return result;
+            }
+
+            throw new ConversionException(LanguageResource.Converter_InvalidType, [typeof(TParsable).Name]);
+        }
+    }
+
+    internal sealed class NullableParsableConverter<TParsable>(Func<CultureInfo> culture)
+        : IReversibleConverter<TParsable?, string?>
+        where TParsable : struct, IParsable<TParsable>
+    {
+        public string? Convert(TParsable? input) => input?.ToString();
+
+        public TParsable? ConvertBack(string? input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
+            if (TParsable.TryParse(input, culture.Invoke(), out var result))
+            {
+                return result;
+            }
+
+            throw new ConversionException(LanguageResource.Converter_InvalidType, [typeof(TParsable).Name]);
+        }
+    }
+}

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -150,19 +150,6 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         return _dispatcher.ConvertBack(input);
     }
 
-    private static bool IsNullableEnum(Type type, [NotNullWhen(true)] out Type? result)
-    {
-        var underlyingType = Nullable.GetUnderlyingType(type);
-        if (underlyingType?.IsEnum is true)
-        {
-            result = underlyingType;
-            return true;
-        }
-
-        result = null!;
-        return false;
-    }
-
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2090",
@@ -208,5 +195,18 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
             .Any(x => x.IsGenericType
                       && x.GetGenericTypeDefinition() == typeof(IParsable<>)
                       && x.GenericTypeArguments[0] == type);
+    }
+
+    private static bool IsNullableEnum(Type type, [NotNullWhen(true)] out Type? result)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(type);
+        if (underlyingType?.IsEnum is true)
+        {
+            result = underlyingType;
+            return true;
+        }
+
+        result = null!;
+        return false;
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -153,16 +153,16 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
     // TODO: Consider adding DynamicallyAccessedMembers attribute in future as DefaultConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]T>, affects MudBaseInput, MudBaseDatePicker, MudFileUpload, MudColorPicker + 3rd party libraries.
     [UnconditionalSuppressMessage(
         "Trimming",
-        "IL2090",
-        Justification = "We should add DAM.Interfaces to DefaultConverter<[DAM(DAM.PublicParameterlessConstructor)]T> for true safety, but it would require MudInput<T> etc to be annotate with it too, external library will get compilation errors. Perhaps a change for future major versions?")]
+        "IL2090", // Missing DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+        Justification = "Not 200% safe without annotation, but considering if type is supplied by the user, it should work. Suppressed for backward compatibility.")]
     [UnconditionalSuppressMessage(
         "Trimming",
-        "IL2091",
-        Justification = "We should add DAM.Interfaces to DefaultConverter<[DAM(DAM.PublicParameterlessConstructor)]T> for true safety, but it would require MudInput<T> etc to be annotate with it too, external library will get compilation errors. Perhaps a change for future major versions?")]
+        "IL2091", // Missing DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+        Justification = "Not 200% safe without annotation, but considering if type is supplied by the user, it should work. Suppressed for backward compatibility.")]
     [UnconditionalSuppressMessage(
         "Trimming",
-        "IL2087",
-        Justification = "We should add DAM.Interfaces to DefaultConverter<[DAM(DAM.Interfaces)]T> for true safety, but it would require MudInput<T> etc to be annotate with it too, external library will get compilation errors. Perhaps a change for future major versions?")]
+        "IL2087", // Missing DynamicallyAccessedMemberTypes.Interfaces
+        Justification = "Not 200% safe without annotation, but considering if type is supplied by the user, it should work. Suppressed for backward compatibility.")]
     private void AddParsableConverters(IReversibleDispatcherBuilder<T?, string?> builder)
     {
         var targetType = typeof(T);

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -150,6 +150,7 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         return _dispatcher.ConvertBack(input);
     }
 
+    // TODO: Consider adding DynamicallyAccessedMembers attribute in future as DefaultConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]T>, affects MudBaseInput, MudBaseDatePicker, MudFileUpload, MudColorPicker + 3rd party libraries.
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2090",

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -42,7 +42,7 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         // The dispatcher caches method delegates and captures the converter's field values at registration time.
         // Using () => Culture() and () => Format() ensures the converters always read the latest property values.
         // We could make Add a factory Func<IConverter> overload, but that would create instance on each conversion attempt which is less performant than current the trick.
-        _dispatcher = ReversibleTypeDispatcher.Create<T?, string?>()
+        var builder = ReversibleTypeDispatcher.Create<T?, string?>(DispatcherRegistrationPolicy.FirstWins)
             .Add(StringConverter.Instance)
             .Add<char>(CharConverter.Instance)
             .Add<char?>(CharConverter.Instance)
@@ -83,10 +83,13 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
             .Add<TimeOnly>(new TimeOnlyConverter(() => Culture(), () => Format()))
             .Add<TimeOnly?>(new TimeOnlyConverter(() => Culture(), () => Format()))
             .Add<TimeSpan>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()))
-            .Add<TimeSpan?>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()))
+            .Add<TimeSpan?>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()));
             // Let's not use that for now and see if we really need it
             //.Add(new ObjectConverter(() => Culture(), () => Format()))
-            .Build();
+
+        AddParsableConverters(builder);
+
+        _dispatcher = builder.Build();
     }
 
     /// <inheritdoc />
@@ -158,5 +161,52 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
 
         result = null!;
         return false;
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2090",
+        Justification = "We should add DAM.Interfaces to DefaultConverter<[DAM(DAM.PublicParameterlessConstructor)]T> for true safety, but it would require MudInput<T> etc to be annotate with it too, external library will get compilation errors. Perhaps a change for future major versions?")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2091",
+        Justification = "We should add DAM.Interfaces to DefaultConverter<[DAM(DAM.PublicParameterlessConstructor)]T> for true safety, but it would require MudInput<T> etc to be annotate with it too, external library will get compilation errors. Perhaps a change for future major versions?")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2087",
+        Justification = "We should add DAM.Interfaces to DefaultConverter<[DAM(DAM.Interfaces)]T> for true safety, but it would require MudInput<T> etc to be annotate with it too, external library will get compilation errors. Perhaps a change for future major versions?")]
+    private void AddParsableConverters(IReversibleDispatcherBuilder<T?, string?> builder)
+    {
+        var targetType = typeof(T);
+
+        var nullableUnderlyingType = Nullable.GetUnderlyingType(targetType);
+        if (nullableUnderlyingType is not null && ImplementsIParsable(nullableUnderlyingType))
+        {
+            var nullableConverterType = typeof(NullableParsableConverter<>).MakeGenericType(nullableUnderlyingType);
+            var nullableConverter = Activator.CreateInstance(nullableConverterType, (Func<CultureInfo>)(() => Culture()));
+            if (nullableConverter is not null)
+            {
+                builder.AddDynamic(targetType, nullableConverter);
+            }
+        }
+
+        if (ImplementsIParsable(targetType))
+        {
+            var converterType = typeof(ParsableConverter<>).MakeGenericType(targetType);
+            var converter = Activator.CreateInstance(converterType, (Func<CultureInfo>)(() => Culture()));
+            if (converter is not null)
+            {
+                builder.AddDynamic(targetType, converter);
+            }
+        }
+    }
+
+    private static bool ImplementsIParsable([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+    {
+        return type
+            .GetInterfaces()
+            .Any(x => x.IsGenericType
+                      && x.GetGenericTypeDefinition() == typeof(IParsable<>)
+                      && x.GenericTypeArguments[0] == type);
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -84,8 +84,8 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
             .Add<TimeOnly?>(new TimeOnlyConverter(() => Culture(), () => Format()))
             .Add<TimeSpan>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()))
             .Add<TimeSpan?>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()));
-            // Let's not use that for now and see if we really need it
-            //.Add(new ObjectConverter(() => Culture(), () => Format()))
+        // Let's not use that for now and see if we really need it
+        //.Add(new ObjectConverter(() => Culture(), () => Format()))
 
         AddParsableConverters(builder);
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/DispatcherRegistrationPolicy.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/DispatcherRegistrationPolicy.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Utilities.Converter.Dispatcher;
+
+/// <summary>
+/// Determines how dispatcher builders handle registrations for the same specific input type.
+/// </summary>
+public enum DispatcherRegistrationPolicy
+{
+    /// <summary>
+    /// The newest registration replaces the previous one.
+    /// </summary>
+    LastWins = 0,
+
+    /// <summary>
+    /// The first registration is kept and later duplicates are ignored.
+    /// </summary>
+    FirstWins = 1,
+
+    /// <summary>
+    /// Duplicate registrations throw an exception.
+    /// </summary>
+    Throw = 2
+}

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -77,7 +77,6 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             catch (TargetInvocationException ex) when (ex.InnerException is not null)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw;
             }
         }
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -154,7 +154,7 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
                     _reverseHandlers.Add(specificType, backwardHandler);
                     return;
                 default:
-                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {registrationPolicy}.");
+                    throw new InvalidOperationException($"Unsupported registration policy: {registrationPolicy}.");
             }
         }
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.ExceptionServices;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -23,7 +24,21 @@ public static class ReversibleTypeDispatcher
     /// A builder implementing <see cref="IReversibleDispatcherBuilder{TIn,TOut}"/>
     /// to register per-type reversible converters and produce a concrete dispatcher via <see cref="IReversibleDispatcherBuilder{TIn,TOut}.Build"/>.
     /// </returns>
-    public static IReversibleDispatcherBuilder<TIn, TOut> Create<TIn, TOut>() => new ReversibleTypeDispatcher<TIn, TOut>.ReversibleBuilder();
+    public static IReversibleDispatcherBuilder<TIn, TOut> Create<TIn, TOut>()
+        => new ReversibleTypeDispatcher<TIn, TOut>.ReversibleBuilder(DispatcherRegistrationPolicy.LastWins);
+
+    /// <summary>
+    /// Creates a new reversible dispatcher builder for dispatching conversions from <typeparamref name="TIn"/> to <typeparamref name="TOut"/>.
+    /// </summary>
+    /// <typeparam name="TIn">The general input type accepted by the resulting dispatcher.</typeparam>
+    /// <typeparam name="TOut">The output type produced by registered reversible converters.</typeparam>
+    /// <param name="duplicateRegistrationPolicy">How registrations for the same concrete type are handled.</param>
+    /// <returns>
+    /// A builder implementing <see cref="IReversibleDispatcherBuilder{TIn,TOut}"/>
+    /// to register per-type reversible converters and produce a concrete dispatcher via <see cref="IReversibleDispatcherBuilder{TIn,TOut}.Build"/>.
+    /// </returns>
+    public static IReversibleDispatcherBuilder<TIn, TOut> Create<TIn, TOut>(DispatcherRegistrationPolicy duplicateRegistrationPolicy)
+        => new ReversibleTypeDispatcher<TIn, TOut>.ReversibleBuilder(duplicateRegistrationPolicy);
 }
 
 internal class ReversibleTypeDispatcher<TIn, TOut> :
@@ -55,7 +70,15 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
 
         if (_backwards.TryGetValue(runtimeType, out var del))
         {
-            return (TIn)del.DynamicInvoke(input)!;
+            try
+            {
+                return (TIn)del.DynamicInvoke(input)!;
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
         }
 
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));
@@ -65,14 +88,20 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
     {
         private readonly Dictionary<Type, Delegate> _handlers = new();
         private readonly Dictionary<Type, Delegate> _reverseHandlers = new();
+        private readonly DispatcherRegistrationPolicy _duplicateRegistrationPolicy;
+
+        public ReversibleBuilder(DispatcherRegistrationPolicy duplicateRegistrationPolicy)
+        {
+            _duplicateRegistrationPolicy = duplicateRegistrationPolicy;
+        }
 
         /// <inheritdoc />
         public IReversibleDispatcherBuilder<TIn, TOut> Add<TSpecific>(IReversibleConverter<TSpecific, TOut> converter)
         {
-            _handlers[typeof(TSpecific)] = new Func<TSpecific, TOut>(converter.Convert);
-
-            // backward
-            _reverseHandlers[typeof(TSpecific)] = new Func<TOut, TSpecific>(converter.ConvertBack);
+            AddHandlers(
+                typeof(TSpecific),
+                new Func<TSpecific, TOut>(converter.Convert),
+                new Func<TOut, TSpecific>(converter.ConvertBack));
 
             return this;
         }
@@ -104,13 +133,39 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             var forwardDelegate = convertMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
             var backwardDelegate = convertBackMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(typeof(TOut), specificType), converter);
 
-            _handlers[specificType] = forwardDelegate;
-            _reverseHandlers[specificType] = backwardDelegate;
+            AddHandlers(specificType, forwardDelegate, backwardDelegate);
 
             return this;
+        }
+
+        private void AddHandlers(Type specificType, Delegate forwardHandler, Delegate backwardHandler)
+        {
+            switch (_duplicateRegistrationPolicy)
+            {
+                case DispatcherRegistrationPolicy.LastWins:
+                    _handlers[specificType] = forwardHandler;
+                    _reverseHandlers[specificType] = backwardHandler;
+                    return;
+                case DispatcherRegistrationPolicy.FirstWins:
+                    _handlers.TryAdd(specificType, forwardHandler);
+                    _reverseHandlers.TryAdd(specificType, backwardHandler);
+                    return;
+                case DispatcherRegistrationPolicy.Throw:
+                    if (_handlers.ContainsKey(specificType) || _reverseHandlers.ContainsKey(specificType))
+                    {
+                        throw new InvalidOperationException($"Converter already registered for {specificType}.");
+                    }
+
+                    _handlers.Add(specificType, forwardHandler);
+                    _reverseHandlers.Add(specificType, backwardHandler);
+                    return;
+                default:
+                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {_duplicateRegistrationPolicy}.");
+            }
         }
 
         /// <inheritdoc />
         public IReversibleConverter<TIn, TOut> Build() => new ReversibleTypeDispatcher<TIn, TOut>(_handlers, _reverseHandlers);
     }
 }
+

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -109,23 +109,24 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             var convType = converter.GetType();
 
             var convertMethodInterface = typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-            if (convertMethod is null)
+            if (!convertMethodInterface.IsAssignableFrom(convType))
             {
                 throw new InvalidOperationException($"Converter type {convType.FullName} does not implement Convert({specificType})");
             }
 
-            var convertBackMethodInterface = typeof(IReversibleConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            var convertBackMethod = convertBackMethodInterface.GetMethod(nameof(IReversibleConverter<TIn, TOut>.ConvertBack), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
-            if (convertBackMethod is null)
+            var convertBackMethodInterface = typeof(IReversibleConverter<,>).MakeGenericType(specificType, typeof(TOut));
+            if (!convertBackMethodInterface.IsAssignableFrom(convType))
             {
                 throw new InvalidOperationException($"Converter type {convType.FullName} does not implement ConvertBack({typeof(TOut)})");
             }
 
-            var forwardDelegate = convertMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
-            var backwardDelegate = convertBackMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(typeof(TOut), specificType), converter);
+            var convertBackMethod = convertBackMethodInterface.GetMethod(nameof(IReversibleConverter<TIn, TOut>.ConvertBack), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            // Cannot be null since we already verified the interface is implemented
+            var forwardDelegate = convertMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
+            var backwardDelegate = convertBackMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(typeof(TOut), specificType), converter);
 
             AddHandlers(specificType, forwardDelegate, backwardDelegate);
 
@@ -162,4 +163,3 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
         public IReversibleConverter<TIn, TOut> Build() => new ReversibleTypeDispatcher<TIn, TOut>(_handlers, _reverseHandlers);
     }
 }
-

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -84,16 +84,11 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));
     }
 
-    internal class ReversibleBuilder : IReversibleDispatcherBuilder<TIn, TOut>
+    internal class ReversibleBuilder(DispatcherRegistrationPolicy registrationPolicy)
+        : IReversibleDispatcherBuilder<TIn, TOut>
     {
         private readonly Dictionary<Type, Delegate> _handlers = new();
         private readonly Dictionary<Type, Delegate> _reverseHandlers = new();
-        private readonly DispatcherRegistrationPolicy _duplicateRegistrationPolicy;
-
-        public ReversibleBuilder(DispatcherRegistrationPolicy duplicateRegistrationPolicy)
-        {
-            _duplicateRegistrationPolicy = duplicateRegistrationPolicy;
-        }
 
         /// <inheritdoc />
         public IReversibleDispatcherBuilder<TIn, TOut> Add<TSpecific>(IReversibleConverter<TSpecific, TOut> converter)
@@ -140,7 +135,7 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
 
         private void AddHandlers(Type specificType, Delegate forwardHandler, Delegate backwardHandler)
         {
-            switch (_duplicateRegistrationPolicy)
+            switch (registrationPolicy)
             {
                 case DispatcherRegistrationPolicy.LastWins:
                     _handlers[specificType] = forwardHandler;
@@ -160,7 +155,7 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
                     _reverseHandlers.Add(specificType, backwardHandler);
                     return;
                 default:
-                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {_duplicateRegistrationPolicy}.");
+                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {registrationPolicy}.");
             }
         }
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.ExceptionServices;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -23,7 +24,21 @@ public static class TypeDispatcher
     /// A builder implementing <see cref="IDispatcherBuilder{TIn,TOut}"/> to register per-type converters
     /// and produce a concrete dispatcher via <see cref="IDispatcherBuilder{TIn,TOut}.Build"/>.
     /// </returns>
-    public static IDispatcherBuilder<TIn, TOut> Create<TIn, TOut>() => new TypeDispatcher<TIn, TOut>.Builder();
+    public static IDispatcherBuilder<TIn, TOut> Create<TIn, TOut>()
+        => new TypeDispatcher<TIn, TOut>.Builder(DispatcherRegistrationPolicy.LastWins);
+
+    /// <summary>
+    /// Creates a new dispatcher builder for dispatching conversions from <typeparamref name="TIn"/> to <typeparamref name="TOut"/>.
+    /// </summary>
+    /// <typeparam name="TIn">The general input type accepted by the resulting dispatcher.</typeparam>
+    /// <typeparam name="TOut">The output type produced by registered converters.</typeparam>
+    /// <param name="duplicateRegistrationPolicy">How registrations for the same concrete type are handled.</param>
+    /// <returns>
+    /// A builder implementing <see cref="IDispatcherBuilder{TIn,TOut}"/> to register per-type converters
+    /// and produce a concrete dispatcher via <see cref="IDispatcherBuilder{TIn,TOut}.Build"/>.
+    /// </returns>
+    public static IDispatcherBuilder<TIn, TOut> Create<TIn, TOut>(DispatcherRegistrationPolicy duplicateRegistrationPolicy)
+        => new TypeDispatcher<TIn, TOut>.Builder(duplicateRegistrationPolicy);
 }
 
 internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
@@ -50,7 +65,15 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
 
         if (_handlers.TryGetValue(runtimeType, out var del))
         {
-            return (TOut)del.DynamicInvoke(input)!;
+            try
+            {
+                return (TOut)del.DynamicInvoke(input)!;
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
         }
 
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));
@@ -59,11 +82,17 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
     internal class Builder : IDispatcherBuilder<TIn, TOut>
     {
         private readonly Dictionary<Type, Delegate> _handlers = new();
+        private readonly DispatcherRegistrationPolicy _duplicateRegistrationPolicy;
+
+        public Builder(DispatcherRegistrationPolicy duplicateRegistrationPolicy)
+        {
+            _duplicateRegistrationPolicy = duplicateRegistrationPolicy;
+        }
 
         /// <inheritdoc />
         public IDispatcherBuilder<TIn, TOut> Add<TSpecific>(IConverter<TSpecific, TOut> converter)
         {
-            _handlers[typeof(TSpecific)] = new Func<TSpecific, TOut>(converter.Convert);
+            AddHandler(typeof(TSpecific), new Func<TSpecific, TOut>(converter.Convert));
 
             return this;
         }
@@ -86,12 +115,35 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
 
             var forwardDelegate = convertMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
 
-            _handlers[specificType] = forwardDelegate;
+            AddHandler(specificType, forwardDelegate);
 
             return this;
+        }
+
+        private void AddHandler(Type specificType, Delegate handler)
+        {
+            switch (_duplicateRegistrationPolicy)
+            {
+                case DispatcherRegistrationPolicy.LastWins:
+                    _handlers[specificType] = handler;
+                    return;
+                case DispatcherRegistrationPolicy.FirstWins:
+                    _handlers.TryAdd(specificType, handler);
+                    return;
+                case DispatcherRegistrationPolicy.Throw:
+                    if (!_handlers.TryAdd(specificType, handler))
+                    {
+                        throw new InvalidOperationException($"Converter already registered for {specificType}.");
+                    }
+
+                    return;
+                default:
+                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {_duplicateRegistrationPolicy}.");
+            }
         }
 
         /// <inheritdoc />
         public IConverter<TIn, TOut> Build() => new TypeDispatcher<TIn, TOut>(_handlers);
     }
 }
+

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -99,14 +99,15 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
             var convType = converter.GetType();
 
             var convertMethodInterface = typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-            if (convertMethod is null)
+            if (!convertMethodInterface.IsAssignableFrom(convType))
             {
                 throw new InvalidOperationException($"Converter type {convType.FullName} does not implement Convert({specificType})");
             }
 
-            var forwardDelegate = convertMethod.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
+            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            // Cannot be null since we already verified the interface is implemented
+            var forwardDelegate = convertMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
 
             AddHandler(specificType, forwardDelegate);
 
@@ -139,4 +140,3 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
         public IConverter<TIn, TOut> Build() => new TypeDispatcher<TIn, TOut>(_handlers);
     }
 }
-

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -79,15 +79,9 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));
     }
 
-    internal class Builder : IDispatcherBuilder<TIn, TOut>
+    internal class Builder(DispatcherRegistrationPolicy registrationPolicy) : IDispatcherBuilder<TIn, TOut>
     {
         private readonly Dictionary<Type, Delegate> _handlers = new();
-        private readonly DispatcherRegistrationPolicy _duplicateRegistrationPolicy;
-
-        public Builder(DispatcherRegistrationPolicy duplicateRegistrationPolicy)
-        {
-            _duplicateRegistrationPolicy = duplicateRegistrationPolicy;
-        }
 
         /// <inheritdoc />
         public IDispatcherBuilder<TIn, TOut> Add<TSpecific>(IConverter<TSpecific, TOut> converter)
@@ -122,7 +116,7 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
 
         private void AddHandler(Type specificType, Delegate handler)
         {
-            switch (_duplicateRegistrationPolicy)
+            switch (registrationPolicy)
             {
                 case DispatcherRegistrationPolicy.LastWins:
                     _handlers[specificType] = handler;
@@ -138,7 +132,7 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
 
                     return;
                 default:
-                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {_duplicateRegistrationPolicy}.");
+                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {registrationPolicy}.");
             }
         }
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -72,7 +72,6 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
             catch (TargetInvocationException ex) when (ex.InnerException is not null)
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                throw;
             }
         }
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -131,7 +131,7 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
 
                     return;
                 default:
-                    throw new InvalidOperationException($"Unsupported duplicate registration policy: {registrationPolicy}.");
+                    throw new InvalidOperationException($"Unsupported registration policy: {registrationPolicy}.");
             }
         }
 


### PR DESCRIPTION
Some user asked for such support.
It's not perfect due to `UnconditionalSuppressMessage`, but solving this would add compilation problems as that would add `DynamicallyAccessedMembers` constraints to all components that have `DefaultConverter` as default.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
