### PR TITLE
Inputs: Don't re-validate on the `@bind-Value` echo

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationFuncOncePerKeystrokeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidationFuncOncePerKeystrokeTest.razor
@@ -1,0 +1,20 @@
+@* Regression component for #13174: counts how many times the validation func runs while typing. *@
+<MudForm @ref="Form" ValidationDelay="0">
+    <MudTextField @bind-Value="_value" Immediate="true" Validation="@(new Func<string, bool>(Validate))" />
+</MudForm>
+
+@code {
+    public static string __description__ =
+        "With Immediate + @bind-Value, the validation func must run exactly once per keystroke, not twice (#13174).";
+
+    public MudForm Form = null!;
+    private string _value = string.Empty;
+
+    public int ValidationCount { get; private set; }
+
+    private bool Validate(string value)
+    {
+        ValidationCount++;
+        return true;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -139,6 +139,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/13174.
+        /// With Immediate=true and a two-way @bind-Value, the validation func must run exactly once per
+        /// keystroke. The parent's ValueChanged echo (the @bind round-trip) must NOT trigger a second
+        /// validation (regression introduced in 9.3.0 by PR #12892, which added BeginValidateAsync to
+        /// MudBaseInput.OnValueParameterChangedAsync).
+        /// </summary>
+        [Test]
+        public async Task FormValidationFuncRunsOncePerKeystrokeWithImmediateBoundInput()
+        {
+            var comp = Context.Render<FormValidationFuncOncePerKeystrokeTest>();
+            var input = comp.Find("input");
+
+            await input.InputAsync(new ChangeEventArgs { Value = "A" });
+            await comp.WaitForAssertionAsync(() => comp.Instance.ValidationCount.Should().Be(1));
+
+            await input.InputAsync(new ChangeEventArgs { Value = "AB" });
+            await comp.WaitForAssertionAsync(() => comp.Instance.ValidationCount.Should().Be(2));
+
+            await input.InputAsync(new ChangeEventArgs { Value = "ABC" });
+            await comp.WaitForAssertionAsync(() => comp.Instance.ValidationCount.Should().Be(3));
+        }
+
+        /// <summary>
         /// Changing the nested form fields value should set IsTouched
         /// </summary>
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -567,7 +567,12 @@ namespace MudBlazor
 
             // Notify the form that the field has changed and trigger re-validation
             // Only do this after the field has been touched.
-            if (wasTouched)
+            // Skip when the change is this input's own ValueChanged echo (the parent's @bind round-trip):
+            // that user edit already validated once in SetValueAndUpdateTextAsync, so re-validating here
+            // would run the validation func twice for every keystroke on Immediate + @bind-Value inputs
+            // (#13174). Genuine external programmatic value changes are not child-originated and still
+            // re-validate, preserving the #12012 fix.
+            if (wasTouched && !arg.IsChildOriginatedChange)
             {
                 FieldChanged(arg.Value);
                 await BeginValidateAsync();


### PR DESCRIPTION
Fixes #13174

### Problem

A two-way `@bind-Value` input with `Immediate="true"` runs its validation func **twice for every keystroke** (regression in 9.3.0; 9.2.0 ran it once). For validators that do real work (DB round-trips, async checks) this doubles the load on every key.

### Root cause

PR #12892 (v9.3.0) added `FieldChanged` + `BeginValidateAsync` to `MudBaseInput.OnValueParameterChangedAsync` so that **programmatic** value changes surface validation (#12012). But with `Immediate` + `@bind-Value`:

1. The user edit calls `SetValueAndUpdateTextAsync`, which validates once **and** fires `ValueChanged`.
2. The parent's `@bind` setter stores the value and re-renders, echoing the same value back down.
3. That re-enters `OnValueParameterChangedAsync` — and since the field is now touched, it validates a **second** time.

### Fix

Gate that block with the framework's own `ParameterChangedEventArgs.IsChildOriginatedChange`, which is `true` exactly when the incoming parameter equals the value this input just set (i.e. the parent is echoing our own `ValueChanged`):

```diff
- if (wasTouched)
+ if (wasTouched && !arg.IsChildOriginatedChange)
  {
      FieldChanged(arg.Value);
      await BeginValidateAsync();
  }
```

The input's own echo no longer re-validates, while **genuine external programmatic changes** (not child-originated) still validate — so the #12012 fix is preserved (covered by the existing `FormValidationErrorClearedOnProgrammaticValueChange` test).

This is deliberately surgical: it does **not** relocate `FieldChanged`/`BeginValidateAsync` out of the shared `SetValueAndUpdateTextAsync` (the approach in the closed #13179), so `MudMask`, `MudRangeInput`, `MudAutocomplete.ClearAsync` and `MudSelect.OnSelectedValuesChangedAsync` keep their touched/validation behavior unchanged.

### Tests

- New regression test `FormValidationFuncRunsOncePerKeystrokeWithImmediateBoundInput` (FormTests) types three characters into an `Immediate` + `@bind-Value` field and asserts the validation func ran exactly 1/2/3 times. Verified to **fail without** the fix (1/2/3 → 2/4/6) and **pass with** it.
- Full input regression run (Form, TextField, Select, Autocomplete, Mask, RangeInput, NumericField, DataGrid — 949 tests) passes.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
