### PR TITLE
MudSelect: Add background-color to outlined input label

### DIFF
--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -43,7 +43,7 @@
   transform: translate(14px, 20px) scale(1);
   max-width: calc(100% - 14px);
   pointer-events: none;
-  background-color: transparent;
+  background-color: var(--mud-palette-surface);
   padding: 0px 5px !important;
 
 


### PR DESCRIPTION
This is an independent contribution — not solicited by or affiliated with any organization.

## Summary

The outlined variant of MudInputLabel (`.mud-input-label-outlined`) had `background-color: transparent`, causing the input border to remain visible behind the floating label text when the input is focused or has a value. This made the label text difficult to read and looked visually broken.

## Root Cause

In `src/MudBlazor/Styles/components/_inputlabel.scss`, line 46, the `.mud-input-label-outlined` class explicitly set `background-color: transparent`. When the label shrinks and floats above the outline border (e.g., when the select has a value or is focused), the transparent background allows the border line to show through the label text.

## Fix

Changed `background-color: transparent` to `background-color: var(--mud-palette-surface)` so the floating label's background matches the page surface, properly covering the border behind it. This is a one-line CSS change.

## Testing

- The fix uses an existing CSS custom property (`--mud-palette-surface`) that is already defined in the MudBlazor theme system.
- No new dependencies or breaking changes.
- Visual verification: outlined inputs (MudSelect, MudTextField with `Variant="Outlined"`) will now show the floating label with proper background coverage.

Closes #9593