### PR TITLE
Fix internal element IDs not overridable

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDynamicItemTouchTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDynamicItemTouchTest.razor
@@ -1,0 +1,13 @@
+<MudDropContainer T="string" Items="_items" ItemsSelector="@((item, zone) => true)">
+    <ChildContent>
+        <MudDropZone T="string" Identifier="Zone" OnlyZone="true">
+            <MudDynamicDropItem T="string" id="custom-item" Item="@("Item A")" Index="0" ZoneIdentifier="Zone">
+                <div class="dyn-item">Item A</div>
+            </MudDynamicDropItem>
+        </MudDropZone>
+    </ChildContent>
+</MudDropContainer>
+
+@code {
+    private readonly IEnumerable<string> _items = ["Item A"];
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneOverriddenIdTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneOverriddenIdTest.razor
@@ -1,0 +1,29 @@
+<MudDropContainer T="SimpleDropItem"
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex">
+    <ChildContent>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone" id="custom-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
+</MudDropContainer>
+
+@code {
+    private readonly IEnumerable<SimpleDropItem> _items =
+    [
+        new("First Item", "Column 1"),
+        new("Second Item", "Column 2")
+    ];
+
+    public class SimpleDropItem(string name, string zoneIdentifier)
+    {
+        public string Name { get; set; } = name;
+        public string ZoneIdentifier { get; set; } = zoneIdentifier;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -129,6 +129,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DynamicDropItem_UserProvidedId_TouchInteropFollowsIt()
+        {
+            var comp = Context.Render<DropZoneDynamicItemTouchTest>();
+
+            var item = comp.Find(".mud-drop-item");
+            item.GetAttribute("id").Should().Be("custom-item");
+
+            // Start a touch drag, then move it. mudDragAndDrop.moveItemByDifference does document.getElementById on the
+            // id, so it must target the overridden rendered id, not the internal generated one (regression for #13070).
+            await item.TouchStartAsync(new TouchEventArgs { ChangedTouches = [new TouchPoint { ClientX = 0, ClientY = 0 }] });
+            await item.TouchMoveAsync(new TouchEventArgs { ChangedTouches = [new TouchPoint { ClientX = 5, ClientY = 5 }] });
+
+            Context.JSInterop.VerifyInvoke("mudDragAndDrop.moveItemByDifference").Arguments[0].Should().Be("custom-item");
+        }
+
+        [Test]
         public void DropZone_DropZoneOverrideContainerRendered()
         {
             var comp = Context.Render<DropZoneCustomItemSelectorTest>();

--- a/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DropZoneTests.cs
@@ -114,6 +114,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DropZone_UserProvidedId_OverridesZoneId_AndInitTargetsIt()
+        {
+            var comp = Context.Render<DropZoneOverriddenIdTest>();
+
+            // The consumer id wins on the rendered zone div (attribute splat comes after the explicit id).
+            comp.Find(".first-drop-zone").GetAttribute("id").Should().Be("custom-zone");
+
+            // Regression for #13070: mudDragAndDrop.initDropZone runs document.getElementById on this value with no
+            // null guard, so it must target the rendered id, not the internal generated one, or it throws when a
+            // consumer sets a custom id and the drop zone never wires up its drag listeners.
+            var initCalls = Context.JSInterop.VerifyInvoke("mudDragAndDrop.initDropZone", 2);
+            initCalls.Select(i => i.Arguments[0]).Should().Contain("custom-zone");
+        }
+
+        [Test]
         public void DropZone_DropZoneOverrideContainerRendered()
         {
             var comp = Context.Render<DropZoneCustomItemSelectorTest>();

--- a/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
@@ -97,4 +97,41 @@ public class SplitPanelTests : BunitTest
         var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_getDividerPosition");
         invocation.Arguments.Count.Should().Be(1);
     }
+
+    [Test]
+    public void NoUserId_JsInteropTargetsRenderedContainerId()
+    {
+        var comp = Context.Render<MudSplitPanel>(parameters => parameters
+            .Add(p => p.FirstPanel, builder => builder.AddContent(0, "First Panel"))
+            .Add(p => p.SecondPanel, builder => builder.AddContent(0, "Second Panel")));
+
+        var renderedId = comp.Find(".mud-split-panel").GetAttribute("id");
+        renderedId.Should().NotBeNullOrWhiteSpace();
+
+        // The JS build must target the exact id rendered on the container, or document.getElementById fails.
+        var build = Context.JSInterop.VerifyInvoke("mudSplitPanel.build");
+        build.Arguments[0].Should().Be(renderedId);
+    }
+
+    [Test]
+    public async Task UserProvidedId_OverridesContainerId_AndJsInteropFollowsIt()
+    {
+        var comp = Context.Render<MudSplitPanel>(parameters => parameters
+            .Add(p => p.FirstPanel, builder => builder.AddContent(0, "First Panel"))
+            .Add(p => p.SecondPanel, builder => builder.AddContent(0, "Second Panel"))
+            .AddUnmatched("id", "custom-split"));
+
+        // The consumer id wins on the rendered container (attribute splat comes after the explicit id).
+        comp.Find(".mud-split-panel").GetAttribute("id").Should().Be("custom-split");
+
+        // Regression for #13070: JS build/destroy must follow the effective rendered id, not the internal GUID,
+        // otherwise document.getElementById('<guid>') is null and the divider drag/keyboard handlers never attach.
+        Context.JSInterop.VerifyInvoke("mudSplitPanel.build").Arguments[0].Should().Be("custom-split");
+
+        await comp.Instance.ResetDividerPositionAsync();
+        Context.JSInterop.VerifyInvoke("mudSplitPanel_resetDividerPosition").Arguments[0].Should().Be("custom-split");
+
+        await Context.DisposeComponentsAsync();
+        Context.JSInterop.VerifyInvoke("mudSplitPanel_destroy").Arguments[0].Should().Be("custom-split");
+    }
 }

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -82,6 +82,31 @@ namespace MudBlazor
             ? id.ToString() ?? _id
             : _id;
 
+        /// <summary>
+        /// Resolves the element ID to use for JavaScript interop, honoring a consumer-supplied <c>id</c>.
+        /// </summary>
+        /// <param name="fallbackId">The internally generated ID used when no <c>id</c> is supplied via <see cref="UserAttributes"/>.</param>
+        /// <returns>The non-empty <c>id</c> from <see cref="UserAttributes"/> when present; otherwise <paramref name="fallbackId"/>.</returns>
+        /// <remarks>
+        /// When a consumer sets <c>id="..."</c> in Razor it is captured into <see cref="UserAttributes"/> and, depending on
+        /// attribute order, can override the generated ID on the rendered element. Components that subscribe JavaScript handlers
+        /// (such as the key interceptor) by element ID must target this effective ID so the subscription, dispatch, and disposal
+        /// all reference the element that is actually rendered, avoiding "no element found for id" lookup mismatches.
+        /// </remarks>
+        protected string GetEffectiveElementId(string fallbackId)
+        {
+            if (UserAttributes.TryGetValue("id", out var id) && id is not null)
+            {
+                var userId = id.ToString();
+                if (!string.IsNullOrWhiteSpace(userId))
+                {
+                    return userId;
+                }
+            }
+
+            return fallbackId;
+        }
+
         /// <inheritdoc />
         protected override void OnAfterRender(bool firstRender)
         {

--- a/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDropZone.razor.cs
@@ -27,6 +27,11 @@ namespace MudBlazor
         private bool _disposedValue = false;
         private readonly string _id = MudBlazor.Identifier.Create();
 
+        // The id actually rendered on the drop-zone div: a consumer-supplied id (splatted after the explicit id, so it
+        // wins) overrides _id. mudDragAndDrop.initDropZone does document.getElementById on this value with no null guard,
+        // so it must target the rendered id or it throws when the consumer sets a custom id.
+        private string ResolvedElementId => GetEffectiveElementId(_id);
+
         private readonly Dictionary<T, int> _indices = new();
 
         [Inject] private IJSRuntime JsRuntime { get; set; } = null!;
@@ -490,7 +495,7 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudDragAndDrop.initDropZone", _id.ToString());
+                await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudDragAndDrop.initDropZone", ResolvedElementId);
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
+++ b/src/MudBlazor/Components/DropZone/MudDynamicDropItem.razor.cs
@@ -13,6 +13,11 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
 {
     private bool _dragOperationIsInProgress = false;
     private readonly string _id = Identifier.Create();
+
+    // The id actually rendered on the item div: a consumer-supplied id (splatted after the explicit id, so it wins)
+    // overrides _id. The mudDragAndDrop touch helpers do document.getElementById on this value (and compare it to
+    // sibling element ids), so they must target the rendered id or drag movement throws / mis-targets the item.
+    private string ResolvedElementId => GetEffectiveElementId(_id);
     private double _onTouchStartX;
     private double _onTouchStartY;
     private double _onTouchLastX;
@@ -178,7 +183,7 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
     private async Task OnDroppedSucceeded()
     {
         _dragOperationIsInProgress = false;
-        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.resetItem", _id);
+        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.resetItem", ResolvedElementId);
         await OnDragEnded.InvokeAsync(Item);
         StateHasChanged();
     }
@@ -186,7 +191,7 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
     private async Task OnDroppedCanceled()
     {
         _dragOperationIsInProgress = false;
-        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.resetItem", _id);
+        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.resetItem", ResolvedElementId);
         await OnDragEnded.InvokeAsync(Item);
         StateHasChanged();
     }
@@ -219,11 +224,11 @@ public partial class MudDynamicDropItem<T> : MudComponentBase where T : notnull
         _onTouchLastY = e.ChangedTouches[0].ClientY;
 
         //Send to JS to move DOM element
-        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.moveItemByDifference", _id, x, y);
+        await JsRuntime.InvokeVoidAsync("mudDragAndDrop.moveItemByDifference", ResolvedElementId, x, y);
 
         if (Container is not null && Container.TransactionInProgress())
         {
-            var dropIndexOnPositionString = await JsRuntime.InvokeAsync<string>("mudDragAndDrop.getDropIndexOnPosition", _onTouchLastX, _onTouchLastY, _id);
+            var dropIndexOnPositionString = await JsRuntime.InvokeAsync<string>("mudDragAndDrop.getDropIndexOnPosition", _onTouchLastX, _onTouchLastY, ResolvedElementId);
             if (int.TryParse(dropIndexOnPositionString, out var dropIndex))
             {
                 Container.UpdateTransactionIndex(dropIndex);

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -300,7 +300,7 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            var effectiveElementId = GetEffectiveElementId();
+            var effectiveElementId = GetEffectiveElementId(ElementId);
 
             if (firstRender || !string.Equals(_subscribedElementId, effectiveElementId, StringComparison.Ordinal))
             {
@@ -403,21 +403,7 @@ namespace MudBlazor
             }
         }
 
-        private Task HandleKeyDownAsync(KeyboardEventArgs args) => KeyInterceptorService.DispatchAsync(_subscribedElementId ?? GetEffectiveElementId(), KeyEventKind.Down, args);
-
-        private string GetEffectiveElementId()
-        {
-            if (UserAttributes.TryGetValue("id", out var idValue) && idValue is not null)
-            {
-                var id = idValue.ToString();
-                if (!string.IsNullOrWhiteSpace(id))
-                {
-                    return id;
-                }
-            }
-
-            return ElementId;
-        }
+        private Task HandleKeyDownAsync(KeyboardEventArgs args) => KeyInterceptorService.DispatchAsync(_subscribedElementId ?? GetEffectiveElementId(ElementId), KeyEventKind.Down, args);
 
         private bool CanHandleKeys() => !GetDisabled() && MudList is not null && MudList.IsInteractive() && TopLevelList is not null && TopLevelList.IsTabbable(this);
 

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -179,13 +179,22 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
 
     private readonly string _containerId = Guid.NewGuid().ToString();
 
+    // The id actually rendered on the container div: a consumer-supplied id (captured into UserAttributes and splatted
+    // after the explicit id, so it wins) overrides _containerId. JS interop must target this same id or document
+    // .getElementById fails and the divider's drag/keyboard handlers are never attached. Captured at build time so
+    // teardown unsubscribes the exact id that was built.
+    private string? _builtContainerId;
+
+    private string ResolvedContainerId => _builtContainerId ?? GetEffectiveElementId(_containerId);
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
 
         if (firstRender)
         {
-            await JsRuntime.InvokeVoidAsync("mudSplitPanel.build", _containerId, Horizontal, ResetOnDoubleClick, MinPanelSize, FirstPanelInitialSize, PanelGap);
+            _builtContainerId = GetEffectiveElementId(_containerId);
+            await JsRuntime.InvokeVoidAsync("mudSplitPanel.build", _builtContainerId, Horizontal, ResetOnDoubleClick, MinPanelSize, FirstPanelInitialSize, PanelGap);
         }
     }
 
@@ -195,7 +204,7 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
 
         if (IsJSRuntimeAvailable)
         {
-            await JsRuntime.InvokeVoidAsync("mudSplitPanel_update", _containerId, Horizontal, ResetOnDoubleClick, MinPanelSize, PanelGap);
+            await JsRuntime.InvokeVoidAsync("mudSplitPanel_update", ResolvedContainerId, Horizontal, ResetOnDoubleClick, MinPanelSize, PanelGap);
         }
     }
 
@@ -204,7 +213,7 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// </summary>
     public async Task ResetDividerPositionAsync()
     {
-        await JsRuntime.InvokeVoidAsync("mudSplitPanel_resetDividerPosition", _containerId);
+        await JsRuntime.InvokeVoidAsync("mudSplitPanel_resetDividerPosition", ResolvedContainerId);
     }
 
     /// <summary>
@@ -216,7 +225,7 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// <param name="offset">The offset in pixels from the left or top border.</param>
     public async Task SetDividerPositionAsync(int offset)
     {
-        await JsRuntime.InvokeVoidAsync("mudSplitPanel_setDividerPosition", _containerId, offset);
+        await JsRuntime.InvokeVoidAsync("mudSplitPanel_setDividerPosition", ResolvedContainerId, offset);
     }
 
     /// <summary>
@@ -224,13 +233,13 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// </summary>
     public async Task<int> GetDividerPositionAsync()
     {
-        return await JsRuntime.InvokeAsync<int>("mudSplitPanel_getDividerPosition", _containerId);
+        return await JsRuntime.InvokeAsync<int>("mudSplitPanel_getDividerPosition", ResolvedContainerId);
     }
 
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudSplitPanel_destroy", _containerId);
+        await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudSplitPanel_destroy", ResolvedContainerId);
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
Closes #13070

Several components subscribe JavaScript handlers **by element id** (the key interceptor, drag-and-drop, split-panel resize). The id passed to JS was always the generated internal id, even when a consumer overrode `id` in Razor. Because the attribute splat is applied *after* the explicit `id`, the consumer's value wins on the rendered element — so the DOM carried the custom id while JS kept looking up the internal one. `document.getElementById(internalId)` then returned `null` and the feature **silently broke** (SplitPanel: `console.warn`, divider drag/keyboard resize dead) or **threw** (DropZone: `initDropZone`/`resetItem` have no null guard).

This generalizes the fix already shipped for `MudList`/`MudListItem` in #13066.

Components that couple an internal id to JS were audited and verified each against the actual element + attribute-splat order rather than assuming:

- **Genuinely broken → fixed here:** `MudSplitPanel`, `MudDropZone`, `MudDynamicDropItem` (`MudListItem` was already fixed in #13066).
- **Safe, no change needed:** `MudSelect`, `MudMask`, `MudNumericField`, `MudPicker`, `MudAutocomplete`, `MudMenu`, `MudTabs`, `MudTable`, `MudChip`, `MudSwitch`, `MudCheckBox`, `MudRadio` — their JS subscription targets a dedicated wrapper element that never receives the `UserAttributes` splat, or keyboard is handled by native `@onkeydown` (not id-coupled).
- **Intentionally left as-is:** `MudDialogContainer` and `MudOverlay` place the splat *before* the explicit id, so the internal id wins and a custom `id` is silently *ignored* rather than honored. They don't break; making them honor an override is a behavior change with little real-world demand and can be a follow-up if desired.
- The `MudDynamicDropItem` fix is correct but mostly defensive: a custom `id` reaches the **zone** div (covered by the test), but items rendered through `ItemRenderer` always keep their generated id, so the item path is only reachable via a directly-placed `<MudDynamicDropItem id="…">`.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
