### PR TITLE
MudChart: Ensure fill-opacity renders invariantly across cultures

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -742,5 +742,62 @@ namespace MudBlazor.UnitTests.Components
             yaxis.Should().NotBeNull();
             yaxis[0].Children[0].InnerHtml.Trim().Should().Be(testCase.ExpectedValue);
         }
+
+        [Test]
+        public void RadarChart_FillOpacity_Should_RenderInvariant_InDifferentCultures()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUiCulture = CultureInfo.CurrentUICulture;
+
+            try
+            {
+                var noNbCulture = new CultureInfo("nb-NO");
+                CultureInfo.CurrentCulture = noNbCulture;
+                CultureInfo.CurrentUICulture = noNbCulture;
+
+                var noNbComp = Context.Render<MudChart<double>>(parameters => parameters
+                    .Add(p => p.ChartType, ChartType.Radar)
+                    .Add(p => p.ChartSeries, new List<ChartSeries<double>>
+                    {
+                        new() { Name = "Series 1", Data = new([10, 20, 30]) }
+                    })
+                    .Add(p => p.ChartLabels, new[] { "A", "B", "C" })
+                    .Add(p => p.ChartOptions, new RadarChartOptions
+                    {
+                        FillOpacity = 0.4,
+                        AggregationOption = AggregationOption.GroupByDataSet
+                    })
+                );
+
+                var noNbOpacity = noNbComp.Find("path.mud-chart-serie").GetAttribute("fill-opacity");
+
+                CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+                CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+                var invariantComp = Context.Render<MudChart<double>>(parameters => parameters
+                    .Add(p => p.ChartType, ChartType.Radar)
+                    .Add(p => p.ChartSeries, new List<ChartSeries<double>>
+                    {
+                        new() { Name = "Series 1", Data = new([10, 20, 30]) }
+                    })
+                    .Add(p => p.ChartLabels, new[] { "A", "B", "C" })
+                    .Add(p => p.ChartOptions, new RadarChartOptions
+                    {
+                        FillOpacity = 0.4,
+                        AggregationOption = AggregationOption.GroupByDataSet
+                    })
+                );
+
+                var invariantOpacity = invariantComp.Find("path.mud-chart-serie").GetAttribute("fill-opacity");
+
+                noNbOpacity.Should().Be("0.4");
+                invariantOpacity.Should().Be("0.4");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUiCulture;
+            }
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -21,7 +21,7 @@
         {
             <path @onclick="() => OnPathClick.InvokeAsync(item.Index)"
                   class="mud-chart-serie"
-                  fill-opacity="@ChartOptions.FillOpacity"
+                  fill-opacity="@ChartOptions.FillOpacity.ToString(System.Globalization.CultureInfo.InvariantCulture)"
                   stroke="@GetColor(item.Index)"
                   stroke-width="@(ChartOptions is IHasDataPointOptions dataPoint ? dataPoint.StrokeWidth : 0)"
                   fill="@GetColor(item.Index)"

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -21,7 +21,7 @@
         {
             <path @onclick="() => OnPathClick.InvokeAsync(item.Index)"
                   class="mud-chart-serie"
-                  fill-opacity="@ChartOptions.FillOpacity.ToString(System.Globalization.CultureInfo.InvariantCulture)"
+                  fill-opacity="@ChartOptions.FillOpacity.ToStr()"
                   stroke="@GetColor(item.Index)"
                   stroke-width="@(ChartOptions is IHasDataPointOptions dataPoint ? dataPoint.StrokeWidth : 0)"
                   fill="@GetColor(item.Index)"


### PR DESCRIPTION
Ensure fill-opacity renders invariantly across cultures. Issue #11314

Added a unit test to verify fill-opacity is culture-invariant for radar charts. Updated BaseRadialChart.razor to use InvariantCulture when rendering fill-opacity, preventing locale-specific formatting issues in SVG output.

<img width="957" height="633" alt="MudBlazor 9 1 0" src="https://github.com/user-attachments/assets/3105e36b-e358-4a82-a18d-c17f549e2d3a" />
<img width="867" height="630" alt="MudBlazor 9 1 1" src="https://github.com/user-attachments/assets/3200df3f-09d2-49cf-8295-f1577e490b5e" />

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests