### PR TITLE
Components: Remove redundant and misleading ARIA markup

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/RadioGroup/RadioGroupRequiredTest.razor
@@ -9,7 +9,7 @@
 </MudRadioGroup>
 
 @code {
-    public static string __description__ = "Required RadioGroup should have required & aria-required attributes.";
+    public static string __description__ = "Required RadioGroup should have aria-required attributes.";
 
     [Parameter]
     public bool Required { get; set; }

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -361,46 +361,33 @@ namespace MudBlazor.UnitTests.Components
             radioGroup.FindAll(".mud-radio > span.mud-readonly").Count.Should().Be(4);
         }
 
-        /// <summary>
-        /// Optional RadioGroup should not have required attribute and aria-required should be false.
-        /// </summary>
         [Test]
-        public void OptionalRadioGroup_Should_NotHaveRequiredAttributeAndAriaRequiredShouldBeFalse()
+        public void OptionalRadioGroup_Should_HaveAriaRequiredFalse()
         {
             var comp = Context.Render<RadioGroupRequiredTest>();
 
-            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("false");
         }
 
-        /// <summary>
-        /// Required RadioGroup should have required and aria-required attributes.
-        /// </summary>
         [Test]
-        public void RequiredRadioGroup_Should_HaveRequiredAndAriaRequiredAttributes()
+        public void RequiredRadioGroup_Should_HaveAriaRequiredTrue()
         {
             var comp = Context.Render<RadioGroupRequiredTest>(parameters => parameters
                 .Add(p => p.Required, true));
 
-            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("true");
         }
 
-        /// <summary>
-        /// Required and aria-required RadioGroup attributes should be dynamic.
-        /// </summary>
         [Test]
-        public async Task RequiredAndAriaRequiredRadioGroupAttributes_Should_BeDynamic()
+        public async Task RadioGroupAriaRequired_Should_BeDynamic()
         {
             var comp = Context.Render<RadioGroupRequiredTest>();
 
-            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("false");
 
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(p => p.Required, true));
 
-            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("true");
         }
 

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -405,18 +405,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Radio_Uses_Native_Semantics()
-        {
-            var comp = Context.Render<MudRadio<bool>>(parameters => parameters.Add(x => x.Disabled, true));
-
-            var input = comp.Find("input");
-            input.GetAttribute("type").Should().Be("radio");
-            input.GetAttribute("disabled").Should().Be(string.Empty);
-            input.HasAttribute("role").Should().BeFalse();
-            input.HasAttribute("aria-disabled").Should().BeFalse();
-        }
-
-        [Test]
         public void Radio_Respects_Custom_TabIndex()
         {
             var comp = Context.Render<MudRadio<bool>>(parameters => parameters.AddUnmatched("tabindex", "-1"));

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -382,7 +382,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<RadioGroupRequiredTest>(parameters => parameters
                 .Add(p => p.Required, true));
 
-            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeTrue();
+            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("true");
         }
 
@@ -400,8 +400,20 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(p => p.Required, true));
 
-            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeTrue();
+            comp.Find("div[role=\"radiogroup\"]").HasAttribute("required").Should().BeFalse();
             comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-required").Should().Be("true");
+        }
+
+        [Test]
+        public void Radio_Uses_Native_Semantics()
+        {
+            var comp = Context.Render<MudRadio<bool>>(parameters => parameters.Add(x => x.Disabled, true));
+
+            var input = comp.Find("input");
+            input.GetAttribute("type").Should().Be("radio");
+            input.GetAttribute("disabled").Should().Be(string.Empty);
+            input.HasAttribute("role").Should().BeFalse();
+            input.HasAttribute("aria-disabled").Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -140,10 +140,6 @@ namespace MudBlazor.UnitTests.Components
                 input.GetAttribute(item.Key).Should().Be(item.Value);
             }
 
-            input.HasAttribute("aria-valuenow").Should().BeFalse();
-            input.HasAttribute("aria-valuemin").Should().BeFalse();
-            input.HasAttribute("aria-valuemax").Should().BeFalse();
-            input.HasAttribute("role").Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -130,10 +130,6 @@ namespace MudBlazor.UnitTests.Components
 
             var expectedAttributes = new Dictionary<string, string>()
             {
-                { "aria-valuenow","120" },
-                { "aria-valuemin","100" },
-                { "aria-valuemax","200" },
-                { "role","slider" },
                 { "min","100" },
                 { "max","200" },
                 { "step","10" },
@@ -143,6 +139,11 @@ namespace MudBlazor.UnitTests.Components
             {
                 input.GetAttribute(item.Key).Should().Be(item.Value);
             }
+
+            input.HasAttribute("aria-valuenow").Should().BeFalse();
+            input.HasAttribute("aria-valuemin").Should().BeFalse();
+            input.HasAttribute("aria-valuemax").Should().BeFalse();
+            input.HasAttribute("role").Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -139,7 +139,6 @@ namespace MudBlazor.UnitTests.Components
             {
                 input.GetAttribute(item.Key).Should().Be(item.Value);
             }
-
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -41,14 +41,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task TimePickerClockFace_Should_NotExpose_MenuRole()
-        {
-            var comp = await OpenPicker();
-
-            comp.Find(".mud-picker-time-clock-mask").HasAttribute("role").Should().BeFalse();
-        }
-
-        [Test]
         public async Task TimePicker_Should_Clear()
         {
             var comp = Context.Render<MudTimePicker>();

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -41,6 +41,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TimePickerClockFace_Should_NotExpose_MenuRole()
+        {
+            var comp = await OpenPicker();
+
+            comp.Find(".mud-picker-time-clock-mask").HasAttribute("role").Should().BeFalse();
+        }
+
+        [Test]
         public async Task TimePicker_Should_Clear()
         {
             var comp = Context.Render<MudTimePicker>();

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,7 +6,7 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" aria-disabled="@(GetDisabledState().ToString().ToLower())" checked="@Checked" role="radio" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" checked="@Checked" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -14,7 +14,7 @@
             <CascadingValue TValue="IForm" Value="null">
                 <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                     <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
-                        <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" required="@Required" aria-required="@Required.ToString().ToLowerInvariant()">
+                        <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" aria-required="@Required.ToString().ToLowerInvariant()">
                             @ChildContent
                         </div>
                     </CascadingValue>

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -35,7 +35,7 @@
 			</div>
 		}
         
-        <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)" max="@Max.ToString(null, CultureInfo.InvariantCulture)" step="@Step.ToString(null, CultureInfo.InvariantCulture)" aria-valuenow="@_valueState.Value" aria-valuemin="@Min.ToString(null, CultureInfo.InvariantCulture)" aria-valuemax="@Max.ToString(null, CultureInfo.InvariantCulture)" role="slider" @attributes="UserAttributes" disabled="@Disabled"
+        <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)" max="@Max.ToString(null, CultureInfo.InvariantCulture)" step="@Step.ToString(null, CultureInfo.InvariantCulture)" @attributes="UserAttributes" disabled="@Disabled"
                @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
         @if (ValueLabel)
         {

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor
@@ -31,7 +31,7 @@
         <MudPickerContent>
             <div class="mud-picker-time-container">
                 <div class="mud-picker-time-clock">
-                    <div role="menu" tabindex="-1" class="mud-picker-time-clock-mask" @ref="ClockElementReference" @oncontextmenu:preventDefault>
+                    <div tabindex="-1" class="mud-picker-time-clock-mask" @ref="ClockElementReference" @oncontextmenu:preventDefault>
                         <div class="@GetClockPinColor()"></div>
                         <div class="@GetClockPointerColor()" style="height: @GetPointerHeight(); transform: @GetPointerRotation()">
                             <div class="@GetClockPointerThumbColor()"></div>


### PR DESCRIPTION
## Summary

This PR removes ARIA and `role` attributes that are redundant for native controls or inaccurate for the rendered UI. The goal is to simplify the markup and let browsers expose the correct native semantics by default.

Closes #12967

## Changes

- Removed `role="slider"` and manual `aria-valuenow` / `aria-valuemin` / `aria-valuemax` from the native `input[type="range"]` used by `MudSlider`.
  Justification: native range inputs already expose slider semantics and current/min/max values, so duplicating them adds noise and can drift from the real control state.

- Removed `role="radio"` and `aria-disabled` from the native radio input used by `MudRadio`.
  Justification: native radio inputs already expose radio semantics, and `disabled` is the correct source of disabled state for assistive technology.

- Removed the plain `required` attribute from the `radiogroup` wrapper in `MudRadioGroup` while keeping `aria-required`.
  Justification: `required` is not valid on a generic `div`, but `aria-required` is appropriate for communicating group-level required state.

- Removed `role="menu"` from the `MudTimePicker` clock face container.
  Justification: the clock face is not a menu and should not announce a menu interaction model to assistive technology.

- Updated unit tests to assert the simplified markup and preserve the intended accessibility behavior.
  Justification: this locks in the native-semantics approach and prevents regressions back to redundant or misleading attributes.

## Why this is safe

These changes do not remove meaningful accessibility information from custom widgets. They only stop overriding or duplicating semantics that the browser already provides correctly, and they remove one incorrect role that announced the wrong pattern entirely.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
