### PR TITLE
MudNumericField: Fix cursor jumping when using Immediate and Format together

### DIFF
--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -492,7 +492,8 @@ namespace MudBlazor
 
             // Keep formatted text in sync when using formatted input mode.
             // This also covers onchange updates that can occur around blur timing.
-            if (IsFormatted && DebounceInterval <= 0 && !ConversionError)
+            // Skip formatting during Immediate mode to prevent cursor jumping.
+            if (IsFormatted && !Immediate && DebounceInterval <= 0 && !ConversionError)
             {
                 var formattedText = ConvertSet(ReadValue);
                 if (!string.Equals(ReadText, formattedText, StringComparison.Ordinal))


### PR DESCRIPTION
Fixes #12804. When Immediate mode is enabled with a Format specifier, the cursor jumps to the end of the input while typing. This occurs because OnInputValueChanged was replacing the entire text with the formatted version on every keystroke.

The fix excludes Immediate mode from the formatting update condition. Formatting now only occurs on blur (as already handled in OnBlurredAsync), allowing users to type without cursor disruption.