### PR TITLE
MudSelect, MudAutocomplete, MudMenu: Fix modeless overlay reopen on same activator click

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -86,6 +86,19 @@ namespace MudBlazor.UnitTests.Components
             autocomplete.ReadText.Should().Be("California");
         }
 
+        [Test]
+        public async Task Autocomplete_ModelessOverlay_IgnoresActivatorRootForAutoCloseHitTesting()
+        {
+            var comp = Context.Render<AutocompleteTest1>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+
+            await autocompleteComponent.Find("input").InputAsync("Calif");
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var overlay = comp.Find("div.mud-overlay");
+            overlay.GetAttribute("data-modeless-ignore-element-id").Should().Be(comp.Find("div.mud-autocomplete").Id);
+        }
+
         /// <summary>
         /// Popup should open when 3 characters are typed and close when below.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -112,6 +112,20 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task Menu_ModelessOverlay_IgnoresActivatorRootForAutoCloseHitTesting()
+        {
+            var comp = Context.Render<MenuTest1>();
+
+            await comp.Find("button.mud-button-root").ClickAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
+
+            var menuRoot = comp.Find("div.mud-menu");
+            var overlay = comp.Find("div.mud-overlay");
+            overlay.GetAttribute("data-modeless-ignore-element-id").Should().Be(menuRoot.Id);
+            menuRoot.Id.Should().NotBeNullOrEmpty();
+        }
+
+        [Test]
         public async Task IsOpen_CheckState()
         {
             var comp = Context.Render<MenuTest1>();

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -92,6 +92,19 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task Select_ModelessOverlay_IgnoresActivatorRootForAutoCloseHitTesting()
+        {
+            var comp = Context.Render<SelectTest1>();
+            var select = comp.FindComponent<MudSelect<string>>();
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+
+            var overlay = comp.Find("div.mud-overlay");
+            overlay.GetAttribute("data-modeless-ignore-element-id").Should().Be(select.Instance.ElementId);
+        }
+
+        [Test]
         public async Task SelectTestCustomToString()
         {
             var comp = Context.Render<SelectCustomToStringTest>();

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
-    <div class="@AutocompleteClassname" @onclick:stopPropagation @onmousedown:stopPropagation>
+    <div id="@_componentId" class="@AutocompleteClassname" @onclick:stopPropagation @onmousedown:stopPropagation>
         <MudInputControl Label="@Label"
                          Variant="@Variant"
                          HelperId="@GetHelperId()"
@@ -143,6 +143,7 @@
 
 <MudOverlay AutoClose
             Visible="Open"
+            data-modeless-ignore-element-id="@_componentId"
             OnClosed="OnOverlayClosedAsync"
             LockScroll="@LockScroll"
             Modal="@GetModal()" />

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes"
+<div id="@FieldId"
+     @attributes="UserAttributes"
      class="@Classname"
      style="@Style"
      @onpointerenter="@PointerEnterAsync"
@@ -123,6 +124,7 @@
     {
         <MudOverlay Visible="_openState.Value && !_isTransient"
                     AutoClose
+                    data-modeless-ignore-element-id="@FieldId"
                     OnClosed="CloseMenuAsync"
                     LockScroll="LockScroll"
                     Modal="@GetModal()" />

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -136,6 +136,7 @@ feature relies on pointerdown event resulting in the same order of events.
 -->
 <MudOverlay Visible="_openState.Value"
             @onpointerdown="@(() => CloseMenu(false))"
+            data-modeless-ignore-element-id="@ElementId"
             LockScroll="@LockScroll"
             AutoClose="@(!GetModal())"
             Modal="@GetModal()"

--- a/src/MudBlazor/TScripts/mudPointerEventsNone.js
+++ b/src/MudBlazor/TScripts/mudPointerEventsNone.js
@@ -129,6 +129,11 @@ class MudPointerEventsNone {
                 break;
             }
 
+            if (this._shouldIgnorePointerEvent(element, event.target)) {
+                this.logger("Ignoring pointer event for element", element.id);
+                continue;
+            }
+
             matchingIds.push(element.id);
         }
 
@@ -139,6 +144,16 @@ class MudPointerEventsNone {
 
         this.logger("Raising", raiseMethod, "for matching element(s):", matchingIds);
         this.dotnet.invokeMethodAsync(raiseMethod, matchingIds);
+    }
+
+    _shouldIgnorePointerEvent(element, target) {
+        const ignoreElementId = element.dataset.modelessIgnoreElementId;
+        if (!ignoreElementId || !(target instanceof Element)) {
+            return false;
+        }
+
+        const ignoreElement = document.getElementById(ignoreElementId);
+        return !!ignoreElement && ignoreElement.contains(target);
     }
 
     /**


### PR DESCRIPTION
Fixes a modeless overlay interaction bug affecting `MudSelect`, `MudAutocomplete`, and `MudMenu`.

In modeless mode, overlay auto-close runs on `pointerdown`. When the component was already open and the user clicked its activator again, the overlay could close on `pointerdown` and then immediately reopen on the activator click.

This change prevents modeless overlay auto-close from triggering when the pointer event originated inside the owning component’s activator/root area.

**What changed:**
- Updated modeless overlay hit-testing in `mudPointerEventsNone.js` to ignore pointer events originating from an explicitly marked owner element.
- Wired the owner element for:
  - `MudSelect`
  - `MudAutocomplete`
  - `MudMenu`
- Added targeted regression tests covering the new ignore-region wiring.

**Related:**
- Regression likely caused by #10893
- Fixes #12855
- Closes #12715 (attempt 1)
- Closes #12720 (attempt 2)

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
