### PR TITLE
MudNumericField: Use Comparer<T>.Default instead of Comparer

### DIFF
--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -31,7 +31,7 @@ namespace MudBlazor
         private readonly string _elementId = Identifier.Create("numericField");
 
         private readonly Comparer<T> _comparer = Comparer<T>.Default;
-        
+
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -30,8 +30,8 @@ namespace MudBlazor
         private MudInput<string> _elementReference = null!;
         private readonly string _elementId = Identifier.Create("numericField");
 
-        private readonly Comparer _comparer = new(CultureInfo.InvariantCulture);
-
+        private readonly Comparer<T> _comparer = Comparer<T>.Default;
+        
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
 


### PR DESCRIPTION
`MudNumericField<T>` used the untyped `Comparer` with an `CultureInfo.InvariantCulture`. But all checks being done actually pass in variables of type `T`.

Thus we can use `Comparer<T>.Default` instead. This saves on memory due to a non boxing comparison also increases the performance of the comparison (which is probably not relevant in the grand scheme of things).

It also saves on further ressources, because we don't have to create a new `Comparer` instance each time the component is initialized.

(A small benchmark, which simply rips out the `ConstrainBoundaries` method and uses `int?` as a type, comparing `50` against the `_minValue`)
<img width="735" height="199" alt="Screenshot_2026-03-20_11-50-55" src="https://github.com/user-attachments/assets/1debca38-5a02-4a38-8aee-9e9b0e6424e0" />

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
