### PR TITLE
MudInput: Avoid duplicate blur interop during normal focus changes

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1238,6 +1238,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task InputBlurBridgeShouldNotProcessBlurTwiceWhenNativeBlurRunsFirst()
+        {
+            var blurCount = 0;
+            var comp = Context.Render<MudInput<string>>(parameters => parameters
+                .Add(p => p.OnBlur, _ => blurCount++));
+
+            await comp.Find("input").FocusAsync();
+            await comp.Find("input").BlurAsync();
+            await comp.InvokeAsync(comp.Instance.CallOnBlurredAsync);
+
+            blurCount.Should().Be(1);
+        }
+
+        [Test]
+        public async Task InputBlurBridgeShouldNotProcessBlurTwiceWhenFallbackRunsFirst()
+        {
+            var blurCount = 0;
+            var comp = Context.Render<MudInput<string>>(parameters => parameters
+                .Add(p => p.OnBlur, _ => blurCount++));
+
+            await comp.Find("input").FocusAsync();
+            await comp.InvokeAsync(comp.Instance.CallOnBlurredAsync);
+            await comp.Find("input").BlurAsync();
+
+            blurCount.Should().Be(1);
+        }
+
+        [Test]
         public async Task OnKeyDownErrorContentCaughtException()
         {
             var comp = Context.Render<TextFieldErrorContenCaughtException>();

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1242,25 +1242,12 @@ namespace MudBlazor.UnitTests.Components
         {
             var blurCount = 0;
             var comp = Context.Render<MudInput<string>>(parameters => parameters
+                .Add(p => p.Immediate, true)
                 .Add(p => p.OnBlur, _ => blurCount++));
 
-            await comp.Find("input").FocusAsync();
+            await comp.Find("input").InputAsync("abc");
             await comp.Find("input").BlurAsync();
             await comp.InvokeAsync(comp.Instance.CallOnBlurredAsync);
-
-            blurCount.Should().Be(1);
-        }
-
-        [Test]
-        public async Task InputBlurBridgeShouldNotProcessBlurTwiceWhenFallbackRunsFirst()
-        {
-            var blurCount = 0;
-            var comp = Context.Render<MudInput<string>>(parameters => parameters
-                .Add(p => p.OnBlur, _ => blurCount++));
-
-            await comp.Find("input").FocusAsync();
-            await comp.InvokeAsync(comp.Instance.CallOnBlurredAsync);
-            await comp.Find("input").BlurAsync();
 
             blurCount.Should().Be(1);
         }

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -30,8 +30,7 @@
                   disabled=@GetDisabledState()
                   readonly="@GetReadOnlyState()"
                   inputmode="@InputMode.ToStringFast(true)"
-                  @onfocus="@OnFocusedAsync"
-                  @onblur="@OnNativeBlurredAsync"
+                  @onblur="@OnBlurredAsync"
                   @bind:event="@(Immediate ? "oninput" : "onchange")"
                   @bind:get="@_internalText"
                   @bind:set="@OnInputOrOnChangeAsync"
@@ -60,8 +59,7 @@
                @bind:event="@(Immediate ? "oninput" : "onchange")"
                @bind:get="@_internalText"
                @bind:set="@OnInputOrOnChangeAsync"
-               @onfocus="@OnFocusedAsync"
-               @onblur="@OnNativeBlurredAsync"
+               @onblur="@OnBlurredAsync"
                placeholder="@Placeholder"
                disabled=@GetDisabledState()
                readonly="@GetReadOnlyState()"

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -30,7 +30,8 @@
                   disabled=@GetDisabledState()
                   readonly="@GetReadOnlyState()"
                   inputmode="@InputMode.ToStringFast(true)"
-                  @onblur="@OnBlurredAsync"
+                  @onfocus="@OnFocusedAsync"
+                  @onblur="@OnNativeBlurredAsync"
                   @bind:event="@(Immediate ? "oninput" : "onchange")"
                   @bind:get="@_internalText"
                   @bind:set="@OnInputOrOnChangeAsync"
@@ -59,7 +60,8 @@
                @bind:event="@(Immediate ? "oninput" : "onchange")"
                @bind:get="@_internalText"
                @bind:set="@OnInputOrOnChangeAsync"
-               @onblur="@OnBlurredAsync"
+               @onfocus="@OnFocusedAsync"
+               @onblur="@OnNativeBlurredAsync"
                placeholder="@Placeholder"
                disabled=@GetDisabledState()
                readonly="@GetReadOnlyState()"

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -17,7 +17,6 @@ namespace MudBlazor
         private bool _shouldInitSizing;
         private bool _shouldUpdateSizingParams;
         private bool _shouldAdjustSizingAfterRender;
-        private bool _blurHandled;
         private ElementReference _elementReference1;
         private readonly Lazy<DotNetObjectReference<MudInput<T>>> _dotNetReferenceLazy;
 
@@ -194,18 +193,6 @@ namespace MudBlazor
             _internalText = args;
             await OnInternalInputChanged.InvokeAsync(args);
             await SetTextAndUpdateValueAsync(args);
-        }
-
-        protected Task OnFocusedAsync(FocusEventArgs _)
-        {
-            _isFocused = true;
-            _blurHandled = false;
-            return Task.CompletedTask;
-        }
-
-        protected Task OnNativeBlurredAsync(FocusEventArgs args)
-        {
-            return HandleBlurredAsync(args);
         }
 
         /// <summary>
@@ -451,18 +438,13 @@ namespace MudBlazor
         [JSInvokable]
         public async Task CallOnBlurredAsync()
         {
-            await HandleBlurredAsync(new FocusEventArgs { Type = "jsBlur.OnBlur" });
-        }
-
-        private async Task HandleBlurredAsync(FocusEventArgs args)
-        {
-            if (_blurHandled)
+            // If native blur already ran, do not process the fallback callback again.
+            if (!_isFocused)
             {
                 return;
             }
 
-            _blurHandled = true;
-            await OnBlurredAsync(args);
+            await OnBlurredAsync(new FocusEventArgs { Type = "jsBlur.OnBlur" });
         }
     }
 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
         private bool _shouldInitSizing;
         private bool _shouldUpdateSizingParams;
         private bool _shouldAdjustSizingAfterRender;
+        private bool _blurHandled;
         private ElementReference _elementReference1;
         private readonly Lazy<DotNetObjectReference<MudInput<T>>> _dotNetReferenceLazy;
 
@@ -193,6 +194,18 @@ namespace MudBlazor
             _internalText = args;
             await OnInternalInputChanged.InvokeAsync(args);
             await SetTextAndUpdateValueAsync(args);
+        }
+
+        protected Task OnFocusedAsync(FocusEventArgs _)
+        {
+            _isFocused = true;
+            _blurHandled = false;
+            return Task.CompletedTask;
+        }
+
+        protected Task OnNativeBlurredAsync(FocusEventArgs args)
+        {
+            return HandleBlurredAsync(args);
         }
 
         /// <summary>
@@ -381,8 +394,7 @@ namespace MudBlazor
             }
             if (firstRender)
             {
-                // add onblur event through javascript which will trigger CallOnBlurredAsync
-                // must do in javascript or it won't detect ios Keyboard button - limitation of Blazor/React/other frameworks of the DOM
+                // Attach a JS blur fallback for cases where focus is dismissed without Blazor observing the native blur event.
                 await ElementReference.MudAttachBlurEventWithJS(_dotNetReferenceLazy.Value);
             }
 
@@ -439,11 +451,18 @@ namespace MudBlazor
         [JSInvokable]
         public async Task CallOnBlurredAsync()
         {
-            // If onblurred already fired then cancel
-            if (!_isFocused)
-                return;
+            await HandleBlurredAsync(new FocusEventArgs { Type = "jsBlur.OnBlur" });
+        }
 
-            await OnBlurredAsync(new FocusEventArgs { Type = "jsBlur.OnBlur" });
+        private async Task HandleBlurredAsync(FocusEventArgs args)
+        {
+            if (_blurHandled)
+            {
+                return;
+            }
+
+            _blurHandled = true;
+            await OnBlurredAsync(args);
         }
     }
 

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -232,31 +232,47 @@ class MudElementReference {
         }
     }
 
-    // ios doesn't trigger Blazor/React/Other dom style blur event so add a base event listener here
-    // that will trigger with IOS Done button and regular blur events
+    // Some virtual keyboard flows can dismiss focus without Blazor observing the blur.
+    // Bridge only those fallback cases and keep normal focus-to-control transitions on Blazor's native path.
     /**
      * Attaches a blur bridge that calls back into .NET.
-     * Used to normalize blur behavior on iOS virtual keyboard flows.
+     * Used as a fallback when blur doesn't move focus to another interactive element.
      */
     addOnBlurEvent(element, dotNetReference) {
         if (!element) return;
 
         element._mudBlurHandler = function (e) {
-            if (!element || !document.contains(element)) {
-                // iOS keyboard flows can blur after disposal; clean up to prevent stale callbacks.
-                window.mudElementRef.removeOnBlurEvent(element);
-                return;
-            }
-            e.preventDefault();
+            const relatedTarget = e.relatedTarget;
 
-            if (dotNetReference) {
-                dotNetReference.invokeMethodAsync('CallOnBlurredAsync').catch(err => {
-                    console.warn("Error invoking CallOnBlurredAsync, possibly disposed:", err);
+            window.setTimeout(() => {
+                if (!element || !document.contains(element)) {
+                    // Virtual keyboard flows can blur after disposal; clean up to prevent stale callbacks.
                     window.mudElementRef.removeOnBlurEvent(element);
-                });
-            } else {
-                console.error("No dotNetReference found for iosKeyboardFocus");
-            }
+                    return;
+                }
+
+                const activeElement = document.activeElement;
+                const nextFocusedElement = relatedTarget && document.contains(relatedTarget)
+                    ? relatedTarget
+                    : activeElement;
+                const movedFocusToAnotherElement = !!nextFocusedElement
+                    && nextFocusedElement !== element
+                    && nextFocusedElement !== document.body
+                    && nextFocusedElement !== document.documentElement;
+
+                if (movedFocusToAnotherElement) {
+                    return;
+                }
+
+                if (dotNetReference) {
+                    dotNetReference.invokeMethodAsync('CallOnBlurredAsync').catch(err => {
+                        console.warn("Error invoking CallOnBlurredAsync, possibly disposed:", err);
+                        window.mudElementRef.removeOnBlurEvent(element);
+                    });
+                } else {
+                    console.error("No dotNetReference found for blur fallback");
+                }
+            }, 0);
         };
 
         element.addEventListener('blur', element._mudBlurHandler);


### PR DESCRIPTION
This fixes #13011, a `MudTextField` / `MudButton` race where clicking a button immediately after editing a non-`Immediate` text field could execute the button `OnClick` before the field value was committed.

Root cause: `MudInput` had two independent blur paths:
- the normal Blazor `@onblur` handler
- a JS blur bridge added in [#10842](https://github.com/MudBlazor/MudBlazor/pull/10842) that called back into `.NET` separately

That extra JS interop path could bypass Blazor’s normal ordered `change -> blur -> click` processing and create intermittent stale model values, especially on Blazor Server.

What changed:
- keep native Blazor blur as the primary path
- treat the JS blur bridge as a fallback only
- skip the JS callback when focus moves normally to another element
- dedupe native blur and JS fallback so the same blur is only processed once
- add regression coverage for duplicate blur delivery

This keeps the fix platform-agnostic instead of relying on an iOS-only device check (closes #13047), while still preserving a fallback for cases where focus is dismissed without Blazor observing a native blur.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
