### PR TITLE
MudTabs: Fix scroll buttons inside disabled form

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabScrollButtonsEnabledInsideFormTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabScrollButtonsEnabledInsideFormTest.razor
@@ -1,0 +1,27 @@
+﻿
+<MudContainer MaxWidth="MaxWidth.ExtraSmall">
+    <MudButton OnClick="@ToggleForm" Variant="Variant.Filled" Color="Color.Primary">Toggle Form Enable/Disable</MudButton>
+    <MudForm Disabled="@FormDisabled">
+        <MudTabs ActivePanelIndex="1">
+            <MudTabPanel Text="Tab One">
+                <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!" />
+            </MudTabPanel>
+            <MudTabPanel Text="Tab Two">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary">Does nothing</MudButton>
+            </MudTabPanel>
+            <MudTabPanel Text="Tab Three">
+                <MudText>Content Two</MudText>
+            </MudTabPanel>
+        </MudTabs>
+    </MudForm>
+</MudContainer>
+
+@code {
+    public static string __description__ = "Setting a form to disabled should not disable the individual tabs.";
+    public bool FormDisabled { get; set; }
+
+    void ToggleForm()
+    {
+        FormDisabled = !FormDisabled;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabScrollButtonsEnabledInsideFormTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabScrollButtonsEnabledInsideFormTest.razor
@@ -17,7 +17,7 @@
 </MudContainer>
 
 @code {
-    public static string __description__ = "Setting a form to disabled should not disable the individual tabs.";
+    public static string __description__ = "Tab scroll buttons should remain interactive even when the containing form is disabled.";
     public bool FormDisabled { get; set; }
 
     void ToggleForm()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabScrollButtonsEnabledInsideFormTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabScrollButtonsEnabledInsideFormTest.razor
@@ -2,16 +2,23 @@
 <MudContainer MaxWidth="MaxWidth.ExtraSmall">
     <MudButton OnClick="@ToggleForm" Variant="Variant.Filled" Color="Color.Primary">Toggle Form Enable/Disable</MudButton>
     <MudForm Disabled="@FormDisabled">
-        <MudTabs ActivePanelIndex="1">
+        <MudTabs ActivePanelIndex="9" AlwaysShowScrollButtons="true">
             <MudTabPanel Text="Tab One">
                 <MudTextField T="string" Label="Username" Required="true" RequiredError="User name is required!" />
             </MudTabPanel>
             <MudTabPanel Text="Tab Two">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary">Does nothing</MudButton>
             </MudTabPanel>
-            <MudTabPanel Text="Tab Three">
-                <MudText>Content Two</MudText>
-            </MudTabPanel>
+            <MudTabPanel Text="Three" />
+            <MudTabPanel Text="Four" />
+            <MudTabPanel Text="Five" />
+            <MudTabPanel Text="Six" />
+            <MudTabPanel Text="Seven" />
+            <MudTabPanel Text="Eight" />
+            <MudTabPanel Text="Nine" />
+            <MudTabPanel Text="Ten" />
+            <MudTabPanel Text="Eleven" />
+            <MudTabPanel Text="Thirteen" />
         </MudTabs>
     </MudForm>
 </MudContainer>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1897,24 +1897,36 @@ namespace MudBlazor.UnitTests.Components
 
             var comp = Context.Render<TabScrollButtonsEnabledInsideFormTest>();
 
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.FindComponents<MudIconButton>().Should().HaveCount(2);
+            });
+
             var scrollButtons = comp.FindComponents<MudIconButton>();
-            scrollButtons.Should().HaveCount(2);
+            var initialPreviousDisabled = scrollButtons.First().Instance.Disabled;
+            var initialNextDisabled = scrollButtons.Last().Instance.Disabled;
 
-            scrollButtons.First().Instance.Disabled.Should().BeFalse("scroll button should be enabled initially");
-            scrollButtons.Last().Instance.Disabled.Should().BeFalse("scroll button should be enabled initially");
+            await comp.Find("button.mud-button-root:not(.mud-icon-button)").ClickAsync();
 
-            var toggleFormDisabledButton = comp.Find("button.mud-button-root:not(.mud-icon-button)");
-            await toggleFormDisabledButton.ClickAsync();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var currentScrollButtons = comp.FindComponents<MudIconButton>();
+                currentScrollButtons.First().Instance.Disabled.Should().Be(initialPreviousDisabled,
+                    "scroll button disabled state should not change when the parent form becomes disabled");
+                currentScrollButtons.Last().Instance.Disabled.Should().Be(initialNextDisabled,
+                    "scroll button disabled state should not change when the parent form becomes disabled");
+            });
 
-            scrollButtons = comp.FindComponents<MudIconButton>();
-            scrollButtons.First().Instance.Disabled.Should().BeFalse("scroll button should remain enabled even when form is disabled");
-            scrollButtons.Last().Instance.Disabled.Should().BeFalse("scroll button should remain enabled even when form is disabled");
+            await comp.Find("button.mud-button-root:not(.mud-icon-button)").ClickAsync();
 
-            await toggleFormDisabledButton.ClickAsync();
-
-            scrollButtons = comp.FindComponents<MudIconButton>();
-            scrollButtons.First().Instance.Disabled.Should().BeFalse("scroll button should be enabled when form is re-enabled");
-            scrollButtons.Last().Instance.Disabled.Should().BeFalse("scroll button should be enabled when form is re-enabled");
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var currentScrollButtons = comp.FindComponents<MudIconButton>();
+                currentScrollButtons.First().Instance.Disabled.Should().Be(initialPreviousDisabled,
+                    "scroll button disabled state should remain unchanged when the parent form is re-enabled");
+                currentScrollButtons.Last().Instance.Disabled.Should().Be(initialNextDisabled,
+                    "scroll button disabled state should remain unchanged when the parent form is re-enabled");
+            });
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1876,5 +1876,45 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-tab").Count
                 .Should().Be(0);
         }
+
+        /// <summary>
+        /// Scroll buttons should remain enabled even when the parent form is disabled via CascadingValue ParentDisabled.
+        /// The tabs navigation should not be affected by the form's disabled state.
+        /// The tabs themselves may be disabled, but scroll buttons should always be interactive for navigation.
+        /// See: https://github.com/MudBlazor/MudBlazor/issues/12366
+        /// </summary>
+        [Test]
+        public async Task ScrollButtons_RemainEnabled_WhenParentFormDisabled()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 200,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.Render<TabScrollButtonsEnabledInsideFormTest>();
+
+            var scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons.Should().HaveCount(2);
+
+            scrollButtons.First().Instance.Disabled.Should().BeFalse("scroll button should be enabled initially");
+            scrollButtons.Last().Instance.Disabled.Should().BeFalse("scroll button should be enabled initially");
+
+            var toggleFormDisabledButton = comp.Find("button.mud-button-root:not(.mud-icon-button)");
+            await toggleFormDisabledButton.ClickAsync();
+
+            scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons.First().Instance.Disabled.Should().BeFalse("scroll button should remain enabled even when form is disabled");
+            scrollButtons.Last().Instance.Disabled.Should().BeFalse("scroll button should remain enabled even when form is disabled");
+
+            await toggleFormDisabledButton.ClickAsync();
+
+            scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons.First().Instance.Disabled.Should().BeFalse("scroll button should be enabled when form is re-enabled");
+            scrollButtons.Last().Instance.Disabled.Should().BeFalse("scroll button should be enabled when form is re-enabled");
+        }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -14,49 +14,53 @@
                 }
                 @if (_showScrollButtons)
                 {
-                    <div class="mud-tabs-scroll-button" 
-                         @ondragover="@(e => _throttleDispatcher.Value.ThrottleAsync(() => { ScrollPrev(); return Task.CompletedTask; }))">
-                        <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" aria-label="@GetPrevAriaLabel()"/>
-                    </div>
+                    <CascadingValue Value="false" Name="ParentDisabled" IsFixed="true">
+                        <div class="mud-tabs-scroll-button"
+                             @ondragover="@(e => _throttleDispatcher.Value.ThrottleAsync(() => { ScrollPrev(); return Task.CompletedTask; }))">
+                            <MudIconButton Icon="@_prevIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollPrev())" Disabled="@_prevButtonDisabled" aria-label="@GetPrevAriaLabel()" />
+                        </div>
+                    </CascadingValue>
                 }
                 <div @ref="@_tabsContentSize" class="mud-tabs-tabbar-content">
-                        @if (EnableDragAndDrop)
-                        {
-                            <MudDropContainer @ref="_dropContainer" T="MudTabPanel" Class="@WrapperClassnames" Style="@WrapperScrollStyle" Items="_panels"
-                                              ItemsSelector="@((item,dropzone) => true)" ItemDropped="@ItemUpdated"
-                                              ItemDisabled="@((item) => item.Disabled)" role="tablist">
-                                <ChildContent>
-                                    <MudDropZone T="MudTabPanel" Identifier="mud-tabs-dropzone" Class="@DropZoneClassnames" AllowReorder="true" />
-                                    @if (!HideSlider && _isSliderPositionDetermined)
-                                    {
-                                        <div class="@SliderClass" style="@SliderStyle"></div>
-                                    }
-                                </ChildContent>
-                                <ItemRenderer>
-                                    @RenderTabWrapperSection(context)
-                                </ItemRenderer>
-                            </MudDropContainer>                        
-                        }
-                        else
-                        {
-                            <div class="@WrapperClassnames" style="@WrapperScrollStyle" role="tablist">
-                                @foreach (MudTabPanel panel in _panels)
-                                {
-                                    @RenderTabWrapperSection(panel)
-                                }
+                    @if (EnableDragAndDrop)
+                    {
+                        <MudDropContainer @ref="_dropContainer" T="MudTabPanel" Class="@WrapperClassnames" Style="@WrapperScrollStyle" Items="_panels"
+                                          ItemsSelector="@((item,dropzone) => true)" ItemDropped="@ItemUpdated"
+                                          ItemDisabled="@((item) => item.Disabled)" role="tablist">
+                            <ChildContent>
+                                <MudDropZone T="MudTabPanel" Identifier="mud-tabs-dropzone" Class="@DropZoneClassnames" AllowReorder="true" />
                                 @if (!HideSlider && _isSliderPositionDetermined)
                                 {
                                     <div class="@SliderClass" style="@SliderStyle"></div>
                                 }
-                            </div>
-                        }                    
+                            </ChildContent>
+                            <ItemRenderer>
+                                @RenderTabWrapperSection(context)
+                            </ItemRenderer>
+                        </MudDropContainer>
+                    }
+                    else
+                    {
+                        <div class="@WrapperClassnames" style="@WrapperScrollStyle" role="tablist">
+                            @foreach (MudTabPanel panel in _panels)
+                            {
+                                @RenderTabWrapperSection(panel)
+                            }
+                            @if (!HideSlider && _isSliderPositionDetermined)
+                            {
+                                <div class="@SliderClass" style="@SliderStyle"></div>
+                            }
+                        </div>
+                    }
                 </div>
                 @if (_showScrollButtons)
                 {
-                    <div class="mud-tabs-scroll-button" 
-                         @ondragover="@(e => _throttleDispatcher.Value.ThrottleAsync(() => { ScrollNext(); return Task.CompletedTask; }))">
-                        <MudIconButton Icon="@_nextIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollNext())" Disabled="@_nextButtonDisabled" aria-label="@GetNextAriaLabel()"/>
-                    </div>
+                    <CascadingValue Value="false" Name="ParentDisabled" IsFixed="true">
+                        <div class="mud-tabs-scroll-button"
+                             @ondragover="@(e => _throttleDispatcher.Value.ThrottleAsync(() => { ScrollNext(); return Task.CompletedTask; }))">
+                            <MudIconButton Icon="@_nextIcon" Color="@ScrollIconColor" OnClick="@((e) => ScrollNext())" Disabled="@_nextButtonDisabled" aria-label="@GetNextAriaLabel()" />
+                        </div>
+                    </CascadingValue>
                 }
                 @if (HeaderPosition == TabHeaderPosition.After && Header != null)
                 {
@@ -79,26 +83,26 @@
 @code {
     private RenderFragment RenderTabWrapperSection(MudTabPanel panel) =>
         @<text>
-             @if (panel.TabContent is null && panel.TabWrapperContent is null)
-             {
-                 <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip" @key="@panel">
-                     @RenderTab(panel)
-                 </MudTooltip>
-             }
-             else
-             {
-                 <div class="d-inline-block" style="width: fit-content;" @key="@panel">
-                     @if (panel.TabWrapperContent is null)
-                     {
-                         @RenderTab(panel)
-                     }
-                     else
-                     {
-                         @panel.TabWrapperContent(RenderTab(panel))
-                     }
-                 </div>
-             }
-         </text>;
+            @if (panel.TabContent is null && panel.TabWrapperContent is null)
+            {
+                <MudTooltip Placement="@GetTooltipPlacement()" Text="@panel.ToolTip" @key="@panel">
+                    @RenderTab(panel)
+                </MudTooltip>
+            }
+            else
+            {
+                <div class="d-inline-block" style="width: fit-content;" @key="@panel">
+                    @if (panel.TabWrapperContent is null)
+                    {
+                        @RenderTab(panel)
+                    }
+                    else
+                    {
+                        @panel.TabWrapperContent(RenderTab(panel))
+                    }
+                </div>
+            }
+        </text>;
 
     private RenderFragment RenderTab(MudTabPanel panel) =>
         @<div @ref="panel.PanelRef" class="@GetTabClass(panel)" style="@GetTabStyle(panel)" @onclick="@(e => ActivatePanelClickAsync(panel, e, false))" @onmousedown="panel.OnMouseDown" @oncontextmenu="panel.OnContextMenu" @oncontextmenu:preventDefault="@(panel.OnContextMenu.HasDelegate)"
@@ -120,16 +124,16 @@
             }
             else if (string.IsNullOrEmpty(panel.Text) && !string.IsNullOrEmpty(panel.Icon))
             {
-                <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)"/>
+                <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)" />
             }
             else if (!string.IsNullOrEmpty(panel.Text) && !string.IsNullOrEmpty(panel.Icon))
             {
-                <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)" Class="mud-tab-icon-text"/>
+                <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)" Class="mud-tab-icon-text" />
                 @panel.Text
             }
             @if (panel.BadgeData is not null || panel.BadgeIcon is not null || panel.BadgeDot)
             {
-                <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Color="@panel.BadgeColor" Class="mud-tab-badge"/>
+                <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Color="@panel.BadgeColor" Class="mud-tab-badge" />
             }
             @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader is not null)
             {


### PR DESCRIPTION
There's a bug that if a Disabled Form wrap MudTabs the scroll buttons are disabled because of the CascadingValue ParentDisabled, so I added around only the scroll buttons an fixed CascadingValue ParentDisabled with value false to prevent this bug to happens, the issue 

fixes #12366 

- Create ScrollButtons viewer test and unit test for the bug
- Add fixed CascadingValue ParentDisabled with false value aroud the scroll buttons

https://github.com/user-attachments/assets/76b4b27b-55da-4fbc-bff2-4c5248beba5e

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

- Verified tabs are considered navigation and general consensus is not to be disabled per MUI standards. There was not a hard and fast standard for it but that seems to be the generally accepted practice.