### PR TITLE
Tests: Set invariant culture for test assemblies

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/TestAssemblySettings.cs
+++ b/src/MudBlazor.UnitTests.Docs/TestAssemblySettings.cs
@@ -6,5 +6,3 @@ using NUnit.Framework;
 
 [assembly: SetCulture("")]
 [assembly: SetUICulture("")]
-[assembly: Parallelizable(ParallelScope.Fixtures)]
-[assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]

--- a/src/MudBlazor.UnitTests/TestAssemblySettings.cs
+++ b/src/MudBlazor.UnitTests/TestAssemblySettings.cs
@@ -4,5 +4,7 @@
 
 using NUnit.Framework;
 
+[assembly: SetCulture("")]
+[assembly: SetUICulture("")]
 [assembly: Parallelizable(ParallelScope.Fixtures)]
 [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]


### PR DESCRIPTION
Sets NUnit assembly-level `SetCulture("")` and `SetUICulture("")` for the unit, docs, and analyzer test assemblies.

Closes #13157. Instead of doubling CI test runs with a language matrix that only exercises `en_US` and `de_DE`, this makes the test harness deterministic by default for every test in the affected assemblies. That avoids extra CI time and prevents local/hosted machine culture from changing test behavior.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
