### PR TITLE
MudRating: Skip hover effects when ReadOnly or Disabled

### DIFF
--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -220,11 +220,14 @@ namespace MudBlazor
         }
 
         internal Task HandleItemHoveredAsync(int? itemValue)
-    {
-        if (ReadOnly || Disabled)
-            return Task.CompletedTask;
-        return SetHoveredValueAsync(itemValue);
-    }
+        {
+            if (ReadOnly || Disabled)
+            {
+                return Task.CompletedTask;
+            }
+
+            return SetHoveredValueAsync(itemValue);
+        }
 
         private async Task IncreaseValueAsync(int val)
         {

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -219,7 +219,12 @@ namespace MudBlazor
             }
         }
 
-        internal Task HandleItemHoveredAsync(int? itemValue) => SetHoveredValueAsync(itemValue);
+        internal Task HandleItemHoveredAsync(int? itemValue)
+    {
+        if (ReadOnly || Disabled)
+            return Task.CompletedTask;
+        return SetHoveredValueAsync(itemValue);
+    }
 
         private async Task IncreaseValueAsync(int val)
         {


### PR DESCRIPTION
Fixes #13265 — Rating hover CSS applies even when ReadOnly=true.

Added ReadOnly/Disabled early-return to HandleItemHoveredAsync.

Before:
```csharp
internal Task HandleItemHoveredAsync(int? itemValue) => SetHoveredValueAsync(itemValue);
```
After:
```csharp
internal Task HandleItemHoveredAsync(int? itemValue)
{
    if (ReadOnly || Disabled)
        return Task.CompletedTask;
    return SetHoveredValueAsync(itemValue);
}
```