### PR TITLE
Inputs: Add TextAlign parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldTextAlignExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldTextAlignExample.razor
@@ -1,0 +1,12 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTextField @bind-Value="TextValue" Label="Text align left" TextAlign="Align.Left"></MudTextField>
+<MudTextField @bind-Value="TextValue" Label="Text align right" TextAlign="Align.Right"></MudTextField>
+<MudTextField @bind-Value="TextValue" Label="Text align center" TextAlign="Align.Center"></MudTextField>
+<MudTextField @bind-Value="TextValue" Label="Text align justify" TextAlign="Align.Justify"></MudTextField>
+<MudTextField @bind-Value="TextValue" Label="Text align start (RTL)" dir="rtl" TextAlign="Align.Start"></MudTextField>
+<MudTextField @bind-Value="TextValue" Label="Text align end (RTL)" dir="rtl" TextAlign="Align.End"></MudTextField>
+
+@code{
+    public string TextValue { get; set; }
+}

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -2,337 +2,348 @@
 
 <DocsPage>
     <DocsPageHeader Title="Text Field" Component="@nameof(MudTextField<T>)" />
-<DocsPageContent>
-
-<DocsPageSection>
-    <SectionHeader Title="Basic Usage">
-        <Description>
-            Text fields allow users to enter text input. MudBlazor provides three visual variants: <strong>Text</strong> (standard), <strong>Filled</strong>, and <strong>Outlined</strong>.
-            Filled text fields naturally draw more attention, making them ideal for dialogs and short forms where their visual emphasis is beneficial.
-            In contrast, outlined text fields have a subtler appearance, which helps simplify the layout in longer forms by reducing visual clutter.
-        </Description>
-    </SectionHeader>
-    <SectionContent Code="@nameof(TextFieldBasicExample)" ShowCode="false">
-        <TextFieldBasicExample/>
-    </SectionContent>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Common Properties">
-        <Description>
-            These are the most frequently used properties that control the basic behavior and appearance of text fields.
-        </Description>
-    </SectionHeader>
-    <SectionSubGroups>
+    <DocsPageContent>
 
         <DocsPageSection>
-            <SectionHeader Title="Helper Text">
+            <SectionHeader Title="Basic Usage">
                 <Description>
-                    Helper text provides additional context or instructions below the text field. It helps users understand what to enter or provides formatting guidance.
+                    Text fields allow users to enter text input. MudBlazor provides three visual variants: <strong>Text</strong> (standard), <strong>Filled</strong>, and <strong>Outlined</strong>.
+                    Filled text fields naturally draw more attention, making them ideal for dialogs and short forms where their visual emphasis is beneficial.
+                    In contrast, outlined text fields have a subtler appearance, which helps simplify the layout in longer forms by reducing visual clutter.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldFormPropsHelperTextExample)" ShowCode="false">
-                <TextFieldFormPropsHelperTextExample />
+            <SectionContent Code="@nameof(TextFieldBasicExample)" ShowCode="false">
+                <TextFieldBasicExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Helper Text On Focus">
+            <SectionHeader Title="Common Properties">
                 <Description>
-                    When <CodeInline>HelperTextOnFocus</CodeInline> is enabled, the helper text only appears when the field is focused, reducing visual clutter while still providing guidance when needed.
+                    These are the most frequently used properties that control the basic behavior and appearance of text fields.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldHelperTextExample)" ShowCode="false">
-                <TextFieldHelperTextExample />
-            </SectionContent>
+            <SectionSubGroups>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Helper Text">
+                        <Description>
+                            Helper text provides additional context or instructions below the text field. It helps users understand what to enter or provides formatting guidance.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldFormPropsHelperTextExample)" ShowCode="false">
+                        <TextFieldFormPropsHelperTextExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Helper Text On Focus">
+                        <Description>
+                            When <CodeInline>HelperTextOnFocus</CodeInline> is enabled, the helper text only appears when the field is focused, reducing visual clutter while still providing guidance when needed.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldHelperTextExample)" ShowCode="false">
+                        <TextFieldHelperTextExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Disabled State">
+                        <Description>
+                            Disabled text fields prevent user interaction and are typically used when a field should not be editable under certain conditions.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldFormPropsDisabledExample)" ShowCode="false">
+                        <TextFieldFormPropsDisabledExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Read Only">
+                        <Description>
+                            Read-only text fields display data that users can see and select but cannot modify. The field remains interactive for copying text.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldFormPropsReadOnlyExample)" ShowCode="false">
+                        <TextFieldFormPropsReadOnlyExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Clear Button">
+                        <Description>
+                            Enable the <CodeInline>Clearable</CodeInline> property to add a clear button that allows users to quickly empty the text field. This works alongside other adornments.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldClearableAndInputTypeExample)" ShowCode="false">
+                        <TextFieldClearableAndInputTypeExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+            </SectionSubGroups>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Disabled State">
+            <SectionHeader Title="Appearance & Styling">
                 <Description>
-                    Disabled text fields prevent user interaction and are typically used when a field should not be editable under certain conditions.
+                    Customize the visual appearance of text fields to match your design requirements.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldFormPropsDisabledExample)" ShowCode="false">
-                <TextFieldFormPropsDisabledExample/>
-            </SectionContent>
+            <SectionSubGroups>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Dense Layout">
+                        <Description>
+                            Use the <CodeInline>Margin="Margin.Dense"</CodeInline> property to reduce the text field height for compact layouts.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldDenseExample)" ShowCode="false">
+                        <TextFieldDenseExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Typography">
+                        <Description>
+                            Control the text appearance with the <CodeInline>Typo</CodeInline> property to match different content hierarchies.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldTypoExample)" ShowCode="false">
+                        <TextFieldTypoExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Shrink Label">
+                        <Description>
+                            When <CodeInline>ShrinkLabel</CodeInline> is enabled, the label remains in its reduced size position and doesn't move when the field is empty.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldShrinkLabelExample)" ShowCode="false">
+                        <TextFieldShrinkLabelExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Text align">
+                        <Description>
+                            With <CodeInline>TextAling</CodeInline> align text in the input box
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldTextAlignExample)" ShowCode="false">
+                        <TextFieldTextAlignExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+            </SectionSubGroups>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Read Only">
+            <SectionHeader Title="Adornments">
                 <Description>
-                    Read-only text fields display data that users can see and select but cannot modify. The field remains interactive for copying text.
+                    Adornments allow you to add icons, text, or buttons to the start or end of text fields. They're perfect for adding context, actions, or visual cues.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldFormPropsReadOnlyExample)" ShowCode="false">
-                <TextFieldFormPropsReadOnlyExample/>
+            <SectionContent Code="@nameof(TextFieldAdornmentsExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TextFieldAdornmentsExample />
             </SectionContent>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Clear Button">
-                <Description>
-                    Enable the <CodeInline>Clearable</CodeInline> property to add a clear button that allows users to quickly empty the text field. This works alongside other adornments.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldClearableAndInputTypeExample)" ShowCode="false">
-                <TextFieldClearableAndInputTypeExample/>
-            </SectionContent>
-        </DocsPageSection>
-
-    </SectionSubGroups>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Appearance & Styling">
-        <Description>
-            Customize the visual appearance of text fields to match your design requirements.
-        </Description>
-    </SectionHeader>
-    <SectionSubGroups>
-
-        <DocsPageSection>
-            <SectionHeader Title="Dense Layout">
-                <Description>
-                    Use the <CodeInline>Margin="Margin.Dense"</CodeInline> property to reduce the text field height for compact layouts.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldDenseExample)" ShowCode="false">
-                <TextFieldDenseExample/>
-            </SectionContent>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Typography">
-                <Description>
-                    Control the text appearance with the <CodeInline>Typo</CodeInline> property to match different content hierarchies.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldTypoExample)" ShowCode="false">
-                <TextFieldTypoExample/>
-            </SectionContent>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Shrink Label">
-                <Description>
-                    When <CodeInline>ShrinkLabel</CodeInline> is enabled, the label remains in its reduced size position and doesn't move when the field is empty.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldShrinkLabelExample)" ShowCode="false">
-                <TextFieldShrinkLabelExample/>
-            </SectionContent>
-        </DocsPageSection>
-
-    </SectionSubGroups>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Adornments">
-        <Description>
-            Adornments allow you to add icons, text, or buttons to the start or end of text fields. They're perfect for adding context, actions, or visual cues.
-        </Description>
-    </SectionHeader>
-    <SectionContent Code="@nameof(TextFieldAdornmentsExample)" ShowCode="false" Block="true" FullWidth="true">
-        <TextFieldAdornmentsExample />
-    </SectionContent>
-    <SectionSubGroups>
+            <SectionSubGroups>
         
-        <DocsPageSection>
-            <SectionHeader Title="Adornment Color">
-                <Description>
-                    The color of adornments can be customized independently from the text field using the <CodeInline>AdornmentColor</CodeInline> property.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldAdornmentColorExample)" ShowCode="false">
-                <TextFieldAdornmentColorExample />
-            </SectionContent>
+                <DocsPageSection>
+                    <SectionHeader Title="Adornment Color">
+                        <Description>
+                            The color of adornments can be customized independently from the text field using the <CodeInline>AdornmentColor</CodeInline> property.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldAdornmentColorExample)" ShowCode="false">
+                        <TextFieldAdornmentColorExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+            </SectionSubGroups>
         </DocsPageSection>
 
-    </SectionSubGroups>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Character Counter">
-        <Description>
-            Display character counts and enforce length limits to help users stay within content boundaries. Set <CodeInline>Counter</CodeInline> to show the count, 
-            and combine with <CodeInline>MaxLength</CodeInline> to enforce limits at the input level.
-        </Description>
-    </SectionHeader>
-    <SectionContent Code="@nameof(TextFieldCharacterCountExample)" ShowCode="false">
-        <TextFieldCharacterCountExample/>
-    </SectionContent>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Data Binding">
-        <Description>
-            Text fields support comprehensive data binding patterns for different scenarios and data types.
-        </Description>
-    </SectionHeader>
-    <SectionSubGroups>
-
         <DocsPageSection>
-            <SectionHeader Title="Object Properties">
+            <SectionHeader Title="Character Counter">
                 <Description>
-                    Bind text fields to properties of objects (POCOs). Changes in the fields automatically update the model, and model changes reflect in the fields.
-                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with text fields.</MudAlert>
-
+                    Display character counts and enforce length limits to help users stay within content boundaries. Set <CodeInline>Counter</CodeInline> to show the count,
+                    and combine with <CodeInline>MaxLength</CodeInline> to enforce limits at the input level.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldBindingExample)" ShowCode="false">
-                <TextFieldBindingExample/>
+            <SectionContent Code="@nameof(TextFieldCharacterCountExample)" ShowCode="false">
+                <TextFieldCharacterCountExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Value Types vs Nullables">
+            <SectionHeader Title="Data Binding">
                 <Description>
-                    Value types always have a default value (e.g., <CodeInline>0</CodeInline> for <CodeInline>int</CodeInline>), so text fields won't appear empty initially.
-                    Use nullable types (e.g., <CodeInline>int?</CodeInline>) when you want fields to start empty until the user enters a value.
+                    Text fields support comprehensive data binding patterns for different scenarios and data types.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldBindingValueTypesExample)" ShowCode="false">
-                <TextFieldBindingValueTypesExample/>
+            <SectionSubGroups>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Object Properties">
+                        <Description>
+                            Bind text fields to properties of objects (POCOs). Changes in the fields automatically update the model, and model changes reflect in the fields.
+                            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with text fields.</MudAlert>
+
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldBindingExample)" ShowCode="false">
+                        <TextFieldBindingExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Value Types vs Nullables">
+                        <Description>
+                            Value types always have a default value (e.g., <CodeInline>0</CodeInline> for <CodeInline>int</CodeInline>), so text fields won't appear empty initially.
+                            Use nullable types (e.g., <CodeInline>int?</CodeInline>) when you want fields to start empty until the user enters a value.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldBindingValueTypesExample)" ShowCode="false">
+                        <TextFieldBindingValueTypesExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Update Timing">
+                        <Description>
+                            By default, text fields update on Enter or blur. Use <CodeInline>Immediate="true"</CodeInline> for real-time updates, or set <CodeInline>DebounceInterval</CodeInline>
+                            to delay updates until the user stops typing. The debounced example updates 500ms after typing stops.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(DebouncedTextFieldExample)" ShowCode="false">
+                        <DebouncedTextFieldExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+            </SectionSubGroups>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Input Types">
+                <Description>
+                    You can change the InputType of MudTextField to use the native browser implementation of the
+                    <MudLink Href="https://developer.mozilla.org/docs/Web/HTML/Element/input">HTML input element</MudLink>.
+                    Note that any Placeholder will be ignored where the browser provides a default placeholder.
+                    <br />
+                    <br />
+                    All inputs can be bound to <CodeInline>string</CodeInline> types; alternatively, input types <CodeInline>Date</CodeInline> and <CodeInline>DateTimeLocal</CodeInline>
+                    can be bound to a nullable <CodeInline>DateTime?</CodeInline>. When binding to a <CodeInline>DateTime?</CodeInline> you <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>yyyy-MM-dd</CodeInline> for input type <CodeInline>Date</CodeInline>, and you
+                    <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>s</CodeInline> (<MudLink Href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable">ISO 8601</MudLink>) for input type <CodeInline>DateTimeLocal</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldNativeInputsExample)">
+                <TextFieldNativeInputsExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Update Timing">
+            <SectionHeader Title="Multiline">
                 <Description>
-                    By default, text fields update on Enter or blur. Use <CodeInline>Immediate="true"</CodeInline> for real-time updates, or set <CodeInline>DebounceInterval</CodeInline> 
-                    to delay updates until the user stops typing. The debounced example updates 500ms after typing stops.
+                    Text fields can be expanded to accommodate multiple lines of text by setting the <CodeInline>Lines</CodeInline> property.
+                    Use <CodeInline>Sizing</CodeInline> to control whether the field grows with content.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(DebouncedTextFieldExample)" ShowCode="false">
-                <DebouncedTextFieldExample/>
+            <SectionContent Code="@nameof(TextFieldMultilineExample)" ShowCode="false">
+                <TextFieldMultilineExample />
             </SectionContent>
-        </DocsPageSection>
-
-    </SectionSubGroups>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Input Types">
-        <Description>
-            You can change the InputType of MudTextField to use the native browser implementation of the
-            <MudLink Href="https://developer.mozilla.org/docs/Web/HTML/Element/input">HTML input element</MudLink>.
-            Note that any Placeholder will be ignored where the browser provides a default placeholder.
-            <br/>
-            <br/>
-            All inputs can be bound to <CodeInline>string</CodeInline> types; alternatively, input types <CodeInline>Date</CodeInline> and <CodeInline>DateTimeLocal</CodeInline>
-            can be bound to a nullable <CodeInline>DateTime?</CodeInline>. When binding to a <CodeInline>DateTime?</CodeInline> you <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>yyyy-MM-dd</CodeInline> for input type <CodeInline>Date</CodeInline>, and you
-            <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>s</CodeInline> (<MudLink Href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable">ISO 8601</MudLink>) for input type <CodeInline>DateTimeLocal</CodeInline>.
-        </Description>
-    </SectionHeader>
-    <SectionContent Code="@nameof(TextFieldNativeInputsExample)">
-        <TextFieldNativeInputsExample/>
-    </SectionContent>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Multiline">
-        <Description>
-            Text fields can be expanded to accommodate multiple lines of text by setting the <CodeInline>Lines</CodeInline> property.
-            Use <CodeInline>Sizing</CodeInline> to control whether the field grows with content.
-        </Description>
-    </SectionHeader>
-    <SectionContent Code="@nameof(TextFieldMultilineExample)" ShowCode="false">
-        <TextFieldMultilineExample/>
-    </SectionContent>
-    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-        If you use Blazor Server for your app, note that there is a default limit on the maximum message size SignalR can handle. If you want to support large texts in the input element (around 15k characters and more)
-        you need to increase the message size limit by setting <CodeInline>MaximumReceiveMessageSize</CodeInline> accordingly in the HubOptions in your Program.cs file.
-        For more details see <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
-    </MudAlert>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Input Masking">
-        <Description>
-            If you set the <CodeInline>Mask</CodeInline> property, the text field will apply formatting rules or input restrictions on-the-fly
-            while the user is typing.
-
-            <MudAlert  Class="my-3" Severity="Severity.Info">
-                Check out the <MudLink Href="features/masking">Masking</MudLink> page for more info and examples.
+            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                If you use Blazor Server for your app, note that there is a default limit on the maximum message size SignalR can handle. If you want to support large texts in the input element (around 15k characters and more)
+                you need to increase the message size limit by setting <CodeInline>MaximumReceiveMessageSize</CodeInline> accordingly in the HubOptions in your Program.cs file.
+                For more details see <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
             </MudAlert>
-
-            In this example we apply a <CodeInline>PatternMask</CodeInline> with a mask string of
-            <CodeInline>"0000 0000 0000 0000"</CodeInline> prompting for blocks of digits and
-            refusing invalid input. Note how the cursor automatically
-            jumps over delimiters so you don't have to type them. You can also try pasting the test credit card number <i>4543474002249996</i>.
-        </Description>
-    </SectionHeader>
-    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(PatternMaskExample)" ShowCode="false">
-        <PatternMaskExample />
-    </SectionContent>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Programmatic Control">
-        <Description>
-            Text fields provide methods for programmatically controlling focus and text selection. These are useful for creating better user experiences and accessibility features.
-        </Description>
-    </SectionHeader>
-    <SectionSubGroups>
+        </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Focus Control">
+            <SectionHeader Title="Input Masking">
                 <Description>
-                    Use the <CodeInline>FocusAsync()</CodeInline> method to programmatically set focus to a text field. This is particularly useful for form validation feedback or guiding user attention.
+                    If you set the <CodeInline>Mask</CodeInline> property, the text field will apply formatting rules or input restrictions on-the-fly
+                    while the user is typing.
+
+                    <MudAlert Class="my-3" Severity="Severity.Info">
+                        Check out the <MudLink Href="features/masking">Masking</MudLink> page for more info and examples.
+                    </MudAlert>
+
+                    In this example we apply a <CodeInline>PatternMask</CodeInline> with a mask string of
+                    <CodeInline>"0000 0000 0000 0000"</CodeInline> prompting for blocks of digits and
+                    refusing invalid input. Note how the cursor automatically
+                    jumps over delimiters so you don't have to type them. You can also try pasting the test credit card number <i>4543474002249996</i>.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldFocusExample)" ShowCode="false" Block="true" FullWidth="true">
-                <TextFieldFocusExample />
+            <SectionContent FullWidth="true" Outlined="true" Code="@nameof(PatternMaskExample)" ShowCode="false">
+                <PatternMaskExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Text Selection">
+            <SectionHeader Title="Programmatic Control">
                 <Description>
-                    The <CodeInline>SelectAsync()</CodeInline> method selects all text in the field, while <CodeInline>SelectRangeAsync()</CodeInline> allows you to select specific character ranges.
+                    Text fields provide methods for programmatically controlling focus and text selection. These are useful for creating better user experiences and accessibility features.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldSelectExample)" ShowCode="false" Block="true" FullWidth="true">
-                <TextFieldSelectExample />
-            </SectionContent>
+            <SectionSubGroups>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Focus Control">
+                        <Description>
+                            Use the <CodeInline>FocusAsync()</CodeInline> method to programmatically set focus to a text field. This is particularly useful for form validation feedback or guiding user attention.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldFocusExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TextFieldFocusExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Text Selection">
+                        <Description>
+                            The <CodeInline>SelectAsync()</CodeInline> method selects all text in the field, while <CodeInline>SelectRangeAsync()</CodeInline> allows you to select specific character ranges.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldSelectExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TextFieldSelectExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Range Selection">
+                        <Description>
+                            Select specific ranges of text using <CodeInline>SelectRangeAsync(start, end)</CodeInline>. This example selects characters 5-10 when you click the button.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldSelectRangeExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TextFieldSelectRangeExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+                <DocsPageSection>
+                    <SectionHeader Title="Text Insertion">
+                        <Description>
+                            There are three functions which allow you to insert text: <CodeInline>GetCurrentCaretPositionAsync</CodeInline>, <CodeInline>InsertAtCurrentCaretPositionAsync</CodeInline> and <CodeInline>InsertTextAsync</CodeInline>.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent Code="@nameof(TextFieldTextInsertionExample)" ShowCode="false" Block="true" FullWidth="true">
+                        <TextFieldTextInsertionExample />
+                    </SectionContent>
+                </DocsPageSection>
+
+            </SectionSubGroups>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Range Selection">
+            <SectionHeader Title="Building Blocks">
                 <Description>
-                    Select specific ranges of text using <CodeInline>SelectRangeAsync(start, end)</CodeInline>. This example selects characters 5-10 when you click the button.
+                    MudInput is the underlying component that powers MudTextField, providing a simpler interface without labels or helper text for when you need basic input functionality.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldSelectRangeExample)" ShowCode="false" Block="true" FullWidth="true">
-                <TextFieldSelectRangeExample />
+            <SectionContent Code="@nameof(TextFieldInputsExample)" ShowCode="false">
+                <TextFieldInputsExample />
             </SectionContent>
         </DocsPageSection>
 
-        <DocsPageSection>
-            <SectionHeader Title="Text Insertion">
-                <Description>
-                    There are three functions which allow you to insert text: <CodeInline>GetCurrentCaretPositionAsync</CodeInline>, <CodeInline>InsertAtCurrentCaretPositionAsync</CodeInline> and <CodeInline>InsertTextAsync</CodeInline>. 
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldTextInsertionExample)" ShowCode="false" Block="true" FullWidth="true">
-                <TextFieldTextInsertionExample />
-            </SectionContent>
-        </DocsPageSection>
-
-    </SectionSubGroups>
-</DocsPageSection>
-
-<DocsPageSection>
-    <SectionHeader Title="Building Blocks">
-        <Description>
-            MudInput is the underlying component that powers MudTextField, providing a simpler interface without labels or helper text for when you need basic input functionality.
-        </Description>
-    </SectionHeader>
-    <SectionContent Code="@nameof(TextFieldInputsExample)" ShowCode="false">
-        <TextFieldInputsExample/>
-    </SectionContent>
-</DocsPageSection>
-
-</DocsPageContent>
+    </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -2,349 +2,349 @@
 
 <DocsPage>
     <DocsPageHeader Title="Text Field" Component="@nameof(MudTextField<T>)" />
-    <DocsPageContent>
+<DocsPageContent>
+
+<DocsPageSection>
+    <SectionHeader Title="Basic Usage">
+        <Description>
+            Text fields allow users to enter text input. MudBlazor provides three visual variants: <strong>Text</strong> (standard), <strong>Filled</strong>, and <strong>Outlined</strong>.
+            Filled text fields naturally draw more attention, making them ideal for dialogs and short forms where their visual emphasis is beneficial.
+            In contrast, outlined text fields have a subtler appearance, which helps simplify the layout in longer forms by reducing visual clutter.
+        </Description>
+    </SectionHeader>
+    <SectionContent Code="@nameof(TextFieldBasicExample)" ShowCode="false">
+        <TextFieldBasicExample/>
+    </SectionContent>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Common Properties">
+        <Description>
+            These are the most frequently used properties that control the basic behavior and appearance of text fields.
+        </Description>
+    </SectionHeader>
+    <SectionSubGroups>
 
         <DocsPageSection>
-            <SectionHeader Title="Basic Usage">
+            <SectionHeader Title="Helper Text">
                 <Description>
-                    Text fields allow users to enter text input. MudBlazor provides three visual variants: <strong>Text</strong> (standard), <strong>Filled</strong>, and <strong>Outlined</strong>.
-                    Filled text fields naturally draw more attention, making them ideal for dialogs and short forms where their visual emphasis is beneficial.
-                    In contrast, outlined text fields have a subtler appearance, which helps simplify the layout in longer forms by reducing visual clutter.
+                    Helper text provides additional context or instructions below the text field. It helps users understand what to enter or provides formatting guidance.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldBasicExample)" ShowCode="false">
-                <TextFieldBasicExample />
+            <SectionContent Code="@nameof(TextFieldFormPropsHelperTextExample)" ShowCode="false">
+                <TextFieldFormPropsHelperTextExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Common Properties">
+            <SectionHeader Title="Helper Text On Focus">
                 <Description>
-                    These are the most frequently used properties that control the basic behavior and appearance of text fields.
+                    When <CodeInline>HelperTextOnFocus</CodeInline> is enabled, the helper text only appears when the field is focused, reducing visual clutter while still providing guidance when needed.
                 </Description>
             </SectionHeader>
-            <SectionSubGroups>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Helper Text">
-                        <Description>
-                            Helper text provides additional context or instructions below the text field. It helps users understand what to enter or provides formatting guidance.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldFormPropsHelperTextExample)" ShowCode="false">
-                        <TextFieldFormPropsHelperTextExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Helper Text On Focus">
-                        <Description>
-                            When <CodeInline>HelperTextOnFocus</CodeInline> is enabled, the helper text only appears when the field is focused, reducing visual clutter while still providing guidance when needed.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldHelperTextExample)" ShowCode="false">
-                        <TextFieldHelperTextExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Disabled State">
-                        <Description>
-                            Disabled text fields prevent user interaction and are typically used when a field should not be editable under certain conditions.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldFormPropsDisabledExample)" ShowCode="false">
-                        <TextFieldFormPropsDisabledExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Read Only">
-                        <Description>
-                            Read-only text fields display data that users can see and select but cannot modify. The field remains interactive for copying text.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldFormPropsReadOnlyExample)" ShowCode="false">
-                        <TextFieldFormPropsReadOnlyExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Clear Button">
-                        <Description>
-                            Enable the <CodeInline>Clearable</CodeInline> property to add a clear button that allows users to quickly empty the text field. This works alongside other adornments.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldClearableAndInputTypeExample)" ShowCode="false">
-                        <TextFieldClearableAndInputTypeExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-            </SectionSubGroups>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Appearance & Styling">
-                <Description>
-                    Customize the visual appearance of text fields to match your design requirements.
-                </Description>
-            </SectionHeader>
-            <SectionSubGroups>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Dense Layout">
-                        <Description>
-                            Use the <CodeInline>Margin="Margin.Dense"</CodeInline> property to reduce the text field height for compact layouts.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldDenseExample)" ShowCode="false">
-                        <TextFieldDenseExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Typography">
-                        <Description>
-                            Control the text appearance with the <CodeInline>Typo</CodeInline> property to match different content hierarchies.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldTypoExample)" ShowCode="false">
-                        <TextFieldTypoExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Shrink Label">
-                        <Description>
-                            When <CodeInline>ShrinkLabel</CodeInline> is enabled, the label remains in its reduced size position and doesn't move when the field is empty.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldShrinkLabelExample)" ShowCode="false">
-                        <TextFieldShrinkLabelExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Text align">
-                        <Description>
-                            With <CodeInline>TextAlign</CodeInline> you can align text in the input box.
-                            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: <CodeInline>TextAlign</CodeInline> also available for <CodeInline>MudNumericField</CodeInline>, <CodeInline>MudAutocomplete</CodeInline>, and <CodeInline>MudSelect</CodeInline></MudAlert>
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldTextAlignExample)" ShowCode="false">
-                        <TextFieldTextAlignExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-            </SectionSubGroups>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Adornments">
-                <Description>
-                    Adornments allow you to add icons, text, or buttons to the start or end of text fields. They're perfect for adding context, actions, or visual cues.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldAdornmentsExample)" ShowCode="false" Block="true" FullWidth="true">
-                <TextFieldAdornmentsExample />
+            <SectionContent Code="@nameof(TextFieldHelperTextExample)" ShowCode="false">
+                <TextFieldHelperTextExample />
             </SectionContent>
-            <SectionSubGroups>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Disabled State">
+                <Description>
+                    Disabled text fields prevent user interaction and are typically used when a field should not be editable under certain conditions.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldFormPropsDisabledExample)" ShowCode="false">
+                <TextFieldFormPropsDisabledExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Read Only">
+                <Description>
+                    Read-only text fields display data that users can see and select but cannot modify. The field remains interactive for copying text.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldFormPropsReadOnlyExample)" ShowCode="false">
+                <TextFieldFormPropsReadOnlyExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Clear Button">
+                <Description>
+                    Enable the <CodeInline>Clearable</CodeInline> property to add a clear button that allows users to quickly empty the text field. This works alongside other adornments.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldClearableAndInputTypeExample)" ShowCode="false">
+                <TextFieldClearableAndInputTypeExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+    </SectionSubGroups>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Appearance & Styling">
+        <Description>
+            Customize the visual appearance of text fields to match your design requirements.
+        </Description>
+    </SectionHeader>
+    <SectionSubGroups>
+
+        <DocsPageSection>
+            <SectionHeader Title="Dense Layout">
+                <Description>
+                    Use the <CodeInline>Margin="Margin.Dense"</CodeInline> property to reduce the text field height for compact layouts.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldDenseExample)" ShowCode="false">
+                <TextFieldDenseExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Typography">
+                <Description>
+                    Control the text appearance with the <CodeInline>Typo</CodeInline> property to match different content hierarchies.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldTypoExample)" ShowCode="false">
+                <TextFieldTypoExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Shrink Label">
+                <Description>
+                    When <CodeInline>ShrinkLabel</CodeInline> is enabled, the label remains in its reduced size position and doesn't move when the field is empty.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldShrinkLabelExample)" ShowCode="false">
+                <TextFieldShrinkLabelExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Text align">
+                <Description>
+                    With <CodeInline>TextAlign</CodeInline> you can align text in the input box.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: <CodeInline>TextAlign</CodeInline> also available for <CodeInline>MudNumericField</CodeInline>, <CodeInline>MudAutocomplete</CodeInline>, and <CodeInline>MudSelect</CodeInline></MudAlert>
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldTextAlignExample)" ShowCode="false">
+                <TextFieldTextAlignExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+    </SectionSubGroups>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Adornments">
+        <Description>
+            Adornments allow you to add icons, text, or buttons to the start or end of text fields. They're perfect for adding context, actions, or visual cues.
+        </Description>
+    </SectionHeader>
+    <SectionContent Code="@nameof(TextFieldAdornmentsExample)" ShowCode="false" Block="true" FullWidth="true">
+        <TextFieldAdornmentsExample />
+    </SectionContent>
+    <SectionSubGroups>
         
-                <DocsPageSection>
-                    <SectionHeader Title="Adornment Color">
-                        <Description>
-                            The color of adornments can be customized independently from the text field using the <CodeInline>AdornmentColor</CodeInline> property.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldAdornmentColorExample)" ShowCode="false">
-                        <TextFieldAdornmentColorExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-            </SectionSubGroups>
-        </DocsPageSection>
-
         <DocsPageSection>
-            <SectionHeader Title="Character Counter">
+            <SectionHeader Title="Adornment Color">
                 <Description>
-                    Display character counts and enforce length limits to help users stay within content boundaries. Set <CodeInline>Counter</CodeInline> to show the count,
-                    and combine with <CodeInline>MaxLength</CodeInline> to enforce limits at the input level.
+                    The color of adornments can be customized independently from the text field using the <CodeInline>AdornmentColor</CodeInline> property.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldCharacterCountExample)" ShowCode="false">
-                <TextFieldCharacterCountExample />
+            <SectionContent Code="@nameof(TextFieldAdornmentColorExample)" ShowCode="false">
+                <TextFieldAdornmentColorExample />
+            </SectionContent>
+        </DocsPageSection>
+
+    </SectionSubGroups>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Character Counter">
+        <Description>
+            Display character counts and enforce length limits to help users stay within content boundaries. Set <CodeInline>Counter</CodeInline> to show the count, 
+            and combine with <CodeInline>MaxLength</CodeInline> to enforce limits at the input level.
+        </Description>
+    </SectionHeader>
+    <SectionContent Code="@nameof(TextFieldCharacterCountExample)" ShowCode="false">
+        <TextFieldCharacterCountExample/>
+    </SectionContent>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Data Binding">
+        <Description>
+            Text fields support comprehensive data binding patterns for different scenarios and data types.
+        </Description>
+    </SectionHeader>
+    <SectionSubGroups>
+
+        <DocsPageSection>
+            <SectionHeader Title="Object Properties">
+                <Description>
+                    Bind text fields to properties of objects (POCOs). Changes in the fields automatically update the model, and model changes reflect in the fields.
+                    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with text fields.</MudAlert>
+
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldBindingExample)" ShowCode="false">
+                <TextFieldBindingExample/>
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Data Binding">
+            <SectionHeader Title="Value Types vs Nullables">
                 <Description>
-                    Text fields support comprehensive data binding patterns for different scenarios and data types.
+                    Value types always have a default value (e.g., <CodeInline>0</CodeInline> for <CodeInline>int</CodeInline>), so text fields won't appear empty initially.
+                    Use nullable types (e.g., <CodeInline>int?</CodeInline>) when you want fields to start empty until the user enters a value.
                 </Description>
             </SectionHeader>
-            <SectionSubGroups>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Object Properties">
-                        <Description>
-                            Bind text fields to properties of objects (POCOs). Changes in the fields automatically update the model, and model changes reflect in the fields.
-                            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: Always use two-way bindings (<CodeInline>@("@bind-Value")</CodeInline>) with text fields.</MudAlert>
-
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldBindingExample)" ShowCode="false">
-                        <TextFieldBindingExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Value Types vs Nullables">
-                        <Description>
-                            Value types always have a default value (e.g., <CodeInline>0</CodeInline> for <CodeInline>int</CodeInline>), so text fields won't appear empty initially.
-                            Use nullable types (e.g., <CodeInline>int?</CodeInline>) when you want fields to start empty until the user enters a value.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldBindingValueTypesExample)" ShowCode="false">
-                        <TextFieldBindingValueTypesExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Update Timing">
-                        <Description>
-                            By default, text fields update on Enter or blur. Use <CodeInline>Immediate="true"</CodeInline> for real-time updates, or set <CodeInline>DebounceInterval</CodeInline>
-                            to delay updates until the user stops typing. The debounced example updates 500ms after typing stops.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(DebouncedTextFieldExample)" ShowCode="false">
-                        <DebouncedTextFieldExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-            </SectionSubGroups>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Input Types">
-                <Description>
-                    You can change the InputType of MudTextField to use the native browser implementation of the
-                    <MudLink Href="https://developer.mozilla.org/docs/Web/HTML/Element/input">HTML input element</MudLink>.
-                    Note that any Placeholder will be ignored where the browser provides a default placeholder.
-                    <br />
-                    <br />
-                    All inputs can be bound to <CodeInline>string</CodeInline> types; alternatively, input types <CodeInline>Date</CodeInline> and <CodeInline>DateTimeLocal</CodeInline>
-                    can be bound to a nullable <CodeInline>DateTime?</CodeInline>. When binding to a <CodeInline>DateTime?</CodeInline> you <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>yyyy-MM-dd</CodeInline> for input type <CodeInline>Date</CodeInline>, and you
-                    <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>s</CodeInline> (<MudLink Href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable">ISO 8601</MudLink>) for input type <CodeInline>DateTimeLocal</CodeInline>.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldNativeInputsExample)">
-                <TextFieldNativeInputsExample />
+            <SectionContent Code="@nameof(TextFieldBindingValueTypesExample)" ShowCode="false">
+                <TextFieldBindingValueTypesExample/>
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Multiline">
+            <SectionHeader Title="Update Timing">
                 <Description>
-                    Text fields can be expanded to accommodate multiple lines of text by setting the <CodeInline>Lines</CodeInline> property.
-                    Use <CodeInline>Sizing</CodeInline> to control whether the field grows with content.
+                    By default, text fields update on Enter or blur. Use <CodeInline>Immediate="true"</CodeInline> for real-time updates, or set <CodeInline>DebounceInterval</CodeInline> 
+                    to delay updates until the user stops typing. The debounced example updates 500ms after typing stops.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldMultilineExample)" ShowCode="false">
-                <TextFieldMultilineExample />
+            <SectionContent Code="@nameof(DebouncedTextFieldExample)" ShowCode="false">
+                <DebouncedTextFieldExample/>
             </SectionContent>
-            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
-                If you use Blazor Server for your app, note that there is a default limit on the maximum message size SignalR can handle. If you want to support large texts in the input element (around 15k characters and more)
-                you need to increase the message size limit by setting <CodeInline>MaximumReceiveMessageSize</CodeInline> accordingly in the HubOptions in your Program.cs file.
-                For more details see <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
+        </DocsPageSection>
+
+    </SectionSubGroups>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Input Types">
+        <Description>
+            You can change the InputType of MudTextField to use the native browser implementation of the
+            <MudLink Href="https://developer.mozilla.org/docs/Web/HTML/Element/input">HTML input element</MudLink>.
+            Note that any Placeholder will be ignored where the browser provides a default placeholder.
+            <br/>
+            <br/>
+            All inputs can be bound to <CodeInline>string</CodeInline> types; alternatively, input types <CodeInline>Date</CodeInline> and <CodeInline>DateTimeLocal</CodeInline>
+            can be bound to a nullable <CodeInline>DateTime?</CodeInline>. When binding to a <CodeInline>DateTime?</CodeInline> you <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>yyyy-MM-dd</CodeInline> for input type <CodeInline>Date</CodeInline>, and you
+            <strong>must</strong> set the <CodeInline>Format</CodeInline> property to <CodeInline>s</CodeInline> (<MudLink Href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings#Sortable">ISO 8601</MudLink>) for input type <CodeInline>DateTimeLocal</CodeInline>.
+        </Description>
+    </SectionHeader>
+    <SectionContent Code="@nameof(TextFieldNativeInputsExample)">
+        <TextFieldNativeInputsExample/>
+    </SectionContent>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Multiline">
+        <Description>
+            Text fields can be expanded to accommodate multiple lines of text by setting the <CodeInline>Lines</CodeInline> property.
+            Use <CodeInline>Sizing</CodeInline> to control whether the field grows with content.
+        </Description>
+    </SectionHeader>
+    <SectionContent Code="@nameof(TextFieldMultilineExample)" ShowCode="false">
+        <TextFieldMultilineExample/>
+    </SectionContent>
+    <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+        If you use Blazor Server for your app, note that there is a default limit on the maximum message size SignalR can handle. If you want to support large texts in the input element (around 15k characters and more)
+        you need to increase the message size limit by setting <CodeInline>MaximumReceiveMessageSize</CodeInline> accordingly in the HubOptions in your Program.cs file.
+        For more details see <MudLink Href="https://github.com/MudBlazor/MudBlazor/issues/7263">this issue</MudLink> on github.
+    </MudAlert>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Input Masking">
+        <Description>
+            If you set the <CodeInline>Mask</CodeInline> property, the text field will apply formatting rules or input restrictions on-the-fly
+            while the user is typing.
+
+            <MudAlert  Class="my-3" Severity="Severity.Info">
+                Check out the <MudLink Href="features/masking">Masking</MudLink> page for more info and examples.
             </MudAlert>
-        </DocsPageSection>
+
+            In this example we apply a <CodeInline>PatternMask</CodeInline> with a mask string of
+            <CodeInline>"0000 0000 0000 0000"</CodeInline> prompting for blocks of digits and
+            refusing invalid input. Note how the cursor automatically
+            jumps over delimiters so you don't have to type them. You can also try pasting the test credit card number <i>4543474002249996</i>.
+        </Description>
+    </SectionHeader>
+    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(PatternMaskExample)" ShowCode="false">
+        <PatternMaskExample />
+    </SectionContent>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Programmatic Control">
+        <Description>
+            Text fields provide methods for programmatically controlling focus and text selection. These are useful for creating better user experiences and accessibility features.
+        </Description>
+    </SectionHeader>
+    <SectionSubGroups>
 
         <DocsPageSection>
-            <SectionHeader Title="Input Masking">
+            <SectionHeader Title="Focus Control">
                 <Description>
-                    If you set the <CodeInline>Mask</CodeInline> property, the text field will apply formatting rules or input restrictions on-the-fly
-                    while the user is typing.
-
-                    <MudAlert Class="my-3" Severity="Severity.Info">
-                        Check out the <MudLink Href="features/masking">Masking</MudLink> page for more info and examples.
-                    </MudAlert>
-
-                    In this example we apply a <CodeInline>PatternMask</CodeInline> with a mask string of
-                    <CodeInline>"0000 0000 0000 0000"</CodeInline> prompting for blocks of digits and
-                    refusing invalid input. Note how the cursor automatically
-                    jumps over delimiters so you don't have to type them. You can also try pasting the test credit card number <i>4543474002249996</i>.
+                    Use the <CodeInline>FocusAsync()</CodeInline> method to programmatically set focus to a text field. This is particularly useful for form validation feedback or guiding user attention.
                 </Description>
             </SectionHeader>
-            <SectionContent FullWidth="true" Outlined="true" Code="@nameof(PatternMaskExample)" ShowCode="false">
-                <PatternMaskExample />
+            <SectionContent Code="@nameof(TextFieldFocusExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TextFieldFocusExample />
             </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Programmatic Control">
+            <SectionHeader Title="Text Selection">
                 <Description>
-                    Text fields provide methods for programmatically controlling focus and text selection. These are useful for creating better user experiences and accessibility features.
+                    The <CodeInline>SelectAsync()</CodeInline> method selects all text in the field, while <CodeInline>SelectRangeAsync()</CodeInline> allows you to select specific character ranges.
                 </Description>
             </SectionHeader>
-            <SectionSubGroups>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Focus Control">
-                        <Description>
-                            Use the <CodeInline>FocusAsync()</CodeInline> method to programmatically set focus to a text field. This is particularly useful for form validation feedback or guiding user attention.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldFocusExample)" ShowCode="false" Block="true" FullWidth="true">
-                        <TextFieldFocusExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Text Selection">
-                        <Description>
-                            The <CodeInline>SelectAsync()</CodeInline> method selects all text in the field, while <CodeInline>SelectRangeAsync()</CodeInline> allows you to select specific character ranges.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldSelectExample)" ShowCode="false" Block="true" FullWidth="true">
-                        <TextFieldSelectExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Range Selection">
-                        <Description>
-                            Select specific ranges of text using <CodeInline>SelectRangeAsync(start, end)</CodeInline>. This example selects characters 5-10 when you click the button.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldSelectRangeExample)" ShowCode="false" Block="true" FullWidth="true">
-                        <TextFieldSelectRangeExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-                <DocsPageSection>
-                    <SectionHeader Title="Text Insertion">
-                        <Description>
-                            There are three functions which allow you to insert text: <CodeInline>GetCurrentCaretPositionAsync</CodeInline>, <CodeInline>InsertAtCurrentCaretPositionAsync</CodeInline> and <CodeInline>InsertTextAsync</CodeInline>.
-                        </Description>
-                    </SectionHeader>
-                    <SectionContent Code="@nameof(TextFieldTextInsertionExample)" ShowCode="false" Block="true" FullWidth="true">
-                        <TextFieldTextInsertionExample />
-                    </SectionContent>
-                </DocsPageSection>
-
-            </SectionSubGroups>
-        </DocsPageSection>
-
-        <DocsPageSection>
-            <SectionHeader Title="Building Blocks">
-                <Description>
-                    MudInput is the underlying component that powers MudTextField, providing a simpler interface without labels or helper text for when you need basic input functionality.
-                </Description>
-            </SectionHeader>
-            <SectionContent Code="@nameof(TextFieldInputsExample)" ShowCode="false">
-                <TextFieldInputsExample />
+            <SectionContent Code="@nameof(TextFieldSelectExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TextFieldSelectExample />
             </SectionContent>
         </DocsPageSection>
 
-    </DocsPageContent>
+        <DocsPageSection>
+            <SectionHeader Title="Range Selection">
+                <Description>
+                    Select specific ranges of text using <CodeInline>SelectRangeAsync(start, end)</CodeInline>. This example selects characters 5-10 when you click the button.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldSelectRangeExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TextFieldSelectRangeExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
+            <SectionHeader Title="Text Insertion">
+                <Description>
+                    There are three functions which allow you to insert text: <CodeInline>GetCurrentCaretPositionAsync</CodeInline>, <CodeInline>InsertAtCurrentCaretPositionAsync</CodeInline> and <CodeInline>InsertTextAsync</CodeInline>. 
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TextFieldTextInsertionExample)" ShowCode="false" Block="true" FullWidth="true">
+                <TextFieldTextInsertionExample />
+            </SectionContent>
+        </DocsPageSection>
+
+    </SectionSubGroups>
+</DocsPageSection>
+
+<DocsPageSection>
+    <SectionHeader Title="Building Blocks">
+        <Description>
+            MudInput is the underlying component that powers MudTextField, providing a simpler interface without labels or helper text for when you need basic input functionality.
+        </Description>
+    </SectionHeader>
+    <SectionContent Code="@nameof(TextFieldInputsExample)" ShowCode="false">
+        <TextFieldInputsExample/>
+    </SectionContent>
+</DocsPageSection>
+
+</DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/TextFieldPage.razor
@@ -127,7 +127,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Text align">
                         <Description>
-                            With <CodeInline>TextAling</CodeInline> align text in the input box
+                            With <CodeInline>TextAlign</CodeInline> you can align text in the input box.
+                            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">Note: <CodeInline>TextAlign</CodeInline> also available for <CodeInline>MudNumericField</CodeInline>, <CodeInline>MudAutocomplete</CodeInline>, and <CodeInline>MudSelect</CodeInline></MudAlert>
                         </Description>
                     </SectionHeader>
                     <SectionContent Code="@nameof(TextFieldTextAlignExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldTextAlignTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldTextAlignTest.razor
@@ -1,0 +1,9 @@
+﻿<div style="display:grid; grid-template-columns: 280px minmax(0,1fr) minmax(0,1fr); gap: 12px; align-items:start;">
+    <MudTextField T="string" TextAlign="Align.Left" Label="Left align text"></MudTextField>
+    <MudTextField T="string" TextAlign="Align.Right" Label="Right align text"></MudTextField>
+    <MudTextField T="string" TextAlign="Align.Center" Label="Center align text"></MudTextField>
+</div>
+
+@code {
+    public static string __description__ = "Testing text align property";
+}

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2531,6 +2531,28 @@ namespace MudBlazor.UnitTests.Components
             auto.Instance.Modal.Should().BeNull();
         }
 
+        [Test]
+        public async Task TextAlign_Default_ShouldNotApplyAlignClass()
+        {
+            var comp = Context.Render<MudAutocomplete<string>>();
+
+            comp.Find("input").ClassList.Should()
+                .NotContain(c => c.StartsWith("mud-input-align-"));
+        }
+
+        [Test]
+        public async Task TextAlign_AllValues_ShouldApplyCorrectCssClass()
+        {
+            foreach (var align in Enum.GetValues<Align>().Where(a => a != Align.Inherit))
+            {
+                var comp = Context.Render<MudAutocomplete<string>>(p => p
+                    .Add(x => x.TextAlign, align));
+
+                comp.Find("input").ClassList.Should()
+                    .Contain($"mud-input-align-{align.ToStringFast(true)}");
+            }
+        }
+
         private sealed class CoerceValueElement
         {
             public string Name { get; set; } = string.Empty;

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1416,5 +1416,27 @@ namespace MudBlazor.UnitTests.Components
                 numericField.ConversionErrorMessage.Should().BeNull();
             });
         }
+
+        [Test]
+        public async Task TextAlign_Default_ShouldNotApplyAlignClass()
+        {
+            var comp = Context.Render<MudNumericField<int>>();
+
+            comp.Find("input").ClassList.Should()
+                .NotContain(c => c.StartsWith("mud-input-align-"));
+        }
+
+        [Test]
+        public async Task TextAlign_AllValues_ShouldApplyCorrectCssClass()
+        {
+            foreach (var align in Enum.GetValues<Align>().Where(a => a != Align.Inherit))
+            {
+                var comp = Context.Render<MudNumericField<int>>(p => p
+                    .Add(x => x.TextAlign, align));
+
+                comp.Find("input").ClassList.Should()
+                    .Contain($"mud-input-align-{align.ToStringFast(true)}");
+            }
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -2213,6 +2213,28 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
+        [Test]
+        public async Task TextAlign_Default_ShouldNotApplyAlignClass()
+        {
+            var comp = Context.Render<MudSelect<string>>();
+
+            comp.Find("input").ClassList.Should()
+                .NotContain(c => c.StartsWith("mud-input-align-"));
+        }
+
+        [Test]
+        public async Task TextAlign_AllValues_ShouldApplyCorrectCssClass()
+        {
+            foreach (var align in Enum.GetValues<Align>().Where(a => a != Align.Inherit))
+            {
+                var comp = Context.Render<MudSelect<string>>(p => p
+                    .Add(x => x.TextAlign, align));
+
+                comp.Find("input").ClassList.Should()
+                    .Contain($"mud-input-align-{align.ToStringFast(true)}");
+            }
+        }
+
         private static string GetCheckboxPath(IElement item)
         {
             return item.QuerySelectorAll("path").Last().GetAttribute("d")!;

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1998,5 +1998,27 @@ namespace MudBlazor.UnitTests.Components
             await textField.InsertTextAtCurrentCaretPositionAsync("test");
             jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudInput.insertAtCurrentCaretPosition", It.IsAny<object[]>()), Times.Exactly(1));
         }
+
+        [Test]
+        public async Task TextAlign_AllValues_ShouldApplyCorrectCssClass()
+        {
+            foreach (var align in Enum.GetValues<Align>().Where(a => a != Align.Inherit))
+            {
+                var comp = Context.Render<MudTextField<string>>(p => p
+                    .Add(x => x.TextAlign, align));
+
+                comp.Find("input").ClassList.Should()
+                    .Contain($"mud-input-align-{align.ToStringFast(true)}");
+            }
+        }
+
+        [Test]
+        public async Task TextAlign_Default_ShouldNotApplyAlignClass()
+        {
+            var comp = Context.Render<MudTextField<string>>();
+
+            comp.Find("input").ClassList.Should()
+                .NotContain(c => c.StartsWith("mud-input-align-"));
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -340,6 +340,13 @@ namespace MudBlazor
         public bool ShrinkLabel { get; set; }
 
         /// <summary>
+        /// Sets horizontal text alignment within the input.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public Align TextAlign { get; set; }
+
+        /// <summary>
         /// Occurs when the <see cref="Text"/> property has changed.
         /// </summary>
         [Parameter]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -344,7 +344,7 @@ namespace MudBlazor
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public Align TextAlign { get; set; }
+        public Align TextAlign { get; set; } = Align.Inherit;
 
         /// <summary>
         /// Occurs when the <see cref="Text"/> property has changed.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -52,7 +52,8 @@
                           InputMode="@InputMode" Pattern="@Pattern"
                           ShrinkLabel="@ShrinkLabel"
                           Required="@Required"
-                          InputId="@InputElementId" />
+                          InputId="@InputElementId" 
+                          TextAlign="@TextAlign"/>
 
                 @if (ShowProgressIndicator && IsLoading)
                 {

--- a/src/MudBlazor/Components/Input/MudInputCssHelper.cs
+++ b/src/MudBlazor/Components/Input/MudInputCssHelper.cs
@@ -41,6 +41,7 @@ internal static class MudInputCssHelper
             .AddClass($"mud-input-root-{baseInput.Variant.ToStringFast(true)}")
             .AddClass($"mud-input-root-adorned-{baseInput.Adornment.ToStringFast(true)}", baseInput.Adornment != Adornment.None)
             .AddClass($"mud-input-root-margin-{baseInput.Margin.ToStringFast(true)}", () => baseInput.Margin != Margin.None)
+            .AddClass($"mud-input-align-{baseInput.TextAlign.ToStringFast(true)}", baseInput.TextAlign != Align.Inherit)
             .AddClass(baseInput.Class)
             .Build();
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -65,7 +65,8 @@
                           ClearIcon="@ClearIcon"
                           ShrinkLabel="@ShrinkLabel"
                           InputId="@InputElementId"
-                          Required="@Required" />
+                          Required="@Required" 
+                          TextAlign="@TextAlign"/>
             </CascadingValue>
         </InputContent>
     </MudInputControl>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -51,7 +51,8 @@
                           OnBlur="@OnBlurAsync"
                           ShrinkLabel="@(ShrinkLabel || CanRenderValue)"
                           InputId="@InputElementId"
-                          Required="@Required">
+                          Required="@Required"
+                          TextAlign="@TextAlign">
                     @if (CanRenderValue)
                     {
                         @GetSelectedValuePresenter()

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -67,7 +67,8 @@
                               Pattern="@Pattern"
                               ShrinkLabel="@ShrinkLabel"
                               InputId="@InputElementId"
-                              Required="@Required"/>
+                              Required="@Required"
+                              TextAlign="@TextAlign"/>
                 }
                 else
                 {

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -554,38 +554,32 @@
   user-select: none;
 }
 
-.mud-input-align-left {
-  input, textarea {
-    text-align: left;
-  }
+input.mud-input-align-left,
+div.mud-input-align-left {
+  text-align: left;
 }
 
-.mud-input-align-center {
-  input, textarea {
-    text-align: center;
-  }
+input.mud-input-align-center,
+div.mud-input-align-center {
+  text-align: center;
 }
 
-.mud-input-align-right {
-  input, textarea {
-    text-align: right;
-  }
+input.mud-input-align-right,
+div.mud-input-align-right {
+  text-align: right;
 }
 
-.mud-input-align-justify {
-  input, textarea {
-    text-align: justify;
-  }
+input.mud-input-align-justify,
+div.mud-input-align-justify {
+  text-align: justify;
 }
 
-.mud-input-align-start {
-  input, textarea {
-    text-align: start;
-  }
+input.mud-input-align-start,
+div.mud-input-align-start {
+  text-align: start;
 }
 
-.mud-input-align-end {
-  input, textarea {
-    text-align: end;
-  }
+input.mud-input-align-end,
+div.mud-input-align-end {
+  text-align: end;
 }

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -553,3 +553,21 @@
 .mud-input-input-control {
   user-select: none;
 }
+
+.mud-input-align-left {
+  input, textarea {
+    text-align: left;
+  }
+}
+
+.mud-input-align-center {
+  input, textarea {
+    text-align: center;
+  }
+}
+
+.mud-input-align-right {
+  input, textarea {
+    text-align: right;
+  }
+}

--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -571,3 +571,21 @@
     text-align: right;
   }
 }
+
+.mud-input-align-justify {
+  input, textarea {
+    text-align: justify;
+  }
+}
+
+.mud-input-align-start {
+  input, textarea {
+    text-align: start;
+  }
+}
+
+.mud-input-align-end {
+  input, textarea {
+    text-align: end;
+  }
+}


### PR DESCRIPTION
## Description
Adds `TextAlign` parameter to `MudBaseInput<T>` to allow horizontal text alignment within input components. Closes #1114.

## Changes
- Added `TextAlign` parameter (`Align` enum, default `Align.Inherit`) to `MudBaseInput`
- Added `TextAlign` support for `MudTextField`, `MudNumericField`, `MudAutocomplete` and `MudSelect`
- Added CSS class generation in `MudInputCssHelper.GetInputClassname`
- Added corresponding styles in `_input.scss` for all `Align` values (`left`, `center`,   `right`, `justify`, `start`, `end`)
- Added unit tests for `MudTextField`, `MudNumericField`, `MudAutocomplete` and `MudSelect`
- Added documentation example including RTL demonstration for `Align.Start` and `Align.End`

## Notes
- Named `TextAlign` instead of `AlignContent` (as discussed in the issue) - `TextAlign` more accurately describes what is being aligned and since `align-content` is a flexbox property with a different meaning in CSS, I guess `TextAlign` is better
- `Align.Start` and `Align.End` are logical CSS properties — they automatically adapt 
  to RTL languages (e.g. Arabic, Hebrew) when `dir="rtl"` is set
- `Align.Inherit` (default) adds no CSS class, preserving existing behavior

## Screenshots

<img width="796" height="575" alt="image" src="https://github.com/user-attachments/assets/43647a07-8f19-4a53-9751-64f1fe7a0e6e" />

## Open questions
- Should `Align.Justify` be included? I guess it only makes visual sense for multiline inputs (`Lines > 1`) but I wasn't able to reproduce this kind of case....
- Should `TextAlign` be available on `MudAutocomplete` and `MudSelect`? They inherit it automatically from `MudBaseInput`, but use cases are less obvious.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
