### PR TITLE
Test Viewer: Discover components by location and add `[ViewerHidden]` opt-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,8 @@ private Task ToggleAsync()
 
 ### Test locations and naming
 - Test components belong in `src/MudBlazor.UnitTests.Viewer/TestComponents/<ComponentName>/`.
-- Viewer test component file names should start with the component prefix, use correct component casing, and end with `Test`, optionally followed by an indexer such as `MenuTest1`.
+- Viewer components are discovered by location: any component under `TestComponents/` (a `TestComponents.*` namespace) is loaded and addressable at `/viewer/<path>`, where `<path>` is its folder path relative to `TestComponents` plus the type name (e.g. `Menu/MenuTest1`). The historical "name must contain `Test`" requirement no longer applies, though `Test`-suffixed scenario names remain the convention.
+- Add `@attribute [ViewerHidden]` to a helper or sub-component (e.g. dialog content shown via the dialog service) to keep it routable but out of the sidebar listing.
 - Keep viewer test component file names at 40 characters or fewer. Prefer concise scenario names over long descriptive file names.
 - Unit tests belong in `src/MudBlazor.UnitTests/Components/<ComponentName>Tests.cs`.
 - Add a viewer test component only when the scenario is too cumbersome to express directly in bUnit C# syntax. In those cases, add the viewer component first, then the unit test.

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -313,19 +313,22 @@
 
         _availableComponentTypes = GetTestComponentTypes().ToArray();
 
-        _entries = _availableComponentTypes
-            .Select(CreateEntry)
-            .OrderBy(x => x.Name)
-            .ToArray();
-
-        _entryByType = _entries.ToDictionary(x => x.Type, x => x);
-
+        // Everything discovered is routable...
         _typeByRouteKey = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
         foreach (var type in _availableComponentTypes)
         {
             // Route keys are unique by construction (one file per path); TryAdd guards against any future clash.
             _typeByRouteKey.TryAdd(RouteKey(type), type);
         }
+
+        // ...but [ViewerHidden] helpers are kept out of the sidebar listing.
+        _entries = _availableComponentTypes
+            .Where(type => !type.IsDefined(typeof(ViewerHiddenAttribute), inherit: false))
+            .Select(CreateEntry)
+            .OrderBy(x => x.Name)
+            .ToArray();
+
+        _entryByType = _entries.ToDictionary(x => x.Type, x => x);
 
         StartSearch();
 
@@ -485,8 +488,11 @@
 
     private static IEnumerable<Type> GetTestComponentTypes()
     {
+        // Discover by location: anything under a TestComponents namespace. A few legacy components
+        // override @namespace away from their folder, so also keep the historical "name contains Test".
         var types = typeof(Program).Assembly.GetTypes()
-            .Where(type => type.Name.Contains("Test"))
+            .Where(type => type.Namespace?.Contains("TestComponents", StringComparison.Ordinal) == true
+                           || type.Name.Contains("Test"))
             .Where(type => !type.Name.StartsWith("<"))
             .Where(type => type.GetInterfaces().Contains(typeof(IComponent)))
             .OrderBy(type => type.Name);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallback.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallback.razor
@@ -1,4 +1,6 @@
-﻿<MudDialog>
+﻿@attribute [ViewerHidden]
+
+<MudDialog>
     <DialogContent>
         Dialog Content
         <MudTextField T="string" Immediate TextChanged="@OnTextChangedAsync" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/SimpleDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/SimpleDialog.razor
@@ -1,3 +1,5 @@
+@attribute [ViewerHidden]
+
 <MudDialog>
     <TitleContent>
         Dialog Title

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingDialog.razor
@@ -1,5 +1,6 @@
 @namespace MudBlazor.UnitTests.TestComponents.TextField
 @using MudBlazor
+@attribute [ViewerHidden]
 
 <MudDialog DefaultFocus="DefaultFocus.FirstChild" OnBackdropClick="Submit">
     <TitleContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFixedSizingDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFixedSizingDialog.razor
@@ -1,5 +1,6 @@
 @namespace MudBlazor.UnitTests.TestComponents.TextField
 @using MudBlazor
+@attribute [ViewerHidden]
 
 <MudDialog DefaultFocus="DefaultFocus.FirstChild" OnBackdropClick="Submit">
     <TitleContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/_README.txt
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/_README.txt
@@ -1,8 +1,16 @@
-﻿All test components must have the substring "Test" in their names in order to be loaded by the viewer.
+Components placed under TestComponents (i.e. in a TestComponents.* namespace) are loaded by the viewer.
+The substring "Test" in the name is no longer required - discovery is location-based.
 
-It is advised to name the test component exactly the same as the bUnit testcase under UnitTests.
+Each component is addressable at /viewer/<path>, where <path> is its folder path relative to
+TestComponents plus the type name (for example Menu/MenuTest1). Naming the component the same as the
+bUnit testcase under UnitTests is still encouraged.
 
-In order to have the test description show up, make sure the component implements a static field __description__ in the @code section:
+Helper or sub-components that are not meaningful to open on their own (for example dialog content shown
+via the dialog service) can be hidden from the sidebar while staying routable by adding:
+
+@attribute [ViewerHidden]
+
+To show a description in the viewer, add a static __description__ field in the @code section:
 
 @code {
     public static string __description__ = "...";

--- a/src/MudBlazor.UnitTests.Viewer/ViewerHiddenAttribute.cs
+++ b/src/MudBlazor.UnitTests.Viewer/ViewerHiddenAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace MudBlazor.UnitTests;
+
+/// <summary>
+/// Marks a viewer test component as routable but hidden from the sidebar listing.
+/// Use for helper or sub-components (e.g. dialog content shown via the dialog service)
+/// that are not meaningful to open on their own.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ViewerHiddenAttribute : Attribute
+{
+}

--- a/src/MudBlazor.UnitTests/Other/ViewerTestComponentRouteTests.cs
+++ b/src/MudBlazor.UnitTests/Other/ViewerTestComponentRouteTests.cs
@@ -14,7 +14,8 @@ namespace MudBlazor.UnitTests.Other
             var assembly = Assembly.Load("MudBlazor.UnitTests.Viewer");
 
             return assembly.GetTypes()
-                .Where(type => type.Name.Contains("Test"))
+                .Where(type => type.Namespace?.Contains("TestComponents", StringComparison.Ordinal) == true
+                               || type.Name.Contains("Test"))
                 .Where(type => !type.Name.StartsWith("<"))
                 .Where(type => type.GetInterfaces().Contains(typeof(IComponent)))
                 .ToList();
@@ -47,6 +48,21 @@ namespace MudBlazor.UnitTests.Other
                 .ToList();
 
             duplicates.Should().BeEmpty();
+        }
+
+        [Test]
+        public void ViewerHiddenComponentsAreRoutableButDetectable()
+        {
+            // [ViewerHidden] is applied as a Razor @attribute; the viewer keeps such components routable
+            // but filters them out of the sidebar listing. Confirm the attribute round-trips through
+            // reflection (how that filter detects them) and that those components are still discovered.
+            var components = GetViewerComponentTypes();
+
+            var hidden = components
+                .Where(type => type.IsDefined(typeof(ViewerHiddenAttribute), inherit: false))
+                .ToList();
+
+            hidden.Should().NotBeEmpty();
         }
     }
 }


### PR DESCRIPTION
Drop the "name must contain `Test`" requirement so viewer components are discovered by **where they live**, not how they are named. This surfaces helper components that previously had no way to be opened, and lets a scratch repro be named anything as long as it lives under `TestComponents`. Builds on #13303 / #13305 / #13306.

### What changed
`src/MudBlazor.UnitTests.Viewer/Pages/Index.razor`:
- **Location-based discovery** — discover any component under a `TestComponents` namespace. A few legacy components override `@namespace` away from their folder (`ParameterState*`/`SharedState*` in `Utilities/` use `MudBlazor.UnitTests`; two use `MudBlazor.Docs.Examples`), so the historical `name contains "Test"` is kept as a **fallback** to avoid dropping any currently-visible component.
- **`[ViewerHidden]` opt-out** (new `ViewerHiddenAttribute`) — a marked component stays **routable** at `/viewer/<path>` but is kept **out of the sidebar listing**. Applied to four dialog-content fragments that only render meaningfully inside a dialog: `SimpleDialog`, `DialogWithEventCallback`, `TextFieldAutoSizingDialog`, `TextFieldFixedSizingDialog`.

`_README.txt` and `AGENTS.md` — updated to describe location-based discovery and the `[ViewerHidden]` opt-out (the old "must contain `Test`" rule is gone).

`ViewerTestComponentRouteTests` — extended to assert `[ViewerHidden]` components are discovered and detectable via reflection (the listing filter relies on that round-trip), alongside the existing route-key uniqueness check.

### Why
The agentic loop wants to create a focused repro, open it, and delete it. Tying discovery to a `Test` substring in the name was an unnecessary constraint; location is the natural identity (and matches the `/viewer/<path>` routing from #13306). Helpers that aren't meaningful standalone opt out of the listing while remaining addressable.

### Verification
- Scoped viewer build: 0 warnings / 0 errors. `dotnet format whitespace`: clean.
- `dotnet test ... --filter "FullyQualifiedName~ViewerTestComponentRouteTests"` → 2/2 pass (route keys unique across the expanded set; `[ViewerHidden]` detected via reflection).
- Drove the running viewer: a previously-invisible helper (`Autocomplete/AutocompleteContainer`, no `Test` in its name) now renders; a `[ViewerHidden]` component (`Dialog/SimpleDialog`) is still routable (and renders blank standalone, which is why it's hidden from the list).

### Notes for reviewers
- No component is dropped by the discovery change (the name-based fallback covers the `@namespace`-overridden outliers); route-key uniqueness is enforced by the test.
- `[ViewerHidden]` is applied to four clear dialog fragments here; more helpers can opt out the same way over time.
- Fourth of a small series making the viewer a stable reproduction host.

**Checklist:**
- [x] I have read the contribution guidelines
- [x] My code follows the style of this project
- [x] I have added or updated relevant unit tests