### PR TITLE
Tests: Document the reproduction workflow and add a Scratch folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,20 @@ private Task ToggleAsync()
 - Test names must not use `Test` or `Async` suffixes, must not contain `Test_` in the middle, and must not end with trailing underscores.
 - Reference tests: `TextTests.cs`, `ApiMemberTableTests.cs`.
 
+### Reproducing visual issues with the Viewer
+
+Use `src/MudBlazor.UnitTests.Viewer` to reproduce and verify visual, layout, focus, overlay, popover, drag/drop, responsive, RTL, dark-mode, or browser-interaction behavior that bUnit alone cannot confidently verify. Prefer a focused viewer component over the docs app unless the issue depends on docs-only composition.
+
+Reproduction loop:
+1. Add a focused component under `TestComponents/<Component>/`, or under `TestComponents/Scratch/` for a throwaway repro (that folder is gitignored, so scratch components are never committed).
+2. Build the viewer with `dotnet build src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj /p:SkipBunCompile=true`. Components are discovered by reflection at startup, so a newly added file is not visible until the app is rebuilt and reloaded; `dotnet watch` does not reliably pick up added files or routes.
+3. Run it with `dotnet run --project src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj` and open `/viewer/<path>`, where `<path>` is the folder relative to `TestComponents` plus the type name (e.g. `/viewer/Menu/MenuEdgeCasesTest`).
+4. Set visual state through the query string: `theme=light|dark`, `dir=ltr|rtl`, `chrome=full|none`. `chrome=none` hides the viewer UI (drawer and header) while keeping theme, RTL, and the popover/dialog/snackbar providers intact, which is useful for clean screenshots.
+5. Capture the route, query parameters, viewport, and steps as before/after evidence.
+6. Delete the component (and rebuild) when done; a scratch component is removed with a single file delete.
+
+Use `@attribute [ViewerHidden]` for helper or sub-components that are not meaningful to open on their own; they stay routable but are kept out of the sidebar listing.
+
 ## Code Style and Analyzer Rules
 
 - Fix new warnings instead of suppressing them.

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Scratch/.gitignore
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Scratch/.gitignore
@@ -1,0 +1,7 @@
+# Throwaway viewer repro components (e.g. created while reproducing an issue) live here.
+# They are discovered and routable at /viewer/Scratch/<Name> like any other test component,
+# but are intentionally not committed. Delete them when you are done.
+#
+# This .gitignore keeps the folder in the repo while ignoring everything placed in it.
+*
+!.gitignore


### PR DESCRIPTION
The capstone of the viewer series (#13303, #13305, #13306, #13308): make `src/MudBlazor.UnitTests.Viewer` the default local host for reproducing and verifying visual/component issues, including autonomous create -> interact -> delete loops.

Changes
- **Gitignored `TestComponents/Scratch/` folder** for throwaway repro components. They are discovered and routable at `/viewer/Scratch/<Name>` like any other test component, but are never committed (the folder's `.gitignore` ignores everything except itself). Cleanup is a single file delete.
- **AGENTS.md - "Reproducing visual issues with the Viewer"**: when to reach for the viewer instead of bUnit/the docs app, and the full loop:
  1. add a focused component (under the relevant folder, or `Scratch/` for throwaway),
  2. **rebuild** (components are discovered by reflection at startup, so a newly added file is not visible until rebuilt + reloaded; `dotnet watch` does not reliably pick up added files/routes),
  3. open `/viewer/<path>`,
  4. set `theme`/`dir`/`chrome` via the query string (`chrome=none` for clean screenshots),
  5. capture before/after evidence,
  6. delete when done.

PR1-4 gave the viewer stable path URLs, URL-controlled visual state, crash-proof rendering, and location-based discovery. This PR documents how to actually use those for issue reproduction and gives a clean, disposable place for throwaway components - which is what turns the series into an end-to-end agent/browser workflow.


**Checklist:**
- [x] I have read the contribution guidelines
- [x] My code follows the style of this project
- [ ] I have added or updated relevant unit tests - N/A (documentation + gitignore only)