### PR TITLE
MudDataGrid: Simplify icon customization to grid-level defaults

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
@@ -5,12 +5,7 @@
              FilterIconClear="test_grid_filter_clear_icon"
              ColumnOptionsIcon="test_grid_column_options_icon">
     <Columns>
-        <PropertyColumn Property="x => x.Name"
-                        SortIcon="test_column_sort_icon"
-                        FilterIconEmpty="test_column_filter_empty_icon"
-                        FilterIconFilled="test_column_filter_filled_icon"
-                        FilterIconClear="test_column_filter_clear_icon"
-                        ColumnOptionsIcon="test_column_column_options_icon" />
+        <PropertyColumn Property="x => x.Name" />
         <PropertyColumn Property="x => x.Age" />
     </Columns>
 </MudDataGrid>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
@@ -1,7 +1,16 @@
-﻿<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="FilterMode"
-             FilterIconEmpty="@Icons.Material.Filled.Battery0Bar" FilterIconFilled="@Icons.Material.Filled.BatteryFull" FilterIconClear="@Icons.Material.Filled.BatteryAlert">
+<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="FilterMode"
+             SortIcon="test_grid_sort_icon"
+             FilterIconEmpty="test_grid_filter_empty_icon"
+             FilterIconFilled="test_grid_filter_filled_icon"
+             FilterIconClear="test_grid_filter_clear_icon"
+             ColumnOptionsIcon="test_grid_column_options_icon">
     <Columns>
-        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Name"
+                        SortIcon="test_column_sort_icon"
+                        FilterIconEmpty="test_column_filter_empty_icon"
+                        FilterIconFilled="test_column_filter_filled_icon"
+                        FilterIconClear="test_column_filter_clear_icon"
+                        ColumnOptionsIcon="test_column_column_options_icon" />
         <PropertyColumn Property="x => x.Age" />
     </Columns>
 </MudDataGrid>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6263,21 +6263,34 @@ namespace MudBlazor.UnitTests.Components
         public async Task DataGridFilterIcons()
         {
             var comp = Context.Render<DataGridFilterIconsTest>();
-            MudIconButton FirstFilterButton() =>
-                comp.FindComponents<MudIconButton>().FirstOrDefault(x => x.Markup.Contains("filter-button"))?.Instance;
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterIconsTest.Model>>();
 
-            // Check filter buttons when no filter applied
-            var mudIconButton = FirstFilterButton();
-            mudIconButton.Icon.Should().Be(Icons.Material.Filled.Battery0Bar);
+            dataGrid.Instance.SortIcon.Should().Be("test_grid_sort_icon");
+            dataGrid.Instance.FilterIconEmpty.Should().Be("test_grid_filter_empty_icon");
+            dataGrid.Instance.FilterIconFilled.Should().Be("test_grid_filter_filled_icon");
+            dataGrid.Instance.FilterIconClear.Should().Be("test_grid_filter_clear_icon");
+            dataGrid.Instance.ColumnOptionsIcon.Should().Be("test_grid_column_options_icon");
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Markup.Should().Contain("test_column_sort_icon");
+                comp.Markup.Should().Contain("test_grid_sort_icon");
+                comp.Markup.Should().Contain("test_column_filter_empty_icon");
+                comp.Markup.Should().Contain("test_grid_filter_empty_icon");
+                comp.Markup.Should().Contain("test_column_column_options_icon");
+                comp.Markup.Should().Contain("test_grid_column_options_icon");
+            });
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
 
-            mudIconButton = FirstFilterButton();
-            mudIconButton.Icon.Should().Be(Icons.Material.Filled.Battery0Bar);
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Markup.Should().Contain("test_column_filter_empty_icon");
+                comp.Markup.Should().Contain("test_grid_filter_empty_icon");
+            });
 
             // Check filter buttons when filter applied
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.Simple));
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterIconsTest.Model>>();
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFilterIconsTest.Model>
             {
                 Column = dataGrid.Instance.RenderedColumns.First(),
@@ -6285,22 +6298,30 @@ namespace MudBlazor.UnitTests.Components
                 Value = "Sam"
             }));
 
-            mudIconButton = FirstFilterButton();
-            mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Markup.Should().Contain("test_column_filter_filled_icon");
+                comp.Markup.Should().Contain("test_grid_filter_empty_icon");
+            });
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
 
-            mudIconButton = FirstFilterButton();
-            mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Markup.Should().Contain("test_column_filter_filled_icon");
+                comp.Markup.Should().Contain("test_grid_filter_empty_icon");
+            });
 
             // Check filter buttons when FilterMode is ColumnFilterRow
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterRow));
 
-            var mudMenu = comp.FindComponents<MudMenu>().FirstOrDefault(x => x.Markup.Contains("column-filter-menu"))?.Instance;
-            mudMenu.Icon.Should().Be(Icons.Material.Filled.BatteryFull);
-
-            mudIconButton = FirstFilterButton();
-            mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryAlert);
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Markup.Should().Contain("test_column_filter_filled_icon");
+                comp.Markup.Should().Contain("test_grid_filter_filled_icon");
+                comp.Markup.Should().Contain("test_column_filter_clear_icon");
+                comp.Markup.Should().Contain("test_grid_filter_clear_icon");
+            });
         }
 
         #region Selection Cleanup Tests (ObservableCollection)

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6273,11 +6273,8 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() =>
             {
-                comp.Markup.Should().Contain("test_column_sort_icon");
                 comp.Markup.Should().Contain("test_grid_sort_icon");
-                comp.Markup.Should().Contain("test_column_filter_empty_icon");
                 comp.Markup.Should().Contain("test_grid_filter_empty_icon");
-                comp.Markup.Should().Contain("test_column_column_options_icon");
                 comp.Markup.Should().Contain("test_grid_column_options_icon");
             });
 
@@ -6285,7 +6282,6 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() =>
             {
-                comp.Markup.Should().Contain("test_column_filter_empty_icon");
                 comp.Markup.Should().Contain("test_grid_filter_empty_icon");
             });
 
@@ -6300,16 +6296,14 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() =>
             {
-                comp.Markup.Should().Contain("test_column_filter_filled_icon");
-                comp.Markup.Should().Contain("test_grid_filter_empty_icon");
+                comp.Markup.Should().Contain("test_grid_filter_filled_icon");
             });
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.FilterMode, DataGridFilterMode.ColumnFilterMenu));
 
             await comp.WaitForAssertionAsync(() =>
             {
-                comp.Markup.Should().Contain("test_column_filter_filled_icon");
-                comp.Markup.Should().Contain("test_grid_filter_empty_icon");
+                comp.Markup.Should().Contain("test_grid_filter_filled_icon");
             });
 
             // Check filter buttons when FilterMode is ColumnFilterRow
@@ -6317,9 +6311,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() =>
             {
-                comp.Markup.Should().Contain("test_column_filter_filled_icon");
                 comp.Markup.Should().Contain("test_grid_filter_filled_icon");
-                comp.Markup.Should().Contain("test_column_filter_clear_icon");
                 comp.Markup.Should().Contain("test_grid_filter_clear_icon");
             });
         }

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -314,8 +314,52 @@ namespace MudBlazor
         /// <summary>
         /// The icon shown when <see cref="Sortable"/> is <c>true</c>.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.SortIcon"/>.
+        /// </remarks>
         [Parameter]
-        public string SortIcon { get; set; } = Icons.Material.Filled.ArrowUpward;
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string? SortIcon { get; set; }
+
+        /// <summary>
+        /// The empty filter icon shown when no filters are applied to this column.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.FilterIconEmpty"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string? FilterIconEmpty { get; set; }
+
+        /// <summary>
+        /// The filled filter icon shown when filters are applied to this column.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.FilterIconFilled"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string? FilterIconFilled { get; set; }
+
+        /// <summary>
+        /// The clear filter icon shown to remove this column's filter.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.FilterIconClear"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string? FilterIconClear { get; set; }
+
+        /// <summary>
+        /// The icon used for this column's options menu.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.ColumnOptionsIcon"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string? ColumnOptionsIcon { get; set; }
 
         /// <summary>
         /// Allows values in this column to be grouped.
@@ -572,6 +616,16 @@ namespace MudBlazor
                 return Filterable ?? DataGrid?.Filterable ?? false;
             }
         }
+
+        internal string? ResolvedSortIcon => SortIcon ?? DataGrid?.SortIcon;
+
+        internal string? ResolvedFilterIconEmpty => FilterIconEmpty ?? DataGrid?.FilterIconEmpty;
+
+        internal string? ResolvedFilterIconFilled => FilterIconFilled ?? DataGrid?.FilterIconFilled;
+
+        internal string? ResolvedFilterIconClear => FilterIconClear ?? DataGrid?.FilterIconClear;
+
+        internal string? ResolvedColumnOptionsIcon => ColumnOptionsIcon ?? DataGrid?.ColumnOptionsIcon;
 
         #endregion
 

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -319,47 +319,8 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.DataGrid.Appearance)]
+        [Obsolete("Column-level sort icon customization is no longer supported. Configure MudDataGrid.SortIcon or use HeaderTemplate for full header customization.", true)]
         public string? SortIcon { get; set; }
-
-        /// <summary>
-        /// The empty filter icon shown when no filters are applied to this column.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.FilterIconEmpty"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.DataGrid.Appearance)]
-        public string? FilterIconEmpty { get; set; }
-
-        /// <summary>
-        /// The filled filter icon shown when filters are applied to this column.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.FilterIconFilled"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.DataGrid.Appearance)]
-        public string? FilterIconFilled { get; set; }
-
-        /// <summary>
-        /// The clear filter icon shown to remove this column's filter.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.FilterIconClear"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.DataGrid.Appearance)]
-        public string? FilterIconClear { get; set; }
-
-        /// <summary>
-        /// The icon used for this column's options menu.
-        /// </summary>
-        /// <remarks>
-        /// Defaults to <c>null</c>, which falls back to <see cref="MudDataGrid{T}.ColumnOptionsIcon"/>.
-        /// </remarks>
-        [Parameter]
-        [Category(CategoryTypes.DataGrid.Appearance)]
-        public string? ColumnOptionsIcon { get; set; }
 
         /// <summary>
         /// Allows values in this column to be grouped.
@@ -616,16 +577,6 @@ namespace MudBlazor
                 return Filterable ?? DataGrid?.Filterable ?? false;
             }
         }
-
-        internal string? ResolvedSortIcon => SortIcon ?? DataGrid?.SortIcon;
-
-        internal string? ResolvedFilterIconEmpty => FilterIconEmpty ?? DataGrid?.FilterIconEmpty;
-
-        internal string? ResolvedFilterIconFilled => FilterIconFilled ?? DataGrid?.FilterIconFilled;
-
-        internal string? ResolvedFilterIconClear => FilterIconClear ?? DataGrid?.FilterIconClear;
-
-        internal string? ResolvedColumnOptionsIcon => ColumnOptionsIcon ?? DataGrid?.ColumnOptionsIcon;
 
         #endregion
 

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -59,7 +59,7 @@
                 }
                 @if (!Column.ShowFilterIcon.HasValue || Column.ShowFilterIcon.Value)
                 {
-                    <MudMenu Class="column-filter-menu" Icon="@Column.ResolvedFilterIconFilled" Size="@Size.Small" Dense="true">
+                    <MudMenu Class="column-filter-menu" Icon="@DataGrid.FilterIconFilled" Size="@Size.Small" Dense="true">
                         @foreach (var o in operators)
                         {
                             if (!string.IsNullOrWhiteSpace(o))
@@ -68,7 +68,7 @@
                             }
                         }
                     </MudMenu>
-                    <MudIconButton Class="align-self-center filter-button clear" Icon="@Column.ResolvedFilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
+                    <MudIconButton Class="align-self-center filter-button clear" Icon="@DataGrid.FilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
                 }
             </MudStack>
         }

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -59,7 +59,7 @@
                 }
                 @if (!Column.ShowFilterIcon.HasValue || Column.ShowFilterIcon.Value)
                 {
-                    <MudMenu Class="column-filter-menu" Icon="@DataGrid.FilterIconFilled" Size="@Size.Small" Dense="true">
+                    <MudMenu Class="column-filter-menu" Icon="@Column.ResolvedFilterIconFilled" Size="@Size.Small" Dense="true">
                         @foreach (var o in operators)
                         {
                             if (!string.IsNullOrWhiteSpace(o))
@@ -68,7 +68,7 @@
                             }
                         }
                     </MudMenu>
-                    <MudIconButton Class="align-self-center filter-button clear" Icon="@DataGrid.FilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
+                    <MudIconButton Class="align-self-center filter-button clear" Icon="@Column.ResolvedFilterIconClear" Size="@Size.Small" OnClick="@ClearFilterAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_ClearFilter]"></MudIconButton>
                 }
             </MudStack>
         }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -87,14 +87,7 @@ else if (Column != null && !Column.HiddenState.Value)
             <span class="@OptionsClass">
                 @if (sortable)
                 {
-                    if (SortDirection == SortDirection.None)
-                    {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
-                    }
-                    else
-                    {
-                        <MudIconButton Icon="@Column.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
-                    }
+                    <MudIconButton Icon="@Column.ResolvedSortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
 
                     if (DataGrid.SortMode == SortMode.Multiple)
                     {
@@ -113,17 +106,17 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (hasFilter)
                     {
-                        <MudIconButton Class="filter-button filtered" Icon="@DataGrid.FilterIconFilled" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
+                        <MudIconButton Class="filter-button filtered" Icon="@Column.ResolvedFilterIconFilled" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
                     }
                     else if (showFilterIcon)
                     {
-                        <MudIconButton Class="filter-button" Icon="@DataGrid.FilterIconEmpty" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
+                        <MudIconButton Class="filter-button" Icon="@Column.ResolvedFilterIconEmpty" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
                     }
                 }
 
                 @if (showColumnOptions)
                 {
-                    <MudMenu Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
+                    <MudMenu Icon="@Column.ResolvedColumnOptionsIcon" Size="Size.Small" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
                         <MudMenuItem Disabled="@(SortDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -87,7 +87,7 @@ else if (Column != null && !Column.HiddenState.Value)
             <span class="@OptionsClass">
                 @if (sortable)
                 {
-                    <MudIconButton Icon="@Column.ResolvedSortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
+                    <MudIconButton Icon="@DataGrid.SortIcon" Class="@sortIconClass" Size="@Size.Small" OnClick="@SortChangedAsync" aria-label="@Localizer[LanguageResource.MudDataGrid_Sort]"></MudIconButton>
 
                     if (DataGrid.SortMode == SortMode.Multiple)
                     {
@@ -106,17 +106,17 @@ else if (Column != null && !Column.HiddenState.Value)
                 {
                     if (hasFilter)
                     {
-                        <MudIconButton Class="filter-button filtered" Icon="@Column.ResolvedFilterIconFilled" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
+                        <MudIconButton Class="filter-button filtered" Icon="@DataGrid.FilterIconFilled" Size="@Size.Small" OnClick="@OpenFilters" aria-label="@Localizer[LanguageResource.MudDataGrid_OpenFilters]"></MudIconButton>
                     }
                     else if (showFilterIcon)
                     {
-                        <MudIconButton Class="filter-button" Icon="@Column.ResolvedFilterIconEmpty" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
+                        <MudIconButton Class="filter-button" Icon="@DataGrid.FilterIconEmpty" Size="@Size.Small" OnClick="@AddFilter" aria-label="@Localizer[LanguageResource.MudDataGrid_AddFilter]"></MudIconButton>
                     }
                 }
 
                 @if (showColumnOptions)
                 {
-                    <MudMenu Icon="@Column.ResolvedColumnOptionsIcon" Size="Size.Small" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
+                    <MudMenu Icon="@DataGrid.ColumnOptionsIcon" Size="Size.Small" Dense="true" AriaLabel="@Localizer[LanguageResource.MudDataGrid_ShowColumnOptions]">
                         <MudMenuItem Disabled="@(SortDirection == SortDirection.None)" OnClick="@RemoveSortAsync">@Localizer[LanguageResource.MudDataGrid_Unsort]</MudMenuItem>
                         @if (filterable && DataGrid.FilterMode != DataGridFilterMode.ColumnFilterRow)
                         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -138,7 +138,7 @@
                                                                 <MudSpacer />
 
                                                                 <div>
-                                                                    <MudIconButton Ripple="false" Icon="@context.ResolvedSortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context.HeaderCell.SortChangedAsync(e))"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@context.DataGrid.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context.HeaderCell.SortChangedAsync(e))"></MudIconButton>
                                                                     @if (context.DataGrid.SortMode == SortMode.Multiple)
                                                                     {
                                                                         if (context.SortIndex < 0)
@@ -154,11 +154,11 @@
 
                                                                 @if (context.HeaderCell.hasFilter)
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.ResolvedFilterIconFilled" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.DataGrid.FilterIconFilled" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
                                                                 }
                                                                 else
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.ResolvedFilterIconEmpty" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.DataGrid.FilterIconEmpty" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
                                                                 }
 
                                                                 @if (ColumnsPanelReordering)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -138,7 +138,7 @@
                                                                 <MudSpacer />
 
                                                                 <div>
-                                                                    <MudIconButton Ripple="false" Icon="@context.SortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context.HeaderCell.SortChangedAsync(e))"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Icon="@context.ResolvedSortIcon" Class="@context.HeaderCell.sortIconClass" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Sort] Disabled="!context.sortable" OnClick="@(e => context.HeaderCell.SortChangedAsync(e))"></MudIconButton>
                                                                     @if (context.DataGrid.SortMode == SortMode.Multiple)
                                                                     {
                                                                         if (context.SortIndex < 0)
@@ -154,11 +154,11 @@
 
                                                                 @if (context.HeaderCell.hasFilter)
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.DataGrid.FilterIconFilled" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button filtered" Icon="@context.ResolvedFilterIconFilled" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.OpenFilters"></MudIconButton>
                                                                 }
                                                                 else
                                                                 {
-                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.DataGrid.FilterIconEmpty" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
+                                                                    <MudIconButton Ripple="false" Class="filter-button" Icon="@context.ResolvedFilterIconEmpty" Size="@Size.Small" title=@Localizer[LanguageResource.MudDataGrid_Filter] Disabled="!context.filterable" OnClick="@context.HeaderCell.AddFilter"></MudIconButton>
                                                                 }
 
                                                                 @if (ColumnsPanelReordering)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -483,7 +483,7 @@ namespace MudBlazor
         /// The icon shown when a column is sortable.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Icons.Material.Filled.ArrowUpward"/>.  Can be overridden for individual columns via <see cref="Column{T}.SortIcon"/>.
+        /// Defaults to <see cref="Icons.Material.Filled.ArrowUpward"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.DataGrid.Appearance)]
@@ -661,7 +661,7 @@ namespace MudBlazor
         /// The icon used for column options menus in header cells.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Icons.Material.Filled.MoreVert"/>.  Can be overridden for individual columns via <see cref="Column{T}.ColumnOptionsIcon"/>.
+        /// Defaults to <see cref="Icons.Material.Filled.MoreVert"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.DataGrid.Appearance)]

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -480,6 +480,16 @@ namespace MudBlazor
         public SortMode SortMode { get; set; } = SortMode.Multiple;
 
         /// <summary>
+        /// The icon shown when a column is sortable.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.ArrowUpward"/>.  Can be overridden for individual columns via <see cref="Column{T}.SortIcon"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string SortIcon { get; set; } = Icons.Material.Filled.ArrowUpward;
+
+        /// <summary>
         /// Allows filtering of data in this grid.
         /// </summary>
         /// <remarks>
@@ -630,19 +640,32 @@ namespace MudBlazor
         /// The empty filter icon shown on a column when <see cref="Filterable"/> is <c>true</c> and no filters are applied to this column.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
         public string FilterIconEmpty { get; set; } = Icons.Material.Outlined.FilterAlt;
 
         /// <summary>
         /// The filled filter icon shown on a column when <see cref="Filterable"/> is <c>true</c> and filters are applied to this column.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
         public string FilterIconFilled { get; set; } = Icons.Material.Filled.FilterAlt;
 
         /// <summary>
         /// The clear filter icon shown on a column when <see cref="Filterable"/> is <c>true</c> to remove filters applied to this column.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
         public string FilterIconClear { get; set; } = Icons.Material.Filled.FilterAltOff;
+
+        /// <summary>
+        /// The icon used for column options menus in header cells.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Icons.Material.Filled.MoreVert"/>.  Can be overridden for individual columns via <see cref="Column{T}.ColumnOptionsIcon"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Appearance)]
+        public string ColumnOptionsIcon { get; set; } = Icons.Material.Filled.MoreVert;
 
         /// <summary>
         /// The way that this grid filters data.


### PR DESCRIPTION
This PR simplifies the DataGrid icon API by keeping icon customization at the grid level and removing per-column icon overrides from the public surface.

**What changed**

- Kept DataGrid-level icon parameters for the core semantic actions:
  - `SortIcon`
  - `FilterIconEmpty`
  - `FilterIconFilled`
  - `FilterIconClear`
  - `ColumnOptionsIcon`
- Removed the branch-only per-column icon customization work from `Column<T>`.
- Marked the pre-existing `Column<T>.SortIcon` as obsolete with an error and pointed callers to:
  - `MudDataGrid.SortIcon` for shared defaults
  - `HeaderTemplate` for full per-column header customization
- Updated header and filter rendering to use the grid-owned icon values consistently.
- Reduced the test coverage to verify the supported API shape only.

**Benefits:**
- Lower maintenance cost: fewer public parameters, fewer combinations to support, fewer tests tied to implementation details.
- Clearer customization model: grid-level icons for standard DataGrid behavior, templates for advanced per-column customization.
- Better long-term design: avoids continuing down the path of adding one-off icon parameters every time a new DataGrid control appears.
- Easier documentation and support: one obvious place to set icon defaults for the grid.
- Safer evolution: header and filter UI can change internally without expanding the API surface each time.

DataGrid already has strong extension points for advanced cases:
- `HeaderTemplate`
- `FilterTemplate`

Those templates are a better fit for column-specific customization than a growing list of string icon parameters. They allow callers to change not just the icon, but the entire action UI when needed.

This PR therefore keeps the simple case simple:
- set icons once on the grid
- use templates when a column needs something special

That is a cleaner long-term direction than adding more knobs.

Closes #12922
Related to #10701, #8428, #6238

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
