### PR TITLE
MudBaseInput: Preserve initial value & preserve invalid text across key-triggered rerenders

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteInitialTextComplexTypeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteInitialTextComplexTypeTest.razor
@@ -1,0 +1,22 @@
+﻿<MudPopoverProvider />
+
+<MudAutocomplete T="ComplexItem"
+                 Text="InitialValue"
+                 SearchFunc="@Search"
+                 ToStringFunc="@(item => item?.Name)" />
+
+@code {
+    public static string __description__ = "Autocomplete with complex type should preserve initial Text";
+
+    private static Task<IEnumerable<ComplexItem?>> Search(string? value, CancellationToken token)
+    {
+        var items = new List<ComplexItem>
+        {
+            new("One"), new("Two"), new("Three")
+        };
+        return Task.FromResult<IEnumerable<ComplexItem?>>(
+            items.Where(x => x.Name.Contains(value ?? "", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private record ComplexItem(string Name);
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteKeyDownRerenderTextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteKeyDownRerenderTextTest.razor
@@ -1,0 +1,40 @@
+@using Microsoft.AspNetCore.Components.Web
+
+<MudAutocomplete T="User"
+                 Label="User Select"
+                 Clearable="true"
+                 Strict="false"
+                 ResetValueOnEmptyText="true"
+                 OnKeyDown="OnUserListKeyDown"
+                 SearchFunc="SearchUsersAsync"
+                 @bind-Value="SelectedUser"
+                 Variant="Variant.Outlined" />
+
+@code {
+    public static string __description__ = "Autocomplete should preserve the current text during key-triggered rerenders while no value is selected.";
+
+    private User? SelectedUser { get; set; }
+
+    private readonly List<User> _userList =
+    [
+        new(1, "User One"),
+        new(2, "User Two"),
+        new(3, "User Three")
+    ];
+
+    private Task<IEnumerable<User>> SearchUsersAsync(string? searchText, CancellationToken cancellationToken)
+    {
+        var users = _userList.Where(user => user.Username.Contains(searchText ?? string.Empty, StringComparison.InvariantCultureIgnoreCase));
+        return Task.FromResult<IEnumerable<User>>(users);
+    }
+
+    private Task OnUserListKeyDown(KeyboardEventArgs args)
+    {
+        return Task.CompletedTask;
+    }
+
+    public record User(int Id, string Username)
+    {
+        public override string ToString() => Username;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldConversionErrorKeyRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldConversionErrorKeyRerenderTest.razor
@@ -1,0 +1,50 @@
+﻿@using MudBlazor.Utilities.Exceptions
+
+<MudTextField T="Pod"
+              Value="@Value"
+              ValueChanged="@OnValueChangedAsync"
+              Immediate="true"
+              OnlyValidateIfDirty="true"
+              Converter="@Converter"
+              OnKeyDown="@OnKeyDownAsync" />
+
+<MudText>@Value?.Value</MudText>
+
+@code {
+    public Pod? Value { get; set; }
+
+    public PodConverter Converter { get; } = new();
+
+    private Task OnValueChangedAsync(Pod? value)
+    {
+        Value = value;
+        return Task.CompletedTask;
+    }
+
+    private static Task OnKeyDownAsync(KeyboardEventArgs args) => Task.CompletedTask;
+
+    public sealed class Pod
+    {
+        public string? Value { get; set; }
+    }
+
+    public sealed class PodConverter : IReversibleConverter<Pod?, string?>
+    {
+        public string? Convert(Pod? input) => input?.Value;
+
+        public Pod? ConvertBack(string? input)
+        {
+            if (input is not null && input.Length < 7)
+            {
+                throw new ConversionException("Error message");
+            }
+
+            return input is null
+                ? null
+                : new Pod
+                {
+                    Value = input
+                };
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -686,6 +686,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// When T is a complex type and Text is explicitly set without a Value,
+        /// the initial Text should be preserved and not overwritten.
+        /// </summary>
+        [Test(Description = "https://github.com/MudBlazor/MudBlazor/issues/12900")]
+        public void Autocomplete_ComplexType_Should_Preserve_Initial_Text()
+        {
+            var comp = Context.Render<AutocompleteInitialTextComplexTypeTest>();
+            comp.Find("input").GetAttribute("value").Should().Be("InitialValue");
+        }
+
+        /// <summary>
         /// Test for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/1415"/>
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -1630,6 +1630,29 @@ namespace MudBlazor.UnitTests.Components
             result.Count.Should().Be(2);
         }
 
+        [Test]
+        public async Task Autocomplete_Should_PreserveText_OnKeyRerender_WhenValueIsUnchanged()
+        {
+            var comp = Context.Render<AutocompleteKeyDownRerenderTextTest>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<AutocompleteKeyDownRerenderTextTest.User>>();
+
+            await autocompleteComponent.Find("input").InputAsync("U");
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                autocompleteComponent.Instance.ReadText.Should().Be("U");
+                autocompleteComponent.Find("input").GetAttribute("value").Should().Be("U");
+            });
+
+            await autocompleteComponent.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "s", Type = "keydown" });
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                autocompleteComponent.Instance.ReadText.Should().Be("U");
+                autocompleteComponent.Find("input").GetAttribute("value").Should().Be("U");
+            });
+        }
+
         /// <summary>
         /// Test case for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/6412"/>
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -126,6 +126,28 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
         }
 
+        [Test]
+        public async Task TextField_Should_PreserveInvalidTextOnKeyRerender()
+        {
+            var comp = Context.Render<TextFieldConversionErrorKeyRerenderTest>();
+
+            await comp.Find("input").InputAsync("123456");
+
+            var textField = comp.FindComponent<MudTextField<TextFieldConversionErrorKeyRerenderTest.Pod>>().Instance;
+            textField.ReadValue.Should().BeNull();
+            textField.ReadText.Should().Be("123456");
+            textField.ConversionError.Should().BeTrue();
+            textField.ConversionErrorMessage.Should().Be("Error message");
+
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "6", Type = "keydown" });
+
+            textField = comp.FindComponent<MudTextField<TextFieldConversionErrorKeyRerenderTest.Pod>>().Instance;
+            textField.ReadValue.Should().BeNull();
+            textField.ReadText.Should().Be("123456");
+            textField.ConversionError.Should().BeTrue();
+            comp.Find("input").GetAttribute("value").Should().Be("123456");
+        }
+
         /// <summary>
         /// If Debounce Interval is null or 0, Value should change immediately
         /// </summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -661,7 +661,7 @@ namespace MudBlazor
         {
             var hasText = parameters.Contains<string>(nameof(Text));
             var hasValue = parameters.Contains<T>(nameof(Value));
-
+            var currentValue = ReadValue;
             await base.SetParametersAsync(parameters);
 
             // Refresh Text from Value if Value is present but Text is not
@@ -670,6 +670,14 @@ namespace MudBlazor
             // but we need to update Text even when Value is passed unchanged (for formatting)
             if (hasValue && !hasText)
             {
+                var valueChanged = !EqualityComparer<T?>.Default.Equals(currentValue, ReadValue);
+
+                // Preserve invalid user input across parent rerenders until Value actually changes.
+                if (ConversionError && !valueChanged && !_forceTextUpdate)
+                {
+                    return;
+                }
+
                 // Always update text when Value changes (TextUpdateSuppression removed)
                 _forceTextUpdate = false;
                 await UpdateTextPropertyAsync(false);

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -672,8 +672,8 @@ namespace MudBlazor
             {
                 var valueChanged = !EqualityComparer<T?>.Default.Equals(currentValue, ReadValue);
 
-                // Preserve invalid user input across parent rerenders until Value actually changes.
-                if (ConversionError && !valueChanged && !_forceTextUpdate)
+                // Preserve in-progress user text across parent rerenders until Value actually changes.
+                if (_isFocused && !valueChanged && !_forceTextUpdate)
                 {
                     return;
                 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -627,7 +627,7 @@ namespace MudBlazor
 
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
             // equal to the initial value. This is why we force an update to the Text property here.
-            if (typeof(T) != typeof(string))
+            if (typeof(T) != typeof(string) && string.IsNullOrWhiteSpace(ReadText))
             {
                 await UpdateTextPropertyAsync(false);
             }


### PR DESCRIPTION
## First issue

Fixes: https://github.com/MudBlazor/MudBlazor/issues/12876 regression where `MudTextField<T>` can clear user input when all of these are true:

- Immediate="true"
- OnKeyDown and/or OnKeyUp is used
- a custom converter throws ConversionException for intermediate input

In this case, the key event triggers a Blazor rerender, and `MudBaseInput.SetParametersAsync` refreshes Text from an unchanged `Value`. When the current text is only invalid temporarily, that sync wipes the in-progress user input.

Regression was introduced by #12306, which removed the guard that previously prevented focused/in-progress text from being overwritten during rerenders

## Second issue
Fixes: https://github.com/MudBlazor/MudBlazor/issues/12900

When using `MudAutocomplete<T>` with a complex type and setting initial `Text`, the text was silently
overwritten to null. This worked correctly for `T=string`.

`OnInitializedAsync` unconditionally called `UpdateTextPropertyAsync` for non-string types, which converted `Value` (null)
to `Text` (null), discarding the user-provided text.

Probably regression from #12259 due to timing diff.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
