### PR TITLE
MudMenu: Fix JSInterop focus crash on WebView when closing/navigating

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -1267,5 +1267,26 @@ namespace MudBlazor.UnitTests.Components
             Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count
                 .Should().Be(focusCountBeforeDispose);
         }
+
+        [Test]
+        public async Task Dispose_CalledTwiceAfterHover_IsIdempotent()
+        {
+            // https://github.com/MudBlazor/MudBlazor/issues/12184 (review follow-up)
+            // Dispose must be idempotent. A hovered menu holds a live CancellationTokenSource,
+            // so a second Dispose() (e.g. user code disposing a @ref before the renderer tears
+            // the component down) would otherwise call Cancel() on the already-disposed CTS and
+            // throw ObjectDisposedException.
+            var comp = Context.Render<MenuTestMouseOver>();
+            var menu = comp.FindComponent<MudMenu>().Instance;
+
+            // Hover to open, which creates the hover CancellationTokenSource.
+            await comp.Find("div.mud-menu").PointerEnterAsync();
+            await comp.WaitForAssertionAsync(() => comp.Markup.Should().Contain("mud-popover-open"));
+
+            menu.Dispose();
+            var secondDispose = () => menu.Dispose();
+
+            secondDispose.Should().NotThrow();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -7,6 +7,7 @@ using AngleSharp.Dom;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.Menu;
 using NUnit.Framework;
@@ -1201,6 +1202,70 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("button:contains('1')").ClickAsync();
             var icon = comp.Find(".mud-menu-submenu-icon");
             icon.InnerHtml.Should().Contain("M14 7l-5 5 5 5V7z"); // ArrowLeft path
+        }
+
+        [Test]
+        public async Task OpenMenu_WhenFocusInteropThrows_DoesNotCrash()
+        {
+            // https://github.com/MudBlazor/MudBlazor/issues/12184
+            // On MAUI BlazorWebView the wrapper-focus interop in OnAfterRenderAsync can run after
+            // the element has been detached (rapid open/close, navigation), throwing
+            // "Unable to focus an invalid element". Opening the menu must swallow that rather
+            // than surface it as an unhandled JSException. This reproduces the reported stack
+            // frame (MudMenu.OnAfterRenderAsync -> focus) as closely as bUnit allows.
+            Context.JSInterop
+                .SetupVoid("Blazor._internal.domWrapper.focus", _ => true)
+                .SetException(new JSException("Unable to focus an invalid element."));
+
+            var comp = Context.Render<MenuTest1>();
+
+            var open = async () => await comp.Find("button.mud-button-root").ClickAsync();
+
+            await open.Should().NotThrowAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
+        }
+
+        [Test]
+        public async Task FocusItemAsync_WhenFocusInteropThrows_DoesNotPropagate()
+        {
+            // https://github.com/MudBlazor/MudBlazor/issues/12184
+            // Every keyboard navigation path funnels through FocusItemAsync (including the
+            // fire-and-forget calls in TrackKeyboardInteraction). If the target element is
+            // detached when focus runs, the JSException must be swallowed, not propagated.
+            var comp = Context.Render<MenuTest1>();
+            var menu = comp.FindComponent<MudMenu>().Instance;
+            await comp.Find("button.mud-button-root").ClickAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
+
+            // Simulate the element being detached: the focus interop now throws.
+            Context.JSInterop
+                .SetupVoid("Blazor._internal.domWrapper.focus", _ => true)
+                .SetException(new JSException("Unable to focus an invalid element."));
+
+            var focus = async () => await comp.InvokeAsync(() => menu.FocusItemAsync(0));
+
+            await focus.Should().NotThrowAsync();
+        }
+
+        [Test]
+        public async Task FocusItemAsync_AfterDispose_DoesNotInvokeFocusInterop()
+        {
+            // https://github.com/MudBlazor/MudBlazor/issues/12184
+            // When the menu is torn down mid-flight (navigation), queued focus work must
+            // short-circuit on the _disposed guard and not run JS interop against the
+            // disposed component / detached DOM.
+            var comp = Context.Render<MenuTest1>();
+            var menu = comp.FindComponent<MudMenu>().Instance;
+            await comp.Find("button.mud-button-root").ClickAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
+
+            var focusCountBeforeDispose = Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count;
+
+            menu.Dispose();
+            await comp.InvokeAsync(() => menu.FocusItemAsync(0));
+
+            Context.JSInterop.Invocations["Blazor._internal.domWrapper.focus"].Count
+                .Should().Be(focusCountBeforeDispose);
         }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -797,9 +797,15 @@ namespace MudBlazor
         /// <param name="disposing">Indicates if managed resources should be disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
-            // Set first so any in-flight async callback (e.g. the fire-and-forget focus
-            // calls in TrackKeyboardInteraction, or a queued OnAfterRenderAsync) short-circuits
-            // instead of running JS interop against the now-detached DOM. See issue #12184.
+            // Idempotent: a second Dispose() (e.g. user code disposing a @ref before the
+            // renderer tears the component down) must not re-run cleanup such as Cancel() on
+            // an already-disposed CancellationTokenSource.
+            if (_disposed)
+                return;
+
+            // Set before cleanup so any in-flight async callback (e.g. the fire-and-forget
+            // focus calls in TrackKeyboardInteraction, or a queued OnAfterRenderAsync)
+            // short-circuits instead of running JS interop against the detached DOM. See #12184.
             _disposed = true;
 
             if (disposing)

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -28,6 +28,7 @@ namespace MudBlazor
         private CancellationTokenSource? _hoverCts;
         private CancellationTokenSource? _leaveCts;
         private int _focusedIndex = -1;
+        private bool _disposed;
         private MudButton? _buttonActivator;
         private MudMenuItem? _menuItemActivator;
         private MudIconButton? _iconButtonActivator;
@@ -796,6 +797,11 @@ namespace MudBlazor
         /// <param name="disposing">Indicates if managed resources should be disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
+            // Set first so any in-flight async callback (e.g. the fire-and-forget focus
+            // calls in TrackKeyboardInteraction, or a queued OnAfterRenderAsync) short-circuits
+            // instead of running JS interop against the now-detached DOM. See issue #12184.
+            _disposed = true;
+
             if (disposing)
             {
                 _hoverCts?.Cancel();
@@ -1013,11 +1019,28 @@ namespace MudBlazor
         {
             await base.OnAfterRenderAsync(firstRender);
 
+            // The component may have been torn down (e.g. navigation) before this async
+            // callback runs; don't touch the DOM if so. See issue #12184.
+            if (_disposed)
+                return;
+
             if (_openState.Value && _focusedIndex == -1)
             {
                 // Focus the container first. This makes the menu "listen" for keys.
+                // The element can be detached between this render and the focus interop call
+                // (rapid open/close, navigation), which throws "Unable to focus an invalid
+                // element" on WebView hosts. Guard it like FocusActivatorAsync does. See #12184.
                 if (_menuWrapperRef.Context is not null)
-                    await _menuWrapperRef.FocusAsync(preventScroll: true);
+                {
+                    try
+                    {
+                        await _menuWrapperRef.FocusAsync(preventScroll: true);
+                    }
+                    catch (JSException)
+                    {
+                        // Element already gone from the DOM, safe to ignore.
+                    }
+                }
 
                 // Check if opened with keyboard and focus the first item
                 if (_lastInteractionWasKeyboard && _menuItems.Count > 0)
@@ -1045,6 +1068,11 @@ namespace MudBlazor
         /// </summary>
         internal async Task FocusItemAsync(int index)
         {
+            // Reached from every keyboard navigation path, including the fire-and-forget calls
+            // in TrackKeyboardInteraction. Don't touch the DOM after disposal. See issue #12184.
+            if (_disposed)
+                return;
+
             if (index >= 0 && index < _menuItems.Count)
             {
                 var item = _menuItems[index];
@@ -1059,7 +1087,14 @@ namespace MudBlazor
 
                 if (elementRef.Context is not null)
                 {
-                    await elementRef.FocusAsync();
+                    try
+                    {
+                        await elementRef.FocusAsync();
+                    }
+                    catch (JSException)
+                    {
+                        // Element already gone from the DOM (closed/navigated mid-focus), safe to ignore.
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #12184

## Problem

`MudMenu` throws `Microsoft.JSInterop.JSException: Unable to focus an invalid element` on MAUI BlazorWebView (iOS/Android) when the menu is closed or the page is navigated while the menu is open. Reported repro paths: navigate while open, rapidly open/close an overflow menu, and keyboard submenu navigation. It only manifests on the WebView host — desktop browsers don't crash.

## Cause

A regression introduced in **v8.14.0** by #11762, which added an `OnAfterRenderAsync` override that focuses `_menuWrapperRef` (and, via `FocusItemAsync`, menu items). Before that PR, `MudMenu` had **no** focus interop at all.

The `…Context is not null` guards on those calls are **not liveness checks** — `ElementReference.Context` stays non-null after the underlying DOM node is detached (TOCTOU). So the deferred focus interop runs against a missing element and Blazor's `domWrapper.focus` throws. It only reproduces on the WebView host because its native↔WebView message bridge is asynchronous, so the queued focus call can land *after* the close/navigation render batch removes the element; desktop browsers win that race.

Tellingly, the same PR already guards `FocusActivatorAsync` with `try/catch (JSException)` but omitted equivalent handling on the two new focus calls.

## Fix

- Wrap the wrapper focus in `OnAfterRenderAsync` and the item focus in `FocusItemAsync` in `try/catch (JSException)`, matching the existing `FocusActivatorAsync` / `CloseMenuAsync` idiom in this file. (`JSDisconnectedException` derives from `JSException`, so circuit-disconnect is covered too.) This handles the **rapid open/close** path, which closes without disposing.
- Add a `_disposed` flag set in `Dispose(bool)` and checked in `OnAfterRenderAsync` and `FocusItemAsync`, so the fire-and-forget focus calls scheduled by `TrackKeyboardInteraction` short-circuit after teardown instead of raising an *unobserved* exception. This handles the **navigate-while-open** path. Because every keyboard navigation path funnels through `FocusItemAsync`, hardening that one method covers all of them.

## Tests

Added three regression tests in `MenuTests` that drive `Blazor._internal.domWrapper.focus` to throw "Unable to focus an invalid element":
- `OpenMenu_WhenFocusInteropThrows_DoesNotCrash` — the `OnAfterRenderAsync` wrapper-focus path (the exact reported stack frame).
- `FocusItemAsync_WhenFocusInteropThrows_DoesNotPropagate` — the keyboard focus funnel.
- `FocusItemAsync_AfterDispose_DoesNotInvokeFocusInterop` — the `_disposed` guard.

Verified: with the fix reverted, **exactly these 3 tests fail** (93/96 pass); with the fix, **all 96 `MenuTests` pass**.

> ⚠️ **Note:** bUnit cannot reproduce the WebView *timing* race itself — the tests throw the JSException deterministically to lock in the guard behavior. Final validation should be a manual pass on a real MAUI BlazorWebView device (a desktop browser will always look fine because it wins the race).

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests