### PR TITLE
Docs: Update XML documentation for DropzoneIdentifier

### DIFF
--- a/src/MudBlazor/Components/DropZone/MudItemDropInfo.cs
+++ b/src/MudBlazor/Components/DropZone/MudItemDropInfo.cs
@@ -11,7 +11,7 @@ namespace MudBlazor;
 /// </summary>
 /// <typeparam name="T">Type of dragged item</typeparam>
 /// <param name="Item">The dragged item during the transaction</param>
-/// <param name="DropzoneIdentifier">Identifier of the zone where the transaction started</param>
+/// <param name="DropzoneIdentifier">Identifier of the zone where the transaction ended</param>
 /// <param name="IndexInZone">The index of the item within in the drop zone</param>
 public record MudItemDropInfo<T>(T? Item, string DropzoneIdentifier, int IndexInZone)
 {


### PR DESCRIPTION
The Documentation of the MudItemDropInfo<T> was wrong in one thing. The DropzoneIdentfier give you the Zone where the Drag-n-Drop Journey ended, not startet.
