### PR TITLE
MudInput: Fix FullWidth not applied

### DIFF
--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -55,4 +55,21 @@ public class InputTests : BunitTest
         inputs[0].Attributes.GetNamedItem("aria-label")?.Value.Should().Be(startAriaLabel);
         inputs[1].Attributes.GetNamedItem("aria-label")?.Value.Should().Be(endAriaLabel);
     }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void FullWidthShouldSetClass(bool fullWidth)
+    {
+        var comp = Context.Render<MudInput<string>>(parameters => parameters
+            .Add(p => p.FullWidth, fullWidth));
+
+        if (fullWidth)
+        {
+            comp.Find("div.mud-input").ClassList.Should().Contain("mud-input-full-width");
+        }
+        else
+        {
+            comp.Find("div.mud-input").ClassList.Should().NotContain("mud-input-full-width");
+        }
+    }
 }

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -35,6 +35,7 @@ namespace MudBlazor
                               !string.IsNullOrWhiteSpace(Placeholder) ||
                               ShrinkLabel))
                 .AddClass($"mud-input-sizing-{Sizing.ToStringFast(true)}")
+                .AddClass("mud-input-full-width", FullWidth)
                 .Build();
 
         protected string InputClassname => MudInputCssHelper.GetInputClassname(this);


### PR DESCRIPTION
Closes #6341

Hello, 
MudInput was not filling the parent container because the outer div that the component renders did not have a width style applied. By adding the "mud-input-full-width" class to the div it is now expanding to fill the avaliable space correctly.

https://github.com/user-attachments/assets/2ae184a1-9eb7-4633-8e16-06e7a2df1fc1

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
