### PR TITLE
MudChart: Prevent Rounding Height Values

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -859,7 +859,15 @@ namespace MudBlazor.UnitTests.Components
             var yAxisLabels = comp.FindAll(".mud-charts-yaxis text");
             yAxisLabels.Select(x => x.TextContent).Should().Contain("330");
 
-            var circles = comp.FindAll("circle.mud-chart-line-point");
+            var circles = comp.FindAll("circle.mud-chart-point");
+            circles.Count.Should().Be(2);
+
+            var cyValues = circles
+                .Select(c => double.Parse(c.GetAttribute("cy")!, CultureInfo.InvariantCulture))
+                .ToList();
+
+            cyValues[0].Should().NotBe(cyValues[1]);
+            cyValues[0].Should().BeGreaterThan(cyValues[1]);
         }
 
         [Test]
@@ -886,6 +894,28 @@ namespace MudBlazor.UnitTests.Components
 
             var yAxisLabels = comp.FindAll(".mud-charts-yaxis text");
             yAxisLabels.Select(x => x.TextContent).Should().Contain("330");
+
+            var barPaths = comp.FindAll("path.mud-chart-bar");
+            barPaths.Should().NotBeEmpty("stacked bar chart should render bar paths");
+            var smallSegmentPath = barPaths.First();
+            var dAttribute = smallSegmentPath.GetAttribute("d");
+            dAttribute.Should().NotBeNullOrWhiteSpace("bar path should have a valid 'd' attribute");
+
+            var numericChars = dAttribute!
+                .Select(c => char.IsDigit(c) || c == '-' || c == '+' || c == '.' || c == 'e' || c == 'E' ? c : ' ')
+                .ToArray();
+            var numericParts = new string(numericChars)
+                .Split((char[])null!, StringSplitOptions.RemoveEmptyEntries);
+            var coordinates = numericParts
+                .Select(p => double.Parse(p, CultureInfo.InvariantCulture))
+                .ToList();
+            var yCoordinates = coordinates
+                .Skip(1)
+                .Where((_, index) => index % 2 == 0)
+                .ToList();
+
+            yCoordinates.Count.Should().BeGreaterThan(0, "bar path should contain Y coordinates");
+            yCoordinates.Distinct().Count().Should().BeGreaterThan(1, "small stacked segment should have non-zero height (different Y coordinates)");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -799,5 +799,93 @@ namespace MudBlazor.UnitTests.Components
                 CultureInfo.CurrentUICulture = originalUiCulture;
             }
         }
+
+        [Test]
+        public void BarChart_LongValues_ShouldNotRoundDown()
+        {
+            var chartSeries = new List<ChartSeries<long>>()
+            {
+                new() { Name = "A", Data = new long[] { 3 } },
+                new() { Name = "B", Data = new long[] { 324 } },
+            };
+            string[] xAxisLabels = { "DataPoint" };
+
+            var comp = Context.Render<MudChart<long>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.Height, "550px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new BarChartOptions
+                {
+                    YAxisTicks = 10,
+                    YAxisLines = true,
+                    MaxNumYAxisTicks = 50
+                })
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels));
+
+            var bars = comp.FindAll("path.mud-chart-bar");
+            bars.Count.Should().Be(2);
+
+            var barA = bars[0];
+            var dA = barA.GetAttribute("d").Split(' ');
+
+            dA[2].Should().NotBe(dA[5], "Bar A should have a non-zero height for value 3");
+
+            var yAxisLabels = comp.FindAll(".mud-charts-yaxis text");
+            yAxisLabels.Select(x => x.TextContent).Should().Contain("330", "Y-axis should extend to 330 for value 324 with ticks of 10");
+        }
+
+        [Test]
+        public void LineChart_LongValues_ShouldNotRoundDown()
+        {
+            var chartSeries = new List<ChartSeries<long>>()
+            {
+                new() { Name = "A", Data = new long[] { 3, 324 } },
+            };
+            string[] xAxisLabels = { "D1", "D2" };
+
+            var comp = Context.Render<MudChart<long>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.Height, "550px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new LineChartOptions
+                {
+                    YAxisTicks = 10,
+                    MaxNumYAxisTicks = 50
+                })
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels));
+
+            var yAxisLabels = comp.FindAll(".mud-charts-yaxis text");
+            yAxisLabels.Select(x => x.TextContent).Should().Contain("330");
+
+            var circles = comp.FindAll("circle.mud-chart-line-point");
+        }
+
+        [Test]
+        public void StackedBarChart_LongValues_ShouldNotRoundDown()
+        {
+            var chartSeries = new List<ChartSeries<long>>()
+            {
+                new() { Name = "A", Data = new long[] { 3 } },
+                new() { Name = "B", Data = new long[] { 324 } },
+            };
+            string[] xAxisLabels = { "DataPoint" };
+
+            var comp = Context.Render<MudChart<long>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.Height, "550px")
+                .Add(p => p.Width, "100%")
+                .Add(p => p.ChartOptions, new StackedBarChartOptions
+                {
+                    YAxisTicks = 10,
+                    MaxNumYAxisTicks = 50
+                })
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels));
+
+            var yAxisLabels = comp.FindAll(".mud-charts-yaxis text");
+            yAxisLabels.Select(x => x.TextContent).Should().Contain("330");
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -46,7 +46,10 @@ namespace MudBlazor.Charts
         public override void RebuildChart()
         {
             // shared plot points should be initialized before generating overlay charts
-            if (IsOverlayChart && SharedData is null) return;
+            if (IsOverlayChart && SharedData is null)
+            {
+                return;
+            }
 
             Series = ChartContainer != null && ChartReference is MudChart<T>
                 ? ChartContainer.ChartSeries
@@ -105,8 +108,8 @@ namespace MudBlazor.Charts
                     ? allValues.Max()
                     : T.Max(T.CreateSaturating(ChartOptions.YAxisSuggestedMax.Value), allValues.Max());
 
-                lowestHorizontalLine = Math.Min((int)Math.Floor(double.CreateSaturating(minY / gridYUnits)), 0);
-                var highestHorizontalLine = Math.Max((int)Math.Ceiling(double.CreateSaturating(maxY / gridYUnits)), 0);
+                lowestHorizontalLine = Math.Min((int)Math.Floor(double.CreateSaturating(minY) / double.CreateSaturating(gridYUnits)), 0);
+                var highestHorizontalLine = Math.Max((int)Math.Ceiling(double.CreateSaturating(maxY) / double.CreateSaturating(gridYUnits)), 0);
                 numHorizontalLines = highestHorizontalLine - lowestHorizontalLine + 1;
 
                 // Safeguard against too many gridlines
@@ -115,8 +118,8 @@ namespace MudBlazor.Charts
                 while (numHorizontalLines > maxYTicks)
                 {
                     gridYUnits *= T.CreateSaturating(2);
-                    lowestHorizontalLine = Math.Min((int)Math.Floor(double.CreateSaturating(minY / gridYUnits)), 0);
-                    highestHorizontalLine = Math.Max((int)Math.Ceiling(double.CreateSaturating(maxY / gridYUnits)), 0);
+                    lowestHorizontalLine = Math.Min((int)Math.Floor(double.CreateSaturating(minY) / double.CreateSaturating(gridYUnits)), 0);
+                    highestHorizontalLine = Math.Max((int)Math.Ceiling(double.CreateSaturating(maxY) / double.CreateSaturating(gridYUnits)), 0);
 
                     numHorizontalLines = highestHorizontalLine - lowestHorizontalLine + 1;
                 }
@@ -177,7 +180,7 @@ namespace MudBlazor.Charts
                     var gridValueX = groupStartX + (i * (_barWidth + _barGap)) + (_barWidth / 2);
 
                     var gridValueY = _boundHeight - VerticalStartSpace + (lowestHorizontalLine * verticalSpace);
-                    var barHeight = (double.CreateSaturating(dataValue / gridYUnits) - lowestHorizontalLine) * verticalSpace;
+                    var barHeight = ((double.CreateSaturating(dataValue) / double.CreateSaturating(gridYUnits)) - lowestHorizontalLine) * verticalSpace;
                     var gridValue = _boundHeight - VerticalStartSpace - double.CreateSaturating(barHeight);
 
                     var bar = new SvgPath
@@ -198,7 +201,10 @@ namespace MudBlazor.Charts
         {
             var dataSetCount = Series.Count;
 
-            if (dataSetCount == 0) return [];
+            if (dataSetCount == 0)
+            {
+                return [];
+            }
 
             var context = new BarGroupContext
             {
@@ -221,7 +227,10 @@ namespace MudBlazor.Charts
 
         private int CalculateSpaceWidth(double horizontalSpace, int groupCount)
         {
-            if (groupCount <= 1) return 0;
+            if (groupCount <= 1)
+            {
+                return 0;
+            }
 
             var spaceCount = groupCount - 1;
             var remainingWidth = horizontalSpace - HorizontalStartSpace - HorizontalEndSpace - ((_barGroupWidth + (_barWidth / 2)) * groupCount);
@@ -260,7 +269,9 @@ namespace MudBlazor.Charts
             _hoveredBar = bar;
 
             if (IsOverlayChart && ChartReference is IMudStateHasChanged chart)
+            {
                 chart.StateHasChanged();
+            }
         }
 
         private void OnBarMouseOut()
@@ -268,7 +279,9 @@ namespace MudBlazor.Charts
             _hoveredBar = null;
 
             if (IsOverlayChart && ChartReference is IMudStateHasChanged chart)
+            {
                 chart.StateHasChanged();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -34,7 +34,10 @@ namespace MudBlazor.Charts
 
         public override void RebuildChart()
         {
-            if (IsOverlayChart && SharedData is null) return;
+            if (IsOverlayChart && SharedData is null)
+            {
+                return;
+            }
 
             Series = (ChartContainer != null && ChartReference is MudChart<T>)
                 ? ChartContainer.ChartSeries
@@ -75,7 +78,10 @@ namespace MudBlazor.Charts
             verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);
 
             // If this is an overlay chart, we do not generate the grid lines
-            if (IsOverlayChart) return;
+            if (IsOverlayChart)
+            {
+                return;
+            }
 
             GenerateHorizontalGridLines(numHorizontalLines, lowestHorizontalLine, gridYUnits, verticalSpace);
             GenerateVerticalGridLines(numVerticalLines, 0, horizontalSpace);
@@ -85,9 +91,13 @@ namespace MudBlazor.Charts
         {
             var yAxisTicks = ChartOptions?.YAxisTicks;
             if (yAxisTicks.HasValue && yAxisTicks.Value > 0)
+            {
                 gridYUnits = T.CreateSaturating(yAxisTicks.Value);
+            }
             else
+            {
                 gridYUnits = T.CreateSaturating(20);
+            }
 
             var visibleSeries = Series.Where(series => series.Visible).ToArray();
             var values = visibleSeries.SelectMany(series => series.Data.Values);
@@ -109,8 +119,8 @@ namespace MudBlazor.Charts
                     maxY = T.Max(maxY, T.Zero); // we want to include the 0 in the grid
                 }
 
-                lowestHorizontalLine = (int)Math.Floor(double.CreateSaturating(minY / gridYUnits));
-                var highestHorizontalLine = (int)Math.Ceiling(double.CreateSaturating(maxY / gridYUnits));
+                lowestHorizontalLine = (int)Math.Floor(double.CreateSaturating(minY) / double.CreateSaturating(gridYUnits));
+                var highestHorizontalLine = (int)Math.Ceiling(double.CreateSaturating(maxY) / double.CreateSaturating(gridYUnits));
                 numHorizontalLines = highestHorizontalLine - lowestHorizontalLine + 1;
 
                 // this is a safeguard against millions of gridlines which might arise with very high values
@@ -118,8 +128,8 @@ namespace MudBlazor.Charts
                 while (numHorizontalLines > maxYTicks)
                 {
                     gridYUnits *= T.CreateSaturating(2);
-                    lowestHorizontalLine = (int)Math.Floor(double.CreateSaturating(minY / gridYUnits));
-                    highestHorizontalLine = (int)Math.Ceiling(double.CreateSaturating(maxY / gridYUnits));
+                    lowestHorizontalLine = (int)Math.Floor(double.CreateSaturating(minY) / double.CreateSaturating(gridYUnits));
+                    highestHorizontalLine = (int)Math.Ceiling(double.CreateSaturating(maxY) / double.CreateSaturating(gridYUnits));
                     numHorizontalLines = highestHorizontalLine - lowestHorizontalLine + 1;
                 }
 
@@ -140,7 +150,7 @@ namespace MudBlazor.Charts
 
         protected override TReturn GetDataValue<TReturn>(int seriesIndex, int dataPointIndex)
         {
-            return (TReturn)Convert.ChangeType(Series[seriesIndex].Data.Values[dataPointIndex], typeof(T));
+            return (TReturn)Convert.ChangeType(Series[seriesIndex].Data.Values[dataPointIndex], typeof(TReturn));
         }
 
         protected override string GetLabelXValue(int seriesIndex, int dataPointIndex)
@@ -152,7 +162,7 @@ namespace MudBlazor.Charts
         {
             var data = Series[seriesIndex].Data;
             var x = HorizontalStartSpace + (dataPointIndex * horizontalSpace);
-            var gridValue = (double.CreateSaturating(data[dataPointIndex].Y / gridYUnits) - lowestHorizontalLine) * verticalSpace;
+            var gridValue = ((double.CreateSaturating(data[dataPointIndex].Y) / double.CreateSaturating(gridYUnits)) - lowestHorizontalLine) * verticalSpace;
             var y = _boundHeight - VerticalStartSpace - double.CreateSaturating(gridValue);
             return (x, y);
         }

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -44,7 +44,10 @@ namespace MudBlazor.Charts
         public override void RebuildChart()
         {
             // shared plot points should be initialized before generating overlay charts
-            if (IsOverlayChart && SharedData is null) return;
+            if (IsOverlayChart && SharedData is null)
+            {
+                return;
+            }
 
             Series = (ChartContainer != null && ChartReference is MudChart<T>)
                 ? ChartContainer.ChartSeries
@@ -88,7 +91,10 @@ namespace MudBlazor.Charts
             verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);
 
             // If this is an overlay chart, we do not generate the grid lines
-            if (IsOverlayChart) return;
+            if (IsOverlayChart)
+            {
+                return;
+            }
 
             GenerateHorizontalGridLines(numHorizontalLines, lowestHorizontalLine, gridYUnits, verticalSpace);
             GenerateVerticalGridLines(numVerticalLines, horizontalSpace);
@@ -124,14 +130,20 @@ namespace MudBlazor.Charts
                 foreach (var seriesData in Series.Select(x => x.Data))
                 {
                     if (j >= seriesData.Values.Count)
+                    {
                         continue;
+                    }
 
                     var value = seriesData[j].Y;
 
                     if (value < T.Zero)
+                    {
                         negTotals[j] += value;
+                    }
                     else
+                    {
                         posTotals[j] += value;
+                    }
                 }
             }
 
@@ -143,7 +155,9 @@ namespace MudBlazor.Charts
             var maxY = stackedPositiveTotals.Length == 0 ? T.Zero : stackedPositiveTotals.Max();
 
             if (ChartOptions?.YAxisSuggestedMax is { } suggestedMax)
+            {
                 maxY = T.Max(T.CreateSaturating(suggestedMax), maxY);
+            }
 
             var minY = stackedNegativeTotals.Length == 0 ? T.Zero : stackedNegativeTotals.Min();
 
@@ -152,8 +166,8 @@ namespace MudBlazor.Charts
 
         private static int CalculateNumHorizontalLines(T gridYUnits, T maxY, T minY, out int lowestLine)
         {
-            var highestLine = Math.Max((int)Math.Ceiling(double.CreateSaturating(maxY / gridYUnits)), 0);
-            lowestLine = Math.Min((int)Math.Floor(double.CreateSaturating(minY / gridYUnits)), 0);
+            var highestLine = Math.Max((int)Math.Ceiling(double.CreateSaturating(maxY) / double.CreateSaturating(gridYUnits)), 0);
+            lowestLine = Math.Min((int)Math.Floor(double.CreateSaturating(minY) / double.CreateSaturating(gridYUnits)), 0);
             return highestLine - lowestLine + 1;
         }
 
@@ -249,14 +263,18 @@ namespace MudBlazor.Charts
                 foreach (var (series, seriesIndex) in Series.Select((s, i) => (s, i)))
                 {
                     if (dataIndex >= series.Data.Values.Count)
+                    {
                         continue;
+                    }
 
                     var dataValue = series.Visible ? series.Data[dataIndex].Y : T.Zero;
 
                     if (dataValue == T.Zero && !ChartOptions!.ShowZeroValues)
+                    {
                         continue;
+                    }
 
-                    var segmentHeight = dataValue / T.CreateSaturating(gridYUnits) * T.CreateSaturating(verticalSpace);
+                    var segmentHeight = double.CreateSaturating(dataValue) / double.CreateSaturating(gridYUnits) * verticalSpace;
                     var isNegative = dataValue < T.Zero;
 
                     var yStart = isNegative ? negativeStack : positiveStack;
@@ -273,16 +291,23 @@ namespace MudBlazor.Charts
                     });
 
                     if (isNegative)
+                    {
                         negativeStack = yEnd;
+                    }
                     else
+                    {
                         positiveStack = yEnd;
+                    }
                 }
             }
         }
 
         private double[] CalculateBarGroupPositions(double horizontalSpace, int maxColumns)
         {
-            if (Series.Count == 0) return [];
+            if (Series.Count == 0)
+            {
+                return [];
+            }
 
             var context = new StackedBarContext
             {
@@ -301,7 +326,10 @@ namespace MudBlazor.Charts
 
         private int CalculateSpaceWidth(double horizontalSpace, int maxColumns)
         {
-            if (maxColumns <= 1) return 0;
+            if (maxColumns <= 1)
+            {
+                return 0;
+            }
 
             var spaceCount = maxColumns - 1;
             var remainingWidth = horizontalSpace - (_barWidth * maxColumns);
@@ -316,7 +344,9 @@ namespace MudBlazor.Charts
             _hoveredBar = bar;
 
             if (IsOverlayChart && ChartReference is IMudStateHasChanged chart)
+            {
                 chart.StateHasChanged();
+            }
         }
 
         private void OnBarMouseOut()
@@ -324,7 +354,9 @@ namespace MudBlazor.Charts
             _hoveredBar = null;
 
             if (IsOverlayChart && ChartReference is IMudStateHasChanged chart)
+            {
                 chart.StateHasChanged();
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Interpolation;
 
-
 namespace MudBlazor.Charts;
 
 /// <summary>
@@ -42,7 +41,10 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
 
     public override void RebuildChart()
     {
-        if (IsOverlayChart && SharedData is null) return;
+        if (IsOverlayChart && SharedData is null)
+        {
+            return;
+        }
 
         Series = (ChartContainer != null && ChartReference is MudChart<T>)
             ? ChartContainer.ChartSeries
@@ -52,8 +54,15 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
 
         GeneratePlotArea(out var gridYUnits, out var lowestHorizontalLine, out var numHorizontalLines, out var horizontalSpace, out var verticalSpace);
 
-        if (Series.Count == 0) return;
-        if (!_generateChartLines) return;
+        if (Series.Count == 0)
+        {
+            return;
+        }
+
+        if (!_generateChartLines)
+        {
+            return;
+        }
 
         if (!IsOverlayChart)
         {
@@ -122,7 +131,9 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
         _maxDateTime = maxDate.Value;
 
         if (!ChartOptions.TimeLabelSpacingRounding)
+        {
             return;
+        }
 
         ApplyLabelRounding(labelSpacing);
     }
@@ -135,8 +146,15 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
         {
             foreach (var dt in series.Data.Points.Select(p => p.X).OfType<DateTime>())
             {
-                if (min == null || dt < min) min = dt;
-                if (max == null || dt > max) max = dt;
+                if (min == null || dt < min)
+                {
+                    min = dt;
+                }
+
+                if (max == null || dt > max)
+                {
+                    max = dt;
+                }
             }
         }
 
@@ -168,9 +186,13 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
             var offset = new TimeSpan(_minDateTime.Ticks % spacing.Ticks);
 
             if (ChartOptions!.TimeLabelSpacingRoundingPadSeries)
+            {
                 _minDateTime = _minDateTime.Subtract(offset);
+            }
             else
+            {
                 _minDateLabelOffset = spacing - offset;
+            }
         }
 
         if (ChartOptions!.TimeLabelSpacingRoundingPadSeries && _maxDateTime.Ticks % spacing.Ticks != 0)
@@ -228,7 +250,9 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
         }
 
         if (minY.Equals(T.MaxValue))
+        {
             return (T.Zero, T.Zero);
+        }
 
         var requireZero = ChartOptions?.YAxisRequireZeroPoint == true || HasAreaSeries();
         if (requireZero)
@@ -247,14 +271,16 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
     private void AdjustSuggestedMax(ref T maxY)
     {
         if (ChartOptions?.YAxisSuggestedMax is { } suggested)
+        {
             maxY = T.Max(T.CreateSaturating(suggested), maxY);
+        }
     }
 
     private static int GetLowestLine(T minY, T unit) =>
-        (int)Math.Floor(double.CreateSaturating(minY / unit));
+        (int)Math.Floor(double.CreateSaturating(minY) / double.CreateSaturating(unit));
 
     private static int GetHighestLine(T maxY, T unit) =>
-        (int)Math.Ceiling(double.CreateSaturating(maxY / unit));
+        (int)Math.Ceiling(double.CreateSaturating(maxY) / double.CreateSaturating(unit));
 
     private void ClampHorizontalLines(ref T unit, T minY, T maxY, ref int numLines, ref int lowestLine)
     {
@@ -286,7 +312,9 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
     private TimeValue<T>[][] GetCachedDataPoints()
     {
         if (_cachedDataPoints != null)
+        {
             return _cachedDataPoints;
+        }
 
         _cachedDataPoints = new TimeValue<T>[Series.Count][];
 
@@ -345,7 +373,7 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
     {
         var dataPoint = GetCachedDataPoints()[seriesIndex][dataPointIndex];
 
-        var gridValue = ((dataPoint.Value / T.CreateSaturating(gridYUnits)) - T.CreateSaturating(lowestHorizontalLine)) * T.CreateSaturating(verticalSpace);
+        var gridValue = ((double.CreateSaturating(dataPoint.Value) / double.CreateSaturating(gridYUnits)) - lowestHorizontalLine) * verticalSpace;
         var y = _boundHeight - VerticalStartSpace - double.CreateSaturating(gridValue);
 
         var diffFromMin = dataPoint.DateTime - _minDateTime;


### PR DESCRIPTION
Fix issue where bar chart values (and other axis-based charts) were being rounded down to the nearest Y-axis tick when using integer types like `long`. This was caused by integer division in the height and coordinate calculations.

Closes #12867 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
