### PR TITLE
EnumExtensions: Allow extension methods for public enums to be public

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>
 
   <!--Analyzer Config-->

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -39,5 +39,27 @@ namespace MudBlazor.UnitTests.Extensions
             // Assert
             result.Should().Be(expectedEdge);
         }
+
+        [Test]
+        public void GeneratedEnumExtensions_ShouldBePublic()
+        {
+            // Arrange
+            var breakPointAssembly = typeof(Breakpoint).Assembly;
+            var sizeAssembly = typeof(Size).Assembly;
+            var variantAssembly = typeof(Variant).Assembly;
+
+            // Assert
+            var breakpointExtensionsType = breakPointAssembly.GetType("MudBlazor.BreakpointExtensions");
+            breakpointExtensionsType.Should().NotBeNull();
+            breakpointExtensionsType.IsPublic.Should().BeTrue();
+
+            var sizeExtensionsType = sizeAssembly.GetType("MudBlazor.SizeExtensions");
+            sizeExtensionsType.Should().NotBeNull();
+            sizeExtensionsType.IsPublic.Should().BeTrue();
+
+            var variantExtensionsType = variantAssembly.GetType("MudBlazor.VariantExtensions");
+            variantExtensionsType.Should().NotBeNull();
+            variantExtensionsType.IsPublic.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR aims to fix a regression introduced by an unrelated change in #12932 

By adding the MSBuild property `EnumGenerator_ForceInternal` this change effectively locked users from using the extension methods on a public (as in, part of exposed interface) enum. By removing this access, the project breaks compatibility with client code.

The fix is simply to remove the msbuild lines. I also added a test that uses reflection to test the visibility, since the UnitTest has access to the MudBlazor internals.

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
