### PR TITLE
MudDataGrid: Add state save and restore APIs

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -505,6 +505,18 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Save And Restore State">
+                <Description>
+                    Use <CodeInline>GetState</CodeInline> and <CodeInline>SetStateAsync</CodeInline> to capture and restore filters, sorting, paging, grouping, and selected rows.
+                    Selection is persisted through item keys supplied by your application.
+                </Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(DataGridStateSaveRestoreExample)" Block="true" FullWidth="true">
+                <DataGridStateSaveRestoreExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Other Options">
                 <Description>
                     There are many options available for the <CodeInline>&lt;MudDataGrid></CodeInline> that are not covered in the examples above.

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridStateSaveRestoreExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridStateSaveRestoreExample.razor
@@ -1,0 +1,77 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudStack Spacing="2">
+    <MudStack Row="true" Spacing="2">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveStateAsync">Save State</MudButton>
+        <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="RestoreStateAsync">Restore State</MudButton>
+        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="ClearSavedStateAsync">Clear Saved State</MudButton>
+    </MudStack>
+
+    <MudText Typo="Typo.body2">@_statusMessage</MudText>
+
+    <MudDataGrid @ref="_dataGrid"
+                 T="Employee"
+                 Items="@_employees"
+                 Filterable="true"
+                 Groupable="true"
+                 MultiSelection="true"
+                 SortMode="SortMode.Multiple"
+                 RowsPerPage="5">
+        <Columns>
+            <SelectColumn T="Employee" />
+            <PropertyColumn Property="x => x.Department" Grouping="true" />
+            <PropertyColumn Property="x => x.Name" />
+            <PropertyColumn Property="x => x.Salary" Format="C0" />
+        </Columns>
+        <PagerContent>
+            <MudDataGridPager T="Employee" />
+        </PagerContent>
+    </MudDataGrid>
+</MudStack>
+
+@code {
+    private MudDataGrid<Employee> _dataGrid = null!;
+    private readonly List<Employee> _employees =
+    [
+        new(1, "Alex", "Sales", 62000),
+        new(2, "Bailey", "Sales", 58000),
+        new(3, "Casey", "Engineering", 91000),
+        new(4, "Dana", "Engineering", 88000),
+        new(5, "Ellis", "Support", 54000),
+        new(6, "Finley", "Support", 56000),
+    ];
+
+    private DataGridPersistedState _savedState = new();
+    private bool _hasSavedState;
+    private string _statusMessage = "Change sorting, filters, paging, grouping, or selection, then save and restore the state.";
+
+    private async Task SaveStateAsync()
+    {
+        _savedState = _dataGrid.GetState(employee => employee.Id.ToString());
+        _hasSavedState = true;
+        _statusMessage = $"Saved page {_savedState.Page + 1}, {_savedState.Filters.Count} filter(s), {_savedState.Sorts.Count} sort(s), and {_savedState.SelectedItemKeys.Count} selected row(s).";
+        await Task.CompletedTask;
+    }
+
+    private async Task RestoreStateAsync()
+    {
+        if (!_hasSavedState)
+        {
+            _statusMessage = "Save state before restoring.";
+            return;
+        }
+
+        await _dataGrid.SetStateAsync(_savedState, key => _employees.FirstOrDefault(employee => employee.Id.ToString() == key));
+        _statusMessage = "Restored the last saved grid state.";
+    }
+
+    private async Task ClearSavedStateAsync()
+    {
+        _hasSavedState = false;
+        _savedState = new DataGridPersistedState();
+        await _dataGrid.SetStateAsync(_savedState);
+        _statusMessage = "Cleared saved state and reset the grid.";
+    }
+
+    private sealed record Employee(int Id, string Name, string Department, decimal Salary);
+}

--- a/src/MudBlazor.Examples.DataGridState/App.razor
+++ b/src/MudBlazor.Examples.DataGridState/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(Layout.MainLayout)">
+            <MudText Typo="Typo.h6">Page not found.</MudText>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/MudBlazor.Examples.DataGridState/Data/Person.cs
+++ b/src/MudBlazor.Examples.DataGridState/Data/Person.cs
@@ -1,0 +1,20 @@
+﻿namespace MudBlazor.Examples.DataGridState.Data;
+
+public sealed class Person
+{
+    public Guid Id { get; init; }
+
+    public string FullName { get; init; } = string.Empty;
+
+    public string Email { get; init; } = string.Empty;
+
+    public string Company { get; init; } = string.Empty;
+
+    public string City { get; init; } = string.Empty;
+
+    public int Age { get; init; }
+
+    public decimal Salary { get; init; }
+
+    public DateTime Joined { get; init; }
+}

--- a/src/MudBlazor.Examples.DataGridState/Data/PersonDataGenerator.cs
+++ b/src/MudBlazor.Examples.DataGridState/Data/PersonDataGenerator.cs
@@ -1,0 +1,25 @@
+﻿using Bogus;
+
+namespace MudBlazor.Examples.DataGridState.Data;
+
+public static class PersonDataGenerator
+{
+    private const int Seed = 8675309;
+    private static readonly DateTime ReferenceDate = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public static IReadOnlyList<Person> CreatePeople(int count = 250)
+    {
+        var faker = new Faker<Person>()
+            .UseSeed(Seed)
+            .RuleFor(person => person.Id, faker => faker.Random.Guid())
+            .RuleFor(person => person.FullName, faker => faker.Name.FullName())
+            .RuleFor(person => person.Email, (faker, person) => faker.Internet.Email(person.FullName))
+            .RuleFor(person => person.Company, faker => faker.Company.CompanyName())
+            .RuleFor(person => person.City, faker => faker.Address.City())
+            .RuleFor(person => person.Age, faker => faker.Random.Int(22, 65))
+            .RuleFor(person => person.Salary, faker => faker.Random.Decimal(45000, 160000))
+            .RuleFor(person => person.Joined, faker => faker.Date.PastOffset(8, ReferenceDate).DateTime);
+
+        return faker.Generate(count);
+    }
+}

--- a/src/MudBlazor.Examples.DataGridState/Layout/MainLayout.razor
+++ b/src/MudBlazor.Examples.DataGridState/Layout/MainLayout.razor
@@ -1,0 +1,18 @@
+@inherits LayoutComponentBase
+
+<MudThemeProvider />
+<MudPopoverProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+<MudLayout>
+    <MudAppBar Elevation="1">
+        <MudText Typo="Typo.h6">MudDataGrid State Example</MudText>
+        <MudSpacer />
+        <MudButton Href="/" Color="Color.Inherit">Manual</MudButton>
+        <MudButton Href="/automatic" Color="Color.Inherit">Automatic</MudButton>
+    </MudAppBar>
+    <MudMainContent Class="pa-4">
+        @Body
+    </MudMainContent>
+</MudLayout>

--- a/src/MudBlazor.Examples.DataGridState/MudBlazor.Examples.DataGridState.csproj
+++ b/src/MudBlazor.Examples.DataGridState/MudBlazor.Examples.DataGridState.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>MudBlazor.Examples.DataGridState</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MudBlazor\MudBlazor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MudBlazor.Examples.DataGridState/Pages/Automatic.razor
+++ b/src/MudBlazor.Examples.DataGridState/Pages/Automatic.razor
@@ -1,0 +1,187 @@
+@page "/automatic"
+@inject LocalStorageService LocalStorage
+@inject PersonDataStore PersonDataStore
+@inject ISnackbar Snackbar
+
+<MudStack Spacing="3">
+    <MudPaper Class="pa-4" Elevation="1">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h5">Automatic DataGrid State Persistence</MudText>
+            <MudText Typo="Typo.body2">
+                Sorting, filters, paging, grouping, and selection are saved automatically to localStorage.
+                Reload the page to restore the last grid state.
+            </MudText>
+            <MudStack Row="true" Spacing="2">
+                <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="ClearStateAsync">Clear Saved State</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="@(_groupingEnabled ? Color.Secondary : Color.Default)" OnClick="ToggleGroupingAsync">
+                    @(_groupingEnabled ? "Disable Grouping" : "Enable Grouping")
+                </MudButton>
+            </MudStack>
+            <MudText Typo="Typo.body2">@_statusMessage</MudText>
+            @if (!string.IsNullOrWhiteSpace(_loadError))
+            {
+                <MudAlert Severity="Severity.Error">@_loadError</MudAlert>
+            }
+        </MudStack>
+    </MudPaper>
+
+    @if (!_dataLoaded)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else
+    {
+        <MudDataGrid @ref="_dataGrid"
+                     T="Person"
+                     Items="@_people"
+                     Filterable="true"
+                     Groupable="@_groupingEnabled"
+                     MultiSelection="true"
+                     SortMode="SortMode.Multiple"
+                     RowsPerPage="10"
+                     Height="520px"
+                     FixedHeader="true"
+                     SortChanged="@(_ => AutoSaveStateAsync())"
+                     FilterChanged="@(_ => AutoSaveStateAsync())"
+                     CurrentPageChanged="@(_ => AutoSaveStateAsync())"
+                     RowsPerPageChanged="@(_ => AutoSaveStateAsync())"
+                     SelectedItemsChanged="@(_ => AutoSaveStateAsync())">
+            <ToolBarContent>
+                <MudText Typo="Typo.h6">People</MudText>
+                <MudSpacer />
+                <MudText Typo="Typo.body2">@_people.Count records</MudText>
+            </ToolBarContent>
+            <Columns>
+                <SelectColumn T="Person" />
+                <PropertyColumn Property="x => x.Company" Title="Company" Groupable="true" Grouping="@_groupingEnabled" GroupingChanged="@(_ => AutoSaveStateAsync())" />
+                <PropertyColumn Property="x => x.FullName" Title="Name" />
+                <PropertyColumn Property="x => x.Email" Title="Email" />
+                <PropertyColumn Property="x => x.City" Title="City" />
+                <PropertyColumn Property="x => x.Age" Title="Age" />
+                <PropertyColumn Property="x => x.Salary" Title="Salary" Format="C0" />
+                <PropertyColumn Property="x => x.Joined" Title="Joined" Format="d" />
+            </Columns>
+            <PagerContent>
+                <MudDataGridPager T="Person" />
+            </PagerContent>
+        </MudDataGrid>
+    }
+</MudStack>
+
+@code {
+    private const string StateStorageKey = "mudblazor.datagrid-state.demo.automatic-state";
+
+    private MudDataGrid<Person>? _dataGrid;
+    private IReadOnlyList<Person> _people = [];
+    private DataGridPersistedState? _pendingStateRestore;
+    private bool _dataLoaded;
+    private bool _groupingEnabled = true;
+    private bool _stateRestored;
+    private bool _readyForAutoSave;
+    private bool _suppressAutoSave;
+    private string? _loadError;
+    private string _statusMessage = "Change the grid, then reload the page to verify automatic restore.";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _people = await PersonDataStore.EnsureInitializedAsync();
+                _pendingStateRestore = await LocalStorage.GetItemAsync<DataGridPersistedState>(StateStorageKey);
+                if (_pendingStateRestore is not null)
+                {
+                    _groupingEnabled = _pendingStateRestore.Groups.Count > 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                _loadError = $"Failed to load sample data: {ex.Message}";
+                _people = PersonDataGenerator.CreatePeople();
+            }
+            finally
+            {
+                _dataLoaded = true;
+                await InvokeAsync(StateHasChanged);
+            }
+
+            return;
+        }
+
+        if (!_dataLoaded || _stateRestored || _dataGrid is null)
+        {
+            return;
+        }
+
+        _stateRestored = true;
+        _suppressAutoSave = true;
+        try
+        {
+            if (_pendingStateRestore is not null)
+            {
+                await _dataGrid.SetStateAsync(_pendingStateRestore, ResolvePersonKey);
+                _groupingEnabled = _pendingStateRestore.Groups.Count > 0;
+                _statusMessage = "Restored state from localStorage.";
+            }
+            else
+            {
+                _statusMessage = "No saved state found. Changes will be saved automatically.";
+            }
+        }
+        finally
+        {
+            _readyForAutoSave = true;
+            _suppressAutoSave = false;
+            _pendingStateRestore = null;
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task AutoSaveStateAsync()
+    {
+        if (!_readyForAutoSave || _suppressAutoSave || _dataGrid is null)
+        {
+            return;
+        }
+
+        var state = _dataGrid.GetState(person => person.Id.ToString());
+        await LocalStorage.SetItemAsync(StateStorageKey, state);
+        _statusMessage = $"Auto-saved page {state.Page + 1}, {state.Filters.Count} filter(s), {state.Sorts.Count} sort(s), and {state.SelectedItemKeys.Count} selected row(s).";
+    }
+
+    private async Task ClearStateAsync()
+    {
+        await LocalStorage.RemoveItemAsync(StateStorageKey);
+        _suppressAutoSave = true;
+        try
+        {
+            if (_dataGrid is not null)
+            {
+                await _dataGrid.SetStateAsync(new DataGridPersistedState());
+            }
+
+            _groupingEnabled = false;
+            _statusMessage = "Cleared saved state.";
+        }
+        finally
+        {
+            _suppressAutoSave = false;
+        }
+
+        Snackbar.Add("Cleared saved DataGrid state.", Severity.Info);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task ToggleGroupingAsync()
+    {
+        _groupingEnabled = !_groupingEnabled;
+        _dataGrid?.GroupItems();
+        await AutoSaveStateAsync();
+        Snackbar.Add(_groupingEnabled ? "Grouping enabled." : "Grouping disabled.", Severity.Info);
+    }
+
+    private Person? ResolvePersonKey(string key) =>
+        Guid.TryParse(key, out var id) ? _people.FirstOrDefault(person => person.Id == id) : null;
+}

--- a/src/MudBlazor.Examples.DataGridState/Pages/Home.razor
+++ b/src/MudBlazor.Examples.DataGridState/Pages/Home.razor
@@ -1,0 +1,170 @@
+@page "/"
+@inject LocalStorageService LocalStorage
+@inject PersonDataStore PersonDataStore
+@inject ISnackbar Snackbar
+
+<MudStack Spacing="3">
+    <MudPaper Class="pa-4" Elevation="1">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.h5">DataGrid State Persistence</MudText>
+            <MudText Typo="Typo.body2">
+                This sample uses Bogus-generated data and stores both the data set and grid state in browser localStorage.
+                Change sorting, filters, paging, grouping, or selection, then reload the page to verify restore.
+            </MudText>
+            <MudStack Row="true" Spacing="2">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveStateAsync">Save To localStorage</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="RestoreStateAsync">Restore From localStorage</MudButton>
+                <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="ClearStateAsync">Clear Saved State</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="@(_groupingEnabled ? Color.Secondary : Color.Default)" OnClick="ToggleGroupingAsync">
+                    @(_groupingEnabled ? "Disable Grouping" : "Enable Grouping")
+                </MudButton>
+            </MudStack>
+            @if (!string.IsNullOrWhiteSpace(_loadError))
+            {
+                <MudAlert Severity="Severity.Error">@_loadError</MudAlert>
+            }
+        </MudStack>
+    </MudPaper>
+
+    @if (!_dataLoaded)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+    }
+    else
+    {
+        <MudDataGrid @ref="_dataGrid"
+                     T="Person"
+                     Items="@_people"
+                     Filterable="true"
+                     Groupable="@_groupingEnabled"
+                     MultiSelection="true"
+                     SortMode="SortMode.Multiple"
+                     RowsPerPage="10"
+                     Height="520px"
+                     FixedHeader="true">
+            <ToolBarContent>
+                <MudText Typo="Typo.h6">People</MudText>
+                <MudSpacer />
+                <MudText Typo="Typo.body2">@_people.Count records</MudText>
+            </ToolBarContent>
+            <Columns>
+                <SelectColumn T="Person" />
+                <PropertyColumn Property="x => x.Company" Title="Company" Groupable="true" Grouping="@_groupingEnabled" />
+                <PropertyColumn Property="x => x.FullName" Title="Name" />
+                <PropertyColumn Property="x => x.Email" Title="Email" />
+                <PropertyColumn Property="x => x.City" Title="City" />
+                <PropertyColumn Property="x => x.Age" Title="Age" />
+                <PropertyColumn Property="x => x.Salary" Title="Salary" Format="C0" />
+                <PropertyColumn Property="x => x.Joined" Title="Joined" Format="d" />
+            </Columns>
+            <PagerContent>
+                <MudDataGridPager T="Person" />
+            </PagerContent>
+        </MudDataGrid>
+    }
+</MudStack>
+
+@code {
+    private const string StateStorageKey = "mudblazor.datagrid-state.demo.state";
+
+    private MudDataGrid<Person>? _dataGrid;
+    private IReadOnlyList<Person> _people = [];
+    private DataGridPersistedState? _pendingStateRestore;
+    private bool _dataLoaded;
+    private bool _groupingEnabled = true;
+    private bool _stateRestored;
+    private string? _loadError;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _people = await PersonDataStore.EnsureInitializedAsync();
+                _pendingStateRestore = await LocalStorage.GetItemAsync<DataGridPersistedState>(StateStorageKey);
+                _groupingEnabled = _pendingStateRestore?.Groups.Count > 0;
+            }
+            catch (Exception ex)
+            {
+                _loadError = $"Failed to load sample data: {ex.Message}";
+                _people = PersonDataGenerator.CreatePeople();
+            }
+            finally
+            {
+                _dataLoaded = true;
+                await InvokeAsync(StateHasChanged);
+            }
+
+            return;
+        }
+
+        if (!_dataLoaded || _stateRestored || _dataGrid is null || _pendingStateRestore is null)
+        {
+            return;
+        }
+
+        _stateRestored = true;
+        await _dataGrid.SetStateAsync(_pendingStateRestore, ResolvePersonKey);
+        _groupingEnabled = _pendingStateRestore.Groups.Count > 0;
+        _pendingStateRestore = null;
+        Snackbar.Add("Restored DataGrid state from localStorage.", Severity.Info);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task SaveStateAsync()
+    {
+        if (_dataGrid is null)
+        {
+            return;
+        }
+
+        var state = _dataGrid.GetState(person => person.Id.ToString());
+        await LocalStorage.SetItemAsync(StateStorageKey, state);
+        Snackbar.Add("Saved DataGrid state to localStorage.", Severity.Success);
+    }
+
+    private async Task RestoreStateAsync()
+    {
+        if (_dataGrid is null)
+        {
+            return;
+        }
+
+        var savedState = await LocalStorage.GetItemAsync<DataGridPersistedState>(StateStorageKey);
+        if (savedState is null)
+        {
+            Snackbar.Add("No saved state found in localStorage.", Severity.Warning);
+            return;
+        }
+
+        await _dataGrid.SetStateAsync(savedState, ResolvePersonKey);
+        _groupingEnabled = savedState.Groups.Count > 0;
+        Snackbar.Add("Restored DataGrid state from localStorage.", Severity.Success);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task ClearStateAsync()
+    {
+        await LocalStorage.RemoveItemAsync(StateStorageKey);
+        if (_dataGrid is not null)
+        {
+            await _dataGrid.SetStateAsync(new DataGridPersistedState());
+        }
+
+        _groupingEnabled = false;
+        Snackbar.Add("Cleared saved DataGrid state.", Severity.Info);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task ToggleGroupingAsync()
+    {
+        _groupingEnabled = !_groupingEnabled;
+        _dataGrid?.GroupItems();
+        Snackbar.Add(_groupingEnabled ? "Grouping enabled." : "Grouping disabled.", Severity.Info);
+        return Task.CompletedTask;
+    }
+
+    private Person? ResolvePersonKey(string key) =>
+        Guid.TryParse(key, out var id) ? _people.FirstOrDefault(person => person.Id == id) : null;
+}

--- a/src/MudBlazor.Examples.DataGridState/Program.cs
+++ b/src/MudBlazor.Examples.DataGridState/Program.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using MudBlazor.Examples.DataGridState.Services;
+using MudBlazor.Services;
+
+namespace MudBlazor.Examples.DataGridState;
+
+public class Program
+{
+    public static Task Main(string[] args)
+    {
+        var builder = WebAssemblyHostBuilder.CreateDefault(args);
+        builder.RootComponents.Add<App>("#app");
+
+        builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+        builder.Services.AddMudServices();
+        builder.Services.AddScoped<LocalStorageService>();
+        builder.Services.AddScoped<PersonDataStore>();
+
+        return builder.Build().RunAsync();
+    }
+}

--- a/src/MudBlazor.Examples.DataGridState/Properties/launchSettings.json
+++ b/src/MudBlazor.Examples.DataGridState/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "MudBlazor.Examples.DataGridState": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/MudBlazor.Examples.DataGridState/Services/LocalStorageService.cs
+++ b/src/MudBlazor.Examples.DataGridState/Services/LocalStorageService.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace MudBlazor.Examples.DataGridState.Services;
+
+public sealed class LocalStorageService(IJSRuntime jsRuntime)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+
+    public async Task SetItemAsync<T>(string key, T value)
+    {
+        var json = JsonSerializer.Serialize(value, JsonOptions);
+        await jsRuntime.InvokeVoidAsync("localStorage.setItem", key, json);
+    }
+
+    public async Task<T?> GetItemAsync<T>(string key)
+    {
+        var json = await jsRuntime.InvokeAsync<string?>("localStorage.getItem", key);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        return JsonSerializer.Deserialize<T>(json, JsonOptions);
+    }
+
+    public async Task RemoveItemAsync(string key)
+    {
+        await jsRuntime.InvokeVoidAsync("localStorage.removeItem", key);
+    }
+}

--- a/src/MudBlazor.Examples.DataGridState/Services/PersonDataStore.cs
+++ b/src/MudBlazor.Examples.DataGridState/Services/PersonDataStore.cs
@@ -1,0 +1,46 @@
+using MudBlazor.Examples.DataGridState.Data;
+
+namespace MudBlazor.Examples.DataGridState.Services;
+
+/// <summary>
+/// Keeps the generated people data in memory for the current app session
+/// and persists it to localStorage so refreshes reuse the same records.
+/// </summary>
+public sealed class PersonDataStore(LocalStorageService localStorage)
+{
+    public const string DataStorageKey = "mudblazor.datagrid-state.demo.people";
+
+    private IReadOnlyList<Person> _people = [];
+    private bool _initialized;
+
+    public IReadOnlyList<Person> People => _people;
+
+    public bool IsInitialized => _initialized;
+
+    public async Task<IReadOnlyList<Person>> EnsureInitializedAsync()
+    {
+        if (_initialized)
+        {
+            return _people;
+        }
+
+        var people = await localStorage.GetItemAsync<List<Person>>(DataStorageKey);
+        if (people is not { Count: > 0 })
+        {
+            people = [.. PersonDataGenerator.CreatePeople()];
+            await localStorage.SetItemAsync(DataStorageKey, people);
+        }
+
+        _people = people;
+        _initialized = true;
+        return _people;
+    }
+
+    public async Task ResetAsync()
+    {
+        var people = PersonDataGenerator.CreatePeople().ToList();
+        await localStorage.SetItemAsync(DataStorageKey, people);
+        _people = people;
+        _initialized = true;
+    }
+}

--- a/src/MudBlazor.Examples.DataGridState/Services/PersonDataStore.cs
+++ b/src/MudBlazor.Examples.DataGridState/Services/PersonDataStore.cs
@@ -1,4 +1,4 @@
-using MudBlazor.Examples.DataGridState.Data;
+﻿using MudBlazor.Examples.DataGridState.Data;
 
 namespace MudBlazor.Examples.DataGridState.Services;
 

--- a/src/MudBlazor.Examples.DataGridState/_Imports.razor
+++ b/src/MudBlazor.Examples.DataGridState/_Imports.razor
@@ -1,0 +1,11 @@
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.JSInterop
+@using MudBlazor
+@using MudBlazor.Examples.DataGridState
+@using MudBlazor.Examples.DataGridState.Data
+@using MudBlazor.Examples.DataGridState.Services

--- a/src/MudBlazor.Examples.DataGridState/wwwroot/index.html
+++ b/src/MudBlazor.Examples.DataGridState/wwwroot/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MudDataGrid State Example</title>
+    <base href="/" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+</head>
+
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+</body>
+
+</html>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -7162,6 +7162,312 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.FilterDefinitions.Count.Should().Be(0, "Filter should be removable");
         }
 
+        [Test]
+        public async Task DataGridGetStateCapturesPagingSortAndFilter()
+        {
+            var items = Enumerable.Range(1, 20).Select(i => new DataGridStateTestModel(i, $"Item {i}", i * 10)).ToList();
+            var comp = Context.Render<MudDataGrid<DataGridStateTestModel>>(parameters => parameters
+                .Add(grid => grid.Items, items)
+                .Add(grid => grid.Filterable, true)
+                .Add(grid => grid.RowsPerPage, 5)
+                .Add(grid => grid.Columns, builder =>
+                {
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, string>>(0);
+                    builder.AddAttribute(1, nameof(PropertyColumn<DataGridStateTestModel, string>.Property), (Expression<Func<DataGridStateTestModel, string>>)(x => x.Name));
+                    builder.CloseComponent();
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, int>>(2);
+                    builder.AddAttribute(3, nameof(PropertyColumn<DataGridStateTestModel, int>.Property), (Expression<Func<DataGridStateTestModel, int>>)(x => x.Score));
+                    builder.CloseComponent();
+                })
+                .Add(grid => grid.PagerContent, builder =>
+                {
+                    builder.OpenComponent<MudDataGridPager<DataGridStateTestModel>>(0);
+                    builder.CloseComponent();
+                }));
+
+            var dataGrid = comp;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync(nameof(DataGridStateTestModel.Name), SortDirection.Descending, x => x.Name));
+            await comp.InvokeAsync(() => dataGrid.Instance.NavigateTo(Page.Next));
+
+            var nameColumn = dataGrid.Instance.GetColumnByPropertyName(nameof(DataGridStateTestModel.Name));
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridStateTestModel>
+            {
+                Column = nameColumn,
+                Operator = FilterOperator.String.Contains,
+                Value = "Item 1",
+                Title = "Name",
+            }));
+
+            var state = dataGrid.Instance.GetState();
+
+            state.Page.Should().Be(1);
+            state.PageSize.Should().Be(5);
+            state.Sorts.Should().ContainSingle();
+            state.Sorts[0].Column.Should().Be(nameof(DataGridStateTestModel.Name));
+            state.Sorts[0].Descending.Should().BeTrue();
+            state.Filters.Should().ContainSingle();
+            state.Filters[0].Column.Should().Be(nameof(DataGridStateTestModel.Name));
+            state.Filters[0].Operator.Should().Be(FilterOperator.String.Contains);
+            state.Filters[0].ValueJson.Should().Contain("Item 1");
+        }
+
+        [Test]
+        public async Task DataGridSetStateRestoresPagingSortAndFilter()
+        {
+            var items = Enumerable.Range(1, 20).Select(i => new DataGridStateTestModel(i, $"Item {i}", i * 10)).ToList();
+            var savedState = new DataGridPersistedState
+            {
+                Page = 2,
+                PageSize = 4,
+                Sorts =
+                [
+                    new DataGridSortState
+                    {
+                        Column = nameof(DataGridStateTestModel.Score),
+                        Descending = false,
+                        Index = 0,
+                    }
+                ],
+                Filters =
+                [
+                    new DataGridFilterState
+                    {
+                        Column = nameof(DataGridStateTestModel.Name),
+                        Operator = FilterOperator.String.StartsWith,
+                        Title = "Name",
+                        ValueJson = "\"Item 1\"",
+                        ValueType = typeof(string).AssemblyQualifiedName,
+                    }
+                ],
+            };
+
+            var comp = Context.Render<MudDataGrid<DataGridStateTestModel>>(parameters => parameters
+                .Add(grid => grid.Items, items)
+                .Add(grid => grid.Filterable, true)
+                .Add(grid => grid.Columns, builder =>
+                {
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, string>>(0);
+                    builder.AddAttribute(1, nameof(PropertyColumn<DataGridStateTestModel, string>.Property), (Expression<Func<DataGridStateTestModel, string>>)(x => x.Name));
+                    builder.CloseComponent();
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, int>>(2);
+                    builder.AddAttribute(3, nameof(PropertyColumn<DataGridStateTestModel, int>.Property), (Expression<Func<DataGridStateTestModel, int>>)(x => x.Score));
+                    builder.CloseComponent();
+                })
+                .Add(grid => grid.PagerContent, builder =>
+                {
+                    builder.OpenComponent<MudDataGridPager<DataGridStateTestModel>>(0);
+                    builder.CloseComponent();
+                }));
+
+            var dataGrid = comp;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetStateAsync(savedState));
+
+            dataGrid.Instance.CurrentPage.Should().Be(2);
+            dataGrid.Instance.RowsPerPage.Should().Be(4);
+            dataGrid.Instance.SortDefinitions.Should().ContainKey(nameof(DataGridStateTestModel.Score));
+            dataGrid.Instance.FilterDefinitions.Should().ContainSingle();
+            dataGrid.Instance.FilterDefinitions[0].Value.Should().Be("Item 1");
+            dataGrid.Instance.FilteredItems.Count().Should().BeLessThan(items.Count);
+        }
+
+        [Test]
+        public async Task DataGridSetStateRestoresGrouping()
+        {
+            var items = new List<DataGridStateTestModel>
+            {
+                new(1, "Alpha", 10),
+                new(2, "Alpha", 20),
+                new(3, "Beta", 30),
+            };
+
+            var savedState = new DataGridPersistedState
+            {
+                Groups =
+                [
+                    new DataGridGroupState
+                    {
+                        Column = nameof(DataGridStateTestModel.Name),
+                        Order = 0,
+                        Expanded = true,
+                    }
+                ],
+            };
+
+            var comp = Context.Render<MudDataGrid<DataGridStateTestModel>>(parameters => parameters
+                .Add(grid => grid.Items, items)
+                .Add(grid => grid.Groupable, true)
+                .Add(grid => grid.Columns, builder =>
+                {
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, string>>(0);
+                    builder.AddAttribute(1, nameof(PropertyColumn<DataGridStateTestModel, string>.Property), (Expression<Func<DataGridStateTestModel, string>>)(x => x.Name));
+                    builder.AddAttribute(2, nameof(PropertyColumn<DataGridStateTestModel, string>.Grouping), true);
+                    builder.CloseComponent();
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, int>>(3);
+                    builder.AddAttribute(4, nameof(PropertyColumn<DataGridStateTestModel, int>.Property), (Expression<Func<DataGridStateTestModel, int>>)(x => x.Score));
+                    builder.CloseComponent();
+                }));
+
+            var dataGrid = comp;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetStateAsync(savedState));
+
+            var nameColumn = dataGrid.Instance.GetColumnByPropertyName(nameof(DataGridStateTestModel.Name));
+            nameColumn!.GroupingState.Value.Should().BeTrue();
+            dataGrid.Instance.GetState().Groups.Should().ContainSingle(group => group.Column == nameof(DataGridStateTestModel.Name));
+        }
+
+        [Test]
+        public async Task DataGridSetStateRestoresSelection()
+        {
+            var items = new List<DataGridStateTestModel>
+            {
+                new(1, "Alpha", 10),
+                new(2, "Beta", 20),
+                new(3, "Gamma", 30),
+            };
+
+            var savedState = new DataGridPersistedState
+            {
+                SelectedItemKeys = ["2", "3"],
+            };
+
+            var comp = Context.Render<MudDataGrid<DataGridStateTestModel>>(parameters => parameters
+                .Add(grid => grid.Items, items)
+                .Add(grid => grid.MultiSelection, true)
+                .Add(grid => grid.Columns, builder =>
+                {
+                    builder.OpenComponent<SelectColumn<DataGridStateTestModel>>(0);
+                    builder.CloseComponent();
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, string>>(1);
+                    builder.AddAttribute(2, nameof(PropertyColumn<DataGridStateTestModel, string>.Property), (Expression<Func<DataGridStateTestModel, string>>)(x => x.Name));
+                    builder.CloseComponent();
+                }));
+
+            var dataGrid = comp;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetStateAsync(
+                savedState,
+                key => items.FirstOrDefault(item => item.Id.ToString() == key)));
+
+            dataGrid.Instance.Selection.Select(item => item.Id).Should().BeEquivalentTo([2, 3]);
+        }
+
+        [Test]
+        public async Task DataGridGetStateAndSetStateRoundTripSelection()
+        {
+            var items = new List<DataGridStateTestModel>
+            {
+                new(1, "Alpha", 10),
+                new(2, "Beta", 20),
+            };
+
+            var comp = Context.Render<MudDataGrid<DataGridStateTestModel>>(parameters => parameters
+                .Add(grid => grid.Items, items)
+                .Add(grid => grid.MultiSelection, true)
+                .Add(grid => grid.Columns, builder =>
+                {
+                    builder.OpenComponent<SelectColumn<DataGridStateTestModel>>(0);
+                    builder.CloseComponent();
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, string>>(1);
+                    builder.AddAttribute(2, nameof(PropertyColumn<DataGridStateTestModel, string>.Property), (Expression<Func<DataGridStateTestModel, string>>)(x => x.Name));
+                    builder.CloseComponent();
+                }));
+
+            var dataGrid = comp;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, items[1]));
+            var savedState = dataGrid.Instance.GetState(item => item.Id.ToString());
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetStateAsync(
+                new DataGridPersistedState(),
+                key => items.FirstOrDefault(item => item.Id.ToString() == key)));
+
+            dataGrid.Instance.Selection.Should().BeEmpty();
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetStateAsync(
+                savedState,
+                key => items.FirstOrDefault(item => item.Id.ToString() == key)));
+
+            dataGrid.Instance.Selection.Single().Id.Should().Be(2);
+        }
+
+        [Test]
+        public async Task DataGridSetStateReloadsServerDataWithRestoredState()
+        {
+            var items = Enumerable.Range(1, 20).Select(i => new DataGridStateTestModel(i, $"Item {i}", i * 10)).ToList();
+            var capturedStates = new List<GridState<DataGridStateTestModel>>();
+            Task<GridData<DataGridStateTestModel>> ServerData(GridState<DataGridStateTestModel> state, CancellationToken _)
+            {
+                capturedStates.Add(state);
+                return Task.FromResult(new GridData<DataGridStateTestModel>
+                {
+                    Items = items.Skip(state.Page * state.PageSize).Take(state.PageSize),
+                    TotalItems = items.Count,
+                });
+            }
+
+            var savedState = new DataGridPersistedState
+            {
+                Page = 1,
+                PageSize = 6,
+                Sorts =
+                [
+                    new DataGridSortState
+                    {
+                        Column = nameof(DataGridStateTestModel.Score),
+                        Descending = true,
+                        Index = 0,
+                    }
+                ],
+                Filters =
+                [
+                    new DataGridFilterState
+                    {
+                        Column = nameof(DataGridStateTestModel.Name),
+                        Operator = FilterOperator.String.Contains,
+                        Title = "Name",
+                        ValueJson = "\"Item\"",
+                        ValueType = typeof(string).AssemblyQualifiedName,
+                    }
+                ],
+            };
+
+            var comp = Context.Render<MudDataGrid<DataGridStateTestModel>>(parameters => parameters
+                .Add(grid => grid.ServerData, ServerData)
+                .Add(grid => grid.Filterable, true)
+                .Add(grid => grid.Columns, builder =>
+                {
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, string>>(0);
+                    builder.AddAttribute(1, nameof(PropertyColumn<DataGridStateTestModel, string>.Property), (Expression<Func<DataGridStateTestModel, string>>)(x => x.Name));
+                    builder.CloseComponent();
+                    builder.OpenComponent<PropertyColumn<DataGridStateTestModel, int>>(2);
+                    builder.AddAttribute(3, nameof(PropertyColumn<DataGridStateTestModel, int>.Property), (Expression<Func<DataGridStateTestModel, int>>)(x => x.Score));
+                    builder.CloseComponent();
+                })
+                .Add(grid => grid.PagerContent, builder =>
+                {
+                    builder.OpenComponent<MudDataGridPager<DataGridStateTestModel>>(0);
+                    builder.CloseComponent();
+                }));
+
+            var dataGrid = comp;
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetStateAsync(savedState));
+
+            capturedStates.Should().NotBeEmpty();
+            var restoredState = capturedStates.Last();
+            restoredState.Page.Should().Be(1);
+            restoredState.PageSize.Should().Be(6);
+            restoredState.SortDefinitions.Should().ContainSingle();
+            restoredState.SortDefinitions.Single().SortBy.Should().Be(nameof(DataGridStateTestModel.Score));
+            restoredState.FilterDefinitions.Should().ContainSingle();
+            restoredState.FilterDefinitions.Single().Value.Should().Be("Item");
+        }
+
+        private sealed record DataGridStateTestModel(int Id, string Name, int Score);
+
         #endregion
     }
 }

--- a/src/MudBlazor.slnx
+++ b/src/MudBlazor.slnx
@@ -10,6 +10,7 @@
     <Project Path="MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj" />
     <Project Path="MudBlazor.Docs/MudBlazor.Docs.csproj" />
     <Project Path="MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj" />
+    <Project Path="MudBlazor.Examples.DataGridState/MudBlazor.Examples.DataGridState.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -378,6 +378,16 @@ namespace MudBlazor
         /// </summary>
         public string? Identifier { get; set; }
 
+        /// <summary>
+        /// A stable identifier used when saving and restoring grid state.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="PropertyName"/>. Set this on <see cref="TemplateColumn{T}"/> columns so persisted state can be restored across page reloads.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Data)]
+        public string? StateIdentifier { get; set; }
+
         private CultureInfo? _culture;
 
         /// <summary>
@@ -585,6 +595,9 @@ namespace MudBlazor
 
         private Func<T, object?>? _sortBy;
         internal Func<T, object?>? groupBy;
+
+        internal string? GetStateIdentifier() =>
+            !string.IsNullOrWhiteSpace(StateIdentifier) ? StateIdentifier : PropertyName;
 
         // These are set in OnInitialized() so they can't be null
         internal HeaderContext<T> headerContext = null!;

--- a/src/MudBlazor/Components/DataGrid/DataGridPersistedState.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridPersistedState.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+/// <summary>
+/// Represents a serializable snapshot of a <see cref="MudDataGrid{T}"/> state.
+/// </summary>
+/// <remarks>
+/// This type is intended for persistence scenarios such as browser storage, URLs, or databases.
+/// Restore selection by providing item key selectors and resolvers to <see cref="MudDataGrid{T}.GetState(Func{T, string}?)"/>
+/// and <see cref="MudDataGrid{T}.SetStateAsync(DataGridPersistedState, Func{string, T}?)"/>.
+/// </remarks>
+public sealed class DataGridPersistedState
+{
+    /// <summary>
+    /// The zero-based page index.
+    /// </summary>
+    public int Page { get; set; }
+
+    /// <summary>
+    /// The number of rows displayed on each page.
+    /// </summary>
+    public int PageSize { get; set; } = 10;
+
+    /// <summary>
+    /// The active sort definitions.
+    /// </summary>
+    public List<DataGridSortState> Sorts { get; set; } = [];
+
+    /// <summary>
+    /// The active filter definitions.
+    /// </summary>
+    public List<DataGridFilterState> Filters { get; set; } = [];
+
+    /// <summary>
+    /// The active grouping definitions.
+    /// </summary>
+    public List<DataGridGroupState> Groups { get; set; } = [];
+
+    /// <summary>
+    /// The selected item key when <see cref="MudDataGrid{T}.MultiSelection"/> is <c>false</c>.
+    /// </summary>
+    public string? SelectedItemKey { get; set; }
+
+    /// <summary>
+    /// The selected item keys when <see cref="MudDataGrid{T}.MultiSelection"/> is <c>true</c>.
+    /// </summary>
+    public List<string> SelectedItemKeys { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a serializable sort definition for a <see cref="MudDataGrid{T}"/>.
+/// </summary>
+public sealed class DataGridSortState
+{
+    /// <summary>
+    /// The column identifier used to resolve the sort column during restore.
+    /// </summary>
+    public string Column { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When <c>true</c>, sorts in descending order.
+    /// </summary>
+    public bool Descending { get; set; }
+
+    /// <summary>
+    /// The order of this sort relative to other sort definitions.
+    /// </summary>
+    public int Index { get; set; }
+}
+
+/// <summary>
+/// Represents a serializable filter definition for a <see cref="MudDataGrid{T}"/>.
+/// </summary>
+public sealed class DataGridFilterState
+{
+    /// <summary>
+    /// The column identifier used to resolve the filter column during restore.
+    /// </summary>
+    public string Column { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The display title of the filter.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The filter operator.
+    /// </summary>
+    public string? Operator { get; set; }
+
+    /// <summary>
+    /// The JSON-serialized filter value.
+    /// </summary>
+    public string? ValueJson { get; set; }
+
+    /// <summary>
+    /// The assembly-qualified type name of <see cref="ValueJson"/>.
+    /// </summary>
+    public string? ValueType { get; set; }
+}
+
+/// <summary>
+/// Represents a serializable grouping definition for a <see cref="MudDataGrid{T}"/>.
+/// </summary>
+public sealed class DataGridGroupState
+{
+    /// <summary>
+    /// The column identifier used to resolve the grouped column during restore.
+    /// </summary>
+    public string Column { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The grouping order relative to other grouped columns.
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Whether groups created from this column are expanded.
+    /// </summary>
+    public bool Expanded { get; set; }
+}

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.State.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.State.cs
@@ -1,0 +1,281 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace MudBlazor;
+
+public partial class MudDataGrid<T>
+{
+    private static readonly JsonSerializerOptions s_filterValueJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <summary>
+    /// Captures the current grid state as a serializable snapshot.
+    /// </summary>
+    /// <param name="itemKeySelector">
+    /// When provided, maps selected items to stable keys for persistence. Required to capture selection state.
+    /// </param>
+    /// <returns>The current grid state.</returns>
+    public DataGridPersistedState GetState(Func<T, string>? itemKeySelector = null)
+    {
+        var state = new DataGridPersistedState
+        {
+            Page = CurrentPage,
+            PageSize = RowsPerPage,
+            Sorts = SortDefinitions.Values
+                .OrderBy(sortDefinition => sortDefinition.Index)
+                .Select(sortDefinition => new DataGridSortState
+                {
+                    Column = GetColumnIdentifierForSort(sortDefinition.SortBy),
+                    Descending = sortDefinition.Descending,
+                    Index = sortDefinition.Index,
+                })
+                .ToList(),
+            Filters = FilterDefinitions
+                .Select(CreateFilterState)
+                .Where(filterState => !string.IsNullOrWhiteSpace(filterState.Column))
+                .ToList(),
+            Groups = RenderedColumns
+                .Where(column => column.GroupingState.Value)
+                .OrderBy(column => column._groupByOrderState.Value)
+                .Select(column => new DataGridGroupState
+                {
+                    Column = column.GetStateIdentifier() ?? string.Empty,
+                    Order = column._groupByOrderState.Value,
+                    Expanded = column._groupExpandedState.Value,
+                })
+                .ToList(),
+        };
+
+        if (itemKeySelector is null)
+        {
+            return state;
+        }
+
+        if (MultiSelection)
+        {
+            state.SelectedItemKeys = Selection
+                .Select(itemKeySelector)
+                .Where(key => !string.IsNullOrWhiteSpace(key))
+                .ToList();
+        }
+        else if (_selectedItemState.Value is not null)
+        {
+            state.SelectedItemKey = itemKeySelector(_selectedItemState.Value);
+        }
+
+        return state;
+    }
+
+    /// <summary>
+    /// Restores grid state from a serializable snapshot.
+    /// </summary>
+    /// <param name="state">The state to restore.</param>
+    /// <param name="itemResolver">
+    /// When provided, resolves persisted item keys back to data items for selection restore.
+    /// </param>
+    /// <remarks>
+    /// Call this after the grid has rendered and columns are registered.
+    /// Unknown columns in the saved state are skipped.
+    /// </remarks>
+    public async Task SetStateAsync(DataGridPersistedState state, Func<string, T?>? itemResolver = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var removedSortDefinitions = new HashSet<string>(SortDefinitions.Keys);
+
+        SortDefinitions.Clear();
+        FilterDefinitions.Clear();
+
+        foreach (var column in RenderedColumns)
+        {
+            await column.RemoveGrouping();
+        }
+
+        foreach (var groupState in state.Groups.OrderBy(group => group.Order))
+        {
+            var column = GetColumnByStateIdentifier(groupState.Column);
+            if (column is null)
+            {
+                continue;
+            }
+
+            await column.SetGroupingAsync(true);
+            await column._groupByOrderState.SetValueAsync(groupState.Order);
+            await column._groupExpandedState.SetValueAsync(groupState.Expanded);
+        }
+
+        foreach (var sortState in state.Sorts.OrderBy(sort => sort.Index))
+        {
+            var column = GetColumnByStateIdentifier(sortState.Column);
+            if (column?.PropertyName is null)
+            {
+                continue;
+            }
+
+            SortDefinitions[column.PropertyName] = new SortDefinition<T>(
+                column.PropertyName,
+                sortState.Descending,
+                sortState.Index,
+                column.GetLocalSortFunc(),
+                column.Comparer);
+
+            removedSortDefinitions.Remove(column.PropertyName);
+        }
+
+        foreach (var filterState in state.Filters)
+        {
+            var column = GetColumnByStateIdentifier(filterState.Column);
+            if (column is null)
+            {
+                continue;
+            }
+
+            var filterDefinition = CreateFilterDefinitionInstance();
+            filterDefinition.Column = column;
+            filterDefinition.Title = filterState.Title ?? column.Title;
+            filterDefinition.Operator = filterState.Operator;
+            filterDefinition.Value = DeserializeFilterValue(filterState.ValueJson, filterState.ValueType);
+            FilterDefinitions.Add(filterDefinition);
+        }
+
+        var pageSize = state.PageSize > 0 ? state.PageSize : 10;
+        if (_rowsPerPage != pageSize)
+        {
+            _rowsPerPage = pageSize;
+            await RowsPerPageChanged.InvokeAsync(pageSize);
+        }
+
+        var page = Math.Max(0, state.Page);
+        var currentPageChanged = _currentPage != page;
+        _currentPage = page;
+        if (currentPageChanged)
+        {
+            await CurrentPageChanged.InvokeAsync(_currentPage);
+        }
+
+        await ApplySelectionStateAsync(state, itemResolver);
+
+        SortChangedEvent?.Invoke(SortDefinitions, removedSortDefinitions);
+        if (_isFirstRendered)
+        {
+            await SortChanged.InvokeAsync(new Dictionary<string, SortDefinition<T>>(SortDefinitions));
+        }
+
+        await InvokeServerLoadFunc();
+        GroupItems();
+        await NotifyFilterChangedAsync();
+
+        if (HasServerData && CurrentPage * RowsPerPage > _serverData.TotalItems)
+        {
+            CurrentPage = 0;
+        }
+
+        PagerStateHasChangedEvent?.Invoke();
+        StateHasChanged();
+    }
+
+    private async Task ApplySelectionStateAsync(DataGridPersistedState state, Func<string, T?>? itemResolver)
+    {
+        if (itemResolver is null)
+        {
+            return;
+        }
+
+        if (MultiSelection)
+        {
+            var selectedItems = state.SelectedItemKeys
+                .Select(itemResolver)
+                .Where(item => item is not null)
+                .Cast<T>()
+                .ToHashSet(Comparer);
+
+            Selection.Clear();
+            Selection.UnionWith(selectedItems);
+            await _selectedItemsState.SetValueAsync(new HashSet<T>(selectedItems, Comparer));
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(state.SelectedItemKey))
+        {
+            Selection.Clear();
+            await _selectedItemState.SetValueAsync(default);
+            return;
+        }
+
+        var selectedItem = itemResolver(state.SelectedItemKey);
+        Selection.Clear();
+        if (selectedItem is not null)
+        {
+            Selection.Add(selectedItem);
+        }
+
+        await _selectedItemState.SetValueAsync(selectedItem);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "Filter values are supplied by the application and serialized for optional persistence.")]
+    private DataGridFilterState CreateFilterState(IFilterDefinition<T> filterDefinition)
+    {
+        var columnIdentifier = filterDefinition.Column?.GetStateIdentifier();
+        var value = filterDefinition.Value;
+        return new DataGridFilterState
+        {
+            Column = columnIdentifier ?? string.Empty,
+            Title = filterDefinition.Title,
+            Operator = filterDefinition.Operator,
+            ValueJson = value is null ? null : JsonSerializer.Serialize(value, value.GetType(), s_filterValueJsonOptions),
+            ValueType = value?.GetType().AssemblyQualifiedName,
+        };
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification = "Filter values are supplied by the application and deserialized during optional state restore.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2057:UnrecognizedValuePassedToParameter", Justification = "The persisted type name is supplied by the application during optional state restore.")]
+    private static object? DeserializeFilterValue(string? valueJson, string? valueType)
+    {
+        if (string.IsNullOrEmpty(valueJson))
+        {
+            return null;
+        }
+
+        var type = ResolveValueType(valueType) ?? typeof(string);
+        return JsonSerializer.Deserialize(valueJson, type, s_filterValueJsonOptions);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057:UnrecognizedValuePassedToParameter", Justification = "The persisted type name is supplied by the application during optional state restore.")]
+    private static Type? ResolveValueType(string? valueType)
+    {
+        if (string.IsNullOrWhiteSpace(valueType))
+        {
+            return null;
+        }
+
+        return Type.GetType(valueType, throwOnError: false);
+    }
+
+    private string GetColumnIdentifierForSort(string sortBy)
+    {
+        var column = RenderedColumns.FirstOrDefault(renderedColumn => renderedColumn.PropertyName == sortBy);
+        return column?.GetStateIdentifier() ?? sortBy;
+    }
+
+    /// <summary>
+    /// Gets the column with the specified state identifier.
+    /// </summary>
+    /// <param name="columnIdentifier">The column identifier or property name.</param>
+    /// <returns>The matching column, if found.</returns>
+    public Column<T>? GetColumnByStateIdentifier(string? columnIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(columnIdentifier))
+        {
+            return null;
+        }
+
+        return RenderedColumns.FirstOrDefault(column =>
+            string.Equals(column.GetStateIdentifier(), columnIdentifier, StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds serializable `MudDataGrid` state APIs for saving and restoring paging, sorting, filters, grouping, and selection.
- Adds stable column state identifiers so persisted state can be restored across reloads.
- Adds unit tests, docs, and a standalone DataGrid state persistence example with manual and automatic localStorage restore flows.
- 
## Motivation
Applications often need to preserve a user's `MudDataGrid` configuration across page reloads, navigation, or sessions. This adds a first-class snapshot API so apps can persist grid state to localStorage, URLs, or server-side storage without relying on internal grid details.

## Test plan
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~DataGrid"`
- `dotnet build src/MudBlazor.Docs/MudBlazor.Docs.csproj --no-restore /p:SkipBunCompile=true`
- `dotnet build src/MudBlazor.Examples.DataGridState/MudBlazor.Examples.DataGridState.csproj --no-restore`