### PR TITLE
MudPopover: Rework layout-change handling

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverResponsiveLayoutShiftTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverResponsiveLayoutShiftTest.razor
@@ -1,0 +1,112 @@
+<MudPopoverProvider />
+
+<style>
+    .popover-layout-shift-host {
+        display: flex;
+        min-height: 420px;
+        border: 1px solid var(--mud-palette-lines-default);
+        border-radius: var(--mud-default-borderradius);
+        overflow: hidden;
+        background:
+            linear-gradient(135deg, rgba(0, 0, 0, 0.02), transparent 45%),
+            var(--mud-palette-surface);
+    }
+
+    .popover-layout-shift-sidebar {
+        flex: 0 0 var(--layout-rail-width);
+        width: var(--layout-rail-width);
+        transition: width 220ms ease, flex-basis 220ms ease;
+        background:
+            linear-gradient(180deg, rgba(0, 0, 0, 0.04), rgba(0, 0, 0, 0.01)),
+            var(--mud-palette-background-grey);
+        border-right: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .popover-layout-shift-sidebar.popover-layout-shift-sidebar-collapsed {
+        --layout-rail-width: 84px;
+    }
+
+    .popover-layout-shift-sidebar:not(.popover-layout-shift-sidebar-collapsed) {
+        --layout-rail-width: 272px;
+    }
+
+    .popover-layout-shift-content {
+        flex: 1 1 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px;
+    }
+
+    .popover-layout-shift-card {
+        width: min(100%, 560px);
+    }
+</style>
+
+<MudStack Spacing="2">
+    <MudText Typo="Typo.subtitle1">Responsive layout shift popover repro</MudText>
+    <MudText Typo="Typo.body2">
+        Open the select, then toggle the rail. The popover should continue to look attached while the layout animates.
+    </MudText>
+</MudStack>
+
+<div class="popover-layout-shift-host mt-4">
+    <div class="@SidebarClassname">
+        <MudStack Class="pa-4" Spacing="2">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ToggleRail">
+                Toggle Rail
+            </MudButton>
+            <MudText Typo="Typo.body2">
+                Rail width: @_railWidthLabel
+            </MudText>
+        </MudStack>
+    </div>
+
+    <div class="popover-layout-shift-content">
+        <MudPaper Class="popover-layout-shift-card pa-6" Elevation="2">
+            <MudStack Spacing="3">
+                <MudText Typo="Typo.h6">Fixed-width select inside moving layout</MudText>
+                <MudText Typo="Typo.body2">
+                    This reproduces the case where an open popover must follow its anchor while surrounding layout width changes.
+                </MudText>
+                <MudSelect T="string"
+                           Label="State"
+                           Style="width: 280px"
+                           PopoverClass="layout-shift-popover"
+                           @bind-Value="_value">
+                    @foreach (var item in _items)
+                    {
+                        <MudSelectItem T="string" Value="@item">@item</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudStack>
+        </MudPaper>
+    </div>
+</div>
+
+@code {
+    public static string __description__ = "Open a fixed-width select and change surrounding layout width to verify the popover stays aligned during responsive shifts.";
+
+    private bool _collapsed;
+    private string _value = "Illinois";
+
+    private readonly string[] _items =
+    [
+        "Illinois",
+        "Iowa",
+        "Kansas",
+        "Nebraska",
+        "Wisconsin"
+    ];
+
+    private string SidebarClassname => _collapsed
+        ? "popover-layout-shift-sidebar popover-layout-shift-sidebar-collapsed"
+        : "popover-layout-shift-sidebar";
+
+    private string _railWidthLabel => _collapsed ? "84px" : "272px";
+
+    private void ToggleRail()
+    {
+        _collapsed = !_collapsed;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/PopoverTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PopoverTests.cs
@@ -228,6 +228,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Popover_ResponsiveLayoutShiftViewer_RendersFixedWidthSelect()
+        {
+            var comp = Context.Render<PopoverResponsiveLayoutShiftTest>();
+
+            comp.Find(".popover-layout-shift-host").Should().NotBeNull();
+            comp.Find("button").TextContent.Should().Contain("Toggle Rail");
+            comp.Find("div.mud-input-control").Should().NotBeNull();
+            comp.Markup.Should().Contain("width: 280px");
+        }
+
+        [Test]
         public void MudPopover_Property_Elevation()
         {
             var comp = Context.Render<PopoverPropertyTest>(p =>

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -787,124 +787,416 @@ class MudPopover {
     constructor() {
         this.map = {};
         this.contentObserver = null;
-        this.onResize = () => window.mudpopoverHelper.debouncedResize();
-        this.onScroll = () => window.mudpopoverHelper.handleScroll(null);
-        this.onScrollableNodes = (node) => window.mudpopoverHelper.handleScroll(node);
+        this.currentMainProvider = null;
+        this.pendingUpdateIds = new Set();
+        this.pendingUpdateAll = false;
+        this.updateFrameId = 0;
+        this.resizeSubscriptions = new Map();
+        this.scrollSubscriptions = new Map();
+        this.resizeObserver = typeof ResizeObserver === 'function'
+            ? new ResizeObserver((entries) => this.handleObservedResize(entries))
+            : null;
+        this.onResize = () => this.scheduleUpdateAll(true);
+        this.onScroll = () => this.handleWindowScroll();
+        this.onVisualViewportResize = () => this.scheduleUpdateAll(true);
+        this.onVisualViewportScroll = () => this.handleWindowScroll();
     }
 
     /**
-     * Registers scroll listeners on scrollable ancestors up to the body element.
+     * Schedules a reposition for one open popover on the next animation frame.
      */
-    popoverScrollListener(node) {
-        let currentNode = node.parentNode;
-        const scrollableElements = [];
-        while (currentNode) {
-            const isScrollable =
-                (currentNode.scrollHeight > currentNode.clientHeight) || // Vertical scroll
-                (currentNode.scrollWidth > currentNode.clientWidth);    // Horizontal scroll
-            if (isScrollable) {
-                const handler = () => this.onScrollableNodes(node);
-                currentNode.addEventListener('scroll', handler, { passive: true });
-                scrollableElements.push({ element: currentNode, handler });
+    schedulePopoverUpdate(id, trackPosition = false) {
+        const item = this.map[id];
+        if (!item?.isOpened) {
+            return;
+        }
+
+        this.pendingUpdateIds.add(id);
+
+        if (trackPosition) {
+            this.startTracking(id);
+        }
+
+        this.requestFlush();
+    }
+
+    /**
+     * Schedules a reposition for every open popover on the next animation frame.
+     */
+    scheduleUpdateAll(trackPosition = false) {
+        this.pendingUpdateAll = true;
+
+        if (trackPosition) {
+            this.startTrackingAll();
+        }
+
+        this.requestFlush();
+    }
+
+    /**
+     * Schedules a reposition for the subset of open popovers matching a CSS class.
+     */
+    scheduleUpdateByClassSelector(classSelector, trackPosition = false) {
+        const ids = Object.keys(this.map);
+        for (const id of ids) {
+            const item = this.map[id];
+            if (!item?.isOpened || !item.popoverContentNode?.classList?.contains(classSelector)) {
+                continue;
             }
-            // Stop if we reach the body, or head
-            if (currentNode.tagName === "BODY") {
+
+            this.pendingUpdateIds.add(id);
+
+            if (trackPosition) {
+                this.startTracking(id);
+            }
+        }
+
+        this.requestFlush();
+    }
+
+    /**
+     * Starts a short requestAnimationFrame tracking window for a popover so it stays visually attached while
+     * surrounding layout transitions settle.
+     */
+    startTracking(id, duration = null) {
+        const item = this.map[id];
+        if (!item?.isOpened) {
+            return;
+        }
+
+        const trackingDuration = duration ?? this.getTrackingDuration(id);
+        const expiresAt = performance.now() + trackingDuration;
+
+        item.trackUntil = Math.max(item.trackUntil ?? 0, expiresAt);
+    }
+
+    /**
+     * Starts transition-aware tracking for all open popovers.
+     */
+    startTrackingAll() {
+        const ids = Object.keys(this.map);
+        for (const id of ids) {
+            if (this.map[id]?.isOpened) {
+                this.startTracking(id);
+            }
+        }
+    }
+
+    /**
+     * Returns the time window used to keep a popover attached during layout motion.
+     */
+    getTrackingDuration(id) {
+        return Math.max(120, this.getTransitionTimes(id) + 32);
+    }
+
+    /**
+     * Requests the shared reposition flush.
+     */
+    requestFlush() {
+        if (this.updateFrameId) {
+            return;
+        }
+
+        this.updateFrameId = window.requestAnimationFrame((timestamp) => this.flushUpdates(timestamp));
+    }
+
+    /**
+     * Repositions all pending and actively tracked popovers in a single animation frame.
+     */
+    flushUpdates(timestamp) {
+        this.updateFrameId = 0;
+
+        const idsToUpdate = new Set();
+        const now = timestamp ?? performance.now();
+
+        if (this.pendingUpdateAll) {
+            const ids = Object.keys(this.map);
+            for (const id of ids) {
+                if (this.map[id]?.isOpened) {
+                    idsToUpdate.add(id);
+                }
+            }
+        }
+
+        for (const id of this.pendingUpdateIds) {
+            idsToUpdate.add(id);
+        }
+
+        this.pendingUpdateAll = false;
+        this.pendingUpdateIds.clear();
+
+        const trackedIds = Object.keys(this.map);
+        let needsAnotherFrame = false;
+
+        for (const id of trackedIds) {
+            const item = this.map[id];
+            if (!item?.isOpened) {
+                continue;
+            }
+
+            if ((item.trackUntil ?? 0) > now) {
+                idsToUpdate.add(id);
+                needsAnotherFrame = true;
+            }
+        }
+
+        for (const id of idsToUpdate) {
+            this.repositionPopover(id);
+        }
+
+        if (needsAnotherFrame || this.pendingUpdateAll || this.pendingUpdateIds.size > 0) {
+            this.requestFlush();
+        }
+    }
+
+    /**
+     * Repositions one popover if its anchor is still available.
+     */
+    repositionPopover(id) {
+        const popoverNode = document.getElementById('popover-' + id);
+        if (popoverNode) {
+            window.mudpopoverHelper.placePopover(popoverNode);
+        }
+    }
+
+    /**
+     * Clears a delayed close cleanup timer when a popover reopens or disconnects.
+     */
+    clearCloseTimer(id) {
+        const closeTimerId = this.map[id]?.closeTimerId;
+        if (closeTimerId) {
+            clearTimeout(closeTimerId);
+            this.map[id].closeTimerId = null;
+        }
+    }
+
+    /**
+     * Handles the shared resize observer callbacks for tracked anchor/content/ancestor elements.
+     */
+    handleObservedResize(entries) {
+        const idsToTrack = new Set();
+
+        for (const entry of entries) {
+            const ids = this.resizeSubscriptions.get(entry.target);
+            if (!ids) {
+                continue;
+            }
+
+            for (const id of ids) {
+                idsToTrack.add(id);
+            }
+        }
+
+        for (const id of idsToTrack) {
+            this.schedulePopoverUpdate(id, true);
+        }
+    }
+
+    /**
+     * Repositions only the popovers that need to react to viewport scrolling.
+     */
+    handleWindowScroll() {
+        this.scheduleUpdateByClassSelector('mud-popover-fixed');
+        this.scheduleUpdateByClassSelector('mud-popover-overflow-flip-always');
+    }
+
+    /**
+     * Returns the ancestor chain for a node up to and including the body element.
+     */
+    getAncestorElements(node) {
+        const ancestors = [];
+        let currentNode = node;
+
+        while (currentNode && currentNode.nodeType === Node.ELEMENT_NODE) {
+            ancestors.push(currentNode);
+            if (currentNode.tagName === 'BODY') {
                 break;
             }
-            currentNode = currentNode.parentNode;
+
+            currentNode = currentNode.parentElement;
         }
+
+        return ancestors;
+    }
+
+    /**
+     * Returns scrollable ancestors that can move the anchor without a viewport scroll.
+     */
+    getScrollableAncestors(node) {
+        let currentNode = node?.parentElement;
+        const scrollableElements = [];
+
+        while (currentNode && currentNode.nodeType === Node.ELEMENT_NODE) {
+            const style = window.getComputedStyle(currentNode);
+            const canScrollY = /(auto|scroll|overlay)/.test(style.overflowY) && currentNode.scrollHeight > currentNode.clientHeight;
+            const canScrollX = /(auto|scroll|overlay)/.test(style.overflowX) && currentNode.scrollWidth > currentNode.clientWidth;
+
+            if (canScrollY || canScrollX) {
+                scrollableElements.push(currentNode);
+            }
+
+            if (currentNode.tagName === 'BODY') {
+                break;
+            }
+
+            currentNode = currentNode.parentElement;
+        }
+
         return scrollableElements;
     }
 
     /**
-     * Creates resize/scroll observers required for one popover instance.
+     * Registers a popover against a shared resize observer.
      */
-    createObservers(id) {
-        // make sure observer lists are starting clear
-        this.disposeObservers(id);
-
-        // popoverNode is the origin of the popover in the dom, it can be nested inside another popover's content
-        // e.g. the filter popover for datagrid, this would be the inside of <td> where the mudpopover was placed
-        // popoverNode.parentNode is it's immediate parent or the actual <td> element in the above example
-        const popoverNode = document.getElementById('popover-' + id);
-
-        // this is the content node in the provider regardless of the RenderFragment that exists when the popover is active
-        const popoverContentNode = document.getElementById('popovercontent-' + id);
-
-        if (popoverNode?.parentNode && popoverContentNode) {
-            // add a resize observer to catch resize events
-            const resizeObserver = new ResizeObserver(entries => {
-                for (const entry of entries) {
-                    const target = entry.target;
-                    for (const childNode of target.childNodes) {
-                        if (childNode.id?.startsWith('popover-')) {
-                            this.onResize();
-                        }
-                    }
-                }
-            });
-
-            resizeObserver.observe(popoverNode.parentNode);
-            // Add scroll event listeners to the content node and its parents up to the Body
-            const scrollableElements = this.popoverScrollListener(popoverNode);
-
-            // Store all references needed for later cleanup
-            this.map[id].scrollableElements = scrollableElements;
-            this.map[id].parentResizeObserver = resizeObserver;
-
-        } else {
-            console.warn(`Could not connect observers to popover with ID ${id}: One or more required elements not found`);
-        }
-    }
-
-    /**
-     * Disposes resize/scroll observers and listeners for one popover instance.
-     */
-    disposeObservers(id) {
-        if (!this.map[id]) {
+    registerResizeElement(id, element) {
+        if (!element || !this.resizeObserver) {
             return;
         }
 
-        // Get references to items that need cleanup
-        const { scrollableElements, parentResizeObserver } = this.map[id];
-
-        // 1. Remove scroll event listeners from all scrollable parent elements
-        if (scrollableElements && Array.isArray(scrollableElements)) {
-            scrollableElements.forEach(({ element, handler }) => {
-                if (element && typeof element.removeEventListener === 'function') {
-                    element.removeEventListener('scroll', handler);
-                }
-            });
+        let ids = this.resizeSubscriptions.get(element);
+        if (!ids) {
+            ids = new Set();
+            this.resizeSubscriptions.set(element, ids);
+            this.resizeObserver.observe(element);
         }
 
-        // 2. Disconnect any resize observers
-        if (parentResizeObserver && typeof parentResizeObserver.disconnect === 'function') {
-            parentResizeObserver.disconnect();
-        }
-
-        // 3. Clear references to allow garbage collection
-        this.map[id].scrollableElements = null;
-        this.map[id].parentResizeObserver = null;
+        ids.add(id);
+        this.map[id].resizeObservedElements.push(element);
     }
 
     /**
-     * Activates observers and performs transition-aware repositioning for an opened popover.
+     * Unregisters a popover from shared resize observation.
+     */
+    unregisterResizeElement(id, element) {
+        if (!element || !this.resizeObserver) {
+            return;
+        }
+
+        const ids = this.resizeSubscriptions.get(element);
+        if (!ids) {
+            return;
+        }
+
+        ids.delete(id);
+
+        if (ids.size === 0) {
+            this.resizeSubscriptions.delete(element);
+            this.resizeObserver.unobserve(element);
+        }
+    }
+
+    /**
+     * Registers a popover against shared ancestor scroll listeners.
+     */
+    registerScrollElement(id, element) {
+        if (!element) {
+            return;
+        }
+
+        let subscription = this.scrollSubscriptions.get(element);
+        if (!subscription) {
+            const ids = new Set();
+            const handler = () => {
+                for (const observedId of ids) {
+                    this.schedulePopoverUpdate(observedId);
+                }
+            };
+
+            subscription = { ids, handler };
+            this.scrollSubscriptions.set(element, subscription);
+            element.addEventListener('scroll', handler, { passive: true });
+        }
+
+        subscription.ids.add(id);
+        this.map[id].scrollableElements.push(element);
+    }
+
+    /**
+     * Unregisters a popover from shared ancestor scroll listeners.
+     */
+    unregisterScrollElement(id, element) {
+        if (!element) {
+            return;
+        }
+
+        const subscription = this.scrollSubscriptions.get(element);
+        if (!subscription) {
+            return;
+        }
+
+        subscription.ids.delete(id);
+
+        if (subscription.ids.size === 0) {
+            element.removeEventListener('scroll', subscription.handler);
+            this.scrollSubscriptions.delete(element);
+        }
+    }
+
+    /**
+     * Creates resize and scroll subscriptions for one open popover instance.
+     */
+    createObservers(id) {
+        this.disposeObservers(id);
+
+        const popoverNode = document.getElementById('popover-' + id);
+        const popoverContentNode = document.getElementById('popovercontent-' + id);
+        const anchorNode = popoverNode?.parentNode instanceof Element
+            ? popoverNode.parentNode
+            : null;
+
+        if (!popoverNode || !popoverContentNode || !anchorNode) {
+            console.warn(`Could not connect observers to popover with ID ${id}: One or more required elements not found`);
+            return;
+        }
+
+        this.map[id].popoverNode = popoverNode;
+        this.map[id].popoverContentNode = popoverContentNode;
+        this.map[id].anchorNode = anchorNode;
+
+        const resizeTargets = new Set([
+            ...this.getAncestorElements(anchorNode),
+            popoverContentNode
+        ]);
+
+        for (const element of resizeTargets) {
+            this.registerResizeElement(id, element);
+        }
+
+        const scrollableElements = this.getScrollableAncestors(anchorNode);
+        for (const element of scrollableElements) {
+            this.registerScrollElement(id, element);
+        }
+    }
+
+    /**
+     * Disposes resize and scroll subscriptions for one popover instance.
+     */
+    disposeObservers(id) {
+        const item = this.map[id];
+        if (!item) {
+            return;
+        }
+
+        if (Array.isArray(item.scrollableElements)) {
+            item.scrollableElements.forEach((element) => this.unregisterScrollElement(id, element));
+        }
+
+        if (Array.isArray(item.resizeObservedElements)) {
+            item.resizeObservedElements.forEach((element) => this.unregisterResizeElement(id, element));
+        }
+
+        item.scrollableElements = [];
+        item.resizeObservedElements = [];
+        item.trackUntil = 0;
+    }
+
+    /**
+     * Activates shared observers and transition-aware tracking for an opened popover.
      */
     openPopover(target, id) {
-        // create observers for this popover (resizeObserver and scroll Listeners)
+        this.clearCloseTimer(id);
         this.createObservers(id);
-
-        // reposition popover individually through transition duration of itself/parents
-        const total = this.getTransitionTimes(id);
-        const interval = Math.ceil(total / 12);
-        const start = performance.now();
-        window.mudpopoverHelper.placePopoverByNode(target);
-        const intervalId = setInterval(() => {
-            window.mudpopoverHelper.placePopoverByNode(target);
-            if (performance.now() - start > total) {
-                clearInterval(intervalId);
-            }
-        }, interval);
+        this.schedulePopoverUpdate(id, true);
     }
 
     /**
@@ -919,52 +1211,46 @@ class MudPopover {
         const id = target.id.substr(15);
         if (mutation.type == 'attributes' && mutation.attributeName == 'class') {
             if (target.classList.contains('mud-popover-open')) {
-                // setup for an open popover and create observers
                 if (this.map[id]?.isOpened === false) {
                     this.map[id].isOpened = true;
                 }
                 this.openPopover(target, id);
             }
             else {
-                // tell the map that this popover is closed
                 if (this.map[id]?.isOpened) {
                     this.map[id].isOpened = false;
                 }
-                // wait this long until we "move it off screen"
+
                 const delay = Number.parseFloat(target.style['transition-duration']) || 0;
                 if (delay == 0) {
-                    // remove left and top styles
                     target.style.removeProperty('left');
                     target.style.removeProperty('top');
                 }
                 else {
-                    setTimeout(() => {
+                    this.clearCloseTimer(id);
+                    this.map[id].closeTimerId = setTimeout(() => {
                         if (this.map[id]?.isOpened) return; // in case it's reopened before the timeout is over
                         if (!target?.classList?.contains('mud-popover-open')) {
                             target.style.removeProperty('left');
                             target.style.removeProperty('top');
                         }
+                        if (this.map[id]) {
+                            this.map[id].closeTimerId = null;
+                        }
                     }, delay);
                 }
-                // reset flip status
+
                 target.mudPopoverFliped = null;
                 target.removeAttribute('data-mudpopover-flip');
 
-                // Remove individual observers and listeners that might exist
                 this.disposeObservers(id);
-                // reposition overlays as needed
                 window.mudpopoverHelper.popoverOverlayUpdates();
             }
         }
         else if (mutation.type == 'attributes' && mutation.attributeName == 'data-ticks') {
-            // when data-ticks attribute is the mutation something has changed with the popover
-            // and it needs to be repositioned and shown, note we don't use mud-popover-open here
-            // instead we use data-ticks since we know the newest data-ticks > 0 is the top most.
             const tickAttribute = target.getAttribute('data-ticks');
-            // data ticks is not 0 so let's reposition the popover and overlay
             if (tickAttribute > 0 && target?.parentNode && this.map[id]?.isOpened) {
-                // reposition popover individually
-                window.mudpopoverHelper.placePopoverByNode(target);
+                this.schedulePopoverUpdate(id);
             }
         }
     }
@@ -973,26 +1259,27 @@ class MudPopover {
      * Initializes the popover runtime and global observers for the provider container.
      */
     initialize(containerClass, flipMargin, overflowPadding) {
-        // only happens when the PopoverService is created which happens on application start and anytime the service might crash
-        // "mud-popover-provider" is the default name of containerClass.
-
-        if (this.map.length > 0) {
+        if (Object.keys(this.map).length > 0) {
             console.error('Popover Service already initialized, disposing to reinitialize.');
             this.dispose();
         }
-        // store options from PopoverOptions in mudpopoverHelper
+
         window.mudpopoverHelper.mainContainerClass = containerClass;
         window.mudpopoverHelper.overflowPadding = overflowPadding;
 
         if (flipMargin) {
             window.mudpopoverHelper.flipMargin = flipMargin;
         }
-        // create a single observer to watch all popovers in the provider
+
         this.observeMainContainer();
 
-        // setup event listeners
         window.addEventListener('resize', this.onResize, { passive: true });
         window.addEventListener('scroll', this.onScroll, { passive: true });
+
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', this.onVisualViewportResize, { passive: true });
+            window.visualViewport.addEventListener('scroll', this.onVisualViewportScroll, { passive: true });
+        }
     }
 
     /**
@@ -1004,19 +1291,16 @@ class MudPopover {
         const provider = mainContent[0];
 
         if (!provider) {
-            console.error(`No Popover Container found with class ${containerClass}`);
+            console.error(`No Popover Container found with class ${window.mudpopoverHelper.mainContainerClass}`);
             return;
         }
 
-        // Avoid re-observing same element unless it's been removed from DOM
         if (this.currentMainProvider === provider) {
             return;
         }
 
-        // Assign and update reference
         this.currentMainProvider = provider;
 
-        // Cleanup old observer
         if (this.contentObserver) {
             this.contentObserver.disconnect();
             this.contentObserver = null;
@@ -1093,39 +1377,38 @@ class MudPopover {
      * @param {string} id - The ID of the popover to connect
      */
     connect(id) {
-        // this happens when a popover is created in the dom (not necessarily displayed)
-        // Ensure we're not creating duplicate listeners for the same ID
         if (this.map[id]) {
             this.disconnect(id);
         }
 
-        // compare this.contentObserver = observer to see if the container being observed still exists
-        // will recreate if not, comment out this line if you want to see PopoverTwoLayoutsTest fail in the Viewer
         this.observeMainContainer();
 
-        // this is the origin of the popover in the dom, it can be nested inside another popover's content
-        // e.g. the filter popover for datagrid, this would be the inside of <td> where the mudpopover was placed
-        // popoverNode.parentNode is it's immediate parent or the actual <td> element in the above example
-        const _ = document.getElementById('popover-' + id);
-
-        // this is the content node in the provider regardless of the RenderFragment that exists when the popover is active
+        const popoverNode = document.getElementById('popover-' + id);
         const popoverContentNode = document.getElementById('popovercontent-' + id);
+        const anchorNode = popoverNode?.parentNode instanceof Element
+            ? popoverNode.parentNode
+            : null;
+
+        if (!popoverNode || !popoverContentNode) {
+            return;
+        }
 
         const startOpened = popoverContentNode.classList.contains('mud-popover-open');
 
-        // Store all references needed for later cleanup
         this.map[id] = {
+            popoverNode: popoverNode,
             popoverContentNode: popoverContentNode,
-            scrollableElements: null,
-            parentResizeObserver: null,
-            isOpened: startOpened
+            anchorNode: anchorNode,
+            scrollableElements: [],
+            resizeObservedElements: [],
+            isOpened: startOpened,
+            trackUntil: 0,
+            closeTimerId: null
         };
 
         if (startOpened) {
             this.openPopover(popoverContentNode, id);
         }
-        // debounce a full reposition
-        window.mudpopoverHelper.debouncedResize();
     }
 
     /**
@@ -1138,13 +1421,14 @@ class MudPopover {
         }
 
         try {
-            // 1. Remove individual observers and listeners that might exist
+            this.clearCloseTimer(id);
             this.disposeObservers(id);
 
-            // 2. Clear final reference to allow garbage collection
+            this.pendingUpdateIds.delete(id);
             this.map[id].popoverContentNode = null;
+            this.map[id].popoverNode = null;
+            this.map[id].anchorNode = null;
 
-            // 3. Remove this entry from the map
             delete this.map[id];
         } catch (error) {
             console.error(`Error disconnecting popover with ID ${id}:`, error);
@@ -1157,24 +1441,42 @@ class MudPopover {
      */
     dispose() {
         try {
-            // 1. Disconnect all popovers
             const ids = Object.keys(this.map);
             for (const id of ids) {
                 this.disconnect(id);
             }
 
-            // 2. Ensure map is empty
             this.map = {};
+            this.pendingUpdateIds.clear();
+            this.pendingUpdateAll = false;
 
-            // 3. Disconnect the content observer
+            if (this.updateFrameId) {
+                window.cancelAnimationFrame(this.updateFrameId);
+                this.updateFrameId = 0;
+            }
+
             if (this.contentObserver) {
                 this.contentObserver.disconnect();
                 this.contentObserver = null;
             }
 
-            // 4. Remove global event listeners (handled outside this class, listed here for reference)
+            if (this.resizeObserver) {
+                this.resizeObserver.disconnect();
+                this.resizeSubscriptions.clear();
+            }
+
+            for (const [element, subscription] of this.scrollSubscriptions.entries()) {
+                element.removeEventListener('scroll', subscription.handler);
+            }
+            this.scrollSubscriptions.clear();
+
             window.removeEventListener('resize', this.onResize);
             window.removeEventListener('scroll', this.onScroll);
+
+            if (window.visualViewport) {
+                window.visualViewport.removeEventListener('resize', this.onVisualViewportResize);
+                window.visualViewport.removeEventListener('scroll', this.onVisualViewportScroll);
+            }
         } catch (error) {
             console.error("Error disposing MudPopover:", error);
         }
@@ -1188,27 +1490,26 @@ class MudPopover {
     }
 }
 
-window.mudpopoverHelper.debouncedResize = window.mudpopoverHelper.debounce(() => {
-    window.mudpopoverHelper.placePopoverByClassSelector();
-}, 25);
+window.mudpopoverHelper.debouncedResize = function () {
+    window.mudPopover.scheduleUpdateAll(true);
+};
 
 /**
  * Repositions popovers after scroll events from body or nested scroll containers.
  */
 window.mudpopoverHelper.handleScroll = function (node = null) {
-    // node is a container scrollable element, doesn't need fixed position or flip always to fire
-    // does need itself to be repositioned to stay anchored to where it's at
-    // the areas that use node are scrollable containers
     if (node) {
-        window.mudpopoverHelper.placePopover(node);
+        const id = node.id?.startsWith('popover-')
+            ? node.id.substr(8)
+            : null;
+
+        if (id) {
+            window.mudPopover.schedulePopoverUpdate(id);
+        }
     }
     else {
-        // reposition all fixed/flip popovers as a body container has scrolled
-        window.mudpopoverHelper.placePopoverByClassSelector('mud-popover-fixed');
-        window.mudpopoverHelper.placePopoverByClassSelector('mud-popover-overflow-flip-always');
+        window.mudPopover.handleWindowScroll();
     }
-    // queue a debounced check all
-    window.mudpopoverHelper.debouncedResize();
 };
 
 window.mudPopover = new MudPopover();

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -1517,6 +1517,7 @@ class MudPopover {
                 this.contentObserver.disconnect();
                 this.contentObserver = null;
             }
+            this.currentMainProvider = null;
 
             if (this.resizeObserver) {
                 this.resizeObserver.disconnect();

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -958,10 +958,34 @@ class MudPopover {
     /**
      * Repositions one popover if its anchor is still available.
      */
-    repositionPopover(id) {
+    repositionPopover(id, visitedIds = new Set()) {
+        if (visitedIds.has(id)) {
+            return;
+        }
+
+        visitedIds.add(id);
+
         const popoverNode = document.getElementById('popover-' + id);
         if (popoverNode) {
             window.mudpopoverHelper.placePopover(popoverNode);
+        }
+
+        const popoverContentNode = this.map[id]?.popoverContentNode;
+        if (!popoverContentNode) {
+            return;
+        }
+
+        for (const childId of Object.keys(this.map)) {
+            if (childId === id) {
+                continue;
+            }
+
+            const childItem = this.map[childId];
+            if (!childItem?.isOpened || !childItem.anchorNode || !popoverContentNode.contains(childItem.anchorNode)) {
+                continue;
+            }
+
+            this.repositionPopover(childId, visitedIds);
         }
     }
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -788,9 +788,13 @@ class MudPopover {
         this.map = {};
         this.contentObserver = null;
         this.currentMainProvider = null;
+        // Coalesce every external signal into a single RAF flush so many open popovers still
+        // behave well on WASM/Server during resize, drawer animation, or nested scroll.
         this.pendingUpdateIds = new Set();
         this.pendingUpdateAll = false;
         this.updateFrameId = 0;
+        // Share observers/listeners across popovers instead of creating one full observer graph
+        // per instance. That keeps the responsive path cheap when multiple menus/tooltips are open.
         this.resizeSubscriptions = new Map();
         this.scrollSubscriptions = new Map();
         this.resizeObserver = typeof ResizeObserver === 'function'
@@ -934,6 +938,8 @@ class MudPopover {
                 continue;
             }
 
+            // Keep repainting for a short window after the triggering event so anchors that move
+            // due to CSS transition or responsive layout settle without the popover lagging behind.
             if ((item.trackUntil ?? 0) > now) {
                 idsToUpdate.add(id);
                 needsAnotherFrame = true;
@@ -996,6 +1002,9 @@ class MudPopover {
      * Repositions only the popovers that need to react to viewport scrolling.
      */
     handleWindowScroll() {
+        // A body/viewport scroll only changes the screen position of fixed popovers or popovers that
+        // intentionally re-evaluate overflow on every move. Absolute popovers anchored in normal flow
+        // are handled by their own scrollable ancestors and should not all be recomputed here.
         this.scheduleUpdateByClassSelector('mud-popover-fixed');
         this.scheduleUpdateByClassSelector('mud-popover-overflow-flip-always');
     }
@@ -1057,6 +1066,8 @@ class MudPopover {
         if (!ids) {
             ids = new Set();
             this.resizeSubscriptions.set(element, ids);
+            // ResizeObserver is the main fix for layout-shift cases like responsive drawers:
+            // the anchor can move even when there was no viewport resize event.
             this.resizeObserver.observe(element);
         }
 
@@ -1153,11 +1164,16 @@ class MudPopover {
         this.map[id].popoverContentNode = popoverContentNode;
         this.map[id].anchorNode = anchorNode;
 
+        // Observe the full ancestor chain, not only the immediate anchor parent. Fixed-width selects
+        // inside collapsing drawers/regids can move because an outer layout node changes size.
         const resizeTargets = new Set([
             ...this.getAncestorElements(anchorNode),
             popoverContentNode
         ]);
 
+        // This broader subscription set is intentional. Drawer collapse/expand and similar responsive
+        // container changes can move the anchor without changing the immediate parent box, which was a
+        // source of select/popover offset regressions.
         for (const element of resizeTargets) {
             this.registerResizeElement(id, element);
         }
@@ -1203,9 +1219,12 @@ class MudPopover {
      * Handles provider mutations that affect popover open state and placement.
      */
     callbackPopover(mutation) {
-        // good viewertests to check anytime you make a change
-        // DrawerDialogSelectTest, OverlayNestedFreezeTest, OverlayDialogTest, PopoverDataGridFilterOptionsTest
-        // TooltipNotRemovedTest (performance), PopoverFlipDirectionTest (flip test)
+        // Viewer regression map for future popover runtime changes:
+        // DrawerDialogSelectTest: popovers/selects must stay attached while dialogs and drawers interact.
+        // OverlayNestedFreezeTest / OverlayDialogTest: nested overlays must not freeze or desync z-index/position.
+        // PopoverDataGridFilterOptionsTest: nested popovers inside complex container layouts must still place correctly.
+        // TooltipNotRemovedTest: tooltip/popover churn must remain cheap and leak-free.
+        // PopoverFlipDirectionTest: overflow flipping must stay stable while reposition events keep firing.
         const target = mutation.target;
         if (!target) return;
         const id = target.id.substr(15);
@@ -1227,6 +1246,8 @@ class MudPopover {
                     target.style.removeProperty('top');
                 }
                 else {
+                    // Closing is delayed to respect the fade-out, but that delay must not win over a
+                    // fast reopen or we will clear the position of an already visible popover.
                     this.clearCloseTimer(id);
                     this.map[id].closeTimerId = setTimeout(() => {
                         if (this.map[id]?.isOpened) return; // in case it's reopened before the timeout is over
@@ -1250,6 +1271,8 @@ class MudPopover {
         else if (mutation.type == 'attributes' && mutation.attributeName == 'data-ticks') {
             const tickAttribute = target.getAttribute('data-ticks');
             if (tickAttribute > 0 && target?.parentNode && this.map[id]?.isOpened) {
+                // data-ticks changes mean the provider reordered or refreshed a live popover. Reposition
+                // here so the top-most/open item stays attached after provider-side updates.
                 this.schedulePopoverUpdate(id);
             }
         }
@@ -1276,6 +1299,8 @@ class MudPopover {
         window.addEventListener('resize', this.onResize, { passive: true });
         window.addEventListener('scroll', this.onScroll, { passive: true });
 
+        // visualViewport catches mobile/browser chrome shifts that do not always surface as a normal
+        // layout resize, but still move what the user perceives as the anchor position.
         if (window.visualViewport) {
             window.visualViewport.addEventListener('resize', this.onVisualViewportResize, { passive: true });
             window.visualViewport.addEventListener('scroll', this.onVisualViewportScroll, { passive: true });
@@ -1295,6 +1320,8 @@ class MudPopover {
             return;
         }
 
+        // Provider identity can change across layout switches/navigation. Rebind when that happens
+        // or mutations from the new provider will be missed.
         if (this.currentMainProvider === provider) {
             return;
         }
@@ -1318,6 +1345,9 @@ class MudPopover {
                     mutation.target.parentNode === this.currentMainProvider &&
                     mutation.target.classList.contains('mud-popover')
                 ) {
+                    // Only react to direct provider children. Nested content mutations are too noisy and
+                    // caused unnecessary reposition churn in the past; the open popover's own observers
+                    // handle the real geometry changes we care about.
                     this.callbackPopover(mutation);
                 }
             }
@@ -1381,6 +1411,8 @@ class MudPopover {
             this.disconnect(id);
         }
 
+        // Re-check the provider on each connect. This preserves behavior for scenarios where the app
+        // swaps layouts/providers after initialization, such as the existing PopoverTwoLayoutsTest.
         this.observeMainContainer();
 
         const popoverNode = document.getElementById('popover-' + id);
@@ -1407,6 +1439,8 @@ class MudPopover {
         };
 
         if (startOpened) {
+            // A popover can already be open when it reconnects after provider/layout changes. Re-running
+            // the open path preserves attachment across scenarios covered by PopoverTwoLayoutsTest.
             this.openPopover(popoverContentNode, id);
         }
     }
@@ -1491,6 +1525,8 @@ class MudPopover {
 }
 
 window.mudpopoverHelper.debouncedResize = function () {
+    // Preserve the historic "re-evaluate everything" safety net for global layout changes, but route it
+    // through the shared scheduler so repeated resize/layout bursts do not stampede all popovers.
     window.mudPopover.scheduleUpdateAll(true);
 };
 


### PR DESCRIPTION
Reworks popover layout-change handling so open popovers stay attached to their anchors while surrounding layout changes, including responsive drawer collapse/expand, viewport changes, and other DOM-driven shifts.

The previous behavior depended too much on an initial resize pass plus short-lived polling after open, which could leave fixed-width select popovers visibly offset if the anchor moved after that first pass. This change makes repositioning more event-driven and frame-coalesced without broadening the amount of work done on every change.

The goal is for popovers to look attached at all times with low-latency updates and no visible “catch-up” repositioning.

Closes #13054, Closes #13055

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
