### PR TITLE
MudButtonGroup: Fix tooltip wrapped icon button alignment

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonGroupTooltipsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonGroupTooltipsTest.razor
@@ -7,6 +7,14 @@
 		</MudButtonGroup>
 	</div>
 
+	<div class="d-flex mb-3">
+		<MudButtonGroup Color="Color.Dark" Variant="Variant.Filled">
+			<MudTooltip Text="Open 1"><MudIconButton Icon="@Icons.Material.Filled.Edit" aria-label="Edit" /></MudTooltip>
+			<MudTooltip Text="Open 2"><MudButton>Save</MudButton></MudTooltip>
+			<MudTooltip Text="Open 3"><MudIconButton Icon="@Icons.Material.Filled.Delete" aria-label="Delete" /></MudTooltip>
+		</MudButtonGroup>
+	</div>
+
 	<div class="d-flex mr-3">
 		<MudButtonGroup Color="Color.Dark" Variant="Variant.Filled" Vertical="true" Style="margin-right: 4px">
 			<MudTooltip Text="Open 1"><MudButton>1</MudButton></MudTooltip>

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -4,6 +4,10 @@
   border-radius: var(--mud-default-borderradius);
   display: inline-flex;
 
+  > .mud-tooltip-root {
+    display: flex;
+  }
+
   .mud-button-root {
     border-radius: var(--mud-default-borderradius);
   }


### PR DESCRIPTION
## Description

Fixes tooltip-wrapped mixed `MudIconButton` and `MudButton` content inside `MudButtonGroup`.

The tooltip wrapper was rendered as a direct child of the button group, which could prevent wrapped icon buttons from stretching consistently with regular buttons. Making direct tooltip wrappers flex items inside the button group keeps the button borders aligned.

Fixes #7003

## How Has This Been Tested?

- `dotnet build src\MudBlazor\MudBlazor.csproj --no-restore --nologo`
- `dotnet build src\MudBlazor.UnitTests\MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true --nologo`
- `dotnet run --project src\MudBlazor.UnitTests\MudBlazor.UnitTests.csproj --no-build --no-restore -- --filter "FullyQualifiedName~ButtonGroupTests" --output Normal --no-ansi --hangdump --hangdump-timeout 30s`
- Verified visually in `MudBlazor.UnitTests.Viewer` with mixed tooltip-wrapped icon and text buttons.