### PR TITLE
MudInputControl: Show label as tooltip on hover

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -50,6 +50,18 @@ namespace MudBlazor.UnitTests.Components
             label[2].Attributes.GetNamedItem("for")?.Value.Should().Be("fieldLabelTest");
         }
 
+        [Test]
+        public void TextFieldLabelUsesTitleAttribute()
+        {
+            const string labelText = "A very long text field label";
+
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.Label, labelText));
+
+            var label = comp.Find(".mud-input-label");
+            label.Attributes.GetNamedItem("title")?.Value.Should().Be(labelText);
+        }
+
         /// <summary>
         /// Initial Text for double should be 0, with F1 format it should be 0.0
         /// </summary>

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor
@@ -7,7 +7,7 @@
         @if (!string.IsNullOrEmpty(Label))
         {
             <MudInputLabel Class="mud-input-label-inputcontrol" Variant="@Variant" Disabled=@Disabled Error="@Error"
-                           Margin="@Margin" ForId="@ForId">
+                           Margin="@Margin" ForId="@ForId" title="@Label">
                 @Label
             </MudInputLabel>
         }


### PR DESCRIPTION
Adds a title attribute to the label element so truncated labels display their full text as a browser-native tooltip on hover.

Fixes #12499

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>