### PR TITLE
Tests: Enable deterministic menu tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -163,12 +163,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MouseOver_Click_ShouldKeepMenuOpen()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             var hoverDelay = MudGlobal.MenuDefaults.HoverDelay;
             var comp = Context.Render<MenuTestMouseOver>();
             var menu = comp.FindComponent<MudMenu>().Instance;
 
             // Enter opens the menu (after a delay).
-            await comp.Find("div.mud-menu").PointerEnterAsync();
+            comp.Find("div.mud-menu").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
+            timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100));
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Clicking the button should close the menu.
@@ -181,17 +183,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Leaving the menu should no longer close it.
-            await comp.Find("div.mud-menu").PointerLeaveAsync();
-            await Task.Delay(hoverDelay + 100);
+            comp.Find("div.mud-menu").PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100)));
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Hover the list shouldn't change anything.
-            await comp.Find("[data-testid='menu-wrapper']").PointerEnterAsync(new PointerEventArgs());
+            comp.Find("[data-testid='menu-wrapper']").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Leave the list shouldn't change anything.
-            await comp.Find("[data-testid='menu-wrapper']").PointerLeaveAsync(new PointerEventArgs());
-            await Task.Delay(hoverDelay + 100);
+            comp.Find("[data-testid='menu-wrapper']").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100)));
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Clicking the button should now close the menu.
@@ -693,6 +695,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Menu_PointerEvents_ShowHide_WithDebounce()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             // This method uses CatchAndLog to allow async events to run syncronously so we can test timing
             var hoverDelay = MudGlobal.MenuDefaults.HoverDelay;
 
@@ -711,8 +714,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1, "Submenu should not open immediately");
 
             // After the hover delay, submenu should become visible
-            await Task.Delay(hoverDelay + 50);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "Submenu should open after hover delay");
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 50)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "Submenu should open after hover delay"));
 
             // 2. Test HIDE debounce behavior
 
@@ -723,17 +726,18 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "Submenu should remain open immediately after pointer leave");
 
             // Wait less than the delay
-            await Task.Delay(hoverDelay / 2);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "Submenu should still be open before hide delay completes");
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay / 2)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "Submenu should still be open before hide delay completes"));
 
             // After the full delay, submenu should close
-            await Task.Delay(hoverDelay + 50);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(1, "Submenu should close after full hide delay (2x hover delay)");
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 50)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1, "Submenu should close after full hide delay (2x hover delay)"));
         }
 
         [Test]
         public async Task Menu_PointerEvents_MultipleLevels()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             // This method uses CatchAndLog to allow async events to run syncronously so we can test timing
             var hoverDelay = MudGlobal.MenuDefaults.HoverDelay;
 
@@ -744,33 +748,32 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1, "Main menu should be open");
 
             // Open first level submenu
-            var menuItem1 = comp.Find("div.mud-menu:contains('1.3')");
-            menuItem1.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(hoverDelay + 100);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "First level submenu should be open");
+            comp.Find("div.mud-menu:contains('1.3')").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(2, "First level submenu should be open"));
 
             // Open second level submenu
-            var menuItem2 = comp.Find("div.mud-menu:contains('2.1')");
-            menuItem2.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(hoverDelay + 100);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(3, "Second level submenu should be open");
+            comp.Find("div.mud-menu:contains('2.1')").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(3, "Second level submenu should be open"));
 
             // Leaving second level should close only that level after delay
-            menuItem2.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay((hoverDelay * 2) + 100);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2,
-                "Second level should close but first level should remain open");
+            comp.Find("div.mud-menu:contains('2.1')").PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds((hoverDelay * 2) + 100)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(2,
+                "Second level should close but first level should remain open"));
 
             // Leaving first level should close it after delay
-            menuItem1.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay((hoverDelay * 2) + 100);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(1,
-                "First level should close but main menu should remain open");
+            comp.Find("div.mud-menu:contains('1.3')").PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds((hoverDelay * 2) + 100)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1,
+                "First level should close but main menu should remain open"));
         }
 
         [Test]
         public async Task Menu_PointerEvents_RapidMovement()
         {
+            var timeProvider = Context.AddFakeTimeProvider();
             // This method uses CatchAndLog to allow async events to run syncronously so we can test timing
             var hoverDelay = MudGlobal.MenuDefaults.HoverDelay;
 
@@ -784,31 +787,31 @@ namespace MudBlazor.UnitTests.Components
 
             // Simulate rapid mouse movement: enter -> leave -> enter -> leave -> enter
             menuItem.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(50)));
             menuItem.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(50)));
             menuItem.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(50)));
             menuItem.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(50)));
             menuItem.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
 
             // Final state should be "entering" so menu should open
-            await Task.Delay(hoverDelay + 50);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(2,
-                "Menu should open after rapid movement ending with pointer enter");
+            timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 50));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(2,
+                "Menu should open after rapid movement ending with pointer enter"));
 
             // Now rapid movement ending with leaving
             menuItem.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(50)));
             menuItem.PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            await Task.Delay(50);
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(50)));
             menuItem.PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
 
             // Final state should be "leaving" so menu should close
-            await Task.Delay((hoverDelay * 2) + 50);
-            comp.FindAll("div.mud-popover-open").Count.Should().Be(1,
-                "Menu should close after rapid movement ending with pointer leave");
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds((hoverDelay * 2) + 50)));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1,
+                "Menu should close after rapid movement ending with pointer leave"));
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -170,7 +170,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Enter opens the menu (after a delay).
             comp.Find("div.mud-menu").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
-            timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100));
+            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100)));
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Clicking the button should close the menu.

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -192,7 +192,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 
             // Leave the list shouldn't change anything.
-            comp.Find("[data-testid='menu-wrapper']").PointerEnterAsync(new PointerEventArgs()).CatchAndLog();
+            comp.Find("[data-testid='menu-wrapper']").PointerLeaveAsync(new PointerEventArgs()).CatchAndLog();
             await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(hoverDelay + 100)));
             await comp.WaitForAssertionAsync(() => menu.GetState(x => x.Open).Should().BeTrue());
 


### PR DESCRIPTION
Enables menu unit tests to run deterministically by replacing delays with fake time advancement.
Changes: 
- Replace Task.Delay with FakeTimeProvider advancements
- Update assertions to use WaitForAssertionAsync
- Remove caching of component references

Notes
PointerEnterAsync is fired as fire-and-forget via CatchAndLog — awaiting it directly deadlocks against the fake clock. Time is advanced via comp.InvokeAsync rather than directly, as calling it from the test thread causes state changes not to propagate correctly.

Part of #13188