### PR TITLE
DateMask: Reset stale month/year state when inserting text

### DIFF
--- a/src/MudBlazor.UnitTests/Utilities/Mask/DateMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/DateMaskTests.cs
@@ -326,6 +326,38 @@ public class DateMaskTests
     }
 
     [Test]
+    public void DateMask_SetText_Day31AfterShorterMonth_Issue10772()
+    {
+        var mask = new DateMask("dd.MM.yyyy");
+        mask.SetText("01.04.2025");
+        mask.Text.Should().Be("01.04.2025");
+        // replacing the text must not clamp the day to the previous text's month (April = 30 days)
+        mask.SetText("31.03.2025");
+        mask.Text.Should().Be("31.03.2025");
+    }
+
+    [Test]
+    public void DateMask_SetText_Day31AfterFebruary_Issue10772()
+    {
+        var mask = new DateMask("dd-MM-yyyy");
+        mask.SetText("01-02-2025");
+        mask.Text.Should().Be("01-02-2025");
+        // the leading 3 must not be padded to 03 based on the previous text's month (February)
+        mask.SetText("31-01-2025");
+        mask.Text.Should().Be("31-01-2025");
+    }
+
+    [Test]
+    public void DateMask_Insert_AfterSelectAll_DoesNotUseStaleMonth()
+    {
+        var mask = new DateMask("dd.MM.yyyy");
+        mask.SetText("01.02.2025");
+        mask.Selection = (0, 10);
+        mask.Insert("3");
+        mask.ToString().Should().Be("3|");
+    }
+
+    [Test]
     public void DateMask_GetCleanText()
     {
         // Arrange

--- a/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
@@ -49,6 +49,18 @@ public partial class DateMask : PatternMask
     }
 
     /// <inheritdoc />
+    public override void Insert(string? input)
+    {
+        // _year and _month may still hold values from a previous text, for instance after SetText
+        // replaced the text entirely. Reset them so day validation only uses what is re-extracted
+        // from the current text during alignment, otherwise a valid day like 31 could be clamped
+        // or padded based on the previous month (#10772).
+        _year = 0;
+        _month = 0;
+        base.Insert(input);
+    }
+
+    /// <inheritdoc />
     protected override void ModifyPartiallyAlignedMask(string mask, string text, int maskOffset, ref int textIndex, ref int maskIndex, ref string alignedText)
     {
         if (alignedText.IsEmpty())


### PR DESCRIPTION
When the text of a DateMask was replaced (SetText -> Clear + Insert), the internal _month and _year fields still held values extracted from the previous text. The day digits of the new text were then validated against the old month:

- selecting the 31st after a 30-day month clamped the day to 30
- selecting Jan 31st after a February date padded the leading 3 to 03, shifting all following digits and producing garbage like 03-10-1202

Reset the fields at the start of Insert. Insert always re-aligns the text before the caret, which re-extracts month and year from the current text, so interactive typing keeps working as before.

Fixes #10772