### PR TITLE
MudPopoverProvider - Switch to Popover API based provider

### DIFF
--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor
@@ -7,7 +7,13 @@
         @foreach (var handler in PopoverService.ActivePopovers)
         {
             <MudRender @ref="handler.ElementReference" @key="handler.Id">
-                <div id="@($"popovercontent-{handler.Id}")" data-ticks="@(handler.ActivationDate?.Ticks ?? 0)" @attributes="@handler.UserAttributes" class="@handler.Class" style="@handler.Style">
+                <div id="@GetPopoverElementId(handler.Id)"
+                     popover="manual"
+                     data-popover-id="@handler.Id"
+                     data-ticks="@(handler.ActivationDate?.Ticks ?? 0)"
+                     @attributes="handler.UserAttributes"
+                     class="@handler.Class"
+                     style="@handler.Style">
                     @if (handler.ShowContent)
                     {
                         @handler.Fragment

--- a/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverProvider.razor.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Interfaces;
+using MudBlazor.Interop;
 
 namespace MudBlazor
 {
@@ -20,9 +22,14 @@ namespace MudBlazor
     public partial class MudPopoverProvider : IDisposable, IPopoverObserver
     {
         private bool _isConnectedToService;
+        private bool _pendingSync;
+        private PopoverJsInterop? _jsInterop;
 
         [Inject]
         internal IPopoverService PopoverService { get; set; } = null!;
+
+        [Inject]
+        internal IJSRuntime JSRuntime { get; set; } = null!;
 
         /// <summary>
         /// Controls whether this provider is enabled.
@@ -50,6 +57,7 @@ namespace MudBlazor
             {
                 return;
             }
+            _jsInterop = new PopoverJsInterop(JSRuntime);
 
             PopoverService.Subscribe(this);
             _isConnectedToService = true;
@@ -86,6 +94,16 @@ namespace MudBlazor
                     throw new InvalidOperationException("Duplicate MudPopoverProvider detected. Please ensure there is only one provider, or disable this warning with PopoverOptions.ThrowOnDuplicateProvider.");
                 }
             }
+
+            if (Enabled && _pendingSync && _jsInterop != null)
+            {
+                _pendingSync = false;
+
+                var states = PopoverService.ActivePopovers.Select(s => (GetPopoverElementId(s.Id), s.ShowContent)).ToArray();
+
+                await _jsInterop.SynchroniseAll(states);
+            }
+
             await base.OnAfterRenderAsync(firstRender);
         }
 
@@ -111,6 +129,11 @@ namespace MudBlazor
                             {
                                 await InvokeAsync(stateHasChanged.StateHasChanged);
                             }
+
+                            if (_jsInterop != null)
+                            {
+                                await _jsInterop.Synchronise(GetPopoverElementId(holder.Id), holder.ShowContent, cancellationToken);
+                            }
                         }
 
                         break;
@@ -118,9 +141,12 @@ namespace MudBlazor
                 // Update whole MudPopoverProvider
                 case PopoverHolderOperation.Create:
                 case PopoverHolderOperation.Remove:
+                    _pendingSync = true;
                     await InvokeAsync(StateHasChanged);
                     break;
             }
         }
+
+        private static string GetPopoverElementId(Guid id) => $"popovercontent-{id}";
     }
 }

--- a/src/MudBlazor/Interop/PopoverJsInterop.cs
+++ b/src/MudBlazor/Interop/PopoverJsInterop.cs
@@ -30,6 +30,16 @@ internal class PopoverJsInterop
         return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.disconnect", cancellationToken, id);
     }
 
+    public ValueTask<bool> SynchroniseAll((string id, bool open)[] states, CancellationToken cancellationToken = default)
+    {
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.synchroniseAll", cancellationToken, states);
+    }
+
+    public ValueTask<bool> Synchronise(string id, bool open, CancellationToken cancellationToken = default)
+    {
+        return _jsRuntime.InvokeVoidAsyncWithErrorHandling("mudPopover.synchronise", cancellationToken, id, open);
+    }
+
     public ValueTask<(bool success, int value)> CountProviders(CancellationToken cancellationToken = default)
     {
         return _jsRuntime.InvokeAsyncWithErrorHandling<int>("mudpopoverHelper.countProviders", cancellationToken);

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -752,6 +752,18 @@ window.mudpopoverHelper = {
 
         return maxZIndex;
     },
+    
+    triggerPopoverState: function (element, open) {
+
+        // Showing an already open popover or hiding an already closed popover will error, so we check the current state before trying to change it
+        const isOpen = element.matches(":popover-open");
+
+        if (open && !isOpen) {
+            try { element.showPopover(); } catch { }
+        } else if (!open && isOpen) {
+            try { element.hidePopover(); } catch { }
+        }
+    },
 
     popoverOverlayUpdates: function () {
         let highestTickItem = null;
@@ -905,6 +917,25 @@ class MudPopover {
                 clearInterval(intervalId);
             }
         }, interval);
+    }
+
+    synchroniseAll(states) {
+        if (!Array.isArray(states)) return;
+
+        for (const s of states) {
+            const element = document.getElementById(s.id);
+            if (!element) continue;
+
+            window.mudpopoverHelper.triggerPopoverState(element, s.open);
+        }
+    }
+    synchronise(id, open) {
+        if (!id) return;
+
+        const element = document.getElementById(id);
+        if (!element) return;
+
+        window.mudpopoverHelper.triggerPopoverState(element, open);
     }
 
     /**


### PR DESCRIPTION
This pull request is a first look implementation of the web native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for providing MudBlazor popovers. This is intended to be compatible with the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API), which when activated does not support the existing popover provider (#12369). Per discussion with @ScarletKuro in [discord](https://discord.com/channels/786656789310865418/1489495322127499286), this is a draft PR with my approach for using the native API. 

**Note for those using the Fullscreen API**: The provider must be within the element you request to be fullscreened. Otherwise, the browser will correctly display the popovers but not allow interacting with them. [The spec](https://fullscreen.spec.whatwg.org/#simple-fullscreen-document) suggests that this is a supported use case for dialogs, not sure why popovers do not work. As a consequence, you will likely need to move your popover provider per page if you have a fullscreen element with popovers inside. Since the provider uses the Popover API, it can successfully position a popover no matter where it is placed within the DOM unlike the previous implementation, which allows for the support of the Fullscreen API.

I am open to feedback on how to improve this implementation, especially regarding the javascript integration, however there is a wider scope for a more thorough refactor that could potentially make use of the auto or hint popover types, simplifying MudTooltip and the MudOverlay required behind input popovers for autoclose. 

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
