### PR TITLE
MudSelect: Set display to block to fix height disparity

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MudSelectDifferentHeightTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MudSelectDifferentHeightTest.razor
@@ -1,19 +1,19 @@
 ﻿<MudGrid>
     <MudItem xs="6">
         <MudPaper>
-            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+            <MudSelect T="string" Label="Total Height: 48px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
                 <MudSelectItem T="string" Value="@("TestText")"/>
             </MudSelect>
-            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+            <MudSelect T="string" Label="Total Height: 48px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
                 <MudSelectItem T="string" Value="@("TestText")"/>
             </MudSelect>
-            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+            <MudSelect T="string" Label="Total Height: 48px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
                 <MudSelectItem T="string" Value="@("TestText")"/>
             </MudSelect>
-            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+            <MudSelect T="string" Label="Total Height: 48px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
                 <MudSelectItem T="string" Value="@("TestText")"/>
             </MudSelect>
-            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+            <MudSelect T="string" Label="Total Height: 48px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
                 <MudSelectItem T="string" Value="@("TestText")"/>
             </MudSelect>
         </MudPaper>        

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MudSelectDifferentHeightTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/MudSelectDifferentHeightTest.razor
@@ -1,0 +1,34 @@
+﻿<MudGrid>
+    <MudItem xs="6">
+        <MudPaper>
+            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+                <MudSelectItem T="string" Value="@("TestText")"/>
+            </MudSelect>
+            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+                <MudSelectItem T="string" Value="@("TestText")"/>
+            </MudSelect>
+            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+                <MudSelectItem T="string" Value="@("TestText")"/>
+            </MudSelect>
+            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+                <MudSelectItem T="string" Value="@("TestText")"/>
+            </MudSelect>
+            <MudSelect T="string" Label="Total Height: 56px" Strict="true" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2">
+                <MudSelectItem T="string" Value="@("TestText")"/>
+            </MudSelect>
+        </MudPaper>        
+    </MudItem>
+    <MudItem xs="6">
+        <MudPaper>
+            <MudTextField T="string" Value="@("TestText")" Label="Taotal Height: 48px" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2"/>
+            <MudTextField T="string" Value="@("TestText")" Label="Taotal Height: 48px" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2"/>
+            <MudTextField T="string" Value="@("TestText")" Label="Taotal Height: 48px" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2"/>
+            <MudTextField T="string" Value="@("TestText")" Label="Taotal Height: 48px" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2"/>
+            <MudTextField T="string" Value="@("TestText")" Label="Taotal Height: 48px" Variant="Variant.Outlined" Margin="Margin.Dense" Class="my-2"/>
+        </MudPaper>    
+    </MudItem>   
+</MudGrid>
+
+@code {
+    public static string __description__ = "Testing MudSelect height";
+}

--- a/src/MudBlazor/Styles/components/_select.scss
+++ b/src/MudBlazor/Styles/components/_select.scss
@@ -31,6 +31,7 @@
     & .mud-input-adorned-end input {
       padding-right: 4.5rem !important;
     }
+
     // hide only when the wrapper does NOT contain mud-input-adornment-start
     // AND DOES contain .progress-indicator-circular somewhere inside
     &:not(:has(.mud-input-adornment-start)):has(.progress-indicator-circular) .mud-select-input .mud-icon-button {

--- a/src/MudBlazor/Styles/components/_select.scss
+++ b/src/MudBlazor/Styles/components/_select.scss
@@ -1,5 +1,5 @@
 .mud-select {
-  display: flex;
+  display: block;
   flex-grow: 1;
   position: relative;
 
@@ -31,7 +31,6 @@
     & .mud-input-adorned-end input {
       padding-right: 4.5rem !important;
     }
-
     // hide only when the wrapper does NOT contain mud-input-adornment-start
     // AND DOES contain .progress-indicator-circular somewhere inside
     &:not(:has(.mud-input-adornment-start)):has(.progress-indicator-circular) .mud-select-input .mud-icon-button {


### PR DESCRIPTION
# Description
Changed `.mud-select` display to block. Added `MudSelectDifferentHeightTest.razor` to compare select and text field heights.

Fixes #1505 

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

# Screenshots
Previous view:
<img width="632" height="294" alt="image" src="https://github.com/user-attachments/assets/0a0e6c67-fc82-4f08-ab25-074b6d212c5c" />

Current view:
<img width="995" height="285" alt="image" src="https://github.com/user-attachments/assets/20fffa79-a46a-48d6-b9a4-726ec6e31f03" />

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests
