### PR TITLE
MudSelect: Preserve initial SelectedValues when Comparer is set

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithCustomComparerInitialBindTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithCustomComparerInitialBindTest.razor
@@ -1,0 +1,32 @@
+<MudPopoverProvider />
+
+<MudSelect @bind-SelectedValues="SelectedItems"
+           Label="Test"
+           Variant="Variant.Outlined"
+           MultiSelection="true"
+           Comparer="TestStringComparer">
+    @foreach (var item in TestItems)
+    {
+        <MudSelectItem Value="item" />
+    }
+</MudSelect>
+
+@code {
+    public IReadOnlyCollection<string> TestItems { get; set; } = ["test1", "test2", "test3"];
+
+    public IReadOnlyCollection<string> SelectedItems { get; set; } = ["test1"];
+
+    public StringComparer TestStringComparer { get; set; } = new StringComparer();
+
+    public class StringComparer : IEqualityComparer<string?>
+    {
+        public bool Equals(string? x, string? y)
+        {
+            if (x is null && y is null) return true;
+            if (x is null || y is null) return false;
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(string obj) => obj.GetHashCode();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithCustomComparerInitialSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MultiSelectWithCustomComparerInitialSelectionTest.razor
@@ -1,0 +1,48 @@
+<MudPopoverProvider />
+
+<MudGrid>
+    <MudItem xs="12">
+        <MudSelect T="Coffee" Label="Coffee"
+                   MultiSelection="true"
+                   SelectedValues="_selected" SelectedValuesChanged="SelectedChanged"
+                   Comparer="Comparer"
+                   ToStringFunc="@(x => x?.Name)">
+            <MudSelectItem Value="@(new Coffee("cap","Cappuccino"))" />
+            <MudSelectItem Value="@(new Coffee("lat","Cafe Latte"))" />
+            <MudSelectItem Value="@(new Coffee("esp","Espresso"))" />
+            <MudSelectItem Value="@(new Coffee("ire","Irish Coffee"))" />
+        </MudSelect>
+    </MudItem>
+</MudGrid>
+
+@code {
+    private static CoffeeComparer Comparer { get; } = new();
+
+    // Non-empty initial selection set at construction time: the regression case.
+    // Keys match "lat" and "esp" but Name differs to prove the custom comparer is honored.
+    public IReadOnlyCollection<Coffee?> _selected { get; set; } = new HashSet<Coffee?>(Comparer)
+    {
+        new Coffee("lat", "Preselected Latte"),
+        new Coffee("esp", "Preselected Espresso")
+    };
+
+    private void SelectedChanged(IReadOnlyCollection<Coffee?>? newSelected)
+    {
+        _selected = newSelected is null
+            ? new HashSet<Coffee?>(Comparer)
+            : new HashSet<Coffee?>(newSelected, Comparer);
+    }
+
+    public class Coffee(string key, string name)
+    {
+        public string Key { get; } = key;
+        public string Name { get; } = name;
+    }
+
+    private class CoffeeComparer : IEqualityComparer<Coffee?>
+    {
+        public bool Equals(Coffee? a, Coffee? b) => a?.Key == b?.Key;
+
+        public int GetHashCode(Coffee? x) => HashCode.Combine(x?.Key);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1461,6 +1461,38 @@ namespace MudBlazor.UnitTests.Components
             icons[7].Attributes["d"].Value.Should().Be(@unchecked);
         }
 
+        /// <summary>
+        /// Regression for MudSelect losing a non-empty initial <c>SelectedValues</c> when a custom <c>Comparer</c>
+        /// is supplied. Before the fix, <c>OnComparerChangedAsync</c> pushed an empty snapshot to the parameter state
+        /// during initial parameter processing, invoking <c>SelectedValuesChanged</c> with an empty collection and
+        /// silently overwriting the parent's bound field.
+        /// </summary>
+        [Test]
+        public async Task MultiSelectWithCustomComparer_InitialSelectionPreservedOnFirstRender()
+        {
+            var comp = Context.Render<MultiSelectWithCustomComparerInitialSelectionTest>();
+
+            // The parent's bound collection must still contain both preselected items.
+            comp.Instance._selected.Should().HaveCount(2);
+            comp.Instance._selected.Select(c => c!.Key).Should().BeEquivalentTo(new[] { "lat", "esp" });
+
+            // The input text reflects the preselected values' names (proves the comparer matched on Key).
+            comp.Find("input").GetAttribute("value").Should().Be("Preselected Latte, Preselected Espresso");
+
+            // Open the menu and assert checkbox icons.
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+
+            const string @unchecked =
+                "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
+            const string @checked =
+                "M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
+            var icons = comp.FindAll("div.mud-list-item path").ToArray();
+            icons[1].Attributes["d"].Value.Should().Be(@unchecked); // Cappuccino
+            icons[3].Attributes["d"].Value.Should().Be(@checked);   // Cafe Latte (Key="lat")
+            icons[5].Attributes["d"].Value.Should().Be(@checked);   // Espresso   (Key="esp")
+            icons[7].Attributes["d"].Value.Should().Be(@unchecked); // Irish Coffee
+        }
+
         [Test]
         public async Task Select_Item_Collection_Should_Match_Number_Of_Select_Options()
         {

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1461,20 +1461,14 @@ namespace MudBlazor.UnitTests.Components
             icons[7].Attributes["d"].Value.Should().Be(@unchecked);
         }
 
-        /// <summary>
-        /// Regression for MudSelect losing a non-empty initial <c>SelectedValues</c> when a custom <c>Comparer</c>
-        /// is supplied. Before the fix, <c>OnComparerChangedAsync</c> pushed an empty snapshot to the parameter state
-        /// during initial parameter processing, invoking <c>SelectedValuesChanged</c> with an empty collection and
-        /// silently overwriting the parent's bound field.
-        /// </summary>
-        [Test]
+        [Test(Description = "https://github.com/MudBlazor/MudBlazor/issues/13106")]
         public async Task MultiSelectWithCustomComparer_InitialSelectionPreservedOnFirstRender()
         {
             var comp = Context.Render<MultiSelectWithCustomComparerInitialSelectionTest>();
 
             // The parent's bound collection must still contain both preselected items.
             comp.Instance._selected.Should().HaveCount(2);
-            comp.Instance._selected.Select(c => c!.Key).Should().BeEquivalentTo(new[] { "lat", "esp" });
+            comp.Instance._selected.Select(c => c!.Key).Should().BeEquivalentTo("lat", "esp");
 
             // The input text reflects the preselected values' names (proves the comparer matched on Key).
             comp.Find("input").GetAttribute("value").Should().Be("Preselected Latte, Preselected Espresso");
@@ -1491,6 +1485,29 @@ namespace MudBlazor.UnitTests.Components
             icons[3].Attributes["d"].Value.Should().Be(@checked);   // Cafe Latte (Key="lat")
             icons[5].Attributes["d"].Value.Should().Be(@checked);   // Espresso   (Key="esp")
             icons[7].Attributes["d"].Value.Should().Be(@unchecked); // Irish Coffee
+        }
+
+        [Test(Description = "https://github.com/MudBlazor/MudBlazor/issues/13106")]
+        public async Task MultiSelectWithCustomComparer_InitialBindPreservedOnFirstRender()
+        {
+            var comp = Context.Render<MultiSelectWithCustomComparerInitialBindTest>();
+
+            // @bind target must still hold ["test1"].
+            comp.Instance.SelectedItems.Should().BeEquivalentTo("test1");
+
+            // Rendered input reflects the preselected value.
+            comp.Find("input").GetAttribute("value").Should().Be("test1");
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+
+            const string @unchecked =
+                "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z";
+            const string @checked =
+                "M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z";
+            var icons = comp.FindAll("div.mud-list-item path").ToArray();
+            icons[1].Attributes["d"].Value.Should().Be(@checked);   // test1
+            icons[3].Attributes["d"].Value.Should().Be(@unchecked); // test2
+            icons[5].Attributes["d"].Value.Should().Be(@unchecked); // test3
         }
 
         [Test]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -779,11 +779,15 @@ namespace MudBlazor
             return _elementReference.SelectRangeAsync(pos1, pos2);
         }
 
-        private async Task OnComparerChangedAsync(ParameterChangedEventArgs<IEqualityComparer<T?>?> arg)
+        private Task OnComparerChangedAsync(ParameterChangedEventArgs<IEqualityComparer<T?>?> arg)
         {
-            // Apply comparer and refresh selected values
+            // Rebuild the internal HashSet so future equality checks use the new comparer.
+            // Do NOT push to _selectedValuesState here: during initial parameter processing,
+            // this handler fires before OnSelectedValuesChangedAsync has populated _selectedValues,
+            // so SetValueAsync would publish an empty snapshot and invoke SelectedValuesChanged,
+            // silently overwriting the parent's @bind-SelectedValues binding to empty.
             _selectedValues = new HashSet<T?>(_selectedValues, arg.Value);
-            await UpdateSelectedValuesStateAsync(arg.Value);
+            return Task.CompletedTask;
         }
 
         private async Task OnSelectedValuesChangedAsync(ParameterChangedEventArgs<IReadOnlyCollection<T?>?> arg)


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/MudBlazor/issues/13106 a regression where `<MudSelect MultiSelection="true" @bind-SelectedValues="..." Comparer="...">` lost its initial selection on first render.

`OnComparerChangedAsync` fires before `OnSelectedValuesChangedAsync` on initial parameter processing. It was calling `UpdateSelectedValuesStateAsync` while `_selectedValues` was still empty, which pushed an empty HashSet to the parameter state and invoked `SelectedValuesChanged`. silently overwriting the parent's bound collection to empty.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
