### PR TITLE
MudTextField: Reapply Converter/Format when the same value is re-entered

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldReformatSameValueConverterTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldReformatSameValueConverterTest.razor
@@ -1,0 +1,21 @@
+@* #13096 repro A: formatting via the field's Converter. *@
+@using MudBlazor.Utilities.Converter.Chain
+
+<MudTextField T="string"
+              Value="@Value"
+              ValueChanged="@OnValueChangedAsync"
+              Converter="@Converter" />
+
+@code {
+    public string? Value { get; set; }
+
+    public ReversibleChain<string?, string?> Converter { get; } = Conversions.From<string?, string?>(
+        value => value == "10" ? "1.0" : value,   // Set: value -> display text
+        text => text == "1.0" ? "10" : text);      // Get: display text -> value
+
+    private Task OnValueChangedAsync(string? value)
+    {
+        Value = value;
+        return Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldReformatSameValueFormatTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldReformatSameValueFormatTest.razor
@@ -1,0 +1,18 @@
+@* #13096 repro C: formatting via the field's Format (the idiomatic case). *@
+@using System.Globalization
+
+<MudTextField T="decimal?"
+              Value="@Value"
+              ValueChanged="@OnValueChangedAsync"
+              Culture="@CultureInfo.GetCultureInfo("en-US")"
+              Format="F2" />
+
+@code {
+    public decimal? Value { get; set; }
+
+    private Task OnValueChangedAsync(decimal? value)
+    {
+        Value = value;
+        return Task.CompletedTask;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -376,6 +376,43 @@ namespace MudBlazor.UnitTests.Components
             textfield.ReadText.Should().Be("B");
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/13096 (Converter case).
+        /// Entering text that parses to the same Value a second time must still re-apply the converter's
+        /// formatting, not leave the raw text. Previously the unchanged value short-circuited the
+        /// value->text round-trip, so only the first occurrence of a value formatted.
+        /// </summary>
+        [Test]
+        public async Task TextField_WithConverter_ReformatsWhenSameValueReentered()
+        {
+            var comp = Context.Render<TextFieldReformatSameValueConverterTest>();
+            var input = comp.Find("input");
+
+            await input.ChangeAsync("10");
+            await comp.WaitForAssertionAsync(() => comp.Find("input").GetAttribute("value").Should().Be("1.0"));
+
+            // Re-enter the same raw value: it parses to the same Value, but the display must still reformat.
+            await comp.Find("input").ChangeAsync("10");
+            await comp.WaitForAssertionAsync(() => comp.Find("input").GetAttribute("value").Should().Be("1.0"));
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/13096 (Format case).
+        /// Re-entering a raw value that parses to the same number must still re-apply the Format.
+        /// </summary>
+        [Test]
+        public async Task TextField_WithFormat_ReformatsWhenSameValueReentered()
+        {
+            var comp = Context.Render<TextFieldReformatSameValueFormatTest>();
+            var input = comp.Find("input");
+
+            await input.ChangeAsync("1");
+            await comp.WaitForAssertionAsync(() => comp.Find("input").GetAttribute("value").Should().Be("1.00"));
+
+            await comp.Find("input").ChangeAsync("1");
+            await comp.WaitForAssertionAsync(() => comp.Find("input").GetAttribute("value").Should().Be("1.00"));
+        }
+
         [Test]
         public void TextField_Should_FireValueChangedOnTextParameterChange()
         {

--- a/src/MudBlazor/Components/TextField/MudTextField.razor
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor
@@ -36,7 +36,7 @@
                               Variant="@Variant"
                               Typo="@Typo"
                               Value="@ReadText"
-                              ValueChanged="(s) => SetTextAndUpdateValueAsync(s)"
+                              ValueChanged="@OnInnerValueChangedAsync"
                               Placeholder="@Placeholder"
                               Disabled=@GetDisabledState()
                               Underline="@Underline"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -289,6 +289,29 @@ namespace MudBlazor
             return Clearable && !GetDisabledState();
         }
 
+        private async Task OnInnerValueChangedAsync(string? text)
+        {
+            var valueBefore = ReadValue;
+            await SetTextAndUpdateValueAsync(text);
+
+            // When the entered text parses to the SAME Value, SetValueAndUpdateTextAsync returns early and
+            // the value->text round-trip that MudTextField relies on for formatting never runs, so a
+            // Converter or Format is not re-applied and the raw text is left on screen (#13096). Only in
+            // that value-unchanged case, resync the displayed text to the value's formatted representation.
+            // Gated to committed changes (not live oninput typing, not while debouncing) so we never
+            // reformat mid-keystroke and jump the caret, matching MudNumericField.
+            if (!Immediate && DebounceInterval <= 0 && !ConversionError && !HasMask
+                && EqualityComparer<T?>.Default.Equals(valueBefore, ReadValue))
+            {
+                var formatted = ConvertSet(ReadValue);
+                if (!string.Equals(ReadText, formatted, StringComparison.Ordinal))
+                {
+                    await SetTextCoreAsync(formatted);
+                    await InputReference.SetText(formatted, updateValue: false);
+                }
+            }
+        }
+
         private Task OnMaskedValueChangedAsync(string s) => SetTextAndUpdateValueAsync(s);
 
         private string GetCounterText() => Counter switch


### PR DESCRIPTION
Addresses #13096 (Converter/Format case)

Entering text that parses to the **same** `Value` a second time leaves the raw text on screen instead of reformatting. E.g. with a converter/format that maps `10` → `1.0`: type `10` → shows `1.0`, then select-all and type `10` again → stays `10`. Only the first occurrence of a given value formats. Regression from v7.x.

### Root cause

`MudTextField` has no self-reformat step; it relies on the value→text round-trip (`ValueChanged` → parent re-render → `Text` resync) to apply a `Converter` or `Format`. But `MudBaseInput.SetValueAndUpdateTextAsync` short-circuits (`!valueChanged && !force`) when the parsed `Value` is unchanged, so `ValueChanged` never fires, the round-trip never runs, and the raw text is left in place.

### Fix

Route the inner input's `ValueChanged` through a new `OnInnerValueChangedAsync` that, **only when the entered text parsed to the same `Value`** (so the round-trip was skipped), resyncs the displayed text to `ConvertSet(Value)`:

```csharp
var valueBefore = ReadValue;
await SetTextAndUpdateValueAsync(text);
if (!Immediate && DebounceInterval <= 0 && !ConversionError && !HasMask
    && EqualityComparer<T?>.Default.Equals(valueBefore, ReadValue))
{
    var formatted = ConvertSet(ReadValue);
    if (!string.Equals(ReadText, formatted, StringComparison.Ordinal))
    {
        await SetTextCoreAsync(formatted);
        await InputReference.SetText(formatted, updateValue: false);
    }
}
```

- The `valueBefore == ReadValue` guard scopes the resync to the unchanged-value case only, so `Clear` (value → default) and the unstable-converter loop-protection test (value changes) are untouched — an earlier, broader version regressed both.
- Gated `!Immediate` / no-pending-debounce / no-conversion-error / no-mask so it never reformats mid-keystroke or jumps the caret, mirroring the `MudNumericField` behavior from #13311.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
