### PR TITLE
MudNumericField: Don't reformat text while typing with Immediate

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4921,6 +4921,28 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridNumericColumnFilter_CanTypeDecimalCharByChar()
+        {
+            // Regression test for #13250: typing a decimal value such as "1.008" one character at a time
+            // into a numeric column filter (which renders a MudNumericField with Immediate=true and the
+            // column Culture bound) must produce 1.008. Previously the field reformatted on every
+            // keystroke, so the "." and the leading "0" were stripped and the filter became 1008.
+            var comp = Context.Render<DataGridCultureEditableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCultureEditableTest.Model>>();
+
+            // Amount column (index 2) uses InvariantCulture, so "." is the decimal separator.
+            IElement AmountFilter() => dataGrid.FindAll("th.filter-header-cell input")[2];
+            foreach (var ch in "1.008")
+            {
+                var current = AmountFilter().GetAttribute("value") ?? string.Empty;
+                await AmountFilter().InputAsync(current + ch);
+            }
+
+            dataGrid.Instance.FilterDefinitions.Count.Should().Be(1);
+            dataGrid.Instance.FilterDefinitions[0].Value.Should().Be(1.008);
+        }
+
+        [Test]
         public async Task DataGridCultureColumnFilterHeader()
         {
             var comp = Context.Render<DataGridCultureEditableTest>();

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -601,8 +601,11 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NumericField_Immediate_Should_Reformat_Repeated_Input_With_F3()
+        public async Task NumericField_Immediate_Should_Not_Reformat_While_Typing_But_Format_On_Blur_With_F3()
         {
+            // Regression test for #13266 / #13002 / #13250: with Immediate=true and a Format, the field
+            // must NOT reformat the text on every keystroke (which jumped the caret and made multi-digit
+            // entry impossible). The parsed value stays correct while typing; the format is applied on blur.
             var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
                 .Add(x => x.Immediate, true)
                 .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
@@ -610,15 +613,83 @@ namespace MudBlazor.UnitTests.Components
 
             var input = comp.Find("input");
 
+            // While the user is typing (oninput), the raw text is preserved, not reformatted to "3.145".
             await input.InputAsync("3.14514515415414515");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
+            comp.Instance.ReadText.Should().Be("3.14514515415414515");
+            input.GetAttribute("value").Should().Be("3.14514515415414515");
+
+            // On blur the value is reformatted with the supplied format.
+            await input.BlurAsync();
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
             input.GetAttribute("value").Should().Be("3.145");
+        }
 
-            await input.InputAsync("3.145145154154145159");
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.145145154154145159d));
-            input.GetAttribute("value").Should().Be("3.145");
+        // Simulate a user typing one character at a time, appending each keystroke to whatever is
+        // currently displayed in the input (cursor-at-end), exactly like a browser does.
+        private static async Task TypeCharByCharAsync(IRenderedComponent<MudNumericField<double?>> comp, string toType)
+        {
+            IElement Input() => comp.Find("input");
+            foreach (var ch in toType)
+            {
+                var current = Input().GetAttribute("value") ?? string.Empty;
+                await Input().InputAsync(current + ch);
+            }
+        }
+
+        [Test]
+        public async Task NumericField_Immediate_WithFormat_TypingMultiDigit_IsNotReformattedMidway()
+        {
+            // #13266: typing "1234" one character at a time with Immediate=true and Format="F3" must
+            // build up the value 1234, not collapse to 1 because the field reformatted to "1.000"
+            // after the first keystroke (which moved the caret to the end and ate every later digit).
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "F3"));
+
+            await TypeCharByCharAsync(comp, "1234");
+
+            comp.Instance.ReadText.Should().Be("1234", "the raw text is preserved while typing");
+            comp.Instance.ReadValue.Should().Be(1234d);
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1234.000"));
+            comp.Instance.ReadValue.Should().Be(1234d);
+        }
+
+        [Test]
+        public async Task NumericField_Immediate_WithCulture_CanTypeZeroAfterDecimalPoint()
+        {
+            // #13250: with Immediate=true and an explicit Culture (as the DataGrid numeric filter uses),
+            // typing "1.008" one character at a time must produce 1.008. Previously the "." and the
+            // leading "0" were stripped by the mid-typing reformat, turning the input into 1008.
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US")));
+
+            await TypeCharByCharAsync(comp, "1.008");
+
+            comp.Instance.ReadText.Should().Be("1.008", "the raw text is preserved while typing");
+            comp.Instance.ReadValue.Should().Be(1.008d);
+        }
+
+        [Test]
+        public async Task NumericField_Immediate_WithPattern_IsNotReformattedWhileTyping()
+        {
+            // Covers the Pattern trigger of UsesManagedFormatting (the Format and Culture triggers are
+            // covered by the two tests above). Typing "1.5" one character at a time with Immediate must
+            // not strip the "." mid-entry.
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Pattern, @"[0-9.\-]"));
+
+            await TypeCharByCharAsync(comp, "1.5");
+
+            comp.Instance.ReadText.Should().Be("1.5", "the raw text is preserved while typing");
+            comp.Instance.ReadValue.Should().Be(1.5d);
         }
 
         [Test]

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -516,9 +516,14 @@ namespace MudBlazor
         {
             await SetTextAndUpdateValueAsync(text);
 
-            // Keep formatted text in sync when using formatted input mode.
-            // This also covers onchange updates that can occur around blur timing.
-            if (UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
+            // Keep formatted text in sync with the value when using managed formatting, but only for a
+            // committed change (onchange), never for live typing (oninput). When Immediate is true this
+            // callback runs on every keystroke; reformatting then would rewrite the text mid-typing and
+            // jump the caret to the end, making multi-digit or decimal entry impossible (e.g. typing
+            // "1234" with Format="F3" collapses to "1.000", and "1." loses its trailing characters).
+            // The parsed value stays correct while typing; the text is reformatted on blur instead
+            // (see OnBlurredAsync). This matches the non-Immediate behavior and pre-v9.1 formatting.
+            if (!Immediate && UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
             {
                 var formattedText = ConvertSet(ReadValue);
                 if (!string.Equals(ReadText, formattedText, StringComparison.Ordinal))


### PR DESCRIPTION
Fixes #13266
Fixes #13250
Related to #13002

### Problem

When `Immediate="true"` and a managed format (`Format`, `Pattern`, or an explicit `Culture`) is set, `MudNumericField` reformatted the input text on every keystroke. This rewrote the box and moved the caret to the end after the first character, making multi-digit and decimal entry impossible:

- Typing `1234` with `Format="F3"` collapsed to `1.000` (so you end up with `1`). — #13266
- In the DataGrid numeric filter, typing `1.008` lost the `.` and the leading `0`, producing `1008`. — #13250

This is a regression from v8.x, which only applied the format on blur. It was introduced in #12766 (v9.1.0), which added a reformat block to `OnInputValueChanged` to fix a .NET 10 blur-timing issue (#12677) — but that block also runs on `oninput` (every keystroke) when `Immediate=true`.

### Fix

`OnInputValueChanged` is wired to the inner `MudInput.ValueChanged`, which fires on `oninput` when `Immediate=true` and on `onchange` (a commit) when `Immediate=false`. The reformat now skips the live `oninput` path:

```diff
- if (UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
+ if (!Immediate && UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
```

So the raw text is preserved while typing and the value is reformatted on blur (`OnBlurredAsync`, unchanged) — restoring the v8.x / `Immediate="false"` behavior. The value still tracks every keystroke. The non-Immediate commit reformat that fixed #12677 is untouched, and the debounce path (`DebounceInterval > 0`, which already short-circuits this block) is unchanged.

### Repro (before this PR)

1. `<MudNumericField Immediate="true" Format="F3" T="double?" />`
2. Type `1234` one digit at a time → field snaps to `1.000` after the first key and you can never enter the rest.
3. Same in the DataGrid numeric filter (it always renders `Immediate="true"` with the column `Culture` bound): typing `1.008` produces `1008`.

After this PR the text stays raw while typing (`1234`, `1.008`) and is formatted on blur.

### Tests

- Two char-by-char regression tests for `MudNumericField` (#13266 `F3` multi-digit, #13250 decimal-zero) plus a `Pattern`-trigger variant — each verified to fail before the fix and pass after.
- A DataGrid numeric-filter integration test that types `1.008` one character at a time (the real-world #13250 repro; previously produced `1008`).
- Updated the one existing test that asserted the old per-keystroke reformat to assert the corrected raw-while-typing / format-on-blur behavior.
- The existing #12677 non-Immediate blur tests still pass.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
