### PR TITLE
MudColorPicker: Re-sync spectrum base color on external Value change

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -222,6 +222,12 @@ namespace MudBlazor.UnitTests.Components
             var selectorStyleAttribute = selector!.GetAttribute("style");
             selectorStyleAttribute.Should().Be($"transform: translate({expectedX.ToString(CultureInfo.InvariantCulture)}px, {expectedY.ToString(CultureInfo.InvariantCulture)}px);");
 
+            // The spectrum base color (the "color field" hue) must follow the color too. Pure hues share the
+            // same selector corner, so the transform alone cannot catch a stale base color (#13037).
+            var overlay = scope.QuerySelector(".mud-picker-color-overlay");
+            overlay.Should().NotBeNull();
+            overlay!.GetAttribute("style").Should().Be($"background-color: {GetExpectedBaseColor(expectedColor).ToString(MudColorOutputFormats.RGB)}");
+
             var hueSlideValue = scope.QuerySelectorAll(".mud-picker-color-slider.hue input");
             hueSlideValue.Should().ContainSingle();
             hueSlideValue[0].Should().BeAssignableTo<IHtmlInputElement>();
@@ -244,6 +250,36 @@ namespace MudBlazor.UnitTests.Components
             {
                 alphaSliderStyleAttribute.Should().Be($"background-image: linear-gradient(to left, transparent, {expectedColor.ToString(MudColorOutputFormats.RGB)});");
             }
+        }
+
+        /// <summary>
+        /// Derives the pure spectrum hue (base color) the rendered overlay should show for a given color.
+        /// </summary>
+        /// <remarks>
+        /// Mirrors <c>MudColorPicker.UpdateBaseColor</c> so the tests can assert that the spectrum hue tracks the
+        /// bound value. This is the facet that stayed stale on external value changes in #13037.
+        /// </remarks>
+        private static MudColor GetExpectedBaseColor(MudColor color)
+        {
+            var index = (int)color.H / 60;
+            if (index == 6)
+            {
+                index = 5;
+            }
+
+            var valueInDeg = (int)color.H - (index * 60);
+            var value = (int)MathExtensions.Map(0, 60, 0, 255, valueInDeg);
+
+            return index switch
+            {
+                0 => new MudColor(255, value, 0, 255),
+                1 => new MudColor(255 - value, 255, 0, 255),
+                2 => new MudColor(0, 255, value, 255),
+                3 => new MudColor(0, 255 - value, 255, 255),
+                4 => new MudColor(value, 0, 255, 255),
+                5 => new MudColor(255, 0, 255 - value, 255),
+                _ => new MudColor(255, 0, 0, 255),
+            };
         }
 
         /// <summary>
@@ -377,6 +413,31 @@ namespace MudBlazor.UnitTests.Components
 
             var (selectorX, selectorY) = GetExpectedSelectorPosition(expectedColor);
             await CheckColorRelatedValues(comp, selectorX, selectorY, expectedColor, mode);
+        }
+
+        [Test]
+        [TestCase(ColorPickerMode.RGB)]
+        [TestCase(ColorPickerMode.HSL)]
+        public async Task BoundValueChangedToNewHue_ShouldRefreshSpectrumBaseColor(ColorPickerMode mode)
+        {
+            // #13037: an external Value change after first render must re-sync the spectrum base color (hue),
+            // not just the numeric inputs. The selector transform alone cannot catch this because fully
+            // saturated pure hues share the same corner, so this asserts the base-color overlay directly.
+            var initialColor = new MudColor("#ff0000ff");
+            var newColor = new MudColor("#0000ffff");
+            var comp = Context.Render<SimpleColorPickerTest>(p =>
+            {
+                p.Add(x => x.ColorValue, initialColor);
+                p.Add(x => x.ColorPickerMode, mode);
+            });
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.ColorValue, newColor));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var overlayStyle = comp.Find(".mud-picker-color-overlay").GetAttribute("style");
+                overlayStyle.Should().Contain($"background-color: {newColor.ToString(MudColorOutputFormats.RGB)}");
+            });
         }
 
         [Test]

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -416,8 +416,13 @@ namespace MudBlazor
             var colorChanged = rgbChanged || hslChanged;
             var shouldUpdateBinding = rgbChanged || (UpdateBindingIfOnlyHSLChanged && hslChanged);
 
-            //if color is cleared, keep _baseColor so that the picker uses the last value
-            if (newColor is not null && colorChanged)
+            //if color is cleared, keep _baseColor so that the picker uses the last value.
+            //An external Value binding change after first render arrives with the parameter state
+            //already synced (colorChanged is false), yet the spectrum/selector still need to re-sync.
+            //A value echoed back from our own selector interaction equals _lastColor, so excluding it
+            //avoids snapping the selector off the user's drag position. (#13037)
+            var externalValueChange = forceUpdate && newColor is not null && !newColor.Equals(_lastColor);
+            if (newColor is not null && (colorChanged || externalValueChange))
             {
                 _lastColor = newColor;
                 if (!_skipFeedback)


### PR DESCRIPTION
Fixes #13037

When a `MudColorPicker`'s bound `Value` changes **after the first render** (e.g. set from an async initialization), the spectrum "color field" keeps the *previous* hue: the base-color gradient and selector stay stale even though the numeric inputs, preview swatch, and sliders all update to the new color.

This was reproduced on `dev` in a browser (Test Viewer). For a picker initialized to `#ff000088` (red) and then set to `#0000ffff` (blue) after an `await`:

- `Value`, RGB inputs `[0,0,255,1]`, preview, sliders → blue ✅
- spectrum base color → **`rgb(255,0,0)`, stale red** ❌

**Root cause:** `SetColorAsync` recomputed the base color + selector only when `colorChanged` was `true`. On an external binding change after render, `ParameterState` has already synced the value before the change handler runs, so `colorChanged` is `false` and the recompute is skipped. The numeric channels are unaffected because they read `ValueOrDefault.*` live. This path has been unchanged since #12567, so the released build and `dev` behave the same.

**Fix:** Recompute the spectrum/selector on a genuine external change, identified by `forceUpdate` together with the new value differing from the last color the picker applied (`_lastColor`). The `_lastColor` check is essential: a value echoed back from the picker's own selector drag equals `_lastColor`, so excluding it keeps dragging from snapping the selector off the user's chosen point (a broad `|| forceUpdate` regressed the drag/click tests).

All five cases from the report in both RGB and HSL modes were checked:

| Case | Color | Channels | Spectrum base | Status |
|---|---|---|---|---|
| broken | `#00000088` | correct | red (H=0) ✅ | already OK |
| alpha | `#00000188` | correct | blue ✅ | already OK |
| lightness | `#ff0000ff` | correct | red ✅ | already OK |
| pseudo (sync pre-`await`) | `#0f0f` | correct | green ✅ | already OK |
| async (post-`await`) | `#00ff` | correct | **was stale red → now blue** | **fixed here** |

The channel/selector facets for the other cases were already resolved by #13043; the remaining defect was the post-render external-change base color, fixed here.

Independent of #13235 / #13301 (the HEX-unbound text field).