### PR TITLE
MudTreeView: Fix selected value reset when adding data-bound items

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewNewItemSelectTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewNewItemSelectTest.razor
@@ -1,0 +1,62 @@
+﻿<MudTreeView Items="@_treeItems" SelectionMode="SelectionMode.SingleSelection" @bind-SelectedValue="this.SelectedValue">
+    <ItemTemplate>
+        <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.Children" Value="@context.Value" Text="@context.Text" />
+    </ItemTemplate>
+</MudTreeView>
+
+<MudChipSet T="MyItem" @bind-SelectedValue="@SelectedValue" Color="Color.Primary" Variant="Variant.Text">
+    @foreach (var item in _myItems)
+    {
+        <MudChip Value="item" Text="@item.Name" />
+    }
+</MudChipSet>
+
+<MudButton id="add_item" OnClick="@AddItem">Add Item</MudButton>
+
+@code {
+    private readonly List<MyItem> _myItems =
+    [
+        new MyItem("1"),
+        new MyItem("2"),
+        new MyItem("3",
+            new MyItem("A"),
+            new MyItem("B"),
+            new MyItem("C"))
+    ];
+
+    private TreeItemData<MyItem?>[] _treeItems = [];
+
+    public MyItem? SelectedValue { get; private set; }
+
+    protected override void OnInitialized()
+    {
+        UpdateTreeItems();
+        SelectedValue = _myItems[1];
+    }
+
+    private void UpdateTreeItems()
+    {
+        _treeItems = _myItems.Select(BuildTreeItem).ToArray();
+        return;
+
+        static TreeItemData<MyItem?> BuildTreeItem(MyItem? item)
+        {
+            return new TreeItemData<MyItem?>
+            {
+                Text = item?.Name,
+                Value = item,
+                Children = item?.Children.Select(BuildTreeItem).ToArray()
+            };
+        }
+    }
+
+    private void AddItem()
+    {
+        MyItem newItem = new((_myItems.Count + 1).ToString());
+        _myItems.Add(newItem);
+        UpdateTreeItems();
+        SelectedValue = newItem;
+    }
+
+    public record MyItem(string Name, params MyItem[] Children);
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1326,5 +1326,16 @@ namespace MudBlazor.UnitTests.Components
             var act = () => l2.ClickAsync();
             await act.Should().NotThrowAsync();
         }
+
+        [Test]
+        public async Task TreeView_NewItem_ShouldBeSelected()
+        {
+            var comp = Context.Render<TreeViewNewItemSelectTest>();
+            comp.Instance.SelectedValue.Should().NotBeNull();
+            comp.Instance.SelectedValue!.Name.Should().Be("2");
+            await comp.Find("#add_item").ClickAsync();
+            comp.Instance.SelectedValue.Should().NotBeNull();
+            comp.Instance.SelectedValue!.Name.Should().Be("4");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1327,7 +1327,7 @@ namespace MudBlazor.UnitTests.Components
             await act.Should().NotThrowAsync();
         }
 
-        [Test]
+        [Test(Description = "https://github.com/MudBlazor/MudBlazor/issues/12833")]
         public async Task TreeView_NewItem_ShouldBeSelected()
         {
             var comp = Context.Render<TreeViewNewItemSelectTest>();

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -430,7 +430,9 @@ namespace MudBlazor
         public async Task ExpandAllAsync()
         {
             foreach (var item in _childItems)
+            {
                 await item.ExpandAllAsync();
+            }
         }
 
         /// <summary>
@@ -439,7 +441,9 @@ namespace MudBlazor
         public async Task CollapseAllAsync()
         {
             foreach (var item in _childItems)
+            {
                 await item.CollapseAllAsync();
+            }
         }
 
         /// <summary>
@@ -543,9 +547,13 @@ namespace MudBlazor
                 {
                     var parentSelected = parentItem.ChildItems.Select(x => x.GetValue()).Where(x => x is not null).All(x => _selection.Contains(x!));
                     if (parentSelected)
+                    {
                         _selection.Add(parentValue);
+                    }
                     else
+                    {
                         _selection.Remove(parentValue);
+                    }
                 }
                 parentItem = parentItem.Parent;
             }
@@ -608,7 +616,7 @@ namespace MudBlazor
         ///  <param name="value">The value to be set as the selected value.</param>
         internal async Task SetSelectedValueAsync(T? value)
         {
-            var isValid = value != null && GetChildValuesRecursive().Contains(value);
+            var isValid = value != null && GetSelectableValues().Contains(value);
             // note: if there is no item that corresponds to the value, the value is reset to default!
             await _selectedValueState.SetValueAsync(isValid ? value : default);
             await UpdateItemsAsync();
@@ -620,7 +628,7 @@ namespace MudBlazor
         ///  </summary>
         private async Task SetSelectedValuesAsync(IReadOnlyCollection<T> newValues)
         {
-            var allChildValues = GetChildValuesRecursive();
+            var allChildValues = GetSelectableValues();
             var newSelection = new HashSet<T>(newValues.Where(x => allChildValues.Contains(x)), Comparer);
             if (_selection.SetEquals(newSelection))
             {
@@ -662,6 +670,37 @@ namespace MudBlazor
             return selection;
         }
 
+        private HashSet<T> GetSelectableValues()
+        {
+            if (ItemTemplate is not null && Items is not null)
+            {
+                return GetItemValuesRecursive(Items);
+            }
+
+            return GetChildValuesRecursive();
+        }
+
+        // TODO: speed this up with caching
+        private HashSet<T> GetItemValuesRecursive(IEnumerable<ITreeItemData<T>> items, HashSet<T>? values = null)
+        {
+            values ??= new HashSet<T>(Comparer);
+
+            foreach (var item in items)
+            {
+                if (item.Value is not null)
+                {
+                    values.Add(item.Value);
+                }
+
+                if (item.Children is not null && item.Children.Count > 0)
+                {
+                    GetItemValuesRecursive(item.Children, values);
+                }
+            }
+
+            return values;
+        }
+
         // TODO: speed this up with caching
         private HashSet<T> GetChildValuesRecursive(IEnumerable<MudTreeViewItem<T>>? children = null, HashSet<T>? values = null)
         {
@@ -675,6 +714,7 @@ namespace MudBlazor
                 {
                     values.Add(value);
                 }
+
                 if (item.ChildItems.Count > 0)
                 {
                     GetChildValuesRecursive(item.ChildItems, values);
@@ -683,6 +723,5 @@ namespace MudBlazor
 
             return values;
         }
-
     }
 }


### PR DESCRIPTION
 ## Summary
Fixes: https://github.com/MudBlazor/MudBlazor/issues/12833

Fixes a `MudTreeView` issue where `SelectedValue` could be reset to null when a new item was added to a data-bound tree and selected in the same render cycle.

## Root Cause

`SetSelectedValueAsync` validated the selected value against the rendered child tree items. In the data-bound case, the Items collection had already been updated, but the new `MudTreeViewItem` had not finished registering yet, so the value was treated as invalid and cleared.

## Fix

Use the current data-bound Items values for selection validation when the tree is rendered from `Items`/`ItemTemplate`, and fall back to child component traversal otherwise.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
