### PR TITLE
Docs: Add MessageBox reverse button order example

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogConfigurationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Dialog/Examples/DialogConfigurationExample.razor
@@ -8,4 +8,5 @@
     NoHeader="true"
     Position="DialogPosition.Center"
     CloseOnEscapeKey="true"
-    BackgroundClass="my-custom-class"/>
+    BackgroundClass="my-custom-class"
+    ReverseMessageBoxButtonOrder="true"/>

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxConfigurationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/Examples/MessageBoxConfigurationExample.razor
@@ -1,0 +1,4 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudDialogProvider
+    ReverseMessageBoxButtonOrder="true"/>

--- a/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/MessageBox/MessageBoxPage.razor
@@ -54,6 +54,18 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Button Order">
+                <Description>
+                    By default, MessageBox buttons are rendered in the order: Cancel, No, Yes.
+                    If you want to reverse this order globally across your entire application (Yes, No, Cancel),
+                    you can configure the <CodeInline>ReverseMessageBoxButtonOrder</CodeInline> property on your global <CodeInline>&lt;MudDialogProvider /&gt;</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(MessageBoxConfigurationExample)">
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>
 


### PR DESCRIPTION
I have updated the documentation to reflect the recent configuration changes made to the MessageBox component, specifically regarding the reversal of button orders.

Changes made:

- MessageBox Docs: Added a new section at the bottom of the page explaining the change, including a code snippet showing users how to reverse the order globally.
- Dialog Docs: Expanded the DialogConfigurationExample to include the ReverseMessageBoxButtonOrder property for completeness.

<img width="1195" height="297" alt="image" src="https://github.com/user-attachments/assets/82fe4bf8-48b1-416b-a171-32043ff68533" />
<br />
<img width="1196" height="344" alt="image" src="https://github.com/user-attachments/assets/b31ab924-2b3b-4e3c-9cb6-f530635098d8" />



**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
