### PR TITLE
Docs: Add MudKeyboard to community extensions list

### DIFF
--- a/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
+++ b/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
@@ -103,5 +103,13 @@
     "Link": "https://github.com/mcbodge/MudMCP",
     "GitHubUserPath": "mcbodge",
     "GitHubRepoPath": "MudMCP"
-  }
+  },
+  {
+  "Category": "Components",
+  "Name": "MudKeyboard",
+  "Description": "A pure Blazor on-screen virtual keyboard for MudBlazor applications. Includes full QWERTY, numpad, and a pence-first pricepad. Automatic dark and light mode via MudBlazor CSS variables. AOT and trim-friendly with no JavaScript dependency.",
+  "Link": "https://mudkeyboard.pages.dev",
+  "GitHubUserPath": "sardar97",
+  "GitHubRepoPath": "mudkeyboard"
+}
 ]

--- a/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
+++ b/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
@@ -105,11 +105,11 @@
     "GitHubRepoPath": "MudMCP"
   },
   {
-  "Category": "Components",
-  "Name": "MudKeyboard",
-  "Description": "A pure Blazor on-screen virtual keyboard for MudBlazor applications. Includes full QWERTY, numpad, and a pence-first pricepad. Automatic dark and light mode via MudBlazor CSS variables. AOT and trim-friendly with no JavaScript dependency.",
-  "Link": "https://mudkeyboard.pages.dev",
-  "GitHubUserPath": "sardar97",
-  "GitHubRepoPath": "mudkeyboard"
-}
+    "Category": "Components",
+    "Name": "MudKeyboard",
+    "Description": "A pure Blazor on-screen virtual keyboard for MudBlazor applications. Includes full QWERTY, numpad, and a pence-first pricepad. Automatic dark and light mode via MudBlazor CSS variables. AOT and trim-friendly with no JavaScript dependency.",
+    "Link": "https://mudkeyboard.pages.dev",
+    "GitHubUserPath": "sardar97",
+    "GitHubRepoPath": "mudkeyboard"
+  }
 ]


### PR DESCRIPTION
Add MudKeyboard to the community extensions list.

MudKeyboard is a pure Blazor on-screen virtual keyboard for MudBlazor applications. 
It includes a full QWERTY keyboard, numpad, and a pence-first pricepad. Theming is 
automatic via MudBlazor CSS variables with no additional configuration required. 
The library is AOT and trim-friendly and has no JavaScript dependency.

- Docs: https://mudkeyboard.pages.dev
- NuGet: https://www.nuget.org/packages/MudKeyboard
- GitHub: https://github.com/sardar97/mudkeyboard