### PR TITLE
MudTextField: Adjust max-width of input label for Text variant

### DIFF
--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -65,6 +65,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
   .mud-input:focus-within ~ & {
     transform: translate(0, 1.5px) scale(0.75);
     transform-origin: top left;
+    max-width: calc(100% / 0.75);
 
     &.mud-input-label-filled {
       transform: translate(12px, 10px) scale(0.75);


### PR DESCRIPTION
For MudTextField the input label width for the variants Outlined and Filled were 100% but for the variant Text it was only 75%.
This fixes one point of #12499 

<!-- Describe your changes and what the purpose of them is. -->
Screenshot before:
<img width="318" height="286" alt="grafik" src="https://github.com/user-attachments/assets/ecf09306-0a11-41b2-8400-70395054c780" />

and after:
<img width="314" height="265" alt="grafik" src="https://github.com/user-attachments/assets/13ee46ab-2b9b-4184-a046-4c2361fa2d56" />



**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [] I've added or updated relevant unit tests
