### PR TITLE
Tests: Make carousel tests deterministic

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -10,14 +10,6 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class CarouselTests : BunitTest
     {
-        private FakeTimeProvider _timeProvider;
-
-        [SetUp]
-        public void CarouselSetUp()
-        {
-            _timeProvider = Context.AddFakeTimeProvider();
-        }
-
         /// <summary>
         /// Default Carousel, with three pages.
         /// Testing if selection is sync with move commands.
@@ -180,6 +172,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Carousel_AutoCycle()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var comp = Context.Render<MudCarousel<object>>();
             // print the generated html
             // adding some pages
@@ -194,13 +187,13 @@ namespace MudBlazor.UnitTests.Components
             for (var interval = 150; interval <= 300; interval += 150)
             {
                 await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.AutoCycleTime, TimeSpan.FromMilliseconds(interval)));
-                await comp.InvokeAsync(() => _timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
+                await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
                 comp.Instance.SelectedIndex.Should().Be(1);
                 comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[1]);
-                await comp.InvokeAsync(() => _timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
+                await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
                 comp.Instance.SelectedIndex.Should().Be(2);
                 comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[2]);
-                await comp.InvokeAsync(() => _timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
+                await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
                 comp.Instance.SelectedIndex.Should().Be(0);
                 comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
             }

--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -187,15 +187,24 @@ namespace MudBlazor.UnitTests.Components
             for (var interval = 150; interval <= 300; interval += 150)
             {
                 await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.AutoCycleTime, TimeSpan.FromMilliseconds(interval)));
-                await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
-                comp.Instance.SelectedIndex.Should().Be(1);
-                comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[1]);
-                await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
-                comp.Instance.SelectedIndex.Should().Be(2);
-                comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[2]);
-                await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
-                comp.Instance.SelectedIndex.Should().Be(0);
-                comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
+                timeProvider.Advance(TimeSpan.FromMilliseconds(interval));
+                await comp.WaitForAssertionAsync(() =>
+                {
+                    comp.Instance.SelectedIndex.Should().Be(1);
+                    comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[1]);
+                });
+                timeProvider.Advance(TimeSpan.FromMilliseconds(interval));
+                await comp.WaitForAssertionAsync(() =>
+                {
+                    comp.Instance.SelectedIndex.Should().Be(2);
+                    comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[2]);
+                });
+                timeProvider.Advance(TimeSpan.FromMilliseconds(interval));
+                await comp.WaitForAssertionAsync(() =>
+                {
+                    comp.Instance.SelectedIndex.Should().Be(0);
+                    comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
+                });
             }
         }
 

--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -1,6 +1,7 @@
 ﻿using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Time.Testing;
 using MudBlazor.UnitTests.TestComponents.Carousel;
 using NUnit.Framework;
 
@@ -9,6 +10,14 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class CarouselTests : BunitTest
     {
+        private FakeTimeProvider _timeProvider;
+
+        [SetUp]
+        public void CarouselSetUp()
+        {
+            _timeProvider = Context.AddFakeTimeProvider();
+        }
+
         /// <summary>
         /// Default Carousel, with three pages.
         /// Testing if selection is sync with move commands.
@@ -185,14 +194,14 @@ namespace MudBlazor.UnitTests.Components
             for (var interval = 150; interval <= 300; interval += 150)
             {
                 await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.AutoCycleTime, TimeSpan.FromMilliseconds(interval)));
-                await Task.Delay(interval);
-                await comp.WaitForAssertionAsync(() => comp.Instance.SelectedIndex.Should().Be(1), TimeSpan.FromMilliseconds(3000));
+                await comp.InvokeAsync(() => _timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
+                comp.Instance.SelectedIndex.Should().Be(1);
                 comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[1]);
-                await Task.Delay(interval);
-                await comp.WaitForAssertionAsync(() => comp.Instance.SelectedIndex.Should().Be(2), TimeSpan.FromMilliseconds(3000));
+                await comp.InvokeAsync(() => _timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
+                comp.Instance.SelectedIndex.Should().Be(2);
                 comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[2]);
-                await Task.Delay(interval);
-                await comp.WaitForAssertionAsync(() => comp.Instance.SelectedIndex.Should().Be(0), TimeSpan.FromMilliseconds(3000));
+                await comp.InvokeAsync(() => _timeProvider.Advance(TimeSpan.FromMilliseconds(interval)));
+                comp.Instance.SelectedIndex.Should().Be(0);
                 comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
             }
         }


### PR DESCRIPTION
Removes blocking calls in carousel tests.

Changes:
- Injects a per-test FakeTimeProvider into CarouselTests and advances carousel timers deterministically.
- Replaces Task.Delay calls with fake-time advancement.
- Replaces WaitForAssertionAsync with direct assertions.

Part of #13188 