### PR TITLE
MudNumericField: keep managed formatting off live input

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -601,7 +601,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task NumericField_Immediate_Should_Reformat_Repeated_Input_With_F3()
+        public async Task NumericField_Immediate_WithFormat_ShouldKeepRawTextUntilBlur()
         {
             var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
                 .Add(x => x.Immediate, true)
@@ -610,15 +610,60 @@ namespace MudBlazor.UnitTests.Components
 
             var input = comp.Find("input");
 
-            await input.InputAsync("3.14514515415414515");
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.14514515415414515d));
-            input.GetAttribute("value").Should().Be("3.145");
+            await input.InputAsync("1");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1d));
+            input.GetAttribute("value").Should().Be("1");
 
-            await input.InputAsync("3.145145154154145159");
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("3.145"));
-            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(3.145145154154145159d));
-            input.GetAttribute("value").Should().Be("3.145");
+            await input.InputAsync("12");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("12"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(12d));
+            input.GetAttribute("value").Should().Be("12");
+
+            await input.InputAsync("1234");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1234"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234d));
+            input.GetAttribute("value").Should().Be("1234");
+
+            await input.BlurAsync();
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1234.000"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1234d));
+            input.GetAttribute("value").Should().Be("1234.000");
+        }
+
+        [Test]
+        public async Task NumericField_Immediate_WithExplicitCulture_ShouldPreserveDecimalTextWhileTyping()
+        {
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US")));
+
+            var input = comp.Find("input");
+
+            await input.InputAsync("1");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1d));
+            input.GetAttribute("value").Should().Be("1");
+
+            await input.InputAsync("1.");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1."));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1d));
+            input.GetAttribute("value").Should().Be("1.");
+
+            await input.InputAsync("1.0");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1.0"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1d));
+            input.GetAttribute("value").Should().Be("1.0");
+
+            await input.InputAsync("1.00");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1.00"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1d));
+            input.GetAttribute("value").Should().Be("1.00");
+
+            await input.InputAsync("1.008");
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1.008"));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1.008d));
+            input.GetAttribute("value").Should().Be("1.008");
         }
 
         [Test]

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -516,9 +516,10 @@ namespace MudBlazor
         {
             await SetTextAndUpdateValueAsync(text);
 
-            // Keep formatted text in sync when using formatted input mode.
-            // This also covers onchange updates that can occur around blur timing.
-            if (UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
+            // OnInputValueChanged is used for both live oninput and committed onchange updates.
+            // Managed formats must not rewrite live input because that moves the caret and drops
+            // incomplete decimal text, but non-immediate onchange still needs the formatted text.
+            if (!Immediate && UsesManagedFormatting && DebounceInterval <= 0 && !ConversionError)
             {
                 var formattedText = ConvertSet(ReadValue);
                 if (!string.Equals(ReadText, formattedText, StringComparison.Ordinal))


### PR DESCRIPTION
## Description

Fixes #13266.
Fixes #13250.
Related to #13002.

`MudNumericField` was reapplying managed formatting from `OnInputValueChanged` on every live `oninput` event when `Immediate="true"`. With `Format`, `Pattern`, or explicit `Culture`, that rewrote the input text while the user was still typing, which moved the caret and dropped incomplete decimal text.

This keeps the managed reformatting path for non-immediate committed `onchange` updates, but skips it during immediate live input. Immediate fields still update `Value` as the user types; formatted display is applied on blur through the existing blur path.

## Tests

- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~NumericField_Immediate_WithFormat_ShouldKeepRawTextUntilBlur|FullyQualifiedName~NumericField_Immediate_WithExplicitCulture_ShouldPreserveDecimalTextWhileTyping|FullyQualifiedName~NumericField_Should_Reformat_On_Blur_With_Custom_Format_When_Not_Immediate|FullyQualifiedName~NumericField_NotImmediate_Should_Reformat_When_Blur_Fires_Before_Change|FullyQualifiedName~NumericField_NotImmediate_Should_Reformat_Consistently_Across_Repeated_Blurs|FullyQualifiedName~NumericField_should_ReformatTextOnBlur"`
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~NumericFieldTests" --no-restore`
