### PR TITLE
Docs: Improve AGENTS.md as a single-file agent harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,25 @@
 # AGENTS.md - AI Coding Agent Guide for MudBlazor
 
+## Start Here
+
+1. Identify the change type: component, docs, docs example, analyzer, TS/style, asset pipeline, or metadata-only.
+2. Inspect nearby code and tests before editing.
+3. Keep the diff scoped to the affected project or feature.
+4. Use the smallest valid verification loop for the change type.
+5. Run final whitespace formatting only for relevant changed source files.
+6. In the final response, report changed areas, exact verification commands, and any skipped checks.
+
+## Change Type Matrix
+
+| Change type | Common locations | Verification | Notes |
+| --- | --- | --- | --- |
+| Component C#/Razor behavior | `src/MudBlazor`, `src/MudBlazor.UnitTests*` | Filtered `dotnet test` on `MudBlazor.UnitTests.csproj` | Use `/p:SkipBunCompile=true` unless assets are affected. |
+| Component public API | Component, tests, docs | Unit tests plus relevant docs validation | XML docs and `[Category(...)]` are required. |
+| Docs page/example | `src/MudBlazor.Docs*` | Relevant docs build or generated docs tests | Do not edit generated docs tests. |
+| TS/style/assets | `TScripts`, styles, `wwwroot`, asset inputs | Normal scoped build | Do not use `/p:SkipBunCompile=true`. |
+| Analyzer/code fix | `src/MudBlazor.Analyzers*` | Filtered analyzer tests | Keep diagnostics, fixes, and tests aligned. |
+| Metadata/prose only | Root markdown, `.github` text | No `dotnet` verification | Do not run build/test/format for prose-only changes. |
+
 ## Scope and Workflow
 
 ### Keep changes focused
@@ -18,6 +38,14 @@
 - If no code, project, test, docs app, or asset-pipeline inputs changed, do not call `dotnet`. Changes limited to files such as `README.md`, changelog text, issue templates, or other repo metadata do not require restore, build, test, or format.
 - Prefer a single scoped `dotnet build` or `dotnet test` command as the first verification step. Split build and test only when you will reuse the build outputs for multiple test runs.
 - Do not build `src/MudBlazor/MudBlazor.csproj` immediately before testing `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj`; the test project already builds `MudBlazor`, `MudBlazor.UnitTests.Shared`, and `MudBlazor.UnitTests.Viewer`.
+
+## Before Editing
+
+- Search for existing patterns before adding helpers, abstractions, or new APIs.
+- For component behavior changes, identify the likely unit test file before editing.
+- For public API changes, identify the docs page and examples that may need updates.
+- For TS, style, or asset changes, check whether `entrypoint.js` or generated assets are affected.
+- If the task is ambiguous and a wrong assumption could cause a broad change, ask a focused clarifying question.
 
 ## Repository Layout
 
@@ -43,6 +71,17 @@
 - Docs: `src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj`, `src/MudBlazor.Docs/MudBlazor.Docs.csproj`, `src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj`, and `src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj`
 - Docs tests: `src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj`
 - Analyzers and code fixes: `src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj`, `src/MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj`, and `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`
+
+### Choose the smallest valid verification loop
+- For repository metadata or prose-only changes outside the build inputs, such as `README.md`, `CHANGELOG.md`, or `.github/` text-only edits: do not run `dotnet`.
+- For component `.cs` or `.razor` changes with behavior coverage: prefer a single filtered `dotnet test --project ... -- --filter ...` run against `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` with `/p:SkipBunCompile=true`. Build `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` first only when you plan to reuse the outputs for multiple test filters.
+- For component `.cs` or `.razor` changes that only need compile validation: build `src/MudBlazor/MudBlazor.csproj` with `/p:SkipBunCompile=true`.
+- For `TScripts` or `Styles`: run a normal scoped project build.
+- For docs changes: build the relevant docs project. Avoid docs host run loops during agent verification.
+- For docs example or API-page changes that need parity with CI, run `dotnet test --project src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true`.
+- For analyzer or code-fix changes: prefer a single filtered `dotnet test --project ... -- --filter ...` run from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`. Build that project first only when you plan multiple filtered test runs.
+- Prefer the narrowest relevant test filter over running an entire test project.
+- Use `dotnet clean <project.csproj>` only when incremental outputs are clearly stale or corrupted.
 
 ### Restore
 Do not run restore automatically at the start of every session. Reuse existing assets in the working tree.
@@ -111,17 +150,6 @@ If `src/.editorconfig` changed, format the whole `src` tree:
 ```bash
 dotnet format --no-restore
 ```
-
-### Choose the smallest valid verification loop
-- For repository metadata or prose-only changes outside the build inputs, such as `README.md`, `CHANGELOG.md`, or `.github/` text-only edits: do not run `dotnet`.
-- For component `.cs` or `.razor` changes with behavior coverage: prefer a single filtered `dotnet test --project ... -- --filter ...` run against `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` with `/p:SkipBunCompile=true`. Build `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` first only when you plan to reuse the outputs for multiple test filters.
-- For component `.cs` or `.razor` changes that only need compile validation: build `src/MudBlazor/MudBlazor.csproj` with `/p:SkipBunCompile=true`.
-- For `TScripts` or `Styles`: run a normal scoped project build.
-- For docs changes: build the relevant docs project. Avoid docs host run loops during agent verification.
-- For docs example or API-page changes that need parity with CI, run `dotnet test --project src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true`.
-- For analyzer or code-fix changes: prefer a single filtered `dotnet test --project ... -- --filter ...` run from `src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj`. Build that project first only when you plan multiple filtered test runs.
-- Prefer the narrowest relevant test filter over running an entire test project.
-- Use `dotnet clean <project.csproj>` only when incremental outputs are clearly stale or corrupted.
 
 ## Component Authoring Rules
 
@@ -275,6 +303,35 @@ private Task ToggleAsync()
 - Comments should usually explain why a decision exists, not restate what the code already shows or describe straightforward mechanics.
 - Keep `src/MudBlazor/TScripts/entrypoint.js` in sync with files in `src/MudBlazor/TScripts/` except `entrypoint.js`.
 
+## When Verification Fails
+
+- If `--no-restore` fails because assets are missing or stale, run the scoped restore for the project being verified.
+- If a filtered test fails, inspect the failure and rerun the narrowest relevant filter after changes.
+- Do not broaden to solution-wide build or test unless explicitly requested.
+- Do not use `dotnet clean` unless incremental outputs are clearly stale or corrupted.
+- Do not suppress warnings introduced by the change.
+- If verification cannot be completed, report the exact command, failure reason, and next recommended step.
+
+## Common Agent Mistakes To Avoid
+
+- Do not run solution-wide commands for routine validation.
+- Do not build `MudBlazor.csproj` immediately before testing `MudBlazor.UnitTests.csproj`.
+- Do not use `/p:SkipBunCompile=true` for TS, style, `package.json`, `bun.lock`, or asset-pipeline changes.
+- Do not edit generated docs tests.
+- Do not cache bUnit `Find()` or `FindAll()` results across interactions.
+- Do not add public component parameters without XML docs and `[Category(...)]`.
+- Do not add viewer test components when direct bUnit markup is enough.
+
+## Final Response Requirements
+
+When finishing a task, include:
+
+- What changed.
+- Exact verification commands run.
+- Whether formatting was run.
+- Any skipped verification and the reason.
+- Follow-up work intentionally left out of scope.
+
 ## Change Checklist
 
 Before finishing, verify all of the following:
@@ -283,3 +340,15 @@ Before finishing, verify all of the following:
 - Tests were updated and run when behavior changed.
 - Docs were updated when component behavior or public API changed.
 - No new dependencies were added without approval.
+
+## Maintaining This File
+
+When review feedback identifies a repeated agent mistake, update this file with one of:
+
+- a routing rule,
+- a concrete example,
+- a verification command,
+- a common mistake entry,
+- or a final-response expectation.
+
+Prefer concise, enforceable guidance over broad advice. If a rule becomes stable and frequently violated, consider promoting it to an analyzer, script, or CI check.


### PR DESCRIPTION
## Summary

This PR keeps `AGENTS.md` as a single file, but reshapes it into a more useful execution harness for coding agents working in MudBlazor.

The existing file already had the right domain knowledge: scoped build rules, component authoring conventions, docs expectations, bUnit guidance, and verification constraints. The main issue was navigability. The most important routing decisions were embedded below longer reference sections, so an agent had to read deeply before choosing the right workflow.

This change keeps the detailed rules intact and adds a small decision layer at the top and operational sections at the end.

## What changed

- Added a `Start Here` section that gives agents a consistent task flow before they enter the detailed rules.
- Added a `Change Type Matrix` that maps common MudBlazor change types to likely locations, verification commands, and important caveats.
- Added a `Before Editing` checklist so agents inspect nearby code, tests, docs, and asset implications before changing files.
- Moved the existing `Choose the smallest valid verification loop` section earlier, directly under scoped verification, where it is easier to find before running commands.
- Added `When Verification Fails` guidance to keep recovery narrow and avoid escalating to solution-wide builds or broad cleanup.
- Added `Common Agent Mistakes To Avoid` to make repeated review feedback explicit and easy to extend.
- Added `Final Response Requirements` so maintainers get the exact verification and skipped-check context they need from agent-authored work.
- Added `Maintaining This File` so future review feedback can be converted into durable guidance, and frequently violated rules can be promoted to scripts, analyzers, or CI checks.

## Why this shape

The goal is not to make `AGENTS.md` longer for its own sake. The goal is to make it more operational.

OpenAI's harness engineering write-up frames the engineer's role in agent-heavy workflows as designing environments, specifying intent, and creating feedback loops that let agents do reliable work. It also calls out several themes that apply directly here: repository-local knowledge, application and agent legibility, enforcing architecture and taste, and ongoing cleanup of accumulated entropy. Source: https://openai.com/index/harness-engineering/

This PR applies those ideas conservatively:

- Repository knowledge stays in one file, as requested, but the top of the file now acts as a routing layer.
- Existing MudBlazor-specific rules remain the system of record instead of being replaced by generic agent advice.
- Verification guidance is made more legible by change type, which should reduce wrong-command failures and unnecessary solution-wide work.
- Recovery guidance is explicit, so a failed `--no-restore` or filtered test run leads to a scoped next step rather than broad cleanup.
- Review feedback has a home. The new maintenance section gives maintainers a pattern for turning repeated agent mistakes into a rule, example, command, common-mistake entry, or eventually a mechanical check.

## Why keep this in one file

Splitting the file into smaller documents may be useful later, but doing that now would add structure without proving the workflow. A single file is easier to review and keeps the current contribution model unchanged.

The compromise here is to keep `AGENTS.md` monolithic while giving it an internal hierarchy:

1. Fast routing and task classification.
2. Existing project and verification detail.
3. Component, docs, testing, and style rules.
4. Failure recovery, final response expectations, and maintenance guidance.

That gives agents a practical path through the document without forcing a docs reorganization in this PR.

## Follow-up work

These are intentionally left out of scope, but they are natural next steps if maintainers see repeated issues:

- Promote stable repeated rules to analyzers, scripts, or CI checks. This follows the same harness-engineering principle of enforcing architecture and taste mechanically where possible instead of relying only on memory or review comments. Source: https://openai.com/index/harness-engineering/
- Add small repository scripts for checks that are easy to automate, such as orphaned docs examples or banned blocking test patterns. This would turn review feedback into faster local feedback for both humans and agents.
- Revisit splitting `AGENTS.md` only after the single-file routing model proves which sections are most frequently used. That would avoid premature documentation churn and keep any future split based on observed maintenance needs.

## Verification

- `git diff --check -- AGENTS.md`

No `dotnet` command was run. This is a prose-only root markdown change, and the existing repository instructions say not to run `dotnet` for metadata or prose-only edits outside build inputs.