### PR TITLE
Converter: Improve performance and rework Enum

### DIFF
--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -735,7 +735,7 @@ public class DefaultConverterTests
     [Test]
     public void Guid_Convert_ShouldReturnString()
     {
-        var conv = DefaultConverter.GuidConverter.Instance;
+        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
         var guid = Guid.NewGuid();
 
         conv.Convert(guid).Should().Be(guid.ToString());
@@ -744,14 +744,14 @@ public class DefaultConverterTests
     [Test]
     public void Guid_Convert_NullableNull_ReturnsNull()
     {
-        var conv = DefaultConverter.GuidConverter.Instance;
+        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
         conv.Convert(null).Should().BeNull();
     }
 
     [Test]
     public void Guid_ConvertBack_NullOrEmpty_ReturnsEmptyGuid()
     {
-        var conv = DefaultConverter.GuidConverter.Instance;
+        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
         conv.ConvertBack(null).Should().Be(Guid.Empty);
         conv.ConvertBack(string.Empty).Should().Be(Guid.Empty);
     }
@@ -759,7 +759,7 @@ public class DefaultConverterTests
     [Test]
     public void Guid_ConvertBack_ValidGuidString_ReturnsParsedGuid()
     {
-        var conv = DefaultConverter.GuidConverter.Instance;
+        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
         var guid = Guid.NewGuid();
         var text = guid.ToString();
 
@@ -769,7 +769,7 @@ public class DefaultConverterTests
     [Test]
     public void Guid_ConvertBack_Invalid_ThrowsConversionException_WithExpectedKey()
     {
-        var conv = DefaultConverter.GuidConverter.Instance;
+        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
 
         Action act = () => conv.ConvertBack("not-a-guid");
 
@@ -783,7 +783,7 @@ public class DefaultConverterTests
     [Test]
     public void Guid_NullableInterfaceConvertBack_EmptyOrNull_ReturnsNull_And_ParsesValidValue()
     {
-        var conv = DefaultConverter.GuidConverter.Instance;
+        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
         IReversibleConverter<Guid?, string?> nullableConv = conv;
 
         nullableConv.ConvertBack(null).Should().BeNull();

--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Numerics;
 using AwesomeAssertions;
 using MudBlazor.Resources;
+using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 using NUnit.Framework;
 
@@ -732,26 +733,50 @@ public class DefaultConverterTests
 
     #region Guid
 
+    private static DefaultConverter.GuidConverter CreateGuidConverter(Func<CultureInfo>? culture = null, Func<string?>? format = null)
+    {
+        return new DefaultConverter.GuidConverter(culture ?? (() => CultureInfo.InvariantCulture), format ?? (() => null));
+    }
+
     [Test]
     public void Guid_Convert_ShouldReturnString()
     {
-        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
+        var conv = CreateGuidConverter();
         var guid = Guid.NewGuid();
 
-        conv.Convert(guid).Should().Be(guid.ToString());
+        conv.Convert(guid).Should().Be(guid.ToString("D", CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void Guid_Convert_WithCustomFormat_ShouldReturnFormattedString()
+    {
+        var conv = CreateGuidConverter(() => CultureInfo.InvariantCulture, () => "B");
+        var guid = Guid.NewGuid();
+
+        conv.Convert(guid).Should().Be(guid.ToString("B", CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void Guid_Convert_WithCustomFormat_AndNonInvariantCulture_ShouldReturnFormattedString()
+    {
+        var culture = new CultureInfo("tr-TR");
+        var conv = CreateGuidConverter(() => culture, () => "N");
+        var guid = Guid.NewGuid();
+
+        conv.Convert(guid).Should().Be(guid.ToString("N", culture));
     }
 
     [Test]
     public void Guid_Convert_NullableNull_ReturnsNull()
     {
-        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
+        var conv = CreateGuidConverter();
         conv.Convert(null).Should().BeNull();
     }
 
     [Test]
     public void Guid_ConvertBack_NullOrEmpty_ReturnsEmptyGuid()
     {
-        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
+        var conv = CreateGuidConverter();
         conv.ConvertBack(null).Should().Be(Guid.Empty);
         conv.ConvertBack(string.Empty).Should().Be(Guid.Empty);
     }
@@ -759,17 +784,53 @@ public class DefaultConverterTests
     [Test]
     public void Guid_ConvertBack_ValidGuidString_ReturnsParsedGuid()
     {
-        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
+        var conv = CreateGuidConverter();
         var guid = Guid.NewGuid();
-        var text = guid.ToString();
+        var text = guid.ToString("D");
 
         conv.ConvertBack(text).Should().Be(guid);
     }
 
     [Test]
+    public void Guid_ConvertBack_WithCustomFormat_ReturnsParsedGuid()
+    {
+        var conv = CreateGuidConverter(() => CultureInfo.InvariantCulture, () => "N");
+        var guid = Guid.NewGuid();
+        var text = guid.ToString("N");
+
+        conv.ConvertBack(text).Should().Be(guid);
+    }
+
+    [Test]
+    public void Guid_ConvertBack_WithCustomFormat_AndNonInvariantCulture_ReturnsParsedGuid()
+    {
+        var conv = CreateGuidConverter(() => new CultureInfo("de-DE"), () => "N");
+        var guid = Guid.NewGuid();
+        var text = guid.ToString("N");
+
+        conv.ConvertBack(text).Should().Be(guid);
+    }
+
+    [Test]
+    public void Guid_ConvertBack_WhenInputFormatDiffersFromConfigured_ThrowsConversionException()
+    {
+        var conv = CreateGuidConverter(() => CultureInfo.InvariantCulture, () => "N");
+        var guid = Guid.NewGuid();
+        var text = guid.ToString("D");
+
+        Action act = () => conv.ConvertBack(text);
+
+        act.Should()
+            .Throw<ConversionException>()
+            .Which.ErrorMessageKey
+            .Should()
+            .Be(LanguageResource.Converter_InvalidGUID);
+    }
+
+    [Test]
     public void Guid_ConvertBack_Invalid_ThrowsConversionException_WithExpectedKey()
     {
-        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
+        var conv = CreateGuidConverter();
 
         Action act = () => conv.ConvertBack("not-a-guid");
 
@@ -783,14 +844,14 @@ public class DefaultConverterTests
     [Test]
     public void Guid_NullableInterfaceConvertBack_EmptyOrNull_ReturnsNull_And_ParsesValidValue()
     {
-        var conv = new DefaultConverter.GuidConverter(() => CultureInfo.InvariantCulture, () => null);
+        var conv = CreateGuidConverter();
         IReversibleConverter<Guid?, string?> nullableConv = conv;
 
         nullableConv.ConvertBack(null).Should().BeNull();
         nullableConv.ConvertBack(string.Empty).Should().BeNull();
 
         var guid = Guid.NewGuid();
-        nullableConv.ConvertBack(guid.ToString()).Should().Be(guid);
+        nullableConv.ConvertBack(guid.ToString("D")).Should().Be(guid);
     }
 
     #endregion
@@ -1147,6 +1208,19 @@ public class DefaultConverterTests
     }
 
     [Test]
+    public void DefaultConverter_IParsableFormattable_Convert_UsesFormatAndCulture()
+    {
+        var conv = new DefaultConverter<ParsableFormattableTemperature>
+        {
+            Culture = () => new CultureInfo("fr-FR"),
+            Format = () => "0.00"
+        };
+        var value = new ParsableFormattableTemperature(12.5m);
+
+        conv.Convert(value).Should().Be("12,50");
+    }
+
+    [Test]
     public void DefaultConverter_IParsableReference_Convert_Null_ReturnsNull()
     {
         var conv = new DefaultConverter<ParsableLabel>();
@@ -1171,6 +1245,68 @@ public class DefaultConverterTests
 
         conv.Convert(value).Should().Be(value.ToString());
         conv.Convert(null).Should().BeNull();
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableFormattableNullable_Convert_UsesFormatAndCulture()
+    {
+        var conv = new DefaultConverter<ParsableFormattableTemperature?>
+        {
+            Culture = () => new CultureInfo("fr-FR"),
+            Format = () => "0.00"
+        };
+        ParsableFormattableTemperature? value = new ParsableFormattableTemperature(7.25m);
+
+        conv.Convert(value).Should().Be("7,25");
+        conv.Convert(null).Should().BeNull();
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableFormattable_MudColor_Convert_UsesConfiguredFormat()
+    {
+        var culture = new CultureInfo("tr-TR");
+        var conv = new DefaultConverter<MudColor>
+        {
+            Culture = () => culture,
+            Format = () => "hex"
+        };
+        var value = new MudColor("#12ab34ff");
+
+        var converted = conv.Convert(value);
+
+        converted.Should().Be("#12ab34");
+        converted.Should().Be(value.ToString("hex", culture));
+        converted.Should().NotBe(value.ToString());
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableFormattableNullable_MudColor_Convert_UsesConfiguredFormat()
+    {
+        var culture = new CultureInfo("de-DE");
+        var conv = new DefaultConverter<MudColor?>
+        {
+            Culture = () => culture,
+            Format = () => "hexa"
+        };
+        var value = new MudColor("#12ab34cd");
+
+        conv.Convert(value).Should().Be("#12ab34cd");
+        conv.Convert(value).Should().Be(value.ToString("hexa", culture));
+        conv.Convert(null).Should().BeNull();
+    }
+
+    [Test]
+    public void DefaultConverter_IParsableFormattable_MudColor_ConvertBack_ParsesConfiguredFormatOutput()
+    {
+        var conv = new DefaultConverter<MudColor>
+        {
+            Culture = () => new CultureInfo("fr-FR"),
+            Format = () => "rgba"
+        };
+        var value = new MudColor("#12ab34ff");
+        var text = conv.Convert(value);
+
+        conv.ConvertBack(text).Should().Be(value);
     }
 
     [Test]
@@ -1249,6 +1385,37 @@ public class DefaultConverterTests
 
             result = default;
             return false;
+        }
+    }
+
+    private readonly record struct ParsableFormattableTemperature(decimal Value)
+        : IParsable<ParsableFormattableTemperature>, IFormattable
+    {
+        public static ParsableFormattableTemperature Parse(string s, IFormatProvider? provider)
+        {
+            if (!TryParse(s, provider, out var result))
+            {
+                throw new FormatException();
+            }
+
+            return result;
+        }
+
+        public static bool TryParse(string? s, IFormatProvider? provider, out ParsableFormattableTemperature result)
+        {
+            if (decimal.TryParse(s, NumberStyles.Any, provider, out var value))
+            {
+                result = new ParsableFormattableTemperature(value);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            return Value.ToString(format, formatProvider);
         }
     }
 

--- a/src/MudBlazor/Converters/BoolConverter.Bool.cs
+++ b/src/MudBlazor/Converters/BoolConverter.Bool.cs
@@ -16,6 +16,6 @@ internal partial class BoolConverter
 
         public bool? ConvertBack(bool? value) => value;
 
-        public static readonly BoolIdentity Instance = new();
+        public static BoolIdentity Instance { get; } = new();
     }
 }

--- a/src/MudBlazor/Converters/BoolConverter.Object.cs
+++ b/src/MudBlazor/Converters/BoolConverter.Object.cs
@@ -36,6 +36,6 @@ internal partial class BoolConverter
             return value;
         }
 
-        public static readonly ObjectBoolConverter Instance = new();
+        public static ObjectBoolConverter Instance { get; } = new();
     }
 }

--- a/src/MudBlazor/Converters/BoolConverter.String.cs
+++ b/src/MudBlazor/Converters/BoolConverter.String.cs
@@ -29,6 +29,6 @@ internal partial class BoolConverter
                 _ => null
             };
 
-        public static readonly StringConverter Instance = new();
+        public static StringConverter Instance { get; } = new();
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.BigInteger.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.BigInteger.cs
@@ -21,12 +21,16 @@ internal partial class DefaultConverter
         public BigInteger ConvertBack(string? input)
         {
             if (string.IsNullOrEmpty(input))
+            {
                 return BigInteger.Zero;
+            }
 
             var currentCulture = culture.Invoke();
 
             if (BigInteger.TryParse(input, NumberStyles.Any, currentCulture, out var result))
+            {
                 return result;
+            }
 
             throw new ConversionException(LanguageResource.Converter_InvalidNumber);
         }

--- a/src/MudBlazor/Converters/DefaultConverter.Char.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.Char.cs
@@ -29,6 +29,6 @@ internal partial class DefaultConverter
             return ConvertBack(input);
         }
 
-        public static readonly CharConverter Instance = new();
+        public static CharConverter Instance { get; } = new();
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.Enum.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.Enum.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using MudBlazor.Resources;
+using MudBlazor.Utilities.Exceptions;
+
+namespace MudBlazor;
+
+internal partial class DefaultConverter
+{
+    internal sealed class EnumConverter<TEnum> : IReversibleConverter<TEnum, string?>
+        where TEnum : struct, Enum
+    {
+        public string Convert(TEnum input) => input.ToString();
+
+        public TEnum ConvertBack(string? input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return default;
+            }
+
+            if (Enum.TryParse<TEnum>(input, out var result))
+            {
+                return result;
+            }
+
+            throw new ConversionException(LanguageResource.Converter_NotValueOf, [typeof(TEnum).Name]);
+        }
+    }
+
+    internal sealed class NullableEnumConverter<TEnum> : IReversibleConverter<TEnum?, string?>
+        where TEnum : struct, Enum
+    {
+        public string? Convert(TEnum? input) => input?.ToString();
+
+        public TEnum? ConvertBack(string? input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
+            if (Enum.TryParse<TEnum>(input, out var result))
+            {
+                return result;
+            }
+
+            throw new ConversionException(LanguageResource.Converter_NotValueOf, [typeof(TEnum).Name]);
+        }
+    }
+}

--- a/src/MudBlazor/Converters/DefaultConverter.Guid.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.Guid.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -9,8 +10,10 @@ namespace MudBlazor;
 
 internal partial class DefaultConverter
 {
-    internal sealed class GuidConverter : IReversibleConverter<Guid, string?>, IReversibleConverter<Guid?, string?>
+    internal sealed class GuidConverter(Func<CultureInfo> culture, Func<string?> format) : IReversibleConverter<Guid, string?>, IReversibleConverter<Guid?, string?>
     {
+        private const string DefaultGuidFormat = "D";
+
         public Guid ConvertBack(string? input)
         {
             if (string.IsNullOrEmpty(input))
@@ -18,7 +21,7 @@ internal partial class DefaultConverter
                 return Guid.Empty;
             }
 
-            if (Guid.TryParse(input, out var guid))
+            if (Guid.TryParseExact(input, format.Invoke() ?? DefaultGuidFormat, out var guid))
             {
                 return guid;
             }
@@ -26,9 +29,9 @@ internal partial class DefaultConverter
             throw new ConversionException(LanguageResource.Converter_InvalidGUID);
         }
 
-        public string Convert(Guid value) => value.ToString();
+        public string Convert(Guid value) => value.ToString(format.Invoke(), culture.Invoke());
 
-        public string? Convert(Guid? value) => value is null ? null : value.ToString();
+        public string? Convert(Guid? value) => value?.ToString(format.Invoke(), culture.Invoke());
 
         Guid? IReversibleConverter<Guid?, string?>.ConvertBack(string? input)
         {
@@ -39,7 +42,5 @@ internal partial class DefaultConverter
 
             return ConvertBack(input);
         }
-
-        public static GuidConverter Instance { get; } = new();
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.Parsable.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.Parsable.cs
@@ -10,11 +10,16 @@ namespace MudBlazor;
 
 internal partial class DefaultConverter
 {
-    internal sealed class ParsableConverter<TParsable>(Func<CultureInfo> culture)
+    internal sealed class ParsableConverter<TParsable>(Func<CultureInfo> culture, Func<string?> format)
         : IReversibleConverter<TParsable?, string?>
         where TParsable : IParsable<TParsable>
     {
-        public string? Convert(TParsable? input) => input is null ? null : input.ToString();
+        public string? Convert(TParsable? input) => input switch
+        {
+            null => null,
+            IFormattable formattable => formattable.ToString(format.Invoke(), culture.Invoke()),
+            _ => input.ToString()
+        };
 
         public TParsable? ConvertBack(string? input)
         {
@@ -32,11 +37,16 @@ internal partial class DefaultConverter
         }
     }
 
-    internal sealed class NullableParsableConverter<TParsable>(Func<CultureInfo> culture)
+    internal sealed class NullableParsableConverter<TParsable>(Func<CultureInfo> culture, Func<string> format)
         : IReversibleConverter<TParsable?, string?>
         where TParsable : struct, IParsable<TParsable>
     {
-        public string? Convert(TParsable? input) => input?.ToString();
+        public string? Convert(TParsable? input) => input switch
+        {
+            null => null,
+            IFormattable formattable => formattable.ToString(format.Invoke(), culture.Invoke()),
+            _ => input.ToString()
+        };
 
         public TParsable? ConvertBack(string? input)
         {

--- a/src/MudBlazor/Converters/DefaultConverter.String.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.String.cs
@@ -12,6 +12,6 @@ internal partial class DefaultConverter
 
         public string? ConvertBack(string? input) => input;
 
-        public static readonly StringConverter Instance = new();
+        public static StringConverter Instance { get; } = new();
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -6,9 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
 using MudBlazor.Extensions;
-using MudBlazor.Resources;
 using MudBlazor.Utilities.Converter.Dispatcher;
-using MudBlazor.Utilities.Exceptions;
 using static MudBlazor.DefaultConverter;
 
 namespace MudBlazor;
@@ -87,6 +85,7 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         // Let's not use that for now and see if we really need it
         //.Add(new ObjectConverter(() => Culture(), () => Format()))
 
+        AddEnumConverters(builder);
         AddParsableConverters(builder);
 
         _dispatcher = builder.Build();
@@ -95,60 +94,13 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
     /// <inheritdoc />
     public string? Convert(T? input)
     {
-        // Special handling for enums
-        if (IsNullableEnum(typeof(T), out _))
-        {
-            var value = input as Enum;
-            return value?.ToString();
-        }
-
-        if (typeof(T).IsEnum)
-        {
-            var value = input as Enum;
-            return value?.ToString();
-        }
-
         var result = _dispatcher.TryConvert(input);
         // If conversion failed, fallback to ToString() implementation of the T
         return result.Success ? result.Value : input?.ToString();
     }
 
     /// <inheritdoc />
-    public T? ConvertBack(string? input)
-    {
-        // Special handling for enums
-        if (IsNullableEnum(typeof(T), out var enumType))
-        {
-            if (string.IsNullOrEmpty(input))
-            {
-                return default;
-            }
-
-            if (Enum.TryParse(enumType, input, out var result))
-            {
-                return (T)result;
-            }
-
-            throw new ConversionException(LanguageResource.Converter_NotValueOf, [enumType.Name]);
-        }
-
-        if (typeof(T).IsEnum)
-        {
-            if (string.IsNullOrEmpty(input))
-            {
-                return default;
-            }
-
-            if (Enum.TryParse(typeof(T), input, out var result))
-            {
-                return (T)result;
-            }
-
-            throw new ConversionException(LanguageResource.Converter_NotValueOf, [typeof(T).Name]);
-        }
-
-        return _dispatcher.ConvertBack(input);
-    }
+    public T? ConvertBack(string? input) => _dispatcher.ConvertBack(input);
 
     // TODO: Consider adding DynamicallyAccessedMembers attribute in future as DefaultConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]T>, affects MudBaseInput, MudBaseDatePicker, MudFileUpload, MudColorPicker + 3rd party libraries.
     [UnconditionalSuppressMessage(
@@ -198,16 +150,39 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
                       && x.GenericTypeArguments[0] == type);
     }
 
-    private static bool IsNullableEnum(Type type, [NotNullWhen(true)] out Type? result)
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2090", // Missing DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+        Justification = "Not 200% safe without annotation, but considering if type is supplied by the user, it should work. Suppressed for backward compatibility.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2091", // Missing DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+        Justification = "Not 200% safe without annotation, but considering if type is supplied by the user, it should work. Suppressed for backward compatibility.")]
+    private static void AddEnumConverters(IReversibleDispatcherBuilder<T?, string?> builder)
     {
-        var underlyingType = Nullable.GetUnderlyingType(type);
-        if (underlyingType?.IsEnum is true)
+        var targetType = typeof(T);
+
+        var nullableUnderlyingType = Nullable.GetUnderlyingType(targetType);
+        if (nullableUnderlyingType?.IsEnum is true)
         {
-            result = underlyingType;
-            return true;
+            var nullableEnumConverterType = typeof(NullableEnumConverter<>).MakeGenericType(nullableUnderlyingType);
+            var nullableEnumConverter = Activator.CreateInstance(nullableEnumConverterType);
+            if (nullableEnumConverter is not null)
+            {
+                builder.AddDynamic(targetType, nullableEnumConverter);
+            }
+
+            return;
         }
 
-        result = null!;
-        return false;
+        if (targetType.IsEnum)
+        {
+            var enumConverterType = typeof(EnumConverter<>).MakeGenericType(targetType);
+            var enumConverter = Activator.CreateInstance(enumConverterType);
+            if (enumConverter is not null)
+            {
+                builder.AddDynamic(targetType, enumConverter);
+            }
+        }
     }
 }

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -46,8 +46,8 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
             .Add<char?>(CharConverter.Instance)
             .Add<bool>(DefaultConverter.BoolConverter.Instance)
             .Add<bool?>(DefaultConverter.BoolConverter.Instance)
-            .Add<Guid>(GuidConverter.Instance)
-            .Add<Guid?>(GuidConverter.Instance)
+            .Add<Guid>(new GuidConverter(() => Culture(), () => Format()))
+            .Add<Guid?>(new GuidConverter(() => Culture(), () => Format()))
             .Add(new NumberConverter<sbyte>(() => Culture(), () => Format()))
             .Add(new NullableNumberConverter<sbyte>(() => Culture(), () => Format()))
             .Add(new NumberConverter<byte>(() => Culture(), () => Format()))
@@ -123,7 +123,7 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         if (nullableUnderlyingType is not null && ImplementsIParsable(nullableUnderlyingType))
         {
             var nullableConverterType = typeof(NullableParsableConverter<>).MakeGenericType(nullableUnderlyingType);
-            var nullableConverter = Activator.CreateInstance(nullableConverterType, (Func<CultureInfo>)(() => Culture()));
+            var nullableConverter = Activator.CreateInstance(nullableConverterType, (Func<CultureInfo>)(() => Culture()), (Func<string?>)(() => Format()));
             if (nullableConverter is not null)
             {
                 builder.AddDynamic(targetType, nullableConverter);
@@ -133,7 +133,7 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         if (ImplementsIParsable(targetType))
         {
             var converterType = typeof(ParsableConverter<>).MakeGenericType(targetType);
-            var converter = Activator.CreateInstance(converterType, (Func<CultureInfo>)(() => Culture()));
+            var converter = Activator.CreateInstance(converterType, (Func<CultureInfo>)(() => Culture()), (Func<string?>)(() => Format()));
             if (converter is not null)
             {
                 builder.AddDynamic(targetType, converter);

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -48,18 +48,23 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
     /// <summary>
     /// Initializes a new instance of the <see cref="ReversibleTypeDispatcher{TIn,TOut}"/> class.
     /// </summary>
-    /// <param name="forwards">A pre-populated map of concrete input <see cref="Type"/> to forward conversion delegates.</param>
-    /// <param name="backwards">A pre-populated map of concrete input <see cref="Type"/> to backward conversion delegates.</param>
+    /// <param name="forward">The resolved forward delegate for <typeparamref name="TIn"/>, or <c>null</c> when no converter is registered.</param>
+    /// <param name="backward">The resolved backward delegate for <typeparamref name="TIn"/>, or <c>null</c> when no converter is registered.</param>
     protected ReversibleTypeDispatcher(
-        Dictionary<Type, Delegate> forwards,
-        Dictionary<Type, Delegate> backwards)
-        : base(forwards)
+        Func<TIn, TOut>? forward,
+        Func<TOut, TIn>? backward)
+        : base(forward)
+        => _backward = backward;
+
+    internal static Func<TOut, TIn>? ResolveBackwardHandler(Dictionary<Type, Delegate> reverseHandlers)
     {
-        if (backwards.TryGetValue(typeof(TIn), out var del))
+        var runtimeType = typeof(TIn);
+        if (reverseHandlers.TryGetValue(runtimeType, out var del))
         {
-            _backward = del as Func<TOut, TIn>
-                ?? (input => (TIn)del.DynamicInvoke(input)!);
+            return del as Func<TOut, TIn> ?? (input => (TIn)del.DynamicInvoke(input)!);
         }
+
+        return null;
     }
 
     /// <inheritdoc />
@@ -69,12 +74,12 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
     /// </exception>
     public TIn ConvertBack(TOut input)
     {
-        var runtimeType = typeof(TIn);
-
         if (_backward is not null)
         {
             return _backward(input);
         }
+
+        var runtimeType = typeof(TIn);
 
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));
     }
@@ -156,6 +161,11 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
         }
 
         /// <inheritdoc />
-        public IReversibleConverter<TIn, TOut> Build() => new ReversibleTypeDispatcher<TIn, TOut>(_handlers, _reverseHandlers);
+        public IReversibleConverter<TIn, TOut> Build()
+        {
+            var forward = ResolveForwardHandler(_handlers);
+            var backward = ResolveBackwardHandler(_reverseHandlers);
+            return new ReversibleTypeDispatcher<TIn, TOut>(forward, backward);
+        }
     }
 }

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -50,11 +50,8 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
     /// </summary>
     /// <param name="forward">The resolved forward delegate for <typeparamref name="TIn"/>, or <c>null</c> when no converter is registered.</param>
     /// <param name="backward">The resolved backward delegate for <typeparamref name="TIn"/>, or <c>null</c> when no converter is registered.</param>
-    protected ReversibleTypeDispatcher(
-        Func<TIn, TOut>? forward,
-        Func<TOut, TIn>? backward)
-        : base(forward)
-        => _backward = backward;
+    protected ReversibleTypeDispatcher(Func<TIn, TOut>? forward, Func<TOut, TIn>? backward)
+        : base(forward) => _backward = backward;
 
     internal static Func<TOut, TIn>? ResolveBackwardHandler(Dictionary<Type, Delegate> reverseHandlers)
     {

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.ExceptionServices;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -44,7 +43,7 @@ public static class ReversibleTypeDispatcher
 internal class ReversibleTypeDispatcher<TIn, TOut> :
     TypeDispatcher<TIn, TOut>, IReversibleConverter<TIn, TOut>
 {
-    private readonly Dictionary<Type, Delegate> _backwards;
+    private readonly Func<TOut, TIn>? _backward;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReversibleTypeDispatcher{TIn,TOut}"/> class.
@@ -56,7 +55,11 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
         Dictionary<Type, Delegate> backwards)
         : base(forwards)
     {
-        _backwards = backwards;
+        if (backwards.TryGetValue(typeof(TIn), out var del))
+        {
+            _backward = del as Func<TOut, TIn>
+                ?? (input => (TIn)del.DynamicInvoke(input)!);
+        }
     }
 
     /// <inheritdoc />
@@ -68,16 +71,9 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
     {
         var runtimeType = typeof(TIn);
 
-        if (_backwards.TryGetValue(runtimeType, out var del))
+        if (_backward is not null)
         {
-            try
-            {
-                return (TIn)del.DynamicInvoke(input)!;
-            }
-            catch (TargetInvocationException ex) when (ex.InnerException is not null)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-            }
+            return _backward(input);
         }
 
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.ExceptionServices;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -43,7 +42,7 @@ public static class TypeDispatcher
 
 internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
 {
-    private readonly Dictionary<Type, Delegate> _handlers;
+    private readonly Func<TIn, TOut>? _forward;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeDispatcher{TIn,TOut}"/> class.
@@ -51,7 +50,11 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
     /// <param name="handlers">A pre-populated map of concrete input <see cref="Type"/> to conversion delegates.</param>
     protected TypeDispatcher(Dictionary<Type, Delegate> handlers)
     {
-        _handlers = handlers;
+        if (handlers.TryGetValue(typeof(TIn), out var del))
+        {
+            _forward = del as Func<TIn, TOut>
+                ?? (input => (TOut)del.DynamicInvoke(input)!);
+        }
     }
 
     /// <inheritdoc />
@@ -63,16 +66,9 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
     {
         var runtimeType = typeof(TIn);
 
-        if (_handlers.TryGetValue(runtimeType, out var del))
+        if (_forward is not null)
         {
-            try
-            {
-                return (TOut)del.DynamicInvoke(input)!;
-            }
-            catch (TargetInvocationException ex) when (ex.InnerException is not null)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-            }
+            return _forward(input);
         }
 
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -47,14 +47,18 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
     /// <summary>
     /// Initializes a new instance of the <see cref="TypeDispatcher{TIn,TOut}"/> class.
     /// </summary>
-    /// <param name="handlers">A pre-populated map of concrete input <see cref="Type"/> to conversion delegates.</param>
-    protected TypeDispatcher(Dictionary<Type, Delegate> handlers)
+    /// <param name="forward">The resolved forward delegate for <typeparamref name="TIn"/>, or <c>null</c> when no converter is registered.</param>
+    protected TypeDispatcher(Func<TIn, TOut>? forward) => _forward = forward;
+
+    internal static Func<TIn, TOut>? ResolveForwardHandler(Dictionary<Type, Delegate> handlers)
     {
-        if (handlers.TryGetValue(typeof(TIn), out var del))
+        var runtimeType = typeof(TIn);
+        if (handlers.TryGetValue(runtimeType, out var del))
         {
-            _forward = del as Func<TIn, TOut>
-                ?? (input => (TOut)del.DynamicInvoke(input)!);
+            return del as Func<TIn, TOut> ?? (input => (TOut)del.DynamicInvoke(input)!);
         }
+
+        return null;
     }
 
     /// <inheritdoc />
@@ -64,12 +68,12 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
     /// </exception>
     public TOut Convert(TIn input)
     {
-        var runtimeType = typeof(TIn);
-
         if (_forward is not null)
         {
             return _forward(input);
         }
+
+        var runtimeType = typeof(TIn);
 
         throw new ConversionException(LanguageResource.Converter_ConversionNotImplemented, [runtimeType], new InvalidOperationException($"No converter registered for {runtimeType}"));
     }
@@ -133,6 +137,10 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
         }
 
         /// <inheritdoc />
-        public IConverter<TIn, TOut> Build() => new TypeDispatcher<TIn, TOut>(_handlers);
+        public IConverter<TIn, TOut> Build()
+        {
+            var forward = ResolveForwardHandler(_handlers);
+            return new TypeDispatcher<TIn, TOut>(forward);
+        }
     }
 }


### PR DESCRIPTION
* Added formatting support for `Guid`.
* Added `IFormattable` support to `IParsable`.
* Removed the need for hacky `Enum` workarounds.
* Improved performance. `Convert`/`ConvertBack` hot-path calls are now very cheap. Since there is only one `TIn` (the converter's `T`) during initialization, the appropriate converter is resolved in the `Build` method instead of inside the converter methods. Previously these calls were not cached and always used `DynamicInvoke`.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
