### PR TITLE
MudText: Add Truncate property

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextTests.cs
@@ -203,4 +203,25 @@ public class TextTests : BunitTest
             element.ClassList.Should().NotContain("d-inline");
         }
     }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Truncate_ShouldAddNowrapClass(bool truncate)
+    {
+        var comp = Context.Render<MudText>(parameters => parameters
+            .Add(p => p.Truncate, truncate));
+
+        var element = comp.Find(".mud-typography");
+
+        if (truncate)
+        {
+            element.ClassList.Should().Contain("mud-typography-nowrap");
+        }
+        else
+        {
+            element.ClassList.Should().NotContain("mud-typography-nowrap");
+        }
+
+    }
 }

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -16,6 +16,7 @@ public partial class MudText : MudComponentBase
             .AddClass("mud-typography-gutterbottom", GutterBottom)
             .AddClass($"mud-typography-align-{ConvertAlign(Align).ToStringFast(true)}", Align != Align.Inherit)
             .AddClass("d-inline", Inline)
+            .AddClass("mud-typography-nowrap", Truncate)
             .AddClass(Class)
             .Build();
 
@@ -95,6 +96,13 @@ public partial class MudText : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Text.Behavior)]
     public string? HtmlTag { get; set; }
+
+    /// <summary>
+    /// Truncates the text with an ellipsis if it overflows its container.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Text.Behavior)]
+    public bool Truncate { get; set; }
 
     private string GetActualTag() => string.IsNullOrEmpty(HtmlTag) ? GetTagName(Typo) : HtmlTag;
 


### PR DESCRIPTION
Closes #1969
Hi,
I've taken a look at this issue and implemented a solution.
I've added a Truncate property which conditionally adds the existing mud-typography-nowrap to the element.

I did some research into how similar problems were handled elsewhere in the codebase:
- For MudSelect (#2478), truncation is applied via CSS unconditionally. This makes sense there since a select input is always a single line, but that approach wouldn't work for MudText since we don't want all text to truncate by default.
- For MudDataGrid (#12711), truncation is left to the consumer via inline styles. That works, but feels clunky—a single boolean parameter is a much cleaner API for something this common.

While digging through the codebase I also found that .mud-typography-nowrap already exists in the stylesheet with exactly the CSS needed for truncation. So rather than generating inline styles I've wired the Truncate parameter to conditionally apply this existing class instead, which feels more consistent with how the rest of the library works.

This approach works perfectly with block-style elements. However, if the element is rendered as a span, the text will still overflow because text-overflow: ellipsis requires a block container. To make this work with inline elements, a display: block or inline-block property would have to be forced, but this risks colliding with the Inline property that already exists on MudText.

I didn't go further here since I think input is needed from the mantainers. Happy to hear your thoughts.

Here is an example of truncation working on most types of elements including MudCard and MudPaper and also span elements which overflow:

<img width="854" height="518" alt="image" src="https://github.com/user-attachments/assets/19ddabfa-6f21-4938-9cb6-77c98460bd71" />

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
