### PR TITLE
MudChart [TimeSeries]: Fix Types other than T="double" to work

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
@@ -80,6 +80,67 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
+        public void TimeSeriesChartRendersWithIntData()
+        {
+            var mockYAxisLabelSize = new ElementSize
+            {
+                Width = 27.5,
+                Height = 14.8,
+            };
+            var mockXAxisLabelSize = new ElementSize
+            {
+                Width = 670.5,
+                Height = 14.8,
+            };
+
+            var counter = 1;
+
+            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
+            {
+                if (counter % 2 == 0)
+                {
+                    counter++;
+                    return true;
+                }
+
+                return false;
+            }).SetResult(mockXAxisLabelSize);
+
+            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
+            {
+                if (counter % 2 == 1)
+                {
+                    counter++;
+                    return true;
+                }
+
+                return false;
+            }).SetResult(mockYAxisLabelSize);
+
+            var time = new DateTime(2000, 1, 1);
+
+            var comp = Context.Render<MudChart<int>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Timeseries)
+                .Add(p => p.ChartSeries, [
+                    new ()
+                    {
+                        Name = "Series 1",
+                        Data = new[] {-1, 0, 1, 2}.Select(x => new TimeValue<int>(time.AddHours(x), 1000)).ToList(),
+                        Visible = true,
+                    }
+                ])
+                .Add(p => p.ChartOptions, new TimeSeriesChartOptions() { TimeLabelSpacing = TimeSpan.FromHours(1) }));
+
+            // check the line path
+            comp.Markup.Should().ContainEquivalentOf("<path class=\"mud-chart-serie mud-chart-line\" blazor:onclick=\"15\" fill=\"none\" stroke=\"#2979FF\" stroke-opacity=\"1\" stroke-width=\"3\" d=\"M 30 320 L 243.3333 320 L 456.6667 320 L 670 320\"></path>");
+
+            // check the axis
+            comp.Markup.Should().ContainEquivalentOf("<g class=\"mud-charts-gridlines-yaxis\"><path stroke=\"#e0e0e0\" stroke-width=\"0.3\" d=\"M 30 320 L 670 320\"></path></g></g>");
+            comp.Markup.Should().ContainEquivalentOf("<text x='20' y='325' font-size='12px' text-anchor='end' dominant-baseline='auto'>1000</text></g>");
+            comp.Markup.Should().ContainEquivalentOf("<text x='30' y='340' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate(0 30 340)'>23:00</text><text x='243.3333' y='340' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate(0 243.3333 340)'>00:00</text><text x='456.6667' y='340' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate(0 456.6667 340)'>01:00</text><text x='670' y='340' font-size='12px' text-anchor='middle' dominant-baseline='middle' transform='rotate(0 670 340)'>02:00</text></g>");
+        }
+
+        [Test]
         public void TimeSeriesChartMatchBounds()
         {
             var mockYAxisLabelSize = new ElementSize

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Globalization;
+using System.Numerics;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Interpolation;
 
@@ -359,13 +360,13 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
 
     protected override string GetDataValueAsString(int seriesIndex, int dataPointIndex)
     {
-        var dataValue = GetDataValue<TimeValue<double>>(seriesIndex, dataPointIndex);
-        return dataValue.Value.ToString(Series[seriesIndex].TooltipYValueFormat);
+        var dataValue = GetDataValue<TimeValue<T>>(seriesIndex, dataPointIndex);
+        return dataValue.Value.ToString(Series[seriesIndex].TooltipYValueFormat, CultureInfo.CurrentCulture);
     }
 
     protected override string GetLabelXValue(int seriesIndex, int dataPointIndex)
     {
-        var dataValue = GetDataValue<TimeValue<double>>(seriesIndex, dataPointIndex);
+        var dataValue = GetDataValue<TimeValue<T>>(seriesIndex, dataPointIndex);
         return dataValue.DateTime.ToString(ChartOptions?.TooltipTimeLabelFormat ?? "G");
     }
 
@@ -391,4 +392,4 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
 /// <summary>
 /// Represents a data point in a time series chart, containing a DateTime and a value.
 /// </summary>
-public readonly record struct TimeValue<TNumber>(DateTime DateTime, TNumber Value) where TNumber : INumber<TNumber>;
+public readonly record struct TimeValue<TNumber>(DateTime DateTime, TNumber Value) where TNumber : INumber<TNumber>, IFormattable;


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
Currently TimeSeries fails with types like `int` if it is set as `T="int"`. At runtime it tries to convert `TimeValue<int>` to `TimeValue<double>` and just silently fails without drawing any of the points but making the skeleton of the chart. The culprit line: https://github.com/MudBlazor/MudBlazor/blob/e7235a7368088e62b58dff418caa94af321a7612/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs#L357
as it fails to convert `(TimeValue<double>)(object)data[dataPointIndex]` which is `TimeValue<int>`

(TReturn)(object)data[dataPointIndex] | '(TReturn)(object)data[dataPointIndex]' threw an exception of type 'System.InvalidCastException' | MudBlazor.Charts.TimeValue<double> {System.InvalidCastException}

Example snippet
https://try.mudblazor.com/snippet/wkGKuRxPRsOzFKij
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

The fix changes double variables to generic T so it matches the Types. It also adds an IFormattable constraint to TNumber for TimeValue<TNumber> so `.ToString()` could be used for the TooltipLabelFormat and is already a requirement on T

**Tests**
* Tested on MudBlazor.Docs.Server - changing all the types to int and comparing the results to match
* Packaging the project and using where I needed it and it shows the correct result without resorting to conversions
* Running the current UnitTests - All passing, at least locally

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
---
- [x] I've added or updated relevant unit tests
* I looked at the unit tests for other charts and they have no tests for Types except for DonutChart. I can try and add some if needed though.
