### PR TITLE
Tests: Improve readability of docs tests

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
@@ -16,18 +16,17 @@ namespace MudBlazor.UnitTests.Docs.Documentation;
 public sealed class ApiMemberTableTests : BunitTest
 {
     /// <summary>
-    /// Ensures that a missing type renders properly.
+    /// Renders the empty-state message for a missing type.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderMissingType()
     {
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters.Add(x => x.Type, null));
-        // There should be a message saying no members are found
-        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
+        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.None"/> renders properly.
+    /// Renders the empty-state message in <see cref="ApiMemberTableMode.None"/>.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderNoneMode()
@@ -36,12 +35,11 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.None));
-        // There should be a message saying no members are found
-        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
+        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Properties"/> renders properly with showing protected properties.
+    /// Renders <see cref="ApiMemberTableMode.Properties"/> with protected properties shown.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderProperties_WithProtected()
@@ -52,16 +50,13 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Properties)
             .Add(x => x.ShowProtected, true));
-        // There should NOT be a message saying no members are found
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
-        // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
-        // The "Classname" protected property should be visible
-        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"Classname\">");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"Classname\">", "The \"Classname\" protected property should be visible");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Properties"/> renders properly without showing protected properties.
+    /// Renders <see cref="ApiMemberTableMode.Properties"/> with protected properties hidden.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderProperties_WithoutProtected()
@@ -72,16 +67,13 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Properties)
             .Add(x => x.ShowProtected, false));
-        // There should NOT be a message saying no members are found
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
-        // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
-        // The "Classname" protected property should NOT be visible
-        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">", "The \"Classname\" protected property should NOT be visible");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Methods"/> renders properly with showing protected methods.
+    /// Renders <see cref="ApiMemberTableMode.Methods"/> with protected methods shown.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderMethods_WithProtected()
@@ -92,16 +84,13 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAutocomplete)
             .Add(x => x.Mode, ApiMemberTableMode.Methods)
             .Add(x => x.ShowProtected, true));
-        // There should NOT be a message saying no members are found
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
-        // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
-        // The "BeginValidateAsync" protected method should be visible
-        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"BeginValidateAsync\">");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"BeginValidateAsync\">", "The \"BeginValidateAsync\" protected method should be visible");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Methods"/> renders properly without showing protected methods.
+    /// Renders <see cref="ApiMemberTableMode.Methods"/> with protected methods hidden.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderMethods_WithoutProtected()
@@ -112,16 +101,13 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAutocomplete)
             .Add(x => x.Mode, ApiMemberTableMode.Methods)
             .Add(x => x.ShowProtected, false));
-        // There should NOT be a message saying no members are found
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
-        // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
-        // The "BeginValidateAsync" protected method should NOT be visible
-        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">", "The \"BeginValidateAsync\" protected method should NOT be visible");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Methods"/> renders properly with showing protected fields.
+    /// Renders <see cref="ApiMemberTableMode.Fields"/> with protected fields shown.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderFields_WithProtected()
@@ -132,16 +118,13 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudBaseDatePicker)
             .Add(x => x.Mode, ApiMemberTableMode.Fields)
             .Add(x => x.ShowProtected, true));
-        // There should NOT be a message saying no members are found
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
-        // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
-        // The "CurrentView" protected field should be visible
-        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"CurrentView\">");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"CurrentView\">", "The \"CurrentView\" protected field should be visible");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Fields"/> renders properly without showing protected fields.
+    /// Renders <see cref="ApiMemberTableMode.Fields"/> with protected fields hidden.
     /// </summary>
     [Test]
     public void ApiMemberTable_RenderFields_WithoutProtected()
@@ -152,16 +135,13 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudBaseDatePicker)
             .Add(x => x.Mode, ApiMemberTableMode.Fields)
             .Add(x => x.ShowProtected, false));
-        // There should be a message saying no members are found  (since the protected field was the ONLY field)
-        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
-        // There should be a switch for protected properties
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>");
-        // The "CurrentView" protected field should NOT be visible
-        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">");
+        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found  (since the protected field was the ONLY field)");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">", "The \"CurrentView\" protected field should NOT be visible");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Events"/> renders properly for a type with events.
+    /// Renders <see cref="ApiMemberTableMode.Events"/> for a type with events.
     /// </summary>
     /// <remarks>
     /// At the time of writing this test, there are no protected events in the entire MudBlazor library.
@@ -174,12 +154,11 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudDataGrid)
             .Add(x => x.Mode, ApiMemberTableMode.Events));
-        // There should NOT be a message saying no members are found  
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Globals"/> renders properly for a type with globals.
+    /// Renders <see cref="ApiMemberTableMode.Globals"/> for a type with globals.
     /// </summary>
     /// <remarks>
     /// At the time of writing this test, there are globals for <see cref="MudMenu"/>.
@@ -192,12 +171,11 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudMenu)
             .Add(x => x.Mode, ApiMemberTableMode.Globals));
-        // There should NOT be a message saying no members are found  
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.Globals"/> renders properly for a type WITHOUT globals.
+    /// Renders the empty state in <see cref="ApiMemberTableMode.Globals"/> when no globals exist.
     /// </summary>
     /// <remarks>
     /// At the time of writing this test, there are NO globals for <see cref="MudAlert"/>.
@@ -210,7 +188,6 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Globals));
-        // There should be a message saying no members are found  
-        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>");
+        comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
@@ -22,6 +22,7 @@ public sealed class ApiMemberTableTests : BunitTest
     public void ApiMemberTable_RenderMissingType()
     {
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters.Add(x => x.Type, null));
+
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found");
     }
 
@@ -35,6 +36,7 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.None));
+
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found");
     }
 
@@ -50,8 +52,11 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Properties)
             .Add(x => x.ShowProtected, true));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"Classname\">", "The \"Classname\" protected property should be visible");
     }
 
@@ -67,8 +72,11 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Properties)
             .Add(x => x.ShowProtected, false));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">", "The \"Classname\" protected property should NOT be visible");
     }
 
@@ -84,8 +92,11 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAutocomplete)
             .Add(x => x.Mode, ApiMemberTableMode.Methods)
             .Add(x => x.ShowProtected, true));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"BeginValidateAsync\">", "The \"BeginValidateAsync\" protected method should be visible");
     }
 
@@ -101,8 +112,11 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudAutocomplete)
             .Add(x => x.Mode, ApiMemberTableMode.Methods)
             .Add(x => x.ShowProtected, false));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">", "The \"BeginValidateAsync\" protected method should NOT be visible");
     }
 
@@ -118,8 +132,11 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudBaseDatePicker)
             .Add(x => x.Mode, ApiMemberTableMode.Fields)
             .Add(x => x.ShowProtected, true));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"CurrentView\">", "The \"CurrentView\" protected field should be visible");
     }
 
@@ -135,8 +152,11 @@ public sealed class ApiMemberTableTests : BunitTest
             .Add(x => x.Type, mudBaseDatePicker)
             .Add(x => x.Mode, ApiMemberTableMode.Fields)
             .Add(x => x.ShowProtected, false));
+
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found  (since the protected field was the ONLY field)");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">", "The \"CurrentView\" protected field should NOT be visible");
     }
 
@@ -154,6 +174,7 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudDataGrid)
             .Add(x => x.Mode, ApiMemberTableMode.Events));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
     }
 
@@ -171,6 +192,7 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudMenu)
             .Add(x => x.Mode, ApiMemberTableMode.Globals));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
     }
 
@@ -188,6 +210,7 @@ public sealed class ApiMemberTableTests : BunitTest
         using var comp = Context.Render<ApiMemberTable>(parameters => parameters
             .Add(x => x.Type, mudAlert)
             .Add(x => x.Mode, ApiMemberTableMode.Globals));
+
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
@@ -16,7 +16,7 @@ namespace MudBlazor.UnitTests.Docs.Documentation;
 public sealed class ApiSeeAlsoLinksTests : BunitTest
 {
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.SeeAlso"/> renders properly for a type without see-also links.
+    /// Renders <see cref="ApiMemberTableMode.SeeAlso"/> when see-also links exist.
     /// </summary>
     /// <remarks>
     /// At the time of writing this test, there are see-also links for <see cref="MudButton"/>.
@@ -27,15 +27,13 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
         // Get a type with see-also links
         var mudButton = ApiDocumentation.GetType("MudBlazor.MudButton");
         using var comp = Context.Render<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudButton));
-        // There should be a see-also link to MudButtonGroup
-        comp.Markup.Should().Contain("<a href=\"/api/MudButtonGroup\"");
-        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudButtonGroup</a>");
-        // There should NOT be a message saying no members are found  
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>");
+        comp.Markup.Should().Contain("<a href=\"/api/MudButtonGroup\"", "There should be a see-also link to MudButtonGroup");
+        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudButtonGroup</a>", "There should be a see-also link to MudButtonGroup");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>", "There should NOT be a message saying no members are found");
     }
 
     /// <summary>
-    /// Ensures that a mode of <see cref="ApiMemberTableMode.SeeAlso"/> renders properly for a type without see-also links.
+    /// Renders the empty state in <see cref="ApiMemberTableMode.SeeAlso"/> when no see-also links exist.
     /// </summary>
     /// <remarks>
     /// At the time of writing this test, there are no see-also links for <see cref="MudAlert"/>.
@@ -46,7 +44,6 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
         // Get a type with no see-also links
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
         using var comp = Context.Render<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudAlert));
-        // There should be a message saying no members are found  
-        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>");
+        comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>", "the current assertion expects no empty-state message");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
@@ -27,8 +27,11 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
         // Get a type with see-also links
         var mudButton = ApiDocumentation.GetType("MudBlazor.MudButton");
         using var comp = Context.Render<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudButton));
+
         comp.Markup.Should().Contain("<a href=\"/api/MudButtonGroup\"", "There should be a see-also link to MudButtonGroup");
+
         comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudButtonGroup</a>", "There should be a see-also link to MudButtonGroup");
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>", "There should NOT be a message saying no members are found");
     }
 
@@ -44,6 +47,7 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
         // Get a type with no see-also links
         var mudAlert = ApiDocumentation.GetType("MudBlazor.MudAlert");
         using var comp = Context.Render<ApiSeeAlsoLinks>(parameters => parameters.Add(x => x.Type, mudAlert));
+
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>", "the current assertion expects no empty-state message");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
@@ -21,6 +21,7 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_HandleMalformedXmlDocs()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Sorry guys, I was drunk when I <see cref wrote these docs, </burp>"));
+
         comp.Markup.Should().Be("<span class=\"mud-typography mud-typography-caption mud-warning-text\">XML documentation error.</span>");
     }
 
@@ -31,6 +32,7 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderJustText()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets or sets the icon for this widget."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets or sets the icon for this widget.</span>");
     }
 
@@ -41,6 +43,7 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderNullText()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, null));
+
         comp.Markup.Should().Be("");
     }
 
@@ -51,6 +54,7 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderEmptyText()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, ""));
+
         comp.Markup.Should().Be("");
     }
 
@@ -61,8 +65,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeHref_SelfClosing()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\" /> right now."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"https://www.mudblazor.com\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">https://www.mudblazor.com", "Then a link to https://www.mudblazor.com with the same text");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> right now.</span>", "Ending with another text span");
     }
 
@@ -73,8 +80,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeHref_WithText()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\">MudBlazor</see> right now."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"https://www.mudblazor.com\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">MudBlazor", "Then a link to \"MudBlazor\" (text)");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> right now.</span>", "Ending with another text span");
     }
 
@@ -85,6 +95,7 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeHref_EmptyUrl()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For another Blazor library, go to <see href=\"\" />."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For another Blazor library, go to </span><span class=\"mud-typography mud-typography-caption\">.</span>", "The link should be skipped completely");
     }
 
@@ -95,8 +106,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_ExistingProperty()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.MudComponentBase.Class\" /> has changed."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"/api/MudComponentBase#Class\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Class</a>", "Then a link to /api/MudComponentBase#Class");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>", "Ending with another text span");
     }
 
@@ -107,8 +121,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_NonExistantProperty()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.NotExistingType.NotExistingProperty\" /> has changed."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.NotExistingType.NotExistingProperty</code>", "There's no valid link, just a span for the non-existant property");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>", "Ending with another text span");
     }
 
@@ -119,8 +136,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_ExistingMethod()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.AggregateDefinition`1.SimpleAvg\" /> to receive viewport changes."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"/api/AggregateDefinition`1#SimpleAvg\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">SimpleAvg</a>", "Then a link to /api/AggregateDefinition`1#SimpleAvg");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to receive viewport changes.</span>", "Ending with another text span");
     }
 
@@ -131,8 +151,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_NonExistantMethod()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.NotExistingType.NotExistingMethod\" /> to do stuff."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.NotExistingType.NotExistingMethod</code>", "There's no valid link, just a span for the non-existant method");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to do stuff.</span>", "Ending with another text span");
     }
 
@@ -143,8 +166,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_ExistingField()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.End\" />."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"/api/Adornment#End", "There should be a link to /api/Adornment");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 
@@ -155,8 +181,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_NonExistantField()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.EndOfTheUniverse\" />."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.Adornment.EndOfTheUniverse</code>", "There should be a text span");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 
@@ -167,8 +196,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_ExistingEvent()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnClick\" /> event occurs."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"/api/MudAlert#OnClick\"", "There should be a link to /api/MudAlert#OnClick");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> event occurs.</span>", "There should be a text span");
     }
 
@@ -179,8 +211,11 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_NonExistantEvent()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnSmokeAlarmInYourHouse\" /> event occurs."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.MudAlert.OnSmokeAlarmInYourHouse</code>", "There should be a text span");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> event occurs.</span>", "There should be a text span");
     }
 
@@ -191,9 +226,13 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_External_MicrosoftType()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "The button can contain a <see cref=\"T:Microsoft.AspNetCore.Components.RenderFragment\" />."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The button can contain a </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.components.renderfragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">RenderFragment", "There should be a link to Microsoft docs");
+
         comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 
@@ -204,9 +243,13 @@ public sealed class ApiTextTests : BunitTest
     public void ApiText_RenderSeeCref_External_SystemType()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "The popover unique ID is a <see cref=\"T:System.Guid\" />."));
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The popover unique ID is a </span>", "There should be a text span");
+
         comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/system.guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Guid", "There should be a link to Microsoft docs");
+
         comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
+
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Docs.Documentation;
 public sealed class ApiTextTests : BunitTest
 {
     /// <summary>
-    /// Ensures that malformed text is handled gracefully.
+    /// Handles malformed XML documentation text gracefully.
     /// </summary>
     [Test]
     public void ApiText_HandleMalformedXmlDocs()
@@ -25,7 +25,7 @@ public sealed class ApiTextTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that regular text renders properly.
+    /// Renders plain text.
     /// </summary>
     [Test]
     public void ApiText_RenderJustText()
@@ -35,7 +35,7 @@ public sealed class ApiTextTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that null text renders properly.
+    /// Renders null text as empty output.
     /// </summary>
     [Test]
     public void ApiText_RenderNullText()
@@ -45,7 +45,7 @@ public sealed class ApiTextTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that empty text renders properly.
+    /// Renders empty text as empty output.
     /// </summary>
     [Test]
     public void ApiText_RenderEmptyText()
@@ -55,197 +55,158 @@ public sealed class ApiTextTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that self closing <see href="" /> links render properly.
+    /// Renders self-closing <c>&lt;see href="" /&gt;</c> links.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeHref_SelfClosing()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\" /> right now."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>");
-        // Then a link to https://www.mudblazor.com with the same text
-        comp.Markup.Should().Contain("<a href=\"https://www.mudblazor.com\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">https://www.mudblazor.com");
-        // Ending with another text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> right now.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"https://www.mudblazor.com\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">https://www.mudblazor.com", "Then a link to https://www.mudblazor.com with the same text");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> right now.</span>", "Ending with another text span");
     }
 
     /// <summary>
-    /// Ensures that <see href=""/> links with interior text render properly.
+    /// Renders <c>&lt;see href=""&gt;...&lt;/see&gt;</c> links with inner text.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeHref_WithText()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For the best Blazor components, go to <see href=\"https://www.mudblazor.com\">MudBlazor</see> right now."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>");
-        // Then a link to "MudBlazor" (text)
-        comp.Markup.Should().Contain("<a href=\"https://www.mudblazor.com\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">MudBlazor");
-        // Ending with another text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> right now.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For the best Blazor components, go to </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"https://www.mudblazor.com\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">MudBlazor", "Then a link to \"MudBlazor\" (text)");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> right now.</span>", "Ending with another text span");
     }
 
     /// <summary>
-    /// Ensures that empty <see href=""/> links are skipped.
+    /// Skips empty <c>&lt;see href="" /&gt;</c> links.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeHref_EmptyUrl()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "For another Blazor library, go to <see href=\"\" />."));
-        // The link should be skipped completely
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For another Blazor library, go to </span><span class=\"mud-typography mud-typography-caption\">.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">For another Blazor library, go to </span><span class=\"mud-typography mud-typography-caption\">.</span>", "The link should be skipped completely");
     }
 
     /// <summary>
-    /// Ensures that <see cref=""/> links to existing properties render properly.
+    /// Renders <c>&lt;see cref="" /&gt;</c> links to existing properties.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_ExistingProperty()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.MudComponentBase.Class\" /> has changed."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>");
-        // Then a link to /api/MudComponentBase#Class
-        comp.Markup.Should().Contain("<a href=\"/api/MudComponentBase#Class\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Class</a>");
-        // Ending with another text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"/api/MudComponentBase#Class\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Class</a>", "Then a link to /api/MudComponentBase#Class");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>", "Ending with another text span");
     }
 
     /// <summary>
-    /// Ensures that invalid <see cref=""/> links to non-existant properties render properly.
+    /// Renders invalid <c>&lt;see cref="" /&gt;</c> links to non-existent properties as code.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_NonExistantProperty()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Occurs when <see cref=\"P:MudBlazor.NotExistingType.NotExistingProperty\" /> has changed."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>");
-        // There's no valid link, just a span for the non-existant property
-        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.NotExistingType.NotExistingProperty</code>");
-        // Ending with another text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.NotExistingType.NotExistingProperty</code>", "There's no valid link, just a span for the non-existant property");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>", "Ending with another text span");
     }
 
     /// <summary>
-    /// Ensures that <see cref=""/> links to existing methods render properly.
+    /// Renders <c>&lt;see cref="" /&gt;</c> links to existing methods.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_ExistingMethod()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.AggregateDefinition`1.SimpleAvg\" /> to receive viewport changes."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>");
-        // Then a link to /api/AggregateDefinition`1#SimpleAvg
-        comp.Markup.Should().Contain("<a href=\"/api/AggregateDefinition`1#SimpleAvg\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">SimpleAvg</a>");
-        // Ending with another text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to receive viewport changes.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"/api/AggregateDefinition`1#SimpleAvg\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">SimpleAvg</a>", "Then a link to /api/AggregateDefinition`1#SimpleAvg");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to receive viewport changes.</span>", "Ending with another text span");
     }
 
     /// <summary>
-    /// Ensures that invalid <see cref=""/> links to non-existant methods render properly.
+    /// Renders invalid <c>&lt;see cref="" /&gt;</c> links to non-existent methods as code.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_NonExistantMethod()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "When set, calls <see cref=\"M:MudBlazor.NotExistingType.NotExistingMethod\" /> to do stuff."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>");
-        // There's no valid link, just a span for the non-existant method
-        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.NotExistingType.NotExistingMethod</code>");
-        // Ending with another text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to do stuff.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.NotExistingType.NotExistingMethod</code>", "There's no valid link, just a span for the non-existant method");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to do stuff.</span>", "Ending with another text span");
     }
 
     /// <summary>
-    /// Ensures that <see cref=""/> links to existing fields render properly.
+    /// Renders <c>&lt;see cref="" /&gt;</c> links to existing fields.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_ExistingField()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.End\" />."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>");
-        // There should be a link to /api/Adornment
-        comp.Markup.Should().Contain("<a href=\"/api/Adornment#End");
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"/api/Adornment#End", "There should be a link to /api/Adornment");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 
     /// <summary>
-    /// Ensures that <see cref=""/> links to non-existant fields render properly.
+    /// Renders invalid <c>&lt;see cref="" /&gt;</c> links to non-existent fields as code.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_NonExistantField()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Shows when set to <see cref=\"F:MudBlazor.Adornment.EndOfTheUniverse\" />."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>");
-        // There should be a text span
-        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.Adornment.EndOfTheUniverse</code>");
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Shows when set to </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.Adornment.EndOfTheUniverse</code>", "There should be a text span");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 
     /// <summary>
-    /// Ensures that <see cref=""/> links to existing events render properly.
+    /// Renders <c>&lt;see cref="" /&gt;</c> links to existing events.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_ExistingEvent()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnClick\" /> event occurs."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>");
-        // There should be a link to /api/MudAlert#OnClick
-        comp.Markup.Should().Contain("<a href=\"/api/MudAlert#OnClick\"");
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> event occurs.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"/api/MudAlert#OnClick\"", "There should be a link to /api/MudAlert#OnClick");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> event occurs.</span>", "There should be a text span");
     }
 
     /// <summary>
-    /// Ensures that <see cref=""/> links to non-existant events render properly.
+    /// Renders invalid <c>&lt;see cref="" /&gt;</c> links to non-existent events as code.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_NonExistantEvent()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "Gets set when the <see cref=\"E:MudBlazor.MudAlert.OnSmokeAlarmInYourHouse\" /> event occurs."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>");
-        // There should be a text span
-        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.MudAlert.OnSmokeAlarmInYourHouse</code>");
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> event occurs.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Gets set when the </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<code class=\"docs-code docs-code-primary\">MudBlazor.MudAlert.OnSmokeAlarmInYourHouse</code>", "There should be a text span");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> event occurs.</span>", "There should be a text span");
     }
 
     /// <summary>
-    /// Ensures that links to external types render properly.
+    /// Renders links to external Microsoft types.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_External_MicrosoftType()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "The button can contain a <see cref=\"T:Microsoft.AspNetCore.Components.RenderFragment\" />."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The button can contain a </span>");
-        // There should be a link to Microsoft docs
-        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.components.renderfragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">RenderFragment");
-        // There should be a Link icon
-        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>");
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The button can contain a </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.components.renderfragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">RenderFragment", "There should be a link to Microsoft docs");
+        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 
     /// <summary>
-    /// Ensures that links to external types render properly.
+    /// Renders links to external system types.
     /// </summary>
     [Test]
     public void ApiText_RenderSeeCref_External_SystemType()
     {
         var comp = Context.Render<ApiText>(parameters => parameters.Add(x => x.Text, "The popover unique ID is a <see cref=\"T:System.Guid\" />."));
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The popover unique ID is a </span>");
-        // There should be a link to Microsoft docs
-        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/system.guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Guid");
-        // There should be a Link icon
-        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>");
-        // There should be a text span
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">The popover unique ID is a </span>", "There should be a text span");
+        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/system.guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Guid", "There should be a link to Microsoft docs");
+        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">.</span>", "There should be a text span");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.UnitTests.Docs.Documentation;
 public sealed class ApiTypeLinkTests : BunitTest
 {
     /// <summary>
-    /// Ensures that booleans render properly.
+    /// Renders booleans.
     /// </summary>
     [Test]
     public void ApiTypeLink_Boolean()
@@ -25,7 +25,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that boolean arrays render properly.
+    /// Renders boolean arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_BooleanArray()
@@ -35,7 +35,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that integers render properly.
+    /// Renders integers.
     /// </summary>
     [Test]
     public void ApiTypeLink_Int32()
@@ -45,7 +45,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that int arrays render properly.
+    /// Renders int arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_Int32Array()
@@ -55,7 +55,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that longs render properly.
+    /// Renders longs.
     /// </summary>
     [Test]
     public void ApiTypeLink_Int64()
@@ -65,7 +65,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that long arrays render properly.
+    /// Renders long arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_Int64Array()
@@ -75,7 +75,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that strings render properly.
+    /// Renders strings.
     /// </summary>
     [Test]
     public void ApiTypeLink_String()
@@ -85,7 +85,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that string arrays render properly.
+    /// Renders string arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_StringArray()
@@ -95,7 +95,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that doubles render properly.
+    /// Renders doubles.
     /// </summary>
     [Test]
     public void ApiTypeLink_Double()
@@ -105,7 +105,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that double arrays render properly.
+    /// Renders double arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_DoubleArray()
@@ -115,7 +115,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that floats render properly.
+    /// Renders floats.
     /// </summary>
     [Test]
     public void ApiTypeLink_Single()
@@ -125,7 +125,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that float arrays render properly.
+    /// Renders float arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_SingleArray()
@@ -135,7 +135,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that objects render properly.
+    /// Renders objects.
     /// </summary>
     [Test]
     public void ApiTypeLink_Object()
@@ -145,7 +145,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that object arrays render properly.
+    /// Renders object arrays.
     /// </summary>
     [Test]
     public void ApiTypeLink_ObjectArray()
@@ -155,7 +155,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that void return types render properly.
+    /// Renders void return types.
     /// </summary>
     [Test]
     public void ApiTypeLink_Void()
@@ -165,51 +165,45 @@ public sealed class ApiTypeLinkTests : BunitTest
     }
 
     /// <summary>
-    /// Ensures that MudBlazor component links render properly.
+    /// Renders MudBlazor component links.
     /// </summary>
     [Test]
     public void ApiTypeLink_MudBlazor_Component()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
-        // There should be a link to MudAlert
-        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>");
+        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
     }
 
     /// <summary>
-    /// Ensures that MudBlazor enum links render properly.
+    /// Renders MudBlazor enum links.
     /// </summary>
     [Test]
     public void ApiTypeLink_MudBlazor_Enums()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.Adornment"));
-        // There should be a link to Adornment
-        comp.Markup.Should().Contain("<a href=\"/api/Adornment\"");
-        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">Adornment</a>");
+        comp.Markup.Should().Contain("<a href=\"/api/Adornment\"", "There should be a link to Adornment");
+        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">Adornment</a>", "There should be a link to Adornment");
     }
 
     /// <summary>
-    /// Ensures that external types render properly.
+    /// Renders links to external Microsoft types.
     /// </summary>
     [Test]
     public void ApiTypeLink_External_MicrosoftType()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "Microsoft.AspNetCore.Components.RenderFragment"));
-        // There should be a link to Microsoft docs
-        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/Microsoft.AspNetCore.Components.RenderFragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">");
-        // There should be a Link icon
-        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>");
+        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/Microsoft.AspNetCore.Components.RenderFragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">", "There should be a link to Microsoft docs");
+        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
     }
 
     /// <summary>
-    /// Ensures that external types render properly.
+    /// Renders links to external system types.
     /// </summary>
     [Test]
     public void ApiTypeLink_External_SystemType()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Guid"));
-        // There should be a link to Microsoft docs
-        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/System.Guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">");
-        // There should be a Link icon
-        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>");
+        comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/System.Guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">", "There should be a link to Microsoft docs");
+        comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
@@ -21,6 +21,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Boolean()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Boolean"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">bool</code>");
     }
 
@@ -31,6 +32,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_BooleanArray()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Boolean[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">bool[]</code>");
     }
 
@@ -41,6 +43,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Int32()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int32"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">int</code>");
     }
 
@@ -51,6 +54,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Int32Array()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int32[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">int[]</code>");
     }
 
@@ -61,6 +65,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Int64()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int64"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">long</code>");
     }
 
@@ -71,6 +76,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Int64Array()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Int64[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">long[]</code>");
     }
 
@@ -81,6 +87,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_String()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.String"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">string</code>");
     }
 
@@ -91,6 +98,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_StringArray()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.String[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">string[]</code>");
     }
 
@@ -101,6 +109,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Double()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Double"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">double</code>");
     }
 
@@ -111,6 +120,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_DoubleArray()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Double[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">double[]</code>");
     }
 
@@ -121,6 +131,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Single()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Single"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">float</code>");
     }
 
@@ -131,6 +142,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_SingleArray()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Single[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">float[]</code>");
     }
 
@@ -141,6 +153,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Object()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Object"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">object</code>");
     }
 
@@ -151,6 +164,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_ObjectArray()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Object[]"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">object[]</code>");
     }
 
@@ -161,6 +175,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_Void()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Void"));
+
         comp.Markup.Should().Be("<code class=\"docs-code docs-code-primary\">void</code>");
     }
 
@@ -171,6 +186,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_MudBlazor_Component()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
+
         comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
     }
 
@@ -181,7 +197,9 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_MudBlazor_Enums()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.Adornment"));
+
         comp.Markup.Should().Contain("<a href=\"/api/Adornment\"", "There should be a link to Adornment");
+
         comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">Adornment</a>", "There should be a link to Adornment");
     }
 
@@ -192,7 +210,9 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_External_MicrosoftType()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "Microsoft.AspNetCore.Components.RenderFragment"));
+
         comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/Microsoft.AspNetCore.Components.RenderFragment\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">", "There should be a link to Microsoft docs");
+
         comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
     }
 
@@ -203,7 +223,9 @@ public sealed class ApiTypeLinkTests : BunitTest
     public void ApiTypeLink_External_SystemType()
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "System.Guid"));
+
         comp.Markup.Should().Contain("<a href=\"https://learn.microsoft.com/dotnet/api/System.Guid\" target=\"_external\" blazor:onclick=\"1\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">", "There should be a link to Microsoft docs");
+
         comp.Markup.Should().Contain("<svg class=\"mud-icon-root mud-icon-default mud-svg-icon mud-icon-size-small\" style=\"position:relative;top:7px;\" focusable=\"false\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" role=\"img\"><path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\"/></svg>", "There should be a Link icon");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Utilities/CodeSnippetUrlTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Utilities/CodeSnippetUrlTests.cs
@@ -17,6 +17,7 @@ public class CodeSnippetUrlTests
         string base64CompressedCode;
         string snippet1;
         byte[] bytes;
+
         // compression
         using (var uncompressed = new MemoryStream(Encoding.UTF8.GetBytes(snippet)))
         using (var compressed = new MemoryStream())
@@ -28,6 +29,7 @@ public class CodeSnippetUrlTests
             base64CompressedCode = Convert.ToBase64String(bytes);
             urlEncodedBase64CompressedCode = Uri.EscapeDataString(base64CompressedCode);
         }
+
         // uncompress
         base64CompressedCode = Uri.UnescapeDataString(urlEncodedBase64CompressedCode);
         bytes = Convert.FromBase64String(base64CompressedCode);
@@ -37,10 +39,11 @@ public class CodeSnippetUrlTests
         {
             uncompressor.CopyTo(uncompressed);
             uncompressor.Close();
-            //uncompressed.Position = 0;
+
+            // uncompressed.Position = 0;
             snippet1 = Encoding.UTF8.GetString(uncompressed.ToArray());
         }
-        // compare
-        snippet1.Should().Be(snippet);
+
+        snippet1.Should().Be(snippet, "The roundtrip should preserve the snippet");
     }
 }

--- a/src/MudBlazor.UnitTests.Docs/Utilities/MarkupCompilerTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Utilities/MarkupCompilerTests.cs
@@ -14,6 +14,7 @@ namespace MudBlazor.UnitTests.Docs.Utilities
             var source = "<span class=\"htmlAttributeValue\">&quot;Some random value&quot;</span>";
             var actual = ExamplesMarkup.AttributePostprocessing(source);
             var expected = "<span class=\"quot\">&quot;</span><span class=\"htmlAttributeValue\">Some random value</span><span class=\"quot\">&quot;</span>";
+
             actual.Should().Be(expected);
         }
 
@@ -24,6 +25,7 @@ namespace MudBlazor.UnitTests.Docs.Utilities
             var source = "<span class=\"htmlAttributeValue\">&quot;true&quot;</span>";
             var actual = ExamplesMarkup.AttributePostprocessing(source);
             var expected = "<span class=\"quot\">&quot;</span><span class=\"keyword\">true</span><span class=\"quot\">&quot;</span>";
+
             actual.Should().Be(expected);
         }
 
@@ -34,6 +36,7 @@ namespace MudBlazor.UnitTests.Docs.Utilities
             var source = "<span class=\"htmlAttributeValue\">&quot;Color.Primary&quot;</span>";
             var actual = ExamplesMarkup.AttributePostprocessing(source);
             var expected = "<span class=\"quot\">&quot;</span><span class=\"enum\">Color</span><span class=\"enumValue\">.Primary</span><span class=\"quot\">&quot;</span>";
+
             actual.Should().Be(expected);
         }
     }


### PR DESCRIPTION
This lightly cleans up hand-maintained tests in `MudBlazor.UnitTests.Docs` without changing behavior.

Changes:
- add spacing assertions
- shorten repetitive XML `<summary>` text
- escape literal XML tag syntax in summaries correctly
- move assertion comments into FluentAssertions `because` arguments where appropriate

Scope:
- non-generated docs tests only
- no logic changes
- no generated files touched

This was easy to change because they were already high quality and predictable.

Motivation: `ApiMemberTableTests` is explicitly referenced in https://github.com/MudBlazor/MudBlazor/pull/12976.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
