### PR TITLE
MudChart: Fix Sankey hang on circular edge definitions

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -73,6 +73,24 @@ namespace MudBlazor.UnitTests.Charts
             Assert.DoesNotThrow(() => RenderSankey(edges, options));
         }
 
+        [Test]
+        [CancelAfter(5000)]
+        public void CircularEdgesDoNotHang()
+        {
+            // A cycle (A -> B -> A) has no root node, so every node falls back to a "source".
+            // CalculateNodeColumns previously enqueued targets forever and hung the render;
+            // it must now terminate and still draw both nodes.
+            var edges = new List<SankeyEdge<double>>
+            {
+                new("A", "B", 10),
+                new("B", "A", 5)
+            };
+
+            var sankey = RenderSankey(edges);
+
+            sankey.FindAll("svg > rect").Count.Should().Be(2);
+        }
+
         private static List<SankeyEdge<double>> GetEdges()
         {
             var edges = new List<SankeyEdge<double>>

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -264,8 +264,15 @@ namespace MudBlazor.Charts
                 {
                     var targetColumn = currentColumn + 1;
 
-                    // Always enqueue to ensure we find the longest path
-                    queue.Enqueue((target, targetColumn));
+                    // Only follow an edge when it pushes the target into a deeper column, and never
+                    // past the node count (the longest path in a graph of N nodes spans at most N-1
+                    // edges). Without this guard, circular edge definitions (e.g. A->B, B->A) keep
+                    // enqueueing with an ever-increasing column and hang the render.
+                    if (targetColumn < allNodes.Count && targetColumn > nodeColumns[target])
+                    {
+                        nodeColumns[target] = targetColumn;
+                        queue.Enqueue((target, targetColumn));
+                    }
                 }
             }
 


### PR DESCRIPTION
A Sankey chart whose edges form a cycle (e.g. `A -> B`, `B -> A`) hangs the render. `Sankey.CalculateNodeColumns` runs a BFS that **always re-enqueues every target** to find the longest path. With a cycle there is no root node, so the source-node fallback treats every node as a source and each pass around the cycle increases the column — the queue never drains and rendering loops forever.

The fix is to only enqueue a target when the edge actually pushes it into a deeper column and cap the column at the node count (the longest path in a graph of `N` nodes spans at most `N-1` edges). This terminates on cyclic input while producing identical columns for valid acyclic graphs, so existing layout behaviour is unchanged.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests