### PR TITLE
MudTableSortLabel: Add FullWidth parameter

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSortingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSortingExample.razor
@@ -8,7 +8,7 @@
         <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Number)">Nr</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel Enabled="@enabled" SortBy="new Func<Element, object>(x=>x.Sign)">Sign</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortBy="new Func<Element, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel FullWidth="true" SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Molar)">Mass</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
@@ -34,5 +34,4 @@
         Elements = await httpClient.GetFromJsonAsync<List<Element>>("webapi/periodictable");
     }
 }
-
 

--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSortingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableSortingExample.razor
@@ -8,7 +8,7 @@
         <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Number)">Nr</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel Enabled="@enabled" SortBy="new Func<Element, object>(x=>x.Sign)">Sign</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortBy="new Func<Element, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
-        <MudTh><MudTableSortLabel FullWidth="true" SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Position)">Position</MudTableSortLabel></MudTh>
         <MudTh><MudTableSortLabel SortBy="new Func<Element, object>(x=>x.Molar)">Mass</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>

--- a/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/TablePage.razor
@@ -94,6 +94,7 @@
                         Click on a header to sort the table by that column, then click to cycle through sorting directions.
                         By default, sorting directions are ascending, descending and unsorted; if you want to cycle through ascending and descending only, you need to specify the <CodeInline>&lt;AllowUnsorted></CodeInline> parameter of the <CodeInline>&lt;MudTable></CodeInline>.
                         Sorting can be allowed and disallowed on the column level with the property <CodeInline>Enabled</CodeInline>.
+                        Set <CodeInline>FullWidth</CodeInline> on <CodeInline>&lt;MudTableSortLabel></CodeInline> to make the label fill the available header width.
                     </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(TableSortingExample)" ShowCode="false" Block="true" FullWidth="true">
@@ -333,6 +334,5 @@
 
     </DocsPageContent>
 </DocsPage>
-
 
 

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2864,6 +2864,14 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("span.mud-table-sort-label").ClassList.Should().Contain("mud-table-sort-label-full-width");
         }
 
+        [Test]
+        public void TableSortLabelFullWidthFalseDoesNotAddFullWidthClass()
+        {
+            var comp = Context.Render<MudTableSortLabel<string>>();
+
+            comp.Find("span.mud-table-sort-label").ClassList.Should().NotContain("mud-table-sort-label-full-width");
+        }
+
         private Mock<IScrollManager> _mockScrollManager = null!;
 
         public class TestItem { public int Id { get; set; } public string Name { get; set; } }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2855,13 +2855,13 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void TableSortLabelFullWidthAddsWidthStyle()
+        public void TableSortLabelFullWidthAddsFullWidthClass()
         {
             var comp = Context.Render<MudTableSortLabel<string>>(parameters => parameters
                 .Add(p => p.FullWidth, true)
             );
 
-            comp.Find("span.mud-table-sort-label").GetAttribute("style").Should().Contain("width:100%");
+            comp.Find("span.mud-table-sort-label").ClassList.Should().Contain("mud-table-sort-label-full-width");
         }
 
         private Mock<IScrollManager> _mockScrollManager = null!;

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2854,6 +2854,16 @@ namespace MudBlazor.UnitTests.Components
             icon.ClassList.Contains("mud-direction-desc").Should().Be(direction == SortDirection.Descending);
         }
 
+        [Test]
+        public void TableSortLabelFullWidthAddsWidthStyle()
+        {
+            var comp = Context.Render<MudTableSortLabel<string>>(parameters => parameters
+                .Add(p => p.FullWidth, true)
+            );
+
+            comp.Find("span.mud-table-sort-label").GetAttribute("style").Should().Contain("width:100%");
+        }
+
         private Mock<IScrollManager> _mockScrollManager = null!;
 
         public class TestItem { public int Id { get; set; } public string Name { get; set; } }

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor
@@ -3,7 +3,7 @@
 @inherits MudComponentBase
 @implements IDisposable
 
-<span @onclick="ToggleSortDirection" class="@Classname" style="@Style" @attributes="@UserAttributes">
+<span @onclick="ToggleSortDirection" class="@Classname" style="@Stylename" @attributes="@UserAttributes">
     @if (!AppendIcon)
     {
         @ChildContent

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor
@@ -3,7 +3,7 @@
 @inherits MudComponentBase
 @implements IDisposable
 
-<span @onclick="ToggleSortDirection" class="@Classname" style="@Stylename" @attributes="@UserAttributes">
+<span @onclick="ToggleSortDirection" class="@Classname" style="@Style" @attributes="@UserAttributes">
     @if (!AppendIcon)
     {
         @ChildContent

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -27,11 +27,6 @@ namespace MudBlazor
                 .AddClass("mud-direction-desc", _direction == SortDirection.Descending)
                 .Build();
 
-        protected string Stylename =>
-            new StyleBuilder()
-                .AddStyle(Style)
-                .Build();
-
         /// <summary>
         /// The current state of the <see cref="MudTable{T}"/> containing this sort label.
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -26,6 +26,12 @@ namespace MudBlazor
                 .AddClass("mud-direction-desc", _direction == SortDirection.Descending)
                 .Build();
 
+        protected string Stylename =>
+            new StyleBuilder()
+                .AddStyle("width", "100%", FullWidth)
+                .AddStyle(Style)
+                .Build();
+
         /// <summary>
         /// The current state of the <see cref="MudTable{T}"/> containing this sort label.
         /// </summary>
@@ -74,6 +80,16 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Expands this sort label to fill the available header width.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Table.Sorting)]
+        public bool FullWidth { get; set; }
 
         /// <summary>
         /// The icon for the sort button.

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -16,6 +16,7 @@ namespace MudBlazor
         protected string Classname =>
             new CssBuilder("mud-table-sort-label")
                 .AddClass("mud-clickable", Enabled)
+                .AddClass("mud-table-sort-label-full-width", FullWidth)
                 .AddClass(Class)
                 .Build();
 
@@ -28,7 +29,6 @@ namespace MudBlazor
 
         protected string Stylename =>
             new StyleBuilder()
-                .AddStyle("width", "100%", FullWidth)
                 .AddStyle(Style)
                 .Build();
 

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -73,6 +73,10 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   flex-direction: inherit;
   justify-content: flex-start;
 
+  &.mud-table-sort-label-full-width {
+    width: 100%;
+  }
+
   &.mud-clickable {
     cursor: pointer;
     user-select: none;


### PR DESCRIPTION
Adds a FullWidth parameter to MudTableSortLabel so the clickable sort label can fill the available table header width.

Fixes #11814

Tested with:
- dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter FullyQualifiedName~TableSortLabel --output Normal --no-ansi --hangdump --hangdump-timeout 30s
- dotnet build src/MudBlazor.Docs/MudBlazor.Docs.csproj --no-restore /p:SkipBunCompile=true --nologo
- dotnet format whitespace --no-restore --include changed files