### PR TITLE
MudTabPanel: Add missing `BadgeMax`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
@@ -12,7 +12,7 @@
 <MudTabs Elevation="2" Rounded="true" Centered="true" Class="my-6" Color="Color.Dark">
     <MudTabPanel Icon="@Icons.Material.Filled.Api" Text="API" BadgeData='"!"' BadgeColor="Color.Error" />
     <MudTabPanel Icon="@Icons.Material.Filled.Build" Text="Build" BadgeData="1" BadgeColor="Color.Success" />
-    <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="128" BadgeMax="999" BadgeColor="Color.Error" />
+    <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="@128" BadgeMax="999" BadgeColor="Color.Error" />
 	<MudTabPanel Icon="@Icons.Material.Filled.AccessTime" Text="Timing" BadgeDot="true" BadgeColor="Color.Error" />
 	<MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" Text="Metrics" BadgeIcon="@Icons.Material.Filled.Downloading" />
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
@@ -12,7 +12,7 @@
 <MudTabs Elevation="2" Rounded="true" Centered="true" Class="my-6" Color="Color.Dark">
     <MudTabPanel Icon="@Icons.Material.Filled.Api" Text="API" BadgeData='"!"' BadgeColor="Color.Error" />
     <MudTabPanel Icon="@Icons.Material.Filled.Build" Text="Build" BadgeData="1" BadgeColor="Color.Success" />
-    <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="0" />
+    <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="128" BadgeMax="999" BadgeColor="Color.Error" />
 	<MudTabPanel Icon="@Icons.Material.Filled.AccessTime" Text="Timing" BadgeDot="true" BadgeColor="Color.Error" />
 	<MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" Text="Metrics" BadgeIcon="@Icons.Material.Filled.Downloading" />
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
@@ -12,7 +12,7 @@
 <MudTabs Elevation="2" Rounded="true" Centered="true" Class="my-6" Color="Color.Dark">
     <MudTabPanel Icon="@Icons.Material.Filled.Api" Text="API" BadgeData='"!"' BadgeColor="Color.Error" />
     <MudTabPanel Icon="@Icons.Material.Filled.Build" Text="Build" BadgeData="1" BadgeColor="Color.Success" />
-    <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="@128" BadgeMax="999" BadgeColor="Color.Error" />
+    <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="@(128)" BadgeMax="999" BadgeColor="Color.Error" />
 	<MudTabPanel Icon="@Icons.Material.Filled.AccessTime" Text="Timing" BadgeDot="true" BadgeColor="Color.Error" />
 	<MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" Text="Metrics" BadgeIcon="@Icons.Material.Filled.Downloading" />
 </MudTabs>

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [TestCase(128, 99, "99+")]
-        [TestCase(128, 999, "100")]
+        [TestCase(128, 999, "128")]
         public void TabPanelBadgeMaxControlsIntegerBadgeData(int badgeData, int badgeMax, string expectedBadgeText)
         {
             var comp = Context.Render<MudTabs>(parameters => parameters

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -181,6 +181,21 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".mud-tabs-tabbar").ClassList.Should().Contain(new[] { "testA", "testB" });
         }
 
+        [TestCase(128, 99, "99+")]
+        [TestCase(128, 999, "100")]
+        public void TabPanelBadgeMaxControlsIntegerBadgeData(int badgeData, int badgeMax, string expectedBadgeText)
+        {
+            var comp = Context.Render<MudTabs>(parameters => parameters
+                .AddChildContent<MudTabPanel>(panel => panel
+                    .Add(x => x.Text, "Bugs")
+                    .Add(x => x.BadgeData, badgeData)
+                    .Add(x => x.BadgeMax, badgeMax)
+                )
+            );
+
+            comp.Find(".mud-badge").TrimmedText().Should().Be(expectedBadgeText);
+        }
+
         [Test]
         public async Task ScrollToItem_NoScrollingNeeded()
         {

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor.cs
@@ -113,6 +113,16 @@ public partial class MudTabPanel : MudComponentBase
     public object? BadgeData { get; set; }
 
     /// <summary>
+    /// The maximum number allowed in the badge.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>99</c>. Applies when <see cref="BadgeData"/> is an <c>int</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Tabs.Behavior)]
+    public int BadgeMax { get; set; } = 99;
+
+    /// <summary>
     /// Optional icon to be shown in the badge instead of text.
     /// </summary>
     [Parameter]

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -133,7 +133,7 @@
             }
             @if (panel.BadgeData is not null || panel.BadgeIcon is not null || panel.BadgeDot)
             {
-                <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Color="@panel.BadgeColor" Class="mud-tab-badge" />
+                <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Max="@panel.BadgeMax" Color="@panel.BadgeColor" Class="mud-tab-badge" />
             }
             @if (TabPanelHeaderPosition == TabHeaderPosition.After && TabPanelHeader is not null)
             {


### PR DESCRIPTION
`MudTabPanel` uses a `MudBadge` internally, but doesn't allow the user to provide a `Max` for the badge, only allows `BadgeData`, `BadgeIcon`, `BadgeDot` and `BadgeColor` to be specified.

This change adds a `BadgeMax` property that allows integer `BadgeData` values above the default badge max of 99 to be displayed using a custom maximum instead of always rendering as `99+`.

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests