### PR TITLE
MudColorPicker: Add HEX mode support for unbound color picker

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -347,13 +347,38 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [TestCase(ColorPickerMode.RGB)]
+        [TestCase(ColorPickerMode.HSL)]
+        [TestCase(ColorPickerMode.HEX)]
+        public void UnboundColorPicker_ShouldDisplayDefaultColorInAllModes(ColorPickerMode mode)
+        {
+            var comp = Context.Render<MudColorPicker>(p =>
+            {
+                p.Add(x => x.PickerVariant, PickerVariant.Static);
+                p.Add(x => x.ColorPickerMode, mode);
+            });
+
+            var expectedInputCount = mode == ColorPickerMode.HEX ? 1 : 4;
+            var inputs = comp.FindAll($"{_colorInputCssSelector} input");
+
+            inputs.Should().HaveCount(expectedInputCount);
+            inputs.Should().AllBeAssignableTo<IHtmlInputElement>();
+
+            AssertDisplayedChannelValuesCore(inputs.Cast<IHtmlInputElement>().ToArray(), _defaultColor, mode);
+        }
+
+        [Test]
         [TestCase("#00000088", ColorPickerMode.RGB)]
         [TestCase("#00000088", ColorPickerMode.HSL)]
+        [TestCase("#00000088", ColorPickerMode.HEX)]
         [TestCase("#00000188", ColorPickerMode.RGB)]
         [TestCase("#00000188", ColorPickerMode.HSL)]
+        [TestCase("#00000188", ColorPickerMode.HEX)]
         [TestCase("#ff0000ff", ColorPickerMode.HSL)]
+        [TestCase("#ff0000ff", ColorPickerMode.HEX)]
         [TestCase("#0f0f", ColorPickerMode.RGB)]
         [TestCase("#0f0f", ColorPickerMode.HSL)]
+        [TestCase("#0f0f", ColorPickerMode.HEX)]
         public async Task InitiallyBoundValue_ShouldInitializeAllVisibleControls(string colorHex, ColorPickerMode mode)
         {
             var expectedColor = new MudColor(colorHex);

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -236,7 +236,7 @@
                                         case ColorPickerMode.HEX:
                                             <MudTextField T="string"
                                                           @key="@_inputResetKey"
-                                                          Value="@GetColorTextValue(_valueState.Value)"
+                                                          Value="@GetColorTextValue(ValueOrDefault)"
                                                           ValueChanged="SetInputStringAsync"
                                                           Class="mud-picker-color-inputfield"
                                                           Variant="Variant.Outlined"


### PR DESCRIPTION
Initial HEX display is empty when a value is not set.  Default should be applied like is done with RGB and HSL.

* Updated HEX input binding in MudColorPicker.razor to use ValueOrDefault, ensuring correct display of default color when unbound.
* Extended unit tests to cover HEX mode in unbound MudColorPicker. 

Fixes #13235 

Before: 

<img width="1027" height="1325" alt="image" src="https://github.com/user-attachments/assets/c3729be8-bfdc-4c53-90bf-b34c6e9e07ee" />

After:

<img width="834" height="1084" alt="image" src="https://github.com/user-attachments/assets/3a6696ac-ae50-4983-a5b2-a6ae08893f50" />

