### PR TITLE
MudDataGrid: Fix mobile loading indicator

### DIFF
--- a/src/MudBlazor/Styles/components/_datagrid.scss
+++ b/src/MudBlazor/Styles/components/_datagrid.scss
@@ -166,6 +166,35 @@
   }
 }
 
+@mixin datagrid-loading-display-smalldevices($breakpoint) {
+  .mud-data-grid.mud-#{$breakpoint}table.mud-table-sticky-header {
+    .mud-table-root .mud-table-head .mud-table-loading {
+      // The mobile layout hides header rows, so the loader should stick to the top.
+      top: 0;
+    }
+  }
+}
+
+@media (max-width: $breakpoint-sm) {
+  @include datagrid-loading-display-smalldevices("xs-");
+}
+
+@media (max-width: $breakpoint-md) {
+  @include datagrid-loading-display-smalldevices("sm-");
+}
+
+@media (max-width: $breakpoint-lg) {
+  @include datagrid-loading-display-smalldevices("md-");
+}
+
+@media (max-width: $breakpoint-xl) {
+  @include datagrid-loading-display-smalldevices("lg-");
+}
+
+@media (max-width: $breakpoint-xxl) {
+  @include datagrid-loading-display-smalldevices("xl-");
+}
+
 .mud-data-grid-columns-panel {
   @media(hover: hover) and (pointer: fine) {
     &:hover {


### PR DESCRIPTION
Fixes #12091

The mobile table layout hides the normal header rows, but a fixed-header DataGrid still inherited the desktop sticky header offset for the loading row. That left the progress bar stuck 59px below the top of the hidden header and visually overlapping the first mobile data row.

This scopes the override to MudDataGrid responsive breakpoint classes so the loading cell uses `top: 0` only while the mobile table layout is active. The existing desktop sticky-header offsets remain unchanged.

Visual check:
- Before: the screenshot in #12091 shows the loading bar crossing the first mobile row.
- After: locally verified the Other Options DataGrid at 390x844; `.mud-table-loading` computed `top` is `0px`, the progress bar ends at y=629.3, and the first body cell starts at y=629.3, so the loader no longer overlaps row content.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests where applicable (CSS-only visual fix; no component logic changed)

Testing:
- `dotnet --version` -> `10.0.107`
- `dotnet restore src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~DataGridLoadingProgress" --output Normal --no-ansi --hangdump --hangdump-timeout 30s`
- `dotnet tool run bun -- wrapper --version 1.3.14 -- install --frozen-lockfile`
- `dotnet build src/MudBlazor/MudBlazor.csproj --no-restore --nologo`
- `dotnet restore src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj`
- `dotnet run --project src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj --no-restore --urls http://127.0.0.1:5012`
- Playwright mobile viewport visual check at `390x844` against `/components/datagrid#other-options`
- `dotnet format whitespace --no-restore --include MudBlazor/Styles/components/_datagrid.scss`
- `git diff --check`

Note: I used Codex to help inspect the code path and verify the local visual behavior, but I reviewed the final diff and ran the listed verification commands locally.