### PR TITLE
MudMenu: Fix viewport overflow scrollbar regression

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -97,6 +97,37 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task OpenMenu_ListReachableFromPopoverForOverflowClamping()
+        {
+            // Regression guard for https://github.com/MudBlazor/MudBlazor/issues/13141.
+            // The automatic viewport-overflow scrollbar (and an explicit MaxHeight) only work if
+            // mudPopover.js can reach the menu's .mud-list by descending single-child wrappers from
+            // the popover content node, and if that wrapper carries the class the SCSS max-height
+            // inheritance chain targets. The v9 keyboard/focus wrapper silently broke both, with no
+            // test catching it.
+            var comp = Context.Render<MenuTest1>();
+            await comp.Find("button.mud-button-root").ClickAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
+
+            var popover = comp.FindAll("div.mud-popover").Single(p => p.QuerySelector(".mud-menu-list") is not null);
+
+            // Mirror the descent in mudPopover.js: walk down through single-child wrappers to the list.
+            var node = popover.FirstElementChild;
+            while (node is not null && !node.ClassList.Contains("mud-list") && node.ChildElementCount == 1)
+            {
+                node = node.FirstElementChild;
+            }
+
+            node.Should().NotBeNull("mudPopover.js locates the scrollable menu list by descending single-child wrappers from the popover");
+            node!.ClassList.Should().Contain("mud-list");
+
+            // The list's wrapper must keep the class the SCSS max-height inheritance chain targets.
+            var wrapper = comp.Find("[data-testid='menu-wrapper']");
+            wrapper.ClassList.Should().Contain("mud-menu-list-wrapper");
+            wrapper.QuerySelector(".mud-menu-list").Should().NotBeNull();
+        }
+
+        [Test]
         public async Task Menu_ModelessOverlay_IgnoresActivatorRootForAutoCloseHitTesting()
         {
             var comp = Context.Render<MenuTest1>();

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -107,6 +107,7 @@
                 Duration="@GetTransitionDuration()">
         <CascadingValue Value="@this">
             <div id="@_elementId"
+                 class="mud-menu-list-wrapper"
                  data-testid="menu-wrapper"
                  @ref="_menuWrapperRef"
                  @onkeydown="HandleKeyDownAsync"

--- a/src/MudBlazor/Styles/components/_menu.scss
+++ b/src/MudBlazor/Styles/components/_menu.scss
@@ -90,11 +90,19 @@
   margin-inline-end: 36px;
 }
 
-.mud-popover:has(> .mud-menu-list) {
+// The list is wrapped by a keyboard/focus container. Forward the popover's
+// max-height through the wrapper so the list inherits it and becomes the scroll
+// container. The popover below clips its overflow, so without this an explicit
+// MaxHeight menu would have no scrollbar and clip its items.
+.mud-menu-list-wrapper {
+  max-height: inherit;
+}
+
+.mud-popover:has(.mud-menu-list) {
   // Prevent menu item hover effects peeking through rounded popovers.
   overflow: hidden;
   // Hide the menu if it doesn't have any content.
-  &:has(> .mud-menu-list:empty) {
+  &:has(.mud-menu-list:empty) {
     visibility: hidden;
   }
 }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -322,17 +322,21 @@ window.mudpopoverHelper = {
             // flipping logic
             if (isFlipOnOpen || isFlipAlways) {
 
-                // Reset max-height if it was previously set and anchor is in bounds
-                // Adjust .mud-list children if they would run off screen even after flipping
-                const firstChild = popoverContentNode.firstElementChild;
-                // Check if firstChild exists, has a classList, and is a mud-list
-                const isList = firstChild?.classList?.contains("mud-list");
+                // Reset max-height if it was previously set and anchor is in bounds.
+                // Adjust .mud-list children if they would run off screen even after flipping.
+                // The list can be nested inside single-child wrappers (e.g. the menu's
+                // keyboard/focus container), so descend to it rather than assuming it's the first child.
+                let listChild = popoverContentNode.firstElementChild;
+                while (listChild && !listChild.classList?.contains("mud-list") && listChild.childElementCount === 1) {
+                    listChild = listChild.firstElementChild;
+                }
+                const isList = listChild?.classList?.contains("mud-list") === true;
                 // we do it here to ensure it flips properly if more space becomes available on the other side.
                 if (popoverContentNode.mudHeight && anchorY > 0 && anchorY < window.innerHeight) {
                     popoverContentNode.style.maxHeight = null;
                     if (isList) {
-                        popoverContentNode.mudScrollTop = firstChild.scrollTop;
-                        firstChild.style.maxHeight = null;
+                        popoverContentNode.mudScrollTop = listChild.scrollTop;
+                        listChild.style.maxHeight = null;
                     }
                     popoverContentNode.mudHeight = null;
                 }
@@ -543,7 +547,7 @@ window.mudpopoverHelper = {
                 // height adjustment logic for mud lists
                 if (isList) {
                     const popoverStyle = popoverContentNode.style;
-                    const listStyle = firstChild.style;
+                    const listStyle = listChild.style;
 
                     // If there is no max height set we need to check the height
                     // we reset previously flipped at the start of flipping logic
@@ -586,10 +590,10 @@ window.mudpopoverHelper = {
                             const minVisibleHeight = overflowPadding * 3;
                             const newMaxHeight = Math.max(availableHeight, minVisibleHeight);
                             popoverContentNode.style.maxHeight = `${newMaxHeight}px`;
-                            firstChild.style.maxHeight = `${newMaxHeight}px`;
+                            listChild.style.maxHeight = `${newMaxHeight}px`;
                             popoverContentNode.mudHeight = "setmaxheight";
                             if (popoverContentNode.mudScrollTop) {
-                                firstChild.scrollTop = popoverContentNode.mudScrollTop;
+                                listChild.scrollTop = popoverContentNode.mudScrollTop;
                                 popoverContentNode.mudScrollTop = null;
                             }
                         }


### PR DESCRIPTION
Fixes #13141

### Problem

Since v9, a `MudMenu` with more items than fit the screen height overflows off the bottom of the viewport with **no scrollbar**, leaving the lower items unreachable. In v8 an internal scrollbar appeared automatically.

### Root cause

In v9 the menu's `MudList` was wrapped in a keyboard/focus container (the `data-testid="menu-wrapper"` `<div>`). That extra node moved the list out of the popover's **direct** children, which silently broke three things that all assumed `.mud-list` is the popover's first child:

1. **`mudPopover.js`** — the routine that clamps an over-tall menu to the viewport read `popoverContentNode.firstElementChild` and checked it for `.mud-list`. It now hit the wrapper, so it never clamped → no scrollbar, menu runs off-screen.
2. **`_menu.scss`** — the `:has(> .mud-menu-list)` rules (overflow clipping + empty-menu hiding) no longer matched the wrapped list.
3. **`max-height` inheritance** — once the popover clips its overflow again (2), a menu with an explicit `MaxHeight` needs the list itself to scroll.

### Fix

- **`mudPopover.js`** — find the list by descending single-child wrappers from the popover content node instead of assuming it is the first child. Robust to the menu wrapper, and unchanged for `MudSelect`/`MudAutocomplete` (whose list is still the direct child, so the loop exits immediately).
- **`_menu.scss`** — match the wrapped list with a descendant `:has(.mud-menu-list)`, and forward the popover's `max-height` through the wrapper (`.mud-menu-list-wrapper { max-height: inherit }`) so the list stays the scroll container in every case (automatic clamp **and** explicit `MaxHeight`).
- **Test** — `OpenMenu_ListReachableFromPopoverForOverflowClamping` asserts the list is reachable from the popover by the same descent the script performs, so this structural contract can't break unnoticed again.

### Before / After

A menu with 30 items opened in a short (440&nbsp;px) window.

**Before** — the menu overflows the screen, no scrollbar, lower items unreachable:

<img width="2200" height="880" alt="image" src="https://github.com/user-attachments/assets/c347739a-7809-4a0f-8f9c-3cbd0dc3e752" />


**After** — the menu fits the viewport with an internal scrollbar, every item reachable:

<img width="2200" height="880" alt="image" src="https://github.com/user-attachments/assets/1ccb0c07-518a-42a3-8c2a-ca3cd2fcbe4b" />


**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
