### PR TITLE
Build: Add `dotnet format` instructions back to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,15 +101,9 @@ dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQu
 - If you are unsure whether the build output depends on regenerated frontend assets, run the normal scoped build without `SkipBunCompile`.
 
 ### Formatting
-Formatting is required for changed files:
+Run `dotnet format whitespace src --folder --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass after tests succeed. Do not run it repeatedly during the normal edit-build-test loop.
 
-```bash
-dotnet format <project.csproj> --no-restore --include <path/to/changed/files>
-```
-
-- Run `dotnet format` once at the very end of the task as a final pre-PR quality pass after tests succeed. Do not run it repeatedly during the normal edit-build-test loop.
-
-- If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
+If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
 
 ```bash
 dotnet format src --no-restore
@@ -266,7 +260,7 @@ private Task ToggleAsync()
 ## Change Checklist
 
 Before finishing, verify all of the following:
-- Formatting was run for changed files when formatting-relevant files under `src/` changed.
+- Formatting was run for relevant changed files.
 - The relevant target project builds cleanly with no new warnings when code, docs app, analyzer, or asset inputs changed.
 - Tests were updated and run when behavior changed.
 - Docs were updated when component behavior or public API changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 ### Default working rules
 - Follow `src/.editorconfig`.
 - Treat warnings as errors. Do not ignore analyzer warnings.
-- Do not run solution-wide commands unless explicitly requested.
+- Do not run solution-wide build, test, or format commands unless explicitly requested.
 - Do not make `dotnet clean` part of the normal local loop. Use it only when incremental build state is clearly stale or corrupted.
 - If no code, project, test, docs app, or asset-pipeline inputs changed, do not call `dotnet`. Changes limited to files such as `README.md`, changelog text, issue templates, or other repo metadata do not require restore, build, test, or format.
 - Prefer a single scoped `dotnet build` or `dotnet test` command as the first verification step. Split build and test only when you will reuse the build outputs for multiple test runs.
@@ -101,7 +101,19 @@ dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQu
 - If you are unsure whether the build output depends on regenerated frontend assets, run the normal scoped build without `SkipBunCompile`.
 
 ### Formatting
-Formatting is typically handled by the IDE and validated by CI, so do not add dedicated formatting command runs to the default local loop.
+Formatting is required for changed files:
+
+```bash
+dotnet format <project.csproj> --no-restore --include <path/to/changed/files>
+```
+
+- Run `dotnet format` once at the very end of the task as a final pre-PR quality pass after tests succeed. Do not run it repeatedly during the normal edit-build-test loop.
+
+- If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
+
+```bash
+dotnet format src --no-restore
+```
 
 ### Choose the smallest valid verification loop
 - For repository metadata or prose-only changes outside the build inputs, such as `README.md`, `CHANGELOG.md`, or `.github/` text-only edits: do not run `dotnet`.
@@ -254,6 +266,7 @@ private Task ToggleAsync()
 ## Change Checklist
 
 Before finishing, verify all of the following:
+- Formatting was run for changed files when formatting-relevant files under `src/` changed.
 - The relevant target project builds cleanly with no new warnings when code, docs app, analyzer, or asset inputs changed.
 - Tests were updated and run when behavior changed.
 - Docs were updated when component behavior or public API changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,9 @@ dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQu
 - If you are unsure whether the build output depends on regenerated frontend assets, run the normal scoped build without `SkipBunCompile`.
 
 ### Formatting
-Run `dotnet format whitespace src --folder --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass after tests succeed. Do not run it repeatedly during the normal edit-build-test loop.
+Run `dotnet format whitespace --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass. Do not run it repeatedly during the normal edit-build-test loop.
+
+Run this command from the `src` directory. When using `--include`, pass file paths relative to `src`, for example: `dotnet format whitespace --no-restore --include MudBlazor/Components/List/MudListItem.razor.cs`.
 
 If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQu
 - If you are unsure whether the build output depends on regenerated frontend assets, run the normal scoped build without `SkipBunCompile`.
 
 ### Formatting
-Run `dotnet format whitespace --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass. Do not run it repeatedly during the normal edit-build-test loop.
+Run `dotnet format whitespace --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass to catch whitespace/newline/charset/etc mistakes. Do not run it repeatedly during the normal edit-build-test loop.
 
 Run this command from the `src` directory. When using `--include`, pass file paths relative to `src`, for example: `dotnet format --include MudBlazor/Components/List/MudListItem.razor.cs`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 ### Default working rules
 - Follow `src/.editorconfig`.
 - Treat warnings as errors. Do not ignore analyzer warnings.
-- Do not run solution-wide build, test, or format commands unless explicitly requested.
+- Do not run solution-wide commands unless explicitly requested.
 - Do not make `dotnet clean` part of the normal local loop. Use it only when incremental build state is clearly stale or corrupted.
 - If no code, project, test, docs app, or asset-pipeline inputs changed, do not call `dotnet`. Changes limited to files such as `README.md`, changelog text, issue templates, or other repo metadata do not require restore, build, test, or format.
 - Prefer a single scoped `dotnet build` or `dotnet test` command as the first verification step. Split build and test only when you will reuse the build outputs for multiple test runs.
@@ -103,12 +103,12 @@ dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQu
 ### Formatting
 Run `dotnet format whitespace --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass. Do not run it repeatedly during the normal edit-build-test loop.
 
-Run this command from the `src` directory. When using `--include`, pass file paths relative to `src`, for example: `dotnet format whitespace --no-restore --include MudBlazor/Components/List/MudListItem.razor.cs`.
+Run this command from the `src` directory. When using `--include`, pass file paths relative to `src`, for example: `dotnet format --include MudBlazor/Components/List/MudListItem.razor.cs`.
 
 If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
 
 ```bash
-dotnet format src --no-restore
+dotnet format --no-restore
 ```
 
 ### Choose the smallest valid verification loop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,9 +103,9 @@ dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQu
 ### Formatting
 Run `dotnet format whitespace --no-restore --include <path/to/changed/files>` once at the very end of the task as a final pre-PR pass to catch whitespace/newline/charset/etc mistakes. Do not run it repeatedly during the normal edit-build-test loop.
 
-Run this command from the `src` directory. When using `--include`, pass file paths relative to `src`, for example: `dotnet format --include MudBlazor/Components/List/MudListItem.razor.cs`.
+Run this command from the `src` directory. When using `--include`, pass file paths relative to `src`, for example: `--include MudBlazor/Components/List/MudListItem.razor.cs`.
 
-If `src/.editorconfig` changed, format the whole `src` tree instead of only changed files:
+If `src/.editorconfig` changed, format the whole `src` tree:
 
 ```bash
 dotnet format --no-restore


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#13078

We ran into it quickly due to the wrong charset in https://github.com/MudBlazor/MudBlazor/pull/13065. We can add it back but speed it up a lot by only formatting the whitespace (`dotnet format whitespace`).