### PR TITLE
Docs: Clarify DataGrid culture default docs

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -439,9 +439,10 @@
         <DocsPageSection>
             <SectionHeader Title="CultureInfo">
                 <Description>
-                    DataGrid <CodeInline>Culture</CodeInline> (CultureInfo) property is used to display and editing/filter columns data.
-                    Each <CodeInline>&lt;Column></CodeInline> can define his own culture,
-                    to allow to specify its format individually.
+                    DataGrid <CodeInline>Culture</CodeInline> (CultureInfo) property is used to display and edit/filter column data.
+                    When it is not set, cell values use the current culture through .NET's default formatting behavior.
+                    Set it to <CodeInline>CultureInfo.InvariantCulture</CodeInline> when invariant numeric or date formatting is required.
+                    Each <CodeInline>&lt;Column></CodeInline> can define its own culture to specify its format individually.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(DataGridColumnCultureExample)" ShowCode="false" Block="true" FullWidth="true">

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -384,7 +384,7 @@ namespace MudBlazor
         /// The culture used to parse, filter, and display values in this column.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="MudDataGrid{T}.Culture"/>.
+        /// Defaults to <see cref="MudDataGrid{T}.Culture"/>.  When neither value is set, formatting uses the current culture.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Table.Appearance)]

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1139,7 +1139,8 @@ namespace MudBlazor
         /// The culture used to format numeric and date values.  Can be overridden by <see cref="Column{T}.Culture"/>.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="CultureInfo.InvariantCulture"/>.
+        /// Defaults to <c>null</c>.  When no culture is set, cells use the current culture via .NET's default formatting behavior.
+        /// Set this to <see cref="CultureInfo.InvariantCulture"/> when invariant numeric and date formatting is required.
         /// </remarks>
         [Parameter]
         public CultureInfo? Culture { get; set; }


### PR DESCRIPTION
Clarifies the documented default behavior for `MudDataGrid.Culture` and column-level culture fallback.

The previous XML/API docs said `MudDataGrid.Culture` defaults to `CultureInfo.InvariantCulture`, but the implementation leaves the parameter unset. In that case, cell formatting follows .NET's default formatting behavior and uses the current culture. The docs now explain that setting `CultureInfo.InvariantCulture` explicitly is required when invariant numeric or date formatting is desired.

This PR does not change the `MudDataGrid` implementation because the current behavior appears intentional and consistent with nullable `IFormatProvider` usage in .NET: when no culture is provided, formatting uses the current culture. Changing the component to default to invariant culture would be a behavior change for existing apps and should be considered separately if desired.

This PR also does not change `DataGridBasicExample` to set `CultureInfo.InvariantCulture`. The example currently demonstrates the grid's default behavior, and forcing invariant culture there would hide the behavior that the docs now describe. Users who need invariant output can set `Culture=CultureInfo.InvariantCulture` on the grid or column.

Closes #13268