### PR TITLE
MudDataGrid: Pass down ContentFormat for generated input fields in edit mode

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditFormatTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridEditFormatTest.razor
@@ -1,0 +1,36 @@
+﻿@using System.Globalization
+
+<MudDialogProvider />
+
+<MudDataGrid T="Model" Items="@_items" ReadOnly="false" EditMode="@EditMode" EditTrigger="@EditTrigger">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.MolarMass" Culture="@CultureInfo.InvariantCulture" Format="@_numberFormat" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ =  "A test viewer for visibility testing of Culture and Format in edit mode";
+
+    private readonly string _numberFormat = "N2";
+    private readonly IEnumerable<Model> _items = new List<Model>
+    {
+        new() { Name = "Helium", MolarMass = 4.0026 },
+        new() { Name = "Lithium", MolarMass = 6.94 },
+        new() { Name = "Beryllium", MolarMass = 9.0122 }
+    };
+
+    [Parameter]
+    public DataGridEditMode EditMode { get; set; } = DataGridEditMode.Cell;
+
+    private DataGridEditTrigger EditTrigger => EditMode == DataGridEditMode.Form
+        ? DataGridEditTrigger.OnRowClick
+        : DataGridEditTrigger.Manual;
+
+    public class Model
+    {
+        public required string Name { get; set; }
+
+        public required double MolarMass { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4959,6 +4959,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DataGridPropertyColumnFormat_IsAppliedToBuiltInNumericEditorInCellEditMode()
+        {
+            var comp = Context.Render<DataGridEditFormatTest>();
+
+            comp.FindAll("td input")[1].GetAttribute("value").Should().Be("4.00");
+            comp.FindAll("td input")[3].GetAttribute("value").Should().Be("6.94");
+            comp.FindAll("td input")[5].GetAttribute("value").Should().Be("9.01");
+        }
+
+        [Test]
+        public async Task DataGridPropertyColumnFormat_IsAppliedToBuiltInNumericEditorInFormEditMode()
+        {
+            var comp = Context.Render<DataGridEditFormatTest>(parameters => parameters
+                .Add(x => x.EditMode, DataGridEditMode.Form));
+
+            await comp.FindAll("tbody tr")[1].ClickAsync();
+
+            comp.FindAll("div input")[1].GetAttribute("value").Should().Be("6.94");
+        }
+
+        [Test]
         public async Task DataGridFilteredItemsCache()
         {
             var comp = Context.Render<DataGridSortableTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -296,12 +296,12 @@
                             if (propertyType == typeof(string))
                             {
                                 <MudTextField T="string" Label="@column.Title" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense"
-                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
+                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" Format="@column.ContentFormat" />
                             }
                             else if (TypeIdentifier.IsNumber(propertyType))
                             {
                                 <MudNumericField T="double?" Label="@column.Title" Value="@cell._valueNumber" ValueChanged="@cell.NumberValueChangedAsync" Margin="@Margin.Dense"
-                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
+                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" Format="@column.ContentFormat" />
                             }
                         }
                     }
@@ -380,7 +380,8 @@
                                            ValueChanged="@cell.StringValueChangedAsync"
                                            Margin="@Margin.Dense" Style="margin-top:0"
                                            Required="@column.Required"
-                                           Variant="@Variant.Text" Culture="@column.Culture" />
+                                           Variant="@Variant.Text"
+                                           Culture="@column.Culture" Format="@column.ContentFormat" />
                          }
                          else if (column.isNumber)
                          {
@@ -389,7 +390,8 @@
                                               ValueChanged="@cell.NumberValueChangedAsync"
                                               Margin="@Margin.Dense" Style="margin-top:0"
                                               Required="@column.Required"
-                                              Variant="@Variant.Text" Culture="@column.Culture" />
+                                              Variant="@Variant.Text"
+                                              Culture="@column.Culture" Format="@column.ContentFormat" />
                          }
                      }
                  }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -296,7 +296,7 @@
                             if (propertyType == typeof(string))
                             {
                                 <MudTextField T="string" Label="@column.Title" Value="@cell._valueString" ValueChanged="@cell.StringValueChangedAsync" Margin="@Margin.Dense"
-                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" Format="@column.ContentFormat" />
+                                Required="@column.Required" Variant="@Variant.Outlined" Disabled="@(!column.Editable || ReadOnly)" Class="mt-4" Culture="@column.Culture" />
                             }
                             else if (TypeIdentifier.IsNumber(propertyType))
                             {
@@ -380,8 +380,7 @@
                                            ValueChanged="@cell.StringValueChangedAsync"
                                            Margin="@Margin.Dense" Style="margin-top:0"
                                            Required="@column.Required"
-                                           Variant="@Variant.Text"
-                                           Culture="@column.Culture" Format="@column.ContentFormat" />
+                                           Variant="@Variant.Text" Culture="@column.Culture" />
                          }
                          else if (column.isNumber)
                          {
@@ -390,8 +389,8 @@
                                               ValueChanged="@cell.NumberValueChangedAsync"
                                               Margin="@Margin.Dense" Style="margin-top:0"
                                               Required="@column.Required"
-                                              Variant="@Variant.Text"
-                                              Culture="@column.Culture" Format="@column.ContentFormat" />
+                                              Variant="@Variant.Text" Culture="@column.Culture"
+                                              Format="@column.ContentFormat" />
                          }
                      }
                  }


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Small PR to fix an issue we've encountered. No related issue opened.

### Problem

The `ContentFormat` of the columns are not passed down to the generated input fields in the edit mode of the grid.

### Fix

Passing down the `ContentFormat` parameter will make the formatting consistent since formatting is correctly applied to the cells themselves while not editing the contents of the grid.

With this fix

```cs
<PropertyColumn Property="x => x.Molar" Title="Molar mass" Format="#.##" />
```

would apply to the grid in both `DataGridEditMode.Form` and `DataGridEditMode.Cell` modes.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
