### PR TITLE
MudDebouncedInput: Fix validation

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormValidationSyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormValidationSyncTest.razor
@@ -1,0 +1,52 @@
+﻿<MudForm @ref="_form" ValidationDelay="0">
+    <MudTextField T="string"
+                  id="username"
+                  @bind-Value="Model.Username"
+                  DebounceInterval="@DebounceInterval"
+                  Required="true"
+                  OnlyValidateIfDirty="true"
+                  Variant="Variant.Outlined"
+                  autoComplete="username" />
+    
+    <MudTextField @bind-Value="Model.Password"
+                  id="password"
+                  InputType="InputType.Password"
+                  Required="true"
+                  OnlyValidateIfDirty="true"
+                  Variant="Variant.Outlined"
+                  autoComplete="current-password" />
+
+    <MudButton id="validate-button"
+               OnClick="ValidateAsync">
+        Validate
+    </MudButton>
+</MudForm>
+
+<MudText id="result-text">
+    @ResultText
+</MudText>
+
+@code {
+    public static string __description__ = "Ensures form validation flushes a pending debounced value before validating.";
+
+    public FormModel Model { get; } = new();
+
+    public int DebounceInterval => 500;
+
+    public string ResultText { get; private set; } = string.Empty;
+
+    private MudForm _form = null!;
+
+    private async Task ValidateAsync()
+    {
+        await _form.ValidateAsync();
+        ResultText = _form.IsValid ? "succeeded" : "failed";
+    }
+
+    public class FormModel
+    {
+        public string? Username { get; set; }
+
+        public string? Password { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -235,8 +235,12 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("#password").ChangeAsync(new ChangeEventArgs { Value = "password" });
 
             textField[0].Instance.ReadText.Should().Be("username");
+            textField[0].Instance.ReadValue.Should().BeNull();
+            comp.Instance.Model.Username.Should().BeNull();
             textField[1].Instance.ReadText.Should().Be("password");
-            form.IsValid.Should().BeFalse();
+            textField[1].Instance.ReadValue.Should().Be("password");
+            comp.Instance.Model.Password.Should().Be("password");
+            form.IsValid.Should().BeTrue();
 
             await comp.Find("#validate-button").ClickAsync();
 

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -232,7 +232,7 @@ namespace MudBlazor.UnitTests.Components
             var textField = comp.FindComponents<MudTextField<string>>();
 
             await comp.Find("#username").InputAsync(new ChangeEventArgs { Value = "username" });
-            await comp.Find("#password").InputAsync(new ChangeEventArgs { Value = "password" });
+            await comp.Find("#password").ChangeAsync(new ChangeEventArgs { Value = "password" });
 
             textField[0].Instance.ReadText.Should().Be("username");
             textField[1].Instance.ReadText.Should().Be("password");
@@ -242,8 +242,8 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() =>
             {
-                comp.Instance.Model.Should().Be("username");
-                comp.Instance.Model.Should().Be("password");
+                comp.Instance.Model.Username.Should().Be("username");
+                comp.Instance.Model.Password.Should().Be("password");
                 comp.Instance.ResultText.Should().Be("succeeded");
                 form.IsValid.Should().BeTrue();
                 textField[0].Instance.ReadValue.Should().Be("username");

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -221,6 +221,36 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
+        [Test]
+        public async Task DebouncedTextField_Should_ValidatePendingValueImmediatelyWhenFormIsValidated()
+        {
+            var timeProvider = new FakeTimeProvider();
+            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+
+            var comp = Context.Render<DebouncedTextFieldFormValidationSyncTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var textField = comp.FindComponents<MudTextField<string>>();
+
+            await comp.Find("#username").InputAsync(new ChangeEventArgs { Value = "username" });
+            await comp.Find("#password").InputAsync(new ChangeEventArgs { Value = "password" });
+
+            textField[0].Instance.ReadText.Should().Be("username");
+            textField[1].Instance.ReadText.Should().Be("password");
+            form.IsValid.Should().BeFalse();
+
+            await comp.Find("#validate-button").ClickAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Instance.Model.Should().Be("username");
+                comp.Instance.Model.Should().Be("password");
+                comp.Instance.ResultText.Should().Be("succeeded");
+                form.IsValid.Should().BeTrue();
+                textField[0].Instance.ReadValue.Should().Be("username");
+                textField[1].Instance.ReadValue.Should().Be("password");
+            });
+        }
+
         /// <summary>
         /// Label and placeholder should not overlap.
         /// When placeholder is set, label should shrink

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -77,6 +77,17 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
+        protected override async Task ValidateValue()
+        {
+            if (await SynchronizePendingValueForValidationAsync())
+            {
+                return;
+            }
+
+            await base.ValidateValue();
+        }
+
+        /// <inheritdoc />
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
@@ -113,6 +124,29 @@ namespace MudBlazor
                     await _debouncer.UpdateIntervalAsync(TimeSpan.FromMilliseconds(args.Value));
                 }
             }
+        }
+
+        private async Task<bool> SynchronizePendingValueForValidationAsync()
+        {
+            if (DebounceInterval <= 0 || _debouncer is null || !_debouncer.IsPending)
+            {
+                return false;
+            }
+
+            var pendingValue = ConvertGet(ReadText);
+            var pendingValueChanged = !EqualityComparer<T?>.Default.Equals(ReadValue, pendingValue);
+
+            await _debouncer.CancelAsync();
+
+            if (!pendingValueChanged)
+            {
+                return false;
+            }
+
+            // SetValueAndUpdateTextAsync already triggers FieldChanged and BeginValidateAsync,
+            // so the synced validation happens there and this call can stop.
+            await SetValueAndUpdateTextAsync(pendingValue, updateText: false);
+            return true;
         }
 
         private Task OnDebouncedUpdate()


### PR DESCRIPTION
 Fixes: https://github.com/MudBlazor/MudBlazor/issues/12852

  When a debounced text field is populated by browser autofill, the input text can be present in the DOM before the
  debounced Value update has run. If `MudForm.ValidateAsync()` is triggered during that window, validation reads the stale
  Value and can incorrectly mark the form as invalid.

  This change makes debounced inputs synchronize any pending text to Value before validation runs, so form validation
  sees the current autofilled value instead of the previous committed value.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
