### PR TITLE
MudSelect: Give ToStringFunc Higher Precedence

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectPresentationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectPresentationExample.razor
@@ -30,6 +30,26 @@
     </MudSelectItem>
 </MudSelect>
 
+<MudSelect @bind-Value="country" Label="ToStringFunc Precedence" Variant="Variant.Outlined" ToStringFunc="@GetCountryCode">
+    <MudSelectItem Value="@("Austria")">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/Flag_of_Austria.svg" height="14" class="mr-1" /> Austria
+    </MudSelectItem>
+    <MudSelectItem Value="@("Hungary")">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/0/00/Flag_of_Hungary.png" height="14" class="mr-1" /> Hungary
+    </MudSelectItem>
+    <MudSelectItem Value="@("Sweden")">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/4/4b/Flag_of_Sweden_fixed.svg" height="14" class="mr-1" /> Sweden
+    </MudSelectItem>
+</MudSelect>
+
 @code {
     string country="Austria";
+
+    private string GetCountryCode(string name) => name switch
+    {
+        "Austria" => "AUT",
+        "Hungary" => "HUN",
+        "Sweden" => "SWE",
+        _ => name
+    };
 }

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -104,10 +104,19 @@
         <DocsPageSection>
             <SectionHeader Title="Value presentation">
                 <Description>
-                    Select uses the render fragments you specify for the items to display the selected value (if any). If you don't specify render fragments, the value will be displayed as text. Also, if you have render fragments
-                    but the value that has been set is not in the list, it will also be displayed as text.
+                    Both the <CodeInline>ChildContent</CodeInline> (Render Fragment) and <CodeInline>ToStringFunc</CodeInline> can control how values are displayed.
+                    <MudBadge Class="ml-4" Color="Color.Primary" Origin="Origin.CenterLeft" Dot Bordered>
+                        <div class="pl-2">
+                            When used on their own, either one determines how items appear in the dropdown list and how the selected value is displayed in the <CodeInline>MudSelect</CodeInline> input.
+                        </div>
+                    </MudBadge>
+                    <MudBadge Class="ml-4" Color="Color.Primary" Origin="Origin.CenterLeft" Dot Bordered>
+                        <div class="pl-2">
+                            When both are used, <CodeInline>ChildContent</CodeInline> controls how items are rendered in the dropdown list, while <CodeInline>ToStringFunc</CodeInline> controls how the selected value is displayed.
+                        </div>
+                    </MudBadge>
                     <br /><br />
-                    If you provide a <CodeInline>ToStringFunc</CodeInline>, it takes precedence over the item's render fragment for the selection display, provided it returns a non-empty string.
+                    If neither is specified, the value’s default string representation is used.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(SelectPresentationExample)">

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -106,6 +106,8 @@
                 <Description>
                     Select uses the render fragments you specify for the items to display the selected value (if any). If you don't specify render fragments, the value will be displayed as text. Also, if you have render fragments
                     but the value that has been set is not in the list, it will also be displayed as text.
+                    <br /><br />
+                    If you provide a <CodeInline>ToStringFunc</CodeInline>, it takes precedence over the item's render fragment for the selection display, provided it returns a non-empty string.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(SelectPresentationExample)">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
@@ -1,0 +1,14 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents.Select
+
+<MudSelect @ref="Select" T="string" Label="Select" ToStringFunc="@(x => x == "item1" ? null : x?.ToUpperInvariant())" Value="@("item1")">
+    <MudSelectItem Value="@("item1")">
+        <span class="custom-render">Item 1 Rendered</span>
+    </MudSelectItem>
+    <MudSelectItem Value="@("item2")">
+        <span class="custom-render">Item 2 Rendered</span>
+    </MudSelectItem>
+</MudSelect>
+
+@code {
+    public MudSelect<string>? Select { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.UnitTests.TestComponents.Select
 
-<MudSelect @ref="Select" T="string" Label="Select" ToStringFunc="@(x => x == "item1" ? null : x?.ToUpperInvariant())" Value="@("item1")">
+<MudSelect T="string" Label="Select" ToStringFunc="@(x => x == "item1" ? null : x?.ToUpperInvariant())" Value="@("item1")">
     <MudSelectItem Value="@("item1")">
         <span class="custom-render">Item 1 Rendered</span>
     </MudSelectItem>
@@ -8,7 +8,3 @@
         <span class="custom-render">Item 2 Rendered</span>
     </MudSelectItem>
 </MudSelect>
-
-@code {
-    public MudSelect<string>? Select { get; set; }
-}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1891,5 +1891,66 @@ namespace MudBlazor.UnitTests.Components
             // Modal should be null (using PopoverOptions defaults)
             select.Instance.Modal.Should().BeNull();
         }
+
+        [Test]
+        public async Task Select_ToStringFunc_ShouldTakePrecedenceOverChildContent()
+        {
+            var comp = Context.Render<SelectPrecedenceTest>();
+            var select = comp.Instance.Select;
+
+            // 1. Initially item1 is selected. ToStringFunc returns null for item1.
+            // Should fall back to RenderFragment.
+            var displaySlots = comp.FindAll("div.mud-input-slot");
+            var displaySlot = displaySlots.FirstOrDefault(x => x.GetAttribute("style")?.Contains("display:inline") == true || x.GetAttribute("style")?.Contains("display: inline") == true);
+            displaySlot.Should().NotBeNull("initially it should fall back to RenderFragment");
+            displaySlot.InnerHtml.Should().Contain("custom-render");
+            displaySlot.TextContent.Trim().Should().Be("Item 1 Rendered");
+
+            // 2. Select item2. ToStringFunc returns "ITEM2" (not null).
+            // Should use ToStringFunc and NOT RenderFragment.
+            await comp.InvokeAsync(() => select!.SelectOption("item2"));
+            comp.Render();
+
+            displaySlots = comp.FindAll("div.mud-input-slot");
+            displaySlot = displaySlots.FirstOrDefault(x => x.GetAttribute("style")?.Contains("display:inline") == true || x.GetAttribute("style")?.Contains("display: inline") == true);
+            displaySlot.Should().BeNull("because ToStringFunc should take precedence over RenderFragment when it returns a non-null value");
+
+            var input = comp.Find("input");
+            input.GetAttribute("value").Should().Be("ITEM2");
+        }
+
+        [Test]
+        public async Task Select_FitContent_ShouldPrioritizeToStringFunc()
+        {
+            var comp = Context.Render<SelectPrecedenceTest>();
+            var selectComponent = comp.FindComponent<MudSelect<string>>();
+
+            // Remove label to avoid it being the longest
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.FitContent, true)
+                .Add(x => x.Label, null)
+                .Add(x => x.ToStringFunc, new Func<string?, string?>(x => x == "item2" ? "VERY LONG ITEM 2" : null)));
+
+            // item1 -> null -> "Item 1 Rendered" (15 chars)
+            // item2 -> "VERY LONG ITEM 2" (16 chars)
+
+            // item2 is longest. ToStringFunc is NOT null for item2.
+            // filler should use "VERY LONG ITEM 2" and NOT RenderFragment.
+
+            var filler = comp.Find(".mud-select-filler");
+            filler.TextContent.Should().Contain("VERY LONG ITEM 2");
+            filler.InnerHtml.Should().NotContain("custom-render");
+
+            // Now make item1 longest via ToStringFunc
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ToStringFunc, new Func<string?, string?>(x => x == "item1" ? "EXTREMELY LONG ITEM 1" : "ITEM 2")));
+
+            // Trigger recalculation of _longestItem by toggling FitContent
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.FitContent, false));
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.FitContent, true));
+
+            filler = comp.Find(".mud-select-filler");
+            filler.TextContent.Should().Contain("EXTREMELY LONG ITEM 1");
+            filler.InnerHtml.Should().NotContain("custom-render");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1896,7 +1896,8 @@ namespace MudBlazor.UnitTests.Components
         public async Task Select_ToStringFunc_ShouldTakePrecedenceOverChildContent()
         {
             var comp = Context.Render<SelectPrecedenceTest>();
-            var select = comp.Instance.Select;
+            var selectComponent = comp.FindComponent<MudSelect<string>>();
+            var select = selectComponent.Instance;
 
             // 1. Initially item1 is selected. ToStringFunc returns null for item1.
             // Should fall back to RenderFragment.

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -71,7 +71,7 @@
                         {
                             <MudText Typo="@Typo">@(MultiSelectionTextFunc?.Invoke([defaultValue]) ?? defaultValue)</MudText>
                         }
-                        else if (_longestItem?.ChildContent is null || MultiSelectionTextFunc is not null)
+                        else if (_longestItem?.ChildContent is null || MultiSelectionTextFunc is not null || !string.IsNullOrEmpty(ToStringFunc?.Invoke(_longestItem.Value)))
                         {
                             <MudText Typo="@Typo">@(MultiSelectionTextFunc?.Invoke([value!]) ?? value!)</MudText>
                         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -61,29 +61,46 @@
                 {
                     <MudStack Class="@FillerClassname" Spacing="1" Row>
                         @{
-                            var value = _longestItem is { Value: not null } ? ToStringFunc ?.Invoke(_longestItem.Value) ?? ConvertSet(_longestItem.Value) : string.Empty;
-                            var useLabel = Label is not null && Placeholder is null && !ShrinkLabel
+                            string? toStringValue = null;
+                            var value = string.Empty;
+
+                            if (_longestItem is { Value: not null })
+                            {
+                                toStringValue = ToStringFunc?.Invoke(_longestItem.Value);
+                                value = toStringValue ?? ConvertSet(_longestItem.Value) ?? string.Empty;
+                            }
+
+                            var useLabel = Label is not null && Placeholder is null && !ShrinkLabel 
                                         && (Adornment != Adornment.Start || (AdornmentIcon is null && AdornmentText is null));
 
                             var defaultValue = useLabel ? Label : Placeholder;
+                            var showDefault = defaultValue?.Length > value.Length;
+                            var hasChildContent = _longestItem?.ChildContent is not null;
+                            var hasStringValue = !string.IsNullOrEmpty(toStringValue);
+
+                            var renderText = showDefault || !hasChildContent || MultiSelectionTextFunc is not null || hasStringValue;
                         }
-                        @if (defaultValue?.Length > value!.Length)
+
+                        @if (renderText)
                         {
-                            <MudText Typo="@Typo">@(MultiSelectionTextFunc?.Invoke([defaultValue]) ?? defaultValue)</MudText>
-                        }
-                        else if (_longestItem?.ChildContent is null || MultiSelectionTextFunc is not null || !string.IsNullOrEmpty(ToStringFunc?.Invoke(_longestItem.Value)))
-                        {
-                            <MudText Typo="@Typo">@(MultiSelectionTextFunc?.Invoke([value!]) ?? value!)</MudText>
+                            var text = showDefault ? defaultValue! : value;
+
+                            <MudText Typo="@Typo">
+                                @(MultiSelectionTextFunc?.Invoke([text]) ?? text)
+                            </MudText>
                         }
                         else
                         {
-                            <MudText Typo="@Typo">@_longestItem.ChildContent</MudText>
+                            <MudText Typo="@Typo">@_longestItem!.ChildContent</MudText>
                         }
+
                         @AdornmentText
+
                         @if (AdornmentText is null)
                         {
                             <MudIcon Icon="@(AdornmentIcon ?? OpenIcon)" Size="IconSize"></MudIcon>
                         }
+
                         @if (Clearable)
                         {
                             <MudIcon Icon="@ClearIcon" Size="IconSize"></MudIcon>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -61,13 +61,11 @@
                 {
                     <MudStack Class="@FillerClassname" Spacing="1" Row>
                         @{
-                            string? toStringValue = null;
                             var value = string.Empty;
 
                             if (_longestItem is { Value: not null })
                             {
-                                toStringValue = ToStringFunc?.Invoke(_longestItem.Value);
-                                value = toStringValue ?? ConvertSet(_longestItem.Value) ?? string.Empty;
+                                value = ConvertSet(_longestItem.Value) ?? string.Empty;
                             }
 
                             var useLabel = Label is not null && Placeholder is null && !ShrinkLabel 
@@ -76,7 +74,7 @@
                             var defaultValue = useLabel ? Label : Placeholder;
                             var showDefault = defaultValue?.Length > value.Length;
                             var hasChildContent = _longestItem?.ChildContent is not null;
-                            var hasStringValue = !string.IsNullOrEmpty(toStringValue);
+                            var hasStringValue = ToStringFunc is not null && !string.IsNullOrEmpty(value);
 
                             var renderText = showDefault || !hasChildContent || MultiSelectionTextFunc is not null || hasStringValue;
                         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -476,9 +476,20 @@ namespace MudBlazor
             get
             {
                 if (MultiSelection)
+                {
                     return false;
+                }
+
+                if (ToStringFunc is not null && !string.IsNullOrEmpty(ToStringFunc(ReadValue)))
+                {
+                    return false;
+                }
+
                 if (!_context.TryGetShadowItemByValue(ReadValue, out var item))
+                {
                     return false;
+                }
+
                 return item.ChildContent != null;
             }
         }
@@ -516,9 +527,13 @@ namespace MudBlazor
             if (index < 0 || index >= Items.Count)
             {
                 if (!MultiSelection)
+                {
                     await CloseMenu();
+                }
+
                 return;
             }
+
             await SelectOption(Items[index].Value);
         }
 
@@ -605,11 +620,18 @@ namespace MudBlazor
         public async Task ToggleMenu()
         {
             if (GetDisabledState() || GetReadOnlyState())
+            {
                 return;
+            }
+
             if (_openState.Value)
+            {
                 await CloseMenu(true);
+            }
             else
+            {
                 await OpenMenu();
+            }
         }
 
         /// <summary>
@@ -621,7 +643,9 @@ namespace MudBlazor
         public async Task OpenMenu()
         {
             if (GetDisabledState() || GetReadOnlyState())
+            {
                 return;
+            }
 
             await _openState.SetValueAsync(true);
             _needsHighlightAfterRender = true;
@@ -638,6 +662,7 @@ namespace MudBlazor
                     await ScrollToItemAsync(item);
                 }
             }
+
             //disable escape propagation: if selectmenu is open, only the select popover should close and underlying components should not handle escape key
             await KeyInterceptorService.UpdateKeyAsync(ElementId, new("Escape", stopDown: "key+none"));
         }
@@ -757,8 +782,11 @@ namespace MudBlazor
             {
                 FieldChanged(_selectedValues);
             }
+
             if (MultiSelection && typeof(T) == typeof(string))
+            {
                 await SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false);
+            }
         }
 
         private void OnFitContentChanged(ParameterChangedEventArgs<bool> args)
@@ -778,6 +806,7 @@ namespace MudBlazor
                         longestItemLength = length;
                     }
                 }
+
                 StateHasChanged();
             }
             else
@@ -832,24 +861,39 @@ namespace MudBlazor
         {
             // Manage the fake tri-state of a checkbox
             if (!_selectAllChecked.HasValue)
+            {
                 _selectAllChecked = true;
+            }
             else if (_selectAllChecked.Value)
+            {
                 _selectAllChecked = false;
+            }
             else
+            {
                 _selectAllChecked = true;
+            }
+
             // Define the items selection
             if (_selectAllChecked.Value)
+            {
                 await SelectAllItems();
+            }
             else
+            {
                 await ClearAsync();
+            }
         }
 
         private async Task SelectAllItems()
         {
             if (!MultiSelection)
+            {
                 return;
+            }
+
             var selectedValues = new HashSet<T?>(Items.Where(x => !x.Disabled && x.Value != null).Select(x => x.Value), Comparer);
             _selectedValues = new HashSet<T?>(selectedValues, Comparer);
+
             if (MultiSelectionTextFunc != null)
             {
                 await SetCustomizedTextAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)),
@@ -860,13 +904,17 @@ namespace MudBlazor
             {
                 await SetTextAndUpdateValueAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)), updateValue: false);
             }
+
             UpdateSelectAllChecked();
             _selectedValues = selectedValues; // need to force selected values because Blazor overwrites it under certain circumstances due to changes of Text or Value
             await BeginValidateAsync();
             await _selectedValuesState.SetValueAsync(new HashSet<T?>(_selectedValues, Comparer));
             FieldChanged(_selectedValues);
+
             if (MultiSelection && typeof(T) == typeof(string))
+            {
                 SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false).CatchAndLog();
+            }
         }
 
         private async Task OnFocusOutAsync()
@@ -886,21 +934,36 @@ namespace MudBlazor
         private async Task SelectAdjacentItem(int direction)
         {
             if (Items.Count == 0)
+            {
                 return;
+            }
+
             var index = Items.FindIndex(x => x.ItemId == _activeItemId);
             if (direction < 0 && index < 0)
+            {
                 index = 0;
+            }
+
             MudSelectItem<T>? item = null;
             // the loop allows us to jump over disabled items until we reach the next non-disabled one
             for (var i = 0; i < Items.Count; i++)
             {
                 index += direction;
                 if (index < 0)
+                {
                     index = 0;
+                }
+
                 if (index >= Items.Count)
+                {
                     index = Items.Count - 1;
+                }
+
                 if (Items[index].Disabled)
+                {
                     continue;
+                }
+
                 item = Items[index];
                 if (!MultiSelection)
                 {
@@ -922,6 +985,7 @@ namespace MudBlazor
                 await HighlightItemAsync(item);
                 break;
             }
+
             await _elementReference.SetText(ReadText);
             await ScrollToItemAsync(item);
         }
@@ -1076,10 +1140,16 @@ namespace MudBlazor
         private async Task SelectLastItem()
         {
             if (Items.Count == 0)
+            {
                 return;
+            }
+
             var item = Items.LastOrDefault(x => !x.Disabled);
             if (item == null)
+            {
                 return;
+            }
+
             if (!MultiSelection)
             {
                 _selectedValues.Clear();
@@ -1095,7 +1165,10 @@ namespace MudBlazor
         internal Task HandleMouseDown(MouseEventArgs args)
         {
             if (args.Button != 0) // if it wasn't left click drop out
+            {
                 return Task.CompletedTask;
+            }
+
             return ToggleMenu();
         }
 
@@ -1191,15 +1264,21 @@ namespace MudBlazor
         private async Task HandleCharacterSearchAsync(KeyboardEventArgs args)
         {
             if (args.CtrlKey || args.ShiftKey || args.AltKey || args.MetaKey)
+            {
                 return;
+            }
 
             var key = args.Key;
             if (string.IsNullOrWhiteSpace(key))
+            {
                 return;
+            }
 
             key = key.ToLowerInvariant();
             if (key.Length != 1)
+            {
                 return;
+            }
 
             await SelectFirstItem(key);
             await FocusAsync();
@@ -1302,7 +1381,10 @@ namespace MudBlazor
         protected RenderFragment? GetSelectedValuePresenter()
         {
             if (!_context.TryGetShadowItemByValue(ReadValue, out var item))
+            {
                 return null; //<-- for now. we'll add a custom template to present values (set from outside) which are not on the list?
+            }
+
             return item.ChildContent;
         }
 
@@ -1338,9 +1420,14 @@ namespace MudBlazor
             {
                 _multiSelectionText = text;
                 if (!string.IsNullOrWhiteSpace(_multiSelectionText))
+                {
                     Touched = true;
+                }
+
                 if (updateValue)
+                {
                     await UpdateValuePropertyAsync(false);
+                }
             }
         }
 
@@ -1359,7 +1446,10 @@ namespace MudBlazor
         {
             // For MultiSelection of non-string T's we don't update the Value!!!
             if (typeof(T) == typeof(string) || !MultiSelection)
+            {
                 base.UpdateValuePropertyAsync(updateText);
+            }
+
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
This PR implements the request in issue #12729 by changing the precedence of how the selected value is displayed in `MudSelect`.

Previously, if a `MudSelectItem` had `ChildContent` (a `RenderFragment`), it would always be used for the selection display in the select box, even if the parent `MudSelect` had a `ToStringFunc` defined.

With this change:
1. If `ToStringFunc` is provided and returns a non-null, non-empty string for the selected value, that string will be displayed in the select box (as text).
2. If `ToStringFunc` is not provided, or returns a null/empty string, the component falls back to displaying the `ChildContent` of the selected item (if any).
3. The items inside the popover (dropdown list) continue to use their `ChildContent` as before.
4. The `FitContent` property correctly accounts for this precedence when calculating the required width of the component.

Closes #12729

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
