### PR TITLE
MudSelect: Honor custom Comparer in value-to-item lookups

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SingleSelectComparerHighlightTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SingleSelectComparerHighlightTest.razor
@@ -1,0 +1,32 @@
+<MudPopoverProvider />
+
+<MudSelect T="Coffee" Label="Coffee"
+           Value="_value"
+           Comparer="Comparer"
+           ToStringFunc="@(x => x?.Name)">
+    <MudSelectItem Value="@(new Coffee("cap", "Cappuccino"))" />
+    <MudSelectItem Value="@(new Coffee("lat", "Cafe Latte"))" />
+    <MudSelectItem Value="@(new Coffee("esp", "Espresso"))" />
+    <MudSelectItem Value="@(new Coffee("ire", "Irish Coffee"))" />
+</MudSelect>
+
+@code {
+    private static CoffeeComparer Comparer { get; } = new();
+
+    // A different instance than the matching item, but key-equal ("lat").
+    // Default/reference equality cannot match this against the rendered item; only the comparer can.
+    private readonly Coffee _value = new("lat", "Latte from server");
+
+    private class Coffee(string key, string name)
+    {
+        public string Key { get; } = key;
+        public string Name { get; } = name;
+    }
+
+    private class CoffeeComparer : IEqualityComparer<Coffee?>
+    {
+        public bool Equals(Coffee? a, Coffee? b) => a?.Key == b?.Key;
+
+        public int GetHashCode(Coffee? x) => HashCode.Combine(x?.Key);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SingleSelectComparerNoMatchTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SingleSelectComparerNoMatchTest.razor
@@ -1,0 +1,31 @@
+<MudPopoverProvider />
+
+<MudSelect T="Coffee" Label="Coffee"
+           Value="_value"
+           Comparer="Comparer"
+           ToStringFunc="@(x => x?.Name)">
+    <MudSelectItem Value="@(new Coffee("cap", "Cappuccino"))" />
+    <MudSelectItem Value="@(new Coffee("lat", "Cafe Latte"))" />
+    <MudSelectItem Value="@(new Coffee("esp", "Espresso"))" />
+    <MudSelectItem Value="@(new Coffee("ire", "Irish Coffee"))" />
+</MudSelect>
+
+@code {
+    private static CoffeeComparer Comparer { get; } = new();
+
+    // A value whose key matches no item; the comparer scan must exhaust without a match.
+    private readonly Coffee _value = new("zzz", "Unknown");
+
+    private class Coffee(string key, string name)
+    {
+        public string Key { get; } = key;
+        public string Name { get; } = name;
+    }
+
+    private class CoffeeComparer : IEqualityComparer<Coffee?>
+    {
+        public bool Equals(Coffee? a, Coffee? b) => a?.Key == b?.Key;
+
+        public int GetHashCode(Coffee? x) => HashCode.Combine(x?.Key);
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SingleSelectComparerPresenterTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SingleSelectComparerPresenterTest.razor
@@ -1,0 +1,33 @@
+<MudPopoverProvider />
+
+<MudSelect T="Coffee" Label="Coffee"
+           Value="_value"
+           Comparer="Comparer">
+    <MudSelectItem Value="@(new Coffee("cap", "Cappuccino"))">
+        <span class="coffee-template">Cappuccino template</span>
+    </MudSelectItem>
+    <MudSelectItem Value="@(new Coffee("lat", "Cafe Latte"))">
+        <span class="coffee-template">Latte template</span>
+    </MudSelectItem>
+</MudSelect>
+
+@code {
+    private static CoffeeComparer Comparer { get; } = new();
+
+    // A different instance than the matching item, but key-equal ("lat").
+    // Resolving the selected value's custom template requires honoring the comparer.
+    private readonly Coffee _value = new("lat", "Latte from server");
+
+    private class Coffee(string key, string name)
+    {
+        public string Key { get; } = key;
+        public string Name { get; } = name;
+    }
+
+    private class CoffeeComparer : IEqualityComparer<Coffee?>
+    {
+        public bool Equals(Coffee? a, Coffee? b) => a?.Key == b?.Key;
+
+        public int GetHashCode(Coffee? x) => HashCode.Combine(x?.Key);
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1509,6 +1509,36 @@ namespace MudBlazor.UnitTests.Components
             icons[5].Attributes["d"].Value.Should().Be(@unchecked); // test3
         }
 
+        [Test(Description = "A custom Comparer must drive value->item resolution for highlight/active-descendant, not just selection state.")]
+        public async Task SingleSelectWithCustomComparer_HighlightsKeyEqualItem()
+        {
+            var comp = Context.Render<SingleSelectComparerHighlightTest>();
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var input = comp.Find("input");
+                var latte = comp.FindAll("div.mud-list-item").Single(item => item.TextContent.Contains("Cafe Latte"));
+
+                // The bound value is a different Coffee instance with the same Key ("lat") as "Cafe Latte".
+                // Without honoring the comparer the dictionary lookup misses, so no item is highlighted
+                // and aria-activedescendant is omitted.
+                input.GetAttribute("aria-activedescendant").Should().Be(latte.Id);
+                latte.ToMarkup().Should().Contain("mud-selected-item");
+            });
+        }
+
+        [Test(Description = "A custom Comparer must drive value->item resolution for the selected-value template (shadow lookup).")]
+        public async Task SingleSelectWithCustomComparer_RendersKeyEqualItemTemplate()
+        {
+            var comp = Context.Render<SingleSelectComparerPresenterTest>();
+
+            // The bound value is a different Coffee instance with the same Key ("lat") as "Cafe Latte".
+            // Resolving it to the matching item's ChildContent requires honoring the comparer.
+            comp.Find("div.mud-select-input").TextContent.Should().Contain("Latte template");
+        }
+
         [Test]
         public async Task Select_Item_Collection_Should_Match_Number_Of_Select_Options()
         {

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1539,6 +1539,23 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-select-input").TextContent.Should().Contain("Latte template");
         }
 
+        [Test(Description = "A custom Comparer that matches no item resolves to no highlight rather than mis-highlighting.")]
+        public async Task SingleSelectWithCustomComparer_NoMatch_HighlightsNothing()
+        {
+            var comp = Context.Render<SingleSelectComparerNoMatchTest>();
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                // Menu is open, but no item's key matches the bound value, so nothing is highlighted
+                // and no active descendant is published.
+                comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0);
+                comp.FindAll("div.mud-selected-item").Should().BeEmpty();
+                comp.Find("input").GetAttribute("aria-activedescendant").Should().BeNull();
+            });
+        }
+
         [Test]
         public async Task Select_Item_Collection_Should_Match_Number_Of_Select_Options()
         {

--- a/src/MudBlazor/Components/Select/MudSelectContext.cs
+++ b/src/MudBlazor/Components/Select/MudSelectContext.cs
@@ -174,17 +174,59 @@ internal sealed class MudSelectContext<T>
     /// <summary>
     /// Attempts to get an item by its value from visible items.
     /// </summary>
+    /// <remarks>
+    /// When a custom <see cref="Comparer"/> is set the lookup honors it via a linear scan;
+    /// otherwise the fast dictionary lookup (default equality) is used. This keeps value-to-item
+    /// resolution consistent with the comparer-aware selection state.
+    /// </remarks>
     public bool TryGetItemByValue(T? value, [NotNullWhen(true)] out MudSelectItem<T>? item)
     {
-        return _valueLookup.TryGetValue(value, out item);
+        var comparer = Comparer;
+        if (comparer is null)
+        {
+            return _valueLookup.TryGetValue(value, out item);
+        }
+
+        foreach (var candidate in _items)
+        {
+            if (comparer.Equals(candidate.Value, value))
+            {
+                item = candidate;
+                return true;
+            }
+        }
+
+        item = null;
+        return false;
     }
 
     /// <summary>
     /// Attempts to get an item by its value from all items (including shadow items).
     /// </summary>
+    /// <remarks>
+    /// When a custom <see cref="Comparer"/> is set the lookup honors it via a linear scan;
+    /// otherwise the fast dictionary lookup (default equality) is used. This keeps value-to-item
+    /// resolution consistent with the comparer-aware selection state.
+    /// </remarks>
     public bool TryGetShadowItemByValue(T? value, [NotNullWhen(true)] out MudSelectItem<T>? item)
     {
-        return _shadowLookup.TryGetValue(value, out item);
+        var comparer = Comparer;
+        if (comparer is null)
+        {
+            return _shadowLookup.TryGetValue(value, out item);
+        }
+
+        foreach (var candidate in _shadowLookup.Values)
+        {
+            if (comparer.Equals(candidate.Value, value))
+            {
+                item = candidate;
+                return true;
+            }
+        }
+
+        item = null;
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
`MudSelect<T>` exposes a user-settable value `Comparer`. Selection *state* already honors it — `_selectedValues` is built as a `HashSet<T?>` with the comparer — but value→item *resolution* did not.

`MudSelectContext<T>` resolves values to items through two `Dictionary<NullableObject<T?>, MudSelectItem<T>>` lookups. `NullableObject<T?>` hashes/compares with `EqualityComparer<T?>.Default`, so `TryGetItemByValue` / `TryGetShadowItemByValue` ignore a custom `Comparer`. As a result, selection state and value→item resolution disagree whenever the comparer treats two distinct instances as equal (e.g. a key-based comparer over a reference type).

User-visible symptoms with a custom comparer:
- **Highlight / `aria-activedescendant`**: opening the menu calls `HighlightItemForValueAsync(ReadValue)` → `TryGetItemByValue`, which misses a key-equal-but-different value instance, so no item is highlighted and `aria-activedescendant` is omitted (an accessibility regression).
- **Custom selected-value template**: `CanRenderValue` / `GetSelectedValuePresenter` use `TryGetShadowItemByValue`, so the matching item's `ChildContent` is not rendered for the selected value.

Changes

- Make `TryGetItemByValue` and `TryGetShadowItemByValue` comparer-aware: keep the fast dictionary path when no `Comparer` is set, otherwise scan with the comparer. Fixing it in the context (rather than at one call site) keeps every value→item path consistent with the comparer-aware selection state.
- Add single-select regression tests for both the highlight/`aria-activedescendant` path and the selected-value template path. Both fail on `dev` and pass with the fix.

This is the follow-up split out of [#13080](https://github.com/MudBlazor/MudBlazor/pull/13080), which is now scoped to the presenter accessibility fix. The two are independent (no shared files) and can be reviewed/merged in any order.

Relates to #9717

**Checklist:**
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
