### PR TITLE
Charts: Respect height when MatchBoundsToSize is enabled

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -200,9 +200,9 @@ public class ChartSizingTests : BunitTest
 
         await comp.WaitForAssertionAsync(() =>
         {
-            var fallbackDiv = comp.Find("div[style*='height:400px']");
+            var fallbackDiv = comp.Find("div[style*='height:350px']");
             fallbackDiv.Should().NotBeNull();
-            fallbackDiv.GetAttribute("style").Should().Contain("height:400px");
+            fallbackDiv.GetAttribute("style").Should().Contain("height:350px");
         });
     }
 

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -183,4 +183,45 @@ public class ChartSizingTests : BunitTest
         svg = comp.Find("svg");
         svg.GetAttribute("viewBox").Should().Be("0 0 800 400");
     }
+
+    [Test]
+    public async Task MudChart_MatchBoundsToSize_NoFixedParent_ShouldUseFallbackHeight()
+    {
+        var series = new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20 } } };
+
+        var jsInterop = Context.JSInterop.Setup<bool>("hasDefinedParentHeight", _ => true);
+        jsInterop.SetResult(false);
+
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Height, "100%")
+            .Add(p => p.ChartSeries, series));
+
+        await comp.WaitForAssertionAsync(() =>
+        {
+            var fallbackDiv = comp.Find("div[style*='height:400px']");
+            fallbackDiv.Should().NotBeNull();
+            fallbackDiv.GetAttribute("style").Should().Contain("height:400px");
+        });
+    }
+
+    [Test]
+    public async Task MudChart_MatchBoundsToSize_WithFixedParent_ShouldNotUseFallbackHeight()
+    {
+        var series = new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20 } } };
+
+        var jsInterop = Context.JSInterop.Setup<bool>("hasDefinedParentHeight", _ => true);
+        jsInterop.SetResult(true);
+
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Height, "100%")
+            .Add(p => p.ChartSeries, series));
+
+        await comp.WaitForAssertionAsync(() => Context.JSInterop.Invocations["hasDefinedParentHeight"].Should().HaveCount(1));
+
+        comp.FindAll("div[style*='height:400px']").Should().BeEmpty();
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
@@ -135,7 +135,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.MatchBoundsToSize, true));
 
             // check the size/bounds
-            comp.Markup.Should().ContainEquivalentOf("<svg class=\"mud-chart-line mud-ltr\" width=\"100%\" height=\"100%\" viewBox=\"0 0 1000 400\"");
+            comp.Markup.Should().ContainEquivalentOf("<svg class=\"mud-chart-line mud-ltr\" width=\"1000px\" height=\"400px\" viewBox=\"0 0 1000 400\"");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
@@ -135,7 +135,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.MatchBoundsToSize, true));
 
             // check the size/bounds
-            comp.Markup.Should().ContainEquivalentOf("<svg class=\"mud-chart-line mud-ltr\" width=\"1000px\" height=\"400px\" viewBox=\"0 0 1000 400\"");
+            comp.Markup.Should().ContainEquivalentOf("<svg class=\"mud-chart-line mud-ltr\" width=\"100%\" height=\"400px\" viewBox=\"0 0 1000 400\"");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -6,7 +6,7 @@
 @typeparam TChartOptions
 
 <svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" 
-     width="@Width" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
+     width="@(MatchBoundsToSize ? "100%" : Width)" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
      style="@HoveredStylename">
     <Filters />
 

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -6,8 +6,7 @@
 @typeparam TChartOptions
 
 <svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" 
-     width="@(MatchBoundsToSize ? "100%" : Width)" height="@(MatchBoundsToSize ? "100%" : Height)" 
-     viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
+     width="@Width" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
      style="@HoveredStylename">
     <Filters />
 

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -172,7 +172,10 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     {
         base.OnParametersSet();
 
-        if (MatchBoundsToSize && _elementSize is null) return;
+        if (MatchBoundsToSize && _elementSize is null)
+        {
+            return;
+        }
 
         RebuildChart();
     }
@@ -229,8 +232,13 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
         {
             if (_elementSize is not null)
             {
-                _boundWidth = _elementSize.Width;
-                _boundHeight = _elementSize.Height;
+                _boundWidth = _elementSize.Width > 0
+                    ? _elementSize.Width
+                    : BoundWidthDefault;
+
+                _boundHeight = _elementSize.Height > 0
+                    ? _elementSize.Height
+                    : BoundHeightDefault;
             }
             else if (Width.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
                 && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
@@ -336,7 +344,9 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     protected static string FormatTooltipText(string? format, ChartSeries<T> series, SvgPath path)
     {
         if (string.IsNullOrWhiteSpace(format))
+        {
             return string.Empty;
+        }
 
         return format
             .Replace("{{SERIES_NAME}}", series.Name)
@@ -352,12 +362,16 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     public void OnElementSizeChanged(ElementSize elementSize)
     {
         if (elementSize is null || elementSize.Timestamp <= _elementSize?.Timestamp)
+        {
             return;
+        }
 
         _elementSize = elementSize;
 
         if (!MatchBoundsToSize)
+        {
             return;
+        }
 
         if (Math.Abs(_boundWidth - _elementSize.Width) < Epsilon &&
             Math.Abs(_boundHeight - _elementSize.Height) < Epsilon)

--- a/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
@@ -172,6 +172,7 @@ public abstract class MudChartBase<T, TOptions> : MudComponentBase, IMudChart<T>
     /// </summary>
     protected string Classname => new CssBuilder("mud-chart")
         .AddClass($"mud-chart-legend-{ConvertLegendPosition(LegendPosition).ToStringFast(true)}")
+        .AddClass("mud-chart-fill-bounds", MatchBoundsToSize)
         .AddClass(Class)
         .Build();
 

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -84,7 +84,7 @@ namespace MudBlazor.Charts
             SetBounds();
             ComputeUnitsAndNumberOfLines(out gridYUnits, out numHorizontalLines, out lowestHorizontalLine, out numVerticalLines);
 
-            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount : numHorizontalLines - 1;
+            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount - 1 : numHorizontalLines - 1;
 
             horizontalSpace = _boundWidth - HorizontalStartSpace - HorizontalEndSpace;
             verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -11,8 +11,7 @@
 }
 
 <svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" 
-     width="@(MatchBoundsToSize ? "100%" : Width)" height="@(MatchBoundsToSize ? "100%" : Height)"
-     viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
+     width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
      style="@HoveredStylename">
     @if (_options is { EnableSmoothGradient: true })
     {

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -11,7 +11,8 @@
 }
 
 <svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" 
-     width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
+     width="@(MatchBoundsToSize ? "100%" : Width)" height="@Height" 
+     viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
      style="@HoveredStylename">
     @if (_options is { EnableSmoothGradient: true })
     {

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor.cs
@@ -72,7 +72,7 @@ namespace MudBlazor.Charts
             SetBounds();
             ComputeUnitsAndNumberOfLines(out gridYUnits, out numHorizontalLines, out lowestHorizontalLine, out var numVerticalLines);
 
-            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount : numHorizontalLines - 1;
+            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount - 1 : numHorizontalLines - 1;
 
             horizontalSpace = (_boundWidth - HorizontalStartSpace - HorizontalEndSpace) / Math.Max(1, numVerticalLines - 1);
             verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -38,13 +38,13 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         SetBounds();
 
         if (!HasValidData())
+        {
             return;
+        }
 
         var normalizedData = GetNormalizedData();
         var (seriesData, labelData) = GroupDataSet(ChartLabels ?? [], ChartSeries, ChartOptions!.AggregationOption == AggregationOption.GroupByDataSet);
         var numAxes = labelData.Length;
-
-        BuildLegends([.. seriesData.Select(x => x.Name)]);
 
         var angleStep = 2 * Math.PI / numAxes;
         var currentAngle = (-Math.PI / 2) + (ChartOptions.AngleOffset * (Math.PI / 180)); // Convert offset to radians
@@ -59,13 +59,19 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         );
 
         if (ChartOptions.ShowGridLines)
+        {
             GenerateGridLines(numAxes, angleStep, currentAngle, radius);
+        }
 
         if (ChartOptions.ShowAxisValues)
+        {
             GenerateAxisValues(currentAngle, axisMaxValue, radius);
+        }
 
         GenerateAxisLines(numAxes, angleStep, currentAngle, radius, labelData);
         GenerateSvgPaths(seriesData, normalizedData, numAxes, angleStep, currentAngle, radius, axisMaxValue);
+
+        BuildLegends([.. seriesData.Select(x => x.Name)]);
     }
 
     private bool HasValidData() =>
@@ -76,7 +82,9 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     {
         Debug.Assert(ChartOptions is not null);
         if (!ChartOptions.ShowAxisLabels)
+        {
             return Radius;
+        }
 
         var padding = MatchBoundsToSize ? 60 : 40;
         var maxR = Math.Min((_boundWidth - padding) / 2.0, (_boundHeight - padding) / 2.0);
@@ -93,7 +101,9 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
             var series = seriesData[seriesIndex];
 
             if (series.Data == null || series.Data.Count == 0 || !series.Visible || HiddenIndices.Contains(seriesIndex))
+            {
                 continue;
+            }
 
             var (pathString, points) = GeneratePolygonPath(series, seriesIndex, numAxes, angleStep, currentAngle, radius, axisMaxValue);
 
@@ -153,7 +163,9 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         var gridLevelsOption = ChartOptions.GridLevels;
 
         if (gridLevelsOption <= 0)
+        {
             return;
+        }
 
         var gridLevels = T.CreateSaturating(gridLevelsOption);
         var stepValue = T.Max(T.CreateSaturating(1), axisMaxValue / gridLevels);
@@ -234,7 +246,9 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     private static (List<ChartSeries<T>> Series, string[] Labels) GroupDataSet(string[] labels, List<ChartSeries<T>> dataSet, bool groupByDataSet = false)
     {
         if (groupByDataSet)
+        {
             return (dataSet, labels);
+        }
 
         var groupedData = new List<ChartSeries<T>>();
         var dataLength = dataSet.Count != 0

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -85,7 +85,7 @@ namespace MudBlazor.Charts
             SetBounds();
             ComputeStackedUnitsAndNumberOfLines(out lowestHorizontalLine, out gridYUnits, out numHorizontalLines, out var numVerticalLines);
 
-            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount - 1: numHorizontalLines - 1;
+            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount - 1 : numHorizontalLines - 1;
 
             horizontalSpace = _boundWidth - HorizontalStartSpace - HorizontalEndSpace;
             verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -85,7 +85,7 @@ namespace MudBlazor.Charts
             SetBounds();
             ComputeStackedUnitsAndNumberOfLines(out lowestHorizontalLine, out gridYUnits, out numHorizontalLines, out var numVerticalLines);
 
-            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount : numHorizontalLines - 1;
+            var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount - 1: numHorizontalLines - 1;
 
             horizontalSpace = _boundWidth - HorizontalStartSpace - HorizontalEndSpace;
             verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -92,7 +92,7 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
         ComputeMinAndMaxDateTimes();
         ComputeUnitsAndNumberOfLines(out gridYUnits, out numHorizontalLines, out lowestHorizontalLine, out var numVerticalLines);
 
-        var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount : numHorizontalLines - 1;
+        var horizontalLines = IsOverlayChart ? SharedData!.Value.HorizontalLineCount - 1 : numHorizontalLines - 1;
 
         horizontalSpace = (_boundWidth - HorizontalStartSpace - HorizontalEndSpace) / Math.Max(1, (_maxDateTime - _minDateTime) / ChartOptions!.TimeLabelSpacing);
         verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, horizontalLines);

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -9,9 +9,17 @@
 @attribute [CascadingTypeParameter(nameof(T))]
 
 <CascadingValue Value="@this" IsFixed="true">
-    <div @attributes="UserAttributes" class="@Classname" style="@Style; width: @Width; height: @Height;" dir="ltr">
-        @ChartContent
-    </div>
+    @if (_hasFixedParent)
+    {
+        @ChartContainer
+    }
+    else
+    {
+        <div style="height:@(IsHeightPercentage() ? FallbackHeight : Height); width: @Width;">
+            @ChartContainer
+        </div>
+    }
+
     @if (ChartReference is not null)
     {
         <CascadingValue Value="@ChartReference" IsFixed="true">
@@ -21,6 +29,14 @@
 </CascadingValue>
 
 @code {
+    private RenderFragment ChartContainer => @<div @ref="_containerRef"
+                                                   @attributes="UserAttributes"
+                                                   class="@Classname"
+                                                   style="@($"{Style}; width: {(MatchBoundsToSize ? "100%" : @Width)}; height: {@Height};")"
+                                                   dir="ltr">
+        @ChartContent
+    </div>;
+
     private RenderFragment ChartContent => (_chartType, _chartOptions) switch
     {
         (ChartType.Donut, DonutChartOptions donutOptions) => @<Donut ChartSeries="@ChartSeries"

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -15,7 +15,7 @@
     }
     else
     {
-        <div style="height:@(IsHeightPercentage() ? FallbackHeight : Height); width: @Width;">
+        <div style="height:@(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width);">
             @ChartContainer
         </div>
     }

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -9,15 +9,15 @@
 @attribute [CascadingTypeParameter(nameof(T))]
 
 <CascadingValue Value="@this" IsFixed="true">
-    @if (_hasFixedParent)
-    {
-        @ChartContainer
-    }
-    else
+    @if (_hasFixedParent is false)
     {
         <div style="height:@(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width);">
             @ChartContainer
         </div>
+    }
+    else
+    {
+        @ChartContainer
     }
 
     @if (ChartReference is not null)
@@ -32,7 +32,7 @@
     private RenderFragment ChartContainer => @<div @ref="_containerRef"
                                                    @attributes="UserAttributes"
                                                    class="@Classname"
-                                                   style="@($"{Style}; width: {(MatchBoundsToSize ? "100%" : @Width)}; height: {@Height};")"
+                                                   style="@($"{Style}; width: {(MatchBoundsToSize ? "100%" : @Width)}; height: {(MatchBoundsToSize ? "100%" : Height)};")"
                                                    dir="ltr">
         @ChartContent
     </div>;

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -66,7 +66,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
             return;
         }
 
-        if (firstRender && IsHeightPercentage())
+        if (firstRender && HasPercentageHeight())
         {
             _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
 
@@ -77,7 +77,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
         }
     }
 
-    private bool IsHeightPercentage() => Height.AsSpan().Trim().EndsWith("%", StringComparison.Ordinal);
+    private bool HasPercentageHeight() => Height.AsSpan().Trim().EndsWith("%", StringComparison.Ordinal);
 
     private IChartOptions GetChartTypeOptions(ChartOptions options) => ChartType switch
     {

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Numerics;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Charts;
 
 namespace MudBlazor;
@@ -12,8 +14,20 @@ namespace MudBlazor;
 /// </summary>
 public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
+    [Inject]
+    private IJSRuntime JsRuntime { get; set; } = null!;
+
+    private bool _hasFixedParent = true;
+
     private ChartType? _chartType;
     private IChartOptions? _chartOptions;
+    private ElementReference? _containerRef;
+
+    /// <summary>
+    /// The pixel height used for the fallback wrapper div when <see cref="MudChartBase{T,TOptions}.Height"/>
+    /// is a percentage and no fixed-height ancestor is detected.
+    /// </summary>
+    private const string FallbackHeight = "400px";
 
     protected override void OnParametersSet()
     {
@@ -42,6 +56,28 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
 
         base.OnAfterRender(firstRender);
     }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (!MatchBoundsToSize)
+        {
+            return;
+        }
+
+        if (firstRender && IsHeightPercentage())
+        {
+            _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
+
+            if (!_hasFixedParent)
+            {
+                StateHasChanged();
+            }
+        }
+    }
+
+    private bool IsHeightPercentage() => Height.AsSpan().Trim().EndsWith("%", StringComparison.Ordinal);
 
     private IChartOptions GetChartTypeOptions(ChartOptions options) => ChartType switch
     {

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -17,7 +17,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = null!;
 
-    private bool _hasFixedParent = true;
+    private bool? _hasFixedParent;
 
     private ChartType? _chartType;
     private IChartOptions? _chartOptions;
@@ -61,20 +61,19 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (!MatchBoundsToSize)
+        if (_hasFixedParent is not null)
         {
             return;
         }
 
-        if (firstRender && HasPercentageHeight())
+        _hasFixedParent = true;
+
+        if (MatchBoundsToSize && firstRender && HasPercentageHeight())
         {
             _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
-
-            if (!_hasFixedParent)
-            {
-                StateHasChanged();
-            }
         }
+
+        StateHasChanged();
     }
 
     private bool HasPercentageHeight() => Height.AsSpan().Trim().EndsWith("%", StringComparison.Ordinal);

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -27,7 +27,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     /// The pixel height used for the fallback wrapper div when <see cref="MudChartBase{T,TOptions}.Height"/>
     /// is a percentage and no fixed-height ancestor is detected.
     /// </summary>
-    private const string FallbackHeight = "400px";
+    private const string FallbackHeight = "350px";
 
     protected override void OnParametersSet()
     {
@@ -68,12 +68,22 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
 
         _hasFixedParent = true;
 
-        if (MatchBoundsToSize && firstRender && HasPercentageHeight())
+        if (!MatchBoundsToSize || !HasPercentageHeight())
+        {
+            return;
+        }
+
+        var previousHasFixedParent = _hasFixedParent;
+
+        if (firstRender)
         {
             _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
         }
 
-        StateHasChanged();
+        if (_hasFixedParent != previousHasFixedParent)
+        {
+            StateHasChanged();
+        }
     }
 
     private bool HasPercentageHeight() => Height.AsSpan().Trim().EndsWith("%", StringComparison.Ordinal);

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -9,7 +9,7 @@
     <div @attributes="UserAttributes" class="mud-chart-legend">
         @foreach (var item in Data)        
         {
-            <div class="mud-chart-legend-item" 
+            <div class="@($"mud-chart-legend-item {(CanHideSeries ? "" : "pa-1")}")"
                  @onclick:stopPropagation=@(ChartContainer!=null)
                  @onclick=@(async () => { if (OnLegendSelected.HasDelegate) { await OnLegendSelected.InvokeAsync(item.Index); }})>
                 @if(!CanHideSeries)
@@ -21,7 +21,7 @@
                 {   
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
                         <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense/>
-                        <MudText Typo="Typo.body2" Class="ml-n2 align-self-end" HtmlTag="span">@item.Labels</MudText>
+                        <MudText Typo="Typo.body2" Class="ml-n2 align-self-center" HtmlTag="span">@item.Labels</MudText>
                     </div> 
                 }                 
             </div>

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -90,6 +90,13 @@
   }
 }
 
+.mud-chart-fill-bounds {
+  height: 100%;
+  width: 100%;
+  min-height: unset;
+  min-width: unset;
+}
+
 .mud-charts-yaxis {
   fill: var(--mud-palette-text-primary);
 }

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -112,6 +112,35 @@ window.mudGetSvgBBox = (svgElement) => {
 };
 
 /**
+ * Returns whether or not the element has a parent with a defined height,
+ * either via explicit height or constrained layout context.
+ */
+window.hasDefinedParentHeight = (element) => {
+    console.log('element:', element);
+    const parent = element?.parentElement;
+    console.log('parent:', parent);
+    if (!parent) return false;
+
+    const style = window.getComputedStyle(parent);
+
+    // Explicit height via inline or computed (not auto)
+    const hasExplicitHeight =
+        parent.style.height && parent.style.height !== 'auto';
+
+    // Check for flex/grid constraints
+    const isFlexOrGrid =
+        style.display.includes('flex') ||
+        style.display.includes('grid');
+
+    // Check if height is constrained via layout context
+    const hasConstrainedHeight =
+        style.height !== 'auto' &&
+        style.maxHeight !== 'none';
+
+    return hasExplicitHeight || (hasConstrainedHeight && isFlexOrGrid);
+};
+
+/**
  * Observes element size changes and forwards throttled updates to a .NET callback.
  * Automatically stops observing when the element is removed from the DOM.
  */

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -116,9 +116,8 @@ window.mudGetSvgBBox = (svgElement) => {
  * either via explicit height or constrained layout context.
  */
 window.hasDefinedParentHeight = (element) => {
-    console.log('element:', element);
     const parent = element?.parentElement;
-    console.log('parent:', parent);
+
     if (!parent) return false;
 
     const style = window.getComputedStyle(parent);


### PR DESCRIPTION
Ensure that axis charts respect the provided height when MatchBoundsToSize is enabled.

Closes #12877 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
