### PR TITLE
DefaultConverter: Improve fallback T → string conversion

### DIFF
--- a/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
@@ -138,6 +138,74 @@ public class TypeDispatcherPolicyTests
     }
 
     [Test]
+    public void ReversibleTypeDispatcher_AddForward_RegistersForwardOnly()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>()
+            .AddForward(new ConstantConverter("forward"))
+            .Build();
+
+        dispatcher.Convert(3).Should().Be("forward");
+
+        Action act = () => dispatcher.ConvertBack("forward");
+        act.Should()
+            .Throw<ConversionException>()
+            .Which.ErrorMessageKey
+            .Should()
+            .Be(LanguageResource.Converter_ConversionNotImplemented);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddDynamicForward_RegistersForwardOnly()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>()
+            .AddDynamicForward(typeof(int), new ForwardOnlyIntConverter())
+            .Build();
+
+        dispatcher.Convert(3).Should().Be("3");
+
+        Action act = () => dispatcher.ConvertBack("3");
+        act.Should()
+            .Throw<ConversionException>()
+            .Which.ErrorMessageKey
+            .Should()
+            .Be(LanguageResource.Converter_ConversionNotImplemented);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddForward_LastWinsPolicy_RemovesReverseHandler()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>()
+            .Add(new PrefixConverter("A"))
+            .AddForward(new ConstantConverter("forward"))
+            .Build();
+
+        dispatcher.Convert(3).Should().Be("forward");
+
+        Action act = () => dispatcher.ConvertBack("A3");
+        act.Should()
+            .Throw<ConversionException>()
+            .Which.ErrorMessageKey
+            .Should()
+            .Be(LanguageResource.Converter_ConversionNotImplemented);
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddForward_FirstWinsPolicy_KeepsFirstRegistration()
+    {
+        var dispatcher = ReversibleTypeDispatcher
+            .Create<int, string>(DispatcherRegistrationPolicy.FirstWins)
+            .AddForward(new ConstantConverter("forward"))
+            .Add(new PrefixConverter("A"))
+            .Build();
+
+        dispatcher.Convert(3).Should().Be("forward");
+        dispatcher.ConvertBack("A3").Should().Be(3);
+    }
+
+    [Test]
     public void ReversibleTypeDispatcher_AddDynamic_WhenConverterTypeDoesNotImplementForwardInterface_ThrowsInvalidOperationException()
     {
         var builder = ReversibleTypeDispatcher.Create<int, string>();
@@ -159,6 +227,18 @@ public class TypeDispatcherPolicyTests
         act.Should()
             .Throw<InvalidOperationException>()
             .WithMessage("Converter type*does not implement ConvertBack(System.String)");
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_AddDynamicForward_WhenConverterTypeDoesNotImplementForwardInterface_ThrowsInvalidOperationException()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>();
+
+        Action act = () => builder.AddDynamicForward(typeof(int), new ForwardOnlyStringConverter());
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Converter type*does not implement Convert(System.Int32)");
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
@@ -174,7 +174,7 @@ public class TypeDispatcherPolicyTests
     }
 
     [Test]
-    public void ReversibleTypeDispatcher_AddForward_LastWinsPolicy_RemovesReverseHandler()
+    public void ReversibleTypeDispatcher_AddForward_LastWinsPolicy()
     {
         var dispatcher = ReversibleTypeDispatcher
             .Create<int, string>()
@@ -183,13 +183,7 @@ public class TypeDispatcherPolicyTests
             .Build();
 
         dispatcher.Convert(3).Should().Be("forward");
-
-        Action act = () => dispatcher.ConvertBack("A3");
-        act.Should()
-            .Throw<ConversionException>()
-            .Which.ErrorMessageKey
-            .Should()
-            .Be(LanguageResource.Converter_ConversionNotImplemented);
+        dispatcher.ConvertBack("A3").Should().Be(3);
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/TypeDispatcherPolicyTests.cs
@@ -87,6 +87,24 @@ public class TypeDispatcherPolicyTests
     }
 
     [Test]
+    public void TypeDispatcher_Convert_WhenNoConverterRegistered_ThrowsConversionException()
+    {
+        var dispatcher = TypeDispatcher
+            .Create<int, string>()
+            .Build();
+
+        Action act = () => dispatcher.Convert(1);
+
+        var exception = act.Should()
+            .Throw<ConversionException>()
+            .Which;
+
+        exception.ErrorMessageKey.Should().Be(LanguageResource.Converter_ConversionNotImplemented);
+        exception.ErrorMessageArgs.Should().ContainSingle().Which.Should().Be(typeof(int));
+        exception.InnerException.Should().BeOfType<InvalidOperationException>();
+    }
+
+    [Test]
     public void ReversibleTypeDispatcher_DefaultPolicy_LastWins()
     {
         var dispatcher = ReversibleTypeDispatcher
@@ -200,6 +218,22 @@ public class TypeDispatcherPolicyTests
     }
 
     [Test]
+    public void ReversibleTypeDispatcher_AddForward_ThrowPolicy_ThrowsOnDuplicateRegistration()
+    {
+        var builder = ReversibleTypeDispatcher
+            .Create<int, string>(DispatcherRegistrationPolicy.Throw)
+            .AddForward(new ConstantConverter("forward"));
+
+        builder.Build().Convert(3).Should().Be("forward");
+
+        Action act = () => builder.AddForward(new ConstantConverter("duplicate"));
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Converter already registered for System.Int32.");
+    }
+
+    [Test]
     public void ReversibleTypeDispatcher_AddDynamic_WhenConverterTypeDoesNotImplementForwardInterface_ThrowsInvalidOperationException()
     {
         var builder = ReversibleTypeDispatcher.Create<int, string>();
@@ -273,6 +307,18 @@ public class TypeDispatcherPolicyTests
         var builder = ReversibleTypeDispatcher.Create<int, string>((DispatcherRegistrationPolicy)999);
 
         Action act = () => builder.Add(new PrefixConverter("A"));
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Unsupported registration policy:*");
+    }
+
+    [Test]
+    public void ReversibleTypeDispatcher_UnsupportedRegistrationPolicy_ThrowsOnAddForward()
+    {
+        var builder = ReversibleTypeDispatcher.Create<int, string>((DispatcherRegistrationPolicy)999);
+
+        Action act = () => builder.AddForward(new ConstantConverter("A"));
 
         act.Should()
             .Throw<InvalidOperationException>()

--- a/src/MudBlazor/Converters/DefaultConverter.ToString.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.ToString.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+internal partial class DefaultConverter
+{
+    internal sealed class ToStringFallbackConverter<T> : IConverter<T?, string?>
+    {
+        public string? Convert(T? input) => input?.ToString();
+    }
+}

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities.Converter.Dispatcher;
 using static MudBlazor.DefaultConverter;
 
@@ -87,17 +86,15 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
 
         AddEnumConverters(builder);
         AddParsableConverters(builder);
+        // Make sure this is the last converter added, so it runs only if no other converter can handle the type.
+        // This ensures we don't accidentally bypass a more specific converter with FirstWins.
+        builder.AddForward(new ToStringFallbackConverter<T>());
 
         _dispatcher = builder.Build();
     }
 
     /// <inheritdoc />
-    public string? Convert(T? input)
-    {
-        var result = _dispatcher.TryConvert(input);
-        // If conversion failed, fallback to ToString() implementation of the T
-        return result.Success ? result.Value : input?.ToString();
-    }
+    public string? Convert(T? input) => _dispatcher.Convert(input);
 
     /// <inheritdoc />
     public T? ConvertBack(string? input) => _dispatcher.ConvertBack(input);

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/DelegateHelper.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/DelegateHelper.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace MudBlazor.Utilities.Converter.Dispatcher;
 
-internal sealed class DelegateHelper
+internal static class DelegateHelper
 {
     public static Delegate CreateForwardDelegate<TIn, TOut>(Type specificType, object converter)
         => CreateDelegate(

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/DelegateHelper.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/DelegateHelper.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace MudBlazor.Utilities.Converter.Dispatcher;
+
+internal sealed class DelegateHelper
+{
+    public static Delegate CreateForwardDelegate<TIn, TOut>(Type specificType, object converter)
+        => CreateDelegate(
+            converter,
+            typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut)),
+            nameof(IConverter<TIn, TOut>.Convert),
+            typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)),
+            $"{nameof(IConverter<TIn, TOut>.Convert)}({specificType})");
+
+    public static Delegate CreateBackwardDelegate<TIn, TOut>(Type specificType, object converter)
+        => CreateDelegate(
+            converter,
+            typeof(IReversibleConverter<,>).MakeGenericType(specificType, typeof(TOut)),
+            nameof(IReversibleConverter<TIn, TOut>.ConvertBack),
+            typeof(Func<,>).MakeGenericType(typeof(TOut), specificType),
+            $"{nameof(IReversibleConverter<TIn, TOut>.ConvertBack)}({typeof(TOut)})");
+
+    private static Delegate CreateDelegate(
+        object converter,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.Interfaces)] Type interfaceType,
+        string methodName,
+        Type delegateType,
+        string missingMethodDisplay)
+    {
+        var converterType = converter.GetType();
+        if (!interfaceType.IsAssignableFrom(converterType))
+        {
+            throw new InvalidOperationException($"Converter type {converterType.FullName} does not implement {missingMethodDisplay}");
+        }
+
+        var method = interfaceType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        // Cannot be null since we already verified the interface is implemented
+        return method!.CreateDelegate(delegateType, converter);
+    }
+}

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/IReversibleDispatcherBuilder.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/IReversibleDispatcherBuilder.cs
@@ -23,6 +23,18 @@ public interface IReversibleDispatcherBuilder<TIn, TOut>
     IReversibleDispatcherBuilder<TIn, TOut> Add<TSpecific>(IReversibleConverter<TSpecific, TOut> converter);
 
     /// <summary>
+    /// Register a forward-only converter that handles conversions for the specific concrete input type <typeparamref name="TSpecific"/>.
+    /// </summary>
+    /// <typeparam name="TSpecific">The concrete input type this converter handles.</typeparam>
+    /// <param name="converter">An <see cref="IConverter{TSpecific,TOut}"/> implementation used for forward conversions of <typeparamref name="TSpecific"/>.</param>
+    /// <returns>The same builder instance to allow fluent registrations.</returns>
+    /// <remarks>
+    /// This method registers only the forward conversion (<c>Convert</c>). It does not register a reverse conversion,
+    /// so <c>ConvertBack</c> remains unresolved for <typeparamref name="TSpecific"/>.
+    /// </remarks>
+    IReversibleDispatcherBuilder<TIn, TOut> AddForward<TSpecific>(IConverter<TSpecific, TOut> converter);
+
+    /// <summary>
     /// Register a reversible converter instance for a concrete input type that is known only at runtime.
     /// </summary>
     /// <param name="specificType">The concrete input <see cref="System.Type"/> the supplied converter handles.</param>
@@ -41,6 +53,24 @@ public interface IReversibleDispatcherBuilder<TIn, TOut>
     /// If the instance is incompatible a runtime exception may be thrown by the builder implementation.
     /// </remarks>
     IReversibleDispatcherBuilder<TIn, TOut> AddDynamic(Type specificType, object? converter);
+
+    /// <summary>
+    /// Register a forward-only converter instance for a concrete input type that is known only at runtime.
+    /// </summary>
+    /// <param name="specificType">The concrete input <see cref="System.Type"/> the supplied converter handles.</param>
+    /// <param name="converter">
+    /// A converter instance implementing <c>IConverter&lt;TSpecific,TOut&gt;</c> for the supplied <paramref name="specificType"/>.
+    /// </param>
+    /// <returns>
+    /// A builder typed to <see cref="IReversibleConverter{TIn,TOut}"/> to continue registrations.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="specificType"/> or <paramref name="converter"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the supplied <paramref name="converter"/> does not provide a compatible <c>Convert</c> method for <paramref name="specificType"/>.</exception>
+    /// <remarks>
+    /// This method registers only the forward conversion (<c>Convert</c>). It does not register a reverse conversion,
+    /// so <c>ConvertBack</c> remains unresolved for <typeparamref name="TSpecific"/>.
+    /// </remarks>
+    IReversibleDispatcherBuilder<TIn, TOut> AddDynamicForward(Type specificType, object? converter);
 
     /// <summary>
     /// Builds the reversible dispatcher that routes forward and backward conversions to the registered per-type reversible converters.

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/IReversibleDispatcherBuilder.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/IReversibleDispatcherBuilder.cs
@@ -68,7 +68,7 @@ public interface IReversibleDispatcherBuilder<TIn, TOut>
     /// <exception cref="InvalidOperationException">Thrown when the supplied <paramref name="converter"/> does not provide a compatible <c>Convert</c> method for <paramref name="specificType"/>.</exception>
     /// <remarks>
     /// This method registers only the forward conversion (<c>Convert</c>). It does not register a reverse conversion,
-    /// so <c>ConvertBack</c> remains unresolved for <typeparamref name="TSpecific"/>.
+    /// so <c>ConvertBack</c> remains unresolved for the supplied <paramref name="specificType"/>.
     /// </remarks>
     IReversibleDispatcherBuilder<TIn, TOut> AddDynamicForward(Type specificType, object? converter);
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -99,6 +99,16 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
         }
 
         /// <inheritdoc />
+        public IReversibleDispatcherBuilder<TIn, TOut> AddForward<TSpecific>(IConverter<TSpecific, TOut> converter)
+        {
+            AddForwardHandler(
+                typeof(TSpecific),
+                new Func<TSpecific, TOut>(converter.Convert));
+
+            return this;
+        }
+
+        /// <inheritdoc />
         public IReversibleDispatcherBuilder<TIn, TOut> AddDynamic(Type specificType, object? converter)
         {
             ArgumentNullException.ThrowIfNull(specificType);
@@ -129,6 +139,54 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             AddHandlers(specificType, forwardDelegate, backwardDelegate);
 
             return this;
+        }
+
+        /// <inheritdoc />
+        public IReversibleDispatcherBuilder<TIn, TOut> AddDynamicForward(Type specificType, object? converter)
+        {
+            ArgumentNullException.ThrowIfNull(specificType);
+            ArgumentNullException.ThrowIfNull(converter);
+
+            var convType = converter.GetType();
+
+            var convertMethodInterface = typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut));
+            if (!convertMethodInterface.IsAssignableFrom(convType))
+            {
+                throw new InvalidOperationException($"Converter type {convType.FullName} does not implement Convert({specificType})");
+            }
+
+            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            // Cannot be null since we already verified the interface is implemented
+            var forwardDelegate = convertMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
+
+            AddForwardHandler(specificType, forwardDelegate);
+
+            return this;
+        }
+
+        private void AddForwardHandler(Type specificType, Delegate forwardHandler)
+        {
+            switch (registrationPolicy)
+            {
+                case DispatcherRegistrationPolicy.LastWins:
+                    _handlers[specificType] = forwardHandler;
+                    _reverseHandlers.Remove(specificType);
+                    return;
+                case DispatcherRegistrationPolicy.FirstWins:
+                    _handlers.TryAdd(specificType, forwardHandler);
+                    return;
+                case DispatcherRegistrationPolicy.Throw:
+                    if (_handlers.ContainsKey(specificType) || _reverseHandlers.ContainsKey(specificType))
+                    {
+                        throw new InvalidOperationException($"Converter already registered for {specificType}.");
+                    }
+
+                    _handlers.Add(specificType, forwardHandler);
+                    return;
+                default:
+                    throw new InvalidOperationException($"Unsupported registration policy: {registrationPolicy}.");
+            }
         }
 
         private void AddHandlers(Type specificType, Delegate forwardHandler, Delegate backwardHandler)

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using MudBlazor.Resources;
+﻿using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
 namespace MudBlazor.Utilities.Converter.Dispatcher;

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -140,18 +140,16 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             {
                 case DispatcherRegistrationPolicy.LastWins:
                     _handlers[specificType] = forwardHandler;
-                    _reverseHandlers.Remove(specificType);
                     return;
                 case DispatcherRegistrationPolicy.FirstWins:
                     _handlers.TryAdd(specificType, forwardHandler);
                     return;
                 case DispatcherRegistrationPolicy.Throw:
-                    if (_handlers.ContainsKey(specificType) || _reverseHandlers.ContainsKey(specificType))
+                    if (!_handlers.TryAdd(specificType, forwardHandler))
                     {
                         throw new InvalidOperationException($"Converter already registered for {specificType}.");
                     }
 
-                    _handlers.Add(specificType, forwardHandler);
                     return;
                 default:
                     throw new InvalidOperationException($"Unsupported registration policy: {registrationPolicy}.");

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/ReversibleTypeDispatcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -114,27 +115,8 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             ArgumentNullException.ThrowIfNull(specificType);
             ArgumentNullException.ThrowIfNull(converter);
 
-            var convType = converter.GetType();
-
-            var convertMethodInterface = typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            if (!convertMethodInterface.IsAssignableFrom(convType))
-            {
-                throw new InvalidOperationException($"Converter type {convType.FullName} does not implement Convert({specificType})");
-            }
-
-            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-            var convertBackMethodInterface = typeof(IReversibleConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            if (!convertBackMethodInterface.IsAssignableFrom(convType))
-            {
-                throw new InvalidOperationException($"Converter type {convType.FullName} does not implement ConvertBack({typeof(TOut)})");
-            }
-
-            var convertBackMethod = convertBackMethodInterface.GetMethod(nameof(IReversibleConverter<TIn, TOut>.ConvertBack), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-            // Cannot be null since we already verified the interface is implemented
-            var forwardDelegate = convertMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
-            var backwardDelegate = convertBackMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(typeof(TOut), specificType), converter);
+            var forwardDelegate = DelegateHelper.CreateForwardDelegate<TIn, TOut>(specificType, converter);
+            var backwardDelegate = DelegateHelper.CreateBackwardDelegate<TIn, TOut>(specificType, converter);
 
             AddHandlers(specificType, forwardDelegate, backwardDelegate);
 
@@ -147,18 +129,7 @@ internal class ReversibleTypeDispatcher<TIn, TOut> :
             ArgumentNullException.ThrowIfNull(specificType);
             ArgumentNullException.ThrowIfNull(converter);
 
-            var convType = converter.GetType();
-
-            var convertMethodInterface = typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            if (!convertMethodInterface.IsAssignableFrom(convType))
-            {
-                throw new InvalidOperationException($"Converter type {convType.FullName} does not implement Convert({specificType})");
-            }
-
-            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-            // Cannot be null since we already verified the interface is implemented
-            var forwardDelegate = convertMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
+            var forwardDelegate = DelegateHelper.CreateForwardDelegate<TIn, TOut>(specificType, converter);
 
             AddForwardHandler(specificType, forwardDelegate);
 

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-using MudBlazor.Resources;
+﻿using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
 namespace MudBlazor.Utilities.Converter.Dispatcher;

--- a/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
+++ b/src/MudBlazor/Utilities/Converter/Dispatcher/TypeDispatcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using MudBlazor.Resources;
 using MudBlazor.Utilities.Exceptions;
 
@@ -96,18 +97,7 @@ internal class TypeDispatcher<TIn, TOut> : IConverter<TIn, TOut>
             ArgumentNullException.ThrowIfNull(specificType);
             ArgumentNullException.ThrowIfNull(converter);
 
-            var convType = converter.GetType();
-
-            var convertMethodInterface = typeof(IConverter<,>).MakeGenericType(specificType, typeof(TOut));
-            if (!convertMethodInterface.IsAssignableFrom(convType))
-            {
-                throw new InvalidOperationException($"Converter type {convType.FullName} does not implement Convert({specificType})");
-            }
-
-            var convertMethod = convertMethodInterface.GetMethod(nameof(IConverter<TIn, TOut>.Convert), BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-
-            // Cannot be null since we already verified the interface is implemented
-            var forwardDelegate = convertMethod!.CreateDelegate(typeof(Func<,>).MakeGenericType(specificType, typeof(TOut)), converter);
+            var forwardDelegate = DelegateHelper.CreateForwardDelegate<TIn, TOut>(specificType, converter);
 
             AddHandler(specificType, forwardDelegate);
 


### PR DESCRIPTION
Fixes: [https://github.com/MudBlazor/MudBlazor/issues/12834](https://github.com/MudBlazor/MudBlazor/issues/12834)

The issue above isn’t actually a bug, but it does appear in the IDE when **Just My Code** is disabled.

Instead of using a try–catch that falls back to `ToString()` in the catch block, this change adds a proper one way converter to the `ReversibleDispatcher` pipeline. The converter is added as the last fallback when no appropriate converter for `T` is found.

In this case we need only one way converter from T to string (opposite is not possible), which is why a special `AddForward` is added.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
