### PR TITLE
Build: Align and document analyzer Roslyn package versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,16 @@
             "enabled": false
         },
         {
+            "description": "Shipped analyzer targets Roslyn 4.x; keep the build-time authoring-rules package on the matching 3.x line.",
+            "matchFileNames": [
+                "src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj"
+            ],
+            "matchPackageNames": [
+                "Microsoft.CodeAnalysis.Analyzers"
+            ],
+            "allowedVersions": "<4.0.0"
+        },
+        {
             "matchFileNames": [
                 "src/MudBlazor/MudBlazor.csproj"
             ],

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,6 +12,21 @@
     <EnumGenerator_EnumMetadataSource>DescriptionAttribute</EnumGenerator_EnumMetadataSource>
   </PropertyGroup>
 
+  <!--
+    Roslyn version for the SHIPPED analyzer + code-fix assemblies (MudBlazor.Analyzers and
+    MudBlazor.Analyzers.CodeFixes). Both DLLs are packed side-by-side into analyzers/dotnet/cs of the
+    MudBlazor NuGet package and are loaded by the CONSUMER's build compiler / IDE Roslyn host. The
+    compiler refuses to load an analyzer that references a NEWER Roslyn than the host is running (error
+    CS9057), so this version is effectively the minimum .NET SDK / Visual Studio a MudBlazor consumer
+    must have. It is deliberately kept low (4.7.0 = VS 2022 17.7) to keep working for net8.0 consumers
+    and older toolchains. Do NOT raise it without intentionally dropping support for those SDKs; a
+    previous bump to 4.13.0 broke consumers on .NET SDK 8.0.4xx (see issue #11114, reverted in PR #11116).
+    Sharing one property keeps the analyzer and its code-fix from ever drifting onto different bands.
+  -->
+  <PropertyGroup>
+    <MudBlazorRoslynShippedVersion>4.7.0</MudBlazorRoslynShippedVersion>
+  </PropertyGroup>
+
   <PropertyGroup>
     <BunVersion>1.3.14</BunVersion>
     <BunToolRestore>dotnet tool restore --tool-manifest ../../.config/dotnet-tools.json</BunToolRestore>

--- a/src/MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj
+++ b/src/MudBlazor.Analyzers.CodeFixes/MudBlazor.Analyzers.CodeFixes.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+    <!-- Workspaces transitively pins Microsoft.CodeAnalysis.CSharp to the same band as the analyzer
+         (MudBlazorRoslynShippedVersion in src/Directory.Build.props); both DLLs ship together in
+         analyzers/dotnet/cs and must stay on the same Roslyn band. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MudBlazorRoslynShippedVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj
+++ b/src/MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj
@@ -8,8 +8,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MudBlazor\MudBlazor.csproj" />
-	<!--https://github.com/MudBlazor/MudBlazor/issues/11114-->
-	<!--https://github.com/dotnet/roslyn/issues/77255-->
+    <!--
+      Pinned to the Roslyn version bundled in the GA .NET SDK 10.0.100 that global.json targets (Roslyn
+      5.0.x). This is an ordinary package reference in a Razor helper library (NOT a shipped analyzer),
+      so it is not a CS9057 / compiler-floor concern; the pin keeps the Roslyn API aligned with the base
+      SDK so MSBuildWorkspace + the Razor source generator yield deterministic analyzer results across
+      SDK feature bands (otherwise the analyzer tests find a different set of diagnostics). Do not bump to
+      5.3.0 (a later 10.0.2xx-band Roslyn) without re-validating the analyzer tests.
+      See https://github.com/MudBlazor/MudBlazor/issues/11114 and https://github.com/dotnet/roslyn/issues/77255
+    -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
   </ItemGroup>
   

--- a/src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj
+++ b/src/MudBlazor.Analyzers/MudBlazor.Analyzers.csproj
@@ -7,8 +7,12 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <!-- Build-time analyzer-authoring (RS####) rules; does NOT affect the shipped analyzer's runtime
+         compiler floor. The 3.x line targets the Roslyn 4.x API surface this analyzer builds against,
+         so it stays on 3.11.0 (latest 3.x); 4.14.0/5.x correspond to newer Roslyn targets. -->
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <!-- Shipped-analyzer Roslyn floor; see MudBlazorRoslynShippedVersion in src/Directory.Build.props. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MudBlazorRoslynShippedVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
+++ b/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
@@ -22,8 +22,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
+    <!-- Microsoft.CodeAnalysis.Analyzer.Testing is provided transitively by the two packages below
+         (CSharp.Analyzer.Testing -> Analyzer.Testing; CSharp.CodeFix.Testing -> CodeFix.Testing ->
+         Analyzer.Testing), so it is not referenced directly. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.2.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />


### PR DESCRIPTION
Audit and modernize the code-analysis package graph across the four analyzer projects (`MudBlazor.Analyzers`, `MudBlazor.Analyzers.CodeFixes`, `MudBlazor.Analyzers.TestComponents`, `MudBlazor.UnitTests.Analyzers`). The Roslyn versions were already correct for each layer — 4.7.0 for the shipped analyzer/code-fix floor, 5.0.0 for TestComponents (GA SDK alignment), 5.3.0 / 1.1.4 for the test tooling — so this is mostly **anti-drift + documentation**, not version bumps.

Changes
- **Single source of truth for the shipped Roslyn floor.** Hoisted `4.7.0` into a `MudBlazorRoslynShippedVersion` property in `src/Directory.Build.props`, referenced by both `Microsoft.CodeAnalysis.CSharp` (analyzer) and `Microsoft.CodeAnalysis.CSharp.Workspaces` (code-fix). Both DLLs ship together in `analyzers/dotnet/cs` and must stay on the same band; the property prevents them drifting onto different versions (a silent CS9057 risk). The floor is deliberately low to keep working for net8.0 consumers — see #11114 / #11116.
- **Corrected the `TestComponents` pin comment.** Its `Microsoft.CodeAnalysis.CSharp 5.0.0` aligns the Roslyn API with the GA .NET SDK 10.0.100 floor for deterministic MSBuildWorkspace / Razor source-gen results. It is a Razor helper library (not a shipped analyzer), so it is **not** a CS9057 concern — the previous comment implied otherwise.
- **Kept `Microsoft.CodeAnalysis.Analyzers` at 3.11.0** in the shipped analyzer (build-time RS authoring rules; the 3.x line matches the Roslyn 4.x it targets) and added a Renovate rule pinning it to `<4.0.0` there, mirroring the existing `Microsoft.CodeAnalysis.CSharp` / `.CSharp.Workspaces` pins. This closes the gap that generated #13287.
- **Removed the redundant `Microsoft.CodeAnalysis.Analyzer.Testing` reference** from `MudBlazor.UnitTests.Analyzers` (provided transitively by `CSharp.Analyzer.Testing` and `CSharp.CodeFix.Testing`).
