### PR TITLE
MudTreeViewItem: Read GetDisabled/GetReadOnly

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DisabledTreeViewMultiSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/DisabledTreeViewMultiSelectionTest.razor
@@ -1,0 +1,31 @@
+﻿<MudTreeView T="string" @bind-SelectedValues="SelectedValues" Disabled="@Disabled" SelectionMode="SelectionMode.MultiSelection">
+    <MudTreeViewItem Value='"content"'>
+        <MudTreeViewItem Value='"logo.png"' />
+        <MudTreeViewItem Value='"MudBlazor.svg"' />
+        <MudTreeViewItem Value='"Nuget.png"' />
+    </MudTreeViewItem>
+    <MudTreeViewItem Value='"src"'>
+        <MudTreeViewItem Value='"MudBlazor"' />
+        <MudTreeViewItem Value='"MudBlazor.Docs"'>
+            <MudTreeViewItem Value='"wwwroot"'>
+                <MudTreeViewItem Value='"MudAppbarCorner.svg"' />
+                <MudTreeViewItem Value='"MudBlazorDocs.min.css"' />
+            </MudTreeViewItem>
+        </MudTreeViewItem>
+    </MudTreeViewItem>
+</MudTreeView>
+
+<ul class="selected-values">
+    @foreach (var value in SelectedValues)
+    {
+        <li>@value</li>
+    }
+</ul>
+
+@code {
+    [Parameter]
+    public IReadOnlyCollection<string> SelectedValues { get; set; } = [];
+
+    [Parameter]
+    public bool Disabled { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewMultiSelectionCheckboxTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewMultiSelectionCheckboxTest.razor
@@ -1,4 +1,4 @@
-﻿<MudTreeView T="string" @bind-SelectedValues="SelectedValues" Disabled="@Disabled" SelectionMode="SelectionMode.MultiSelection">
+﻿<MudTreeView T="string" @bind-SelectedValues="SelectedValues" Disabled="@Disabled" ReadOnly="@ReadOnly" SelectionMode="SelectionMode.MultiSelection">
     <MudTreeViewItem Value='"content"'>
         <MudTreeViewItem Value='"logo.png"' />
         <MudTreeViewItem Value='"MudBlazor.svg"' />
@@ -28,4 +28,7 @@
 
     [Parameter]
     public bool Disabled { get; set; }
+
+    [Parameter]
+    public bool ReadOnly { get; set; }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -42,9 +42,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TreeView_ClickMultiSelectionWhileDisabled_DoesNotChangeSelection()
+        public async Task TreeView_MultiSelectionClickCheckboxWhenDisabled_DoesNotChangeSelection()
         {
-            var comp = Context.Render<DisabledTreeViewMultiSelectionTest>(parameters => parameters.Add(x => x.Disabled, true));
+            var comp = Context.Render<TreeViewMultiSelectionCheckboxTest>(parameters => parameters.Add(x => x.Disabled, true)
+                    .Add(x => x.ReadOnly, false));
             await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
             var GetSelectedValue = () => comp.Find("ul.selected-values").ChildElementCount;
             GetSelectedValue().Should().Be(0);
@@ -54,9 +55,36 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TreeView_ClickMultiSelectionWhileActive_DoesChangeSelection()
+        public async Task TreeView_MultiSelectionClickCheckboxWhenReadOnly_DoesNotChangeSelection()
         {
-            var comp = Context.Render<DisabledTreeViewMultiSelectionTest>(self => self.Add(x => x.Disabled, false));
+            var comp = Context.Render<TreeViewMultiSelectionCheckboxTest>(parameters => parameters.Add(x => x.ReadOnly, true)
+                    .Add(x => x.Disabled, false));
+            await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
+            var GetSelectedValue = () => comp.Find("ul.selected-values").ChildElementCount;
+            GetSelectedValue().Should().Be(0);
+
+            await comp.Find("div.mud-treeview-item-checkbox").DoubleClickAsync();
+            GetSelectedValue().Should().Be(0);
+        }
+
+        [Test]
+        public async Task TreeView_MultiSelectionClickCheckboxWhenReadOnlyAndDisabled_DoesNotChangeSelection()
+        {
+            var comp = Context.Render<TreeViewMultiSelectionCheckboxTest>(parameters => parameters.Add(x => x.ReadOnly, true)
+                    .Add(x => x.Disabled, true));
+            await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
+            var GetSelectedValue = () => comp.Find("ul.selected-values").ChildElementCount;
+            GetSelectedValue().Should().Be(0);
+
+            await comp.Find("div.mud-treeview-item-checkbox").DoubleClickAsync();
+            GetSelectedValue().Should().Be(0);
+        }
+
+        [Test]
+        public async Task TreeView_ClickMultiSelectionCheckboxWhileActive_DoesChangeSelection()
+        {
+            var comp = Context.Render<TreeViewMultiSelectionCheckboxTest>(self => self.Add(x => x.Disabled, false)
+                    .Add(x => x.ReadOnly, false));
             await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
             var GetSelectedValue = () => comp.Find("ul.selected-values").ChildElementCount;
             GetSelectedValue().Should().Be(4);

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -42,6 +42,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TreeView_ClickMultiSelectionWhileDisabled_DoesNotChangeSelection()
+        {
+            var comp = Context.Render<DisabledTreeViewMultiSelectionTest>(parameters => parameters.Add(x => x.Disabled, true));
+            await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
+            var GetSelectedValue = () => comp.Find("ul.selected-values").ChildElementCount;
+            GetSelectedValue().Should().Be(0);
+
+            await comp.Find("div.mud-treeview-item-checkbox").DoubleClickAsync();
+            GetSelectedValue().Should().Be(0);
+        }
+
+        [Test]
+        public async Task TreeView_ClickMultiSelectionWhileActive_DoesChangeSelection()
+        {
+            var comp = Context.Render<DisabledTreeViewMultiSelectionTest>(self => self.Add(x => x.Disabled, false));
+            await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
+            var GetSelectedValue = () => comp.Find("ul.selected-values").ChildElementCount;
+            GetSelectedValue().Should().Be(4);
+
+            // To reset
+            await comp.Find("div.mud-treeview-item-checkbox").ClickAsync();
+            GetSelectedValue().Should().Be(0);
+
+            await comp.Find("div.mud-treeview-item-checkbox").DoubleClickAsync();
+            GetSelectedValue().Should().Be(4);
+        }
+
+        [Test]
         [TestCase("item1")]
         [TestCase("item1.1")]
         [TestCase("item1.2")]

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -17,7 +17,7 @@
                 @if (MultiSelection)
                 {
                     <MudCheckBox T="bool?" TriState Class="mud-treeview-item-checkbox" CheckedIcon="@CheckedIcon" UncheckedIcon="@UncheckedIcon" IndeterminateIcon="@GetIndeterminateIcon()"
-                                 @bind-Value:get="GetCheckBoxStateTriState()" @bind-Value:set="@(x=>OnCheckboxChangedAsync())" Disabled="@Disabled"></MudCheckBox>
+                                 @bind-Value:get="GetCheckBoxStateTriState()" @bind-Value:set="@(x=>OnCheckboxChangedAsync())" Disabled="@GetDisabled()" ReadOnly="@GetReadOnly()"></MudCheckBox>
                 }
 
                 @if (HasIcon)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -17,7 +17,7 @@
                 @if (MultiSelection)
                 {
                     <MudCheckBox T="bool?" TriState Class="mud-treeview-item-checkbox" CheckedIcon="@CheckedIcon" UncheckedIcon="@UncheckedIcon" IndeterminateIcon="@GetIndeterminateIcon()"
-                                 @bind-Value:get="GetCheckBoxStateTriState()" @bind-Value:set="@(x=>OnCheckboxChangedAsync())" Disabled="@GetDisabled()" ReadOnly="@GetReadOnly()"></MudCheckBox>
+                                 @bind-Value:get="GetCheckBoxStateTriState()" @bind-Value:set="@(x => OnCheckboxChangedAsync())" Disabled="@GetDisabled()" ReadOnly="@GetReadOnly()"></MudCheckBox>
                 }
 
                 @if (HasIcon)


### PR DESCRIPTION
### Summary

Fixes: #10413

Fixes a `MudTreeView` issue where selection could still change when the component was `Disabled` in `MultiSelection` mode.

### Root Cause

`MudTreeViewItem` checkboxes only respected the `Disabled` state of the item itself. When the parent `MudTreeView` was disabled, the checkbox could still trigger selection changes because the disabled/read-only state was not properly propagated.

### Fix

Propagate the effective disabled/read-only state from the tree to the checkbox by using `GetDisabled()` and `GetReadOnly()` instead of the direct `Disabled` parameter.

Also adds tests verifying that:

* Selection does **not change when the TreeView is disabled**
* Selection **works normally when the TreeView is enabled**


<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
