### PR TITLE
Tests: Make dispatcher tests deterministic and remove obsolete Popover test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,11 +272,11 @@ private Task ToggleAsync()
 - Run the narrowest relevant test filter first.
 - Test logic rather than full HTML snapshots.
 - Prefer a fail-first workflow: add or update the test to fail for the target behavior before implementing the fix.
-- Keep tests isolated so they can run in parallel.
+- Keep tests isolated so they can run in parallel. The suite runs fixtures in parallel (`[assembly: Parallelizable(ParallelScope.Fixtures)]`) with a fresh fixture instance per test (`InstancePerTestCase`). Do not switch the assembly to `ParallelScope.All`: bUnit's renderer requires the test code and render code to share a thread (memory-coherence locking, see bUnit#124), so parallelizing tests *within* a fixture is unsafe. Get throughput from independent fixtures, not from intra-fixture parallelism.
 - Async tests and async helpers must return `Task`, not `async void`.
 - Do not add mutable static state in tests or viewer test components.
 - If a test modifies shared or static state, restore it in `[TearDown]` and keep `[NonParallelizable]` until the shared-state dependency is removed.
-- Use `[NonParallelizable]` only when isolation is not feasible, and document the shared resource it protects.
+- Use `[NonParallelizable]` only when isolation is not feasible, and document the shared resource it protects. Before removing an existing `[NonParallelizable]`, prove the fixture is parallel-safe by running the suite repeatedly under heavy parallel load — bUnit renderer timing under fake time is a common hidden dependency that only surfaces under concurrency.
 - Prefer fixed test data. Use random data only when randomness is the behavior under test or when the random source is seeded per test.
 - Prefer passing explicit culture into APIs or components. If a test must mutate culture, restore it and keep the test nonparallel until the mutation is removed.
 - Tests must not add fixed sleeps, sync-over-async waits, polling waits, local wall-clock hang guards, or fire-and-forget async behavior. Disallowed patterns include `Task.Delay` as a sleep, `Thread.Sleep`, blocking `Task`/`ValueTask` `.Wait()` or `.Result`, `GetAwaiter().GetResult()`, `WaitAsync(TimeSpan)`, `Task.WhenAny(..., Task.Delay(...))`, and `CatchAndLog` to drive assertions. Domain properties named `Result` are allowed. Use fake time, direct awaits, `TaskCompletionSource` gates, bUnit renderer waits, and framework-level cancellation instead.

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -608,48 +608,6 @@ public class PopoverServiceTests
     }
 
     [Test]
-    [Ignore(reason:
-        $"Not used anymore and replace by {nameof(DisposeAsync_ShouldClearActivePopovers)}," +
-        $"because the {nameof(PopoverService.DisposeAsync)} doesn't trigger a guaranteed {nameof(IBatchTimerHandler<MudPopoverHolder>.OnBatchTimerElapsedAsync)} to disconnect popover," +
-        $"since the {nameof(PopoverJsInterop.DisposeAsync)} does it.")]
-    public async Task DisposeAsync_ShouldClearActivePopoversAndFireOnBatchTimerElapsedAsync()
-    {
-        // Arrange
-        var jsRuntimeMock = Mock.Of<IJSRuntime>();
-        var popoverTimerMock = new Mock<PopoverServiceMock.IPopoverTimerMock>();
-        var signalEvent = new ManualResetEventSlim(false);
-        var service = CreateMockService(jsRuntimeMock, popoverTimerMock.Object);
-        var observer = new PopoverObserverMock();
-        service.Subscribe(observer);
-
-        popoverTimerMock
-            .Setup(h => h.OnBatchTimerElapsedAfterAsync(
-                It.IsAny<IReadOnlyCollection<MudPopoverHolder>>(),
-                It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
-            .Callback(signalEvent.Set);
-
-        await service.CreatePopoverAsync(new PopoverMock());
-        await service.CreatePopoverAsync(new PopoverMock());
-
-        // Act
-        await service.DisposeAsync();
-        // Wait for the event to be signaled, consider test failed if we didn't receive signal in period + 2 minutes
-        var signalEventWaitTime = service.PopoverOptions.QueueDelay.Add(TimeSpan.FromMinutes(2));
-        var eventSignaled = signalEvent.Wait(signalEventWaitTime);
-
-        // Assert
-        eventSignaled.Should().BeTrue();
-        service.ActivePopovers.Should().BeEmpty();
-        popoverTimerMock.Verify(
-            h => h.OnBatchTimerElapsedAfterAsync(
-                It.Is<IReadOnlyCollection<MudPopoverHolder>>(items => items.Count == 2),
-                It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce,
-            "The periodic handler method was not called.");
-    }
-
-    [Test]
     [CancelAfter(5000)]
     public async Task DisposeAsync_ShouldCancelDetachRange()
     {

--- a/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Debounce/DebounceDispatcherTests.cs
@@ -819,6 +819,7 @@ public class DebounceDispatcherTests
 
     [Test]
     [Explicit]
+    [CancelAfter(10000)]
     public async Task Cancel_Race_Stress_NoUnhandledExceptions()
     {
         var dispatcher = new DebounceDispatcher(TimeSpan.FromMilliseconds(50));
@@ -835,7 +836,7 @@ public class DebounceDispatcherTests
             });
         }
 
-        var act = async () => await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10));
+        var act = async () => await Task.WhenAll(tasks).WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         await act.Should().NotThrowAsync();
     }
@@ -877,6 +878,7 @@ public class DebounceDispatcherTests
 
     [Test]
     [Explicit]
+    [CancelAfter(10000)]
     public async Task CancelAsync_Race_Stress_NoUnhandledExceptions()
     {
         var dispatcher = new DebounceDispatcher(TimeSpan.FromMilliseconds(50));
@@ -892,7 +894,7 @@ public class DebounceDispatcherTests
             });
         }
 
-        var act = async () => await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10));
+        var act = async () => await Task.WhenAll(tasks).WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         await act.Should().NotThrowAsync();
     }
@@ -933,6 +935,7 @@ public class DebounceDispatcherTests
     }
 
     [Test]
+    [CancelAfter(5000)]
     public async Task Dispose_ConcurrentWithDebounceCalls_DoesNotHangOrThrow()
     {
         var dispatcher = new DebounceDispatcher(TimeSpan.FromMilliseconds(50));
@@ -946,7 +949,7 @@ public class DebounceDispatcherTests
 
         var disposer = Task.Run(() => dispatcher.Dispose());
 
-        var act = async () => await Task.WhenAll(workers.Append(disposer)).WaitAsync(TimeSpan.FromSeconds(5));
+        var act = async () => await Task.WhenAll(workers.Append(disposer)).WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         await act.Should().NotThrowAsync();
     }

--- a/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Throttle/ThrottleDispatcherTests.cs
@@ -252,12 +252,13 @@ public class ThrottleDispatcherTests
     }
 
     [Test]
-    public void ThrottleAsync_Dispose_DoesNotCancelRunningAction()
+    [CancelAfter(5000)]
+    public async Task ThrottleAsync_Dispose_DoesNotCancelRunningAction()
     {
         // Arrange
         var dispatcher = new ThrottleDispatcher(100);
-        var actionStarted = new TaskCompletionSource<bool>();
-        var actionCanComplete = new TaskCompletionSource<bool>();
+        var actionStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionCanComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var actionCompleted = false;
 
         async Task LongRunningAction()
@@ -269,12 +270,12 @@ public class ThrottleDispatcherTests
 
         // Act
         var task = dispatcher.ThrottleAsync(LongRunningAction);
-        actionStarted.Task.Wait(); // Wait for action to start
+        await actionStarted.Task.WaitAsync(TestContext.CurrentContext.CancellationToken); // Wait for action to start
 
         dispatcher.Dispose(); // Dispose while action is running
 
         actionCanComplete.SetResult(true); // Allow action to complete
-        task.Wait();
+        await task.WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         // Assert
         actionCompleted.Should().BeTrue();
@@ -295,12 +296,13 @@ public class ThrottleDispatcherTests
     }
 
     [Test]
-    public void ThrottleAsync_DisposeDuringLock_HandlesGracefully()
+    [CancelAfter(5000)]
+    public async Task ThrottleAsync_DisposeDuringLock_HandlesGracefully()
     {
         // Arrange
         using var dispatcher = new ThrottleDispatcher(100);
-        var firstStarted = new TaskCompletionSource<bool>();
-        var firstCanComplete = new TaskCompletionSource<bool>();
+        var firstStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCanComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         async Task SlowAction()
         {
@@ -310,7 +312,7 @@ public class ThrottleDispatcherTests
 
         // Act - Start a slow action to hold the task
         var task1 = dispatcher.ThrottleAsync(SlowAction);
-        firstStarted.Task.Wait();
+        await firstStarted.Task.WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         // Now dispose and try to call again
         // ReSharper disable once DisposeOnUsingVariable
@@ -319,7 +321,7 @@ public class ThrottleDispatcherTests
 
         // Complete the first action
         firstCanComplete.SetResult(true);
-        task1.Wait();
+        await task1.WaitAsync(TestContext.CurrentContext.CancellationToken);
 
         // Assert - second task should complete immediately (disposed)
         task2.IsCompleted.Should().BeTrue();


### PR DESCRIPTION
Focused slice of #13188 — small, low-risk test-stability cleanups, verified stable under repeated full-parallel load. The larger work (enforcement tooling, `[NonParallelizable]` removals) follows in separate PRs.

Changes
- **ThrottleDispatcherTests** — blocking `.Wait()` → async/await over the existing `TaskCompletionSource` gates (now `RunContinuationsAsynchronously`) with `[CancelAfter]`.
- **DebounceDispatcherTests** — `WaitAsync(TimeSpan)` hang-guards → `[CancelAfter]` + `WaitAsync(TestContext.CurrentContext.CancellationToken)`.
- **PopoverServiceTests** — delete the obsolete, `[Ignore]`d `DisposeAsync_ShouldClearActivePopoversAndFireOnBatchTimerElapsedAsync` (superseded by `DisposeAsync_ShouldClearActivePopovers`), removing the suite's only `ManualResetEventSlim` and a 2-minute blocking wait.
- **AGENTS.md** — document the parallelism bar: keep `ParallelScope.Fixtures`; do **not** use `ParallelScope.All` (bUnit renderer thread-affinity — [#124](https://github.com/bUnit-dev/bUnit/issues/124)); and prove parallel-safety under heavy load before removing an existing `[NonParallelizable]`.

Follow-ups (separate PRs, tracked under #13188)
- Enforcement tooling: a CI anti-pattern **ratchet** gate + a local **stress harness**.
- Remove `[NonParallelizable]` from `TextFieldTests`/`NumericFieldTests`/`DialogTests` — requires a deterministic redesign first: the debounce-rerender tests **deadlock** the bUnit renderer under fake time + concurrency (#124), and `DialogTests` has inline-dialog timing fragility beyond its `DialogRender` static counter.
