### PR TITLE
DebounceDispatcher: Remove .Wait() to avoid PlatformNotSupportedException

### DIFF
--- a/src/MudBlazor/Utilities/Debounce/DebounceDispatcher.cs
+++ b/src/MudBlazor/Utilities/Debounce/DebounceDispatcher.cs
@@ -295,16 +295,24 @@ internal sealed class DebounceDispatcher : IDisposable
     public void Cancel()
     {
         CancellationTokenSource? ctsToCancel;
-        // ReSharper disable once MethodSupportsCancellation
-        _lock.Wait();
-        try
+        if (OperatingSystem.IsBrowser())
         {
             ctsToCancel = _cancellationTokenSource;
             _cancellationTokenSource = null;
         }
-        finally
+        else
         {
-            _lock.Release();
+            // ReSharper disable once MethodSupportsCancellation
+            _lock.Wait();
+            try
+            {
+                ctsToCancel = _cancellationTokenSource;
+                _cancellationTokenSource = null;
+            }
+            finally
+            {
+                _lock.Release();
+            }
         }
 
         CancelAndDispose(ctsToCancel);
@@ -397,21 +405,30 @@ internal sealed class DebounceDispatcher : IDisposable
 
         CancellationTokenSource? ctsToCancel;
         // ReSharper disable once MethodSupportsCancellation
-        _lock.Wait();
-        try
+        if (OperatingSystem.IsBrowser())
         {
-            if (_disposed)
-            {
-                return;
-            }
-
             _disposed = true;
             ctsToCancel = _cancellationTokenSource;
             _cancellationTokenSource = null;
         }
-        finally
+        else
         {
-            _lock.Release();
+            _lock.Wait();
+            try
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                ctsToCancel = _cancellationTokenSource;
+                _cancellationTokenSource = null;
+            }
+            finally
+            {
+                _lock.Release();
+            }
         }
 
         CancelAndDispose(ctsToCancel);


### PR DESCRIPTION
With Net11 we made the PNSE for `.Wait()` more strict.
See https://github.com/dotnet/runtime/pull/123329

```
crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: Arg_PlatformNotSupported
System.PlatformNotSupportedException: Arg_PlatformNotSupported
   at System.Threading.Thread.ThrowIfSingleThreaded()
   at System.Threading.SemaphoreSlim.WaitCore(Int64 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.SemaphoreSlim.Wait()
   at MudBlazor.Utilities.Debounce.DebounceDispatcher.Dispose()
   at MudBlazor.Charts.MudAxisChartBase`2[[System.Double, System.Private.CoreLib, Version=11.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[MudBlazor.StackedBarChartOptions, MudBlazor, Version=9.1.0.0, Culture=neutral, PublicKeyToken=null]].Dispose(Boolean disposing)
   at MudBlazor.Charts.MudAxisChartBase`2[[System.Double, System.Private.CoreLib, Version=11.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[MudBlazor.StackedBarChartOptions, MudBlazor, Version=9.1.0.0, Culture=neutral, PublicKeyToken=null]].Dispose()
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.DisposeAsync()
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.DisposeInBatchAsync(RenderBatchBuilder batchBuilder)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.ProcessDisposalQueueInExistingBatch()
```