### PR TITLE
MudTabs: Fix drag-drop preview sizing for horizontal and vertical tabs

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsDragAndDropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsDragAndDropTest.razor
@@ -1,9 +1,10 @@
-﻿<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@TogglePosition">
-    Toggle Position (@_currentPosition)
-</MudButton>
+<MudRadioGroup T="Position" Value="@_selectedPosition" ValueChanged="@OnPositionChanged">
+    <MudRadio T="Position" Value="@Position.Top">Horizontal</MudRadio>
+    <MudRadio T="Position" Value="@Position.Left">Vertical</MudRadio>
+</MudRadioGroup>
 
 <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6"
-         EnableDragAndDrop="true" OnItemDropped="@ItemDroppedFired" Position="@_currentPosition">
+         EnableDragAndDrop="true" OnItemDropped="@ItemDroppedFired" Position="@_selectedPosition">
     <MudTabPanel Text="Tab One">
         <MudText>Content One</MudText>
     </MudTabPanel>
@@ -20,7 +21,7 @@
 
 @code {
     public static string __description__ = "Viewer for MudTabs. Drag and drop tabs to reorder them.";
-    private Position _currentPosition;
+    private Position _selectedPosition;
 
     [Parameter]
     public Position Position { get; set; } = Position.Top;
@@ -28,13 +29,14 @@
     [Parameter]
     public EventCallback<MudItemDropInfo<MudTabPanel>> ItemDroppedFired { get; set; }
 
-    protected override void OnParametersSet()
+    protected override void OnInitialized()
     {
-        _currentPosition = Position;
+        _selectedPosition = Position;
     }
 
-    private void TogglePosition()
+    private Task OnPositionChanged(Position position)
     {
-        _currentPosition = _currentPosition == Position.Top ? Position.Left : Position.Top;
+        _selectedPosition = position;
+        return Task.CompletedTask;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsDragAndDropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsDragAndDropTest.razor
@@ -1,5 +1,9 @@
-﻿<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6" 
-         EnableDragAndDrop="true" OnItemDropped="@ItemDroppedFired">
+﻿<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@TogglePosition">
+    Toggle Position (@_currentPosition)
+</MudButton>
+
+<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6"
+         EnableDragAndDrop="true" OnItemDropped="@ItemDroppedFired" Position="@_currentPosition">
     <MudTabPanel Text="Tab One">
         <MudText>Content One</MudText>
     </MudTabPanel>
@@ -16,7 +20,21 @@
 
 @code {
     public static string __description__ = "Viewer for MudTabs. Drag and drop tabs to reorder them.";
+    private Position _currentPosition;
+
+    [Parameter]
+    public Position Position { get; set; } = Position.Top;
 
     [Parameter]
     public EventCallback<MudItemDropInfo<MudTabPanel>> ItemDroppedFired { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        _currentPosition = Position;
+    }
+
+    private void TogglePosition()
+    {
+        _currentPosition = _currentPosition == Position.Top ? Position.Left : Position.Top;
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -1403,6 +1403,30 @@ namespace MudBlazor.UnitTests.Components
 #nullable disable
 
         [Test]
+        public void TabsDragAndDrop_Horizontal_AddsHorizontalDropZoneClass()
+        {
+            var comp = Context.Render<TabsDragAndDropTest>(parameters => parameters.Add(p => p.Position, Position.Top));
+
+            var dropZone = comp.Find("div.mud-tabs-dropzone");
+
+            dropZone.ClassList.Should().Contain("mud-tabs-dropzone");
+            dropZone.ClassList.Should().Contain("mud-tabs-dropzone-horizontal");
+            dropZone.ClassList.Should().NotContain("mud-tabs-dropzone-vertical");
+        }
+
+        [Test]
+        public void TabsDragAndDrop_Vertical_AddsVerticalDropZoneClass()
+        {
+            var comp = Context.Render<TabsDragAndDropTest>(parameters => parameters.Add(p => p.Position, Position.Left));
+
+            var dropZone = comp.Find("div.mud-tabs-dropzone");
+
+            dropZone.ClassList.Should().Contain("mud-tabs-dropzone");
+            dropZone.ClassList.Should().Contain("mud-tabs-dropzone-vertical");
+            dropZone.ClassList.Should().NotContain("mud-tabs-dropzone-horizontal");
+        }
+
+        [Test]
         public void LabelSorting_NaturalOrderIfSortingUnspecified()
         {
             // all parameters unspecified

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -860,6 +860,8 @@ namespace MudBlazor
         protected string DropZoneClassnames =>
             new CssBuilder("mud-tabs-dropzone")
                 .AddClass("d-flex", !_isVerticalTabs)
+                .AddClass("mud-tabs-dropzone-horizontal", !_isVerticalTabs)
+                .AddClass("mud-tabs-dropzone-vertical", _isVerticalTabs)
                 .AddClass($"mud-tabs-vertical", _isVerticalTabs)
                 .AddClass("flex-grow-1")
                 .Build();

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -128,6 +128,20 @@
   }
 }
 
+.mud-tabs-dropzone-horizontal {
+  > .mud-drop-item-preview-start {
+    width: 20px;
+    height: 100%;
+  }
+}
+
+.mud-tabs-dropzone-vertical {
+  > .mud-drop-item-preview-start {
+    width: 100%;
+    height: 20px;
+  }
+}
+
 .mud-tab {
   width: 100%;
   display: inline-flex;


### PR DESCRIPTION
## Summary
This PR finishes the MudTabs drag-and-drop hit-area fix by making the drag preview sizing orientation-aware and adding focused structural coverage for the tabs-specific drop-zone hooks.

It keeps the fix scoped to Tabs and does not change generic `MudDropZone` behavior.

## Changes
- adds tabs-specific drop-zone orientation classes for drag-and-drop tabs
- sizes the preview-start element to span the full cross-axis in horizontal and vertical tabs
- adds focused bUnit coverage to verify the correct orientation class is applied
- updates the viewer test component to switch between horizontal and vertical layouts with a radio selection for manual verification

## Verification
- `dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~Tabs" --nologo`

## Follow-up
A separate leading-edge issue on the first horizontal tab was observed and is intentionally deferred to a follow-up issue/PR. It is not included in this fix.

Closes #12813 
Closes #11867
