### PR TITLE
MudButton: Use LinesInputs for outlined button border instead of TextPrimary

### DIFF
--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -83,7 +83,7 @@
 
 .mud-button-outlined {
   color: var(--mud-palette-text-primary);
-  border: 1px solid rgba(var(--mud-palette-text-primary-rgb), var(--mud-palette-border-opacity));
+  border: 1px solid var(--mud-palette-lines-inputs);
   padding: 5px 15px;
 
   &.mud-button-outlined-inherit {


### PR DESCRIPTION
This is an independent contribution made in a personal capacity.

## Summary

Outlined `MudButton` with `Color="Default"` uses `TextPrimary` for both text and border color, preventing independent theming of these properties. Input components (`MudTextField`, `MudSelect`) correctly use `LinesInputs` for their borders. This change aligns the button's outline behavior with inputs.

## Root Cause

In `_button.scss` line 86, the base `.mud-button-outlined` class defines its border using `rgba(var(--mud-palette-text-primary-rgb), var(--mud-palette-border-opacity))`, which ties the border color to `TextPrimary` — the same variable used for text color on line 85. By contrast, `_input.scss` line 157 uses `var(--mud-palette-lines-inputs)` for the outlined input border, giving independent control.

## Fix

Changed the base `.mud-button-outlined` border declaration from `TextPrimary` to `LinesInputs`:

```diff
-  border: 1px solid rgba(var(--mud-palette-text-primary-rgb), var(--mud-palette-border-opacity));
+  border: 1px solid var(--mud-palette-lines-inputs);
```

Color-specific outlined buttons (`.mud-button-outlined-primary`, etc.) are unaffected — they use their own color variables on line 112.

## Testing

- Verified the `LinesInputs` CSS variable is generated by `MudThemeProvider` for both light and dark palettes
- Verified inputs already use the same variable for their outlined borders in `_input.scss`
- No changes to C# logic — this is a SCSS-only change

Closes #12002