### PR TITLE
MudAppBar: Remove scroll-lock compensation

### DIFF
--- a/src/MudBlazor/Styles/layout/_scroll.scss
+++ b/src/MudBlazor/Styles/layout/_scroll.scss
@@ -1,12 +1,8 @@
-﻿.scroll-locked {
+.scroll-locked {
   padding-right: 8px;
   overflow: hidden;
 
   .mud-layout {
-    .mud-appbar {
-      padding-right: 8px;
-    }
-
     .mud-main-content {
       .mud-scroll-to-top {
         padding-right: 8px;
@@ -24,10 +20,6 @@
     padding-right: 17px; //the width of scroll-bar in firefox
 
     .mud-layout {
-      .mud-appbar {
-        padding-right: 17px;
-      }
-
       .mud-main-content {
         .mud-scroll-to-top {
           padding-right: 17px;


### PR DESCRIPTION
This PR fixes an AppBar layout bug that becomes visible when MudBlazor locks body scroll for dialogs and overlays.

Previously, `.scroll-locked` added extra right padding to `.mud-appbar` in addition to the existing body compensation. In layouts like the docs site, that caused the AppBar contents, especially right-aligned icon buttons, to shift noticeably to the left when opening a dialog.

**Before**
<img width="992" height="789" alt="Animation" src="https://github.com/user-attachments/assets/8d2a31a2-1f17-4f87-9960-f63d483a87b1" />

**After**
<img width="992" height="789" alt="Animation" src="https://github.com/user-attachments/assets/ad7efe6b-a286-45ba-a56f-cebaf5836d17" />


This PR is intentionally narrow. It does not change the current scrollbar width detection or the remaining subtle page shift during scroll lock. That will be [handled separately](https://github.com/MudBlazor/MudBlazor/issues/9056). This PR only addresses the overcompensation bug affecting AppBar content positioning.


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
