### PR TITLE
MudStepper: Prevent title overflow with CenterLabels in horizontal mode

### DIFF
--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -145,15 +145,14 @@
           text-align: center;
 
           .mud-step-label-content-title {
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            white-space: normal;
+            overflow-wrap: break-word;
           }
         }
       }
 
       > .mud-stepper-nav > .mud-stepper-nav-connector {
-        margin: 35px -67px 0;
+        margin: 35px 0 0;
         align-self: flex-start;
       }
     }

--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -122,7 +122,12 @@
 
       > .mud-stepper-nav > .mud-step {
         flex-basis: 175px;
-        overflow: hidden;
+      }
+
+      // Only allow steps to collapse (and titles to truncate) when the nav is
+      // not scrollable, so the scrollable nav keeps its `min-width: fit-content`
+      // and still scrolls wide enough to show full titles.
+      > .mud-stepper-nav:not(.mud-stepper-nav-scrollable) > .mud-step {
         min-width: 0;
       }
 
@@ -138,8 +143,6 @@
         .mud-step-label-content {
           margin-top: 12px;
           text-align: center;
-          min-width: 0;
-          overflow: hidden;
 
           .mud-step-label-content-title {
             overflow: hidden;

--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -122,6 +122,8 @@
 
       > .mud-stepper-nav > .mud-step {
         flex-basis: 175px;
+        overflow: hidden;
+        min-width: 0;
       }
 
       > .mud-stepper-nav > .mud-step > .mud-step-label {
@@ -136,6 +138,14 @@
         .mud-step-label-content {
           margin-top: 12px;
           text-align: center;
+          min-width: 0;
+          overflow: hidden;
+
+          .mud-step-label-content-title {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
         }
       }
 


### PR DESCRIPTION
## Problem
When `CenterLabels=true` on a horizontal `MudStepper` with enough steps to overflow, long step titles can extend past their step button bounds and overlap adjacent labels.

## Fix
- set `overflow: hidden` and `min-width: 0` on `.mud-step` inside `.mud-stepper__center-labels`
- set `min-width: 0` and `overflow: hidden` on `.mud-step-label-content`
- truncate `.mud-step-label-content-title` with `text-overflow: ellipsis` and `white-space: nowrap`

This keeps each label constrained to its `flex-basis: 175px` slot instead of bleeding into neighbouring steps.

## Before / After
The previous screenshot links were not loading, so I removed the broken image embeds rather than keeping dead links.

**Before:** step titles overflow their container and overlap adjacent step titles; the step connectors can be hidden behind the text.

**After:** each title is clipped to the step width and truncated with an ellipsis when needed, so the step connectors and numbers stay readable.

Fixes #12254