### PR TITLE
MudTabs: Add overridable `DisposeAsyncCore` to support derived async disposal

### DIFF
--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -559,17 +559,27 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Called to dispose this instance.
+        /// </summary>
+        protected virtual ValueTask DisposeAsyncCore() => ValueTask.CompletedTask;
+
+        /// <summary>
         /// Releases resources used by this component.
         /// </summary>
         public async ValueTask DisposeAsync()
         {
             if (_isDisposed)
+            {
                 return;
+            }
+
             _isDisposed = true;
+
             if (_throttleDispatcher.IsValueCreated)
             {
                 _throttleDispatcher.Value.Dispose();
             }
+
             if (_resizeObserver is not null)
             {
                 _resizeObserver.OnResized -= OnResized;
@@ -578,10 +588,14 @@ namespace MudBlazor
                     await _resizeObserver.DisposeAsync();
                 }
             }
+
             if (IsJSRuntimeAvailable)
             {
                 await KeyInterceptorService.UnsubscribeAsync(_elementId);
             }
+
+            await DisposeAsyncCore();
+            GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -561,12 +561,7 @@ namespace MudBlazor
         /// <summary>
         /// Called to dispose this instance.
         /// </summary>
-        protected virtual ValueTask DisposeAsyncCore() => ValueTask.CompletedTask;
-
-        /// <summary>
-        /// Releases resources used by this component.
-        /// </summary>
-        public async ValueTask DisposeAsync()
+        protected virtual async ValueTask DisposeAsyncCore()
         {
             if (_isDisposed)
             {
@@ -593,7 +588,13 @@ namespace MudBlazor
             {
                 await KeyInterceptorService.UnsubscribeAsync(_elementId);
             }
+        }
 
+        /// <summary>
+        /// Releases resources used by this component.
+        /// </summary>
+        public async ValueTask DisposeAsync()
+        {
             await DisposeAsyncCore();
             GC.SuppressFinalize(this);
         }


### PR DESCRIPTION
Updates `MudTabs` to follow the async dispose extension pattern by introducing `protected virtual ValueTask DisposeAsyncCore()` and invoking it from `DisposeAsync()` after existing cleanup. This allows components inheriting from `MudTabs` to add custom async disposal logic without replacing base disposal behavior.  

Closes #11831

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
