### PR TITLE
MudCard, MudStepper: Ensure consistent header height and prevent stepper title overflow

### DIFF
--- a/src/MudBlazor/Styles/components/_card.scss
+++ b/src/MudBlazor/Styles/components/_card.scss
@@ -30,8 +30,7 @@
 
   & .mud-card-header-actions {
     flex: 0 0 auto;
-    align-self: flex-start;
-    margin-top: -8px;
+    align-self: center;
     margin-right: -8px;
     margin-inline-end: -8px;
     margin-inline-start: unset;

--- a/src/MudBlazor/Styles/components/_stepper.scss
+++ b/src/MudBlazor/Styles/components/_stepper.scss
@@ -122,6 +122,8 @@
 
       > .mud-stepper-nav > .mud-step {
         flex-basis: 175px;
+        overflow: hidden;
+        min-width: 0;
       }
 
       > .mud-stepper-nav > .mud-step > .mud-step-label {
@@ -136,6 +138,14 @@
         .mud-step-label-content {
           margin-top: 12px;
           text-align: center;
+          min-width: 0;
+          overflow: hidden;
+
+          .mud-step-label-content-title {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
         }
       }
 


### PR DESCRIPTION
## Problem
When `CardHeaderActions` is populated (for example with a `MudIconButton`), the card header becomes taller than cards without actions. That causes misaligned titles and inconsistent header heights when cards are displayed side by side.

The root cause is `align-self: flex-start` on `.mud-card-header-actions`, which overrides the parent container's centering. A compensating `margin-top: -8px` shifts the button visually, but it does not reduce the element's computed height.

## Fix
- change `align-self: flex-start` to `align-self: center`
- remove the compensating `margin-top: -8px`

`.mud-card-header` already uses `align-items: center`, so the actions slot can inherit vertical centering without stretching the header.

## Before / After
**Before:** the settings action sits above the header center line, so the header is taller and adjacent titles misalign.

![Before](https://raw.githubusercontent.com/EduardF1/pr-screenshots/main/mudblazor/13256/before.png)

**After:** the actions are vertically centered within the header, keeping a consistent header height across cards in the same row.

![After](https://raw.githubusercontent.com/EduardF1/pr-screenshots/main/mudblazor/13256/after.png)

Fixes #12719