### PR TITLE
Inputs: Do not set Touched during initialization

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithSelectInitialValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWithSelectInitialValueTest.razor
@@ -1,0 +1,16 @@
+﻿<MudForm ValidationDelay="0">
+    <MudSelect @bind-Value="_selectedValue" Label="Select an item">
+        <MudSelectItem Value="@("Item1")">Item 1</MudSelectItem>
+        <MudSelectItem Value="@("Item2")">Item 2</MudSelectItem>
+        <MudSelectItem Value="@("Item3")">Item 3</MudSelectItem>
+    </MudSelect>
+</MudForm>
+
+@code {
+    public static string __description__ = "MudForm IsTouched should be false when MudSelect has an initial value but user hasn't interacted with it";
+
+    [Parameter]
+    public string? InitialValue { get; set; }
+
+    private string? _selectedValue = "Item1";
+}

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -21,6 +21,9 @@ namespace MudBlazor
         private bool _validated;
         protected bool _isFocused;
         protected bool _forceTextUpdate;
+        // When true, SetTextAndUpdateValueAsync will not set Touched=true.
+        // This prevents the form from being marked touched during component initialization.
+        private bool _skipTouchedDuringInitialization;
 
         /// <summary>
         /// The resolved input element ID.
@@ -636,9 +639,12 @@ namespace MudBlazor
 
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
             // equal to the initial value. This is why we force an update to the Text property here.
+            // Set _skipTouchedDuringInitialization to prevent form from being marked touched during this.
             if (typeof(T) != typeof(string) && string.IsNullOrWhiteSpace(ReadText))
             {
+                _skipTouchedDuringInitialization = true;
                 await UpdateTextPropertyAsync(false);
+                _skipTouchedDuringInitialization = false;
             }
 
             if (Label == null && For != null)
@@ -700,6 +706,12 @@ namespace MudBlazor
             if (firstRender && AutoFocus)
             {
                 await FocusAsync();
+            }
+
+            // After first render, allow Touched to be set on subsequent text changes
+            if (firstRender)
+            {
+                _skipTouchedDuringInitialization = false;
             }
 
             await base.OnAfterRenderAsync(firstRender);
@@ -783,7 +795,9 @@ namespace MudBlazor
 
             _validated = false;
 
-            if (!string.IsNullOrEmpty(text))
+            // Don't set Touched during initialization - this prevents the form from being
+            // marked touched when a value is set programmatically on initial load.
+            if (!string.IsNullOrEmpty(text) && !_skipTouchedDuringInitialization)
             {
                 Touched = true;
             }
@@ -799,7 +813,9 @@ namespace MudBlazor
         {
             _validated = false;
 
-            if (!string.IsNullOrEmpty(arg.Value))
+            // Don't set Touched during initialization - this prevents the form from being
+            // marked touched when a value is set programmatically on initial load.
+            if (!string.IsNullOrEmpty(arg.Value) && !_skipTouchedDuringInitialization)
             {
                 Touched = true;
             }


### PR DESCRIPTION
When a MudSelect or MudAutocomplete has an initial value set via @bind-Value, the form's IsTouched was incorrectly set to True on initial load, even without user interaction. This was a regression in v9.3.0.

The issue was that OnInitializedAsync calls UpdateTextPropertyAsync which eventually calls SetTextAndUpdateValueAsync, unconditionally setting Touched=true when text is not empty.

Added a _skipTouchedDuringInitialization flag that prevents Touched from being set during the initialization phase (OnInitializedAsync), and is reset after the first render so subsequent user interactions properly set Touched=true.

Fixes #13064