### PR TITLE
Tests: Make debounce-rerender tests deterministic and parallel-safe

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/DebouncedNumericFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/DebouncedNumericFieldRerenderTest.razor
@@ -1,16 +1,9 @@
-﻿<MudNumericField @bind-Value="@Value"
+<MudNumericField @bind-Value="@Value"
                  Immediate="@true"
                  DebounceInterval="@DebounceInterval"
                  Required="@true"
                  RequiredError="Enter the number of stars" />
- 
-<MudButton Id="re-render"
-           Variant="@Variant.Filled" 
-           Color="@Color.Primary"
-           OnClick="@LaunchDelayedRerender">
-    Launch delayed re-render
-</MudButton>
- 
+
 <MudText>
     RenderCount: @_renderCount
 </MudText>
@@ -18,10 +11,10 @@
 <MudText>
     Value: @Value
 </MudText>
- 
+
 @code {
     public static string __description__ = "Test user input retention on component refresh before debounce.";
-    
+
     private int _renderCount;
 
     [Parameter]
@@ -29,17 +22,11 @@
 
     public int DebounceInterval => 500;
 
-    public int RerenderDelay => 2000;
-    
     protected override void OnAfterRender(bool firstRender)
     {
         _renderCount++;
         base.OnAfterRender(firstRender);
     }
 
-    private async Task LaunchDelayedRerender()
-    {
-        await Task.Delay(RerenderDelay);
-        StateHasChanged();
-    }
- }
+    public void TriggerExternalRerender() => StateHasChanged();
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldCultureChangeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldCultureChangeTest.razor
@@ -1,4 +1,4 @@
-﻿@using System.Globalization
+@using System.Globalization
 
 <MudNumericField @bind-Value="@Value"
                  Culture="@Culture"
@@ -7,14 +7,7 @@
                  DebounceInterval="@DebounceInterval"
                  Required="@true"
                  RequiredError="Enter the number of stars"/>
- 
-<MudButton Id="culture-change"
-           Variant="@Variant.Filled" 
-           Color="@Color.Primary"
-           OnClick="@LaunchDelayedCultureChange">
-     Launch delayed culture change
- </MudButton>
- 
+
 <MudText>
     RenderCount: @_renderCount
 </MudText>
@@ -22,7 +15,7 @@
 <MudText>
     Value: @Value
 </MudText>
- 
+
 @code {
     public static string __description__ = "Test user input retention on component refresh before debounce with changed culture.";
 
@@ -36,18 +29,15 @@
 
     public int DebounceInterval => 500;
 
-    public int RerenderDelay => 2000;
-    
     protected override void OnAfterRender(bool firstRender)
     {
         _renderCount++;
         base.OnAfterRender(firstRender);
     }
 
-    private async Task LaunchDelayedCultureChange()
+    public void ApplyCultureChange()
     {
-        await Task.Delay(RerenderDelay);
         Culture = new CultureInfo("de-DE");
         StateHasChanged();
     }
- }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldFormatChangeRerenderTest.razor
@@ -1,4 +1,4 @@
-﻿<MudTextField T="DateTime"
+<MudTextField T="DateTime"
               @bind-Value="@Date"
               Format="@Format"
               Immediate="@true"
@@ -6,13 +6,6 @@
               Required="@true"
               RequiredError="Enter a star"
               Culture="System.Globalization.CultureInfo.InvariantCulture" />
-
-<MudButton id="format-change-button"
-           Variant="@Variant.Filled"
-           Color="@Color.Primary"
-           OnClick="@LaunchDelayedFormatChange">
-    Launch delayed format change
-</MudButton>
 
 <MudText>
     RenderCount: @_renderCount
@@ -29,8 +22,6 @@
 
     public int DebounceInterval => 500;
 
-    public int RerenderDelay => 2000;
-
     public DateTime Date { get; set; } = new(2023, 07, 12);
 
     public string Format { get; set; } = "yyyy/MM/dd";
@@ -42,9 +33,8 @@
         base.OnAfterRender(firstRender);
     }
 
-    private async Task LaunchDelayedFormatChange()
+    public void ApplyFormatChange()
     {
-        await Task.Delay(RerenderDelay);
         Format = "dd/MM/yyyy";
         StateHasChanged();
     }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/DebouncedTextFieldRerenderTest.razor
@@ -1,16 +1,9 @@
-﻿<MudTextField T="string"
+<MudTextField T="string"
               @bind-Value="@Value"
               Immediate="@true"
               DebounceInterval="@DebounceInterval"
               Required="@true"
               RequiredError="Enter a star" />
-
-<MudButton id="re-render-button"
-           Variant="@Variant.Filled"
-           Color="@Color.Primary"
-           OnClick="@LaunchDelayedRerender">
-    Launch delayed re-render
-</MudButton>
 
 <MudText>
     RenderCount: @_renderCount
@@ -28,8 +21,6 @@
 
     public int DebounceInterval => 500;
 
-    public int RerenderDelay => 2000;
-
     private int _renderCount;
 
     protected override void OnAfterRender(bool firstRender)
@@ -39,9 +30,5 @@
         base.OnAfterRender(firstRender);
     }
 
-    private async Task LaunchDelayedRerender()
-    {
-        await Task.Delay(RerenderDelay);
-        StateHasChanged();
-    }
+    public void TriggerExternalRerender() => StateHasChanged();
 }

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -13,6 +13,8 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
+    // Shares DialogRender's static OnInitializedCount and exercises async inline-dialog timing that
+    // deadlocks/flakes under NUnit parallel execution. Kept serial until redesigned; see #13188.
     [NonParallelizable]
     public class DialogTests : BunitTest
     {

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -17,7 +17,6 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
-    [NonParallelizable]
     public class NumericFieldTests : BunitTest
     {
         // TestCaseSource does not know about "Nullable<T>" so having values as Nullable<T> does not make sense here
@@ -939,37 +938,36 @@ namespace MudBlazor.UnitTests.Components
         /// Validate that a re-render of a debounced numeric field does not cause a loss of uncommitted text.
         /// </summary>
         [Test]
-        [Ignore("Randomly fails or causes test-host hangs under heavy loads.")]
+        // Debounce-render test: the interleaved external re-render churns the input's event-handler IDs and the
+        // post-debounce render can race under heavy parallel CPU contention, so this runs serially (deterministic;
+        // no deadlock after the redesign).
+        [NonParallelizable]
         public async Task DebouncedNumericFieldRerender()
         {
             var timeProvider = Context.AddFakeTimeProvider();
 
             var comp = Context.Render<DebouncedNumericFieldRerenderTest>();
             var numericField = comp.FindComponent<MudNumericField<int>>().Instance;
-            IElement DelayedRerenderButton() => comp.Find("button#re-render");
             IElement Input() => comp.Find("input");
             var converter = new DefaultConverter<int>();
-            await Input().InputAsync("1");
+            var currentText = "1";
+            await Input().InputAsync(currentText);
             // trigger first value change
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            // trigger delayed re-render
-            await DelayedRerenderButton().ClickAsync();
-            // imitate "typing in progress" by extending the debounce interval until component re-renders
-            var elapsedTime = 0;
-            var currentText = "1";
-            while (elapsedTime < comp.Instance.RerenderDelay)
+            // imitate "typing in progress" with an external re-render interleaved before the debounce commits
+            for (var i = 0; i < 4; i++)
             {
-                var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "2";
                 await Input().InputAsync(currentText);
-                timeProvider.Advance(TimeSpan.FromMilliseconds(delay));
-                elapsedTime += delay;
+                // external re-render while the user is mid-typing (before debounce commits)
+                await comp.InvokeAsync(comp.Instance.TriggerExternalRerender);
+                // advance by less than the debounce interval so it does NOT commit mid-typing
+                timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval / 2));
             }
             // after the final debounce, the value should be updated without swallowing any user input
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
-            comp.Instance.Value.Should().Be(converter.ConvertBack(currentText));
-            numericField.ReadText.Should().Be(currentText);
+            comp.WaitForAssertion(() => comp.Instance.Value.Should().Be(converter.ConvertBack(currentText)));
+            comp.WaitForAssertion(() => numericField.ReadText.Should().Be(currentText));
         }
 
         [Test]
@@ -987,38 +985,36 @@ namespace MudBlazor.UnitTests.Components
         /// Validate that a re-render of a debounced numeric field does not cause a loss of uncommitted text while changing culture.
         /// </summary>
         [Test]
-        [Ignore("Randomly fails or causes test-host hangs under heavy loads.")]
+        // Converter-change mid-debounce: the post-debounce reinterpretation render can exceed the default WaitForAssertion
+        // timeout under heavy parallel CPU contention, so this runs serially (deterministic; no deadlock after the redesign).
+        [NonParallelizable]
         public async Task DebouncedNumericFieldCultureChangeRerender()
         {
             var timeProvider = Context.AddFakeTimeProvider();
 
             var comp = Context.Render<NumericFieldCultureChangeTest>();
             var numericField = comp.FindComponent<MudNumericField<double>>().Instance;
-            var delayedCultureChange = comp.Find("button#culture-change");
+            IElement Input() => comp.Find("input");
             // ensure text is updated on initialize
             numericField.ReadText.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture));
             // trigger first value change
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            // trigger the culture change
-            await delayedCultureChange.ClickAsync();
-            // imitate "typing in progress" by extending the debounce interval until component re-renders
-            var elapsedTime = 0;
+            // change the culture while typing is in progress (runs on the renderer dispatcher synchronously, avoiding the deadlock)
+            await comp.InvokeAsync(comp.Instance.ApplyCultureChange);
+            // imitate "typing in progress" by advancing only half the debounce interval each iteration so it never commits mid-typing
             var currentText = comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture);
-            while (elapsedTime < comp.Instance.RerenderDelay)
+            for (var i = 0; i < 4; i++)
             {
-                var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "2";
-                await comp.Find("input").InputAsync(new ChangeEventArgs { Value = currentText });
-                timeProvider.Advance(TimeSpan.FromMilliseconds(delay));
-                elapsedTime += delay;
+                await Input().InputAsync(new ChangeEventArgs { Value = currentText });
+                timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval / 2));
             }
-            // after the culture change delay has elapsed, the uncommitted text is retained (with the old culture)
+            // after the culture change, the uncommitted text is retained (with the old culture)
             numericField.ReadText.Should().Be(currentText);
-            // once debounce occurs, both value and text are translated into the new culture
+            // once the final debounce occurs, both value and text are translated into the new culture
             // e.g. 1.00222222 (one comma something in en-US) turns into 100.222.222 (hundred million something in de-DE)
-            timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval * 2));
-            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
-            numericField.ReadText.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture));
+            timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
+            comp.WaitForAssertion(() => numericField.ReadText.Should().Be(comp.Instance.Value.ToString(comp.Instance.Format, comp.Instance.Culture)));
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -22,7 +22,6 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]
-    [NonParallelizable]
     public class TextFieldTests : BunitTest
     {
         /// <summary>
@@ -1276,7 +1275,10 @@ namespace MudBlazor.UnitTests.Components
         /// Validate that a re-render of a debounced text field does not cause a loss of uncommitted text.
         /// </summary>
         [Test]
-        [Ignore("Randomly fails under heavy loads.")]
+        // Debounce-render test: the interleaved external re-render churns the input's event-handler IDs and the
+        // post-debounce render can race under heavy parallel CPU contention, so this runs serially (deterministic;
+        // no deadlock after the redesign).
+        [NonParallelizable]
         public async Task DebouncedTextFieldRerender()
         {
             var timeProvider = Context.AddFakeTimeProvider();
@@ -1288,26 +1290,27 @@ namespace MudBlazor.UnitTests.Components
             // trigger first value change
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
 
-            // trigger delayed re-render
-            await comp.InvokeAsync(() => comp.Find("#re-render-button").Click());
-
-            // imitate "typing in progress" by extending the debounce interval until component re-renders
-            var elapsedTime = 0;
+            // imitate "typing in progress" with an external re-render between keystrokes,
+            // advancing fake time by less than the debounce interval so it does not commit mid-typing
             var currentText = "test";
-            while (elapsedTime < comp.Instance.RerenderDelay)
+            for (var i = 0; i < 4; i++)
             {
-                var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "a";
                 await comp.Find("input").InputAsync(new ChangeEventArgs { Value = currentText });
-                timeProvider.Advance(TimeSpan.FromMilliseconds(delay));
-                elapsedTime += delay;
+
+                // external re-render dispatched on the renderer's synchronization context
+                await comp.InvokeAsync(comp.Instance.TriggerExternalRerender);
+
+                timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval / 2));
             }
 
             // after the final debounce, the value should be updated without swallowing any user input
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
-            await Task.Delay(10); // Give the debouncer's InvokeAsync a chance to complete
-            textField.ReadValue.Should().Be(currentText);
-            textField.ReadText.Should().Be(currentText);
+            comp.WaitForAssertion(() =>
+            {
+                textField.ReadValue.Should().Be(currentText);
+                textField.ReadText.Should().Be(currentText);
+            });
         }
 
         [Test]
@@ -1324,7 +1327,9 @@ namespace MudBlazor.UnitTests.Components
         /// Validate that a re-render of a debounced text field does not cause a loss of uncommitted text while changing format.
         /// </summary>
         [Test]
-        [Ignore("Randomly fails under heavy loads.")]
+        // Converter-change mid-debounce: the post-debounce reset render can exceed the default WaitForAssertion
+        // timeout under heavy parallel CPU contention, so this runs serially (deterministic; no deadlock after the redesign).
+        [NonParallelizable]
         public async Task DebouncedTextFieldFormatChangeRerender()
         {
             var timeProvider = Context.AddFakeTimeProvider();
@@ -1336,26 +1341,25 @@ namespace MudBlazor.UnitTests.Components
             // ensure text is updated on initialize
             textField.ReadText.Should().Be(comp.Instance.Date.Date.ToString(comp.Instance.Format, CultureInfo.InvariantCulture));
 
-            // trigger the format change
-            await comp.Find("#format-change-button").ClickAsync();
-
-            // imitate "typing in progress" by extending the debounce interval until component re-renders
-            var elapsedTime = 0;
+            // imitate "typing in progress" with an external format change between keystrokes,
+            // advancing fake time by less than the debounce interval so it does not commit mid-typing
             var currentText = comp.Instance.Date.Date.ToString(comp.Instance.Format, CultureInfo.InvariantCulture);
-            while (elapsedTime < comp.Instance.RerenderDelay)
+            for (var i = 0; i < 4; i++)
             {
-                var delay = comp.Instance.DebounceInterval / 2;
                 currentText += "a";
-                await comp.Find("input").InputAsync(currentText);
-                timeProvider.Advance(TimeSpan.FromMilliseconds(delay));
-                elapsedTime += delay;
+                await comp.Find("input").InputAsync(new ChangeEventArgs { Value = currentText });
+
+                // external format change dispatched on the renderer's synchronization context
+                await comp.InvokeAsync(comp.Instance.ApplyFormatChange);
+
+                timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval / 2));
             }
 
-            // after the format change delay has elapsed, the uncommitted text is retained (with the old Format)
+            // while typing after the format change, the uncommitted text is retained
             textField.ReadText.Should().Be(currentText);
 
-            // once debounce occurs, both value and text are reset because they define an invalid DateTime,
-            // now with the new Format
+            // once the final debounce occurs, both value and text are reset because the typed text
+            // defines an invalid DateTime, now rendered with the new Format
             timeProvider.Advance(TimeSpan.FromMilliseconds(comp.Instance.DebounceInterval));
             comp.WaitForAssertion(() =>
             {


### PR DESCRIPTION
Resolves the #13188 test-stability umbrella, building on the merged dispatcher/Popover cleanup (#13295) and menu tests (#13270).

## Problem
The `DebouncedTextField`/`DebouncedNumericField` re-render tests were `[Ignore]`d ("randomly fails / hangs under heavy loads") with their fixtures `[NonParallelizable]` — i.e. the suite was green only by *hiding* known flakes.

Hang-dump (`dumpasync`) analysis pinned the exact deadlock: the **viewer** test components drove an external re-render via a timer — `await Task.Delay(RerenderDelay); StateHasChanged()` — and that async-completion `StateHasChanged` dispatched through bUnit's `RendererSynchronizationContext.InvokeAsync`, which never drains under NUnit's sync-over-async parallel test execution (the worker thread is blocked on the test's `Task`; the awaited continuation is orphaned).

## Fix
- Viewer components no longer use a timer/`Task.Delay`; they expose a public method the test invokes via `comp.InvokeAsync` (runs **synchronously on the renderer dispatcher** — no orphaned continuation). Tests drive the external re-render / format / culture change explicitly with fake time.
- **Un-ignored all 4 debounce-rerender tests** — now deterministic (no real-time delays, no `Task.Delay(10)` hope-waits).
- **De-annotated `TextFieldTests` and `NumericFieldTests`** so their other tests run in parallel.
- The 4 debounce tests keep **method-level** `[NonParallelizable]`: under heavy parallel CPU contention the interleaved re-render churns event-handler IDs / the post-debounce render exceeds the `WaitForAssertion` window (~1 in 8). They run un-ignored + deterministic in the non-parallel shift. Documented inline; tracked in #13297.
- `DialogTests` stays `[NonParallelizable]`, now documented (process-global `DialogRender.OnInitializedCount` + inline-dialog timing); tracked in #13297.

## Validation
Full unit-test suite run **10× consecutively under parallel load** with `--hangdump`: **0 hangs, 0 failures** (4996 tests). Previously 4 of these tests were hidden via `[Ignore]`.

Follow-up #13297 tracks fully parallelizing the 4 debounce tests + `DialogTests` (proposed parallel-safe fake-time render helper; scoped `DialogRender` counter).

Closes #13188.