### PR TITLE
Tests: Enable parallel autocomplete and select tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -19,7 +19,6 @@ using static MudBlazor.UnitTests.TestComponents.Autocomplete.AutocompleteSetPara
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
-    [NonParallelizable]
     public class AutocompleteTests : BunitTest
     {
         [Test]
@@ -164,15 +163,16 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task AutocompleteCancelDispose()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var comp = Context.Render<AutocompleteTest8>();
             var autocompleteContainerComp = comp.FindComponent<AutocompleteContainer>();
             var autocompleteComp = autocompleteContainerComp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComp.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Text, "Alabama"));
-            await Task.Delay(500);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(autocompleteComp.Instance.DebounceInterval));
+            await comp.WaitForAssertionAsync(() => comp.Instance.HasBeenDisposed.Should().BeFalse());
             comp.Instance.MustBeShown = false;
             comp.Render();
-            await Task.Delay(1000);
-            comp.Instance.HasBeenDisposed.Should().Be(true);
+            await comp.WaitForAssertionAsync(() => comp.Instance.HasBeenDisposed.Should().BeTrue());
         }
 
         /// <summary>
@@ -346,6 +346,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
+            var timeProvider = Context.AddFakeTimeProvider();
             var valueChangedCount = 0;
             var comp = Context.Render<AutocompleteStates>(parameters =>
             {
@@ -384,6 +385,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Act : Wait the debounce timer that open the menu
 
+            timeProvider.Advance(TimeSpan.FromMilliseconds(autocomplete.DebounceInterval));
             await autocompletecomp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
             await autocompletecomp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
 
@@ -399,6 +401,7 @@ namespace MudBlazor.UnitTests.Components
         {
             // Arrange
 
+            var timeProvider = Context.AddFakeTimeProvider();
             var debouncedText = string.Empty;
             var debounceElapsedCount = 0;
 
@@ -424,8 +427,9 @@ namespace MudBlazor.UnitTests.Components
             // Assert
 
             debounceElapsedCount.Should().Be(0);
-            await autocompleteComp.WaitForAssertionAsync(() => debounceElapsedCount.Should().Be(1), TimeSpan.FromSeconds(5));
-            await autocompleteComp.WaitForAssertionAsync(() => autocompleteComp.Instance.Open.Should().BeTrue(), TimeSpan.FromSeconds(5));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(autocompleteComp.Instance.DebounceInterval));
+            await autocompleteComp.WaitForAssertionAsync(() => debounceElapsedCount.Should().Be(1));
+            await autocompleteComp.WaitForAssertionAsync(() => autocompleteComp.Instance.Open.Should().BeTrue());
             debounceElapsedCount.Should().Be(1);
             debouncedText.Should().Be("Al");
         }
@@ -1477,38 +1481,49 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_NotIndicateLoadingByDefault()
         {
             // Arrange
+            var (searchStarted, searchCompletion, searchFunc) = CreateControlledSearch();
             var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, searchFunc));
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
-            await autocompleteComponent.Find("input").InputAsync("Calif");
+            var inputTask = autocompleteComponent.Find("input").InputAsync("Calif");
+            await searchStarted.Task.WaitAsync(NUnit.Framework.TestContext.CurrentContext.CancellationToken);
 
             // Test
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().NotContain("progress-indicator-circular"));
+            searchCompletion.SetResult(["California"]);
+            await inputTask;
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
         }
 
         [Test]
         public async Task Autocomplete_Should_IndicateLoadingWithCircularProgressIndicator()
         {
-            // TODO: use a TaskCompletionSource that allows control over the search task
-            // for reliable testing.  Applies to other tests like this one.
-            // Currently, we increase the load time to 50mms to catch the progress UI
-
             // Arrange
+            var (searchStarted, searchCompletion, searchFunc) = CreateControlledSearch();
             var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
-            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ShowProgressIndicator, true));
+            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, searchFunc)
+                .Add(x => x.ShowProgressIndicator, true));
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
-            await autocompleteComponent.Find("input").InputAsync("Calif");
+            var inputTask = autocompleteComponent.Find("input").InputAsync("Calif");
+            await searchStarted.Task.WaitAsync(NUnit.Framework.TestContext.CurrentContext.CancellationToken);
 
             // Test show
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("progress-indicator-circular"));
-            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             // Test hide
+            searchCompletion.SetResult(["California"]);
+            await inputTask;
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().NotContain("progress-indicator-circular"));
         }
@@ -1517,23 +1532,29 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_Should_IndicateLoadingWithCircularProgressIndicatorAndAdornmentAdjustment()
         {
             // Arrange
+            var (searchStarted, searchCompletion, searchFunc) = CreateControlledSearch();
             var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, searchFunc)
                 .Add(x => x.ShowProgressIndicator, true)
                 .Add(x => x.AdornmentIcon, Icons.Material.Filled.Info)
                 .Add(x => x.Adornment, Adornment.End));
 
             comp.Markup.Should().NotContain("progress-indicator-circular");
-            await autocompleteComponent.Find("input").InputAsync("Calif");
+            var inputTask = autocompleteComponent.Find("input").InputAsync("Calif");
+            await searchStarted.Task.WaitAsync(NUnit.Framework.TestContext.CurrentContext.CancellationToken);
 
             // Test show
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("progress-indicator-circular"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.progress-indicator-circular").ClassList.Should().Contain("progress-indicator-circular--with-adornment"));
-            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
 
             // Test hide
+            searchCompletion.SetResult(["California"]);
+            await inputTask;
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().NotContain("progress-indicator-circular"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().NotContain("progress-indicator-circular--with-adornment"));
@@ -1550,19 +1571,25 @@ namespace MudBlazor.UnitTests.Components
 
             var comp = Context.Render<AutocompleteTest1>();
             var autocompletecomp = comp.FindComponent<MudAutocomplete<string>>();
+            var (searchStarted, searchCompletion, searchFunc) = CreateControlledSearch();
 
             await autocompletecomp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, searchFunc)
                 .Add(x => x.ShowProgressIndicator, true)
                 .Add(p => p.ProgressIndicatorTemplate, fragment));
 
             comp.Markup.Should().NotContain("Loading...");
-            await autocompletecomp.Find("input").InputAsync("Calif");
+            var inputTask = autocompletecomp.Find("input").InputAsync("Calif");
+            await searchStarted.Task.WaitAsync(NUnit.Framework.TestContext.CurrentContext.CancellationToken);
 
             // Test show
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().Contain("Loading..."));
 
             // Test hide
+            searchCompletion.SetResult(["California"]);
+            await inputTask;
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").Children.ToMarkup().Should().NotContain("Loading..."));
         }
@@ -1578,19 +1605,25 @@ namespace MudBlazor.UnitTests.Components
 
             var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var (searchStarted, searchCompletion, searchFunc) = CreateControlledSearch();
 
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, searchFunc)
                 .Add(x => x.ShowProgressIndicator, true)
                 .Add(p => p.ProgressIndicatorInPopoverTemplate, fragment));
 
             comp.Markup.Should().NotContain("Loading...");
-            await autocompleteComponent.Find("input").InputAsync("Calif");
+            var inputTask = autocompleteComponent.Find("input").InputAsync("Calif");
+            await searchStarted.Task.WaitAsync(NUnit.Framework.TestContext.CurrentContext.CancellationToken);
 
             // Test show
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().Contain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ToMarkup().Should().Contain("Loading..."));
 
             // Test hide
+            searchCompletion.SetResult(["California"]);
+            await inputTask;
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-autocomplete").ClassList.Should().NotContain("mud-autocomplete--with-progress"));
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ToMarkup().Should().NotContain("Loading..."));
         }
@@ -1598,6 +1631,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_Cancel_Search()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
@@ -1616,7 +1650,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Find("input").InputAsync("Foo");
 
-            await Task.Delay(20);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(autocompleteComponent.Instance.DebounceInterval));
 
             // Test
 
@@ -1633,7 +1667,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Find("input").InputAsync("Bar");
 
-            await Task.Delay(20);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(autocompleteComponent.Instance.DebounceInterval));
 
             // Test
 
@@ -1736,6 +1770,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_Not_Throw_When_SearchFunc_Is_Null()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var comp = Context.Render<AutocompleteTest1>();
             var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
 
@@ -1743,7 +1778,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Find("input").InputAsync("Foo");
 
-            await Task.Delay(20);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(autocompleteComponent.Instance.DebounceInterval));
 
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ToMarkup().Should().NotContain("Foo"));
         }
@@ -2529,6 +2564,23 @@ namespace MudBlazor.UnitTests.Components
             // Verify that the component is using the global defaults
             // Modal should be null (using PopoverOptions defaults)
             auto.Instance.Modal.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Creates a search function that stays pending until the test completes it, allowing deterministic loading-state assertions.
+        /// </summary>
+        private static (TaskCompletionSource<bool> Started, TaskCompletionSource<IEnumerable<string>> Completion, Func<string, CancellationToken, Task<IEnumerable<string>>> SearchFunc) CreateControlledSearch()
+        {
+            var searchStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var searchCompletion = new TaskCompletionSource<IEnumerable<string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            Task<IEnumerable<string>> SearchFunc(string _, CancellationToken __)
+            {
+                searchStarted.TrySetResult(true);
+                return searchCompletion.Task;
+            }
+
+            return (searchStarted, searchCompletion, SearchFunc);
         }
 
         private sealed class CoerceValueElement

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -131,9 +131,9 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        [NonParallelizable]
         public async Task Select_KeyDown_WhileClosed()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var keyInterceptorService = Context.AddKeyInterceptorService();
             var comp = Context.Render<SelectFocusAndTypeTest>();
             var select = comp.FindComponent<MudSelect<string>>();
@@ -145,29 +145,29 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Tennessee"));
 
             //cycle through matching results
-            await Task.Delay(210);
+            timeProvider.Advance(select.Instance.QuickSearchInterval + TimeSpan.FromMilliseconds(10));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "t", Type = "keydown" }));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Texas"));
-            await Task.Delay(210);
+            timeProvider.Advance(select.Instance.QuickSearchInterval + TimeSpan.FromMilliseconds(10));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "t", Type = "keydown" }));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Tennessee"));
 
             //multi-string search
-            await Task.Delay(210);
+            timeProvider.Advance(select.Instance.QuickSearchInterval + TimeSpan.FromMilliseconds(10));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "c", Type = "keydown" }));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "o", Type = "keydown" }));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "l", Type = "keydown" }));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Colorado"));
 
             //paused search
-            await Task.Delay(210);
+            timeProvider.Advance(select.Instance.QuickSearchInterval + TimeSpan.FromMilliseconds(10));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "i", Type = "keydown" }));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "o", Type = "keydown" }));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Iowa"));
 
-            await Task.Delay(210);
+            timeProvider.Advance(select.Instance.QuickSearchInterval + TimeSpan.FromMilliseconds(10));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "i", Type = "keydown" }));
-            await Task.Delay(210);
+            timeProvider.Advance(select.Instance.QuickSearchInterval + TimeSpan.FromMilliseconds(10));
             await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(select.Instance.ElementId, new KeyboardEventArgs { Key = "o", Type = "keydown" }));
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be("Ohio"));
         }
@@ -227,7 +227,7 @@ namespace MudBlazor.UnitTests.Components
             inputs.Count.Should().Be(3);
             inputs[1].GetAttribute("value").Should().Be("Value2");
             await inputs[1].MouseDownAsync();
-            await Task.Delay(500);
+            await comp.WaitForAssertionAsync(() => comp.FindAll(".mud-list-item").Count.Should().BeGreaterThan(0));
             var listItems = comp.FindAll(".mud-list-item");
             foreach (var listItem in listItems)
             {
@@ -413,9 +413,8 @@ namespace MudBlazor.UnitTests.Components
 
             select.Instance.ReadValue.Should().Be(17);
             select.Instance.ReadText.Should().Be("17");
-            await Task.Delay(100);
             // BUT: we have a select with Strict="true" so the Text will not be shown because it is not in the list of selectable values
-            comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be(null);
+            await comp.WaitForAssertionAsync(() => comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be(null));
             comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden);
             await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));


### PR DESCRIPTION
Enables the autocomplete and select unit tests to run under the fixture-level parallelization already configured for the test assembly.

Changes

- Removed the remaining `NonParallelizable` annotations from `AutocompleteTests` and `Select_KeyDown_WhileClosed`.
- Replaced sleep-based waits in the affected autocomplete/select tests with fake time or renderer-driven assertions.
- Made autocomplete progress-indicator tests deterministic by using a controlled search task instead of trying to observe a short real-time loading window.

Part of #13188.
