### PR TITLE
Docs: Detect Ad Blocker

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -1,4 +1,4 @@
-﻿﻿@using System.Runtime.Versioning
+﻿@using System.Runtime.Versioning
 
 <MudMainContent Class="mudblazor-main-content">
     <MudContainer MaxWidth="MaxWidth.Large">
@@ -43,6 +43,16 @@
         @if (_renderAds)
         {
             <MudElement HtmlTag="script" async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CESDLK3E&placement=mudblazorcom" id="_carbonads_js" data-consent-category="carbon"></MudElement>
+        }
+        @if (_adBlockerDetected)
+        {
+            <MudAlert Severity="Severity.Error" Class="ma-4" Elevation="1">
+                <MudText Typo="Typo.subtitle2" GutterBottom="true">Support MudBlazor</MudText>
+                <MudText Typo="Typo.body2" Class="ms-n8">
+                    It looks like an ad blocker is hiding the ad in this slot.
+                    Please consider allowing ads on this site.
+                </MudText>
+            </MudAlert>
         }
     </MudDrawer>
 </MudMainContent>

--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -44,7 +44,7 @@
         {
             <MudElement HtmlTag="script" async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CESDLK3E&placement=mudblazorcom" id="_carbonads_js" data-consent-category="carbon"></MudElement>
         }
-        @if (_adBlockerDetected)
+        @if (_adBlockerDetected == true)
         {
             <MudAlert Severity="Severity.Error" Class="ma-4" Elevation="1">
                 <MudText Typo="Typo.subtitle2" GutterBottom="true">Support MudBlazor</MudText>

--- a/src/MudBlazor.Docs/Components/DocsPage.razor
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor
@@ -44,7 +44,7 @@
         {
             <MudElement HtmlTag="script" async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CESDLK3E&placement=mudblazorcom" id="_carbonads_js" data-consent-category="carbon"></MudElement>
         }
-        @if (_adBlockerDetected == true)
+        @if (_adBlockerDetected)
         {
             <MudAlert Severity="Severity.Error" Class="ma-4" Elevation="1">
                 <MudText Typo="Typo.subtitle2" GutterBottom="true">Support MudBlazor</MudText>

--- a/src/MudBlazor.Docs/Components/DocsPage.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor.cs
@@ -28,10 +28,12 @@ namespace MudBlazor.Docs.Components
         private bool _displayView;
         private string _componentName;
         private bool _renderAds;
+        private bool _adBlockerDetected;
         [Inject] NavigationManager NavigationManager { get; set; }
 
         [Inject] private IDocsNavigationService DocsService { get; set; }
         [Inject] private IRenderQueueService RenderQueue { get; set; }
+        [Inject] private IAdBlockDetectionService AdBlockDetection { get; set; }
         [Parameter] public RenderFragment ChildContent { get; set; }
 
         private bool _contentDrawerOpen = true;
@@ -87,7 +89,7 @@ namespace MudBlazor.Docs.Components
             }*/
         }
 
-        protected override void OnAfterRender(bool firstRender)
+        protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             if (_stopwatch.IsRunning)
             {
@@ -99,6 +101,16 @@ namespace MudBlazor.Docs.Components
             {
                 _renderAds = true;
                 StateHasChanged();
+
+                // Carbon Ads injects '#carbonads' only after carbon.js fetches and runs.
+                // Probe after a short wait so we can show a fallback message when
+                // the script is being blocked by an ad blocker or network filter.
+                var blocked = await AdBlockDetection.IsAdBlockedAsync();
+                if (blocked && !_adBlockerDetected)
+                {
+                    _adBlockerDetected = true;
+                    StateHasChanged();
+                }
             }
         }
 

--- a/src/MudBlazor.Docs/Components/DocsPage.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.Docs.Components
         private bool _displayView;
         private string _componentName;
         private bool _renderAds;
-        private bool? _adBlockerDetected;
+        private bool _adBlockerDetected;
         [Inject] NavigationManager NavigationManager { get; set; }
 
         [Inject] private IDocsNavigationService DocsService { get; set; }
@@ -101,16 +101,14 @@ namespace MudBlazor.Docs.Components
             {
                 _renderAds = true;
                 StateHasChanged();
-                return;
-            }
 
-            if (_renderAds && !_adBlockerDetected.HasValue)
-            {
-                // The ad script is rendered by the follow-up render; sampling earlier would confuse normal Blazor render timing with ad blocking.
+                // Carbon Ads injects '#carbonads' only after carbon.js fetches and runs.
+                // Probe after a short wait so we can show a fallback message when
+                // the script is being blocked by an ad blocker or network filter.
                 var blocked = await AdBlockDetection.IsAdBlockedAsync();
-                _adBlockerDetected = blocked;
-                if (blocked)
+                if (blocked && !_adBlockerDetected)
                 {
+                    _adBlockerDetected = true;
                     StateHasChanged();
                 }
             }

--- a/src/MudBlazor.Docs/Components/DocsPage.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPage.razor.cs
@@ -28,7 +28,7 @@ namespace MudBlazor.Docs.Components
         private bool _displayView;
         private string _componentName;
         private bool _renderAds;
-        private bool _adBlockerDetected;
+        private bool? _adBlockerDetected;
         [Inject] NavigationManager NavigationManager { get; set; }
 
         [Inject] private IDocsNavigationService DocsService { get; set; }
@@ -101,14 +101,16 @@ namespace MudBlazor.Docs.Components
             {
                 _renderAds = true;
                 StateHasChanged();
+                return;
+            }
 
-                // Carbon Ads injects '#carbonads' only after carbon.js fetches and runs.
-                // Probe after a short wait so we can show a fallback message when
-                // the script is being blocked by an ad blocker or network filter.
+            if (_renderAds && !_adBlockerDetected.HasValue)
+            {
+                // The ad script is rendered by the follow-up render; sampling earlier would confuse normal Blazor render timing with ad blocking.
                 var blocked = await AdBlockDetection.IsAdBlockedAsync();
-                if (blocked && !_adBlockerDetected)
+                _adBlockerDetected = blocked;
+                if (blocked)
                 {
-                    _adBlockerDetected = true;
                     StateHasChanged();
                 }
             }

--- a/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
+++ b/src/MudBlazor.Docs/Extensions/DocsViewExtension.cs
@@ -35,6 +35,7 @@ namespace MudBlazor.Docs.Extensions
             });
 
             services.AddScoped<IDocsJsApiService, DocsJsApiService>();
+            services.AddScoped<IAdBlockDetectionService, AdBlockDetectionService>();
             services.AddSingleton<DiscordApiClient>();
             services.AddSingleton<NugetApiClient>();
             services.AddSingleton<GitHubApiClient>();

--- a/src/MudBlazor.Docs/Services/AdBlockDetectionService.cs
+++ b/src/MudBlazor.Docs/Services/AdBlockDetectionService.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Docs.Services
+{
+    /// <summary>
+    /// Detects whether an ad blocker (or network filter) is preventing
+    /// the Carbon Ads slot from rendering on the docs page.
+    /// </summary>
+    public interface IAdBlockDetectionService
+    {
+        /// <summary>
+        /// Returns <c>true</c> when the ad slot is likely being blocked,
+        /// either by an element-hiding cosmetic filter or because the
+        /// carbon.js script could not be fetched.
+        /// </summary>
+        /// <param name="waitMilliseconds">
+        /// How long to wait before sampling the page state. Gives the
+        /// ad blocker time to apply cosmetic filters and the carbon.js
+        /// script time to load on slow connections.
+        /// </param>
+        ValueTask<bool> IsAdBlockedAsync(int waitMilliseconds = 2000);
+    }
+
+    /// <inheritdoc cref="IAdBlockDetectionService"/>
+    public class AdBlockDetectionService : IAdBlockDetectionService
+    {
+        private readonly IJSRuntime _jsRuntime;
+
+        public AdBlockDetectionService(IJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        public async ValueTask<bool> IsAdBlockedAsync(int waitMilliseconds = 2000)
+        {
+            try
+            {
+                return await _jsRuntime.InvokeAsync<bool>("mudBlazorDocs.detectAdBlock", waitMilliseconds);
+            }
+            catch (JSException)
+            {
+                // If the JS layer itself fails (e.g. blocked file or interop error)
+                // we conservatively assume the ad slot is not visible.
+                return true;
+            }
+            catch (JSDisconnectedException)
+            {
+                // Circuit gone (Blazor Server) -- nothing meaningful to report.
+                return false;
+            }
+            catch (TaskCanceledException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.Docs/Services/AdBlockDetectionService.cs
+++ b/src/MudBlazor.Docs/Services/AdBlockDetectionService.cs
@@ -7,20 +7,15 @@ using Microsoft.JSInterop;
 namespace MudBlazor.Docs.Services
 {
     /// <summary>
-    /// Detects whether an ad blocker (or network filter) is preventing
-    /// the Carbon Ads slot from rendering on the docs page.
+    /// Detects whether ad-related cosmetic filters are hiding content on the docs page.
     /// </summary>
     public interface IAdBlockDetectionService
     {
         /// <summary>
-        /// Returns <c>true</c> when the ad slot is likely being blocked,
-        /// either by an element-hiding cosmetic filter or because the
-        /// carbon.js script could not be fetched.
+        /// Returns <c>true</c> when ad-related cosmetic filters are likely active.
         /// </summary>
         /// <param name="waitMilliseconds">
-        /// How long to wait before sampling the page state. Gives the
-        /// ad blocker time to apply cosmetic filters and the carbon.js
-        /// script time to load on slow connections.
+        /// How long to wait for cosmetic filters.
         /// </param>
         ValueTask<bool> IsAdBlockedAsync(int waitMilliseconds = 2000);
     }
@@ -43,9 +38,8 @@ namespace MudBlazor.Docs.Services
             }
             catch (JSException)
             {
-                // If the JS layer itself fails (e.g. blocked file or interop error)
-                // we conservatively assume the ad slot is not visible.
-                return true;
+                // Interop failures do not prove user-side blocking, so stay quiet instead of showing a misleading support message.
+                return false;
             }
             catch (JSDisconnectedException)
             {

--- a/src/MudBlazor.Docs/Services/AdBlockDetectionService.cs
+++ b/src/MudBlazor.Docs/Services/AdBlockDetectionService.cs
@@ -7,15 +7,20 @@ using Microsoft.JSInterop;
 namespace MudBlazor.Docs.Services
 {
     /// <summary>
-    /// Detects whether ad-related cosmetic filters are hiding content on the docs page.
+    /// Detects whether an ad blocker (or network filter) is preventing
+    /// the Carbon Ads slot from rendering on the docs page.
     /// </summary>
     public interface IAdBlockDetectionService
     {
         /// <summary>
-        /// Returns <c>true</c> when ad-related cosmetic filters are likely active.
+        /// Returns <c>true</c> when the ad slot is likely being blocked,
+        /// either by an element-hiding cosmetic filter or because the
+        /// carbon.js script could not be fetched.
         /// </summary>
         /// <param name="waitMilliseconds">
-        /// How long to wait for cosmetic filters.
+        /// How long to wait before sampling the page state. Gives the
+        /// ad blocker time to apply cosmetic filters and the carbon.js
+        /// script time to load on slow connections.
         /// </param>
         ValueTask<bool> IsAdBlockedAsync(int waitMilliseconds = 2000);
     }
@@ -38,8 +43,9 @@ namespace MudBlazor.Docs.Services
             }
             catch (JSException)
             {
-                // Interop failures do not prove user-side blocking, so stay quiet instead of showing a misleading support message.
-                return false;
+                // If the JS layer itself fails (e.g. blocked file or interop error)
+                // we conservatively assume the ad slot is not visible.
+                return true;
             }
             catch (JSDisconnectedException)
             {

--- a/src/MudBlazor.Docs/wwwroot/JS/docs.js
+++ b/src/MudBlazor.Docs/wwwroot/JS/docs.js
@@ -19,6 +19,51 @@ class MudBlazorDocs {
         if (!element) return;
         element.scrollIntoView({ block: 'center', behavior: 'smooth' })
     }
+
+    // Detects whether an ad blocker (or network filter) is preventing
+    // Carbon Ads from rendering in the docs page.
+    // Strategy:
+    //   1. Inject a hidden bait element using class names from common
+    //      ad-blocker filter lists (EasyList) and check whether it gets
+    //      hidden/removed by element-hiding cosmetic filters.
+    //   2. Check whether Carbon Ads injected its '#carbonads' container.
+    //      Network-level blockers don't hide the bait but do prevent
+    //      the carbon.js script from running at all.
+    // Resolves true if either signal indicates the ad was blocked.
+    // The wait gives the ad-blocker time to act and the carbon.js
+    // script time to load on slow connections.
+    detectAdBlock(waitMilliseconds) {
+        return new Promise((resolve) => {
+            const bait = document.createElement('div');
+            bait.className = 'ad-banner ads adsbox doubleclick ad-placement carbon-ads';
+            bait.setAttribute('aria-hidden', 'true');
+            bait.style.cssText = 'position:absolute;left:-10000px;top:-10000px;width:1px;height:1px;pointer-events:none;';
+            bait.innerHTML = '&nbsp;';
+            document.body.appendChild(bait);
+
+            const wait = typeof waitMilliseconds === 'number' && waitMilliseconds >= 0
+                ? waitMilliseconds
+                : 2000;
+
+            setTimeout(() => {
+                let baitBlocked = false;
+                try {
+                    const style = window.getComputedStyle(bait);
+                    baitBlocked = !bait.offsetParent ||
+                        bait.offsetHeight === 0 ||
+                        style.display === 'none' ||
+                        style.visibility === 'hidden';
+                } catch (e) {
+                    baitBlocked = false;
+                }
+                bait.remove();
+
+                const carbonLoaded = !!document.getElementById('carbonads');
+
+                resolve(baitBlocked || !carbonLoaded);
+            }, wait);
+        });
+    }
 };
 window.mudBlazorDocs = new MudBlazorDocs();
 

--- a/src/MudBlazor.Docs/wwwroot/JS/docs.js
+++ b/src/MudBlazor.Docs/wwwroot/JS/docs.js
@@ -20,7 +20,18 @@ class MudBlazorDocs {
         element.scrollIntoView({ block: 'center', behavior: 'smooth' })
     }
 
-    // Bait-only detection avoids treating slow, no-fill, or unavailable Carbon responses as blocking.
+    // Detects whether an ad blocker (or network filter) is preventing
+    // Carbon Ads from rendering in the docs page.
+    // Strategy:
+    //   1. Inject a hidden bait element using class names from common
+    //      ad-blocker filter lists (EasyList) and check whether it gets
+    //      hidden/removed by element-hiding cosmetic filters.
+    //   2. Check whether Carbon Ads injected its '#carbonads' container.
+    //      Network-level blockers don't hide the bait but do prevent
+    //      the carbon.js script from running at all.
+    // Resolves true if either signal indicates the ad was blocked.
+    // The wait gives the ad-blocker time to act and the carbon.js
+    // script time to load on slow connections.
     detectAdBlock(waitMilliseconds) {
         return new Promise((resolve) => {
             const bait = document.createElement('div');
@@ -45,9 +56,11 @@ class MudBlazorDocs {
                 } catch (e) {
                     baitBlocked = false;
                 }
-
                 bait.remove();
-                resolve(baitBlocked);
+
+                const carbonLoaded = !!document.getElementById('carbonads');
+
+                resolve(baitBlocked || !carbonLoaded);
             }, wait);
         });
     }

--- a/src/MudBlazor.Docs/wwwroot/JS/docs.js
+++ b/src/MudBlazor.Docs/wwwroot/JS/docs.js
@@ -20,18 +20,7 @@ class MudBlazorDocs {
         element.scrollIntoView({ block: 'center', behavior: 'smooth' })
     }
 
-    // Detects whether an ad blocker (or network filter) is preventing
-    // Carbon Ads from rendering in the docs page.
-    // Strategy:
-    //   1. Inject a hidden bait element using class names from common
-    //      ad-blocker filter lists (EasyList) and check whether it gets
-    //      hidden/removed by element-hiding cosmetic filters.
-    //   2. Check whether Carbon Ads injected its '#carbonads' container.
-    //      Network-level blockers don't hide the bait but do prevent
-    //      the carbon.js script from running at all.
-    // Resolves true if either signal indicates the ad was blocked.
-    // The wait gives the ad-blocker time to act and the carbon.js
-    // script time to load on slow connections.
+    // Bait-only detection avoids treating slow, no-fill, or unavailable Carbon responses as blocking.
     detectAdBlock(waitMilliseconds) {
         return new Promise((resolve) => {
             const bait = document.createElement('div');
@@ -56,11 +45,9 @@ class MudBlazorDocs {
                 } catch (e) {
                     baitBlocked = false;
                 }
+
                 bait.remove();
-
-                const carbonLoaded = !!document.getElementById('carbonads');
-
-                resolve(baitBlocked || !carbonLoaded);
+                resolve(baitBlocked);
             }, wait);
         });
     }

--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -32,6 +32,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
             _ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             _ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
             _ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
+            _ctx.Services.AddTransient<IAdBlockDetectionService, MockAdBlockDetectionService>();
             _ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             _ctx.Services.AddTransient<IScrollSpyFactory, MockScrollSpyFactory>();
             _ctx.Services.AddSingleton<IDocsNavigationService, DocsNavigationService>();

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -29,6 +29,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
             _ctx.Services.AddTransient<IScrollListenerFactory, MockScrollListenerFactory>();
             _ctx.Services.AddTransient<IJsApiService, MockJsApiService>();
             _ctx.Services.AddTransient<IDocsJsApiService, MockDocsJsApiService>();
+            _ctx.Services.AddTransient<IAdBlockDetectionService, MockAdBlockDetectionService>();
             _ctx.Services.AddTransient<IResizeObserverFactory, MockResizeObserverFactory>();
             _ctx.Services.AddSingleton<IKeyInterceptorService, MockKeyInterceptorService>();
             _ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();

--- a/src/MudBlazor.UnitTests.Docs/Mocks/MockAdBlockDetectionService.cs
+++ b/src/MudBlazor.UnitTests.Docs/Mocks/MockAdBlockDetectionService.cs
@@ -1,0 +1,8 @@
+﻿using MudBlazor.Docs.Services;
+
+namespace MudBlazor.UnitTests.Mocks;
+
+public class MockAdBlockDetectionService : IAdBlockDetectionService
+{
+    public ValueTask<bool> IsAdBlockedAsync(int waitMilliseconds = 2000) => ValueTask.FromResult(false);
+}


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Added a small alert in the content navigation drawer where the small ad is shown if its not rendered on the page.
Left picture is without adblocker and right is with a adblocker on.

Was testing different colors, i think the blue info alert color is nicer looking but then again its meant to catch peoples eyes so went with the alert error red.

Tested with Chrome and Firefox with uBlock and AdBlocker extensions.

<img width="2650" height="1325" alt="image" src="https://github.com/user-attachments/assets/e852bf93-73ee-4278-a87a-43876987c927" />



**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
