### PR TITLE
MudTreeView: Fix server-data reset by tracking lazy-load state per node

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerDataResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewServerDataResetTest.razor
@@ -1,0 +1,58 @@
+﻿<MudTreeView ServerData="@LoadServerData" Items="@_initialTreeItems">
+    <ItemTemplate>
+        <MudTreeViewItem Value="@context.Value"
+                         @bind-Items="context.Children"
+                         @bind-Expanded="@context.Expanded"
+                         CanExpand="@context.Expandable"
+                         Icon="@context.Icon"
+                         LoadingIconColor="Color.Info" />
+    </ItemTemplate>
+</MudTreeView>
+
+<MudButton id="btn_reset" OnClick="ResetItems">Reset</MudButton>
+
+@code {
+    private int _idCounter = 1;
+    private List<TreeItemData<string?>> _initialTreeItems = [];
+
+    protected override void OnInitialized()
+    {
+        ResetItems();
+    }
+
+    public async Task<IReadOnlyCollection<TreeItemData<string?>>> LoadServerData(string? parentValue)
+    {
+        // wait 500ms to simulate a server load
+        await Task.Delay(500);
+        // normally you would use the parentValue to query your server for the children of the given parent
+        // but for the sake of this example we will just return some hardcoded children
+        return [
+            new TreeItemData<string?> { Value = $"More Spam ({_idCounter++})", Icon = Icons.Material.Filled.Group, },
+            new TreeItemData<string?> { Value = $"L.E.D Door Mats ({_idCounter++})", Icon = Icons.Material.Outlined.Lightbulb, Expandable = false },
+            new TreeItemData<string?> { Value = $"Car Beauty Salon ({_idCounter++})", Icon = Icons.Material.Filled.CarRepair, Expandable = false },
+            new TreeItemData<string?> { Value = $"Fakedoors.com ({_idCounter++})", Icon = Icons.Material.Outlined.DoorFront, Expandable = false },
+            new TreeItemData<string?> { Value = $"Bluetooth Toilet ({_idCounter++})", Icon = Icons.Material.Filled.Wc, Expandable = false }
+        ];
+    }
+
+    private void ResetItems()
+    {
+        _initialTreeItems =
+        [
+            new TreeItemData<string?>
+            {
+                Value = "All Mail",
+                Icon = Icons.Material.Filled.Label,
+                Expanded = true,
+                Children =
+                [
+                    new TreeItemData<string?> { Value = "Promotions", Icon = Icons.Material.Filled.Group, },
+                    new TreeItemData<string?> { Value = "Updates", Icon = Icons.Material.Filled.Info, },
+                    new TreeItemData<string?> { Value = "Forums", Icon = Icons.Material.Filled.QuestionAnswer, Expandable = false },
+                    new TreeItemData<string?> { Value = "Social", Icon = Icons.Material.Filled.LocalOffer, Expandable = false }
+                ]
+            },
+            new TreeItemData<string?> { Value = "Trash", Icon = Icons.Material.Filled.Delete }
+        ];
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1235,7 +1235,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void TreeViewItem_SetParameters_ValueIsSetNull_WhenTextUnset_RootServerdataIsSet_Throw()
+        public void TreeViewItem_SetParameters_ValueIsSetNull_WhenTextUnset_RootServerDataIsSet_Throw()
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
             {
@@ -1336,6 +1336,27 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("#add_item").ClickAsync();
             comp.Instance.SelectedValue.Should().NotBeNull();
             comp.Instance.SelectedValue!.Name.Should().Be("4");
+        }
+
+        [Test(Description = "https://github.com/MudBlazor/MudBlazor/issues/12849")]
+        public async Task TreeView_ServerData_Reset()
+        {
+            var comp = Context.Render<TreeViewServerDataResetTest>();
+            var arrows = () => comp.FindAll("button.mud-treeview-item-expand-button");
+            var itemContents = () => comp.FindAll("div.mud-treeview-item-content").Select(x => x.TextContent);
+
+            arrows().Count.Should().Be(4);
+            await arrows()[1].ClickAsync();
+            comp.WaitForAssertion(() => itemContents().Should().Contain("More Spam (1)"));
+            await comp.Find("#btn_reset").ClickAsync();
+            comp.WaitForAssertion(() =>
+            {
+                arrows().Count.Should().Be(4);
+                itemContents().Should().NotContain("More Spam (1)");
+            });
+
+            await arrows()[1].ClickAsync();
+            comp.WaitForAssertion(() => itemContents().Should().Contain("More Spam (6)"));
         }
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor
@@ -5,18 +5,20 @@
 
 <ul @attributes="UserAttributes" class="@Classname" style="@Stylename">
     <CascadingValue Value="@MudTreeRoot" IsFixed="true">
-        @if (ItemTemplate != null && Items != null)
-        {
-            @foreach (var item in Items)
+        <CascadingValue Name="@MudTreeViewCascadingValues.ItemData" Value="default(ITreeItemData<T>)" IsFixed="true">
+            @if (ItemTemplate != null && Items != null)
             {
-                <MudRender @key="GetItemIdentityKey(item)">
-                    @ItemTemplate(item)
-                </MudRender>
+                @foreach (var item in Items)
+                {
+                    <CascadingValue Name="@MudTreeViewCascadingValues.ItemData" Value="item" IsFixed="true">
+                        @ItemTemplate(item)
+                    </CascadingValue>
+                }
             }
-        }
-        else if (ChildContent != null)
-        {
-            @ChildContent
-        }
+            else if (ChildContent != null)
+            {
+                @ChildContent
+            }
+        </CascadingValue>
     </CascadingValue>
 </ul>

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor
@@ -9,7 +9,9 @@
         {
             @foreach (var item in Items)
             {
-                @ItemTemplate(item)
+                <MudRender @key="GetItemIdentityKey(item)">
+                    @ItemTemplate(item)
+                </MudRender>
             }
         }
         else if (ChildContent != null)

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor
@@ -5,6 +5,8 @@
 
 <ul @attributes="UserAttributes" class="@Classname" style="@Stylename">
     <CascadingValue Value="@MudTreeRoot" IsFixed="true">
+        @* Expose the current data node to ItemTemplate-created MudTreeViewItem instances so
+           per-node server-loading state can live on the tree root instead of the component instance. *@
         <CascadingValue Name="@MudTreeViewCascadingValues.ItemData" Value="default(ITreeItemData<T>)" IsFixed="true">
             @if (ItemTemplate != null && Items != null)
             {

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -51,6 +51,8 @@ namespace MudBlazor
 
         private HashSet<T> _selection;
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
+        // ServerData load state belongs to the backing node object, not the rendered component instance.
+        // When the parent replaces Items with new node objects, the old entries can disappear with them.
         private readonly ConditionalWeakTable<ITreeItemData<T>, ServerDataState> _serverDataStates = new();
         private bool _isFirstRender = true;
         internal bool MultiSelection => SelectionMode == SelectionMode.MultiSelection;

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -51,6 +51,7 @@ namespace MudBlazor
 
         private HashSet<T> _selection;
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
+        private readonly ConditionalWeakTable<ITreeItemData<T>, ServerDataState> _serverDataStates = new();
         private bool _isFirstRender = true;
         internal bool MultiSelection => SelectionMode == SelectionMode.MultiSelection;
         private bool ToggleSelection => SelectionMode == SelectionMode.ToggleSelection;
@@ -71,15 +72,6 @@ namespace MudBlazor
                 .AddStyle($"max-height", MaxHeight, !string.IsNullOrWhiteSpace(MaxHeight))
                 .AddStyle(Style)
                 .Build();
-
-        private static ReferenceKey GetItemIdentityKey(ITreeItemData<T> item) => new(item);
-
-        private readonly record struct ReferenceKey(ITreeItemData<T> Item)
-        {
-            public bool Equals(ReferenceKey other) => ReferenceEquals(Item, other.Item);
-
-            public override int GetHashCode() => RuntimeHelpers.GetHashCode(Item);
-        }
 
         [CascadingParameter]
         private MudTreeView<T> MudTreeRoot { get; set; }
@@ -732,6 +724,16 @@ namespace MudBlazor
             }
 
             return values;
+        }
+
+
+        internal bool GetServerDataLoaded(ITreeItemData<T> item) => _serverDataStates.GetOrCreateValue(item).IsLoaded;
+
+        internal void SetServerDataLoaded(ITreeItemData<T> item, bool isLoaded) => _serverDataStates.GetOrCreateValue(item).IsLoaded = isLoaded;
+
+        private sealed class ServerDataState
+        {
+            public bool IsLoaded { get; set; }
         }
     }
 }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
+using System.Runtime.CompilerServices;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -70,6 +71,15 @@ namespace MudBlazor
                 .AddStyle($"max-height", MaxHeight, !string.IsNullOrWhiteSpace(MaxHeight))
                 .AddStyle(Style)
                 .Build();
+
+        private static ReferenceKey GetItemIdentityKey(ITreeItemData<T> item) => new(item);
+
+        private readonly record struct ReferenceKey(ITreeItemData<T> Item)
+        {
+            public bool Equals(ReferenceKey other) => ReferenceEquals(Item, other.Item);
+
+            public override int GetHashCode() => RuntimeHelpers.GetHashCode(Item);
+        }
 
         [CascadingParameter]
         private MudTreeView<T> MudTreeRoot { get; set; }

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Extensions;
-using System.Runtime.CompilerServices;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewCascadingValues.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewCascadingValues.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+internal static class MudTreeViewCascadingValues
+{
+    internal const string ItemData = "MudTreeViewItemData";
+}

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -67,6 +67,9 @@ namespace MudBlazor
         [CascadingParameter]
         internal MudTreeViewItem<T>? Parent { get; set; }
 
+        [CascadingParameter(Name = MudTreeViewCascadingValues.ItemData)]
+        private ITreeItemData<T>? CurrentItemData { get; set; }
+
         /// <summary>
         /// The value associated with this item.
         /// </summary>
@@ -367,7 +370,7 @@ namespace MudBlazor
         {
             return ChildContent != null
                 || (MudTreeRoot != null && GetItems().Count != 0)
-                || (MudTreeRoot?.ServerData != null && CanExpand && !_isServerLoaded && GetItems().Count == 0);
+                || (MudTreeRoot?.ServerData != null && CanExpand && !GetServerDataLoaded() && GetItems().Count == 0);
         }
 
         private bool AreChildrenVisible() => _itemsState.Value is null || _itemsState.Value.Any(i => i.Visible);
@@ -391,6 +394,27 @@ namespace MudBlazor
         private string? GetText() => string.IsNullOrEmpty(Text) ? _converter.Convert(Value) : Text;
 
         private bool GetDisabled() => Disabled || MudTreeRoot?.Disabled == true;
+
+        private bool GetServerDataLoaded()
+        {
+            if (CurrentItemData is not null && MudTreeRoot is not null)
+            {
+                return MudTreeRoot.GetServerDataLoaded(CurrentItemData);
+            }
+
+            return _isServerLoaded;
+        }
+
+        private void SetServerDataLoaded(bool isLoaded)
+        {
+            if (CurrentItemData is not null && MudTreeRoot is not null)
+            {
+                MudTreeRoot.SetServerDataLoaded(CurrentItemData, isLoaded);
+                return;
+            }
+
+            _isServerLoaded = isLoaded;
+        }
 
         private bool? GetCheckBoxStateTriState()
         {
@@ -422,7 +446,9 @@ namespace MudBlazor
                 StateHasChanged();
             }
             foreach (var item in _childItems)
+            {
                 await item.ExpandAllAsync();
+            }
         }
 
         /// <summary>
@@ -436,7 +462,9 @@ namespace MudBlazor
                 StateHasChanged();
             }
             foreach (var item in _childItems)
+            {
                 await item.CollapseAllAsync();
+            }
         }
 
         /// <inheritdoc />
@@ -560,6 +588,8 @@ namespace MudBlazor
         /// </summary>
         public async Task ReloadAsync()
         {
+            SetServerDataLoaded(false);
+
             if (_itemsState.Value is not null)
             {
                 await _itemsState.SetValueAsync(Array.Empty<ITreeItemData<T>>());
@@ -608,15 +638,17 @@ namespace MudBlazor
                 return;
             _loading = true;
             StateHasChanged();
+            var loaded = false;
             try
             {
                 var items = await MudTreeRoot.ServerData(GetValue());
                 await _itemsState.SetValueAsync(items);
+                loaded = true;
             }
             finally
             {
                 _loading = false;
-                _isServerLoaded = true;
+                SetServerDataLoaded(loaded);
 
                 StateHasChanged();
             }

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -206,7 +206,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.TreeView.Behavior)]
-        public RenderFragment<MudTreeViewItem<T?>>? BodyContent { get; set; }
+        public RenderFragment<MudTreeViewItem<T>>? BodyContent { get; set; }
 
         /// <summary>
         /// The child items underneath this item.

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -22,7 +22,7 @@ namespace MudBlazor
         private readonly ParameterState<bool> _selectedState;
         private readonly ParameterState<bool> _expandedState;
         private readonly ParameterState<IReadOnlyCollection<ITreeItemData<T>>?> _itemsState;
-        private readonly IConverter<T?, string?> _converter = new DefaultConverter<T?>();
+        private readonly DefaultConverter<T?> _converter = new();
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
 
         public MudTreeViewItem()
@@ -67,6 +67,7 @@ namespace MudBlazor
         [CascadingParameter]
         internal MudTreeViewItem<T>? Parent { get; set; }
 
+        // When the item comes from ItemTemplate, this links the component instance to its backing node object.
         [CascadingParameter(Name = MudTreeViewCascadingValues.ItemData)]
         private ITreeItemData<T>? CurrentItemData { get; set; }
 


### PR DESCRIPTION

## Summary
Fixes: https://github.com/MudBlazor/MudBlazor/issues/12849


This changes how `MudTreeView` tracks lazy-loaded server state for data-backed items.

Previously, the server-loaded flag lived on the `MudTreeViewItem` component instance. That worked until the parent replaced Items with new `TreeItemData` objects while the existing `MudTreeViewItem` component instances is reused. In that case, stale lazy-load state could survive the data reset (the `_isServerLoaded` stays `true`), which caused server-side nodes to stay treated as already loaded and prevented `ServerData` from running again.

This PR moves that state to the backing node instead of the rendered component.

  ## What changed

  - Added a per-node server-data state store on `MudTreeView` using `ConditionalWeakTable<ITreeItemData<T>, ...>`.
  - Cascaded the current `ITreeItemData<T>` into `ItemTemplate`-created `MudTreeViewItem` instances.
  - Updated `MudTreeViewItem` to resolve lazy-load state through the tree root when the item is data-backed.
  - Kept the existing local fallback for manually declared `<MudTreeViewItem>` trees that are not backed by
    `ITreeItemData<T>`.
  - Preserved and strengthened the regression test for the reported reset scenario.

  ## Result

  When `MudTreeView.Items` is replaced with new node objects:

  - old lazy-load state does not leak into the new nodes
  - previously loaded server-side children are cleared as expected
  - expanding the node again invokes `ServerData` again

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
