### PR TITLE
MudTooltip: preserve flex layout while anchoring to child content

### DIFF
--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -4,10 +4,6 @@
   border-radius: var(--mud-default-borderradius);
   display: inline-flex;
 
-  > .mud-tooltip-root {
-    display: flex;
-  }
-
   .mud-button-root {
     border-radius: var(--mud-default-borderradius);
   }

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -11,9 +11,6 @@
   &.mud-tabs-vertical {
     flex-direction: row;
 
-    .mud-tooltip-root {
-      width: auto;
-    }
   }
 
   &.mud-tabs-vertical-reverse {

--- a/src/MudBlazor/Styles/components/_tooltip.scss
+++ b/src/MudBlazor/Styles/components/_tooltip.scss
@@ -1,12 +1,7 @@
 
 .mud-tooltip-root {
   &.mud-tooltip-inline {
-    display: inline-block;
-  }
-
-  &.mud-tooltip-inline:has(> .mud-width-full) {
-    display: block;
-    width: 100%;
+    display: contents;
   }
 }
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -244,17 +244,77 @@ window.mudpopoverHelper = {
         return true;
     },
 
+    getTooltipAnchorNodes: function (tooltipRoot) {
+        if (!tooltipRoot?.classList?.contains('mud-tooltip-root')) {
+            return [];
+        }
+
+        return Array.from(tooltipRoot.childNodes).filter(node => {
+            if (node.nodeType === Node.COMMENT_NODE) {
+                return false;
+            }
+
+            if (node.nodeType === Node.TEXT_NODE) {
+                return node.textContent?.trim().length > 0;
+            }
+
+            return !node.classList?.contains('mud-popover-cascading-value');
+        });
+    },
+
+    getPopoverAnchorNode: function (popoverNode) {
+        const parentNode = popoverNode?.parentNode;
+        if (!parentNode?.classList?.contains('mud-tooltip-root')) {
+            return parentNode;
+        }
+
+        return this.getTooltipAnchorNodes(parentNode).find(node => node.nodeType === Node.ELEMENT_NODE) || parentNode;
+    },
+
+    getPopoverAnchorRect: function (popoverNode) {
+        const parentNode = popoverNode?.parentNode;
+        if (!parentNode?.classList?.contains('mud-tooltip-root')) {
+            return parentNode?.getBoundingClientRect();
+        }
+
+        const anchorNodes = this.getTooltipAnchorNodes(parentNode);
+        if (anchorNodes.length === 0) {
+            return parentNode.getBoundingClientRect();
+        }
+
+        const range = document.createRange();
+        range.setStartBefore(anchorNodes[0]);
+        range.setEndAfter(anchorNodes[anchorNodes.length - 1]);
+        const rect = range.getBoundingClientRect();
+        range.detach();
+
+        return rect;
+    },
+
+    getPopoverResizeObserverNodes: function (popoverNode) {
+        const parentNode = popoverNode?.parentNode;
+        if (!parentNode?.classList?.contains('mud-tooltip-root')) {
+            return parentNode ? [parentNode] : [];
+        }
+
+        const anchorElements = this.getTooltipAnchorNodes(parentNode)
+            .filter(node => node.nodeType === Node.ELEMENT_NODE);
+
+        return anchorElements.length > 0 ? anchorElements : [parentNode];
+    },
+
     // primary positioning method
     placePopover: function (popoverNode, classSelector) {
         // parentNode is the calling element, mudmenu/tooltip/etc not the parent popover if it's a child popover
         // this happens at page load unless it's popover inside a popover, then it happens when you activate the parent
 
         if (popoverNode?.parentNode) {
+            const anchorNode = window.mudpopoverHelper.getPopoverAnchorNode(popoverNode);
             const id = popoverNode.id.substr(8);
             const popoverContentNode = document.getElementById('popovercontent-' + id);
 
             // if the popover doesn't exist we stop
-            if (!popoverContentNode) return;
+            if (!anchorNode || !popoverContentNode) return;
 
             const classList = popoverContentNode.classList;
 
@@ -265,8 +325,8 @@ window.mudpopoverHelper = {
             if (classSelector && !classList.contains(classSelector)) return;
 
             // Batch DOM reads
-            let boundingRect = popoverNode.parentNode.getBoundingClientRect();
-            if (!window.mudpopoverHelper.isInViewport(popoverNode, boundingRect)) {
+            let boundingRect = window.mudpopoverHelper.getPopoverAnchorRect(popoverNode);
+            if (!boundingRect || !window.mudpopoverHelper.isInViewport(anchorNode, boundingRect)) {
                 // if the parentNode isn't visible at all we stop
                 return;
             }
@@ -836,19 +896,19 @@ class MudPopover {
         const popoverContentNode = document.getElementById('popovercontent-' + id);
 
         if (popoverNode?.parentNode && popoverContentNode) {
+            const resizeObserverNodes = window.mudpopoverHelper.getPopoverResizeObserverNodes(popoverNode);
+
             // add a resize observer to catch resize events
             const resizeObserver = new ResizeObserver(entries => {
-                for (const entry of entries) {
-                    const target = entry.target;
-                    for (const childNode of target.childNodes) {
-                        if (childNode.id?.startsWith('popover-')) {
-                            this.onResize();
-                        }
-                    }
+                if (entries.length > 0) {
+                    this.onResize();
                 }
             });
 
-            resizeObserver.observe(popoverNode.parentNode);
+            for (const resizeObserverNode of resizeObserverNodes) {
+                resizeObserver.observe(resizeObserverNode);
+            }
+
             // Add scroll event listeners to the content node and its parents up to the Body
             const scrollableElements = this.popoverScrollListener(popoverNode);
 


### PR DESCRIPTION
## Description

Fixes #1167.

`MudTooltip` currently inserts a layout wrapper between its child and the parent layout. For flex/grid scenarios that wrapper becomes the child from the parent layout's perspective, so components wrapped in a tooltip no longer stretch or size like the unwrapped component.

This changes inline tooltip roots to `display: contents` so the wrapped component can participate directly in the parent layout again. Because `display: contents` leaves the tooltip root without a usable layout box, popover positioning now resolves tooltip anchors from the rendered child content instead of the wrapper node.

This also removes the scoped tooltip layout band-aids in button groups, vertical tabs, and the `:has(.mud-width-full)` tooltip special case.

## Verification

- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --filter "FullyQualifiedName~ToolTipTests|FullyQualifiedName~TooltipViewerTests|FullyQualifiedName~PopoverServiceTests" --no-restore`
- `dotnet build src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj --no-restore --nologo`
- Playwright/Chrome against `TooltipFlexScenariosTest`: tooltip-wrapped DatePicker measured at the same grid column width as the unwrapped control, and the tooltip popover opened under the child anchor.
