### PR TITLE
Tests: Add deterministic time helpers and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ private Task ToggleAsync()
 - Keep tests isolated so they can run in parallel.
 - If a test modifies shared or static state, restore it in `[TearDown]`.
 - Use `[NonParallelizable]` only when isolation is not feasible.
-- Tests must not add fixed sleeps, blocking waits, polling waits, local wall-clock hang guards, or fire-and-forget async behavior. Use fake time, direct awaits, `TaskCompletionSource` gates, bUnit renderer waits, and framework-level cancellation instead.
+- Tests must not add fixed sleeps, blocking waits, polling waits, local wall-clock hang guards, or fire-and-forget async behavior. Disallowed patterns include `Task.Delay` as a sleep, `Thread.Sleep`, `.Wait()`, `.Result`, `GetAwaiter().GetResult()`, `WaitAsync(TimeSpan)`, `Task.WhenAny(..., Task.Delay(...))`, and `CatchAndLog` to drive assertions. Use fake time, direct awaits, `TaskCompletionSource` gates, bUnit renderer waits, and framework-level cancellation instead.
 - When an awaited gate could hang, use `[CancelAfter]` and await it with `TestContext.CurrentContext.CancellationToken`, such as `task.WaitAsync(TestContext.CurrentContext.CancellationToken)`.
 - In bUnit component tests, register fake time with `Context.AddFakeTimeProvider()` before rendering. In lower-level unit tests, pass `FakeTimeProvider` directly to the subject under test.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,12 +247,15 @@ private Task ToggleAsync()
 - Keep tests isolated so they can run in parallel.
 - If a test modifies shared or static state, restore it in `[TearDown]`.
 - Use `[NonParallelizable]` only when isolation is not feasible.
-- Prefer `TimeProvider` or `FakeTimeProvider` over `Task.Delay`.
+- Tests must not add fixed sleeps, blocking waits, polling waits, local wall-clock hang guards, or fire-and-forget async behavior. Use fake time, direct awaits, `TaskCompletionSource` gates, bUnit renderer waits, and framework-level cancellation instead.
+- When an awaited gate could hang, use `[CancelAfter]` and await it with `TestContext.CurrentContext.CancellationToken`, such as `task.WaitAsync(TestContext.CurrentContext.CancellationToken)`.
+- In bUnit component tests, register fake time with `Context.AddFakeTimeProvider()` before rendering. In lower-level unit tests, pass `FakeTimeProvider` directly to the subject under test.
 
 ### bUnit rules
 - Never cache `Find()` or `FindAll()` results. Re-query after interactions.
 - Always use `InvokeAsync()` for parameter changes or method calls.
 - Prefer async interactions such as `ClickAsync`, `ChangeAsync`, `BlurAsync`, and `InputAsync` over sync methods.
+- For fake-time bUnit flows, dispatch the event, advance the fake time directly, and use bUnit renderer waits for render observation.
 
 ### Test locations and naming
 - Test components belong in `src/MudBlazor.UnitTests.Viewer/TestComponents/<ComponentName>/`.

--- a/src/MudBlazor.UnitTests.Shared/Extensions/TestContextExtensions.cs
+++ b/src/MudBlazor.UnitTests.Shared/Extensions/TestContextExtensions.cs
@@ -2,6 +2,8 @@
 using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor.Services;
 
 namespace MudBlazor.UnitTests.Shared.Extensions
@@ -20,6 +22,18 @@ namespace MudBlazor.UnitTests.Shared.Extensions
             });
             ctx.Services.AddScoped(sp => new HttpClient());
             ctx.Services.AddOptions();
+        }
+
+        /// <summary>
+        /// Replaces the default time provider with a fake provider for the current bUnit context.
+        /// </summary>
+        public static FakeTimeProvider AddFakeTimeProvider(this BunitContext ctx)
+        {
+            var timeProvider = new FakeTimeProvider();
+            ctx.Services.RemoveAll<TimeProvider>();
+            ctx.Services.AddSingleton<TimeProvider>(timeProvider);
+
+            return timeProvider;
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -5,8 +5,6 @@ using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Time.Testing;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using NUnit.Framework;
@@ -683,8 +681,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task PersianCalendarDefault()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
             timeProvider.SetUtcNow(new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc));
 
             var comp = Context.Render<PersianDatePickerTest>(paramter => paramter.Add(p => p.Date, null));
@@ -761,8 +758,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DisableCalendarMonthButtonsWhenFixDayOutOfRange()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
             timeProvider.SetUtcNow(new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc));
 
             var comp = await OpenPicker(parameters => parameters
@@ -1711,8 +1707,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public async Task DatePicker_CustomTimerProvider()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
             timeProvider.SetUtcNow(new DateTime(2003, 4, 4, 0, 0, 0, DateTimeKind.Utc));
             var comp = Context.Render<DatePickerCustomDateTest>();
 

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -7,8 +7,6 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Time.Testing;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
 using MudBlazor.Utilities;
@@ -743,8 +741,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task CurrentDate_ShouldBeMarked()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
             timeProvider.SetUtcNow(new DateTime(2003, 4, 4, 0, 0, 0, DateTimeKind.Utc));
             var currentDate = timeProvider.GetLocalNow().Date;
             var comp = Context.Render<DateRangePickerImpl>(parameters => parameters
@@ -765,8 +762,7 @@ namespace MudBlazor.UnitTests.Components
         [SetCulture("en-US")]
         public async Task DateRangePicker_CustomTimeProvider()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
             timeProvider.SetUtcNow(new DateTime(2003, 4, 4, 0, 0, 0, DateTimeKind.Utc));
 
             var comp = await OpenPicker();

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -9,8 +9,6 @@ using Bunit;
 using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Time.Testing;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.NumericField;
@@ -944,8 +942,7 @@ namespace MudBlazor.UnitTests.Components
         [Ignore("Randomly fails or causes test-host hangs under heavy loads.")]
         public async Task DebouncedNumericFieldRerender()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
 
             var comp = Context.Render<DebouncedNumericFieldRerenderTest>();
             var numericField = comp.FindComponent<MudNumericField<int>>().Instance;
@@ -993,8 +990,7 @@ namespace MudBlazor.UnitTests.Components
         [Ignore("Randomly fails or causes test-host hangs under heavy loads.")]
         public async Task DebouncedNumericFieldCultureChangeRerender()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
 
             var comp = Context.Render<NumericFieldCultureChangeTest>();
             var numericField = comp.FindComponent<MudNumericField<double>>().Instance;

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -7,7 +7,6 @@ using FluentValidation;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Time.Testing;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
@@ -174,6 +173,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task ShouldRespectDebounceIntervalPropertyInTextField()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.DebounceInterval, 200d));
             var textField = comp.Instance;
             var input = comp.Find("input");
@@ -189,10 +189,11 @@ namespace MudBlazor.UnitTests.Components
             textField.ReadValue.Should().BeNull();
 
             //DebounceInterval is 200 ms, so at 100 ms Value should not change in TextField
-            await Task.Delay(100);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
             textField.ReadValue.Should().BeNull();
 
             //More than 200 ms had elapsed, so Value should be updated
+            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
             await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Some Value"));
         }
 
@@ -246,8 +247,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DebouncedTextField_Should_ValidatePendingValueImmediatelyWhenFormIsValidated()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            Context.AddFakeTimeProvider();
 
             var comp = Context.Render<DebouncedTextFieldFormValidationSyncTest>();
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1279,8 +1279,7 @@ namespace MudBlazor.UnitTests.Components
         [Ignore("Randomly fails under heavy loads.")]
         public async Task DebouncedTextFieldRerender()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
 
             var comp = Context.Render<DebouncedTextFieldRerenderTest>();
             var textField = comp.FindComponent<MudTextField<string>>().Instance;
@@ -1328,8 +1327,7 @@ namespace MudBlazor.UnitTests.Components
         [Ignore("Randomly fails under heavy loads.")]
         public async Task DebouncedTextFieldFormatChangeRerender()
         {
-            var timeProvider = new FakeTimeProvider();
-            Context.Services.AddSingleton<TimeProvider>(timeProvider);
+            var timeProvider = Context.AddFakeTimeProvider();
 
             var comp = Context.Render<DebouncedTextFieldFormatChangeRerenderTest>();
             var textField = comp.FindComponent<MudTextField<DateTime>>().Instance;

--- a/src/MudBlazor.UnitTests/Utilities/Background/BatchPeriodicQueueTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Background/BatchPeriodicQueueTests.cs
@@ -45,7 +45,7 @@ public class BatchPeriodicQueueTests
         }
 
         timeProvider.Advance(period);
-        var processedItems = await batchCompletion.Task;
+        var processedItems = await batchCompletion.Task.WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         // Assert
         processedItems.VerifyItemsMatch(expectedItems).Should().BeTrue();

--- a/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
@@ -218,6 +218,7 @@ public class DebounceDispatcherTests
     }
 
     [Test]
+    [CancelAfter(5000)]
     public async Task DebounceAsync_Dispose_CancelsPendingOperation()
     {
         // Arrange
@@ -234,7 +235,7 @@ public class DebounceDispatcherTests
         debounceDispatcher.Dispose();
 
         // Assert - should complete silently without throwing
-        await task.WaitAsync(TimeSpan.FromSeconds(5));
+        await task.WaitAsync(TestContext.CurrentContext.CancellationToken);
         executed.Should().BeFalse();
     }
 
@@ -404,12 +405,12 @@ public class DebounceDispatcherTests
         // Arrange
         var timeProvider = new FakeTimeProvider();
         using var debounceDispatcher = new DebounceDispatcher(50, false, timeProvider);
-        var firstStarted = new TaskCompletionSource<bool>();
-        var firstCanComplete = new TaskCompletionSource<bool>();
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCanComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         async Task LongRunningAction()
         {
-            firstStarted.SetResult(true);
+            firstStarted.TrySetResult();
             await firstCanComplete.Task;
         }
 
@@ -418,10 +419,10 @@ public class DebounceDispatcherTests
         // Act
         var firstTask = debounceDispatcher.DebounceAsync(LongRunningAction);
         timeProvider.Advance(TimeSpan.FromMilliseconds(50));
-        await firstStarted.Task; // Wait for first action to start
+        await firstStarted.Task.WaitAsync(TestContext.CurrentContext.CancellationToken); // Wait for first action to start
 
         // Allow first to complete
-        firstCanComplete.SetResult(true);
+        firstCanComplete.TrySetResult();
         await firstTask;
 
         // Now start a new debounce - should work fine


### PR DESCRIPTION
This keeps the first deterministic-wait cleanup PR focused on shared patterns and existing fake-time usage. Component tests now have one obvious way to register fake time, while lower-level unit tests continue passing `FakeTimeProvider` directly to the subject under test.


Changes

- Add `Context.AddFakeTimeProvider()` for bUnit component tests that need to override `TimeProvider` before rendering.
- Convert existing component tests that already registered a fake `TimeProvider` through `Context.Services` to use the shared helper.
- Tighten test guidance for fixed sleeps, local timeout guards, `TaskCompletionSource` gates, framework cancellation, and bUnit fake-time flows.
- Replace a few representative local timeout/gate patterns with `TestContext.CurrentContext.CancellationToken` and `TaskCreationOptions.RunContinuationsAsynchronously`.

Refs #13188