### PR TITLE
Fix responsive drawer reopening after explicit close

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -405,6 +405,46 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeTrue();
         }
 
+        /// <summary>
+        /// Verifies issue #11541: a responsive drawer explicitly closed on a large viewport must remain closed
+        /// after resizing below and back above its breakpoint.
+        /// </summary>
+        [Test]
+        public async Task Responsive_ExplicitlyClosedOnLarge_RemainsClosedAfterBreakpointRoundTrip()
+        {
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerResponsiveTest>();
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(
+                new BrowserWindowSize { Height = 400, Width = 600 },
+                Breakpoint.Sm,
+                subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(
+                new BrowserWindowSize { Height = 720, Width = 1280 },
+                Breakpoint.Lg,
+                subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+        }
+
         [Test]
         public async Task Responsive_AlwaysOpen_BreakpointAlways()
         {

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -20,6 +20,8 @@ namespace MudBlazor
         private bool _closeOnPointerLeave;
         private bool _initial = true;
         private bool _keepInitialState;
+        private bool _isApplyingResponsiveStateChange;
+        private bool _explicitClosePreventsResponsiveAutoOpen;
         private Breakpoint _lastUpdatedBreakpoint = Breakpoint.None;
 
         /// <summary>
@@ -312,6 +314,11 @@ namespace MudBlazor
 
         private async Task OnOpenParameterChangedAsync(ParameterChangedEventArgs<bool> arg)
         {
+            if (!_isApplyingResponsiveStateChange && HasRendered && IsResponsiveOrMini() && Breakpoint is not Breakpoint.None and not Breakpoint.Always)
+            {
+                _explicitClosePreventsResponsiveAutoOpen = !arg.Value;
+            }
+
             if (HasRendered && _initial && !_keepInitialState)
             {
                 _initial = false;
@@ -374,20 +381,21 @@ namespace MudBlazor
                 breakpoint = await BrowserViewportService.GetCurrentBreakpointAsync();
             }
 
+            var breakpointChanged = _lastUpdatedBreakpoint != breakpoint;
             var isStateChanged = false;
             if (ShouldCloseDrawer(breakpoint))
             {
-                await _openState.SetValueAsync(false);
+                await SetOpenFromResponsiveStateAsync(false);
                 isStateChanged = true;
             }
-            else if (ShouldOpenDrawer(breakpoint))
+            else if (ShouldOpenDrawer(breakpoint) && (Breakpoint == Breakpoint.Always || !_explicitClosePreventsResponsiveAutoOpen))
             {
-                await _openState.SetValueAsync(true);
+                await SetOpenFromResponsiveStateAsync(true);
                 isStateChanged = true;
             }
 
             _lastUpdatedBreakpoint = breakpoint;
-            if (isStateChanged)
+            if (isStateChanged || breakpointChanged)
             {
                 await InvokeAsync(StateHasChanged);
             }
@@ -402,6 +410,19 @@ namespace MudBlazor
         private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
 
         private bool ShouldOpenDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.Always || (!IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint()));
+
+        private async Task SetOpenFromResponsiveStateAsync(bool open)
+        {
+            _isApplyingResponsiveStateChange = true;
+            try
+            {
+                await _openState.SetValueAsync(open);
+            }
+            finally
+            {
+                _isApplyingResponsiveStateChange = false;
+            }
+        }
 
         internal string GetPosition()
         {
@@ -462,10 +483,12 @@ namespace MudBlazor
 
                 if (HandleBreakpointNone())
                 {
+                    _explicitClosePreventsResponsiveAutoOpen = false;
                     await InitialOpenState(false);
                 }
                 else if (HandleBreakpointAlways())
                 {
+                    _explicitClosePreventsResponsiveAutoOpen = false;
                     await InitialOpenState(true);
                 }
                 else if (HandleBelowBreakpointAndOpenState())
@@ -490,7 +513,7 @@ namespace MudBlazor
             Task InitialOpenState(bool open)
             {
                 _keepInitialState = true;
-                return _openState.SetValueAsync(open);
+                return SetOpenFromResponsiveStateAsync(open);
             }
         }
 


### PR DESCRIPTION
## Summary
- fix MudDrawer responsive breakpoint handling so an explicit close remains authoritative across a small-to-large resize round-trip
- keep the existing responsive auto-close and auto-reopen behavior for drawers that were not explicitly closed
- add a regression test for issue #11541

## Testing
- dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter FullyQualifiedName~Responsive_ExplicitlyClosedOnLarge_RemainsClosedAfterBreakpointRoundTrip --nologo
- dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter FullyQualifiedName~DrawerTest --nologo

Closes #11541