### PR TITLE
Tests: Enforce system language independence

### DIFF
--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -67,11 +67,11 @@ jobs:
             "src/MudBlazor.UnitTests.Docs",
             "src/MudBlazor.UnitTests.Analyzers",
           ]
-        language: ["en_US.UTF-8", "de_DE.UTF-8"]
+        language: ["en_US", "de_DE"]
     env:
-      LANG: ${{ matrix.language }}
-      LC_ALL: ${{ matrix.language }}
-      DEFAULT_LANGUAGE: "en-US.UTF-8"
+      LANG: ${{ matrix.language }}.UTF-8
+      LC_ALL: ${{ matrix.language }}.UTF-8
+      DEFAULT_LANGUAGE: "en_US.UTF-8"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       LANG: ${{ matrix.language }}.UTF-8
       LC_ALL: ${{ matrix.language }}.UTF-8
-      DEFAULT_LANGUAGE: "en_US.UTF-8"
+      DEFAULT_LANGUAGE: "en_US"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -67,6 +67,11 @@ jobs:
             "src/MudBlazor.UnitTests.Docs",
             "src/MudBlazor.UnitTests.Analyzers",
           ]
+        language: ["en_US.UTF-8", "de_DE.UTF-8"]
+    env:
+      LANG: ${{ matrix.language }}
+      LC_ALL: ${{ matrix.language }}
+      DEFAULT_LANGUAGE: "en-US.UTF-8"
 
     steps:
       - uses: actions/checkout@v6
@@ -101,7 +106,7 @@ jobs:
           echo "name=${path##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage report
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.language == env.DEFAULT_LANGUAGE }}
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report-${{ steps.project.outputs.name }}

--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -462,6 +462,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase(0.9, _defaultXForColorPanel, _defaultYForColorPanel)]
+        [SetUICulture("en-US")]
         public async Task SetA_InRGBMode(double a, double selectorXPosition, double selectorYPosition)
         {
             var comp = Context.Render<SimpleColorPickerTest>();
@@ -492,6 +493,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase(0.4, 134.88, 61.76)]
+        [SetUICulture("en-US")]
         public async Task SetS(double s, double selectorXPosition, double selectorYPosition)
         {
             var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
@@ -507,6 +509,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase(0.67, 163.43, 23.53)]
+        [SetUICulture("en-US")]
         public async Task SetL(double l, double selectorXPosition, double selectorYPosition)
         {
             var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
@@ -521,6 +524,7 @@ namespace MudBlazor.UnitTests.Components
 
         [Test]
         [TestCase(0.5, _defaultXForColorPanel, _defaultYForColorPanel)]
+        [SetUICulture("en-US")]
         public async Task SetAlpha_AsHLS(double a, double selectorXPosition, double selectorYPosition)
         {
             var comp = Context.Render<SimpleColorPickerTest>(p => p.Add(x => x.ColorPickerMode, ColorPickerMode.HSL));
@@ -566,6 +570,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [SetUICulture("en-US")]
         public async Task SetAlphaSlider()
         {
             var comp = Context.Render<SimpleColorPickerTest>();
@@ -1336,6 +1341,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [SetUICulture("en-US")]
         public async Task SetHLS_NotChangeRBG_ButCallbackFired()
         {
             var comp = Context.Render<SimpleColorPickerTest>(p =>


### PR DESCRIPTION
Some tests fail on my system which is configured to use German formatting. ~~Let's see if these failures are reproducible in CI.~~ Yup, they are reproducible.

The new language matrix makes sure such broken tests won't pass CI in the future.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
