### PR TITLE
Build: Improve deterministic test guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,17 +245,27 @@ private Task ToggleAsync()
 - Test logic rather than full HTML snapshots.
 - Prefer a fail-first workflow: add or update the test to fail for the target behavior before implementing the fix.
 - Keep tests isolated so they can run in parallel.
-- If a test modifies shared or static state, restore it in `[TearDown]`.
-- Use `[NonParallelizable]` only when isolation is not feasible.
-- Tests must not add fixed sleeps, blocking waits, polling waits, local wall-clock hang guards, or fire-and-forget async behavior. Disallowed patterns include `Task.Delay` as a sleep, `Thread.Sleep`, `.Wait()`, `.Result`, `GetAwaiter().GetResult()`, `WaitAsync(TimeSpan)`, `Task.WhenAny(..., Task.Delay(...))`, and `CatchAndLog` to drive assertions. Use fake time, direct awaits, `TaskCompletionSource` gates, bUnit renderer waits, and framework-level cancellation instead.
-- When an awaited gate could hang, use `[CancelAfter]` and await it with `TestContext.CurrentContext.CancellationToken`, such as `task.WaitAsync(TestContext.CurrentContext.CancellationToken)`.
+- Async tests and async helpers must return `Task`, not `async void`.
+- Do not add mutable static state in tests or viewer test components.
+- If a test modifies shared or static state, restore it in `[TearDown]` and keep `[NonParallelizable]` until the shared-state dependency is removed.
+- Use `[NonParallelizable]` only when isolation is not feasible, and document the shared resource it protects.
+- Prefer fixed test data. Use random data only when randomness is the behavior under test or when the random source is seeded per test.
+- Prefer passing explicit culture into APIs or components. If a test must mutate culture, restore it and keep the test nonparallel until the mutation is removed.
+- Tests must not add fixed sleeps, sync-over-async waits, polling waits, local wall-clock hang guards, or fire-and-forget async behavior. Disallowed patterns include `Task.Delay` as a sleep, `Thread.Sleep`, blocking `Task`/`ValueTask` `.Wait()` or `.Result`, `GetAwaiter().GetResult()`, `WaitAsync(TimeSpan)`, `Task.WhenAny(..., Task.Delay(...))`, and `CatchAndLog` to drive assertions. Domain properties named `Result` are allowed. Use fake time, direct awaits, `TaskCompletionSource` gates, bUnit renderer waits, and framework-level cancellation instead.
+- Use `TaskCompletionSource` gates with `TaskCreationOptions.RunContinuationsAsynchronously`. When an awaited gate could hang, use `[CancelAfter]` and await it with `TestContext.CurrentContext.CancellationToken`, such as `task.WaitAsync(TestContext.CurrentContext.CancellationToken)`.
 - In bUnit component tests, register fake time with `Context.AddFakeTimeProvider()` before rendering. In lower-level unit tests, pass `FakeTimeProvider` directly to the subject under test.
+- Do not use `ConfigureAwait(false)` in bUnit component tests. Use it only in non-bUnit helper code when there is a specific context-free requirement.
+- In dialog tests, do not call `DialogService.ShowAsync` without rendering `MudDialogProvider` unless no-provider behavior is the subject of the test.
 
 ### bUnit rules
 - Never cache `Find()` or `FindAll()` results. Re-query after interactions.
 - Always use `InvokeAsync()` for parameter changes or method calls.
 - Prefer async interactions such as `ClickAsync`, `ChangeAsync`, `BlurAsync`, and `InputAsync` over sync methods.
+- Register or replace services before rendering the component or provider under test.
 - For fake-time bUnit flows, dispatch the event, advance the fake time directly, and use bUnit renderer waits for render observation.
+- Use `WaitForAssertion`, `WaitForState`, and `WaitForElement` only to observe renderer updates, not as timers. Custom wait timeouts should be rare and justified by the test scenario.
+- Prefer semantic assertions over broad markup assertions. Query specific elements, text, classes, ARIA attributes, or component state instead of asserting that the whole markup is empty or equal.
+- For JS interop behavior, prefer bUnit JSInterop or narrow recording fakes. Assert user-visible behavior first; if call counts matter, snapshot calls after initial render and assert only the delta caused by the action.
 
 ### Test locations and naming
 - Test components belong in `src/MudBlazor.UnitTests.Viewer/TestComponents/<ComponentName>/`.
@@ -263,6 +273,7 @@ private Task ToggleAsync()
 - Keep viewer test component file names at 40 characters or fewer. Prefer concise scenario names over long descriptive file names.
 - Unit tests belong in `src/MudBlazor.UnitTests/Components/<ComponentName>Tests.cs`.
 - Add a viewer test component only when the scenario is too cumbersome to express directly in bUnit C# syntax. In those cases, add the viewer component first, then the unit test.
+- Viewer test components should expose explicit parameters, callbacks, or `TaskCompletionSource` gates for pending, loading, cancellation, or ordering flows instead of simulating latency with sleeps.
 - Test methods should be self-documenting and should not use XML documentation.
 - Helper methods in test classes should include XML documentation when they are non-trivial or reused.
 - When adding a test for a known issue, reference the issue number in the test name or nearby context for traceability.


### PR DESCRIPTION
## Summary

- Tightens `AGENTS.md` testing guidance for deterministic, parallel-safe test work.
- Clarifies async coordination patterns: `async Task`, fake time, `TaskCompletionSource` gates, framework cancellation, and no fire-and-forget assertion flows.
- Adds bUnit-specific guidance for service registration order, renderer waits, semantic assertions, JSInterop verification, and fake-time event choreography.
- Adds viewer test component guidance so pending/loading/cancellation/order flows use explicit gates instead of simulated latency.

## Rationale

This is guardrail work for the broader test-suite stabilization effort tracked in #13188. The current refactor work is touching tests that have historically relied on wall-clock waits, mutable static state, broad markup assertions, and loose JSInterop timing assumptions. Those patterns make tests difficult to parallelize because they couple assertions to scheduler timing, renderer timing, or shared process state instead of explicit observable behavior.

The updated guidance keeps the existing repo philosophy intact: use narrow verification, keep diffs scoped, and prefer deterministic tests over snapshots or sleeps. The additions make reviewer expectations concrete so future component-test refactors do not reintroduce the same flake sources.

The dialog-specific note is included because `DialogService.ShowAsync` depends on `MudDialogProvider` render completion for normal rendered-dialog tests. Calling it without a provider can hide a no-provider wait path behind the test itself unless that behavior is the explicit subject under test.

## References

- Tracking issue: #13188
- .NET `TimeProvider` and `FakeTimeProvider`: https://learn.microsoft.com/en-us/dotnet/core/extensions/timeprovider-testing
- .NET `TaskCompletionSource`: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcompletionsource
- NUnit `[CancelAfter]`: https://docs.nunit.org/articles/nunit/writing-tests/attributes/cancelafter.html
- bUnit async assertion waits: https://bunit.dev/docs/verification/async-assertion.html
- bUnit event helpers: https://bunit.dev/docs/interaction/trigger-event-handlers.html

## Validation

- `git diff --check -- AGENTS.md`
- `git diff --check HEAD~1..HEAD`

No `dotnet` command was run because this is a prose-only repository guidance change; no code, project, test, docs app, or asset-pipeline input changed.
