### PR TITLE
MudDrawer: Add OnBreakpointChanged event

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -50,8 +50,7 @@
                     <SectionHeader Title="Responsive">
                         <Description>
                             Responsive Drawers behaves persistently on wider screens and responsively on smaller ones.
-                            When <CodeInline>@("@bind-Open")</CodeInline> is used, resize events preserve the bound <CodeInline>Open</CodeInline> state and only change how the drawer is presented at the current breakpoint.
-                            Without two-way binding, the drawer can still update its open state automatically according to its breakpoint configuration.
+                            Opened Responsive Drawers close automatically when the window size becomes small, and opens after the original state has been restored according to its breakpoint configuration.
                         </Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" Code="@nameof(DrawerResponsiveExample)" ShowCode="false">

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -50,7 +50,8 @@
                     <SectionHeader Title="Responsive">
                         <Description>
                             Responsive Drawers behaves persistently on wider screens and responsively on smaller ones.
-                            Opened Responsive Drawers close automatically when the window size becomes small, and opens after the original state has been restored according to its breakpoint configuration.
+                            When <CodeInline>@("@bind-Open")</CodeInline> is used, resize events preserve the bound <CodeInline>Open</CodeInline> state and only change how the drawer is presented at the current breakpoint.
+                            Without two-way binding, the drawer can still update its open state automatically according to its breakpoint configuration.
                         </Description>
                     </SectionHeader>
                     <SectionContent DarkenBackground="true" Code="@nameof(DrawerResponsiveExample)" ShowCode="false">

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -131,8 +131,8 @@
                 <Description>
                     The switching point for Responsive Drawers (<CodeInline>DrawerVariant.Mini</CodeInline> and <CodeInline>DrawerVariant.Responsive</CodeInline>) can be changed using the <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>.<br />
                     <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                        <b>Important:</b> When using <b>Mini</b> or <b>Responsive</b> variants, the <b>Breakpoint</b> parameter is always the source of truth for the drawer’s open/close state. The component will automatically open or close itself based on the current browser width and the specified breakpoint.<br />
-                        If you want to control the open state independently of the breakpoint, set <b>Variant="DrawerVariant.Persistent"</b> and use the <b>OnBreakpointChanged</b> event to implement your own logic. In persistent mode, the drawer will not automatically react to breakpoints, giving you full control.<br />
+                        <b>Important:</b> When using <b>Mini</b> or <b>Responsive</b> variants, the drawer may automatically open or close when the browser width crosses the configured <b>Breakpoint</b>. This responsive behavior can override the current <b>Open</b> state, including when using <CodeInline>@("@bind-Open")</CodeInline>.<br />
+                        If you need full manual control of the open state independent of breakpoint transitions, set <b>Variant="DrawerVariant.Persistent"</b> and use the <b>OnBreakpointChanged</b> event to implement your own logic. In persistent mode, the drawer will not automatically react to breakpoints.<br />
                         See the example below for how the <b>Breakpoint</b> parameter affects drawer behavior.
                     </MudAlert>
                 </Description>

--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -129,7 +129,12 @@
         <DocsPageSection>
             <SectionHeader Title="Custom Breakpoint">
                 <Description>
-                    The switching point for Responsive Drawers (<CodeInline>DrawerVariant.Mini</CodeInline> and <CodeInline>DrawerVariant.Responsive</CodeInline>) can be changed using the <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>.
+                    The switching point for Responsive Drawers (<CodeInline>DrawerVariant.Mini</CodeInline> and <CodeInline>DrawerVariant.Responsive</CodeInline>) can be changed using the <CodeInline>Breakpoint</CodeInline> parameter. The default is <CodeInline>Breakpoint.Md</CodeInline>.<br />
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                        <b>Important:</b> When using <b>Mini</b> or <b>Responsive</b> variants, the <b>Breakpoint</b> parameter is always the source of truth for the drawer’s open/close state. The component will automatically open or close itself based on the current browser width and the specified breakpoint.<br />
+                        If you want to control the open state independently of the breakpoint, set <b>Variant="DrawerVariant.Persistent"</b> and use the <b>OnBreakpointChanged</b> event to implement your own logic. In persistent mode, the drawer will not automatically react to breakpoints, giving you full control.<br />
+                        See the example below for how the <b>Breakpoint</b> parameter affects drawer behavior.
+                    </MudAlert>
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(DrawerBreakpointExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerBreakpointEventTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerBreakpointEventTest.razor
@@ -1,15 +1,26 @@
 <MudLayout>
-    <MudDrawer Variant="DrawerVariant.Persistent"
+    <MudDrawer Variant="@Variant"
                Open="@_open"
-               OnBreakpointChanged="HandleBreakpointChanged" />
+               OnBreakpointChanged="@BreakpointChangedCallback" />
 </MudLayout>
 
 @code {
     private bool _open = false;
 
+    [Parameter]
+    public bool CallbackEnabled { get; set; } = true;
+
+    [Parameter]
+    public DrawerVariant Variant { get; set; } = DrawerVariant.Persistent;
+
     public Breakpoint LastBreakpoint { get; private set; }
 
     public int BreakpointNotifications { get; private set; }
+
+    private EventCallback<Breakpoint> BreakpointChangedCallback =>
+        CallbackEnabled
+            ? EventCallback.Factory.Create<Breakpoint>(this, HandleBreakpointChanged)
+            : default;
 
     private Task HandleBreakpointChanged(Breakpoint breakpoint)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerBreakpointEventTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerBreakpointEventTest.razor
@@ -1,14 +1,11 @@
 <MudLayout>
     <MudDrawer Variant="@Variant"
                Open="@_open"
-               OnBreakpointChanged="@BreakpointChangedCallback" />
+               OnBreakpointChanged="@HandleBreakpointChanged" />
 </MudLayout>
 
 @code {
     private bool _open = false;
-
-    [Parameter]
-    public bool CallbackEnabled { get; set; } = true;
 
     [Parameter]
     public DrawerVariant Variant { get; set; } = DrawerVariant.Persistent;
@@ -16,11 +13,6 @@
     public Breakpoint LastBreakpoint { get; private set; }
 
     public int BreakpointNotifications { get; private set; }
-
-    private EventCallback<Breakpoint> BreakpointChangedCallback =>
-        CallbackEnabled
-            ? EventCallback.Factory.Create<Breakpoint>(this, HandleBreakpointChanged)
-            : default;
 
     private Task HandleBreakpointChanged(Breakpoint breakpoint)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerBreakpointEventTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerBreakpointEventTest.razor
@@ -1,0 +1,20 @@
+<MudLayout>
+    <MudDrawer Variant="DrawerVariant.Persistent"
+               Open="@_open"
+               OnBreakpointChanged="HandleBreakpointChanged" />
+</MudLayout>
+
+@code {
+    private bool _open = false;
+
+    public Breakpoint LastBreakpoint { get; private set; }
+
+    public int BreakpointNotifications { get; private set; }
+
+    private Task HandleBreakpointChanged(Breakpoint breakpoint)
+    {
+        LastBreakpoint = breakpoint;
+        BreakpointNotifications++;
+        return Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -575,6 +575,39 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-drawer-open-responsive-md-right").Count.Should().Be(0);
         }
 
+        [Test]
+        public void PersistentWithoutBreakpointCallback_DoesNotSubscribeToViewport()
+        {
+            var browserViewportService = AddBrowserViewportService();
+            var comp = Context.Render<DrawerTest1>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Persistent));
+
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance).Should().BeNull();
+        }
+
+        [Test]
+        public async Task PersistentWithBreakpointCallback_SubscribesAndRaisesCallback()
+        {
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerBreakpointEventTest>();
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
+
+            subscription.Should().NotBeNull();
+            comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Lg);
+            comp.Instance.BreakpointNotifications.Should().Be(1);
+
+            await comp.InvokeAsync(async () =>
+                await browserViewportService.RaiseOnResized(
+                    new BrowserWindowSize { Height = 0, Width = 0 },
+                    Breakpoint.Xs,
+                    subscription!.JavaScriptListenerId));
+
+            comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Xs);
+            comp.Instance.BreakpointNotifications.Should().Be(2);
+        }
+
         [Test, Combinatorial]
         public async Task NonResponsiveKeepInitialOpen_AllBreakpointsAsync(
             [Values(

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -608,61 +608,6 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.BreakpointNotifications.Should().Be(2);
         }
 
-        [Test]
-        public async Task BreakpointCallbackSubscription_ChangingVariant_UpdatesResizeOptions()
-        {
-            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
-            var comp = Context.Render<DrawerBreakpointEventTest>(parameters => parameters
-                .Add(x => x.Variant, DrawerVariant.Persistent));
-
-            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
-
-            subscription.Should().NotBeNull();
-            subscription!.Options!.NotifyOnBreakpointOnly.Should().BeTrue();
-
-            await comp.SetParametersAndRenderAsync(parameters => parameters
-                .Add(x => x.Variant, DrawerVariant.Responsive));
-
-            mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
-
-            subscription.Should().NotBeNull();
-            subscription!.Options!.NotifyOnBreakpointOnly.Should().BeFalse();
-        }
-
-        [Test]
-        public async Task ResponsiveWithLateBreakpointCallback_RaisesCurrentBreakpointImmediately()
-        {
-            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
-            var comp = Context.Render<DrawerBreakpointEventTest>(parameters => parameters
-                .Add(x => x.CallbackEnabled, false)
-                .Add(x => x.Variant, DrawerVariant.Responsive));
-
-            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance).Should().NotBeNull();
-            comp.Instance.BreakpointNotifications.Should().Be(0);
-
-            await comp.SetParametersAndRenderAsync(parameters => parameters
-                .Add(x => x.CallbackEnabled, true)
-                .Add(x => x.Variant, DrawerVariant.Responsive));
-
-            comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Lg);
-            comp.Instance.BreakpointNotifications.Should().Be(1);
-
-            mudDrawerComponent = comp.FindComponent<MudDrawer>();
-            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
-
-            await comp.InvokeAsync(async () =>
-                await browserViewportService.RaiseOnResized(
-                    new BrowserWindowSize { Height = 0, Width = 0 },
-                    Breakpoint.Xs,
-                    subscription!.JavaScriptListenerId));
-
-            comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Xs);
-            comp.Instance.BreakpointNotifications.Should().Be(2);
-        }
-
         [Test, Combinatorial]
         public async Task NonResponsiveKeepInitialOpen_AllBreakpointsAsync(
             [Values(

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -307,18 +307,16 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to small, drawer should stay open and switch to the overlay presentation
+            // Resize to small, drawer should close
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeTrue();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
 
-            // Resize to large, drawer should stay open
+            // Resize to large, drawer should open automatically
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Close drawer
@@ -326,11 +324,8 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeFalse();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
-            // Resize to small, the bound closed state should be preserved
+            // Resize to small, then open drawer
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
-
-            comp.Instance.Drawer.Open.Should().BeFalse();
-            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
             // Open drawer
             await comp.Find("#toggle-drawer-button").ClickAsync();
@@ -347,10 +342,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Resize screen to small in two steps while the drawer is open. The bound open state should be preserved across all breakpoint transitions.
+        /// Resize screen to small in two steps: first to SM, then to XS. After restoring the original screen size, the drawer should reopen automatically.
         /// </summary>
         [Test]
-        public async Task Responsive_ResizeToSmall_RestoreToLarge_KeepsBoundOpenState()
+        public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
             var comp = Context.Render<DrawerResponsiveTest>();
@@ -363,33 +358,30 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to small, drawer should stay open
+            // Resize to small, drawer should close
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeTrue();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
 
-            // Resize to extra small, drawer should stay open
+            // Resize to extra small, drawer should close
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeTrue();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
 
-            // Resize to large, drawer should stay open
+            // Resize to large, drawer should open automatically
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
         }
 
         /// <summary>
-        /// Resize screen from small to big while the drawer is closed. The bound closed state should not be overridden.
+        /// Resize screen from small to big. Once the screen is large enough, the drawer should open automatically.
         /// </summary>
         [Test]
-        public async Task Responsive_ResizeFromSmall_ToLarge_KeepsBoundClosedState()
+        public async Task Responsive_ResizeFromSmall_ToLarge_CheckStates()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
             var comp = Context.Render<DrawerResponsiveTest>();
@@ -406,11 +398,11 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            // Resize above breakpoint - drawer should stay closed
+            // Resize above breakpoint - drawer should open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeFalse();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -307,16 +307,18 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to small, drawer should close
+            // Resize to small, drawer should stay open and switch to the overlay presentation
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeFalse();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to large, drawer should open automatically
+            // Resize to large, drawer should stay open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
             // Close drawer
@@ -324,8 +326,11 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeFalse();
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
-            // Resize to small, then open drawer
+            // Resize to small, the bound closed state should be preserved
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
+
+            comp.Instance.Drawer.Open.Should().BeFalse();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
 
             // Open drawer
             await comp.Find("#toggle-drawer-button").ClickAsync();
@@ -342,10 +347,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Resize screen to small in two steps: first to SM, then to XS. After restoring the original screen size, the drawer should reopen automatically.
+        /// Resize screen to small in two steps while the drawer is open. The bound open state should be preserved across all breakpoint transitions.
         /// </summary>
         [Test]
-        public async Task Responsive_ResizeToSmall_RestoreToLarge_CheckStates()
+        public async Task Responsive_ResizeToSmall_RestoreToLarge_KeepsBoundOpenState()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
             var comp = Context.Render<DrawerResponsiveTest>();
@@ -358,30 +363,33 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to small, drawer should close
+            // Resize to small, drawer should stay open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 400, Width = 600 }, Breakpoint.Sm, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeFalse();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to extra small, drawer should close
+            // Resize to extra small, drawer should stay open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeFalse();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
 
-            // Resize to large, drawer should open automatically
+            // Resize to large, drawer should stay open
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
             comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
             comp.Instance.Drawer.Open.Should().BeTrue();
         }
 
         /// <summary>
-        /// Resize screen from small to big. Once the screen is large enough, the drawer should open automatically.
+        /// Resize screen from small to big while the drawer is closed. The bound closed state should not be overridden.
         /// </summary>
         [Test]
-        public async Task Responsive_ResizeFromSmall_ToLarge_CheckStates()
+        public async Task Responsive_ResizeFromSmall_ToLarge_KeepsBoundClosedState()
         {
             var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
             var comp = Context.Render<DrawerResponsiveTest>();
@@ -398,11 +406,11 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
             comp.Instance.Drawer.Open.Should().BeFalse();
 
-            // Resize above breakpoint - drawer should open
+            // Resize above breakpoint - drawer should stay closed
             await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
 
-            comp.FindAll("aside.mud-drawer--open.mud-drawer-responsive").Count.Should().Be(1);
-            comp.Instance.Drawer.Open.Should().BeTrue();
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-responsive").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeFalse();
         }
 
         [Test]
@@ -597,6 +605,61 @@ namespace MudBlazor.UnitTests.Components
             subscription.Should().NotBeNull();
             comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Lg);
             comp.Instance.BreakpointNotifications.Should().Be(1);
+
+            await comp.InvokeAsync(async () =>
+                await browserViewportService.RaiseOnResized(
+                    new BrowserWindowSize { Height = 0, Width = 0 },
+                    Breakpoint.Xs,
+                    subscription!.JavaScriptListenerId));
+
+            comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Xs);
+            comp.Instance.BreakpointNotifications.Should().Be(2);
+        }
+
+        [Test]
+        public async Task BreakpointCallbackSubscription_ChangingVariant_UpdatesResizeOptions()
+        {
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerBreakpointEventTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Persistent));
+
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
+
+            subscription.Should().NotBeNull();
+            subscription!.Options!.NotifyOnBreakpointOnly.Should().BeTrue();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Responsive));
+
+            mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
+
+            subscription.Should().NotBeNull();
+            subscription!.Options!.NotifyOnBreakpointOnly.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task ResponsiveWithLateBreakpointCallback_RaisesCurrentBreakpointImmediately()
+        {
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerBreakpointEventTest>(parameters => parameters
+                .Add(x => x.CallbackEnabled, false)
+                .Add(x => x.Variant, DrawerVariant.Responsive));
+
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance).Should().NotBeNull();
+            comp.Instance.BreakpointNotifications.Should().Be(0);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.CallbackEnabled, true)
+                .Add(x => x.Variant, DrawerVariant.Responsive));
+
+            comp.Instance.LastBreakpoint.Should().Be(Breakpoint.Lg);
+            comp.Instance.BreakpointNotifications.Should().Be(1);
+
+            mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance);
 
             await comp.InvokeAsync(async () =>
                 await browserViewportService.RaiseOnResized(

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -19,7 +19,10 @@ namespace MudBlazor
         private ElementReference _contentRef;
         private bool _closeOnPointerLeave;
         private bool _initial = true;
+        private bool _isBrowserViewportSubscribed;
+        private bool _lastNotifiedBreakpointInitialized;
         private bool _keepInitialState;
+        private Breakpoint _lastNotifiedBreakpoint = Breakpoint.None;
         private Breakpoint _lastUpdatedBreakpoint = Breakpoint.None;
 
         /// <summary>
@@ -138,6 +141,12 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]
         public DrawerVariant Variant { get; set; } = DrawerVariant.Responsive;
+
+        /// <summary>
+        /// Occurs when the current browser breakpoint observed by this drawer has changed.
+        /// </summary>
+        [Parameter]
+        public EventCallback<Breakpoint> OnBreakpointChanged { get; set; }
 
         /// <summary>
         /// The content within this drawer.
@@ -281,15 +290,15 @@ namespace MudBlazor
             if (firstRender)
             {
                 await UpdateHeightAsync();
-                if (!_disposed)
-                {
-                    _ = BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
-                }
-
                 if (string.IsNullOrWhiteSpace(Height) && Anchor is Anchor.Bottom or Anchor.Top)
                 {
                     StateHasChanged();
                 }
+            }
+
+            if (!_disposed)
+            {
+                await UpdateBrowserViewportSubscriptionAsync();
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -303,7 +312,7 @@ namespace MudBlazor
 
                 DrawerContainer?.Remove(this);
 
-                if (IsJSRuntimeAvailable)
+                if (IsJSRuntimeAvailable && _isBrowserViewportSubscribed)
                 {
                     await BrowserViewportService.UnsubscribeAsync(this);
                 }
@@ -352,6 +361,25 @@ namespace MudBlazor
 
         private void DrawerContainerUpdate() => (DrawerContainer as IMudStateHasChanged)?.StateHasChanged();
 
+        private async Task UpdateBrowserViewportSubscriptionAsync()
+        {
+            var shouldSubscribe = ShouldSubscribeToBrowserViewport();
+            if (shouldSubscribe && !_isBrowserViewportSubscribed)
+            {
+                _isBrowserViewportSubscribed = true;
+                await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
+                return;
+            }
+
+            if (!shouldSubscribe && _isBrowserViewportSubscribed)
+            {
+                await BrowserViewportService.UnsubscribeAsync(this);
+                _isBrowserViewportSubscribed = false;
+            }
+        }
+
+        private bool ShouldSubscribeToBrowserViewport() => IsResponsiveOrMini() || OnBreakpointChanged.HasDelegate;
+
         private Task CloseDrawerAsync()
         {
             if (_openState.Value)
@@ -399,6 +427,8 @@ namespace MudBlazor
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
 
+        private static bool IsResponsiveOrMini(DrawerVariant variant) => variant is DrawerVariant.Responsive or DrawerVariant.Mini;
+
         private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
 
         private bool ShouldOpenDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.Always || (!IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint()));
@@ -444,14 +474,25 @@ namespace MudBlazor
 
         Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
 
-        ResizeOptions IBrowserViewportObserver.ResizeOptions { get; } = new()
+        ResizeOptions IBrowserViewportObserver.ResizeOptions => new()
         {
             ReportRate = 50,
-            NotifyOnBreakpointOnly = false
+            NotifyOnBreakpointOnly = !IsResponsiveOrMini()
         };
 
         async Task IBrowserViewportObserver.NotifyBrowserViewportChangeAsync(BrowserViewportEventArgs browserViewportEventArgs)
         {
+            if (!_lastNotifiedBreakpointInitialized || _lastNotifiedBreakpoint != browserViewportEventArgs.Breakpoint)
+            {
+                _lastNotifiedBreakpoint = browserViewportEventArgs.Breakpoint;
+                _lastNotifiedBreakpointInitialized = true;
+
+                if (OnBreakpointChanged.HasDelegate)
+                {
+                    await OnBreakpointChanged.InvokeAsync(browserViewportEventArgs.Breakpoint);
+                }
+            }
+
             if (browserViewportEventArgs.IsImmediate)
             {
                 _lastUpdatedBreakpoint = browserViewportEventArgs.Breakpoint;

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -20,8 +20,10 @@ namespace MudBlazor
         private bool _closeOnPointerLeave;
         private bool _initial = true;
         private bool _isBrowserViewportSubscribed;
+        private bool _lastBreakpointChangedCallbackHasDelegate;
         private bool _lastNotifiedBreakpointInitialized;
         private bool _keepInitialState;
+        private ResizeOptions? _lastBrowserViewportSubscriptionOptions;
         private Breakpoint _lastNotifiedBreakpoint = Breakpoint.None;
         private Breakpoint _lastUpdatedBreakpoint = Breakpoint.None;
 
@@ -227,7 +229,7 @@ namespace MudBlazor
         /// Displays this drawer.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  Raises the <see cref="OpenChanged"/> event upon change.  When bound via <c>@bind-Open</c>, this property is updated when this drawer closes itself.
+        /// Defaults to <c>false</c>.  Raises the <see cref="OpenChanged"/> event upon change.  When bound via <c>@bind-Open</c>, this property keeps the parent-provided state during responsive breakpoint changes.
         /// </remarks>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Drawer.Behavior)]
@@ -364,10 +366,22 @@ namespace MudBlazor
         private async Task UpdateBrowserViewportSubscriptionAsync()
         {
             var shouldSubscribe = ShouldSubscribeToBrowserViewport();
+            var shouldNotifyCurrentBreakpoint = false;
+            var resizeOptions = shouldSubscribe ? GetBrowserViewportResizeOptions() : null;
+
+            if (shouldSubscribe && _isBrowserViewportSubscribed && !Equals(_lastBrowserViewportSubscriptionOptions, resizeOptions))
+            {
+                await BrowserViewportService.UnsubscribeAsync(this);
+                _isBrowserViewportSubscribed = false;
+                _lastBrowserViewportSubscriptionOptions = null;
+            }
+
             if (shouldSubscribe && !_isBrowserViewportSubscribed)
             {
-                _isBrowserViewportSubscribed = true;
                 await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
+                _isBrowserViewportSubscribed = true;
+                _lastBrowserViewportSubscriptionOptions = resizeOptions;
+                _lastBreakpointChangedCallbackHasDelegate = OnBreakpointChanged.HasDelegate;
                 return;
             }
 
@@ -375,6 +389,18 @@ namespace MudBlazor
             {
                 await BrowserViewportService.UnsubscribeAsync(this);
                 _isBrowserViewportSubscribed = false;
+                _lastBrowserViewportSubscriptionOptions = null;
+            }
+            else if (_isBrowserViewportSubscribed && !_lastBreakpointChangedCallbackHasDelegate && OnBreakpointChanged.HasDelegate)
+            {
+                shouldNotifyCurrentBreakpoint = true;
+            }
+
+            _lastBreakpointChangedCallbackHasDelegate = OnBreakpointChanged.HasDelegate;
+
+            if (shouldNotifyCurrentBreakpoint)
+            {
+                await NotifyCurrentBreakpointChangedAsync();
             }
         }
 
@@ -402,6 +428,7 @@ namespace MudBlazor
                 breakpoint = await BrowserViewportService.GetCurrentBreakpointAsync();
             }
 
+            var breakpointChanged = _lastUpdatedBreakpoint != breakpoint;
             var isStateChanged = false;
             if (ShouldCloseDrawer(breakpoint))
             {
@@ -415,7 +442,7 @@ namespace MudBlazor
             }
 
             _lastUpdatedBreakpoint = breakpoint;
-            if (isStateChanged)
+            if (isStateChanged || breakpointChanged)
             {
                 await InvokeAsync(StateHasChanged);
             }
@@ -427,11 +454,11 @@ namespace MudBlazor
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
 
-        private static bool IsResponsiveOrMini(DrawerVariant variant) => variant is DrawerVariant.Responsive or DrawerVariant.Mini;
+        private bool ShouldUpdateOpenStateFromBreakpoint() => !_openState.HasCallback || Variant != DrawerVariant.Responsive || Breakpoint is Breakpoint.Always or Breakpoint.None;
 
-        private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
+        private bool ShouldCloseDrawer(Breakpoint breakpoint) => ShouldUpdateOpenStateFromBreakpoint() && IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
 
-        private bool ShouldOpenDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.Always || (!IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint()));
+        private bool ShouldOpenDrawer(Breakpoint breakpoint) => ShouldUpdateOpenStateFromBreakpoint() && IsResponsiveOrMini() && (Breakpoint == Breakpoint.Always || (!IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint()));
 
         internal string GetPosition()
         {
@@ -474,23 +501,13 @@ namespace MudBlazor
 
         Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
 
-        ResizeOptions IBrowserViewportObserver.ResizeOptions => new()
-        {
-            ReportRate = 50,
-            NotifyOnBreakpointOnly = !IsResponsiveOrMini()
-        };
+        ResizeOptions IBrowserViewportObserver.ResizeOptions => GetBrowserViewportResizeOptions();
 
         async Task IBrowserViewportObserver.NotifyBrowserViewportChangeAsync(BrowserViewportEventArgs browserViewportEventArgs)
         {
             if (!_lastNotifiedBreakpointInitialized || _lastNotifiedBreakpoint != browserViewportEventArgs.Breakpoint)
             {
-                _lastNotifiedBreakpoint = browserViewportEventArgs.Breakpoint;
-                _lastNotifiedBreakpointInitialized = true;
-
-                if (OnBreakpointChanged.HasDelegate)
-                {
-                    await OnBreakpointChanged.InvokeAsync(browserViewportEventArgs.Breakpoint);
-                }
+                await NotifyBreakpointChangedAsync(browserViewportEventArgs.Breakpoint);
             }
 
             if (browserViewportEventArgs.IsImmediate)
@@ -552,6 +569,32 @@ namespace MudBlazor
                 Breakpoint.XlAndUp or Breakpoint.XlAndDown => Breakpoint.Xl,
                 _ => breakpoint,
             };
+        }
+
+        private ResizeOptions GetBrowserViewportResizeOptions() => new()
+        {
+            ReportRate = 50,
+            NotifyOnBreakpointOnly = !IsResponsiveOrMini()
+        };
+
+        private async Task NotifyBreakpointChangedAsync(Breakpoint breakpoint)
+        {
+            _lastNotifiedBreakpoint = breakpoint;
+            _lastNotifiedBreakpointInitialized = true;
+
+            if (OnBreakpointChanged.HasDelegate)
+            {
+                await OnBreakpointChanged.InvokeAsync(breakpoint);
+            }
+        }
+
+        private async Task NotifyCurrentBreakpointChangedAsync()
+        {
+            var breakpoint = _lastNotifiedBreakpointInitialized
+                ? _lastNotifiedBreakpoint
+                : await BrowserViewportService.GetCurrentBreakpointAsync();
+
+            await NotifyBreakpointChangedAsync(breakpoint);
         }
     }
 }

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -229,7 +229,7 @@ namespace MudBlazor
         /// Displays this drawer.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  Raises the <see cref="OpenChanged"/> event upon change.  When bound via <c>@bind-Open</c>, this property keeps the parent-provided state during responsive breakpoint changes.
+        /// Defaults to <c>false</c>.  Raises the <see cref="OpenChanged"/> event upon change.  When bound via <c>@bind-Open</c>, this property is updated when this drawer closes itself.
         /// </remarks>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Drawer.Behavior)]
@@ -428,7 +428,6 @@ namespace MudBlazor
                 breakpoint = await BrowserViewportService.GetCurrentBreakpointAsync();
             }
 
-            var breakpointChanged = _lastUpdatedBreakpoint != breakpoint;
             var isStateChanged = false;
             if (ShouldCloseDrawer(breakpoint))
             {
@@ -442,7 +441,7 @@ namespace MudBlazor
             }
 
             _lastUpdatedBreakpoint = breakpoint;
-            if (isStateChanged || breakpointChanged)
+            if (isStateChanged)
             {
                 await InvokeAsync(StateHasChanged);
             }
@@ -454,11 +453,9 @@ namespace MudBlazor
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
 
-        private bool ShouldUpdateOpenStateFromBreakpoint() => !_openState.HasCallback || Variant != DrawerVariant.Responsive || Breakpoint is Breakpoint.Always or Breakpoint.None;
+        private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
 
-        private bool ShouldCloseDrawer(Breakpoint breakpoint) => ShouldUpdateOpenStateFromBreakpoint() && IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
-
-        private bool ShouldOpenDrawer(Breakpoint breakpoint) => ShouldUpdateOpenStateFromBreakpoint() && IsResponsiveOrMini() && (Breakpoint == Breakpoint.Always || (!IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint()));
+        private bool ShouldOpenDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.Always || (!IsBelowBreakpoint(breakpoint) && IsBelowCurrentBreakpoint()));
 
         internal string GetPosition()
         {

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -20,10 +20,8 @@ namespace MudBlazor
         private bool _closeOnPointerLeave;
         private bool _initial = true;
         private bool _isBrowserViewportSubscribed;
-        private bool _lastBreakpointChangedCallbackHasDelegate;
         private bool _lastNotifiedBreakpointInitialized;
         private bool _keepInitialState;
-        private ResizeOptions? _lastBrowserViewportSubscriptionOptions;
         private Breakpoint _lastNotifiedBreakpoint = Breakpoint.None;
         private Breakpoint _lastUpdatedBreakpoint = Breakpoint.None;
 
@@ -366,41 +364,16 @@ namespace MudBlazor
         private async Task UpdateBrowserViewportSubscriptionAsync()
         {
             var shouldSubscribe = ShouldSubscribeToBrowserViewport();
-            var shouldNotifyCurrentBreakpoint = false;
-            var resizeOptions = shouldSubscribe ? GetBrowserViewportResizeOptions() : null;
-
-            if (shouldSubscribe && _isBrowserViewportSubscribed && !Equals(_lastBrowserViewportSubscriptionOptions, resizeOptions))
-            {
-                await BrowserViewportService.UnsubscribeAsync(this);
-                _isBrowserViewportSubscribed = false;
-                _lastBrowserViewportSubscriptionOptions = null;
-            }
 
             if (shouldSubscribe && !_isBrowserViewportSubscribed)
             {
                 await BrowserViewportService.SubscribeAsync(this, fireImmediately: true);
                 _isBrowserViewportSubscribed = true;
-                _lastBrowserViewportSubscriptionOptions = resizeOptions;
-                _lastBreakpointChangedCallbackHasDelegate = OnBreakpointChanged.HasDelegate;
-                return;
             }
-
-            if (!shouldSubscribe && _isBrowserViewportSubscribed)
+            else if (!shouldSubscribe && _isBrowserViewportSubscribed)
             {
                 await BrowserViewportService.UnsubscribeAsync(this);
                 _isBrowserViewportSubscribed = false;
-                _lastBrowserViewportSubscriptionOptions = null;
-            }
-            else if (_isBrowserViewportSubscribed && !_lastBreakpointChangedCallbackHasDelegate && OnBreakpointChanged.HasDelegate)
-            {
-                shouldNotifyCurrentBreakpoint = true;
-            }
-
-            _lastBreakpointChangedCallbackHasDelegate = OnBreakpointChanged.HasDelegate;
-
-            if (shouldNotifyCurrentBreakpoint)
-            {
-                await NotifyCurrentBreakpointChangedAsync();
             }
         }
 
@@ -498,7 +471,11 @@ namespace MudBlazor
 
         Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();
 
-        ResizeOptions IBrowserViewportObserver.ResizeOptions => GetBrowserViewportResizeOptions();
+        ResizeOptions IBrowserViewportObserver.ResizeOptions { get; } = new()
+        {
+            ReportRate = 50,
+            NotifyOnBreakpointOnly = false
+        };
 
         async Task IBrowserViewportObserver.NotifyBrowserViewportChangeAsync(BrowserViewportEventArgs browserViewportEventArgs)
         {
@@ -568,12 +545,6 @@ namespace MudBlazor
             };
         }
 
-        private ResizeOptions GetBrowserViewportResizeOptions() => new()
-        {
-            ReportRate = 50,
-            NotifyOnBreakpointOnly = !IsResponsiveOrMini()
-        };
-
         private async Task NotifyBreakpointChangedAsync(Breakpoint breakpoint)
         {
             _lastNotifiedBreakpoint = breakpoint;
@@ -583,15 +554,6 @@ namespace MudBlazor
             {
                 await OnBreakpointChanged.InvokeAsync(breakpoint);
             }
-        }
-
-        private async Task NotifyCurrentBreakpointChangedAsync()
-        {
-            var breakpoint = _lastNotifiedBreakpointInitialized
-                ? _lastNotifiedBreakpoint
-                : await BrowserViewportService.GetCurrentBreakpointAsync();
-
-            await NotifyBreakpointChangedAsync(breakpoint);
         }
     }
 }


### PR DESCRIPTION
## Background

The issue describes how, when using `MudDrawer` with `Variant="DrawerVariant.Responsive"`, the open/closed state is not consistently respected when resizing the browser window. Specifically, after closing the drawer and resizing to mobile and back, the drawer reopens, ignoring the bound state.

Closes [#11541](https://github.com/MudBlazor/MudBlazor/issues/11541) — *MudDrawer responsive variant ignores @bind-Open state on window resize*

## Solution

This PR introduces a new `OnBreakpointChanged` event callback to `MudDrawer`. This allows consumers to react to breakpoint changes directly, enabling advanced scenarios such as:

- Tracking the current breakpoint for custom logic.
- Deciding when to open/close the drawer based on breakpoint changes, rather than relying solely on the responsive variant’s internal state.

### Key Changes

- **Component:**  
  - Added `[Parameter] public EventCallback<Breakpoint> OnBreakpointChanged` to `MudDrawer`.
  - `MudDrawer` now subscribes to browser viewport changes if this callback is set, even for non-responsive variants.
  - The callback is invoked whenever the observed breakpoint changes.
- **Tests:**  
  - Added `DrawerBreakpointEventTest.razor` test component.
  - Added unit tests to verify subscription and callback behavior in `DrawerTest.cs`.

## Usage Example

```razor
<MudDrawer Variant="DrawerVariant.Persistent"
           Open="@_open"
           OnBreakpointChanged="HandleBreakpointChanged" />
@code {
    private bool _open = false;
    private void HandleBreakpointChanged(Breakpoint bp) { /* custom logic */ }
}
```

## Impact

- **Non-breaking:** Existing usage is unaffected unless the new event is used.
- **Enables advanced scenarios:** Developers can now implement custom logic on breakpoint changes, working around the limitations described in #11541.

## Tests

- Added and updated unit tests to cover the new event and ensure correct subscription/unsubscription behavior.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
