### PR TITLE
Docs: Clarify MudMenu custom activator and activation events

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample1.razor
@@ -37,3 +37,26 @@
     </ChildContent>
 </MudMenu>
 
+<MudMenu ActivationEvent="@MouseEvent.RightClick">
+    <ActivatorContent>
+        <div @oncontextmenu="@context.ToggleAsync" @oncontextmenu:preventDefault style="display: inline-flex">
+            <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Right Click</MudChip>
+        </div>
+    </ActivatorContent>
+    <ChildContent>
+        <MudMenuItem Label="Profile" />
+        <MudMenuItem Label="Theme" />
+        <MudMenuItem Label="Usage" />
+    </ChildContent>
+</MudMenu>
+
+<MudMenu ActivationEvent="@MouseEvent.MouseOver" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
+    <ActivatorContent>
+        <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Mouse Over</MudChip>
+    </ActivatorContent>
+    <ChildContent>
+        <MudMenuItem Label="Profile" />
+        <MudMenuItem Label="Theme" />
+        <MudMenuItem Label="Usage" />
+    </ChildContent>
+</MudMenu>

--- a/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/Examples/MenuActivatorExample2.razor
@@ -1,10 +1,6 @@
-﻿@namespace MudBlazor.Docs.Examples
+@namespace MudBlazor.Docs.Examples
 
-
-<MudMenu FullWidth="true" ActivationEvent="@MouseEvent.LeftClick">
-    <ActivatorContent>
-        <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary" OnClick="@(() => context.ToggleAsync())">Left Click</MudChip>
-    </ActivatorContent>
+<MudMenu Label="Left Click" FullWidth="true" ActivationEvent="@MouseEvent.LeftClick" Variant="Variant.Filled" Color="Color.Primary">
     <ChildContent>
         <MudMenuItem Label="Profile" />
         <MudMenuItem Label="Theme" />
@@ -13,12 +9,7 @@
     </ChildContent>
 </MudMenu>
 
-<MudMenu ActivationEvent="@MouseEvent.RightClick">
-    <ActivatorContent>
-        <div @oncontextmenu="@context.ToggleAsync" @oncontextmenu:preventDefault>
-            <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Right Click</MudChip>
-        </div>
-    </ActivatorContent>
+<MudMenu Label="Right Click" ActivationEvent="@MouseEvent.RightClick" Variant="Variant.Filled" Color="Color.Primary">
     <ChildContent>
         <MudMenuItem Label="Profile" />
         <MudMenuItem Label="Theme" />
@@ -27,12 +18,7 @@
     </ChildContent>
 </MudMenu>
 
-<MudMenu FullWidth="true" ActivationEvent="@MouseEvent.MouseOver" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
-    <ActivatorContent>
-        <div @onpointerenter="@context.OpenAsync" @onpointerleave="@context.CloseAsync">
-            <MudChip T="string" Icon="@Icons.Material.Filled.Mouse" Color="Color.Primary">Mouse Over</MudChip>
-        </div>
-    </ActivatorContent>
+<MudMenu Label="Mouse Over" FullWidth="true" ActivationEvent="@MouseEvent.MouseOver" Variant="Variant.Filled" Color="Color.Primary" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
     <ChildContent>
         <MudMenuItem Label="Profile" />
         <MudMenuItem Label="Theme" />
@@ -40,6 +26,3 @@
         <MudMenuItem Label="Sign Out" />
     </ChildContent>
 </MudMenu>
-
-
-

--- a/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Menu/MenuPage.razor
@@ -56,9 +56,9 @@
                 <DocsPageSection>
                     <SectionHeader Title="Custom Activator">
                         <Description>
-                            If the regular customization options are not enough, use the <CodeInline>ActivatorContent</CodeInline> render fragment to define a custom activator element for opening the menu.
-                            In this example, a custom button, chip, and avatar are each used to open a menu. When generating activator elements inside a Blazor code block (<CodeInline>&#64;{ ... }</CodeInline>) or conditional markup, ensure that the element includes
-							<CodeInline>tabindex="0"</CodeInline> so it can receive focus and remain accessible via keyboard input.
+                            Use <CodeInline>ActivatorContent</CodeInline> when the built-in activators are not enough.
+                            Wire click and right-click activators to the provided menu context; for hover, set <CodeInline>ActivationEvent</CodeInline> to <CodeInline>MouseEvent.MouseOver</CodeInline> and let <CodeInline>MudMenu</CodeInline> handle pointer events.
+                            Add <CodeInline>tabindex="0"</CodeInline> to activators generated from code or conditional markup so they can receive keyboard focus.
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(MenuActivatorExample1)" ShowCode="false">
@@ -140,8 +140,9 @@
                 <DocsPageSection>
                     <SectionHeader Title="Mouse Events">
                         <Description>
-                            Use the <CodeInline>ActivationEvent</CodeInline> property to specify which mouse event opens the menu.
-                            If the menu is a nested menu, this property may act differently.
+                            Use <CodeInline>ActivationEvent</CodeInline> to choose which mouse event opens a menu with a built-in activator.
+                            With <CodeInline>ActivatorContent</CodeInline>, wire only events that are not handled automatically, such as custom right-click.
+                            Nested menus may handle activation differently.
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(MenuActivatorExample2)" ShowCode="false">

--- a/src/MudBlazor/Components/Menu/MenuContext.cs
+++ b/src/MudBlazor/Components/Menu/MenuContext.cs
@@ -32,6 +32,9 @@ public sealed class MenuContext
     /// <summary>
     /// Opens the menu.
     /// </summary>
+    /// <remarks>
+    /// This opens the menu directly and does not filter the event against <see cref="MudMenu.ActivationEvent"/>.
+    /// </remarks>
     /// <param name="args">
     /// Optional event arguments. When <see cref="MudMenu.PositionAtCursor"/> is <c>true</c>,
     /// the menu will be positioned at the coordinates from <see cref="MouseEventArgs"/> or <see cref="TouchEventArgs"/>.
@@ -42,12 +45,21 @@ public sealed class MenuContext
     /// <summary>
     /// Closes the menu and any open sub-menus.
     /// </summary>
+    /// <remarks>
+    /// For hover activators, prefer <see cref="MudMenu.ActivationEvent"/> with <see cref="MouseEvent.MouseOver"/>
+    /// instead of wiring this method to pointer leave events.
+    /// </remarks>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task CloseAsync() => _menu.CloseMenuAsync();
 
     /// <summary>
     /// Toggles the menu between open and closed states.
     /// </summary>
+    /// <remarks>
+    /// When <paramref name="args"/> is a <see cref="MouseEventArgs"/> and <see cref="MudMenu.ActivationEvent"/>
+    /// is <see cref="MouseEvent.LeftClick"/> or <see cref="MouseEvent.RightClick"/>, the mouse button is checked
+    /// before the menu is toggled.
+    /// </remarks>
     /// <param name="args">
     /// Optional event arguments. When <see cref="MudMenu.PositionAtCursor"/> is <c>true</c>,
     /// the menu will be positioned at the coordinates from <see cref="MouseEventArgs"/> or <see cref="TouchEventArgs"/>.

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -254,6 +254,8 @@ namespace MudBlazor
         /// <para>The context provides methods to control the menu: <see cref="MenuContext.OpenAsync"/>,
         /// <see cref="MenuContext.CloseAsync"/>, <see cref="MenuContext.ToggleAsync"/>, and
         /// <see cref="MenuContext.CloseAllAsync"/>.</para>
+        /// <para>For hover activation, set <see cref="ActivationEvent"/> to <see cref="MouseEvent.MouseOver"/>
+        /// and allow the menu to handle pointer enter and leave events.</para>
         /// <para>Example usage:</para>
         /// <code>
         /// &lt;MudMenu&gt;
@@ -271,10 +273,13 @@ namespace MudBlazor
         public RenderFragment<MenuContext>? ActivatorContent { get; set; }
 
         /// <summary>
-        /// The action which opens the menu, when <see cref="ActivatorContent"/> is set.
+        /// The mouse event which opens the menu.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="MouseEvent.LeftClick"/>.
+        /// <para>Defaults to <see cref="MouseEvent.LeftClick"/>.</para>
+        /// <para>Default activators are wired automatically. When using <see cref="ActivatorContent"/>,
+        /// click and context menu activators should call the provided <see cref="MenuContext"/>.
+        /// Hover activation is handled by the menu's built-in pointer handlers.</para>
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Menu.Behavior)]


### PR DESCRIPTION
## Summary

Updates the MudMenu documentation to clarify how `ActivatorContent` and `ActivationEvent` should be used together.

Closes #13134
Follows up on #12145

## Description

This change separates two related but distinct scenarios:

- `ActivationEvent` examples now demonstrate built-in activators, where MudMenu wires the activation behavior automatically.
- `ActivatorContent` examples now show the correct custom activator patterns for click, right-click, and hover.

The main clarification is that hover activators should not manually wire `@onpointerenter` / `@onpointerleave` to `context.OpenAsync` / `context.CloseAsync`. For hover behavior, users should set `ActivationEvent="@MouseEvent.MouseOver"` and let `MudMenu` handle pointer enter/leave behavior internally. This avoids premature closing when moving from the activator into the menu popover or nested menus.

Right-click custom activators remain explicitly wired with `@oncontextmenu`, since custom activator content owns that event.

This should reduce confusion around custom activators and prevent users from copying patterns that interfere with MudMenu’s built-in hover handling.

## Images

<img width="1460" height="916" alt="image" src="https://github.com/user-attachments/assets/0b052ef8-021c-4ad7-bfeb-c062c221880f" />

<img width="1442" height="868" alt="image" src="https://github.com/user-attachments/assets/3533c508-e645-4bac-9551-7190f420b4f0" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
