### PR TITLE
MudDataGrid: Focus selected filter when opening simple filter panel

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2980,6 +2980,84 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGrid_OpenFilters_WithFilterDefinitionId_SetsAutoFocusOnMatchingFilter()
+        {
+            var comp = Context.Render<DataGridFiltersTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
+
+            var nameFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Id = Guid.NewGuid(),
+                Column = dataGrid.Instance.GetColumnByPropertyName("Name"),
+                Operator = FilterOperator.String.Contains,
+                Value = "Sam"
+            };
+
+            var ageFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Id = Guid.NewGuid(),
+                Column = dataGrid.Instance.GetColumnByPropertyName("Age"),
+                Operator = FilterOperator.Number.GreaterThan,
+                Value = 30
+            };
+
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(nameFilterDefinition));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(ageFilterDefinition));
+
+            await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters(ageFilterDefinition.Id));
+
+            comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(2);
+
+            var filterFieldSelects = comp.FindComponents<MudSelect<Column<DataGridFiltersTest.Model>>>()
+                .Where(x => x.Instance.Class == "filter-field")
+                .ToArray();
+
+            filterFieldSelects.Should().HaveCount(2);
+            filterFieldSelects.Count(x => x.Instance.AutoFocus).Should().Be(1);
+            filterFieldSelects[0].Instance.AutoFocus.Should().BeFalse();
+            filterFieldSelects[1].Instance.AutoFocus.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task DataGrid_OpenFilters_WithoutFilterDefinitionId_SetsAutoFocusOnFirstFilter()
+        {
+            var comp = Context.Render<DataGridFiltersTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
+
+            var nameFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Id = Guid.NewGuid(),
+                Column = dataGrid.Instance.GetColumnByPropertyName("Name"),
+                Operator = FilterOperator.String.Contains,
+                Value = "Sam"
+            };
+
+            var ageFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Id = Guid.NewGuid(),
+                Column = dataGrid.Instance.GetColumnByPropertyName("Age"),
+                Operator = FilterOperator.Number.GreaterThan,
+                Value = 30
+            };
+
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(nameFilterDefinition));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(ageFilterDefinition));
+
+            await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
+
+            comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(2);
+
+            var filterFieldSelects = comp.FindComponents<MudSelect<Column<DataGridFiltersTest.Model>>>()
+                .Where(x => x.Instance.Class == "filter-field")
+                .ToArray();
+
+            filterFieldSelects.Should().HaveCount(2);
+            filterFieldSelects.Count(x => x.Instance.AutoFocus).Should().Be(1);
+            filterFieldSelects[0].Instance.AutoFocus.Should().BeTrue();
+            filterFieldSelects[1].Instance.AutoFocus.Should().BeFalse();
+        }
+
+        [Test]
         public async Task DataGridCloseFilters()
         {
             var comp = Context.Render<DataGridFiltersTest>();

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -3058,6 +3058,55 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGrid_OpenFilters_FromHeaderFilterButton_SetsAutoFocusOnMatchingFilter()
+        {
+            var comp = Context.Render<DataGridFiltersTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
+
+            var nameColumn = dataGrid.Instance.GetColumnByPropertyName("Name");
+            var ageColumn = dataGrid.Instance.GetColumnByPropertyName("Age");
+
+            var nameFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Id = Guid.NewGuid(),
+                Column = nameColumn,
+                Operator = FilterOperator.String.Contains,
+                Value = "Sam"
+            };
+
+            var ageFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            {
+                Id = Guid.NewGuid(),
+                Column = ageColumn,
+                Operator = FilterOperator.Number.GreaterThan,
+                Value = 30
+            };
+
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(nameFilterDefinition));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(ageFilterDefinition));
+
+            var ageHeaderCell = dataGrid.FindComponents<HeaderCell<DataGridFiltersTest.Model>>()
+                .First(x => x.Instance.Column?.PropertyName == "Age");
+
+            await comp.InvokeAsync(() => ageHeaderCell.Instance.OpenFilters(new MouseEventArgs
+            {
+                PageX = 100,
+                PageY = 200
+            }));
+
+            comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(2);
+
+            var filterFieldSelects = comp.FindComponents<MudSelect<Column<DataGridFiltersTest.Model>>>()
+                .Where(x => x.Instance.Class == "filter-field")
+                .ToArray();
+
+            filterFieldSelects.Should().HaveCount(2);
+            filterFieldSelects.Count(x => x.Instance.AutoFocus).Should().Be(1);
+            filterFieldSelects[0].Instance.AutoFocus.Should().BeFalse();
+            filterFieldSelects[1].Instance.AutoFocus.Should().BeTrue();
+        }
+
+        [Test]
         public async Task DataGridCloseFilters()
         {
             var comp = Context.Render<DataGridFiltersTest>();

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -2980,84 +2980,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGrid_OpenFilters_WithFilterDefinitionId_SetsAutoFocusOnMatchingFilter()
-        {
-            var comp = Context.Render<DataGridFiltersTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
-
-            var nameFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
-            {
-                Id = Guid.NewGuid(),
-                Column = dataGrid.Instance.GetColumnByPropertyName("Name"),
-                Operator = FilterOperator.String.Contains,
-                Value = "Sam"
-            };
-
-            var ageFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
-            {
-                Id = Guid.NewGuid(),
-                Column = dataGrid.Instance.GetColumnByPropertyName("Age"),
-                Operator = FilterOperator.Number.GreaterThan,
-                Value = 30
-            };
-
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(nameFilterDefinition));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(ageFilterDefinition));
-
-            await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters(ageFilterDefinition.Id));
-
-            comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(2);
-
-            var filterFieldSelects = comp.FindComponents<MudSelect<Column<DataGridFiltersTest.Model>>>()
-                .Where(x => x.Instance.Class == "filter-field")
-                .ToArray();
-
-            filterFieldSelects.Should().HaveCount(2);
-            filterFieldSelects.Count(x => x.Instance.AutoFocus).Should().Be(1);
-            filterFieldSelects[0].Instance.AutoFocus.Should().BeFalse();
-            filterFieldSelects[1].Instance.AutoFocus.Should().BeTrue();
-        }
-
-        [Test]
-        public async Task DataGrid_OpenFilters_WithoutFilterDefinitionId_SetsAutoFocusOnFirstFilter()
-        {
-            var comp = Context.Render<DataGridFiltersTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
-
-            var nameFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
-            {
-                Id = Guid.NewGuid(),
-                Column = dataGrid.Instance.GetColumnByPropertyName("Name"),
-                Operator = FilterOperator.String.Contains,
-                Value = "Sam"
-            };
-
-            var ageFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
-            {
-                Id = Guid.NewGuid(),
-                Column = dataGrid.Instance.GetColumnByPropertyName("Age"),
-                Operator = FilterOperator.Number.GreaterThan,
-                Value = 30
-            };
-
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(nameFilterDefinition));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(ageFilterDefinition));
-
-            await comp.InvokeAsync(() => dataGrid.Instance.OpenFilters());
-
-            comp.FindAll(".filters-panel .mud-grid-item.d-flex").Count.Should().Be(2);
-
-            var filterFieldSelects = comp.FindComponents<MudSelect<Column<DataGridFiltersTest.Model>>>()
-                .Where(x => x.Instance.Class == "filter-field")
-                .ToArray();
-
-            filterFieldSelects.Should().HaveCount(2);
-            filterFieldSelects.Count(x => x.Instance.AutoFocus).Should().Be(1);
-            filterFieldSelects[0].Instance.AutoFocus.Should().BeTrue();
-            filterFieldSelects[1].Instance.AutoFocus.Should().BeFalse();
-        }
-
-        [Test]
         public async Task DataGrid_OpenFilters_FromHeaderFilterButton_SetsAutoFocusOnMatchingFilter()
         {
             var comp = Context.Render<DataGridFiltersTest>();
@@ -3066,24 +2988,23 @@ namespace MudBlazor.UnitTests.Components
             var nameColumn = dataGrid.Instance.GetColumnByPropertyName("Name");
             var ageColumn = dataGrid.Instance.GetColumnByPropertyName("Age");
 
-            var nameFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
+            await comp.InvokeAsync(() =>
             {
-                Id = Guid.NewGuid(),
-                Column = nameColumn,
-                Operator = FilterOperator.String.Contains,
-                Value = "Sam"
-            };
-
-            var ageFilterDefinition = new FilterDefinition<DataGridFiltersTest.Model>
-            {
-                Id = Guid.NewGuid(),
-                Column = ageColumn,
-                Operator = FilterOperator.Number.GreaterThan,
-                Value = 30
-            };
-
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(nameFilterDefinition));
-            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(ageFilterDefinition));
+                dataGrid.Instance.FilterDefinitions.Add(new FilterDefinition<DataGridFiltersTest.Model>
+                {
+                    Id = Guid.NewGuid(),
+                    Column = nameColumn,
+                    Operator = FilterOperator.String.Contains,
+                    Value = "Sam"
+                });
+                dataGrid.Instance.FilterDefinitions.Add(new FilterDefinition<DataGridFiltersTest.Model>
+                {
+                    Id = Guid.NewGuid(),
+                    Column = ageColumn,
+                    Operator = FilterOperator.Number.GreaterThan,
+                    Value = 30
+                });
+            });
 
             var ageHeaderCell = dataGrid.FindComponents<HeaderCell<DataGridFiltersTest.Model>>()
                 .First(x => x.Instance.Column?.PropertyName == "Age");

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -149,23 +149,23 @@ else if (Column != null && !Column.HiddenState.Value)
         {
             <MudOverlay @bind-Visible="@_filtersMenuVisible" AutoClose />
             <MudPopover UserAttributes="@PositionAttributes" Open="@_filtersMenuVisible" OverflowBehavior="OverflowBehavior.FlipOnOpen" AnchorOrigin="@Origin.BottomRight" TransformOrigin="@Origin.TopRight" Class="pa-4 column-filter-popup mud-popover-position-override">
-                            @if (Column.FilterTemplate != null)
-                            {
-                                @Column.FilterTemplate(Column.FilterContext)
-                            }
-                            else
-                            {
-                                <MudGrid>
-                                    <MudItem xs="12">
-                                        @DataGrid?.Filter(Column.FilterContext.FilterDefinition!, Column)
-                                    </MudItem>
-                                    <MudItem xs="12" Class="d-flex justify-end">
-                                        <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
-                                        <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
-                                    </MudItem>
-                                </MudGrid>
-                            }
-                </MudPopover>
+                @if (Column.FilterTemplate != null)
+                {
+                    @Column.FilterTemplate(Column.FilterContext)
+                }
+                else
+                {
+                    <MudGrid>
+                        <MudItem xs="12">
+                            @DataGrid?.Filter(Column.FilterContext.FilterDefinition!, Column)
+                        </MudItem>
+                        <MudItem xs="12" Class="d-flex justify-end">
+                            <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                            <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
+                        </MudItem>
+                    </MudGrid>
+                }
+            </MudPopover>
         }
         </text>;
     }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -149,23 +149,23 @@ else if (Column != null && !Column.HiddenState.Value)
         {
             <MudOverlay @bind-Visible="@_filtersMenuVisible" AutoClose />
             <MudPopover UserAttributes="@PositionAttributes" Open="@_filtersMenuVisible" OverflowBehavior="OverflowBehavior.FlipOnOpen" AnchorOrigin="@Origin.BottomRight" TransformOrigin="@Origin.TopRight" Class="pa-4 column-filter-popup mud-popover-position-override">
-                @if (Column.FilterTemplate != null)
-                {
-                    @Column.FilterTemplate(Column.FilterContext) 
-                }
-                else
-                {
-                    <MudGrid>
-                        <MudItem xs="12">
-                            @DataGrid?.Filter(Column.FilterContext.FilterDefinition!, Column)
-                        </MudItem>
-                        <MudItem xs="12" Class="d-flex justify-end">
-                            <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
-                            <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
-                        </MudItem>
-                    </MudGrid>
-                }
-            </MudPopover>
+                            @if (Column.FilterTemplate != null)
+                            {
+                                @Column.FilterTemplate(Column.FilterContext)
+                            }
+                            else
+                            {
+                                <MudGrid>
+                                    <MudItem xs="12">
+                                        @DataGrid?.Filter(Column.FilterContext.FilterDefinition!, Column)
+                                    </MudItem>
+                                    <MudItem xs="12" Class="d-flex justify-end">
+                                        <MudButton Class="clear-filter-button" OnClick="@ClearFilterAsync">@Localizer[LanguageResource.MudDataGrid_Clear]</MudButton>
+                                        <MudButton Class="apply-filter-button" Color="@Color.Primary" OnClick="@ApplyFilterAsync">@Localizer[LanguageResource.MudDataGrid_Filter]</MudButton>
+                                    </MudItem>
+                                </MudGrid>
+                            }
+                </MudPopover>
         }
         </text>;
     }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -537,18 +537,17 @@ namespace MudBlazor
             var filterDefinition = Column?.FilterContext.FilterDefinition;
             if (DataGrid.FilterMode == DataGridFilterMode.Simple && filterDefinition != null)
             {
-                if (DataGrid.FilterDefinitions.All(x => x.Title != filterDefinition.Title))
+                var filterDefinitionToFocus = DataGrid.FilterDefinitions
+                    .FirstOrDefault(x => x.Title == filterDefinition.Title);
+
+                if (filterDefinitionToFocus is null)
                 {
-                    DataGrid.FilterDefinitions.Add(filterDefinition.Clone());
+                    filterDefinitionToFocus = filterDefinition.Clone();
+                    DataGrid.FilterDefinitions.Add(filterDefinitionToFocus);
                 }
+
                 DataGrid.SetFiltersMenuPosition(args.PageY, args.PageX);
-                DataGrid.OpenFilters();
-            }
-            else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
-            {
-                _filtersMenuPosition = (args.PageY, args.PageX);
-                _filtersMenuVisible = true;
-                DataGrid.DropContainerHasChanged();
+                DataGrid.OpenFilters(filterDefinitionToFocus.Id);
             }
         }
 
@@ -557,8 +556,13 @@ namespace MudBlazor
             Debug.Assert(DataGrid is not null);
             if (DataGrid.FilterMode == DataGridFilterMode.Simple)
             {
+                var filterDefinitionToFocus = DataGrid.FilterDefinitions
+                    .FirstOrDefault(x =>
+                        ReferenceEquals(x.Column, Column) ||
+                        (Column?.PropertyName is not null && x.Column?.PropertyName == Column.PropertyName));
+
                 DataGrid.SetFiltersMenuPosition(args.PageY, args.PageX);
-                DataGrid.OpenFilters();
+                DataGrid.OpenFilters(filterDefinitionToFocus?.Id);
             }
             else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
             {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -535,6 +535,7 @@ namespace MudBlazor
         {
             Debug.Assert(DataGrid is not null);
             var filterDefinition = Column?.FilterContext.FilterDefinition;
+
             if (DataGrid.FilterMode == DataGridFilterMode.Simple && filterDefinition != null)
             {
                 var filterDefinitionToFocus = DataGrid.FilterDefinitions
@@ -548,6 +549,12 @@ namespace MudBlazor
 
                 DataGrid.SetFiltersMenuPosition(args.PageY, args.PageX);
                 DataGrid.OpenFilters(filterDefinitionToFocus.Id);
+            }
+            else if (DataGrid.FilterMode == DataGridFilterMode.ColumnFilterMenu)
+            {
+                _filtersMenuPosition = (args.PageY, args.PageX);
+                _filtersMenuVisible = true;
+                DataGrid.DropContainerHasChanged();
             }
         }
 

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -561,6 +561,7 @@ namespace MudBlazor
         internal void OpenFilters(MouseEventArgs args)
         {
             Debug.Assert(DataGrid is not null);
+
             if (DataGrid.FilterMode == DataGridFilterMode.Simple)
             {
                 var filterDefinitionToFocus = DataGrid.FilterDefinitions

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -69,7 +69,7 @@
                                                     <MudStack>
                                                         @foreach (var f in FilterDefinitions)
                                                         {
-                                                            @Filter(f, null)
+                                                            @Filter(f, null, f.Id == _filterDefinitionIdToFocus)
                                                         }
                                                     </MudStack>
                                                     <MudButton Class="mt-2" StartIcon="@Icons.Material.Filled.Add" OnClick="@AddFilter" Color="@Color.Primary">@Localizer[LanguageResource.MudDataGrid_AddFilter]</MudButton>
@@ -427,7 +427,7 @@
              </td>
          </text>;
 
-    internal RenderFragment Filter(IFilterDefinition<T> filterDefinition, Column<T>? column) =>
+    internal RenderFragment Filter(IFilterDefinition<T> filterDefinition, Column<T>? column, bool autoFocus = false) =>
         @<text>
             @{
                 var filter = new Filter<T>(this, filterDefinition, column);
@@ -440,8 +440,15 @@
                         <MudIconButton Class="remove-filter-button" Icon="@Icons.Material.Filled.Close" OnClick="@filter.RemoveFilterAsync" Size="@Size.Small" Style="align-self: flex-end" aria-label="@Localizer[LanguageResource.MudDataGrid_RemoveFilter]"></MudIconButton>
                     </MudItem>
                     <MudItem xs="4">
-                        <MudSelect T="Column<T>" Value="@filterDefinition.Column" ValueChanged="@filter.FieldChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Column]" Dense="true" Margin="@Margin.Dense"
-                                   Class="filter-field">
+                        <MudSelect T="Column<T>" 
+                                   Value="@filterDefinition.Column" 
+                                   ValueChanged="@filter.FieldChanged" 
+                                   FullWidth="true" 
+                                   Label="@Localizer[LanguageResource.MudDataGrid_Column]" 
+                                   Dense="true" 
+                                   Margin="@Margin.Dense"
+                                   Class="filter-field"
+                                   AutoFocus="@autoFocus">
                             @foreach (var renderColumn in RenderedColumns.Where(x => x.Filterable != false))
                             {
                                 <MudSelectItem T="Column<T>" Value="@renderColumn">@renderColumn.Title</MudSelectItem>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2490,9 +2490,14 @@ namespace MudBlazor
         /// <summary>
         /// Opens the filter panel.
         /// </summary>
-        public void OpenFilters(Guid? filterDefinitionIdToFocus = null)
+        public void OpenFilters()
         {
-            _filterDefinitionIdToFocus = filterDefinitionIdToFocus ?? FilterDefinitions.FirstOrDefault()?.Id;
+            OpenFilters(FilterDefinitions.FirstOrDefault()?.Id);
+        }
+
+        internal void OpenFilters(Guid? filterDefinitionIdToFocus)
+        {
+            _filterDefinitionIdToFocus = filterDefinitionIdToFocus;
             _filtersMenuVisible = true;
             StateHasChanged();
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -49,6 +49,7 @@ namespace MudBlazor
         private Func<IFilterDefinition<T>> _defaultFilterDefinitionFactory = () => new FilterDefinition<T>();
         private (double Top, double Left) _filtersMenuPosition = (0, 0);
         private (double Top, double Left) _columnsPanelPosition = (0, 0);
+        private Guid? _filterDefinitionIdToFocus;
 
         private readonly ParameterState<T?> _selectedItemState;
         private readonly ParameterState<HashSet<T>?> _selectedItemsState;
@@ -1969,6 +1970,7 @@ namespace MudBlazor
             filterDefinition.Title = column?.Title;
             filterDefinition.Column = column;
             FilterDefinitions.Add(filterDefinition);
+            _filterDefinitionIdToFocus = filterDefinition.Id;
             _filtersMenuVisible = true;
             StateHasChanged();
         }
@@ -2490,6 +2492,7 @@ namespace MudBlazor
         /// </summary>
         public void OpenFilters()
         {
+            _filterDefinitionIdToFocus = filterDefinitionIdToFocus ?? FilterDefinitions.FirstOrDefault()?.Id;
             _filtersMenuVisible = true;
             StateHasChanged();
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2490,7 +2490,7 @@ namespace MudBlazor
         /// <summary>
         /// Opens the filter panel.
         /// </summary>
-        public void OpenFilters()
+        public void OpenFilters(Guid? filterDefinitionIdToFocus = null)
         {
             _filterDefinitionIdToFocus = filterDefinitionIdToFocus ?? FilterDefinitions.FirstOrDefault()?.Id;
             _filtersMenuVisible = true;


### PR DESCRIPTION
**Description**
- When a user clicks into a column filter or selects it via keyboard commands, the focus automatically adjusts to the filter popover.
- Previously, selecting a column filter would not change the focus and tabbing over would only select the background items. 


<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**TO TEST:**
- Navigate to Mud Data Grid, find a column filter, use keyboard navigation/tabs to select items within the popover.
- Make sure the focus adjusts to the popover correctly.

**This is the before:**
<img width="1637" height="839" alt="FilterFocusBefore" src="https://github.com/user-attachments/assets/2b9938ca-da9a-477a-b5c7-7970276d4dba" />

**This is the after:**
<img width="1637" height="839" alt="FilterFocusAfter" src="https://github.com/user-attachments/assets/8ea3410a-c4a0-426e-8025-37368dd9c7c8" />

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
