### PR TITLE
MudNumericField: Restore managed text input behavior

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NumericField/NumericFieldPage.razor
@@ -39,7 +39,7 @@
                 <DocsPageSection>
                     <SectionHeader Title="Spin Buttons">
                         <Description>
-                            By default, numeric fields display up/down spin buttons for easy value adjustment. Set <CodeInline>HideSpinButtons="true"</CodeInline> to hide these controls while preserving keyboard navigation (arrow keys) and manual input.
+                            By default, numeric fields display up/down spin buttons for easy value adjustment. Set <CodeInline>HideSpinButtons="true"</CodeInline> to hide these controls while preserving keyboard navigation (arrow keys), Shift + mouse wheel stepping, and manual input.
                         </Description>
                     </SectionHeader>
                     <SectionContent Class="demo-numericfield" Code="@nameof(NumericFieldHideButtonsExample)" ShowCode="false">
@@ -109,7 +109,7 @@
         <DocsPageSection>
             <SectionHeader Title="Mouse Wheel Support">
                 <Description>
-                    Enhance user experience by allowing value changes via mouse wheel. Hold Shift while scrolling to increment or decrement values by the configured step amount.
+                    Numeric fields respond to Shift + mouse wheel to increment or decrement values by the configured step amount without inheriting browser-specific wheel stepping behavior.
                     Use <CodeInline>InvertMouseWheel="true"</CodeInline> to reverse the scroll direction if desired.
                 </Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldRenderTest.razor
@@ -12,7 +12,7 @@
 <MudSwitch @bind-Value="@UsePattern" Label="Use Pattern"/>
 
 @code {
-    public static string __description__ = "Render as Type Number or Text";
+    public static string __description__ = "Render as Type Text and only emit pattern when requested";
 
     [Parameter]
     public bool UsePattern { get; set; }

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1124,13 +1124,13 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Should_render_appropriate_type()
+        public async Task Should_render_text_input_and_only_emit_pattern_when_explicitly_set()
         {
             var comp = Context.Render<NumericFieldRenderTest>();
             var field = comp.Find("#num-field-id");
 
             comp.Markup.Should().NotContain("pattern");
-            field.GetAttribute("type").Should().Be("number");
+            field.GetAttribute("type").Should().Be("text");
 
             await comp.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.UsePattern, true));
@@ -1141,7 +1141,39 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.UsePattern, false));
 
             comp.Markup.Should().NotContain("pattern");
-            field.GetAttribute("type").Should().Be("number");
+            field.GetAttribute("type").Should().Be("text");
+        }
+
+        [Test]
+        public void NumericField_Should_RenderSpinbuttonAriaAttributes()
+        {
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
+                .Add(p => p.Value, 4)
+                .Add(p => p.Min, 1)
+                .Add(p => p.Max, 10));
+
+            var input = comp.Find("input");
+
+            input.GetAttribute("type").Should().Be("text");
+            input.GetAttribute("role").Should().Be("spinbutton");
+            input.GetAttribute("aria-valuenow").Should().Be("4");
+            input.GetAttribute("aria-valuemin").Should().Be("1");
+            input.GetAttribute("aria-valuemax").Should().Be("10");
+            input.HasAttribute("aria-valuetext").Should().BeFalse();
+        }
+
+        [Test]
+        public void NumericField_Should_RenderAriaValueText_WhenFormattedTextDiffers()
+        {
+            var comp = Context.Render<MudNumericField<double>>(parameters => parameters
+                .Add(p => p.Value, 1234.56)
+                .Add(p => p.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(p => p.Format, "N2"));
+
+            var input = comp.Find("input");
+
+            input.GetAttribute("aria-valuenow").Should().Be("1234.56");
+            input.GetAttribute("aria-valuetext").Should().Be("1,234.56");
         }
 
         [Test]
@@ -1157,6 +1189,21 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Instance.Value.Should().Be(123.45M));
             numericField.Instance.ReadText.Should().Be("123.45");
             numericField.Instance.GetState(x => x.Culture).Name.Should().Be("");
+        }
+
+        [Test]
+        [SetUICulture("ru-RU")]
+        public async Task Should_apply_explicit_current_ui_culture()
+        {
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
+                .Add(p => p.Culture, CultureInfo.GetCultureInfo("ru-RU")));
+
+            await comp.Find("input").ChangeAsync("123,45");
+            await comp.Find("input").BlurAsync();
+
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(123.45M));
+            comp.Instance.ReadText.Should().Be("123,45");
+            comp.Instance.Culture.Name.Should().Be("ru-RU");
         }
 
         [Test]

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -23,8 +23,8 @@
             <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
                 <MudInput T="string"
                           @ref="@_elementReference"
-                          @attributes="@UserAttributes"
-                          InputType="@(!IsFormatted && IsNumberMode ? InputType.Number : InputType.Text)"
+                          @attributes="@InputAttributes"
+                          InputType="@InputType.Text"
                           Style="@Style"
                           Variant="@Variant"
                           Typo="@Typo"

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Extensions;
 using MudBlazor.Services;
 using MudBlazor.Utilities;
 
@@ -27,8 +28,10 @@ namespace MudBlazor
         private bool _maxHasValue = false;
         private bool _minHasValue = false;
         private bool _stepHasValue = false;
+        private bool _cultureParameterSpecified;
         private MudInput<string> _elementReference = null!;
         private readonly string _elementId = Identifier.Create("numericField");
+        private const string DefaultKeyFilterPattern = @"[0-9,.\-]";
 
         private readonly Comparer<T> _comparer = Comparer<T>.Default;
 
@@ -130,17 +133,46 @@ namespace MudBlazor
                 .AddClass(Class)
                 .Build();
 
-        private bool IsNumberMode => InputMode == InputMode.numeric || InputMode == InputMode.@decimal;
+        private Dictionary<string, object?> InputAttributes
+        {
+            get
+            {
+                var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["role"] = "spinbutton"
+                };
 
-        // Defensive null check with object pattern: GetCulture() is annotated as non-null, but DataGrid may return null in certain cases.
-        // In typical scenarios it is not null, as MudFormComponent sets a default culture and other components do not override it with null.
-        // The annotation could be changed in the future, but doing so would introduce unnecessary null checks in other components.
-        private bool IsFormatted =>
+                if (TryFormatAriaValue(ReadValue, out var ariaValueNow))
+                {
+                    attributes["aria-valuenow"] = ariaValueNow;
+                }
+
+                if (_minHasValue && TryFormatAriaValue(_min, out var ariaValueMin))
+                {
+                    attributes["aria-valuemin"] = ariaValueMin;
+                }
+
+                if (_maxHasValue && TryFormatAriaValue(_max, out var ariaValueMax))
+                {
+                    attributes["aria-valuemax"] = ariaValueMax;
+                }
+
+                if (!string.IsNullOrWhiteSpace(ReadText) &&
+                    (!attributes.TryGetValue("aria-valuenow", out var currentAriaValue) || !string.Equals(ReadText, currentAriaValue?.ToString(), StringComparison.Ordinal)))
+                {
+                    attributes["aria-valuetext"] = ReadText;
+                }
+
+                return attributes;
+            }
+        }
+
+        private bool UsesManagedFormatting =>
             Pattern is not null ||
             GetFormat() is not null ||
-            // Edgy way to check if the MudComponentForm.Culture is provided explicitly and is a different one than the default CurrentUICulture && InvariantCulture.
-            // If not, then we override to InvariantCulture to avoid issues with <input type="number">.
-            (GetCulture() is { } culture && !culture.Equals(CultureInfo.CurrentUICulture) && !culture.Equals(CultureInfo.InvariantCulture));
+            _cultureParameterSpecified;
+
+        private string EffectiveKeyFilterPattern => (Pattern ?? DefaultKeyFilterPattern).TrimEnd('*');
 
         /// <inheritdoc />
         [ExcludeFromCodeCoverage]
@@ -199,7 +231,7 @@ namespace MudBlazor
 
             await UpdateTextPropertyAsync(false); //Required to update the string formatting after a blur before the debounce period has elapsed
 
-            if (IsFormatted && DebounceInterval <= 0 && !ConversionError)
+            if (UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
             {
                 await _elementReference.SetText(ReadText, updateValue: false);
             }
@@ -317,13 +349,9 @@ namespace MudBlazor
                     new("ArrowDown", preventDown: "key+none"),
                      // prevent dead keys like ^ ` ´ etc
                     new("Dead", preventDown: "key+any"),
+                    // keep the default numeric input constrained even though the field now renders as type="text"
+                    new($"/^(?!{EffectiveKeyFilterPattern}).$/", preventDown: "key+none|key+shift|key+alt"),
                 };
-
-                if (Pattern != null)
-                {
-                    //prevent inputs that do not match the pattern
-                    keyOptions.Add(new($"/^(?!{Pattern.TrimEnd('*')}).$/", preventDown: "key+none|key+shift|key+alt"));
-                }
 
                 var options = new KeyInterceptorOptions("mud-input-slot", keyOptions.ToArray());
 
@@ -340,10 +368,8 @@ namespace MudBlazor
                 return;
             }
 
-            // Overrides the browser's culture since <input type="number"> does not consider culture.
-            // If a specific Culture, Pattern, or Format is defined, <input type="text"> will be used 
-            // with the corresponding attributes applied.
-            if (!IsFormatted)
+            // Numeric fields default to an invariant text representation unless Culture, Pattern, or Format is supplied explicitly.
+            if (!UsesManagedFormatting)
             {
                 await SetCultureAsync(CultureInfo.InvariantCulture);
             }
@@ -492,7 +518,7 @@ namespace MudBlazor
 
             // Keep formatted text in sync when using formatted input mode.
             // This also covers onchange updates that can occur around blur timing.
-            if (IsFormatted && DebounceInterval <= 0 && !ConversionError)
+            if (UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
             {
                 var formattedText = ConvertSet(ReadValue);
                 if (!string.Equals(ReadText, formattedText, StringComparison.Ordinal))
@@ -519,6 +545,19 @@ namespace MudBlazor
         private static long FromInt64(T? v) => Convert.ToInt64((long?)(object?)v);
 
         private static ulong FromUInt64(T? v) => Convert.ToUInt64((ulong?)(object?)v);
+
+        private static bool TryFormatAriaValue(T? value, [NotNullWhen(true)] out string? ariaValue)
+        {
+            ariaValue = FormatParam(value);
+            return !string.IsNullOrWhiteSpace(ariaValue);
+        }
+
+        /// <inheritdoc />
+        public override async Task SetParametersAsync(ParameterView parameters)
+        {
+            _cultureParameterSpecified = parameters.Contains<CultureInfo>(nameof(Culture));
+            await base.SetParametersAsync(parameters);
+        }
 
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()


### PR DESCRIPTION
Stops using native `<input type="number">` as the default rendering mode for `MudNumericField` and returns the component to a single managed text-input behavior model.

The main goal is to remove Chromium’s native focused-wheel stepping, which conflicts with MudBlazor’s intended interaction model and breaks scenarios such as `HideSpinButtons="true"` and Shift + mouse wheel stepping.

De facto reverts #10192, Resolves #13033, Fixes #12899, Closes #10996 as not planned (shift+wheel still works)

## What changed

- `MudNumericField` now renders as `type="text"` consistently.
- `Pattern = null` remains the default, preserving the mobile keyboard fix introduced in `#10192`.
- `inputmode="numeric"` / `inputmode="decimal"` behavior is preserved.
- Managed key filtering is restored internally, without emitting a default HTML `pattern` attribute.
- Explicit `spinbutton` ARIA semantics are added for the text input:
  - `role="spinbutton"`
  - `aria-valuenow`
  - `aria-valuemin`
  - `aria-valuemax`
  - `aria-valuetext` when the formatted text differs from the raw numeric value
- Explicit `Culture` is now respected even when it matches `CurrentUICulture`.

## Why

Using native `type="number"` gave the browser partial ownership of the control’s behavior. That created several problems:

- Chromium can step the value with the mouse wheel when the input is focused.
- `HideSpinButtons` no longer fully hides stepping behavior.
- Page scrolling and value stepping can happen together.
- MudBlazor’s built-in Shift + mouse wheel support competes with native browser behavior.
- Formatting and culture handling become partially browser-owned instead of component-owned.

This PR restores a single, predictable behavior model that MudBlazor fully controls.

## Scope

This intentionally does not:
- add a new opt-in/out API
- special-case `HideSpinButtons`
- add JS wheel interception

The aim is to keep the component behavior coherent rather than split it across multiple browser/input models.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
