### PR TITLE
MudTooltip: Fix flex/grid layouts by making the wrapper layout-transparent

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
@@ -109,7 +109,7 @@ public sealed class ApiTextTests : BunitTest
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>", "There should be a text span");
 
-        comp.Markup.Should().Contain("<a href=\"/api/MudComponentBase#Class\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Class</a>", "Then a link to /api/MudComponentBase#Class");
+        comp.Markup.Should().Contain("<a href=\"/api/MudComponentBase#Class\" blazor:onclick=\"4\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Class</a>", "Then a link to /api/MudComponentBase#Class");
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>", "Ending with another text span");
     }
@@ -139,7 +139,7 @@ public sealed class ApiTextTests : BunitTest
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>", "There should be a text span");
 
-        comp.Markup.Should().Contain("<a href=\"/api/AggregateDefinition`1#SimpleAvg\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">SimpleAvg</a>", "Then a link to /api/AggregateDefinition`1#SimpleAvg");
+        comp.Markup.Should().Contain("<a href=\"/api/AggregateDefinition`1#SimpleAvg\" blazor:onclick=\"4\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">SimpleAvg</a>", "Then a link to /api/AggregateDefinition`1#SimpleAvg");
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to receive viewport changes.</span>", "Ending with another text span");
     }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTextTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using AwesomeAssertions;
+using Bunit;
 using MudBlazor.Docs.Components;
 using NUnit.Framework;
 
@@ -109,7 +110,9 @@ public sealed class ApiTextTests : BunitTest
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">Occurs when </span>", "There should be a text span");
 
-        comp.Markup.Should().Contain("<a href=\"/api/MudComponentBase#Class\" blazor:onclick=\"4\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Class</a>", "Then a link to /api/MudComponentBase#Class");
+        var link = comp.Find("a[href='/api/MudComponentBase#Class']");
+        link.TextContent.Should().Be("Class", "Then a link to /api/MudComponentBase#Class");
+        link.GetAttribute("class").Should().Be("mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary");
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> has changed.</span>", "Ending with another text span");
     }
@@ -139,7 +142,9 @@ public sealed class ApiTextTests : BunitTest
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\">When set, calls </span>", "There should be a text span");
 
-        comp.Markup.Should().Contain("<a href=\"/api/AggregateDefinition`1#SimpleAvg\" blazor:onclick=\"4\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">SimpleAvg</a>", "Then a link to /api/AggregateDefinition`1#SimpleAvg");
+        var link = comp.Find("a[href='/api/AggregateDefinition`1#SimpleAvg']");
+        link.TextContent.Should().Be("SimpleAvg", "Then a link to /api/AggregateDefinition`1#SimpleAvg");
+        link.GetAttribute("class").Should().Be("mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary");
 
         comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-caption\"> to receive viewport changes.</span>", "Ending with another text span");
     }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using AwesomeAssertions;
+using Bunit;
 using MudBlazor.Docs.Components;
 using NUnit.Framework;
 
@@ -187,7 +188,9 @@ public sealed class ApiTypeLinkTests : BunitTest
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
 
-        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"4\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
+        var link = comp.Find("a[href='/api/MudAlert']");
+        link.TextContent.Should().Be("MudAlert", "There should be a link to MudAlert");
+        link.GetAttribute("class").Should().Be("mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary");
     }
 
     /// <summary>

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
@@ -187,7 +187,7 @@ public sealed class ApiTypeLinkTests : BunitTest
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
 
-        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
+        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"4\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
     }
 
     /// <summary>

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Xml.Linq;
+using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
@@ -97,16 +98,20 @@ namespace MudBlazor.UnitTests.Components
             closeButtons.Should().HaveCount(3);
 
             // Tooltips are shown via a JS hover bridge (display:contents wrapper, issue #1167) which
-            // bUnit can't dispatch, so drive the matching tooltip instance directly. Render order of the
-            // tooltip components aligns with the DOM order of the close buttons they wrap.
-            var closeTooltips = comp.FindComponents<MudTooltip>()
-                .Where(x => x.Instance.Text == "close here")
-                .ToList();
-            closeTooltips.Should().HaveCount(3);
-
-            for (var index = 0; index < closeButtons.Count; index++)
+            // bUnit can't dispatch, so drive the matching tooltip instance directly. Each button maps
+            // to its tooltip through the popover marker id rendered inside the tooltip's wrapper.
+            // The marker must be a direct child of the tooltip's own wrapper, otherwise an outer
+            // tooltip (each tab is wrapped in one too) would also match by containing the nested marker.
+            MudTooltip TooltipOf(IElement button)
             {
-                var item = closeButtons[index];
+                var markerId = button.ParentElement!.Children[1].Id;
+                return comp.FindComponents<MudTooltip>()
+                    .Single(x => x.Nodes.OfType<IElement>().Any(root => root.Children.Any(child => child.Id == markerId)))
+                    .Instance;
+            }
+
+            foreach (var item in closeButtons)
+            {
                 item.ClassList.Should().StartWith(["mud-button-root"]);
 
                 var actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
@@ -117,7 +122,8 @@ namespace MudBlazor.UnitTests.Components
                 var parent = (IHtmlElement)item.Parent;
                 parent.Children.Should().HaveCount(2, because: "the button and the empty popover hint since it's not active");
 
-                await comp.InvokeAsync(() => closeTooltips[index].Instance.OnHoverChangedAsync(true));
+                var tooltip = TooltipOf(item);
+                await comp.InvokeAsync(() => tooltip.OnHoverChangedAsync(true));
 
                 var popoverId = parent.Children[1].Id.Substring(8);
 
@@ -126,20 +132,14 @@ namespace MudBlazor.UnitTests.Components
                 toolTip.ClassList.Should().Contain(["mud-tooltip"]);
                 toolTip.TextContent.Should().Be("close here");
 
-                await comp.InvokeAsync(() => closeTooltips[index].Instance.OnHoverChangedAsync(false));
+                await comp.InvokeAsync(() => tooltip.OnHoverChangedAsync(false));
             }
 
             var addButtons = comp.FindAll(".my-add-icon-class");
 
             addButtons.Should().HaveCount(1);
-            var addTooltips = comp.FindComponents<MudTooltip>()
-                .Where(x => x.Instance.Text == "add here")
-                .ToList();
-            addTooltips.Should().HaveCount(1);
-
-            for (var index = 0; index < addButtons.Count; index++)
+            foreach (var item in addButtons)
             {
-                var item = addButtons[index];
                 item.ClassList.Should().StartWith(["mud-button-root"]);
 
                 var actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
@@ -150,7 +150,8 @@ namespace MudBlazor.UnitTests.Components
                 var parent = (IHtmlElement)item.Parent;
                 parent.Children.Should().HaveCount(2, because: "the button and the empty popover hint"); ;
 
-                await comp.InvokeAsync(() => addTooltips[index].Instance.OnHoverChangedAsync(true));
+                var tooltip = TooltipOf(item);
+                await comp.InvokeAsync(() => tooltip.OnHoverChangedAsync(true));
 
                 var popoverId = parent.Children[1].Id.Substring(8);
 
@@ -159,7 +160,7 @@ namespace MudBlazor.UnitTests.Components
                 toolTip.ClassList.Should().Contain(["mud-tooltip"]);
                 toolTip.TextContent.Should().Be("add here");
 
-                await comp.InvokeAsync(() => addTooltips[index].Instance.OnHoverChangedAsync(false));
+                await comp.InvokeAsync(() => tooltip.OnHoverChangedAsync(false));
             }
         }
 

--- a/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DynamicTabsTests.cs
@@ -96,8 +96,17 @@ namespace MudBlazor.UnitTests.Components
             var closeButtons = comp.FindAll(".my-close-icon-class");
             closeButtons.Should().HaveCount(3);
 
-            foreach (var item in closeButtons)
+            // Tooltips are shown via a JS hover bridge (display:contents wrapper, issue #1167) which
+            // bUnit can't dispatch, so drive the matching tooltip instance directly. Render order of the
+            // tooltip components aligns with the DOM order of the close buttons they wrap.
+            var closeTooltips = comp.FindComponents<MudTooltip>()
+                .Where(x => x.Instance.Text == "close here")
+                .ToList();
+            closeTooltips.Should().HaveCount(3);
+
+            for (var index = 0; index < closeButtons.Count; index++)
             {
+                var item = closeButtons[index];
                 item.ClassList.Should().StartWith(["mud-button-root"]);
 
                 var actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
@@ -108,7 +117,7 @@ namespace MudBlazor.UnitTests.Components
                 var parent = (IHtmlElement)item.Parent;
                 parent.Children.Should().HaveCount(2, because: "the button and the empty popover hint since it's not active");
 
-                await item.ParentElement.PointerEnterAsync();
+                await comp.InvokeAsync(() => closeTooltips[index].Instance.OnHoverChangedAsync(true));
 
                 var popoverId = parent.Children[1].Id.Substring(8);
 
@@ -117,15 +126,20 @@ namespace MudBlazor.UnitTests.Components
                 toolTip.ClassList.Should().Contain(["mud-tooltip"]);
                 toolTip.TextContent.Should().Be("close here");
 
-                await item.ParentElement.PointerLeaveAsync();
-
+                await comp.InvokeAsync(() => closeTooltips[index].Instance.OnHoverChangedAsync(false));
             }
 
             var addButtons = comp.FindAll(".my-add-icon-class");
 
             addButtons.Should().HaveCount(1);
-            foreach (var item in addButtons)
+            var addTooltips = comp.FindComponents<MudTooltip>()
+                .Where(x => x.Instance.Text == "add here")
+                .ToList();
+            addTooltips.Should().HaveCount(1);
+
+            for (var index = 0; index < addButtons.Count; index++)
             {
+                var item = addButtons[index];
                 item.ClassList.Should().StartWith(["mud-button-root"]);
 
                 var actual = XElement.Parse($"<test>{item.Children[0].Children[0].InnerHtml}</test>");
@@ -136,7 +150,7 @@ namespace MudBlazor.UnitTests.Components
                 var parent = (IHtmlElement)item.Parent;
                 parent.Children.Should().HaveCount(2, because: "the button and the empty popover hint"); ;
 
-                await item.ParentElement.PointerEnterAsync();
+                await comp.InvokeAsync(() => addTooltips[index].Instance.OnHoverChangedAsync(true));
 
                 var popoverId = parent.Children[1].Id.Substring(8);
 
@@ -145,7 +159,7 @@ namespace MudBlazor.UnitTests.Components
                 toolTip.ClassList.Should().Contain(["mud-tooltip"]);
                 toolTip.TextContent.Should().Be("add here");
 
-                await item.ParentElement.PointerLeaveAsync();
+                await comp.InvokeAsync(() => addTooltips[index].Instance.OnHoverChangedAsync(false));
             }
         }
 

--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -60,7 +60,7 @@ namespace MudBlazor.UnitTests.Components
             tooltipComp.GetState(x => x.Visible).Should().BeFalse();
 
             //trigger pointerover
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             popoverContentNode().TextContent.Should().Be("my tooltip content text");
             popoverContentNode().ClassList.Should().Contain("d-flex");
@@ -70,7 +70,7 @@ namespace MudBlazor.UnitTests.Components
             //trigger pointerleave
             if (!usingFocusout)
             {
-                await button.ParentElement.PointerLeaveAsync(new PointerEventArgs());
+                await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(false));
             }
             else
             {
@@ -124,7 +124,7 @@ namespace MudBlazor.UnitTests.Components
             popoverContentNode.Children.Should().BeEmpty();
 
             //trigger pointerover
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             //content should be visible
             popoverContentNode.ClassList.Should().Contain("mud-tooltip");
@@ -135,7 +135,7 @@ namespace MudBlazor.UnitTests.Components
             //trigger pointerleave
             if (!usingFocusout)
             {
-                await button.ParentElement.PointerLeaveAsync(new PointerEventArgs());
+                await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(false));
             }
             else
             {
@@ -166,7 +166,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<TooltipPopoverClassPropertyTest>();
 
             var button = comp.Find("button");
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             var wrapperDivNode = comp.Find("#my-tooltip-content").ParentElement;
 
@@ -182,7 +182,7 @@ namespace MudBlazor.UnitTests.Components
             p.Add(x => x.Arrow, arrowValue));
 
             var button = comp.Find("button");
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -200,7 +200,7 @@ namespace MudBlazor.UnitTests.Components
             p.Add(x => x.Color, colorValue));
 
             var button = comp.Find("button");
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -221,7 +221,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -251,7 +251,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
 
             var popoverContentNode = comp.Find("#my-tooltip-content").ParentElement.ParentElement;
 
@@ -303,7 +303,7 @@ namespace MudBlazor.UnitTests.Components
 
             if (!usingFocusout)
             {
-                await button.ParentElement.PointerLeaveAsync(new PointerEventArgs());
+                await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(false));
             }
             else
             {
@@ -355,7 +355,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             var button = comp.Find("button");
-            await button.ParentElement.PointerEnterAsync(new PointerEventArgs());
+            await comp.InvokeAsync(() => comp.FindComponent<MudTooltip>().Instance.OnHoverChangedAsync(true));
             comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
         }
 
@@ -376,21 +376,12 @@ namespace MudBlazor.UnitTests.Components
             var tooltip = comp.Instance;
             tooltip.Should().NotBeNull();
 
-            await tooltip.HandlePointerEnterAsync();
+            await comp.InvokeAsync(() => tooltip.OnHoverChangedAsync(true));
             tooltip.GetState(x => x.Visible).Should().Be(showOnHover);
 
             if (showOnHover)
             {
-                await tooltip.HandlePointerLeaveAsync();
-                tooltip.GetState(x => x.Visible).Should().Be(!showOnHover);
-            }
-
-            await div.PointerEnterAsync(new PointerEventArgs());
-            tooltip.GetState(x => x.Visible).Should().Be(showOnHover);
-
-            if (showOnHover)
-            {
-                await div.PointerLeaveAsync(new PointerEventArgs());
+                await comp.InvokeAsync(() => tooltip.OnHoverChangedAsync(false));
                 tooltip.GetState(x => x.Visible).Should().Be(!showOnHover);
             }
         }
@@ -408,9 +399,8 @@ namespace MudBlazor.UnitTests.Components
             var initialCount = complexComp.RenderCount;
             initialCount.Should().Be(1);
 
-            // Simulate hover via bUnit's event trigger
-            var div = comp.Find(".mud-tooltip-root");
-            await div.PointerEnterAsync(new PointerEventArgs());
+            // Simulate hover
+            await comp.InvokeAsync(() => comp.Instance.OnHoverChangedAsync(true));
 
             // Verify that the tooltip is now visible
             comp.Instance.GetState(x => x.Visible).Should().BeTrue();

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" class="@ContainerClass" style="@RootStyle" @onpointerenter="@HandlePointerEnterAsync" @onpointerleave="@HandlePointerLeaveAsync" @onpointerup="@HandlePointerUpAsync" @onfocusin="@HandleFocusInAsync" @onfocusout="@HandleFocusOutAsync">
+<div @ref="_rootRef" @attributes="UserAttributes" class="@ContainerClass" style="@RootStyle" @onpointerup="@HandlePointerUpAsync" @onfocusin="@HandleFocusInAsync" @onfocusout="@HandleFocusOutAsync">
     <MudTooltipChildContainer ChildContent="@ChildContent" UpdateCount="@_parentUpdateCount" />
     @if (ShowToolTip())
     {

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor.cs
@@ -2,7 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.State;
 using MudBlazor.Utilities;
 
@@ -12,15 +14,23 @@ namespace MudBlazor
     /// <summary>
     /// Displays additional context when users hover over or focus on an element.
     /// </summary>
-    public partial class MudTooltip : MudComponentBase
+    public partial class MudTooltip : MudComponentBase, IAsyncDisposable
     {
         private int _parentUpdateCount;
         private readonly ParameterState<bool> _visibleState;
         private Origin _anchorOrigin;
         private Origin _transformOrigin;
+        private ElementReference _rootRef;
+        private readonly Lazy<DotNetObjectReference<MudTooltip>> _dotNetReferenceLazy;
 
+        [Inject]
+        private IJSRuntime JsRuntime { get; set; } = null!;
+
+        [DynamicDependency(nameof(OnHoverChangedAsync))]
         public MudTooltip()
         {
+            _dotNetReferenceLazy = new Lazy<DotNetObjectReference<MudTooltip>>(() => DotNetObjectReference.Create(this));
+
             using var registerScope = CreateRegisterScope();
             _visibleState = registerScope.RegisterParameter<bool>(nameof(Visible))
                 .WithParameter(() => Visible)
@@ -236,9 +246,56 @@ namespace MudBlazor
             ConvertPlacement();
         }
 
-        internal Task HandlePointerEnterAsync() => ShowOnHover ? _visibleState.SetValueAsync(true) : Task.CompletedTask;
+        /// <inheritdoc />
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                // The wrapper is display:contents (issue #1167) and has no box, so pointerenter/leave
+                // never fire on it. Bridge hover through the bubbling pointerover/pointerout events.
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudElementRef.addTooltipHover", _rootRef, _dotNetReferenceLazy.Value);
+            }
 
-        internal Task HandlePointerLeaveAsync() => ShowOnHover ? _visibleState.SetValueAsync(false) : Task.CompletedTask;
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
+        {
+            if (IsJSRuntimeAvailable)
+            {
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudElementRef.removeTooltipHover", _rootRef);
+            }
+
+            if (_dotNetReferenceLazy.IsValueCreated)
+            {
+                _dotNetReferenceLazy.Value.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Invoked from JavaScript (via the hover bridge installed by <c>mudElementRef.addTooltipHover</c>)
+        /// when the pointer enters or leaves the tooltip's content. The bridge is used because the
+        /// <c>display:contents</c> wrapper generates no box, so the native pointerenter/leave events
+        /// never fire on it; the bridge listens to the bubbling pointerover/pointerout events and ignores
+        /// moves that stay within the wrapper subtree.
+        /// </summary>
+        /// <param name="hovered">Whether the pointer is now within the tooltip's content.</param>
+        [JSInvokable]
+        public async Task OnHoverChangedAsync(bool hovered)
+        {
+            if (!ShowOnHover)
+            {
+                return;
+            }
+
+            await _visibleState.SetValueAsync(hovered);
+            // Unlike the UI event handlers (focus/click), a JS interop callback does not trigger an
+            // automatic re-render, so request one explicitly to open/close the popover.
+            await InvokeAsync(StateHasChanged);
+        }
 
         private Task HandleFocusInAsync()
         {

--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -4,10 +4,6 @@
   border-radius: var(--mud-default-borderradius);
   display: inline-flex;
 
-  > .mud-tooltip-root {
-    display: flex;
-  }
-
   .mud-button-root {
     border-radius: var(--mud-default-borderradius);
   }

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -10,10 +10,6 @@
 
   &.mud-tabs-vertical {
     flex-direction: row;
-
-    .mud-tooltip-root {
-      width: auto;
-    }
   }
 
   &.mud-tabs-vertical-reverse {

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -1,12 +1,18 @@
 
 .mud-tooltip-root {
+  // The default (inline) tooltip wrapper is layout-transparent so the wrapped content
+  // participates directly in the parent's flex/grid/inline layout (issue #1167). The popover
+  // is anchored to the wrapped content's box in mudPopover.js, not to this box-less wrapper.
+  // Inline="false" keeps a real block box as an escape hatch for styling the wrapper.
   &.mud-tooltip-inline {
-    display: inline-block;
+    display: contents;
   }
 
-  &.mud-tooltip-inline:has(> .mud-width-full) {
-    display: block;
-    width: 100%;
+  // The popover's in-place node is only an anchor marker (the content is portalled to the
+  // provider). With display:contents it would otherwise be promoted into the parent layout
+  // and consume a flex `gap` slot, so keep it out of flow.
+  > .mud-popover-cascading-value {
+    display: none;
   }
 }
 

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -288,5 +288,43 @@ class MudElementReference {
             delete element._mudBlurHandler;
         }
     }
+
+    // The tooltip wrapper uses display:contents (issue #1167) so it generates no box; the
+    // non-bubbling pointerenter/leave events never fire on it. Bridge hover via the bubbling
+    // pointerover/pointerout events instead and ignore moves that stay within the wrapper
+    // subtree (relatedTarget contained) so crossing a child boundary doesn't flicker the tooltip.
+    /**
+     * Attaches a hover bridge that calls back into .NET (OnHoverChangedAsync).
+     */
+    addTooltipHover(element, dotNetReference) {
+        if (!element) return;
+        element._mudTooltipOver = function (e) {
+            if (!element.contains(e.relatedTarget)) {
+                dotNetReference.invokeMethodAsync('OnHoverChangedAsync', true).catch(() => { });
+            }
+        };
+        element._mudTooltipOut = function (e) {
+            if (!element.contains(e.relatedTarget)) {
+                dotNetReference.invokeMethodAsync('OnHoverChangedAsync', false).catch(() => { });
+            }
+        };
+        element.addEventListener('pointerover', element._mudTooltipOver);
+        element.addEventListener('pointerout', element._mudTooltipOut);
+    }
+
+    /**
+     * Detaches the hover bridge previously installed by addTooltipHover.
+     */
+    removeTooltipHover(element) {
+        if (!element) return;
+        if (element._mudTooltipOver) {
+            element.removeEventListener('pointerover', element._mudTooltipOver);
+            delete element._mudTooltipOver;
+        }
+        if (element._mudTooltipOut) {
+            element.removeEventListener('pointerout', element._mudTooltipOut);
+            delete element._mudTooltipOut;
+        }
+    }
 };
 window.mudElementRef = new MudElementReference();

--- a/src/MudBlazor/TScripts/mudElementReference.js
+++ b/src/MudBlazor/TScripts/mudElementReference.js
@@ -298,14 +298,20 @@ class MudElementReference {
      */
     addTooltipHover(element, dotNetReference) {
         if (!element) return;
+        const invokeHoverChanged = function (hovered) {
+            dotNetReference.invokeMethodAsync('OnHoverChangedAsync', hovered).catch(err => {
+                console.warn("Error invoking OnHoverChangedAsync, possibly disposed:", err);
+                window.mudElementRef.removeTooltipHover(element);
+            });
+        };
         element._mudTooltipOver = function (e) {
             if (!element.contains(e.relatedTarget)) {
-                dotNetReference.invokeMethodAsync('OnHoverChangedAsync', true).catch(() => { });
+                invokeHoverChanged(true);
             }
         };
         element._mudTooltipOut = function (e) {
             if (!element.contains(e.relatedTarget)) {
-                dotNetReference.invokeMethodAsync('OnHoverChangedAsync', false).catch(() => { });
+                invokeHoverChanged(false);
             }
         };
         element.addEventListener('pointerover', element._mudTooltipOver);

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -244,6 +244,24 @@ window.mudpopoverHelper = {
         return true;
     },
 
+    // Resolves the rect the popover should anchor to. Inline tooltips wrap their content in a
+    // display:contents element (issue #1167) which has no box of its own, so anchor to the wrapped
+    // content (everything in the wrapper up to the popover marker) instead of the box-less wrapper.
+    getAnchorBoundingRect: function (popoverNode) {
+        const parent = popoverNode.parentNode;
+        if (parent?.classList?.contains('mud-tooltip-inline')) {
+            const range = document.createRange();
+            range.setStart(parent, 0);
+            range.setEndBefore(popoverNode);
+            const rect = range.getBoundingClientRect();
+            // Fall back to the wrapper for text-only/empty content with no measurable box.
+            if (rect && (rect.width > 0 || rect.height > 0)) {
+                return rect;
+            }
+        }
+        return parent.getBoundingClientRect();
+    },
+
     // primary positioning method
     placePopover: function (popoverNode, classSelector) {
         // parentNode is the calling element, mudmenu/tooltip/etc not the parent popover if it's a child popover
@@ -265,7 +283,7 @@ window.mudpopoverHelper = {
             if (classSelector && !classList.contains(classSelector)) return;
 
             // Batch DOM reads
-            let boundingRect = popoverNode.parentNode.getBoundingClientRect();
+            let boundingRect = window.mudpopoverHelper.getAnchorBoundingRect(popoverNode);
             if (!window.mudpopoverHelper.isInViewport(popoverNode, boundingRect)) {
                 // if the parentNode isn't visible at all we stop
                 return;


### PR DESCRIPTION
## Problem

Wrapping a component in MudTooltip inserts a `display: inline-block` div between the component and its parent. The child stops participating in the parent's flex/grid layout: widths collapse, buttons don't stretch, heights shift (#1167, #10882, #9979).

The wrapper does three jobs at once — layout box, pointer/focus event target, popover anchor — and no single `display` value satisfies all three. That's why this kept regressing and collecting scoped CSS patches (#13292, vertical tabs, the `:has(.mud-width-full)` special case).

## Fix

Make the default (inline) wrapper `display: contents` so the wrapped content sits directly in the parent's layout, then repair the two things that relied on the wrapper having a box:

- Popover anchoring (`mudPopover.js`): a `display:contents` element has no box, so the tooltip anchors to the wrapped content via a DOM Range. Gated to `.mud-tooltip-inline`; every other popover keeps its existing anchoring.
- Hover (`MudTooltip.razor.cs`, `mudElementReference.js`): `pointerenter`/`pointerleave` never fire on a box-less element, so hover is bridged through the bubbling `pointerover`/`pointerout` events, ignoring moves that stay inside the wrapper subtree. Focus and click handlers are unchanged. The bridge warns and detaches itself if the component was disposed.
- The popover's in-place marker is `display:none` so it can't consume a flex `gap` slot.
- Deleted the band-aids this replaces: buttongroup `display:flex` (#13292), vertical-tabs `width:auto`, and the `:has(.mud-width-full)` rule.

`Inline="false"` still renders a real block box as an escape hatch for styling the wrapper.

## Behavior changes

- Box-affecting `RootClass`/`RootStyle` on default tooltips (e.g. `mud-width-full`) no longer have an effect — the child now sizes itself. `Inline="false"` keeps a styleable box. Needs a migration note.
- Layouts that compensated for the old inline-block wrapper will now render the natural (correct) way.

## Related

- Closes #1167
- Closes #9979 
- Closes #10882 
- Closes #11472 
- Closes #13314

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added/updated relevant tests.
