### PR TITLE
MudTable: Fix mobile readability when ColGroup is present

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -572,6 +572,10 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
       border-top: 1px solid var(--mud-palette-table-lines);
     }
 
+    .mud-table-root colgroup {
+      display: none;
+    }
+
     .mud-table-row {
       display: revert;
 


### PR DESCRIPTION
MudTable’s responsive mode is expected to stay readable and usable on small screens, regardless of desktop-oriented column sizing choices. Right now, tables that define `ColGroup` lose that expectation in mobile view: content becomes visually cramped, rows look broken, and the responsive layout no longer matches the behavior users see in the default table. This change restores the intended responsive experience so mobile presentation remains legible and consistent across table configurations.

**Also affects `MudDataGrid`:** the fix lives in the shared responsive table styles (`.mud-{breakpoint}-table .mud-table-root colgroup`), and `MudDataGrid` renders the same `.mud-table-root` markup with an optional user-supplied `ColGroup` and the same default `Breakpoint`. It had the identical cramping issue in mobile view and is fixed by the same rule. Column resizing and sticky columns are unaffected, since those rely on inline cell widths rather than the `<colgroup>` element.

Closes #11943
Related to #8714
Related to #6930

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
