### PR TITLE
MudDrawer: Make mini drawers temporary on mobile by default

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Drawer/DrawerPage.razor
@@ -63,7 +63,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Mini">
                         <Description>
-                            The Mini variant is a streamlined version of the Responsive Drawer. It automatically shrinks to a narrow strip (default width: 56px) according to its breakpoint configuration.
+                            The Mini variant is a streamlined version of the Responsive Drawer. On screens at or above its configured <CodeInline>Breakpoint</CodeInline> it shrinks to a narrow strip (default width: 56px) that can expand on hover when <CodeInline>OpenMiniOnHover</CodeInline> is enabled.
+                            Below the breakpoint it behaves like a <CodeInline>DrawerVariant.Temporary</CodeInline> drawer: hidden when closed, shown over the content with an overlay when open, and closed automatically on navigation.
                             <br />Currently, Mini Drawers have built-in style support only for <CodeInline>MudNavLink</CodeInline> components.
                             To control whether the Mini Drawer is open or closed, use the <CodeInline>Open</CodeInline> parameter.
                             <br />To disable automatic responsiveness and manage the open state manually, set <CodeInline>Breakpoint="Breakpoint.None"</CodeInline>.

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
@@ -2,7 +2,7 @@
     <MudAppBar Elevation="1">
         <MudIconButton id="toggle-drawer-button" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
     </MudAppBar>
-    <MudDrawer @ref="@Drawer" @bind-Open="@_open" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
+    <MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
     </MudDrawer>
     <MudMainContent Class="pt-16 px-16">
         <MudContainer Class="mt-6">
@@ -17,6 +17,9 @@
 
     [Parameter]
     public Breakpoint Breakpoint { get; set; } = Breakpoint.Md;
+
+    [Parameter]
+    public DrawerVariant Variant { get; set; } = DrawerVariant.Responsive;
 
     [Parameter]
     public DrawerClipMode ClipMode { get; set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Drawer/DrawerResponsiveTest.razor
@@ -2,7 +2,7 @@
     <MudAppBar Elevation="1">
         <MudIconButton id="toggle-drawer-button" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
     </MudAppBar>
-    <MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
+    <MudDrawer @ref="@Drawer" @bind-Open="@_open" Variant="@Variant" OpenMiniOnHover="@OpenMiniOnHover" Elevation="1" Breakpoint="@Breakpoint" ClipMode="@ClipMode">
     </MudDrawer>
     <MudMainContent Class="pt-16 px-16">
         <MudContainer Class="mt-6">
@@ -20,6 +20,9 @@
 
     [Parameter]
     public DrawerVariant Variant { get; set; } = DrawerVariant.Responsive;
+
+    [Parameter]
+    public bool OpenMiniOnHover { get; set; }
 
     [Parameter]
     public DrawerClipMode ClipMode { get; set; }

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -240,6 +240,135 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [TestCase(Breakpoint.None)]
+        [TestCase(Breakpoint.Always)]
+        public async Task MiniSentinelBreakpoint_StaysMiniOnLargeScreen(Breakpoint breakpoint)
+        {
+            // Breakpoint.None and Breakpoint.Always are sentinels, not real widths, so a mini drawer using them must
+            // keep its mini behavior on every screen size instead of degrading to a temporary overlay drawer.
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini)
+                .Add(x => x.Breakpoint, breakpoint));
+
+            comp.FindAll("aside.mud-drawer-mini").Count.Should().Be(1);
+            comp.FindAll("aside.mud-drawer-temporary").Count.Should().Be(0);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
+
+            // Toggling forces the drawer to re-render after the viewport breakpoint has been resolved; a sentinel
+            // breakpoint must never flip a mini drawer into temporary mode.
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+
+            comp.FindAll("aside.mud-drawer-mini").Count.Should().Be(1);
+            comp.FindAll("aside.mud-drawer-temporary").Count.Should().Be(0);
+        }
+
+        [Test]
+        [TestCase(Breakpoint.Lg)]
+        [TestCase(Breakpoint.Xl)]
+        public async Task MiniLargeScreen_StaysMiniRailWithoutOverlay(Breakpoint viewport)
+        {
+            // Above its breakpoint a mini drawer stays a docked rail with no overlay and keeps the content offset.
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(viewport));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini));
+
+            comp.FindAll("aside.mud-drawer-mini").Count.Should().Be(1);
+            comp.Find("div.mud-layout").ClassName.Should().Contain("mini-md-left");
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+
+            // Opening a desktop mini drawer keeps it a mini rail and never shows an overlay.
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-mini").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task MiniLargeScreen_OpenMiniOnHover_OpensAndCloses()
+        {
+            // On a large screen the mini drawer is still a real mini drawer, so hover-to-expand keeps working.
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini)
+                .Add(x => x.OpenMiniOnHover, true));
+
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            await comp.Find("aside.mud-drawer").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            await comp.Find("aside.mud-drawer").TriggerEventAsync("onpointerleave", new PointerEventArgs());
+            comp.Instance.Drawer.Open.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task MiniSmallScreen_OpenMiniOnHover_DoesNotOpen()
+        {
+            // Below the breakpoint the drawer behaves like Temporary, so hover must not open it.
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini)
+                .Add(x => x.OpenMiniOnHover, true));
+
+            comp.Instance.Drawer.Open.Should().BeFalse();
+
+            await comp.Find("aside.mud-drawer").TriggerEventAsync("onpointerenter", new PointerEventArgs());
+            comp.Instance.Drawer.Open.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task Mini_ResizeAcrossBreakpoint_SwitchesVariantClasses()
+        {
+            var browserViewportService = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini));
+            var mudDrawerComponent = comp.FindComponent<MudDrawer>();
+            var subscription = browserViewportService.GetInternalSubscription(mudDrawerComponent.Instance)!;
+
+            // Large screen: mini rail with the mini content offset. (The open/close prefix depends on auto-open
+            // timing, so assert on the variant token only.)
+            comp.FindAll("aside.mud-drawer-mini").Count.Should().Be(1);
+            comp.Find("div.mud-layout").ClassName.Should().Contain("mini-md-left");
+            comp.Find("div.mud-layout").ClassName.Should().NotContain("temporary");
+
+            // Resize below the breakpoint: the drawer becomes temporary and the mini offset is dropped.
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 0, Width = 0 }, Breakpoint.Xs, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer-temporary").Count.Should().Be(1);
+            comp.FindAll("aside.mud-drawer-mini").Count.Should().Be(0);
+            comp.Find("div.mud-layout").ClassName.Should().Contain("temporary-left");
+            comp.Find("div.mud-layout").ClassName.Should().NotContain("mini");
+
+            // Resize back above the breakpoint: the drawer returns to the mini rail.
+            await comp.InvokeAsync(async () => await browserViewportService.RaiseOnResized(new BrowserWindowSize { Height = 720, Width = 1280 }, Breakpoint.Lg, subscription.JavaScriptListenerId));
+
+            comp.FindAll("aside.mud-drawer-mini").Count.Should().Be(1);
+            comp.FindAll("aside.mud-drawer-temporary").Count.Should().Be(0);
+            comp.Find("div.mud-layout").ClassName.Should().Contain("mini-md-left");
+            comp.Find("div.mud-layout").ClassName.Should().NotContain("temporary");
+        }
+
+        [Test]
+        public async Task MiniLargeScreen_NavigationDoesNotCloseDesktopRail()
+        {
+            // The "And-up" aliases normalize to a real breakpoint; navigating on a desktop mini rail must not close it.
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Lg));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini)
+                .Add(x => x.Breakpoint, Breakpoint.MdAndUp));
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-mini").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            await comp.InvokeAsync(() => ((MudBlazor.Interfaces.INavigationEventReceiver)comp.Instance.Drawer).OnNavigation());
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-mini").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+        }
+
+        [Test]
         public async Task ResponsiveClosed_Open_CheckOpened_Close_CheckClosedAsync()
         {
             _ = AddBrowserViewportService();

--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -205,6 +205,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task MiniSmallScreen_UsesTemporaryVariantClassesAndOverlay()
+        {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini));
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
+            comp.Find("div.mud-layout").ClassName.Should().Contain("mud-drawer-close-temporary-left");
+            comp.Find("div.mud-layout").ClassName.Should().NotContain("mud-drawer-close-mini");
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+
+            comp.FindAll("aside.mud-drawer--open.mud-drawer-temporary").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(1);
+            comp.Instance.Drawer.Open.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task MiniSmallScreen_NavigationClosesDrawer()
+        {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Variant, DrawerVariant.Mini));
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+            comp.Instance.Drawer.Open.Should().BeTrue();
+
+            await comp.InvokeAsync(() => ((MudBlazor.Interfaces.INavigationEventReceiver)comp.Instance.Drawer).OnNavigation());
+
+            comp.FindAll("aside.mud-drawer--closed.mud-drawer-temporary").Count.Should().Be(1);
+            comp.FindAll(".mud-drawer-overlay").Count.Should().Be(0);
+            comp.Instance.Drawer.Open.Should().BeFalse();
+        }
+
+        [Test]
         public async Task ResponsiveClosed_Open_CheckOpened_Close_CheckClosedAsync()
         {
             _ = AddBrowserViewportService();

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -43,7 +43,9 @@ namespace MudBlazor
                 .WithChangeHandler(OnRightToLeftParameterChanged);
         }
 
-        private bool OverlayVisible => _openState.Value && Overlay && (Variant == DrawerVariant.Temporary || (IsBelowCurrentBreakpoint() && IsResponsiveOrMini()));
+        private DrawerVariant CurrentRenderVariant => GetCurrentRenderVariant();
+
+        private bool OverlayVisible => _openState.Value && Overlay && (CurrentRenderVariant == DrawerVariant.Temporary || (CurrentRenderVariant == DrawerVariant.Responsive && IsBelowCurrentBreakpoint()));
 
         protected string Classname =>
             new CssBuilder("mud-drawer")
@@ -56,7 +58,7 @@ namespace MudBlazor
                 .AddClass($"mud-drawer-clipped-{ClipMode.ToStringFast(true)}")
                 .AddClass($"mud-theme-{Color.ToStringFast(true)}", Color != Color.Default)
                 .AddClass($"mud-elevation-{Elevation}")
-                .AddClass($"mud-drawer-{Variant.ToStringFast(true)}")
+                .AddClass($"mud-drawer-{CurrentRenderVariant.ToStringFast(true)}")
                 .AddClass(Class)
                 .Build();
 
@@ -64,7 +66,7 @@ namespace MudBlazor
             new CssBuilder("mud-drawer-overlay mud-overlay-drawer")
                 .AddClass($"mud-drawer-pos-{GetPosition()}")
                 .AddClass($"mud-drawer-overlay--open", _openState.Value)
-                .AddClass($"mud-drawer-overlay-{Variant.ToStringFast(true)}")
+                .AddClass($"mud-drawer-overlay-{CurrentRenderVariant.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay-{Breakpoint.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay--initial", _initial)
                 .AddClass($"mud-skip-overlay-positioning") // popovers try to position the overlay by zindex, this skips that behavior
@@ -73,7 +75,7 @@ namespace MudBlazor
 
         protected string Stylename =>
             new StyleBuilder()
-                .AddStyle("--mud-drawer-width", Width, !string.IsNullOrWhiteSpace(Width) && (!IsFixed || Variant == DrawerVariant.Temporary))
+                .AddStyle("--mud-drawer-width", Width, !string.IsNullOrWhiteSpace(Width) && (!IsFixed || CurrentRenderVariant == DrawerVariant.Temporary))
                 .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
                 .AddStyle("--mud-drawer-height", string.IsNullOrWhiteSpace(Height) ? _height.ToPx() : Height, Anchor == Anchor.Bottom || Anchor == Anchor.Top)
                 .AddStyle("visibility", "hidden", string.IsNullOrWhiteSpace(Height) && _height == 0 && Anchor is Anchor.Bottom or Anchor.Top)
@@ -150,7 +152,8 @@ namespace MudBlazor
         /// For responsive and temporary drawers, darkens the screen with an overlay when displaying this drawer.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.  Applies when <see cref="Variant"/> is <see cref="DrawerVariant.Responsive"/> or <see cref="DrawerVariant.Temporary"/>.
+        /// Defaults to <c>true</c>. Applies when <see cref="Variant"/> is <see cref="DrawerVariant.Responsive"/> or <see cref="DrawerVariant.Temporary"/>.
+        /// Mini drawers also display the overlay while they behave like <see cref="DrawerVariant.Temporary"/> below their <see cref="Breakpoint"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Drawer.Behavior)]
@@ -208,6 +211,7 @@ namespace MudBlazor
         /// </para>
         /// <para>
         /// Applies when <see cref="Variant" /> is set to <see cref="DrawerVariant.Responsive"/> or <see cref="DrawerVariant.Mini" />.
+        /// Mini drawers behave like <see cref="DrawerVariant.Temporary"/> below this breakpoint.
         /// </para>
         /// </remarks> 
         [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
@@ -369,6 +373,7 @@ namespace MudBlazor
 
         private async Task UpdateBreakpointStateAsync(Breakpoint breakpoint)
         {
+            var previousRenderVariant = CurrentRenderVariant;
             if (breakpoint == Breakpoint.None)
             {
                 breakpoint = await BrowserViewportService.GetCurrentBreakpointAsync();
@@ -387,7 +392,13 @@ namespace MudBlazor
             }
 
             _lastUpdatedBreakpoint = breakpoint;
-            if (isStateChanged)
+            var renderVariantChanged = previousRenderVariant != CurrentRenderVariant;
+            if (renderVariantChanged)
+            {
+                DrawerContainerUpdate();
+            }
+
+            if (isStateChanged || renderVariantChanged)
             {
                 await InvokeAsync(StateHasChanged);
             }
@@ -398,6 +409,11 @@ namespace MudBlazor
         private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < NormalizeBreakpoint(Breakpoint);
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
+
+        private DrawerVariant GetCurrentRenderVariant()
+            => Variant == DrawerVariant.Mini && IsBelowCurrentBreakpoint()
+                ? DrawerVariant.Temporary
+                : Variant;
 
         private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
 
@@ -417,7 +433,7 @@ namespace MudBlazor
 
         private async Task OnPointerEnterAsync()
         {
-            if (Variant == DrawerVariant.Mini && !_openState.Value && OpenMiniOnHover)
+            if (CurrentRenderVariant == DrawerVariant.Mini && !_openState.Value && OpenMiniOnHover)
             {
                 _closeOnPointerLeave = true;
                 await _openState.SetValueAsync(true);
@@ -426,7 +442,7 @@ namespace MudBlazor
 
         private async Task OnPointerLeaveAsync()
         {
-            if (Variant == DrawerVariant.Mini && _openState.Value && _closeOnPointerLeave)
+            if (CurrentRenderVariant == DrawerVariant.Mini && _openState.Value && _closeOnPointerLeave)
             {
                 _closeOnPointerLeave = false;
                 await _openState.SetValueAsync(false);
@@ -435,8 +451,8 @@ namespace MudBlazor
 
         async Task INavigationEventReceiver.OnNavigation()
         {
-            if (Variant == DrawerVariant.Temporary ||
-                (Variant == DrawerVariant.Responsive && await BrowserViewportService.GetCurrentBreakpointAsync() < Breakpoint))
+            if (CurrentRenderVariant == DrawerVariant.Temporary ||
+                (IsResponsiveOrMini() && await BrowserViewportService.GetCurrentBreakpointAsync() < Breakpoint))
             {
                 await _openState.SetValueAsync(false);
             }
@@ -454,6 +470,7 @@ namespace MudBlazor
         {
             if (browserViewportEventArgs.IsImmediate)
             {
+                var previousRenderVariant = CurrentRenderVariant;
                 _lastUpdatedBreakpoint = browserViewportEventArgs.Breakpoint;
                 if (!IsResponsiveOrMini())
                 {
@@ -471,6 +488,11 @@ namespace MudBlazor
                 else if (HandleBelowBreakpointAndOpenState())
                 {
                     await InitialOpenState(false);
+                }
+                else if (previousRenderVariant != CurrentRenderVariant)
+                {
+                    DrawerContainerUpdate();
+                    await InvokeAsync(StateHasChanged);
                 }
 
                 return;
@@ -493,6 +515,8 @@ namespace MudBlazor
                 return _openState.SetValueAsync(open);
             }
         }
+
+        internal DrawerVariant GetContainerVariant() => CurrentRenderVariant;
 
         private static Breakpoint NormalizeBreakpoint(Breakpoint breakpoint)
         {

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -43,9 +43,9 @@ namespace MudBlazor
                 .WithChangeHandler(OnRightToLeftParameterChanged);
         }
 
-        private DrawerVariant CurrentRenderVariant => GetCurrentRenderVariant();
+        internal DrawerVariant EffectiveVariant => Variant == DrawerVariant.Mini && IsBelowCurrentBreakpoint() ? DrawerVariant.Temporary : Variant;
 
-        private bool OverlayVisible => _openState.Value && Overlay && (CurrentRenderVariant == DrawerVariant.Temporary || (CurrentRenderVariant == DrawerVariant.Responsive && IsBelowCurrentBreakpoint()));
+        private bool OverlayVisible => _openState.Value && Overlay && (EffectiveVariant == DrawerVariant.Temporary || (EffectiveVariant == DrawerVariant.Responsive && IsBelowCurrentBreakpoint()));
 
         protected string Classname =>
             new CssBuilder("mud-drawer")
@@ -58,7 +58,7 @@ namespace MudBlazor
                 .AddClass($"mud-drawer-clipped-{ClipMode.ToStringFast(true)}")
                 .AddClass($"mud-theme-{Color.ToStringFast(true)}", Color != Color.Default)
                 .AddClass($"mud-elevation-{Elevation}")
-                .AddClass($"mud-drawer-{CurrentRenderVariant.ToStringFast(true)}")
+                .AddClass($"mud-drawer-{EffectiveVariant.ToStringFast(true)}")
                 .AddClass(Class)
                 .Build();
 
@@ -66,7 +66,7 @@ namespace MudBlazor
             new CssBuilder("mud-drawer-overlay mud-overlay-drawer")
                 .AddClass($"mud-drawer-pos-{GetPosition()}")
                 .AddClass($"mud-drawer-overlay--open", _openState.Value)
-                .AddClass($"mud-drawer-overlay-{CurrentRenderVariant.ToStringFast(true)}")
+                .AddClass($"mud-drawer-overlay-{EffectiveVariant.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay-{Breakpoint.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay--initial", _initial)
                 .AddClass($"mud-skip-overlay-positioning") // popovers try to position the overlay by zindex, this skips that behavior
@@ -75,7 +75,7 @@ namespace MudBlazor
 
         protected string Stylename =>
             new StyleBuilder()
-                .AddStyle("--mud-drawer-width", Width, !string.IsNullOrWhiteSpace(Width) && (!IsFixed || CurrentRenderVariant == DrawerVariant.Temporary))
+                .AddStyle("--mud-drawer-width", Width, !string.IsNullOrWhiteSpace(Width) && (!IsFixed || EffectiveVariant == DrawerVariant.Temporary))
                 .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
                 .AddStyle("--mud-drawer-height", string.IsNullOrWhiteSpace(Height) ? _height.ToPx() : Height, Anchor == Anchor.Bottom || Anchor == Anchor.Top)
                 .AddStyle("visibility", "hidden", string.IsNullOrWhiteSpace(Height) && _height == 0 && Anchor is Anchor.Bottom or Anchor.Top)
@@ -373,7 +373,7 @@ namespace MudBlazor
 
         private async Task UpdateBreakpointStateAsync(Breakpoint breakpoint)
         {
-            var previousRenderVariant = CurrentRenderVariant;
+            var previousEffectiveVariant = EffectiveVariant;
             if (breakpoint == Breakpoint.None)
             {
                 breakpoint = await BrowserViewportService.GetCurrentBreakpointAsync();
@@ -392,7 +392,7 @@ namespace MudBlazor
             }
 
             _lastUpdatedBreakpoint = breakpoint;
-            var renderVariantChanged = previousRenderVariant != CurrentRenderVariant;
+            var renderVariantChanged = previousEffectiveVariant != EffectiveVariant;
             if (renderVariantChanged)
             {
                 DrawerContainerUpdate();
@@ -409,11 +409,6 @@ namespace MudBlazor
         private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < NormalizeBreakpoint(Breakpoint);
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
-
-        private DrawerVariant GetCurrentRenderVariant()
-            => Variant == DrawerVariant.Mini && IsBelowCurrentBreakpoint()
-                ? DrawerVariant.Temporary
-                : Variant;
 
         private bool ShouldCloseDrawer(Breakpoint breakpoint) => IsResponsiveOrMini() && (Breakpoint == Breakpoint.None || (IsBelowBreakpoint(breakpoint) && !IsBelowCurrentBreakpoint()));
 
@@ -433,7 +428,7 @@ namespace MudBlazor
 
         private async Task OnPointerEnterAsync()
         {
-            if (CurrentRenderVariant == DrawerVariant.Mini && !_openState.Value && OpenMiniOnHover)
+            if (EffectiveVariant == DrawerVariant.Mini && !_openState.Value && OpenMiniOnHover)
             {
                 _closeOnPointerLeave = true;
                 await _openState.SetValueAsync(true);
@@ -442,7 +437,7 @@ namespace MudBlazor
 
         private async Task OnPointerLeaveAsync()
         {
-            if (CurrentRenderVariant == DrawerVariant.Mini && _openState.Value && _closeOnPointerLeave)
+            if (EffectiveVariant == DrawerVariant.Mini && _openState.Value && _closeOnPointerLeave)
             {
                 _closeOnPointerLeave = false;
                 await _openState.SetValueAsync(false);
@@ -451,7 +446,7 @@ namespace MudBlazor
 
         async Task INavigationEventReceiver.OnNavigation()
         {
-            if (CurrentRenderVariant == DrawerVariant.Temporary ||
+            if (EffectiveVariant == DrawerVariant.Temporary ||
                 (IsResponsiveOrMini() && await BrowserViewportService.GetCurrentBreakpointAsync() < Breakpoint))
             {
                 await _openState.SetValueAsync(false);
@@ -470,7 +465,7 @@ namespace MudBlazor
         {
             if (browserViewportEventArgs.IsImmediate)
             {
-                var previousRenderVariant = CurrentRenderVariant;
+                var previousEffectiveVariant = EffectiveVariant;
                 _lastUpdatedBreakpoint = browserViewportEventArgs.Breakpoint;
                 if (!IsResponsiveOrMini())
                 {
@@ -489,7 +484,7 @@ namespace MudBlazor
                 {
                     await InitialOpenState(false);
                 }
-                else if (previousRenderVariant != CurrentRenderVariant)
+                else if (previousEffectiveVariant != EffectiveVariant)
                 {
                     DrawerContainerUpdate();
                     await InvokeAsync(StateHasChanged);
@@ -515,8 +510,6 @@ namespace MudBlazor
                 return _openState.SetValueAsync(open);
             }
         }
-
-        internal DrawerVariant GetContainerVariant() => CurrentRenderVariant;
 
         private static Breakpoint NormalizeBreakpoint(Breakpoint breakpoint)
         {

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -43,7 +43,14 @@ namespace MudBlazor
                 .WithChangeHandler(OnRightToLeftParameterChanged);
         }
 
-        internal DrawerVariant EffectiveVariant => Variant == DrawerVariant.Mini && IsBelowCurrentBreakpoint() ? DrawerVariant.Temporary : Variant;
+        // A mini drawer behaves like a temporary drawer below its breakpoint, but only for a finite breakpoint.
+        // Breakpoint.None and Breakpoint.Always are sentinels (not real widths): treating them as "below" would
+        // make every viewport temporary and break, for example, a mini drawer using Breakpoint.None to opt out of
+        // automatic responsiveness, so they keep the mini behavior on all screen sizes.
+        internal DrawerVariant EffectiveVariant =>
+            Variant == DrawerVariant.Mini && Breakpoint is not (Breakpoint.None or Breakpoint.Always) && IsBelowCurrentBreakpoint()
+                ? DrawerVariant.Temporary
+                : Variant;
 
         private bool OverlayVisible => _openState.Value && Overlay && (EffectiveVariant == DrawerVariant.Temporary || (EffectiveVariant == DrawerVariant.Responsive && IsBelowCurrentBreakpoint()));
 
@@ -444,13 +451,19 @@ namespace MudBlazor
             }
         }
 
-        async Task INavigationEventReceiver.OnNavigation()
+        Task INavigationEventReceiver.OnNavigation()
         {
+            // Close on navigation only when the drawer is currently shown as an overlay: a temporary drawer (which
+            // includes a mini drawer below its breakpoint, via EffectiveVariant) or a responsive drawer below its
+            // breakpoint. This mirrors OverlayVisible and uses the normalized, already-resolved breakpoint so
+            // navigation never closes a docked desktop drawer such as a mini rail.
             if (EffectiveVariant == DrawerVariant.Temporary ||
-                (IsResponsiveOrMini() && await BrowserViewportService.GetCurrentBreakpointAsync() < Breakpoint))
+                (EffectiveVariant == DrawerVariant.Responsive && IsBelowCurrentBreakpoint()))
             {
-                await _openState.SetValueAsync(false);
+                return _openState.SetValueAsync(false);
             }
+
+            return Task.CompletedTask;
         }
 
         Guid IBrowserViewportObserver.Id { get; } = Guid.NewGuid();

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -68,8 +68,9 @@ namespace MudBlazor
                 return string.Empty;
             }
 
-            var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{drawer.Variant.ToStringFast(true)}";
-            if (drawer.Variant is DrawerVariant.Responsive or DrawerVariant.Mini)
+            var variant = drawer.GetContainerVariant();
+            var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{variant.ToStringFast(true)}";
+            if (variant is DrawerVariant.Responsive or DrawerVariant.Mini)
             {
                 className += $"-{drawer.Breakpoint.ToStringFast(true)}";
             }

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -68,7 +68,7 @@ namespace MudBlazor
                 return string.Empty;
             }
 
-            var variant = drawer.GetContainerVariant();
+            var variant = drawer.EffectiveVariant;
             var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{variant.ToStringFast(true)}";
             if (variant is DrawerVariant.Responsive or DrawerVariant.Mini)
             {

--- a/src/MudBlazor/Enums/DrawerVariant.cs
+++ b/src/MudBlazor/Enums/DrawerVariant.cs
@@ -28,7 +28,7 @@ public enum DrawerVariant
     Persistent,
 
     /// <summary>
-    /// The drawer has a small width on larger screens, but behaves like <see cref="DrawerVariant.Temporary"/> below its breakpoint.
+    /// The drawer has a small width on larger screens and can expand when hovered, but behaves like <see cref="DrawerVariant.Temporary"/> below its breakpoint.
     /// </summary>
     [Description("mini")]
     Mini

--- a/src/MudBlazor/Enums/DrawerVariant.cs
+++ b/src/MudBlazor/Enums/DrawerVariant.cs
@@ -28,7 +28,7 @@ public enum DrawerVariant
     Persistent,
 
     /// <summary>
-    /// The drawer has a small width but will expand when hovering over it.
+    /// The drawer has a small width on larger screens, but behaves like <see cref="DrawerVariant.Temporary"/> below its breakpoint.
     /// </summary>
     [Description("mini")]
     Mini


### PR DESCRIPTION
Mini drawers now behave like temporary drawers below their configured breakpoint, matching the existing responsive mobile behavior without requiring any new API.

Previously a `DrawerVariant.Mini` drawer kept its collapsed rail at every viewport size, so on a phone it permanently occupied part of an already narrow screen and could not be dismissed.

**Changes below the breakpoint:**
- `DrawerVariant.Mini` renders as temporary, so a closed drawer is hidden completely instead of leaving the mini rail visible
- The overlay is shown while the drawer is open
- Navigating closes the drawer
- Opening on hover no longer applies, since there is no rail to hover

Desktop behavior at or above the breakpoint is unchanged.

**Opting out:**

Set `Breakpoint` to `Breakpoint.None` or `Breakpoint.Always` to keep the mini rail at every viewport size:

```razor
<MudDrawer Variant="DrawerVariant.Mini" Breakpoint="Breakpoint.None" />
```

Both are sentinels rather than real widths, so they are never treated as "below" the breakpoint.

**Rendered output below the breakpoint:**

This matters if you have CSS or automation targeting the drawer.

| | Before | After |
| --- | --- | --- |
| `aside` | `mud-drawer-mini` | `mud-drawer-temporary` |
| `div.mud-layout` | `mud-drawer-close-mini` | `mud-drawer-close-temporary-left` |
| Overlay | none | `.mud-drawer-overlay` present |

Closes #12361, Closes #13017

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests