### PR TITLE
MudFileUpload: Make OnDragEnterAsync protected

### DIFF
--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using MudBlazor.Resources;
@@ -272,7 +271,7 @@ namespace MudBlazor
             return OpenFilePickerAsync();
         }
 
-        private Task OnDragEnterAsync()
+        protected Task OnDragEnterAsync()
         {
             if (GetDisabledState())
             {


### PR DESCRIPTION
I want to (quite heavily) adjust the visual style of the `MudFileUpload` screen. I come very far by just using the right extension points, e.g. `CustomContent` and `SelectedTemplate`.

However, this requires quite a lot of code duplication. I found out that via inheritance I can get quite close without duplicating too much code:

```csharp
@inherits MudFileUpload<IBrowserFile>
@{
    DragAndDrop = true;

    base.BuildRenderTree(__builder);

    CustomContent = context =>
        @<button type="button"
                 class="@DragClass d-flex flex-row gap-4"
                 disabled="@GetDisabledState()"
                 @onclick="context.OpenFilePickerAsync"
                 @ondragenter="OnDragEnterAsync"> <!-- this doesn't work correctly -->
            <div>
                <MudIcon Disabled="GetDisabledState()" Class="mb-2" Icon="@Icons.Material.Filled.CloudUpload" Color="Color.Primary" Size="Size.Large" />
            </div>
        </button>;

}
```

This works great, except that `OnDragEnterAsync` is not available. This PR makes `OnDragEnterAsync` protected (like `GetDisabledState`, `DragClass` and friends) to allow easy extension via inheritance. 

My current workaround revolves around reflection, which isn't great of course
```csharp
    private ParameterState<bool> DraggingState
    {
        get => field ??= Accessors.GetDraggingState(this);
        set => field = value;
    }

    private Task OnDragEnterAsync(DragEventArgs args)
    {
        if (GetDisabledState())
        {
            return Task.CompletedTask;
        }

        return DraggingState.SetValueAsync(true);
    }

    private static class Accessors
    {
        [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_draggingState")]
        public static extern ref readonly ParameterState<bool> GetDraggingState(MudFileUpload<IBrowserFile> instance);
    }
```

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
