### PR TITLE
MudDataGrid: Expose filter state in FilterTemplate context

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridFilterIconsTest.razor
@@ -1,7 +1,11 @@
 ﻿<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="FilterMode"
              FilterIconEmpty="@Icons.Material.Filled.Battery0Bar" FilterIconFilled="@Icons.Material.Filled.BatteryFull" FilterIconClear="@Icons.Material.Filled.BatteryAlert">
     <Columns>
-        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Name">
+            <FilterTemplate>
+                <MudIconButton Class="custom-filter-template-button" Icon="@context.FilterIcon" Size="@Size.Small" />
+            </FilterTemplate>
+        </PropertyColumn>
         <PropertyColumn Property="x => x.Age" />
     </Columns>
 </MudDataGrid>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6303,6 +6303,31 @@ namespace MudBlazor.UnitTests.Components
             mudIconButton.Icon.Should().Be(Icons.Material.Filled.BatteryAlert);
         }
 
+        [Test]
+        public async Task DataGridFilterTemplateUsesContextFilterIcon()
+        {
+            var comp = Context.Render<DataGridFilterIconsTest>(parameters =>
+                parameters.Add(x => x.FilterMode, DataGridFilterMode.ColumnFilterRow));
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterIconsTest.Model>>();
+
+            MudIconButton CustomFilterButton() =>
+                comp.FindComponents<MudIconButton>()
+                    .First(x => x.Markup.Contains("custom-filter-template-button"))
+                    .Instance;
+
+            CustomFilterButton().Icon.Should().Be("test_grid_filter_empty_icon");
+
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridFilterIconsTest.Model>
+            {
+                Column = dataGrid.Instance.RenderedColumns.First(),
+                Operator = FilterOperator.String.Contains,
+                Value = "Sam"
+            }));
+
+            await comp.WaitForAssertionAsync(() =>
+                CustomFilterButton().Icon.Should().Be("test_grid_filter_filled_icon"));
+        }
+
         #region Selection Cleanup Tests (ObservableCollection)
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -31,6 +31,20 @@ namespace MudBlazor
         public IEnumerable<T>? Items => _dataGrid.Items;
 
         /// <summary>
+        /// Indicates whether this filter currently has an applied value in the data grid.
+        /// </summary>
+        public bool IsFiltered => _dataGrid.HasFilter(FilterDefinition?.Column);
+
+        /// <summary>
+        /// The icon which reflects whether this filter is currently applied.
+        /// </summary>
+        /// <remarks>
+        /// Returns <see cref="MudDataGrid{T}.FilterIconFilled"/> when <see cref="IsFiltered"/> is <c>true</c>;
+        /// otherwise returns <see cref="MudDataGrid{T}.FilterIconEmpty"/>.
+        /// </remarks>
+        public string FilterIcon => IsFiltered ? _dataGrid.FilterIconFilled : _dataGrid.FilterIconEmpty;
+
+        /// <summary>
         /// The definitions of all filters in the grid.
         /// </summary>
         public List<IFilterDefinition<T>> FilterDefinitions => _dataGrid.FilterDefinitions;

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -217,16 +217,7 @@ namespace MudBlazor
         {
             get
             {
-                if (DataGrid == null)
-                    return false;
-
-                return DataGrid.FilterDefinitions.Any(x =>
-                    x.Column?.PropertyName == Column?.PropertyName &&
-                    ((x is FilterDefinition<T> filterDefinition && filterDefinition.FilterFunction is not null) ||
-                     x.Value is not null ||
-                     x.Operator is FilterOperator.String.Empty or FilterOperator.String.NotEmpty or
-                         FilterOperator.Number.Empty or FilterOperator.Number.NotEmpty or
-                         FilterOperator.DateTime.Empty or FilterOperator.DateTime.NotEmpty));
+                return DataGrid?.HasFilter(Column) ?? false;
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1825,6 +1825,27 @@ namespace MudBlazor
             return context;
         }
 
+        internal bool HasFilter(Column<T>? column)
+        {
+            if (column is null)
+            {
+                return false;
+            }
+
+            return FilterDefinitions.Any(x =>
+                (ReferenceEquals(x.Column, column) || (column.PropertyName is not null && x.Column?.PropertyName == column.PropertyName)) &&
+                IsFilterApplied(x));
+        }
+
+        private static bool IsFilterApplied(IFilterDefinition<T> filterDefinition)
+        {
+            return (filterDefinition is FilterDefinition<T> dataGridFilterDefinition && dataGridFilterDefinition.FilterFunction is not null) ||
+                   filterDefinition.Value is not null ||
+                   filterDefinition.Operator is FilterOperator.String.Empty or FilterOperator.String.NotEmpty or
+                       FilterOperator.Number.Empty or FilterOperator.Number.NotEmpty or
+                       FilterOperator.DateTime.Empty or FilterOperator.DateTime.NotEmpty;
+        }
+
         private async Task ApplyFilterFromSimpleModeAsync(IFilterDefinition<T> filterDefinition)
         {
             if (FilterDefinitions.All(x => x.Id != filterDefinition.Id))


### PR DESCRIPTION
`FilterTemplate` now exposes filter state directly through its `context`. You can use `context.FilterIcon` to follow the grid’s configured empty/filled filter icons automatically, or `context.IsFiltered` if you want to switch to your own custom icons.

Example:

```razor
<FilterTemplate>
    <MudIconButton OnClick="@OpenFilter" Icon="@context.FilterIcon" Size="@Size.Small" />
    ...
</FilterTemplate>
```

If you want completely custom icons:

```razor
<FilterTemplate>
    <MudIconButton OnClick="@OpenFilter"
                   Icon="@(context.IsFiltered ? MyFilledIcon : MyEmptyIcon)"
                   Size="@Size.Small" />
    ...
</FilterTemplate>
```

This keeps the feature focused on `FilterTemplate` instead of adding more DataGrid icon parameters.

Supersedes #12922, #8428, #6238
Relies on #13004
Closes #7478
Closes #10701

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
