### PR TITLE
MudFormComponent: Stabilize validation error IDs across invalid states

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -427,6 +427,34 @@ namespace MudBlazor.UnitTests.Components
             textfield.GetState(x => x.ErrorText).Should().Be("Not a valid number");
         }
 
+        [Test]
+        public async Task RequiredTextField_Should_ReuseGeneratedErrorIdWhileInvalid()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.Required, true));
+
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
+
+            var firstErrorId = comp.Find("input").GetAttribute("aria-describedby");
+            firstErrorId.Should().NotBeNullOrWhiteSpace();
+            comp.Find($"[id='{firstErrorId}']").TextContent.Should().Be("Required");
+
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
+
+            comp.Find("input").GetAttribute("aria-describedby").Should().Be(firstErrorId);
+
+            await comp.Find("input").ChangeAsync("valid");
+            await comp.Find("input").BlurAsync();
+
+            comp.Find("input").HasAttribute("aria-describedby").Should().BeFalse();
+
+            await comp.Find("input").ChangeAsync(string.Empty);
+            await comp.Find("input").BlurAsync();
+
+            var secondErrorId = comp.Find("input").GetAttribute("aria-describedby");
+            secondErrorId.Should().NotBeNullOrWhiteSpace();
+            secondErrorId.Should().NotBe(firstErrorId);
+        }
+
         /// <summary>
         /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
         /// already fulfill the requirement of Required="true". If it is a valid value is a different question.

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -455,6 +455,27 @@ namespace MudBlazor.UnitTests.Components
             secondErrorId.Should().NotBe(firstErrorId);
         }
 
+        [Test]
+        public async Task RequiredTextField_Should_RestoreProvidedErrorIdAfterBecomingValid()
+        {
+            const string errorId = "provided-error-id";
+
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Required, true)
+                .Add(p => p.ErrorId, errorId));
+
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
+            comp.Find("input").GetAttribute("aria-describedby").Should().Be(errorId);
+
+            await comp.Find("input").ChangeAsync("valid");
+            await comp.Find("input").BlurAsync();
+            comp.Find("input").HasAttribute("aria-describedby").Should().BeFalse();
+
+            await comp.Find("input").ChangeAsync(string.Empty);
+            await comp.Find("input").BlurAsync();
+            comp.Find("input").GetAttribute("aria-describedby").Should().Be(errorId);
+        }
+
         /// <summary>
         /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
         /// already fulfill the requirement of Required="true". If it is a valid value is a different question.

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -424,7 +424,7 @@ namespace MudBlazor
                     ValidationErrors = errors;
                     await ErrorState.SetValueAsync(errors.Count > 0);
                     await ErrorTextState.SetValueAsync(errors.FirstOrDefault());
-                    await ErrorIdState.SetValueAsync(HasErrors ? Guid.NewGuid().ToString() : null);
+                    await UpdateErrorIdStateAsync(HasErrors);
                     Form?.Update(this);
                     StateHasChanged();
                 }
@@ -671,6 +671,7 @@ namespace MudBlazor
             await ErrorState.SetValueAsync(false);
             ValidationErrors.Clear();
             await ErrorTextState.SetValueAsync(null);
+            await UpdateErrorIdStateAsync(false);
             ResetConverterErrors();
             await InvokeAsync(StateHasChanged);
         }
@@ -731,6 +732,7 @@ namespace MudBlazor
                     //TODO: v9 there no async API, but just make it async void (acceptable for EventHandler) 
                     await ErrorState.SetValueAsync(hasError);
                     await ErrorTextState.SetValueAsync(hasError ? errorMessages[0] : null);
+                    await UpdateErrorIdStateAsync(hasError);
 
                     ValidationErrors.Clear();
                     ValidationErrors.AddRange(errorMessages);
@@ -742,6 +744,15 @@ namespace MudBlazor
             {
                 Logger.LogError(exception, "An unexpected exception occurred: {ExceptionMessage}", exception.Message);
             }
+        }
+
+        private Task UpdateErrorIdStateAsync(bool hasErrors)
+        {
+            var errorId = hasErrors
+                ? ErrorIdState.RenderValue ?? ErrorIdState.Value ?? Guid.NewGuid().ToString()
+                : ErrorIdState.RenderValue;
+
+            return ErrorIdState.SetValueAsync(errorId);
         }
 
         /// <summary>


### PR DESCRIPTION
This change stabilizes the error ID used for `aria-describedby` during validation.

Today, when a control remains invalid across multiple validation cycles, MudBlazor generates a new error ID on each pass. That causes unnecessary DOM churn and makes the input-to-error ARIA relationship less stable than it needs to be.

With this change:

- if the consumer provides `ErrorId`, that ID is preserved and reused whenever the control is invalid
- if no `ErrorId` is provided, MudBlazor generates one when the control first becomes invalid
- that generated ID is reused while the control stays invalid
- when the control becomes valid or validation is reset, the active error ID is cleared
- if the control later becomes invalid again and no `ErrorId` was provided, a new generated ID is created for that new invalid state

In other words, the behavior is now stable within a single invalid state, while still preserving a consumer-provided `ErrorId` across valid/invalid transitions.

Before this change:
- each invalid validation pass could generate a fresh error ID
- the error element and `aria-describedby` target could change even though the control was still in the same invalid state

After this change:
- a generated error ID stays stable for the duration of a single invalid state
- a provided `ErrorId` is restored and reused across invalid states
- a new generated ID is only created when entering a new invalid state and no `ErrorId` was supplied

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
