### PR TITLE
Build: Revert Microsoft.ApplicationInsights.AspNetCore v3 update

### DIFF
--- a/src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
+++ b/src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#12641

Causing debug launch error:

> System.InvalidOperationException: A connection string was not found. Please set your connection string.
 
Explanation:

> The startup failure was caused by unconditional Application Insights registration in `Program.cs`. In the current package stack, that eagerly initializes Azure Monitor telemetry, and with no connection string configured it throws during host startup.