### PR TITLE
Inputs: Don't reformat managed-format text while typing on Server

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -660,6 +660,35 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task NumericField_Immediate_Format_TwoWayBound_RawWhileTyping_FormatsOnBlur()
+        {
+            // #13266 completion on Blazor Server: with a two-way @bind-Value the value echoes back through
+            // the parent and previously reformatted the text mid-typing (the wrapper never tracked focus,
+            // so the SetParametersAsync "preserve user text" guard never engaged). Simulate real typing
+            // (keydown sets focus, then input) and assert the raw text is preserved while typing and only
+            // formatted on blur. Keydown is the key difference from the one-way test above.
+            double? bound = null;
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "F3")
+                .Bind(x => x.Value, bound, v => bound = v));
+
+            foreach (var ch in "1234")
+            {
+                var current = comp.Find("input").GetAttribute("value") ?? string.Empty;
+                await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = ch.ToString() });
+                await comp.Find("input").InputAsync(current + ch);
+            }
+
+            comp.Instance.ReadText.Should().Be("1234", "the raw text is preserved while typing");
+            bound.Should().Be(1234d);
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1234.000"));
+        }
+
+        [Test]
         public async Task NumericField_Immediate_WithCulture_CanTypeZeroAfterDecimalPoint()
         {
             // #13250: with Immediate=true and an explicit Culture (as the DataGrid numeric filter uses),

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -377,6 +377,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TextField_Immediate_Format_TwoWayBound_RawWhileTyping_FormatsOnBlur()
+        {
+            // #13002 on Blazor Server: a two-way @bind-Value MudTextField with Format reformatted the text
+            // mid-typing because the value echo round-trip re-derived the formatted text on each keystroke.
+            // Simulate real typing (keydown + input) and assert the raw text is preserved while typing and
+            // the format is applied on blur (the pre-v9 "format on LostFocus" behavior).
+            decimal? bound = null;
+            var comp = Context.Render<MudTextField<decimal?>>(parameters => parameters
+                .Add(x => x.Immediate, true)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US"))
+                .Add(x => x.Format, "N2")
+                .Bind(x => x.Value, bound, v => bound = v));
+
+            foreach (var ch in "1234")
+            {
+                var current = comp.Find("input").GetAttribute("value") ?? string.Empty;
+                await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = ch.ToString() });
+                await comp.Find("input").InputAsync(current + ch);
+            }
+
+            comp.Instance.ReadText.Should().Be("1234", "the raw text is preserved while typing");
+            bound.Should().Be(1234m);
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1,234.00"));
+        }
+
+        [Test]
         public void TextField_Should_FireValueChangedOnTextParameterChange()
         {
             string? changed_value = null;

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -560,9 +560,17 @@ namespace MudBlazor
             // Check ParameterView to see if Text is also present
             if (!arg.ParameterView.Contains<string?>(nameof(Text)))
             {
-                // Always update text when Value changes (TextUpdateSuppression removed)
+                var forceTextUpdate = _forceTextUpdate;
                 _forceTextUpdate = false;
-                await UpdateTextPropertyAsync(false);
+                // Do not reformat the displayed text from Value on this input's own Immediate ValueChanged
+                // echo (the @bind round-trip mid-typing). On Blazor Server the echo can land between
+                // keystrokes and would reformat while the user is typing, corrupting input (#13002; also
+                // completes #13266/#13250 on Server, which #13311 only fixed for the synchronous case).
+                // External value changes, non-Immediate commits, and explicit forced updates still refresh.
+                if (forceTextUpdate || !(Immediate && arg.IsChildOriginatedChange))
+                {
+                    await UpdateTextPropertyAsync(false);
+                }
             }
 
             // Notify the form that the field has changed and trigger re-validation

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -379,6 +379,11 @@ namespace MudBlazor
 
         protected async Task HandleKeyDownAsync(KeyboardEventArgs obj)
         {
+            // Track focus like MudBaseInput.InvokeKeyDownAsync (which MudTextField uses) so the
+            // "preserve user text while editing" guard in SetParametersAsync engages while typing.
+            // Without this, the wrapper's _isFocused stays false and the value->text resync reformats
+            // mid-typing on Blazor Server (#13266/#13002 family).
+            _isFocused = true;
             await KeyInterceptorService.DispatchAsync(_elementId, KeyEventKind.Down, obj);
             await OnKeyDown.InvokeAsync(obj);
         }
@@ -387,6 +392,8 @@ namespace MudBlazor
         {
             if (GetDisabledState() || GetReadOnlyState())
                 return Task.CompletedTask;
+
+            _isFocused = true;
 
             return OnKeyUp.InvokeAsync(obj);
         }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -289,6 +289,22 @@ namespace MudBlazor
             return Clearable && !GetDisabledState();
         }
 
+        /// <inheritdoc />
+        protected internal override async Task OnBlurredAsync(FocusEventArgs obj)
+        {
+            await base.OnBlurredAsync(obj);
+
+            // Apply the format/converter to the displayed text on blur. While the user edits an Immediate
+            // input the value->text echo is suppressed so their raw text is preserved (#13002), so we
+            // re-derive the formatted text here to restore the pre-v9 "format on LostFocus" behavior.
+            // No-op for plain text fields (ConvertSet(Value) == Text); skipped for masks and conversion errors.
+            if (!HasMask && !ConversionError)
+            {
+                await UpdateTextPropertyAsync(false);
+                await InputReference.SetText(ReadText, updateValue: false);
+            }
+        }
+
         private Task OnMaskedValueChangedAsync(string s) => SetTextAndUpdateValueAsync(s);
 
         private string GetCounterText() => Counter switch


### PR DESCRIPTION
Fixes #13002

### Problem

An `Immediate` input with a managed format (`Format`, `Converter`, or explicit `Culture`) reformats its text **while the user is typing** on Blazor Server:

- `MudTextField Format="N2"`: typing `1234` → `1.00` → `1.002` → `1.0023` → `1.00234`
- `MudNumericField Format="F3"`: typing `1234` → `1.000` → `1.0002` → …

It's a **timing race**: the `@bind-Value` echo round-trips and the value→text resync lands *between* keystrokes, reformatting mid-entry. This matches the reporters' "if I type too slow." bUnit's synchronous render collapses the timing, so it isn't reproducible in unit tests — which is why [#13311](https://github.com/MudBlazor/MudBlazor/pull/13311) (which only gated the synchronous `OnInputValueChanged` path) looked complete but **#13266 / #13250 still reproduced on real Server** for slow typists.

### Root cause

`MudBaseInput.OnValueParameterChangedAsync` re-derives `Text` from `Value` on every value change — including the input's own `Immediate` `ValueChanged` echo — with no "is being edited" guard. (`MudNumericField` additionally never set `_isFocused`, so even the `SetParametersAsync` "preserve user text" guard didn't engage for it.)

### Fix (surgical, no validation/touched relocation)

1. **`OnValueParameterChangedAsync`** — skip the text reformat on the `Immediate` child-originated echo: `!(Immediate && arg.IsChildOriginatedChange)`. External value changes, non-`Immediate` commits, and explicit forced updates still refresh the text.
2. **`MudNumericField`** — track `_isFocused` on key down/up (like `MudTextField` via `MudBaseInput.InvokeKeyDownAsync`), so the existing `SetParametersAsync` guard preserves user text for the unchanged-value echo.
3. **`MudTextField`** — reformat the text on blur (parity with `MudNumericField`), restoring the pre-v9 "format on LostFocus" behavior now that mid-typing reformat is suppressed.

This deliberately does **not** relocate validation/touched out of the shared paths (the approach rejected in #13179) — it only gates the text-resync.

### Validation

Reproduced and verified on a minimal **Blazor Server** harness (InteractiveServer + prerender, .NET 10) driving the real circuit with faithful key events:

| | before | after |
|---|---|---|
| MudTextField N2, slow typing | `1`→`1.00`→…→`1.00234` | raw `1234` while typing → `1,234.00` on blur |
| MudNumericField F3, slow typing | `1`→`1.000`→… | raw `1234` while typing → `1234.000` on blur |
| both, fast typing | raw → formats on settle | raw → formats on blur |

bUnit: full **input + picker + DataGrid** suites pass (~1290 tests). New regression tests added (the `MudTextField` two-way-bound test fails without the fix; the `MudNumericField` one is a behavior-lock, since the numeric race is Server-timing-only and not bUnit-reproducible).

### Related

Completes **#13266 / #13250** on real Blazor Server (the slow-typing case the merged #13311 didn't cover). Leaving those closed per maintainer preference; noting here for traceability.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
