### PR TITLE
Docs: Update app bar active state immediately on route changes

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services;
@@ -11,8 +12,9 @@ using MudBlazor.Utilities;
 namespace MudBlazor.Docs.Shared;
 
 #nullable enable
-public partial class Appbar
+public partial class Appbar : IDisposable
 {
+    private DocsBasePage _activePage;
     private bool _searchDialogOpen;
     private bool _searchDialogAutocompleteOpen;
     private int _searchDialogReturnedItemsCount;
@@ -48,6 +50,13 @@ public partial class Appbar
     [Parameter]
     public bool DisplaySearchBar { get; set; } = true;
 
+    protected override void OnInitialized()
+    {
+        UpdateActivePage(NavigationManager.Uri);
+        NavigationManager.LocationChanged += OnLocationChanged;
+        base.OnInitialized();
+    }
+
     private async Task OnSearchResult(ApiLinkServiceEntry? entry)
     {
         if (entry is null)
@@ -70,7 +79,27 @@ public partial class Appbar
 
     private string GetActiveClass(DocsBasePage page)
     {
-        return page == LayoutService.GetDocsBasePage(NavigationManager.Uri) ? "mud-chip-text mud-chip-color-primary mx-1 px-3" : "mx-1 px-3";
+        return page == _activePage ? "mud-chip-text mud-chip-color-primary mx-1 px-3" : "mx-1 px-3";
+    }
+
+    private async void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        if (UpdateActivePage(args.Location))
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private bool UpdateActivePage(string location)
+    {
+        var activePage = LayoutService.GetDocsBasePage(location);
+        if (_activePage == activePage)
+        {
+            return false;
+        }
+
+        _activePage = activePage;
+        return true;
     }
 
     private Task<IReadOnlyCollection<ApiLinkServiceEntry>> Search(string text, CancellationToken token)
@@ -95,5 +124,10 @@ public partial class Appbar
         }
 
         OpenSearchDialog();
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
     }
 }


### PR DESCRIPTION
Refactors `Appbar.razor.cs` so the docs top-nav tracks its active section with a local `_activePage` state instead of recalculating from `NavigationManager.Uri` during a later render. The app bar now initializes that state once, updates it from `LocationChangedEventArgs.Location`, and only calls `StateHasChanged()` when the top-level docs section actually changes. This keeps the selected `Get Started`, `Docs`, or `Learn More` item in sync without the delayed highlight update or unnecessary re-renders.

Closes #12835

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
