### PR TITLE
MudMenu: Fix NullReferenceException when using MouseEvent.RightClick with ActivatorContent (Blazor Server)

### DIFF
--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -7,10 +7,11 @@
      style="@Style"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
-     @oncontextmenu="@((ActivationEvent == MouseEvent.RightClick && ActivatorContent is null ? ToggleMenuAsync : null)!)"
-     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null)"
-     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null)"
+     @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null ? ToggleMenuAsync : (args => Task.CompletedTask))"
+     @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
+     @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)"
      @onkeydown="TrackKeyboardInteraction">
+    
     @if (GetActivatorHidden())
     {
         @* No content was set so no need to render anything *@

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -11,7 +11,6 @@
      @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
      @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)"
      @onkeydown="TrackKeyboardInteraction">
-    
     @if (GetActivatorHidden())
     {
         @* No content was set so no need to render anything *@


### PR DESCRIPTION
**Description**
In Blazor Server applications, using `MudMenu` with `ActivationEvent="@MouseEvent.RightClick"` and providing a custom `ActivatorContent` reliably throws a `System.NullReferenceException` in the underlying Blazor Server renderer (`Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync`). 

This issue is caused by event bubbling and a race condition during the component's re-rendering phase, combined with Blazor's telemetry/logging mechanism attempting to read a null `Delegate.Method.Name` from an empty `EventCallback`.

**Steps to Reproduce**
1. Create a Blazor Server application using MudBlazor v9.3.0.
2. Add a `MudMenu` with right-click activation and custom activator content:
```razor
<MudMenu ActivationEvent="@MouseEvent.RightClick">
    <ActivatorContent Context="context">
        <div @oncontextmenu="@context.ToggleAsync" @oncontextmenu:preventDefault>
            <MudChip>Right Click Me</MudChip>
        </div>
    </ActivatorContent>
    </MudMenu>
```
3. Right-click the activator content in the browser.
4. Check the server console or browser console (via SignalR error). A `NullReferenceException` is thrown.

**Root Cause Analysis**
In `src/MudBlazor/Components/Menu/MudMenu.razor` (lines 7-9), the wrapper `<div>` binds the context menu events conditionally:

```razor
@oncontextmenu="@((ActivationEvent == MouseEvent.RightClick && ActivatorContent is null ? ToggleMenuAsync : null)!)"
@oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null)"
@oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null)"
```

When `ActivatorContent` is **not null**, the condition evaluates to `false`. This results in:
1. `@oncontextmenu="null"` (which translates to `EventCallback.Empty` under the hood).
2. `preventDefault` and `stopPropagation` being disabled.

When the user right-clicks, the event is handled by the inner `ActivatorContent`, but because `stopPropagation` is false on the wrapper, the event **bubbles up**. Blazor Server queues both events. The inner event causes `MudMenu` to trigger `StateHasChanged()`, altering the RenderTree. When the server processes the second (bubbled) event, the `EventCallback` delegate is empty due to the UI refresh. Blazor's internal telemetry attempts to read `item.Delegate.Method?.Name` on this empty callback, resulting in the hard crash.

**Proposed Solution**
To fix this, we must ensure that `null` is never passed to the event handler, and we must unconditionally stop propagation when `RightClick` is active to prevent double-triggering.

In `MudMenu.razor`, update the bindings to:

```razor
@* Provide a no-op Task.CompletedTask fallback instead of null to satisfy Blazor's telemetry logging *@
@oncontextmenu="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null ? ToggleMenuAsync : (args => Task.CompletedTask))"

@* Unconditionally prevent default and stop propagation if RightClick is the activation event *@
@oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
@oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)"
```