### PR TITLE
MudRating: Constrain width when display is overridden

### DIFF
--- a/src/MudBlazor/Styles/components/_rating.scss
+++ b/src/MudBlazor/Styles/components/_rating.scss
@@ -1,5 +1,7 @@
 .mud-rating-root {
   display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
   color: #ffb400;
 
   &:focus-visible, &:active {


### PR DESCRIPTION
Fixes #12013.

Testing: scoped MudBlazor.csproj build passed in a .NET SDK 10 Docker container; dotnet format whitespace passed for src/MudBlazor/Styles/components/_rating.scss; git diff check passed.

This is a CSS-only layout fix, so no bUnit test was added.