### PR TITLE
MudIcon: Fix flickering when using font icons

### DIFF
--- a/src/MudBlazor/Styles/components/_icons.scss
+++ b/src/MudBlazor/Styles/components/_icons.scss
@@ -12,6 +12,7 @@
 .mud-icon-root {
   width: 1em;
   height: 1em;
+  overflow: hidden;
   display: inline-block;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   flex-shrink: 0;


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/MudBlazor.Icons/issues/17

The `.mud-icon-root` sets `width: 1em; height: 1em` but no `overflow: hidden`, which makes the text flash visibly before the icon glyph renders.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
