### PR TITLE
MudFabMenu: Fix hover menu closing prematurely

### DIFF
--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -65,7 +65,8 @@
     pointer-events: none;
     // Default direction: Top
     &.mud-fab-menu-direction-top {
-      bottom: calc(100% + 12px);
+      bottom: 100%;
+      padding-bottom: 12px;
       flex-direction: column-reverse;
       align-items: center;
       width: 100%;
@@ -76,7 +77,8 @@
     }
 
     &.mud-fab-menu-direction-bottom {
-      top: calc(100% + 12px);
+      top: 100%;
+      padding-top: 12px;
       flex-direction: column;
       align-items: center;
       width: 100%;
@@ -87,7 +89,8 @@
     }
 
     &.mud-fab-menu-direction-left {
-      right: calc(100% + 12px);
+      right: 100%;
+      padding-right: 12px;
       flex-direction: row-reverse;
       align-items: center;
       height: 100%;
@@ -102,7 +105,8 @@
     }
 
     &.mud-fab-menu-direction-right {
-      left: calc(100% + 12px);
+      left: 100%;
+      padding-left: 12px;
       flex-direction: row;
       align-items: center;
       height: 100%;
@@ -117,7 +121,8 @@
     }
 
     &.mud-fab-menu-direction-start {
-      inset-inline-end: calc(100% + 12px);
+      inset-inline-end: 100%;
+      padding-inline-end: 12px;
       flex-direction: row-reverse;
       align-items: center;
       height: 100%;
@@ -132,7 +137,8 @@
     }
 
     &.mud-fab-menu-direction-end {
-      inset-inline-start: calc(100% + 12px);
+      inset-inline-start: 100%;
+      padding-inline-start: 12px;
       flex-direction: row;
       align-items: center;
       height: 100%;


### PR DESCRIPTION
Each hover-direction menu is now anchored at `100%` and keeps the existing `12px` visual separation as padding instead of an external offset. That keeps the hoverable box continuous between the trigger and the expanded items, so MudFabMenu no longer closes while the pointer crosses the gap. The diff stayed CSS-only; no C# behavior was touched.

Closes #13032, Closes #13042

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
