### PR TITLE
MudDataGrid: Fix Striped rows not rendering consistently with Virtualize

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -387,36 +387,32 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 
 .mud-table-striped {
   & .mud-table-container .mud-table-root .mud-table-body {
-    & .mud-table-row:nth-of-type(odd) {
+    // Non-virtualized: nth-of-type works because no <tr> spacers exist.
+    &:not(.mud-table-body-virtualized) .mud-table-row:nth-of-type(odd) {
       background-color: var(--mud-palette-table-striped);
     }
 
-    // When virtualized, <Virtualize> renders spacer <tr> elements that shift
-    // :nth-of-type(odd) ordering. Override with index-based .mud-table-row-stripe class instead.
-    &.mud-table-body-virtualized {
-      & .mud-table-row:nth-of-type(odd):not(:hover) {
-        background-color: initial;
-      }
-
-      & .mud-table-row.mud-table-row-stripe {
-        background-color: var(--mud-palette-table-striped);
-      }
+    // Virtualized: <Virtualize> renders <tr> spacers that shift nth-of-type ordering.
+    // Use index-based .mud-table-row-stripe class instead.
+    &.mud-table-body-virtualized .mud-table-row.mud-table-row-stripe {
+      background-color: var(--mud-palette-table-striped);
     }
   }
 }
 
 .mud-table-hover.mud-table-striped {
   & .mud-table-container .mud-table-root .mud-table-body {
-    @media(hover: hover) and (pointer: fine) {
-      & .mud-table-row:nth-of-type(odd):hover {
-        background-color: var(--mud-palette-table-hover);
+    &:not(.mud-table-body-virtualized) {
+      @media(hover: hover) and (pointer: fine) {
+        & .mud-table-row:nth-of-type(odd):hover {
+          background-color: var(--mud-palette-table-hover);
+        }
       }
     }
 
     &.mud-table-body-virtualized {
       @media(hover: hover) and (pointer: fine) {
-        & .mud-table-row.mud-table-row-stripe:hover,
-        & .mud-table-row:nth-of-type(odd):hover {
+        & .mud-table-row.mud-table-row-stripe:hover {
           background-color: var(--mud-palette-table-hover);
         }
       }


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/MudBlazor/issues/12999

CSS conflict introduced in #12799. The nth-of-type(odd) reset rule unintentionally overrode the class-based `.mud-table-row-stripe` rule. When Blazor's Virtualize requested a chunk starting at an odd index, the <tr> spacer shifted even-indexed rows into odd DOM positions, causing both rules to match, with the reset winning.

Fix: Scope nth-of-type(odd) to non-virtualized tables only via `:not(.mud-table-body-virtualized)`, so it never competes with the class-based rule in virtualized tables.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
