### PR TITLE
MudCollapse: Hide scrollbar during nested expansion panel animation

### DIFF
--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -28,5 +28,6 @@
 }
 
 .mud-collapse-wrapper-inner {
+  overflow: hidden;
   width: 100%;
 }


### PR DESCRIPTION
## Summary

Adds `overflow: hidden` to `.mud-collapse-wrapper-inner` in `_collapse.scss` to prevent a scrollbar from flashing during nested expansion panel animations.

## Why this matters

When expansion panels are nested, the inner panel shows a brief scrollbar during the CSS grid expand/collapse transition. The parent `.mud-collapse-wrapper` already has `overflow: hidden` (line 26), but the inner wrapper at line 30 was missing it. The grid-template-rows animation causes a momentary content overflow that triggers the scrollbar on the inner wrapper.

## Changes

`src/MudBlazor/Styles/components/_collapse.scss`: Added `overflow: hidden` to `.mud-collapse-wrapper-inner`.

## Testing

- Fix confirmed by the issue reporter (@LasseHerget) who tested the CSS rule and confirmed it worked

Disclaimer: i didn't validate it on my own just applied the fix they suggested

Fixes #12392