### PR TITLE
Build: Rewrite `AGENTS.md` to improve speed and project rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,24 @@
 ```text
 src/
 - MudBlazor/                      Core library (components, styles, TScripts)
+- MudBlazor.Benchmarks/           Benchmark suite
+- MudBlazor.DevWatcher/           Local development watcher tooling
 - MudBlazor.Docs/                 Documentation site
 - MudBlazor.Docs.Compiler/        Docs generator
+- MudBlazor.Docs.Server/          Docs server host
+- MudBlazor.Docs.Wasm/            Docs WebAssembly client
 - MudBlazor.Docs.WasmHost/        Docs preview host
+- MudBlazor.Examples.Data/        Shared sample data for docs/examples
 - MudBlazor.UnitTests/            bUnit tests
+- MudBlazor.UnitTests.Docs.Generator/ Docs test generator
+- MudBlazor.UnitTests.Docs/       Docs and API page tests
+- MudBlazor.UnitTests.Analyzers/  Analyzer and code-fix tests
 - MudBlazor.UnitTests.Viewer/     Visual test runner
 - MudBlazor.Analyzers/            Roslyn analyzers
-- MudBlazor.SourceGenerator/      Source generators
+- MudBlazor.Analyzers.CodeFixes/  Roslyn code fixes
+- MudBlazor.Analyzers.TestComponents/ Analyzer test assets
+- MudBlazor.SourceGenerator/      Source generator folder present in this checkout
+- MudBlazor.UnitTests.Shared/     Shared test utilities
 ```
 
 ## Environment Requirements
@@ -38,8 +49,9 @@ src/
 
 ### Project targets
 - Components: `src/MudBlazor/MudBlazor.csproj` and `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`
-- Docs: `src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj` and `src/MudBlazor.Docs/MudBlazor.Docs.csproj`
-- Analyzers: `src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj` or `src/MudBlazor.SourceGenerator/MudBlazor.SourceGenerator.csproj`
+- Docs: `src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj`, `src/MudBlazor.Docs/MudBlazor.Docs.csproj`, `src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj`, and `src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj`
+- Docs tests: `src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj`
+- Analyzers and code fixes: `src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj`, `src/MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj`, and `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`
 
 ### Restore
 Run restore when starting a session or after changing project or tooling configuration:
@@ -47,6 +59,7 @@ Run restore when starting a session or after changing project or tooling configu
 ```bash
 dotnet restore src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
 dotnet restore src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
+dotnet tool restore --tool-manifest .config/dotnet-tools.json
 ```
 
 Re-run `dotnet restore` if any of these change:
@@ -64,7 +77,9 @@ dotnet build src/MudBlazor/MudBlazor.csproj --no-restore /p:SkipBunCompile=true 
 dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButtonTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
-### `SkipBunCompile`
+### Bun
+- Frontend asset builds use the local `bundotnet.cli` tool from `.config/dotnet-tools.json`, not a separately installed global Bun.
+- If Bun-related commands fail after tool or config changes, re-run `dotnet tool restore --tool-manifest .config/dotnet-tools.json`.
 - `/p:SkipBunCompile=true` skips the Bun-driven frontend asset compilation steps that normally run during build.
 - Use it when the goal is to validate .NET, C#, or Razor changes and you do not need regenerated frontend assets as part of verification.
 - It is typically safe for C#-only changes, Razor logic or markup changes, test changes, and documentation-only changes.
@@ -79,11 +94,18 @@ Formatting is required for changed files:
 dotnet format <project.csproj> --no-restore --include <path/to/changed/files>
 ```
 
+- If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
+
+```bash
+dotnet format src --no-restore
+```
+
 ### Choose the smallest valid verification loop
 - For component `.cs` or `.razor` changes: build `src/MudBlazor/MudBlazor.csproj`, then run the narrowest relevant unit test filter.
 - For `TScripts` or `Styles`: run a normal scoped project build.
-- For docs changes: build the docs project. Avoid docs host run loops during agent verification.
-- For analyzers or source generators: build the target project and run only analyzer-related tests.
+- For docs changes: build the relevant docs project. Avoid docs host run loops during agent verification.
+- For docs example or API-page changes that need parity with CI, run `dotnet test src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true`.
+- For analyzer or code-fix changes: build the target analyzer project and run the narrowest relevant tests from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`.
 - Prefer the narrowest relevant test filter over running an entire test project.
 - Use `dotnet clean <project.csproj>` only when incremental outputs are clearly stale or corrupted.
 
@@ -94,6 +116,7 @@ dotnet format <project.csproj> --no-restore --include <path/to/changed/files>
 - Do not overwrite component parameters directly. Use the backing `ParameterState<T>` and update through `.Value` or `SetValueAsync`.
 - Do not set other component parameters via `@ref` (`BL0005`). Use declarative binding instead.
 - Use `ParameterState<T>` for parameter updates and change handlers.
+- Parameters managed through the parameter-state framework should be annotated with `[Parameter, ParameterState]`.
 
 ### Styling and naming
 - Use `CssBuilder` for classes and styles.
@@ -180,7 +203,8 @@ private Task ToggleAsync()
 - Prefer minimal, focused examples that demonstrate one concept at a time.
 - Keep docs in sync with behavior and parameter changes.
 - Docs examples are exercised by generated tests, so they must render without exceptions.
-- Generated docs tests are created from examples during build. Generated files start with `_` and must not be edited by hand.
+- Generated docs tests are emitted as `Generated/*.generated.cs` files and must not be edited by hand.
+- `MudBlazor.UnitTests.Docs` does not generate docs tests in the default local build unless `GenerateDocsTests=true`.
 
 ## Breaking Changes and Compatibility
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@
 - Treat warnings as errors. Do not ignore analyzer warnings.
 - Do not run solution-wide build, test, or format commands unless explicitly requested.
 - Do not make `dotnet clean` part of the normal local loop. Use it only when incremental build state is clearly stale or corrupted.
+- Prefer one build-producing `dotnet` command per verification step. Use `dotnet test` when tests are needed, or `dotnet build` when compile validation is enough, but do not run both unless there is a clear reason.
+- Defer `dotnet format` until code has stabilized. Run it once near the end for the changed files instead of after each edit cycle.
 
 ## Repository Layout
 
@@ -40,7 +42,12 @@
 - Analyzers and code fixes: `src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj`, `src/MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj`, and `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`
 
 ### Restore
-Run restore when starting a session or after changing project or tooling configuration:
+Do not restore by default at session start. Restore only when one of these is true:
+- This is a fresh checkout or the relevant `obj/project.assets.json` files do not exist yet.
+- A build or test command fails because restore has not been run.
+- Project or tooling configuration changed.
+
+Common restore commands:
 
 ```bash
 dotnet restore src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -64,9 +71,17 @@ dotnet tool restore --tool-manifest .config/dotnet-tools.json
 
 ### Default local loop for C# or Razor component changes
 
-- Build `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` first so the full test project graph is compiled up front, including viewer and shared test dependencies.
-- Then run the narrowest relevant `dotnet test` command with `--no-build` so filtered test runs stay incremental and any hang diagnostics apply to test execution rather than a hidden build phase.
+- Prefer a single filtered `dotnet test` command for the first verification run. This builds and tests in one `dotnet` invocation.
+- Switch to an explicit `dotnet build` followed by repeated `dotnet test --no-build` commands only when you plan to run multiple test filters against the same compiled output.
 - Use `/p:SkipBunCompile=true` in this loop because it targets C#, Razor, and test validation that does not depend on regenerated frontend assets.
+
+Single-command fast path:
+
+```bash
+dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MenuTests" --no-restore /p:SkipBunCompile=true --nologo --blame-hang --blame-hang-timeout 30s
+```
+
+Multi-filter path when several test runs are expected:
 
 ```bash
 dotnet build src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true --nologo
@@ -97,12 +112,15 @@ dotnet format src --no-restore
 ```
 
 ### Choose the smallest valid verification loop
-- For component `.cs` or `.razor` changes: build `src/MudBlazor/MudBlazor.csproj`, then run the narrowest relevant unit test filter.
-- For `TScripts` or `Styles`: run a normal scoped project build.
-- For docs changes: build the relevant docs project. Avoid docs host run loops during agent verification.
-- For docs example or API-page changes that need parity with CI, run `dotnet test src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true`.
-- For analyzer or code-fix changes: build the target analyzer project and run the narrowest relevant tests from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`.
+- For component `.cs` or `.razor` changes: prefer one filtered `dotnet test` command against `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`. Add a separate `dotnet build` only if there is no meaningful test to run or if you intend to reuse the build for several filtered test invocations.
+- For test-only changes: run the narrowest relevant `dotnet test` filter directly. Do not add a separate build step first.
+- For `TScripts` or `Styles`: run one normal scoped project build.
+- For docs changes: build only the relevant docs project. Avoid docs host run loops during agent verification.
+- For docs example or API-page changes that need parity with CI, run `dotnet test src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true` and avoid extra docs builds unless they cover different risk.
+- For analyzer or code-fix changes: prefer one filtered `dotnet test` run from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`. Use a separate analyzer project build only when compile-only validation is needed.
 - Prefer the narrowest relevant test filter over running an entire test project.
+- Batch edits, then verify once. Do not rebuild after every small file change.
+- After a successful build-producing command, reuse outputs with `--no-build --no-restore` for follow-up test runs.
 - Use `dotnet clean <project.csproj>` only when incremental outputs are clearly stale or corrupted.
 
 ## Component Authoring Rules
@@ -239,7 +257,7 @@ private Task ToggleAsync()
 ## Change Checklist
 
 Before finishing, verify all of the following:
-- Formatting was run for changed files.
+- Formatting was run once for changed files after edits stabilized.
 - The target project builds cleanly with no new warnings.
 - Tests were updated and run when behavior changed.
 - Docs were updated when component logic changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Re-run `dotnet restore` if any of these change:
 
 ```bash
 dotnet build src/MudBlazor/MudBlazor.csproj --no-restore /p:SkipBunCompile=true --nologo
-dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButtonTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s
+dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButtonTests" --no-restore --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
 ### Bun

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,22 @@
 # AGENTS.md - AI Coding Agent Guide for MudBlazor
 
-This file is the project-specific instruction manual for AI coding agents. Follow it exactly unless the user asks otherwise. If a nested `AGENTS.md` exists in a subdirectory, follow the more specific rules for that area in addition to this file.
+## Scope and Workflow
 
-## Do / Don't (Read First)
+### Keep changes focused
+- Target specific projects only. Solution-wide commands are too slow unless explicitly requested.
+- Keep diffs small and focused. Avoid repo-wide rewrites unless explicitly asked.
+- Do not add new heavy dependencies or packages without approval.
+- Do not make speculative large changes when the intent is unclear. Ask a clarifying question or propose a short plan instead.
 
-### Do
-- target specific projects only; solution-wide commands are too slow
-- keep diffs small and focused; avoid repo-wide rewrites unless explicitly asked
-- follow `src/.editorconfig` and add file headers where required
-- add XML `<summary>` docs for all public properties
-- use `CssBuilder` for classes/styles and CSS variables (no hard-coded colors)
-- use `ParameterState<T>` for parameter updates and change handlers
-- keep `src/MudBlazor/TScripts/entrypoint.js` in sync with `src/MudBlazor/TScripts/` files (excluding `entrypoint.js`)
+### Default working rules
+- Follow `src/.editorconfig`.
+- Treat warnings as errors. Do not ignore analyzer warnings.
+- Do not run solution-wide build, test, or format commands unless explicitly requested.
+- Do not make `dotnet clean` part of the normal local loop. Use it only when incremental build state is clearly stale or corrupted.
 
-### Don't
-- do not add new heavy dependencies or packages without approval
-- do not run solution-wide build/test/format unless explicitly requested
-- do not put logic in parameter getters/setters (parameters must be auto-properties)
-- do not set other component parameters via `@ref` (BL0005)
-- do not hard code colors or bypass design tokens/CSS variables
-- do not ignore analyzer warnings; warnings are errors
+## Repository Layout
 
-## Project Map
-
-```
+```text
 src/
 - MudBlazor/                      Core library (components, styles, TScripts)
 - MudBlazor.Docs/                 Documentation site
@@ -35,104 +28,199 @@ src/
 - MudBlazor.SourceGenerator/      Source generators
 ```
 
-Key config:
-- `src/.editorconfig` (code style, file headers)
-- `src/Directory.Build.props` (warnings as errors)
-- `.github/workflows/build-test-mudblazor.yml` (CI)
+## Environment Requirements
 
-## Prerequisites
+- .NET 10.0 SDK (`10.0.100+`) is required for tests.
+- The library targets `net8.0`, `net9.0`, and `net10.0`.
+- Verify the SDK with `dotnet --version`.
 
-- .NET 10.0 SDK (10.0.100+) required for tests. Library targets net8.0/net9.0/net10.0.
-- Verify with `dotnet --version`.
+## Scoped Commands and Verification
 
-## Commands (Scoped)
-
-Target specific projects only:
-- Components: `src/MudBlazor/MudBlazor.csproj` + `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`
-- Docs: `src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj` + `src/MudBlazor.Docs/MudBlazor.Docs.csproj`
+### Project targets
+- Components: `src/MudBlazor/MudBlazor.csproj` and `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`
+- Docs: `src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj` and `src/MudBlazor.Docs/MudBlazor.Docs.csproj`
 - Analyzers: `src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj` or `src/MudBlazor.SourceGenerator/MudBlazor.SourceGenerator.csproj`
 
-Build/Test:
+### Restore
+Run restore when starting a session or after changing project or tooling configuration:
+
 ```bash
-dotnet clean <project.csproj>
-dotnet build <project.csproj> --nologo
-dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButton" --no-build --nologo --blame-hang --blame-hang-timeout 30s
+dotnet restore src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+dotnet restore src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
 ```
 
-C#-only builds (skip Bun for JS/SCSS):
-```bash
-dotnet build <project.csproj> /p:SkipBunCompile=true --nologo
-```
-Avoid this for styling/JS changes or full builds.
+Re-run `dotnet restore` if any of these change:
+- `*.csproj`
+- `src/Directory.Build.*`
+- `src/.editorconfig`
+- `src/package.json`
+- `src/bun.lock`
+- `.config/dotnet-tools.json`
 
-Formatting (required for changed files):
-```bash
-dotnet format <project.csproj> --include <path/to/changed/files>
-```
+### Default local loop for C# or Razor component changes
 
-Run locally:
 ```bash
-dotnet run --project src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
-dotnet run --project src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
-dotnet run --project src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+dotnet build src/MudBlazor/MudBlazor.csproj --no-restore /p:SkipBunCompile=true --nologo
+dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButtonTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
-## Component Rules
+### `SkipBunCompile`
+- `/p:SkipBunCompile=true` skips the Bun-driven frontend asset compilation steps that normally run during build.
+- Use it when the goal is to validate .NET, C#, or Razor changes and you do not need regenerated frontend assets as part of verification.
+- It is typically safe for C#-only changes, Razor logic or markup changes, test changes, and documentation-only changes.
+- Do not use it when changes touch `TScripts`, styles, CSS, SCSS, asset pipeline inputs, or tooling files that affect frontend bundles such as `src/package.json` or `src/bun.lock`.
+- Do not use it when the change depends on rebuilt generated JavaScript, CSS, or other static assets being present or up to date.
+- If you are unsure whether the build output depends on regenerated frontend assets, run the normal scoped build without `SkipBunCompile`.
 
-- Parameters are auto-properties only; no logic in getters/setters.
-- Do not overwrite component parameters; use the backing `ParameterState<T>` (`.Value`/`SetValueAsync`) for updates.
-- Never set other component parameters via `@ref` (BL0005). Use declarative binding.
-- RTL support: add `[CascadingParameter] public bool RightToLeft { get; set; }` when layout depends on direction.
-- Use `CssBuilder` for classes/styles and CSS variables (no hard-coded colors).
-- Add XML `<summary>` for all public properties and use the file header template from `src/.editorconfig`.
-- Components with logic require bUnit tests and a docs page: `src/MudBlazor.Docs/Pages/Components/<ComponentName>.razor`.
-- Follow best ARIA practices.
+### Formatting
+Formatting is required for changed files:
+
+```bash
+dotnet format <project.csproj> --no-restore --include <path/to/changed/files>
+```
+
+### Choose the smallest valid verification loop
+- For component `.cs` or `.razor` changes: build `src/MudBlazor/MudBlazor.csproj`, then run the narrowest relevant unit test filter.
+- For `TScripts` or `Styles`: run a normal scoped project build.
+- For docs changes: build the docs project. Avoid docs host run loops during agent verification.
+- For analyzers or source generators: build the target project and run only analyzer-related tests.
+- Prefer the narrowest relevant test filter over running an entire test project.
+- Use `dotnet clean <project.csproj>` only when incremental outputs are clearly stale or corrupted.
+
+## Component Authoring Rules
+
+### Parameters and state
+- Component parameters must be auto-properties only. Do not put logic in getters or setters.
+- Do not overwrite component parameters directly. Use the backing `ParameterState<T>` and update through `.Value` or `SetValueAsync`.
+- Do not set other component parameters via `@ref` (`BL0005`). Use declarative binding instead.
+- Use `ParameterState<T>` for parameter updates and change handlers.
+
+### Styling and naming
+- Use `CssBuilder` for classes and styles.
+- Use CSS variables and design tokens. Do not hard-code colors.
+- Prefer positive parameter names. Avoid names like `DisableGutters`; prefer `Gutters`.
+
+### Public API documentation
+- Add XML `<summary>` documentation for all public properties.
+- Prefer concise summaries that describe behavior, not "Gets or sets..." boilerplate.
+- Add `<remarks>` for public parameters when useful, including the default value when relevant.
+- Add the appropriate `[Category(CategoryTypes....)]` attribute to public component parameters.
+
+Example:
+
+```csharp
+/// <summary>
+/// Uses compact vertical padding.
+/// </summary>
+/// <remarks>
+/// Defaults to <c>false</c>.
+/// </remarks>
+[Parameter]
+[Category(CategoryTypes.Radio.Appearance)]
+public bool Dense { get; set; }
+```
+
+or
+
+```csharp
+/// <summary>
+/// Prevents interaction with background elements while this list is open.
+/// </summary>
+/// <remarks>
+/// Defaults to <see cref="PopoverOptions.ModalOverlay" />.
+/// </remarks>
+[Parameter]
+[Category(CategoryTypes.FormComponent.ListBehavior)]
+public bool? Modal { get; set; }
+```
+
+### Parameter registration pattern
+- Register parameters in the constructor with `CreateRegisterScope()`.
+- Use `.WithParameter(...)`, `.WithEventCallback(...)`, and `.WithChangeHandler(...)` where appropriate.
+- Put reaction logic in the change handler, not in the property setter.
+- Prefer method-group handlers for shared logic.
+
+Example:
+
+```csharp
+private readonly ParameterState<bool> _expandedState;
+
+[Parameter]
+public bool Expanded { get; set; }
+
+[Parameter]
+public EventCallback<bool> ExpandedChanged { get; set; }
+
+public MudExample()
+{
+    using var registerScope = CreateRegisterScope();
+    _expandedState = registerScope.RegisterParameter<bool>(nameof(Expanded))
+        .WithParameter(() => Expanded)
+        .WithEventCallback(() => ExpandedChanged)
+        .WithChangeHandler(OnExpandedChangedAsync);
+}
+
+private Task ToggleAsync()
+{
+    return _expandedState.SetValueAsync(!_expandedState.Value);
+}
+```
+
+### Accessibility and behavior
+- Add `[CascadingParameter] public bool RightToLeft { get; set; }` when layout depends on direction.
+- Follow best ARIA practices without adding noise.
 - Ensure keyboard navigation works for interactive components.
-- Provide accessible names for interactive controls (label, `aria-label`, or `aria-labelledby`).
+- Provide accessible names for interactive controls through a label, `aria-label`, or `aria-labelledby`.
+- Components with logic require bUnit tests and a docs page at `src/MudBlazor.Docs/Pages/Components/<ComponentName>.razor`.
 
 ## Docs Rules
 
 - Order examples from simple to complex.
 - Collapse examples longer than 15 lines by default.
-- Docs examples are exercised by generated tests; keep them rendering without exceptions.
-- Keep docs in sync with behavior and parameter changes; update examples and descriptions when APIs change.
 - Prefer minimal, focused examples that demonstrate one concept at a time.
+- Keep docs in sync with behavior and parameter changes.
+- Docs examples are exercised by generated tests, so they must render without exceptions.
+- Generated docs tests are created from examples during build. Generated files start with `_` and must not be edited by hand.
 
-## Breaking Changes
+## Breaking Changes and Compatibility
 
-- Avoid breaking changes whenever possible; prefer additive APIs, defaults, or obsoleting old behavior.
-- If a breaking change is required, call it out explicitly in the PR description and update docs/tests accordingly.
-- For parameter renames/removals, consider `[Obsolete]` with a clear message and a migration path.
+- Avoid breaking changes whenever possible.
+- Prefer additive APIs, safe defaults, or obsoleting old behavior.
+- If a breaking change is required, call it out explicitly in the PR description and update docs and tests accordingly.
+- For parameter renames or removals, consider `[Obsolete]` with a clear message and migration path.
 
 ## Testing Rules
 
-- bUnit: never cache `Find()`/`FindAll()` results; re-query after interactions.
-- bUnit: always use `InvokeAsync()` for parameter changes or method calls.
-- Prefer async bUnit interactions (`ClickAsync`, `ChangeAsync`, `BlurAsync`, `InputAsync`) over sync methods.
-- Keep tests isolated for parallel execution; rework tests to run in parallel instead of using `[NonParallelizable]` when possible.
-- Prefer `TimeProvider`/`FakeTimeProvider` over `Task.Delay`.
-- Test logic, not full HTML snapshots; use focused assertions.
-- Test components live in `src/MudBlazor.UnitTests.Viewer/TestComponents/<ComponentName>/`.
-- Tests live in `src/MudBlazor.UnitTests/Components/<ComponentName>Tests.cs`.
-- Test naming: no `Test`/`Async` suffixes, no `Test_` in the middle, no trailing underscores.
+### General testing guidance
+- Run the narrowest relevant test filter first.
+- Test logic rather than full HTML snapshots.
+- Keep tests isolated so they can run in parallel.
+- If a test modifies shared or static state, restore it in `[TearDown]`.
+- Use `[NonParallelizable]` only when isolation is not feasible.
+- Prefer `TimeProvider` or `FakeTimeProvider` over `Task.Delay`.
 
-## Code Style and Analyzers
+### bUnit rules
+- Never cache `Find()` or `FindAll()` results. Re-query after interactions.
+- Always use `InvokeAsync()` for parameter changes or method calls.
+- Prefer async interactions such as `ClickAsync`, `ChangeAsync`, `BlurAsync`, and `InputAsync` over sync methods.
 
-- Follow `src/.editorconfig` (indentation, using placement, file headers).
-- Treat warnings as errors; fix new warnings instead of suppressing them.
-- CS4014: no unobserved async discards (`_ = SomeAsync()` is an error).
-- BL0007: component parameters should be auto-properties.
+### Test locations and naming
+- Test components belong in `src/MudBlazor.UnitTests.Viewer/TestComponents/<ComponentName>/`.
+- Unit tests belong in `src/MudBlazor.UnitTests/Components/<ComponentName>Tests.cs`.
+- Add a viewer test component only when the scenario is too cumbersome to express directly in bUnit C# syntax. In those cases, add the viewer component first, then the unit test.
+- Test names must not use `Test` or `Async` suffixes, must not contain `Test_` in the middle, and must not end with trailing underscores.
+- Reference tests: `TextTests.cs`, `ApiMemberTableTests.cs`.
+
+## Code Style and Analyzer Rules
+
+- Fix new warnings instead of suppressing them.
+- Keep `src/MudBlazor/TScripts/entrypoint.js` in sync with files in `src/MudBlazor/TScripts/` except `entrypoint.js`.
 
 ## Change Checklist
 
-- scope is small and focused
-- formatting run for changed files
-- target project builds cleanly (no new warnings)
-- tests updated and run when behavior changes
-- docs updated for component logic changes
-- no new dependencies without approval
-
-## When Stuck
-
-- ask a clarifying question or propose a short plan
-- avoid speculative, large changes without confirmation
+Before finishing, verify all of the following:
+- Formatting was run for changed files.
+- The target project builds cleanly with no new warnings.
+- Tests were updated and run when behavior changed.
+- Docs were updated when component logic changed.
+- No new dependencies were added without approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,8 +258,8 @@ private Task ToggleAsync()
 ## Change Checklist
 
 Before finishing, verify all of the following:
-- Formatting was run for changed files.
-- The target project builds cleanly with no new warnings.
+- Formatting was run for changed files when formatting-relevant files under `src/` changed.
+- The relevant target project builds cleanly with no new warnings when code, docs app, analyzer, or asset inputs changed.
 - Tests were updated and run when behavior changed.
-- Docs were updated when component logic changed.
+- Docs were updated when component behavior or public API changed.
 - No new dependencies were added without approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ src/
 
 ## Environment Requirements
 
-- .NET 10.0 SDK (`10.0.100+`) is required for tests.
+- A .NET 10.x SDK is required to restore, build, and test this repository.
 - The library targets `net8.0`, `net9.0`, and `net10.0`.
-- Verify the SDK with `dotnet --version`.
+- Verify the active SDK with `dotnet --version`.
 
 ## Scoped Commands and Verification
 
@@ -74,7 +74,7 @@ Re-run `dotnet restore` if any of these change:
 
 ```bash
 dotnet build src/MudBlazor/MudBlazor.csproj --no-restore /p:SkipBunCompile=true --nologo
-dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MudButtonTests" --no-restore --nologo --blame-hang --blame-hang-timeout 30s
+dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~ButtonsTests" --no-restore --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
 ### Bun

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,16 +65,22 @@ dotnet tool restore --tool-manifest .config/dotnet-tools.json
 Re-run `dotnet restore` if any of these change:
 - `*.csproj`
 - `src/Directory.Build.*`
-- `src/.editorconfig`
-- `src/package.json`
-- `src/bun.lock`
-- `.config/dotnet-tools.json`
+- `Directory.Packages.props`, if added later
+- `NuGet.Config` or other NuGet restore configuration files, if added later
+
+- If `.config/dotnet-tools.json` changes, run:
+
+```bash
+dotnet tool restore --tool-manifest .config/dotnet-tools.json
+```
+
+- If `src/package.json` or `src/bun.lock` changes, run a normal scoped build without `SkipBunCompile` for the affected project so the frontend asset pipeline runs.
 
 ### Default local loop for C# or Razor component changes
 
 ```bash
-dotnet build src/MudBlazor/MudBlazor.csproj --no-restore /p:SkipBunCompile=true --nologo
-dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~ButtonsTests" --no-restore --nologo --blame-hang --blame-hang-timeout 30s
+dotnet build src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true --nologo
+dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MenuTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
 ### Bun

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ dotnet tool restore --tool-manifest .config/dotnet-tools.json
 
 ### Default local loop for C# or Razor component changes
 
+- Build `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` first so the full test project graph is compiled up front, including viewer and shared test dependencies.
+- Then run the narrowest relevant `dotnet test` command with `--no-build` so filtered test runs stay incremental and any hang diagnostics apply to test execution rather than a hidden build phase.
+- Use `/p:SkipBunCompile=true` in this loop because it targets C#, Razor, and test validation that does not depend on regenerated frontend assets.
+
 ```bash
 dotnet build src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true --nologo
 dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MenuTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,28 +16,14 @@
 
 ## Repository Layout
 
-```text
-src/
-- MudBlazor/                      Core library (components, styles, TScripts)
-- MudBlazor.Benchmarks/           Benchmark suite
-- MudBlazor.DevWatcher/           Local development watcher tooling
-- MudBlazor.Docs/                 Documentation site
-- MudBlazor.Docs.Compiler/        Docs generator
-- MudBlazor.Docs.Server/          Docs server host
-- MudBlazor.Docs.Wasm/            Docs WebAssembly client
-- MudBlazor.Docs.WasmHost/        Docs preview host
-- MudBlazor.Examples.Data/        Shared sample data for docs/examples
-- MudBlazor.UnitTests/            bUnit tests
-- MudBlazor.UnitTests.Docs.Generator/ Docs test generator
-- MudBlazor.UnitTests.Docs/       Docs and API page tests
-- MudBlazor.UnitTests.Analyzers/  Analyzer and code-fix tests
-- MudBlazor.UnitTests.Viewer/     Visual test runner
-- MudBlazor.Analyzers/            Roslyn analyzers
-- MudBlazor.Analyzers.CodeFixes/  Roslyn code fixes
-- MudBlazor.Analyzers.TestComponents/ Analyzer test assets
-- MudBlazor.SourceGenerator/      Source generator folder present in this checkout
-- MudBlazor.UnitTests.Shared/     Shared test utilities
-```
+- `src/` contains the product code and nearly all project work. Expect the main library, docs app, tests, analyzers, benchmarks, and related support projects to live here.
+- `src/MudBlazor/` is the core component library. Most component, utility, styling, `TScripts`, and `wwwroot` changes land here.
+- `src/MudBlazor.UnitTests*` contains test projects and test support code. Look here for component tests, shared test infrastructure, viewer-only helpers, and docs-related tests.
+- `src/MudBlazor.Docs*` contains the documentation site, examples, and docs build support. Update docs here when component behavior or public API changes.
+- `src/MudBlazor.Analyzers*` contains analyzer, code-fix, and analyzer-test projects.
+- Repo-wide build configuration is centered in `src/`, especially `src/Directory.Build.*` and `src/.editorconfig`.
+- Tooling and automation live primarily in `tools/`, `.config/`, and `.github/`.
+- Treat `bin/`, `obj/`, `TestResults/`, generated files, and similar outputs as build artifacts unless the task explicitly targets them.
 
 ## Environment Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@
 - Treat warnings as errors. Do not ignore analyzer warnings.
 - Do not run solution-wide build, test, or format commands unless explicitly requested.
 - Do not make `dotnet clean` part of the normal local loop. Use it only when incremental build state is clearly stale or corrupted.
-- Prefer one build-producing `dotnet` command per verification step. Use `dotnet test` when tests are needed, or `dotnet build` when compile validation is enough, but do not run both unless there is a clear reason.
-- Defer `dotnet format` until code has stabilized. Run it once near the end for the changed files instead of after each edit cycle.
+- If no code, project, test, docs app, or asset-pipeline inputs changed, do not call `dotnet`. Changes limited to files such as `README.md`, changelog text, issue templates, or other repo metadata do not require restore, build, test, or format.
+- Prefer a single scoped `dotnet build` or `dotnet test` command as the first verification step. Split build and test only when you will reuse the build outputs for multiple test runs.
+- Do not build `src/MudBlazor/MudBlazor.csproj` immediately before testing `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`; the test project already builds `MudBlazor`, `MudBlazor.UnitTests.Shared`, and `MudBlazor.UnitTests.Viewer`.
 
 ## Repository Layout
 
@@ -42,15 +43,16 @@
 - Analyzers and code fixes: `src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj`, `src/MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj`, and `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`
 
 ### Restore
-Do not restore by default at session start. Restore only when one of these is true:
-- This is a fresh checkout or the relevant `obj/project.assets.json` files do not exist yet.
-- A build or test command fails because restore has not been run.
-- Project or tooling configuration changed.
+Do not run restore automatically at the start of every session. Reuse existing assets in the working tree.
 
-Common restore commands:
+Run restore only when restore inputs changed, when the target project's `obj/project.assets.json` is missing, or when a `--no-restore` build or test fails because restore data is stale.
+
+Restore only the project graph you are about to validate:
 
 ```bash
 dotnet restore src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+dotnet restore src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
+dotnet restore src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
 dotnet restore src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
 dotnet tool restore --tool-manifest .config/dotnet-tools.json
 ```
@@ -71,21 +73,19 @@ dotnet tool restore --tool-manifest .config/dotnet-tools.json
 
 ### Default local loop for C# or Razor component changes
 
-- Prefer a single filtered `dotnet test` command for the first verification run. This builds and tests in one `dotnet` invocation.
-- Switch to an explicit `dotnet build` followed by repeated `dotnet test --no-build` commands only when you plan to run multiple test filters against the same compiled output.
+- For a single validation pass, prefer one filtered `dotnet test` command. This builds the component library plus the relevant test graph and runs the selected tests in one invocation.
 - Use `/p:SkipBunCompile=true` in this loop because it targets C#, Razor, and test validation that does not depend on regenerated frontend assets.
-
-Single-command fast path:
 
 ```bash
 dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MenuTests" --no-restore /p:SkipBunCompile=true --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
-Multi-filter path when several test runs are expected:
+- If you expect to run multiple filtered test commands against the same edits, build once and then reuse the outputs with `--no-build`:
 
 ```bash
 dotnet build src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true --nologo
 dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~MenuTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s
+dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~PopoverTests" --no-build --no-restore --nologo --blame-hang --blame-hang-timeout 30s
 ```
 
 ### Bun
@@ -105,6 +105,8 @@ Formatting is required for changed files:
 dotnet format <project.csproj> --no-restore --include <path/to/changed/files>
 ```
 
+- Run `dotnet format` once near the end of the task after edits have stabilized. Do not put format into the normal edit-build-test loop.
+
 - If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
 
 ```bash
@@ -112,15 +114,14 @@ dotnet format src --no-restore
 ```
 
 ### Choose the smallest valid verification loop
-- For component `.cs` or `.razor` changes: prefer one filtered `dotnet test` command against `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`. Add a separate `dotnet build` only if there is no meaningful test to run or if you intend to reuse the build for several filtered test invocations.
-- For test-only changes: run the narrowest relevant `dotnet test` filter directly. Do not add a separate build step first.
-- For `TScripts` or `Styles`: run one normal scoped project build.
-- For docs changes: build only the relevant docs project. Avoid docs host run loops during agent verification.
-- For docs example or API-page changes that need parity with CI, run `dotnet test src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true` and avoid extra docs builds unless they cover different risk.
-- For analyzer or code-fix changes: prefer one filtered `dotnet test` run from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`. Use a separate analyzer project build only when compile-only validation is needed.
+- For repository metadata or prose-only changes outside the build inputs, such as `README.md`, `CHANGELOG.md`, or `.github/` text-only edits: do not run `dotnet`.
+- For component `.cs` or `.razor` changes with behavior coverage: prefer a single filtered `dotnet test` against `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` with `/p:SkipBunCompile=true`. Build `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` first only when you plan to reuse the outputs for multiple test filters.
+- For component `.cs` or `.razor` changes that only need compile validation: build `src/MudBlazor/MudBlazor.csproj` with `/p:SkipBunCompile=true`.
+- For `TScripts` or `Styles`: run a normal scoped project build.
+- For docs changes: build the relevant docs project. Avoid docs host run loops during agent verification.
+- For docs example or API-page changes that need parity with CI, run `dotnet test src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true`.
+- For analyzer or code-fix changes: prefer a single filtered `dotnet test` from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`. Build that project first only when you plan multiple filtered test runs.
 - Prefer the narrowest relevant test filter over running an entire test project.
-- Batch edits, then verify once. Do not rebuild after every small file change.
-- After a successful build-producing command, reuse outputs with `--no-build --no-restore` for follow-up test runs.
 - Use `dotnet clean <project.csproj>` only when incremental outputs are clearly stale or corrupted.
 
 ## Component Authoring Rules
@@ -257,7 +258,7 @@ private Task ToggleAsync()
 ## Change Checklist
 
 Before finishing, verify all of the following:
-- Formatting was run once for changed files after edits stabilized.
+- Formatting was run for changed files.
 - The target project builds cleanly with no new warnings.
 - Tests were updated and run when behavior changed.
 - Docs were updated when component logic changed.


### PR DESCRIPTION
Intent:

- reduce agent time spent on unnecessary restore/build/test work
- make command guidance more decision-oriented instead of purely prescriptive
- reduce style churn in generated parameter/property docs
- keep new component APIs aligned with existing MudBlazor preferences

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
