### PR TITLE
Tests: Enable parallel snackbar tests

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarCustomActionOnCloseTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Snackbar/SnackbarCustomActionOnCloseTest.razor
@@ -67,7 +67,7 @@
     private async Task OnCloseDoSomethingExpensiveAsync(Snackbar snackbar)
     {
         Snackbar.Add("Sure, I'll tell the database you closed me. No big deal...");
-        await Task.Delay(5000);
+        await Task.Yield();
         Snackbar.Add("All sorted. The database is thrilled.");
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -3,21 +3,23 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor.UnitTests.TestComponents.Snackbar;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
-    [NonParallelizable]
     public class SnackbarTests : BunitTest
     {
         private IRenderedComponent<MudSnackbarProvider> _provider;
         private ISnackbar _service;
+        private FakeTimeProvider _timeProvider;
 
         [SetUp]
         public void SnackbarSetUp()
         {
+            _timeProvider = Context.AddFakeTimeProvider();
             _service = Context.Services.GetService<ISnackbar>();
             _provider = Context.Render<MudSnackbarProvider>();
             _provider.Find("#mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
@@ -28,6 +30,16 @@ namespace MudBlazor.UnitTests.Components
         {
             await _provider.InvokeAsync(() => _service.Clear());
             _service.ShownSnackbars.Should().BeEmpty();
+        }
+
+        private Task AdvanceTimeAsync(int milliseconds)
+        {
+            return AdvanceTimeAsync(TimeSpan.FromMilliseconds(milliseconds));
+        }
+
+        private Task AdvanceTimeAsync(TimeSpan time)
+        {
+            return _provider.InvokeAsync(() => _timeProvider.Advance(time));
         }
 
         [Test]
@@ -403,17 +415,16 @@ namespace MudBlazor.UnitTests.Components
 
             primary.PauseTransitions(true);
 
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            await AdvanceTimeAsync(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Test resume.
 
             primary.PauseTransitions(false);
+            await AdvanceTimeAsync(primary.State.Options.HideTransitionDuration);
 
-            await _provider.WaitForAssertionAsync(
-                () => _provider.FindAll(".mud-snackbar").Count.Should().Be(0),
-                TimeSpan.FromSeconds(2));
+            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
         [Test]
@@ -535,7 +546,7 @@ namespace MudBlazor.UnitTests.Components
             snackbar.Should().NotBeNull();
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
-            await Task.Delay(200);
+            await AdvanceTimeAsync(200);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
@@ -587,6 +598,7 @@ namespace MudBlazor.UnitTests.Components
             _provider.Find(".mud-snackbar").TouchStart();
             await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
 
+            await AdvanceTimeAsync(100);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
@@ -613,11 +625,12 @@ namespace MudBlazor.UnitTests.Components
 
             await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
 
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            await AdvanceTimeAsync(primary.State.Options.VisibleStateDuration * 2);
 
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
+            await AdvanceTimeAsync(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -645,12 +658,13 @@ namespace MudBlazor.UnitTests.Components
 
             _provider.Find(".mud-snackbar").TouchStart();
 
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            await AdvanceTimeAsync(primary.State.Options.VisibleStateDuration * 2);
 
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             _provider.Find(".mud-snackbar").TouchEnd();
+            await AdvanceTimeAsync(primary.State.Options.HideTransitionDuration);
 
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
@@ -681,13 +695,13 @@ namespace MudBlazor.UnitTests.Components
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
 
             // Pointer is still over and the state should still be visible.
-            await Task.Delay(primary.State.Options.VisibleStateDuration * 2);
+            await AdvanceTimeAsync(primary.State.Options.VisibleStateDuration * 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // Leave pointer and let the hide transition that's been pending start.
             await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
-            await Task.Delay(primary.State.Options.HideTransitionDuration / 2);
+            await AdvanceTimeAsync(primary.State.Options.HideTransitionDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Hiding);
 
             // Re-enter halfway through hide transition.
@@ -696,6 +710,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Finally make the pointer leave and let it hide.
             await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
+            await AdvanceTimeAsync(primary.State.Options.HideTransitionDuration);
             await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
         }
 
@@ -727,12 +742,12 @@ namespace MudBlazor.UnitTests.Components
             // Ensure that leaving with the pointer does not trigger a hide transition by itself, like if the timer was not properly utilized.
 
             _provider.Find(".mud-snackbar").PointerLeave(new PointerEventArgs());
-            await Task.Delay(primary.State.Options.VisibleStateDuration / 2);
+            await AdvanceTimeAsync(primary.State.Options.VisibleStateDuration / 2);
             primary.State.SnackbarState.Should().Be(SnackbarState.Visible);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(1);
 
             // The snackbar should naturally leave the visibility state after the configured duration.
-            await Task.Delay(primary.State.Options.VisibleStateDuration);
+            await AdvanceTimeAsync(primary.State.Options.VisibleStateDuration);
             _provider.FindAll(".mud-snackbar").Count.Should().Be(0);
         }
 
@@ -753,14 +768,15 @@ namespace MudBlazor.UnitTests.Components
 
             // Prove that the pointer entering the snackbar does not restart the duration from zero.
 
-            await Task.Delay(60); // 60% through the visible duration.
+            await AdvanceTimeAsync(60); // 60% through the visible duration.
             await _provider.Find(".mud-snackbar").PointerEnterAsync(new PointerEventArgs());
             await _provider.Find(".mud-snackbar").PointerLeaveAsync(new PointerEventArgs());
             _provider.Find(".mud-snackbar").TouchStart();
             _provider.Find(".mud-snackbar").TouchEnd();
 
-            // It should close within another 60ms if it's behaving correctly; If the duration was reset this assertion will fail.
-            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0), TimeSpan.FromMilliseconds(60));
+            // It should close after the original remaining duration; if the duration was reset this assertion will fail.
+            await AdvanceTimeAsync(40);
+            _provider.FindAll(".mud-snackbar").Count.Should().Be(0);
         }
 
         [Test]
@@ -785,33 +801,17 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
-            // Click as many times as possible during the hide transition.
-            while (true)
-            {
-                var clicked = false;
+            await _provider.Find(".mud-snackbar-action-button").ClickAsync();
+            clickAttempts++;
 
-                // Click the action button if one was found.
-                await _provider.InvokeAsync(async () =>
-                {
-                    if (_provider.FindAll(".mud-snackbar-action-button").Count == 1)
-                    {
-                        await _provider.Find(".mud-snackbar-action-button").ClickAsync();
-                        clicked = true;
-                    }
-                });
+            await _provider.Find(".mud-snackbar-action-button").ClickAsync();
+            clickAttempts++;
 
-                if (clicked)
-                {
-                    clickAttempts++;
-                }
-                else
-                {
-                    break;
-                }
-            }
+            await AdvanceTimeAsync(300);
+            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
 
-            // Only one click should have been successful and multiple clicks should have been attempted.
-            successfulClicks.Should().Be(1).And.BeLessThan(clickAttempts);
+            successfulClicks.Should().Be(1);
+            clickAttempts.Should().Be(2);
         }
 
         [Test]
@@ -835,33 +835,17 @@ namespace MudBlazor.UnitTests.Components
                 })
             );
 
-            // Click as many times as possible during the hide transition.
-            while (true)
-            {
-                var clicked = false;
+            await _provider.Find(".mud-snackbar").ClickAsync();
+            clickAttempts++;
 
-                // Click the snackbar if one was found.
-                await _provider.InvokeAsync(async () =>
-                {
-                    if (_provider.FindAll(".mud-snackbar").Count == 1)
-                    {
-                        await _provider.Find(".mud-snackbar").ClickAsync();
-                        clicked = true;
-                    }
-                });
+            await _provider.Find(".mud-snackbar").ClickAsync();
+            clickAttempts++;
 
-                if (clicked)
-                {
-                    clickAttempts++;
-                }
-                else
-                {
-                    break;
-                }
-            }
+            await AdvanceTimeAsync(300);
+            await _provider.WaitForAssertionAsync(() => _provider.FindAll(".mud-snackbar").Count.Should().Be(0));
 
-            // Only one click should have been successful and multiple clicks should have been attempted.
-            successfulClicks.Should().Be(1).And.BeLessThan(clickAttempts);
+            successfulClicks.Should().Be(1);
+            clickAttempts.Should().Be(2);
         }
 
         [Test]


### PR DESCRIPTION

Enables snackbar component tests to run in parallel by removing the class-level `[NonParallelizable]` marker and eliminating wall-clock timing dependencies in the snackbar test paths.

Changes

- Injects a per-test `FakeTimeProvider` into `SnackbarTests` and advances snackbar timers deterministically.
- Replaces real `Task.Delay` calls in snackbar timing assertions with fake-time advancement.
- Replaces the click-until-hide loops with deterministic double-click assertions during the hide transition.
- Removes the fixed delay from the snackbar custom action viewer test component.

Part of #13188.
