### PR TITLE
MudDialog: Revert close button `preventDefault` that dropped input on close

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1569,23 +1569,6 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => service.Close(dialogReference));
         }
 
-        [Test]
-        public async Task CloseButton_ShouldHavePreventDefaultOnMouseDownAttribute()
-        {
-            // Arrange
-            var comp = Context.Render<MudDialogProvider>();
-            var service = Context.Services.GetRequiredService<IDialogService>();
-
-            // Act
-            await comp.InvokeAsync(async () =>
-                await service.ShowAsync<DialogOkCancel>("Custom title", new DialogOptions { CloseButton = true }));
-
-            // Assert
-            var closeBtn = comp.Find(".mud-button-close");
-            closeBtn.Should().NotBeNull();
-            closeBtn.GetAttribute("blazor:onmousedown:preventdefault").Should().Be("");
-        }
-
         /// <summary>
         /// InjectOptions() should set the options of the calling IDialogReference.
         /// </summary>

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -22,7 +22,7 @@
                 }
                 @if (GetCloseButton())
                 {
-                    <MudIconButton aria-label="@Localizer[LanguageResource.MudDialog_Close]" @onmousedown:preventDefault="true" Icon="@CloseIcon" @onclick="((IMudDialogInstance)this).Cancel" Class="mud-button-close" />
+                    <MudIconButton aria-label="@Localizer[LanguageResource.MudDialog_Close]" Icon="@CloseIcon" @onclick="((IMudDialogInstance)this).Cancel" Class="mud-button-close" />
                 }
             </div>
          }


### PR DESCRIPTION
Reverts #12332.

#12332 added `@onmousedown:preventDefault` to the dialog close button to avoid a brief validation flash when closing a dialog that has validated fields. That prevents the focused field from blurring — which is also what commits a non-`Immediate` input's typed value (the text lives only in the DOM until the native `change` fires). As a result, closing the dialog via the X button (or Escape) silently dropped the input. See #13172.

This restores the pre-#12332 (v8) behavior: the focused field commits its value on close.

### Trade-off
This brings back the brief validation flash #12332 removed. That's cosmetic and the safer default — silently losing user input is worse than a momentary red border on a dialog that's already closing. The right long-term fix (commit the focused value **and** suppress only its validation, without the `preventDefault` side effect) is a larger change touching the form-validation core, so it's better tracked separately than blocking this regression fix.

### Changes
- Remove `@onmousedown:preventDefault` from the dialog close button.
- Remove the now-obsolete `CloseButton_ShouldHavePreventDefaultOnMouseDownAttribute` test.

Fixes #13172