### PR TITLE
Build: Use recommended renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended"
+        "config:best-practices"
     ],
     "ignorePresets": [
         ":ignoreModulesAndTests",


### PR DESCRIPTION
Renovate recommends using this preset because it does additional things like pinning github actions digest versions. This improves the security posture of the project.

See https://docs.renovatebot.com/upgrade-best-practices/

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
