### PR TITLE
MudDataGrid: Ensure loading indicator displays on mobile viewports

### DIFF
--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -195,7 +195,7 @@
                                 }
                                 @if (Loading)
                                 {
-                                    <tr>
+                                    <tr class="mud-table-loading-row">
                                         <th colspan="1000" class="mud-table-loading">
                                             <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" />
                                         </th>

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -575,7 +575,7 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 
 @mixin table-display-smalldevices($breakpoint) {
   .mud-#{$breakpoint}table {
-    .mud-table-root .mud-table-head .mud-table-row,
+    .mud-table-root .mud-table-head .mud-table-row:not(.mud-table-loading-row),
     .mud-table-root .mud-table-foot {
       display: none;
     }


### PR DESCRIPTION
## Summary

Fixes the loading overlay/progress bar in MudDataGrid not displaying on mobile/touch viewports.

## Root Cause

The table-display-smalldevices SCSS mixin hides all thead .mud-table-row elements on small viewports using display:none. This correctly hides the column header rows on mobile (where a card layout is used instead), but it was also hiding the loading indicator row because it had no distinguishing class.

Note: MudTable.razor already adds class="mud-table-loading-row" to its loading tr -- this PR applies the same pattern to MudDataGrid.razor and updates the mixin to exclude it.

## Changes

- MudDataGrid.razor: Added class="mud-table-loading-row" to the loading tr element (consistent with MudTable.razor)
- _table.scss: Updated the table-display-smalldevices mixin selector to .mud-table-row:not(.mud-table-loading-row), so the loading row remains visible on all viewport sizes

## Testing

1. Open a MudDataGrid with Loading=true and a breakpoint class
2. Resize the viewport to mobile width
3. The loading progress bar should now remain visible

Fixes #12091
