### PR TITLE
MudAlert: Change default content alignment to Start

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AlertTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AlertTests.cs
@@ -4,7 +4,6 @@
 
 using AwesomeAssertions;
 using Bunit;
-using Microsoft.AspNetCore.Components;
 using MudBlazor.UnitTests.TestComponents.Alert;
 using NUnit.Framework;
 

--- a/src/MudBlazor.UnitTests/Components/AlertTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AlertTests.cs
@@ -4,6 +4,7 @@
 
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.UnitTests.TestComponents.Alert;
 using NUnit.Framework;
 
@@ -32,5 +33,20 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => numeric.Instance.Value.Should().Be(1));
         }
 
+        [Test]
+        public void Alert_DefaultContentAlignment_ShouldBeStart()
+        {
+            var comp = Context.Render<MudAlert>();
+            comp.Instance.ContentAlignment.Should().Be(HorizontalAlignment.Start);
+        }
+
+        [Test]
+        public void Alert_RTL_DefaultAlignment_ShouldRenderJustifyStart()
+        {
+            var comp = Context.Render<MudAlert>(p => p.AddCascadingValue("RightToLeft", true));
+            var positionDiv = comp.Find(".mud-alert-position");
+            positionDiv.ClassList.Should().Contain("justify-start");
+            positionDiv.ClassList.Should().NotContain("justify-end");
+        }
     }
 }

--- a/src/MudBlazor/Components/Alert/MudAlert.razor.cs
+++ b/src/MudBlazor/Components/Alert/MudAlert.razor.cs
@@ -55,11 +55,11 @@ namespace MudBlazor
         /// Position of the text to the start (Left in LTR and right in RTL).
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="HorizontalAlignment.Left"/>.
+        /// Defaults to <see cref="HorizontalAlignment.Start"/>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Alert.Appearance)]
-        public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Left;
+        public HorizontalAlignment ContentAlignment { get; set; } = HorizontalAlignment.Start;
 
         /// <summary>
         /// Occurs when the close button has been clicked.


### PR DESCRIPTION
Closes #13210

The default ContentAlignment was breaking the content alignment of the MudAlert component when Right-to-Left mode was enabled.

The default value of HorizontalAlignment.Left would force the content to stick to the physical left side, which fights the browser's native document flow and doesn't make sense for Right-to-Left Mode.

Changing the default value to HorizontalAlignment.Start fixes this issue in RTL mode and preserves the exact same, correct functionality when normal LTR mode is enabled.

Below are some screenshots of the behavior in RTL and normal mode.

<img width="1256" height="542" alt="image" src="https://github.com/user-attachments/assets/041a6618-0584-47a3-99d5-28bbb150f893" />

<img width="1261" height="530" alt="image" src="https://github.com/user-attachments/assets/5dddcc60-0d34-4f9c-aada-0cccdf55999e" />



**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
