### PR TITLE
fix(Card): Fix vertical alignment of header content and actions

### DIFF
--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -6,8 +6,7 @@
 .mud-card-header {
   display: flex;
   align-items: center;
-  border-top-left-radius: inherit;
-  border-top-right-radius: inherit;
+  padding: 16px;
 
   &.mud-card-header-padding {
     padding: 16px;
@@ -22,19 +21,22 @@
 
   & .mud-card-header-content {
     flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    height: 48px;
 
     & .mud-typography {
       margin-bottom: 0;
+      line-height: 1;
     }
   }
 
   & .mud-card-header-actions {
     flex: 0 0 auto;
-    align-self: flex-start;
-    margin-top: -8px;
-    margin-right: -8px;
-    margin-inline-end: -8px;
-    margin-inline-start: unset;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    height: 48px;
   }
 }
 


### PR DESCRIPTION
Fixes [#12719](https://github.com/MudBlazor/MudBlazor/issues/12719)
When having multiple MudCards side by side and some have an MudIconButton, they interfere the CardHeaderContent.
I changed a css file 
Pls check it carefully 

BEFORE
<img width="1146" height="113" alt="image" src="https://github.com/user-attachments/assets/1d82345a-6bf5-4a1c-92ae-fbb76cbc5fd2" />
NOW 
<img width="1903" height="190" alt="image" src="https://github.com/user-attachments/assets/be1c71b0-096e-4e35-8621-844b55ccfba8" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests
