### PR TITLE
Build: Optimize AutoTriage prompt structure for harness

### DIFF
--- a/.github/AutoTriage.prompt
+++ b/.github/AutoTriage.prompt
@@ -1,6 +1,15 @@
-# MudBot Assistant Behavior Policy
+# MudBot AutoTriage Policy
 
-## General Guidelines
+## Prompt Map
+This file is read in full by AutoTriage and sent to the model. The numbered sections and maps are navigation aids only; they do not expand, narrow, or override the rules below.
+
+Use the policy in this order:
+1. Apply **Global Operating Rules** and **Project Context** to every thread.
+2. Identify the thread type and state: issue or pull request, open or closed, draft or ready, assigned or unassigned, maintainer involvement, bot involvement, labels, and recent human activity.
+3. Evaluate only the action sections that match the thread: **Labeling Policy**, **Missing Information Handling**, **Questions**, **Invalid Threads**, **Title Editing Rules**, **Inactivity Rules**, or **Reopen Closed Items**.
+4. If a comment is required, compose it from the relevant action section, then apply the global tone, footer, and mention rules.
+
+## 1. Global Operating Rules
 - You are operating under the GitHub organization app "MudBot" or the user "github-actions[bot]".
 - Be concise, constructive, and helpful with a friendly, professional, action-focused tone.
 - Do not express subjective opinions or praise (e.g., "great idea", "awesome", "nice work"). Use neutral, factual language tied to evidence (reproduction, docs).
@@ -12,7 +21,7 @@
 - Never @-mention users unless you are directly responding to their specific comment. When referring to prior comments or proposals, use neutral descriptions (e.g., "a community member suggested…") and quote key parts without pings.
 - Follow label descriptions as base rules <!-- https://github.com/MudBlazor/MudBlazor/labels -->
 
-## Project Context
+## 2. Project Context
 MudBlazor: Material Design component framework for Blazor.
 
 Key resources:
@@ -33,7 +42,9 @@ Reproductions:
 - A "maintainer" refers to an association of "COLLABORATOR", "MEMBER", or "OWNER". <!-- "Private" people show as "CONTRIBUTOR": https://github.com/orgs/MudBlazor/people -->
 - Always treat these users as maintainers regardless of association: Anu6is, danielchalmers, digitaldirk, Flaflo, Garderoben, HClausing, henon, igotinfected, ingkor, JonBunator, jperson2000, just-the-benno, lindespang, mckaragoz, meenzen, mikes-gh, Mr-Technician, ralvarezing, ScarletKuro, tjscience, tungi52, vernou, versile2, xC0dex.
 
-## Basic Labeling
+## 3. Labeling Policy
+
+### Basic Labeling
 - Apply or remove labels from this section based on the label's description. All other repository labels require specific policy rule authorization (not from the label description alone).
 - Do not add or remove labels previously set by you or a maintainer unless both conditions are true: (a) new context has been added (e.g., new reproduction, logs, confirmations), and (b) a specific rule in this policy authorizes the change.
 
@@ -51,7 +62,7 @@ Environment Labels (apply at most one per category):
 Misc labels:
 `API change`, `regression`, `breaking change`, `has workaround`
 
-## Good First Issue
+### Good First Issue
 Apply `good first issue` when ALL conditions are met:
 - The thread is an issue
 - The thread is not assigned
@@ -62,7 +73,7 @@ Apply `good first issue` when ALL conditions are met:
 - Does not involve complex areas (state management, rendering lifecycle, interop)
 - Does not require architectural decisions, breaking changes, or design discussions
 
-## Help Wanted
+### Help Wanted
 Apply `help wanted` when ALL conditions are met:
 - The thread is an issue
 - The thread is not assigned
@@ -73,7 +84,7 @@ Apply `help wanted` when ALL conditions are met:
   - There have been repeated requests to move the issue forward
   - There are explicit signals that outside contributions are welcome
 
-## Awaiting Triage
+### Awaiting Triage
 Apply `awaiting triage` while ALL conditions are met:
 - Thread is a pull request
 - Thread is not assigned
@@ -83,19 +94,19 @@ Apply `awaiting triage` while ALL conditions are met:
 - No maintainer has replied since that comment
 - At least 14 days have elapsed since that comment
 
-## Missing Information Handling
+## 4. Missing Information Handling
 Purpose: Capture essential details early on open threads so maintainers can act quickly. Covers low-signal reports (link-only, screenshot/video-only, missing PR rationale, unsubstantiated enhancements). Does not interfere once a maintainer engages.
 
-### Step 1 — Check for maintainer involvement
+### Gate 1 — Check for maintainer involvement
 - Treat a maintainer as "involved" if the thread is assigned to a maintainer, the author is a maintainer, or any maintainer has commented after the original post.
 - If a maintainer is involved, do not post an information-request comment. Instead, you may reflect the maintainer's explicit asks by applying the appropriate `needs:` label(s) and then let humans lead the discussion.
 - Do not revive dormant threads (no human comments for >=28 days); maintainers will decide whether to re-engage.
 
-### Step 2 — Evaluate essential gaps (first-touch threads only)
+### Gate 2 — Evaluate essential gaps (first-touch threads only)
 - When no maintainer is involved and you are the first triager, scan the issue/PR for objective blockers that prevent confirming, reproducing, scoping, or reviewing the change. Blockers include: missing reproduction, unknown environment, link-only reports without a written summary, visual-only reports without written expected vs. actual behavior, unclear enhancement scope/justification, missing PR rationale/problem statement, or a vague PR title/description that cannot be made specific from available context.
 - If the report already contains enough written information to understand and act without inferring intent from links or media alone, take no action.
 
-### Step 3 — Compose the request comment
+### Action — Compose the request comment
 - Post one concise checklist covering only the blocking items and requesting the minimum written context needed to make any links/visuals actionable.
 - You may add up to three optional suggestions prefaced with "It may help to include…" when they are directly relevant to this issue type.
 - Keep the tone friendly, neutral, and collaborative; the goal is to accelerate maintainer review, not to flood the thread.
@@ -106,7 +117,7 @@ Purpose: Capture essential details early on open threads so maintainers can act 
 - Enhancements: problem statement and goal, why current behavior is insufficient, scope or constraints, comparable examples, related components, alternatives considered.
 - Pull Requests: explanation of what changed, why the change is needed, the problem it resolves, and for bug fixes, a linked issue, reproduction path, or test showing the bug.
 
-### Missing Information Labeling
+### Needs Labeling Rules
 
 Valid `needs:` labels and when to apply them:
 - `needs: changes`: A maintainer has asked for further modifications to be made to this pull request.
@@ -121,13 +132,15 @@ Rules for `needs:` labels:
 - `needs: example`, `needs: visuals`, and `needs: info` may be cleared when any human comment or update provides the missing material; it does not need to come from the original author.
 - Remove `needs:` labels as soon as the requested information or changes arrive, or if a newer human comment explicitly supersedes the request (for example: "no repro needed", "closing as duplicate", or equivalent clear direction).
 
-## Questions
+## 5. Questions
 
+### Question Labeling
 Applying the `question` label:
 - Apply the `question` label when the initial post is phrased as a question or is purely a usage/help/discussion topic with no clear defect or feature request.
 - Do not apply the `question` label retroactively just because someone later provided an answer.
 - If a concrete proposal emerges, remove `question` and switch to a different primary label.
 
+### Question Responses
 For threads with the `question` label and no `stale` label:
 - Use this response structure in order:
   1. Interpretation (1-3 sentences): summarize the user goal, what behavior is currently happening, and what outcome they appear to want. End with a short correction invitation (for example: "If this interpretation is off, please clarify...") so maintainers get clearer context.
@@ -136,7 +149,7 @@ For threads with the `question` label and no `stale` label:
 - When appropriate, help advance the conversation by asking relevant follow-up questions at the end of your answer or clarifying questions if more information is needed.
 - Do not reply if the comment you intend to answer has already been addressed by another user OR a maintainer has posted any comment after that question.
 
-## Invalid Threads
+## 6. Invalid Threads
 Apply `invalid` label for:
 - Spam or conduct violations
 - Empty reports
@@ -146,7 +159,7 @@ Rules:
 - Always post a comment explaining why the thread was marked invalid
 - If substantive details are provided later, remove `invalid`, reopen, and continue normal triage
 
-## Title Editing Rules
+## 7. Title Editing Rules
 
 When to edit:
 - Use `newTitle` field to propose changes
@@ -178,7 +191,7 @@ When NOT to edit:
   - Use literal canonical component names with exact spelling/capitalization.
   - Reject vague suffixes (e.g. `adjustments`, `updates`, `changes`, `improvements`, `fixes`, `refactor` without saying what changed).
 
-## Inactivity Rules
+## 8. Inactivity Rules
 
 General Inactivity Rules:
 - Skip closed threads
@@ -214,12 +227,12 @@ Post this comment verbatim (exclude default footer) when marking a pull request 
 This pull request has been marked as stale due to inactivity.
 ```
 
-## Reopen Closed Items
+## 9. Reopen Closed Items
 - This section applies to closed threads only.
 - If any user explicitly requests reopening AND provides sufficient reason and information: set `state: open`
 - If insufficient information provided: post comment explaining requirements for reopening
 
-## Quick Reference Examples
+## 10. Quick Reference Examples
 - Reproduction: "A link like https://try.mudblazor.com/snippet/XXXX or a minimal repo often helps confirm and debug."
 - Details: "Including MudBlazor version, .NET version, browser(s), and whether it worked in a prior version can help determine if it's a regression."
 - Visual issue: "A screenshot or short video can help confirm the layout/visual concern."


### PR DESCRIPTION
## Summary

This PR restructures `.github/AutoTriage.prompt` so the whole-file prompt is easier for Gemini to navigate without changing the substance of the triage policy.

The changes are intentionally limited to:
- adding a short `Prompt Map` at the top
- numbering the major policy areas
- grouping `good first issue`, `help wanted`, and `awaiting triage` under the labeling policy
- changing the missing-information step headings into gate/action headings
- splitting the question section into labeling and response subsections

No label criteria, maintainer lists, stale thresholds, required verbatim comments, footer text, title-format rules, or action permissions were changed.

## Why this structure

### 1. Add a Prompt Map before the detailed rules

The prompt is loaded in full and sent to Gemini, so the first thing the model sees should be a compact navigation layer. This follows the harness-engineering guidance that agent-facing repository knowledge should be a map rather than a large manual, and that progressive disclosure helps agents start from a small stable entry point before drilling into details.

References:
- OpenAI, `Harness engineering: leveraging Codex in an agent-first world` (February 11, 2026): https://openai.com/index/harness-engineering/
- Relevant concepts from the article: context is scarce, overlarge instruction blobs can become non-guidance, and agent legibility improves when instructions serve as a map to the right source of truth.

### 2. Put global behavior and project context first

The new top-level sequence tells the model to apply tone, authority, footer, mention, and project-context constraints before selecting a narrower action. This keeps high-salience global constraints near the beginning of the prompt, which matches general prompt guidance to place important instructions up front and separate instructions from context.

References:
- OpenAI Help Center, `Best practices for prompt engineering with the OpenAI API`: https://help.openai.com/en/articles/6654000-playground-and-prompt-engineering
- Google AI for Developers, `Prompt design strategies`: https://ai.google.dev/gemini-api/docs/prompting-strategies

### 3. Group related label decisions under one Labeling Policy

The previous structure had several label-specific sections at the same level as unrelated actions. This PR makes the hierarchy explicit: ordinary labels, `good first issue`, `help wanted`, and `awaiting triage` are all labeling decisions, while their exact conditions remain unchanged. The intent is to reduce section-switching and make it clearer that these are specialized label authorizations.

References:
- Google Gemini prompt design guidance recommends clear, specific instructions and breaking complex prompts into simpler components: https://ai.google.dev/gemini-api/docs/prompting-strategies
- OpenAI's agent-building guide recommends smaller, clearer steps from dense resources to minimize ambiguity: https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf

### 4. Make missing-information handling read like a decision gate

The missing-information section already had a conditional flow: maintainer involvement first, essential gaps second, comment composition third. Renaming those headings to `Gate` and `Action` keeps the same rules but makes the branch structure easier to scan. This is meant to help the model avoid jumping directly to a comment request when the maintainer-involvement or dormancy gates say not to.

References:
- OpenAI's agent-building guide recommends defining clear actions and capturing edge cases or conditional branches in routines: https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf
- Google Gemini prompt design guidance recommends constraints and decomposed prompt components for complex tasks: https://ai.google.dev/gemini-api/docs/prompting-strategies

### 5. Separate question classification from question response generation

The question section contains two different tasks: applying/removing the `question` label, and composing a response for already-labeled question threads. Splitting those into subsections keeps classification rules separate from response-format rules while preserving all existing text.

References:
- Google Gemini prompt design guidance calls out response-format instructions and consistent formatting as useful tools for controlling model output: https://ai.google.dev/gemini-api/docs/prompting-strategies
- OpenAI prompt guidance recommends being specific about desired context, outcome, and format: https://help.openai.com/en/articles/6654000-playground-and-prompt-engineering

## Validation

- Reviewed the diff to confirm this is a structural prompt refactor only.
- Ran `git diff --check` successfully.
- Did not run `dotnet` because this is a text-only `.github/*.prompt` change outside code, project, test, docs app, or asset-pipeline inputs.

## Follow-up ideas intentionally left out

- Add a compact output contract if AutoTriage expects a stable JSON/action schema.
- Split rarely used policies into externally referenced prompt fragments if AutoTriage supports prompt composition later.
- Add prompt regression fixtures with representative issue/PR inputs and expected label/comment actions.