### PR TITLE
MudInput: Remove `OnPaste` handler

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1996,5 +1996,27 @@ namespace MudBlazor.UnitTests.Components
             await textField.InsertTextAtCurrentCaretPositionAsync("test");
             jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudInput.insertAtCurrentCaretPosition", It.IsAny<object[]>()), Times.Exactly(1));
         }
+
+        [TestCase(2, InputSizing.Fixed)]
+        [TestCase(1, InputSizing.Auto)]
+        [TestCase(2, InputSizing.Auto)]
+        public async Task TextFieldWithTextArea_Should_TriggerUserDefinedPasteEventAsync(int lines, InputSizing sizing)
+        {
+            var pasteEventCalled = false;
+            var onPasteHandler = EventCallback.Factory.Create<ClipboardEventArgs>(this, _ =>
+            {
+                pasteEventCalled = true;
+            });
+
+            var comp = Context.Render<MudTextField<string>>(parameters
+                => parameters
+                    .Add(p => p.Lines, lines)
+                    .Add(p => p.Sizing, sizing)
+                    .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "onpaste", onPasteHandler } }));
+
+            var textarea = comp.Find("textarea");
+            await textarea.TriggerEventAsync("onpaste", new ClipboardEventArgs());
+            pasteEventCalled.Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -36,7 +36,6 @@
                   @bind:set="@OnInputOrOnChangeAsync"
                   @onkeydown="@InvokeKeyDownAsync"
                   @onkeyup="@InvokeKeyUpAsync"
-                  @onpaste="@OnPaste"
                   maxlength="@MaxLength"
                   @onkeydown:preventDefault="@KeyDownPreventDefault"
                   @onkeyup:preventDefault="@KeyUpPreventDefault"

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -195,14 +195,6 @@ namespace MudBlazor
             await SetTextAndUpdateValueAsync(args);
         }
 
-        /// <summary>
-        /// Paste hook for descendants.
-        /// </summary>
-        protected virtual Task OnPaste(ClipboardEventArgs args)
-        {
-            return Task.CompletedTask;
-        }
-
         /// <inheritdoc />
         public override async ValueTask FocusAsync()
         {


### PR DESCRIPTION
Closes #13118
As @danielchalmers noted in the issue, the bug was caused by the internally defined onpaste handler on the <textarea>.

This internal handler was overriding the user-defined one. Since the internal handler wasn't actually doing anything, I removed it to allow the user-provided onpaste event to fire correctly.

I have recorded the functionality before and after the change below:

Before:

https://github.com/user-attachments/assets/4bd67283-391d-4ffd-986b-162594cae11f



After:

https://github.com/user-attachments/assets/c06c2d8b-3c5f-4f81-ae46-adff20ee9059




**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
