### PR TITLE
Tests: Expand and tidy chart unit tests

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -621,6 +621,110 @@ namespace MudBlazor.UnitTests.Components
             heatmap.Instance._maxValue.Should().Be(max.HasValue ? max : .98);
         }
 
+        [Test]
+        public async Task HeatMap_CellMouseOver_SetsAndClearsHoveredCellTooltip()
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Name = "Series 1", Data = new([1, 2, 3]) },
+                new() { Name = "Series 2", Data = new([4, 5, 6]) }
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.HeatMap)
+                .Add(p => p.ChartSeries, series)
+                .Add(p => p.ChartOptions, new ChartOptions { ShowToolTips = true })
+            );
+
+            // Hovering toggles the svg overflow to visible and surfaces the cell tooltip; OnCellMouseOut clears both.
+            var firstCellRect = comp.FindAll(".mud-chart-cell rect")[0];
+            await firstCellRect.MouseOverAsync();
+
+            comp.Find("svg.mud-chart-heat").GetAttribute("style").Should().Contain("overflow:visible");
+
+            await firstCellRect.MouseOutAsync();
+            comp.Find("svg.mud-chart-heat").GetAttribute("style").Should().NotContain("overflow:visible");
+            comp.FindAll("tspan").Count.Should().Be(0);
+        }
+
+        [Test]
+        public async Task HeatMap_LegendMouseOver_SetsAndClearsHoveredLegend()
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Name = "Series 1", Data = new([1, 2, 3]) },
+                new() { Name = "Series 2", Data = new([4, 5, 6]) }
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.HeatMap)
+                .Add(p => p.ChartSeries, series)
+                .Add(p => p.ChartOptions, new ChartOptions { ShowLegend = true, ShowToolTips = true })
+            );
+
+            comp.Find("svg.mud-chart-heat").GetAttribute("style").Should().NotContain("overflow:visible");
+
+            // Hovering a legend swatch sets _hoveredLegend, flipping the style and rendering the legend tooltip.
+            var legendRect = comp.FindAll(".mud-chart-heatmap-legend rect")[0];
+            await legendRect.MouseOverAsync();
+
+            comp.Find("svg.mud-chart-heat").GetAttribute("style").Should().Contain("overflow:visible");
+            comp.FindAll("tspan").Count.Should().BeGreaterThan(0);
+
+            await legendRect.MouseOutAsync();
+            comp.Find("svg.mud-chart-heat").GetAttribute("style").Should().NotContain("overflow:visible");
+        }
+
+        [Test]
+        public async Task HeatMap_ClickCell_SetsSelectedCellAndSelectedIndex()
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Name = "Series 1", Data = new([1, 2, 3]) },
+                new() { Name = "Series 2", Data = new([4, 5, 6]) }
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.HeatMap)
+                .Add(p => p.ChartSeries, series)
+            );
+
+            var hm = comp.FindComponent<HeatMap<double>>().Instance;
+
+            // Pre-seed a non-zero selection so the click is proven to mutate state, not merely match the default.
+            await comp.InvokeAsync(() => hm.SetSelectedCellAsync(1, 2));
+            hm.SelectedCell.Should().Be((1, 2));
+
+            // Click a cell on the second row (rect index 3 == row 1, column 0).
+            var rects = comp.FindAll(".mud-chart-cell rect");
+            await rects[3].ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            hm.SelectedCell.Should().Be((1, 0));
+            // SelectedIndex is driven by the row through SetSelectedIndexAsync.
+            hm.SelectedIndex.Should().Be(1);
+        }
+
+        [TestCase("400px", "300px", "0 0 400 300")]
+        [TestCase("100%", "100%", "0 0 800 350")]
+        public void HeatMap_MatchBoundsToSize_ProducesExpectedViewBox(string width, string height, string expectedViewBox)
+        {
+            // With MatchBoundsToSize and no JS-provided element size, SetBounds parses px Width/Height;
+            // non-px values cannot be parsed and fall back to the default 800x350 bounds.
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.HeatMap)
+                .Add(p => p.ChartSeries, new List<ChartSeries<double>>
+                {
+                    new() { Name = "Series 1", Data = new([1, 2, 3]) },
+                    new() { Name = "Series 2", Data = new([4, 5, 6]) }
+                })
+                .Add(p => p.MatchBoundsToSize, true)
+                .Add(p => p.Width, width)
+                .Add(p => p.Height, height)
+            );
+
+            comp.Find("svg.mud-chart-heat").GetAttribute("viewBox").Should().Be(expectedViewBox);
+        }
+
         [TestCase(ChartType.Donut)]
         [TestCase(ChartType.Line)]
         [TestCase(ChartType.Pie)]

--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -345,5 +345,103 @@ namespace MudBlazor.UnitTests.Charts
             chartSeries[2].Visible.Should().BeTrue("Series 3 Visible property should be true");
             comp.FindAll($"path.mud-chart-bar{series3}").Count.Should().Be(chartSeries[2].Data.Values.Count, "Series 3 bars should be visible");
         }
+
+        [Test]
+        public void BarChartOverlay_RendersOverlayBars()
+        {
+            // Outer StackedBar chart with a nested Bar overlay that shares the outer axis chart.
+            var stacked = new List<ChartSeries<double>>
+            {
+                new() { Name = "S0", Data = new double[] { 40, 30, 20, 50 } },
+                new() { Name = "S1", Data = new double[] { 10, 20, 30, 15 } },
+            };
+            var overlayData = new List<ChartSeries<double>>
+            {
+                new() { Name = "Overlay", Data = new double[] { 25, 35, 45, 30 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, stacked)
+                .Add(x => x.ChartLabels, new[] { "A", "B", "C", "D" })
+                .Add(x => x.ChartOptions, new StackedBarChartOptions())
+                .AddChildContent<Bar<double>>(cp => cp
+                    .Add(b => b.ChartSeries, overlayData)
+                    .Add(b => b.ChartOptions, new BarChartOptions())));
+
+            var overlay = comp.FindComponent<Bar<double>>();
+            overlay.Instance.IsOverlayChart.Should().BeTrue(because: "the nested Bar's cascaded reference is the outer axis chart");
+
+            // The overlay child renders after the outer ChartReference is set; settle the renders so the
+            // overlay's shared-data branch emits bars into the outer chart's overlay content.
+            overlay.Render();
+            comp.Render();
+
+            var overlayBars = comp.FindAll("g.mud-charts-bar-series path.mud-chart-bar");
+            overlayBars.Count.Should().Be(overlayData[0].Data.Values.Count, because: "the overlay renders one bar per data point");
+        }
+
+        [Test]
+        public async Task BarChartOverlay_HoverTogglesTooltip()
+        {
+            var stacked = new List<ChartSeries<double>>
+            {
+                new() { Name = "S0", Data = new double[] { 40, 30, 20, 50 } },
+                new() { Name = "S1", Data = new double[] { 10, 20, 30, 15 } },
+            };
+            var overlayData = new List<ChartSeries<double>>
+            {
+                new() { Name = "Overlay", Data = new double[] { 25, 35, 45, 30 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, stacked)
+                .Add(x => x.ChartLabels, new[] { "A", "B", "C", "D" })
+                .Add(x => x.ChartOptions, new StackedBarChartOptions())
+                .AddChildContent<Bar<double>>(cp => cp
+                    .Add(b => b.ChartSeries, overlayData)
+                    .Add(b => b.ChartOptions, new BarChartOptions())));
+
+            var overlay = comp.FindComponent<Bar<double>>();
+            overlay.Instance.IsOverlayChart.Should().BeTrue();
+
+            // Settle the renders so the overlay emits its bars before hovering.
+            overlay.Render();
+            comp.Render();
+
+            var bar = comp.Find("g.mud-charts-bar-series path.mud-chart-bar");
+
+            comp.FindComponents<ChartTooltip>().Should().BeEmpty(because: "nothing is hovered yet");
+
+            await bar.MouseOverAsync();
+            comp.FindComponents<ChartTooltip>().Should().NotBeEmpty(because: "hovering an overlay bar renders its tooltip");
+
+            await bar.MouseOutAsync();
+            comp.FindComponents<ChartTooltip>().Should().BeEmpty(because: "moving out clears the hovered bar and its tooltip");
+        }
+
+        [Test]
+        public void BarChart_TightMaxYAxisTicks_BoundsHorizontalLineCount()
+        {
+            // With YAxisTicks = 1 and a huge value range, the unbounded line count would be ~100000;
+            // the gridYUnits doubling safeguard must keep the rendered gridlines within MaxNumYAxisTicks.
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Name = "S0", Data = new double[] { 1, 100000 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.Bar)
+                .Add(x => x.ChartSeries, series)
+                .Add(x => x.ChartLabels, new[] { "A", "B" })
+                .Add(x => x.ChartOptions, new BarChartOptions { YAxisTicks = 1, MaxNumYAxisTicks = 5 }));
+
+            var hLines = comp.FindAll("g.mud-charts-gridlines-yaxis path");
+            hLines.Count.Should().BeGreaterThan(0, because: "horizontal grid lines are still rendered");
+            hLines.Count.Should().BeLessThanOrEqualTo(5, because: "the doubling safeguard keeps the count within MaxNumYAxisTicks");
+
+            comp.FindAll("path.mud-chart-bar").Count.Should().Be(2, because: "both data points render as bars");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartDataModelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartDataModelTests.cs
@@ -1,0 +1,365 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using AwesomeAssertions;
+using MudBlazor.Charts;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Charts;
+
+[TestFixture]
+public class ChartDataModelTests : BunitTest
+{
+    #region ChartData ctors
+
+    [Test]
+    public void ChartData_SingleValueCtor_HasOnePointWithNullX()
+    {
+        var data = new ChartData<double>(5.0);
+
+        data.Count.Should().Be(1);
+        data[0].X.Should().BeNull();
+        data.GetValue(0).Should().Be(5.0);
+        data.Values.Should().ContainSingle().Which.Should().Be(5.0);
+    }
+
+    [Test]
+    public void ChartData_ReadOnlyListCtor_MapsValues()
+    {
+        IReadOnlyList<double> values = new List<double> { 1.0, 2.0, 3.0 };
+        var data = new ChartData<double>(values);
+
+        data.Count.Should().Be(3);
+        data.Values.Should().Equal(1.0, 2.0, 3.0);
+        data.Points.All(p => p.X is null).Should().BeTrue();
+    }
+
+    [Test]
+    public void ChartData_DefaultCtor_IsEmpty()
+    {
+        var data = new ChartData<double>();
+
+        data.Count.Should().Be(0);
+        data.Points.Should().BeEmpty();
+        data.Values.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ChartData_SinglePointCtor_SetsXAndY()
+    {
+        var data = new ChartData<double>((3.0, 4.0));
+
+        data.Count.Should().Be(1);
+        data[0].X.Should().Be(3.0);
+        data[0].Y.Should().Be(4.0);
+    }
+
+    [Test]
+    public void ChartData_PointListCtor_MapsXY()
+    {
+        IReadOnlyList<(double x, double y)> points = new List<(double, double)> { (1.0, 2.0), (3.0, 4.0) };
+        var data = new ChartData<double>(points);
+
+        data.Count.Should().Be(2);
+        data[0].X.Should().Be(1.0);
+        data[1].Y.Should().Be(4.0);
+    }
+
+    [Test]
+    public void ChartData_DateTimeValueCtor_SetsXAndY()
+    {
+        var dt = new DateTime(2024, 1, 1, 12, 0, 0);
+        var data = new ChartData<double>(dt, 99.0);
+
+        data.Count.Should().Be(1);
+        data[0].X.Should().Be(dt);
+        data[0].Y.Should().Be(99.0);
+    }
+
+    [Test]
+    public void ChartData_DateTimeTupleListCtor_MapsValues()
+    {
+        var dt1 = new DateTime(2024, 3, 1);
+        var dt2 = new DateTime(2024, 3, 2);
+        IReadOnlyList<(DateTime, double)> values = new List<(DateTime, double)> { (dt1, 1.0), (dt2, 2.0) };
+        var data = new ChartData<double>(values);
+
+        data.Count.Should().Be(2);
+        data[0].X.Should().Be(dt1);
+        data[1].Y.Should().Be(2.0);
+    }
+
+    [Test]
+    public void ChartData_SankeyLinkWeightCtor_SetsXAndY()
+    {
+        var link = new SankeyLink("A", "B");
+        var data = new ChartData<double>(link, 7.0);
+
+        data.Count.Should().Be(1);
+        data[0].X.Should().Be(link);
+        data[0].Y.Should().Be(7.0);
+    }
+
+    [Test]
+    public void ChartData_SankeyEdgeTupleListCtor_MapsValues()
+    {
+        var link1 = new SankeyLink("A", "B");
+        var link2 = new SankeyLink("B", "C");
+        IReadOnlyList<(SankeyLink, double)> edges = new List<(SankeyLink, double)> { (link1, 1.0), (link2, 2.0) };
+        var data = new ChartData<double>(edges);
+
+        data.Count.Should().Be(2);
+        data[0].X.Should().Be(link1);
+        data[1].Y.Should().Be(2.0);
+    }
+
+    [Test]
+    public void ChartData_StringEdgeTupleCtor_BuildsSankeyLink()
+    {
+        var data = new ChartData<double>(("Source", "Target", 9.0));
+
+        data.Count.Should().Be(1);
+        data[0].X.Should().Be(new SankeyLink("Source", "Target"));
+        data[0].Y.Should().Be(9.0);
+    }
+
+    #endregion
+
+    #region ChartData enumerators
+
+    [Test]
+    public void ChartData_GenericEnumerator_YieldsValues()
+    {
+        var data = new ChartData<double>(new List<double> { 10.0, 20.0 });
+
+        var collected = new List<double>();
+        foreach (var v in data)
+        {
+            collected.Add(v);
+        }
+
+        collected.Should().Equal(10.0, 20.0);
+    }
+
+    [Test]
+    public void ChartData_NonGenericEnumerator_YieldsValues()
+    {
+        var data = new ChartData<double>(new List<double> { 1.5, 2.5 });
+
+        IEnumerable enumerable = data;
+        var collected = new List<double>();
+        foreach (var v in enumerable)
+        {
+            collected.Add((double)v);
+        }
+
+        collected.Should().Equal(1.5, 2.5);
+    }
+
+    #endregion
+
+    #region ChartData implicit conversions
+
+    [Test]
+    public void ChartData_ImplicitFromValue()
+    {
+        ChartData<double> single = 7.0;
+        single.Values.Should().Equal(7.0);
+        single.Points.Should().OnlyContain(p => p.X == null);
+
+        ChartData<double> array = new[] { 1.0, 2.0 };
+        array.Values.Should().Equal(1.0, 2.0);
+
+        ChartData<double> list = new List<double> { 4.0, 5.0, 6.0 };
+        list.Values.Should().Equal(4.0, 5.0, 6.0);
+    }
+
+    [Test]
+    public void ChartData_ImplicitFromScatterPoint()
+    {
+        ChartData<double> array = new[] { (1.0, 10.0), (2.0, 20.0) };
+        array.Count.Should().Be(2);
+        array[1].X.Should().Be(2.0);
+        array[1].Y.Should().Be(20.0);
+
+        ChartData<double> list = new List<(double x, double y)> { (5.0, 50.0) };
+        list[0].X.Should().Be(5.0);
+        list[0].Y.Should().Be(50.0);
+    }
+
+    [Test]
+    public void ChartData_ImplicitFromTimeValue()
+    {
+        var dt = new DateTime(2024, 4, 1);
+
+        ChartData<double> array = new[] { (dt, 3.0) };
+        array[0].X.Should().Be(dt);
+        array[0].Y.Should().Be(3.0);
+
+        ChartData<double> list = new List<(DateTime, double)> { (dt, 7.0) };
+        list[0].X.Should().Be(dt);
+        list[0].Y.Should().Be(7.0);
+
+        ChartData<double> single = new TimeValue<double>(dt, 12.0);
+        single[0].X.Should().Be(dt);
+        single[0].Y.Should().Be(12.0);
+
+        ChartData<double> timeValueArray = new[] { new TimeValue<double>(dt, 8.0) };
+        timeValueArray[0].X.Should().Be(dt);
+        timeValueArray[0].Y.Should().Be(8.0);
+    }
+
+    [Test]
+    public void ChartData_ImplicitFromSankey()
+    {
+        var link = new SankeyLink("X", "Y");
+
+        ChartData<double> tuple = (link, 3.0);
+        tuple[0].X.Should().Be(link);
+        tuple[0].Y.Should().Be(3.0);
+
+        ChartData<double> tupleList = new List<(SankeyLink, double)> { (link, 4.0) };
+        tupleList[0].X.Should().Be(link);
+        tupleList[0].Y.Should().Be(4.0);
+
+        ChartData<double> edge = new SankeyEdge<double>("A", "B", 5.0);
+        edge[0].X.Should().Be(new SankeyLink("A", "B"));
+        edge[0].Y.Should().Be(5.0);
+
+        ChartData<double> edgeArray = new[] { new SankeyEdge<double>("A", "B", 6.0) };
+        edgeArray[0].X.Should().Be(new SankeyLink("A", "B"));
+        edgeArray[0].Y.Should().Be(6.0);
+    }
+
+    #endregion
+
+    #region ChartPoint
+
+    [Test]
+    public void ChartPoint_SingleYCtor_SetsYAndNullX()
+    {
+        var point = new ChartPoint<double>(42.0);
+
+        point.X.Should().BeNull();
+        point.Y.Should().Be(42.0);
+    }
+
+    [Test]
+    public void ChartPoint_XYCtor_SetsBoth()
+    {
+        var point = new ChartPoint<double>("label", 1.0);
+
+        point.X.Should().Be("label");
+        point.Y.Should().Be(1.0);
+    }
+
+    [TestCaseSource(nameof(ChartPointConversionCases))]
+    public void ChartPoint_ImplicitConversion_SetsXAndY(ChartPoint<double> point, object expectedX, double expectedY)
+    {
+        point.X.Should().Be(expectedX);
+        point.Y.Should().Be(expectedY);
+    }
+
+    public static IEnumerable<TestCaseData> ChartPointConversionCases()
+    {
+        var link = new SankeyLink("A", "B");
+        var dt = new DateTime(2024, 9, 1);
+
+        yield return new TestCaseData((ChartPoint<double>)(link, 3.0), link, 3.0).SetName("ChartPoint_ImplicitFromSankeyTuple");
+        yield return new TestCaseData((ChartPoint<double>)(dt, 4.0), dt, 4.0).SetName("ChartPoint_ImplicitFromDateTimeTuple");
+        yield return new TestCaseData((ChartPoint<double>)(5.0, 6.0), (object)5.0, 6.0).SetName("ChartPoint_ImplicitFromNumericTuple");
+        yield return new TestCaseData((ChartPoint<double>)8.0, null, 8.0).SetName("ChartPoint_ImplicitFromValue");
+    }
+
+    #endregion
+
+    #region ChartSeries
+
+    [Test]
+    public void ChartSeries_ValuesCtor_SetsData()
+    {
+        var series = new ChartSeries<double>(new List<double> { 1.0, 2.0, 3.0 });
+
+        series.Data.Values.Should().Equal(1.0, 2.0, 3.0);
+        series.Visible.Should().BeTrue();
+        series.Name.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ChartSeries_ImplicitFromArray_SetsData()
+    {
+        ChartSeries<double> series = new[] { 1.0, 2.0, 3.0 };
+
+        series.Data.Values.Should().Equal(1.0, 2.0, 3.0);
+    }
+
+    [Test]
+    public void ChartSeries_Equals_SameNameAndValues_IsTrue()
+    {
+        var a = new ChartSeries<double> { Name = "S", Data = new[] { 1.0, 2.0 } };
+        var b = new ChartSeries<double> { Name = "S", Data = new[] { 1.0, 2.0 } };
+
+        a.Equals(b).Should().BeTrue();
+        a.Equals((object)b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [TestCaseSource(nameof(ChartSeriesInequalityCases))]
+    public void ChartSeries_Equals_DifferingSeries_IsFalse(ChartSeries<double> other)
+    {
+        var a = new ChartSeries<double> { Name = "S", Data = new[] { 1.0, 2.0 } };
+
+        a.Equals(other).Should().BeFalse();
+    }
+
+    public static IEnumerable<TestCaseData> ChartSeriesInequalityCases()
+    {
+        yield return new TestCaseData((ChartSeries<double>)null).SetName("ChartSeries_Equals_Null_IsFalse");
+        yield return new TestCaseData(new ChartSeries<double> { Name = "S", Data = new[] { 1.0 } }).SetName("ChartSeries_Equals_DifferentCount_IsFalse");
+        yield return new TestCaseData(new ChartSeries<double> { Name = "X", Data = new[] { 1.0, 2.0 } }).SetName("ChartSeries_Equals_DifferentName_IsFalse");
+        yield return new TestCaseData(new ChartSeries<double> { Name = "S", Data = new[] { 1.0, 9.0 } }).SetName("ChartSeries_Equals_DifferentValues_IsFalse");
+    }
+
+    [Test]
+    public void ChartSeries_GetHashCode_ManyValues_OnlyHashesFirstTen()
+    {
+        // Only the first ten values participate in the hash, so two series differing
+        // beyond index ten still collide on hash code.
+        var first = Enumerable.Range(0, 15).Select(i => (double)i).ToArray();
+        var second = Enumerable.Range(0, 10).Select(i => (double)i).Concat(Enumerable.Repeat(-1.0, 5)).ToArray();
+        var a = new ChartSeries<double> { Name = "S", Data = first };
+        var b = new ChartSeries<double> { Name = "S", Data = second };
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    #endregion
+
+    #region ChartDataSet extensions
+
+    [Test]
+    public void ChartDataSetExtensions_AsList_WrapsSeries()
+    {
+        var series = new ChartSeries<double> { Name = "S", Data = new[] { 1.0 } };
+
+        var list = series.AsList();
+
+        list.Should().ContainSingle().Which.Should().BeSameAs(series);
+    }
+
+    [Test]
+    public void ChartDataSetExtensions_AsChartDataSet_WrapsValues()
+    {
+        var list = new[] { 1.0, 2.0 }.AsChartDataSet();
+
+        list.Should().ContainSingle();
+        list[0].Data.Values.Should().Equal(1.0, 2.0);
+    }
+
+    #endregion
+}

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartOptionsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartOptionsTests.cs
@@ -164,4 +164,86 @@ public class ChartOptionsTests
         options.ScaleFactor.Should().Be(0.9);
         options.ShowValues.Should().BeFalse();
     }
+
+    [Test]
+    public void BarChartOptions_Defaults_AreExpected()
+    {
+        var options = new BarChartOptions();
+
+        options.Justify.Should().Be(Justify.SpaceBetween);
+        options.FixedBarWidth.Should().BeNull();
+        options.TooltipTitleFormat.Should().Be("{{Y_VALUE}}");
+    }
+
+    [Test]
+    public void BarChartOptions_ImplicitConversion_CopiesBaseChartOptions()
+    {
+        var source = new ChartOptions
+        {
+            ShowLegend = false,
+            ShowToolTips = false,
+            TooltipTitleFormat = "title",
+            TooltipSubtitleFormat = "subtitle",
+            ChartPalette = ["#0000FF"],
+        };
+
+        BarChartOptions result = source;
+
+        result.ShowLegend.Should().BeFalse();
+        result.ShowToolTips.Should().BeFalse();
+        result.TooltipTitleFormat.Should().Be("title");
+        result.TooltipSubtitleFormat.Should().Be("subtitle");
+        result.ChartPalette.Should().BeEquivalentTo(["#0000FF"]);
+    }
+
+    [Test]
+    public void BarChartOptions_BarSpacingRatio_ClampsToRange()
+    {
+        var options = new BarChartOptions();
+
+        options.BarSpacingRatio.Should().Be(0.20);
+
+        options.BarSpacingRatio = 0.5;
+        options.BarSpacingRatio.Should().Be(0.5);
+
+        options.BarSpacingRatio = 2.0;
+        options.BarSpacingRatio.Should().Be(1.0);
+
+        options.BarSpacingRatio = -1.0;
+        options.BarSpacingRatio.Should().Be(0.0);
+    }
+
+    [Test]
+    public void BarChartOptions_SeriesSpacingRatio_ClampsToRange()
+    {
+        var options = new BarChartOptions();
+
+        options.SeriesSpacingRatio.Should().Be(1.0);
+
+        options.SeriesSpacingRatio = 0.5;
+        options.SeriesSpacingRatio.Should().Be(0.5);
+
+        options.SeriesSpacingRatio = 5.0;
+        options.SeriesSpacingRatio.Should().Be(1.0);
+
+        options.SeriesSpacingRatio = 0.0;
+        options.SeriesSpacingRatio.Should().Be(0.1);
+    }
+
+    [Test]
+    public void BarChartOptions_BarWidthRatio_ClampsToRange()
+    {
+        var options = new BarChartOptions();
+
+        options.BarWidthRatio.Should().Be(0.40);
+
+        options.BarWidthRatio = 0.5;
+        options.BarWidthRatio.Should().Be(0.5);
+
+        options.BarWidthRatio = 9.0;
+        options.BarWidthRatio.Should().Be(1.0);
+
+        options.BarWidthRatio = 0.0;
+        options.BarWidthRatio.Should().Be(0.01);
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -226,4 +226,72 @@ public class ChartSizingTests : BunitTest
 
         comp.FindAll("div[style*='height:400px']").Should().BeEmpty();
     }
+
+    [Test]
+    public async Task MudRadialChartBase_OnElementSizeChanged_RespectsMatchBoundsAndTimestamp()
+    {
+        var initialSize = new ElementSize { Width = 300, Height = 300, Timestamp = 10 };
+        Context.JSInterop.Setup<ElementSize>("mudObserveElementSize", _ => true).SetResult(initialSize);
+
+        var comp = Context.Render<Pie<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20, 30 } } })
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Width, "100%")
+            .Add(p => p.Height, "100%"));
+
+        var radialChartBase = comp.Instance;
+
+        // A newer, larger size triggers the MatchBoundsToSize branch (min dimension wins):
+        // min(240, 180) = 180 -> viewBox 0 0 180 180.
+        await comp.InvokeAsync(() => radialChartBase.OnElementSizeChanged(new ElementSize { Width = 240, Height = 180, Timestamp = 20 }));
+        await comp.WaitForAssertionAsync(() =>
+        {
+            comp.Instance._paths.Should().NotBeEmpty();
+            comp.Find("svg").GetAttribute("viewBox").Should().Be("0 0 180 180");
+        });
+
+        // A stale (older) timestamp is ignored: the early return keeps the existing viewBox.
+        await comp.InvokeAsync(() => radialChartBase.OnElementSizeChanged(new ElementSize { Width = 50, Height = 50, Timestamp = 1 }));
+        comp.Find("svg").GetAttribute("viewBox").Should().Be("0 0 180 180");
+    }
+
+    [Test]
+    public async Task MudRadialChartBase_OnElementSizeChanged_NotMatchBounds_DoesNotChangeBounds()
+    {
+        var comp = Context.Render<Pie<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20, 30 } } })
+            .Add(p => p.MatchBoundsToSize, false)
+            .Add(p => p.Width, "300px")
+            .Add(p => p.Height, "300px"));
+
+        var viewBoxBefore = comp.Find("svg").GetAttribute("viewBox");
+
+        // MatchBoundsToSize is false -> early return after recording the size; bounds unchanged.
+        await comp.InvokeAsync(() => comp.Instance.OnElementSizeChanged(new ElementSize { Width = 123, Height = 456, Timestamp = 99 }));
+
+        comp.Find("svg").GetAttribute("viewBox").Should().Be(viewBoxBefore);
+    }
+
+    [TestCase("200px", "160px", 80)]
+    [TestCase("100%", "100%", 140)]
+    public async Task MudRadialChartBase_SetBounds_ParsesPixelsAndFallsBackToDefault(string width, string height, int expectedRadius)
+    {
+        // When _elementSize is null (no JS interop), RebuildChart -> SetBounds parses px Width/Height.
+        // Non-px values cannot be parsed, so the 280x280 defaults remain (Radius 140).
+        var comp = Context.Render<Pie<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20, 30 } } })
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Width, width)
+            .Add(p => p.Height, height));
+
+        List<SvgPath> paths = null!;
+        await comp.InvokeAsync(() =>
+        {
+            comp.Instance.RebuildChart();
+            paths = new List<SvgPath>(comp.Instance._paths);
+        });
+
+        paths.Should().HaveCount(3);
+        paths.Should().OnlyContain(p => p.Data.Contains($"A {expectedRadius} {expectedRadius}"));
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/LineChartTests.cs
@@ -295,5 +295,100 @@ namespace MudBlazor.UnitTests.Charts
                 }
             }
         }
+
+        private static List<ChartSeries<double>> PositiveSeries() => new()
+        {
+            new ChartSeries<double> { Name = "Series 1", Data = new double[] { 10, 40, 25, 60, 35, 80 } }
+        };
+
+        private static readonly string[] _sixLabels = { "A", "B", "C", "D", "E", "F" };
+
+        [Test]
+        public void LineChart_AreaDisplayType_RendersAreaPath()
+        {
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartSeries, PositiveSeries())
+                .Add(p => p.ChartLabels, _sixLabels)
+                .Add(p => p.ChartOptions, new LineChartOptions
+                {
+                    ChartPalette = _baseChartPalette,
+                    LineDisplayType = LineDisplayType.Area
+                }));
+
+            comp.FindComponent<Line<double>>().Should().NotBeNull();
+
+            // The area path is filled with the series color and closes with "Z".
+            var areaPaths = comp.FindAll("path.mud-chart-line[fill='#2979FF']");
+            areaPaths.Count.Should().Be(1, "the Area display type renders exactly one filled area path");
+            areaPaths[0].GetAttribute("d").Should().EndWith(" Z", "the area path is a closed shape");
+            areaPaths[0].GetAttribute("fill-opacity").Should().Be("0.4");
+        }
+
+        [TestCase(true, 6)]
+        [TestCase(false, 0)]
+        public void LineChart_ShowToolTips_GatesDataPointCircles(bool showToolTips, int expectedCircles)
+        {
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartSeries, PositiveSeries())
+                .Add(p => p.ChartLabels, _sixLabels)
+                .Add(p => p.ChartOptions, new LineChartOptions
+                {
+                    ChartPalette = _baseChartPalette,
+                    ShowToolTips = showToolTips,
+                    ShowDataMarkers = false
+                }));
+
+            // The line path always renders; only the hoverable data-point circles are gated by ShowToolTips.
+            comp.FindAll("path.mud-chart-line").Count.Should().BeGreaterThan(0);
+            comp.FindAll("circle.mud-chart-point").Count.Should().Be(expectedCircles);
+        }
+
+        [Test]
+        public async Task OverlayLine_HoverDataPoint_TogglesHoveredPath()
+        {
+            var stacked = new List<ChartSeries<double>>
+            {
+                new() { Name = "Stack 1", Data = new double[] { 100, 120, 90, 140, 110, 130 } }
+            };
+            var overlay = new List<ChartSeries<double>>
+            {
+                new() { Name = "Overlay", Data = new double[] { 50, 60, 40, 70, 55, 65 } }
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.ChartSeries, stacked)
+                .Add(p => p.ChartLabels, _sixLabels)
+                .Add(p => p.ChartOptions, new StackedBarChartOptions { ChartPalette = _baseChartPalette })
+                .AddChildContent<Line<double>>(cp => cp
+                    .Add(l => l.ChartSeries, overlay)
+                    .Add(l => l.ChartOptions, new LineChartOptions
+                    {
+                        ChartPalette = new[] { "#000000" },
+                        ShowToolTips = true
+                    })));
+
+            var line = comp.FindComponent<Line<double>>().Instance;
+            line.IsOverlayChart.Should().BeTrue("the nested Line is the overlay chart");
+
+            // A no-op parameter set re-runs the outer chart's RebuildChart -> RenderOverlay, settling the overlay.
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.CanHideSeries, false));
+
+            var circles = comp.FindAll("circle.mud-chart-point");
+            circles.Count.Should().BeGreaterThan(0, "the overlay line renders data point circles");
+
+            // Initially nothing is hovered.
+            comp.FindAll("path.mud-chart-serie-hovered").Count.Should().Be(0);
+
+            // Hovering the first data point marks the overlay line as hovered.
+            await circles[0].MouseOverAsync(new());
+            comp.FindAll("path.mud-chart-serie-hovered").Count.Should().Be(1, "hovering marks the overlay line as hovered");
+
+            // Mousing out clears the hovered state.
+            await comp.FindAll("circle.mud-chart-point")[0].MouseOutAsync(new());
+            comp.FindAll("path.mud-chart-serie-hovered").Count.Should().Be(0, "mousing out clears the hovered state");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/PieChartTests.cs
@@ -4,6 +4,7 @@
 using AngleSharp.Dom;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Charts;
 using NUnit.Framework;
 
@@ -209,6 +210,46 @@ namespace MudBlazor.UnitTests.Charts
             seriesCheckboxes = comp.FindAll(".mud-checkbox-input"); // Re-find
             seriesCheckboxes[2].IsChecked().Should().BeTrue("Slice 3 checkbox should be checked after re-showing");
             comp.FindAll($"path.mud-chart-serie{series3}").Count.Should().Be(1, "Slice 3 path should be visible again");
+        }
+
+        [Test]
+        public async Task PieChart_ClickingSerie_UpdatesSelectedIndex()
+        {
+            var selectedIndex = -1;
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Pie)
+                .Add(p => p.Width, "300px")
+                .Add(p => p.Height, "300px")
+                .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20, 30 } } })
+                .Add(p => p.ChartLabels, new[] { "A", "B", "C" })
+                .Add(p => p.ChartOptions, new PieChartOptions { ChartPalette = _baseChartPalette })
+                .Add(p => p.SelectedIndex, selectedIndex)
+                .Add(p => p.SelectedIndexChanged, EventCallback.Factory.Create<int>(this, v => selectedIndex = v)));
+
+            var paths = comp.FindAll("path.mud-chart-serie");
+            paths.Count.Should().BeGreaterThan(1);
+
+            // Clicking the last serie path raises SelectedIndexChanged with that index.
+            await paths.Last().ClickAsync();
+            selectedIndex.Should().Be(2);
+        }
+
+        [Test]
+        public void PieChart_WhitespaceLabel_IsSkippedInLegend()
+        {
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Pie)
+                .Add(p => p.Width, "300px")
+                .Add(p => p.Height, "300px")
+                .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20, 30 } } })
+                .Add(p => p.ChartLabels, new[] { "Visible", "   ", "Other" })
+                .Add(p => p.ChartOptions, new PieChartOptions { ChartPalette = _baseChartPalette }));
+
+            var pie = comp.FindComponent<Pie<double>>().Instance;
+
+            // The blank/whitespace label produces no legend entry.
+            pie._legends.Should().HaveCount(2);
+            pie._legends.Select(l => l.Labels).Should().Contain("Visible").And.Contain("Other");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
@@ -1473,4 +1473,90 @@ public class RadarChartTests : BunitTest
         axisValues[0].TextContent.Should().Be("2.5");
         axisValues[1].TextContent.Should().Be("5");
     }
+
+    [Test]
+    public void RadarChartOptions_ImplicitOperator_CopiesSharedProperties()
+    {
+        var palette = new[] { "#2979FF", "#1DE9B6", "#FFC400" };
+        var source = new ChartOptions
+        {
+            ShowLegend = false,
+            ShowToolTips = false,
+            TooltipTitleFormat = "T:{{X_VALUE}}",
+            TooltipSubtitleFormat = "S:{{Y_VALUE}}",
+            ChartPalette = palette,
+        };
+
+        RadarChartOptions converted = source;
+
+        converted.ShowLegend.Should().BeFalse();
+        converted.ShowToolTips.Should().BeFalse();
+        converted.TooltipTitleFormat.Should().Be("T:{{X_VALUE}}");
+        converted.TooltipSubtitleFormat.Should().Be("S:{{Y_VALUE}}");
+        converted.ChartPalette.Should().BeSameAs(palette);
+        // Radar default aggregation is preserved (not part of the copy).
+        converted.AggregationOption.Should().Be(AggregationOption.GroupByDataSet);
+    }
+
+    [TestCase(AggregationOption.GroupByLabel, false, "OnlySeries")]
+    [TestCase(AggregationOption.GroupByLabel, true, "2")]
+    [TestCase(AggregationOption.GroupByDataSet, false, "TheLabel")]
+    [TestCase(AggregationOption.GroupByDataSet, true, "2")]
+    public void GetSeriesName_ReturnsNameOrLabelForSingle_AndCountForMultiple(AggregationOption aggregation, bool multiple, string expected)
+    {
+        List<ChartSeries<double>> series;
+        string[] labels;
+        if (multiple)
+        {
+            series = new()
+            {
+                new() { Name = "S1", Data = new double[] { 10, 20 } },
+                new() { Name = "S2", Data = new double[] { 5, 15 } },
+            };
+            labels = new[] { "L1", "L2" };
+        }
+        else if (aggregation == AggregationOption.GroupByLabel)
+        {
+            // Single series -> series name is used.
+            series = new() { new() { Name = "OnlySeries", Data = new double[] { 10, 20, 30 } } };
+            labels = new[] { "A", "B", "C" };
+        }
+        else
+        {
+            // Single label -> label is used.
+            series = new() { new() { Name = "S1", Data = new double[] { 10 } } };
+            labels = new[] { "TheLabel" };
+        }
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, series)
+            .Add(p => p.ChartLabels, labels)
+            .Add(p => p.ChartOptions, new RadarChartOptions { AggregationOption = aggregation }));
+
+        var radial = comp.FindComponent<BaseRadialChart<double, RadarChartOptions>>().Instance;
+        radial.GetSeriesName(aggregation).Should().Be(expected);
+    }
+
+    [Test]
+    public void GetSeriesName_NoSeries_ReturnsEmpty()
+    {
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>>()));
+
+        var radial = comp.FindComponent<BaseRadialChart<double, RadarChartOptions>>().Instance;
+        radial.GetSeriesName(AggregationOption.GroupByLabel).Should().BeEmpty();
+    }
+
+    [Test]
+    public void GetSeriesName_UnsupportedAggregation_Throws()
+    {
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "S1", Data = new double[] { 10, 20 } } })
+            .Add(p => p.ChartLabels, new[] { "A", "B" })
+            .Add(p => p.ChartOptions, new RadarChartOptions { AggregationOption = AggregationOption.GroupByDataSet }));
+
+        var radial = comp.FindComponent<BaseRadialChart<double, RadarChartOptions>>().Instance;
+        var act = () => radial.GetSeriesName(AggregationOption.None);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
@@ -788,4 +788,55 @@ public class RoseChartTests : BunitTest
             markup.Should().Contain($"fill=\"{expectedColor}\"");
         }
     }
+
+    [Test]
+    public void RoseChartOptions_ImplicitOperator_CopiesSharedProperties()
+    {
+        var source = new ChartOptions
+        {
+            ShowLegend = false,
+            ShowToolTips = true,
+            TooltipTitleFormat = "Rose:{{X_VALUE}}",
+            TooltipSubtitleFormat = "RoseSub:{{Y_VALUE}}",
+            ChartPalette = _baseChartPalette,
+        };
+
+        RoseChartOptions converted = source;
+
+        converted.ShowLegend.Should().BeFalse();
+        converted.ShowToolTips.Should().BeTrue();
+        converted.TooltipTitleFormat.Should().Be("Rose:{{X_VALUE}}");
+        converted.TooltipSubtitleFormat.Should().Be("RoseSub:{{Y_VALUE}}");
+        converted.ChartPalette.Should().BeSameAs(_baseChartPalette);
+        // Rose-specific defaults remain intact after conversion.
+        converted.ScaleFactor.Should().Be(0.9);
+        converted.ShowValues.Should().BeFalse();
+    }
+
+    [Test]
+    public void RoseChart_NegativeValue_UsesAbsoluteValueForNormalization()
+    {
+        // GetNormalizedData divides T.Abs(x) by the total, so the negative entry still
+        // contributes a petal. The negative data must yield the same petal geometry as the
+        // absolute-value equivalent, proving the abs() branch is taken.
+        var negative = Context.Render<Rose<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "N", Data = new double[] { -10, 20, 30 } } })
+            .Add(p => p.ChartLabels, new[] { "A", "B", "C" })
+            .Add(p => p.ChartOptions, new RoseChartOptions { ChartPalette = _baseChartPalette })
+            .Add(p => p.Width, "300px")
+            .Add(p => p.Height, "300px"));
+
+        var positive = Context.Render<Rose<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "N", Data = new double[] { 10, 20, 30 } } })
+            .Add(p => p.ChartLabels, new[] { "A", "B", "C" })
+            .Add(p => p.ChartOptions, new RoseChartOptions { ChartPalette = _baseChartPalette })
+            .Add(p => p.Width, "300px")
+            .Add(p => p.Height, "300px"));
+
+        var negativePaths = negative.FindAll("path.mud-chart-serie").Select(p => p.GetAttribute("d")).ToList();
+        var positivePaths = positive.FindAll("path.mud-chart-serie").Select(p => p.GetAttribute("d")).ToList();
+
+        negativePaths.Should().HaveCount(3);
+        negativePaths.Should().Equal(positivePaths);
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -1,16 +1,26 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Charts;
+using MudBlazor.Utilities;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Charts
 {
+    [SuppressMessage("Performance", "SYSLIB1045:Convert to 'GeneratedRegexAttribute'.")]
     public class SankeyChartTests : BunitTest
     {
         [Test]
-        [SuppressMessage("Performance", "SYSLIB1045:Convert to \'GeneratedRegexAttribute\'.")]
         public void ChartRendersCorrectly()
         {
             var edges = GetEdges();
@@ -91,6 +101,303 @@ namespace MudBlazor.UnitTests.Charts
             sankey.FindAll("svg > rect").Count.Should().Be(2);
         }
 
+        [Test]
+        public void ValidNodeWidth_IsReflectedInRectWidth()
+        {
+            var edges = MultiColumnEdges();
+            var options = new SankeyChartOptions { NodeWidth = 25, MinVerticalSpacing = 30 };
+
+            var comp = RenderSankey(edges, options);
+
+            comp.Markup.Should().Contain("width=\"25\"");
+            comp.FindAll("svg > rect").Count.Should().Be(5);
+        }
+
+        [Test]
+        public void MultiColumnLayout_SpreadsNodesAcrossColumns()
+        {
+            var edges = MultiColumnEdges();
+            var comp = RenderSankey(edges);
+
+            var sankey = comp.FindComponent<Sankey<double>>().Instance;
+            // A=0, B=1, C/D=2, E=3 : longest path is 3, so 4 distinct columns.
+            sankey.Nodes.Select(n => n.Column).Distinct().Count().Should().Be(4);
+            sankey.Nodes.Select(n => n.Name).Should().BeEquivalentTo(["A", "B", "C", "D", "E"]);
+        }
+
+        [Test]
+        public void NodeOverrides_ApplyColorAndAddMissingNodes()
+        {
+            var edges = FanEdges();
+            var overrideColor = new MudColor("#123456");
+            var options = new SankeyChartOptions
+            {
+                NodeOverrides =
+                [
+                    // Override an existing node's color.
+                    new SankeyNode("Dogs", 0, overrideColor),
+                    // Add a node that has no edge.
+                    new SankeyNode("Lonely", 2, new MudColor("#abcdef")),
+                ],
+            };
+
+            var comp = RenderSankey(edges, options);
+            var sankey = comp.FindComponent<Sankey<double>>().Instance;
+
+            sankey.Nodes.Select(n => n.Name).Should().Contain("Lonely");
+            sankey.Nodes.First(n => n.Name == "Dogs").Color.ToString(MudColorOutputFormats.HexA)
+                .Should().Be(overrideColor.ToString(MudColorOutputFormats.HexA));
+
+            // The node rect for Dogs is rendered with the overridden color.
+            comp.Markup.Should().Contain(overrideColor.ToString(MudColorOutputFormats.HexA));
+        }
+
+        [Test]
+        public async Task NodeClick_SetsSelectedIndex()
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges);
+
+            comp.FindAll("svg > rect").Count.Should().BeGreaterThan(0);
+
+            await comp.Find("svg > rect").ClickAsync(new());
+
+            comp.Instance.SelectedIndex.Should().BeGreaterThanOrEqualTo(0);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task NodeHover_AppliesGlowOnlyWhenHighlightEnabled(bool highlightOnHover)
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges, new SankeyChartOptions { HighlightOnHover = highlightOnHover });
+
+            await comp.Find("svg > rect").MouseOverAsync(new());
+
+            var glowsOnHover = Regex.Matches(comp.Markup, "filter=\"url\\(#glow_").Count;
+            if (highlightOnHover)
+            {
+                glowsOnHover.Should().BeGreaterThan(0);
+            }
+            else
+            {
+                glowsOnHover.Should().Be(0);
+            }
+
+            await comp.Find("svg > rect").MouseOutAsync(new());
+            comp.Render();
+            // After mouse out the active glow filter is gone from node rects.
+            Regex.Matches(comp.Markup, "filter=\"url\\(#glow_").Count.Should().Be(0);
+        }
+
+        [Test]
+        public async Task EdgeHover_HighlightsActiveEdge_AndShowsEdgeTooltip()
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges, new SankeyChartOptions { HighlightOnHover = true });
+
+            await comp.Find("svg > path").MouseOverAsync(new());
+
+            // Hovering an edge highlights it and renders its tooltip.
+            comp.Markup.Should().Contain("filter=\"url(#glow_");
+            comp.FindComponents<ChartTooltip>().Count.Should().BeGreaterThan(0);
+
+            await comp.Find("svg > path").MouseOutAsync(new());
+            comp.Render();
+            // After mouse out the glow highlight is cleared from edges.
+            Regex.Matches(comp.Markup, "filter=\"url\\(#glow_").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void ShowEdgeLabels_RendersOneEdgeTooltipPerEdge()
+        {
+            var edges = FanEdges();
+            var options = new SankeyChartOptions { ShowEdgeLabels = true, ShowLabels = false };
+            var comp = RenderSankey(edges, options);
+
+            Regex.Matches(comp.Markup, "<g class=\"svg-tooltip\"").Count.Should().Be(edges.Count);
+        }
+
+        [Test]
+        public void CustomEdgeLabelSymbol_IsUsedInEdgeNames()
+        {
+            var edges = FanEdges();
+            var options = new SankeyChartOptions { ShowEdgeLabels = true, EdgeLabelSymbol = "->" };
+            var comp = RenderSankey(edges, options);
+
+            comp.Markup.Should().Contain("Dogs -&gt; Dachshund");
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShowNodeValues_GatesParenthesisedTotalInLabels(bool showNodeValues)
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges, new SankeyChartOptions { ShowLabels = true, ShowNodeValues = showNodeValues });
+
+            if (showNodeValues)
+            {
+                comp.Markup.Should().Contain("Dachshund (10)");
+            }
+            else
+            {
+                comp.Markup.Should().NotContain("Dachshund (10)");
+                comp.Markup.Should().Contain("Dachshund");
+            }
+        }
+
+        [Test]
+        public void ShowLabels_RendersNodeTooltipForEveryNode()
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges, new SankeyChartOptions { ShowLabels = true, ShowEdgeLabels = false });
+
+            // One node tooltip per node (Dogs + 3 breeds = 4).
+            Regex.Matches(comp.Markup, "<g class=\"svg-tooltip\"").Count.Should().Be(4);
+            comp.Markup.Should().Contain(">Dogs (60)<");
+        }
+
+        [Test]
+        public void TooltipTemplate_RendersCustomEdgeMarkup()
+        {
+            var edges = FanEdges();
+            RenderFragment<(SvgPath Segment, string Color)> template = ctx => builder =>
+            {
+                builder.OpenElement(0, "text");
+                builder.AddAttribute(1, "class", "custom-edge-template");
+                builder.AddContent(2, ((EdgePath)ctx.Segment).Name);
+                builder.CloseElement();
+            };
+
+            var comp = RenderSankey(edges, new SankeyChartOptions { ShowEdgeLabels = true },
+                p => p.Add(c => c.TooltipTemplate, template));
+
+            comp.Markup.Should().Contain("custom-edge-template");
+            // The custom template path wraps the content in a mud-chart-tooltip group.
+            comp.Markup.Should().Contain("class=\"mud-chart-tooltip\"");
+        }
+
+        [Test]
+        public void HideNodesWithNoEdges_RemovesIsolatedNodes()
+        {
+            var edges = FanEdges();
+            var options = new SankeyChartOptions
+            {
+                HideNodesWithNoEdges = true,
+                NodeOverrides = [new SankeyNode("Isolated", 1)],
+            };
+
+            var comp = RenderSankey(edges, options);
+
+            // The isolated node exists in the node set but is not drawn as a rect.
+            var sankey = comp.FindComponent<Sankey<double>>().Instance;
+            sankey.Nodes.Select(n => n.Name).Should().Contain("Isolated");
+
+            // 4 connected nodes (Dogs + 3 breeds) are rendered, isolated one is not.
+            comp.FindAll("svg > rect").Count.Should().Be(4);
+        }
+
+        [Test]
+        public void HideNodesSmallerThan_FiltersByValue()
+        {
+            var edges = FanEdges(); // weights 10, 20, 30
+            var options = new SankeyChartOptions { HideNodesSmallerThan = 15 };
+
+            var comp = RenderSankey(edges, options);
+
+            // Dachshund (value 10) is filtered out, leaving Dogs + Bernese + Chihuahua = 3 rects.
+            comp.FindAll("svg > rect").Count.Should().Be(3);
+            comp.Markup.Should().NotContain(">Dachshund");
+        }
+
+        [Test]
+        [TestCase(AggregationOption.GroupByDataSet)]
+        [TestCase(AggregationOption.GroupByLabel)]
+        public void Aggregation_BuildsEdgesBetweenSeriesAndLabels(AggregationOption aggregation)
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Name = "Alpha", Data = new double[] { 5, 3 } },
+                new() { Name = "Beta", Data = new double[] { 2, 8 } },
+            };
+            var labels = new[] { "L1", "L2" };
+
+            var comp = Context.Render<MudChart<double>>(p => p
+                .Add(c => c.ChartType, ChartType.Sankey)
+                .Add(c => c.ChartSeries, series)
+                .Add(c => c.ChartLabels, labels)
+                .Add(c => c.ChartOptions, new SankeyChartOptions { AggregationOption = aggregation }));
+
+            var sankey = comp.FindComponent<Sankey<double>>().Instance;
+            sankey.Nodes.Select(n => n.Name).Should().Contain(["Alpha", "Beta", "L1", "L2"]);
+            comp.FindAll("svg > path").Count.Should().Be(4);
+
+            // The two aggregations differ in edge direction: GroupByDataSet flows series -> label,
+            // GroupByLabel flows label -> series. Source nodes always sit in an earlier column.
+            var edge = sankey.Edges.First();
+            var sourceColumn = sankey.Nodes.First(n => n.Name == edge.Source).Column;
+            var targetColumn = sankey.Nodes.First(n => n.Name == edge.Target).Column;
+            sourceColumn.Should().BeLessThan(targetColumn);
+            if (aggregation == AggregationOption.GroupByDataSet)
+            {
+                edge.Source.Should().BeOneOf("Alpha", "Beta");
+                edge.Target.Should().BeOneOf("L1", "L2");
+            }
+            else
+            {
+                edge.Source.Should().BeOneOf("L1", "L2");
+                edge.Target.Should().BeOneOf("Alpha", "Beta");
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ChartPalette_AppliesColorsOrFallsBackToGray(bool customPalette)
+        {
+            var edges = FanEdges();
+            var options = customPalette
+                ? new SankeyChartOptions { ChartPalette = ["#112233", "#445566"] }
+                : new SankeyChartOptions { ChartPalette = [] };
+
+            var comp = RenderSankey(edges, options);
+
+            if (customPalette)
+            {
+                // Palette colors cycle across node rects.
+                comp.Markup.Should().Contain("fill=\"#112233\"");
+                comp.Markup.Should().Contain("fill=\"#445566\"");
+            }
+            else
+            {
+                // With no palette, node rects fall back to the default gray color.
+                comp.Markup.Should().Contain($"fill=\"{Colors.Gray.Default}\"");
+            }
+        }
+
+        [Test]
+        public void MatchBoundsToSize_UsesPixelWidthAndHeightForViewBox()
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges, new SankeyChartOptions(), p => p
+                .Add(c => c.MatchBoundsToSize, true)
+                .Add(c => c.Width, "500px")
+                .Add(c => c.Height, "300px"));
+
+            comp.Markup.Should().Contain("viewBox=\"0 0 500 300\"");
+        }
+
+        [Test]
+        public void EdgeOpacity_IsAppliedToPaths()
+        {
+            var edges = FanEdges();
+            var comp = RenderSankey(edges, new SankeyChartOptions { EdgeOpacity = 0.8 });
+
+            comp.Markup.Should().Contain("opacity=\"0.8\"");
+        }
+
         private static List<SankeyEdge<double>> GetEdges()
         {
             var edges = new List<SankeyEdge<double>>
@@ -106,14 +413,36 @@ namespace MudBlazor.UnitTests.Charts
             return edges;
         }
 
-        private IRenderedComponent<MudChart<double>> RenderSankey(List<SankeyEdge<double>> edges, SankeyChartOptions options = null)
-        {
-            var result = Context.Render<MudChart<double>>(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Sankey)
-                .Add(p => p.ChartSeries, [new() { Name = "Sankey Test", Data = edges }])
-                .Add(p => p.ChartOptions, options ?? new SankeyChartOptions()));
+        // A->B, B->C, B->D, C->E : forces a 4-column layout (A=0, B=1, C/D=2, E=3)
+        private static List<SankeyEdge<double>> MultiColumnEdges() =>
+        [
+            new("A", "B", 10),
+            new("B", "C", 6),
+            new("B", "D", 4),
+            new("C", "E", 6),
+        ];
 
-            return result;
+        // Simple two-column fan-out used by several tests.
+        private static List<SankeyEdge<double>> FanEdges() =>
+        [
+            new("Dogs", "Dachshund", 10),
+            new("Dogs", "Bernese", 20),
+            new("Dogs", "Chihuahua", 30),
+        ];
+
+        private IRenderedComponent<MudChart<double>> RenderSankey(
+            IReadOnlyList<SankeyEdge<double>> edges,
+            SankeyChartOptions options = null,
+            Action<ComponentParameterCollectionBuilder<MudChart<double>>> extra = null)
+        {
+            return Context.Render<MudChart<double>>(parameters =>
+            {
+                parameters
+                    .Add(p => p.ChartType, ChartType.Sankey)
+                    .Add(p => p.ChartSeries, [new() { Name = "Sankey Test", Data = edges.ToList() }])
+                    .Add(p => p.ChartOptions, options ?? new SankeyChartOptions());
+                extra?.Invoke(parameters);
+            });
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/SplineInterpolationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SplineInterpolationTests.cs
@@ -37,6 +37,14 @@ public class SplineInterpolationTests : BunitTest
         spline.InterpolatedYs[0].Should().Be(10);
         spline.InterpolatedYs[^1].Should().Be(20);
 
+        if (option == InterpolationOption.NaturalSpline)
+        {
+            // Two-point natural spline reduces to a straight line: midpoint x=0.5 -> y=15.
+            var midIndex = Array.FindIndex(spline.InterpolatedXs, x => Math.Abs(x - 0.5) < 1e-9);
+            midIndex.Should().BeGreaterThanOrEqualTo(0);
+            spline.InterpolatedYs[midIndex].Should().BeApproximately(15, 1e-9);
+        }
+
         AssertFinite(spline.InterpolatedXs);
         AssertFinite(spline.InterpolatedYs);
     }
@@ -148,6 +156,170 @@ public class SplineInterpolationTests : BunitTest
 
         var action = () => Interpolation.TridiagonalSolver.Solve(a, b, c, d);
         action.Should().Throw<InvalidOperationException>().WithMessage("*zero or near-zero*");
+    }
+
+    [Test]
+    public void Solve_EmptyInput_ReturnsEmptyArray()
+    {
+        var result = Interpolation.TridiagonalSolver.Solve([], [], [], []);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Solve_MismatchedLengths_Throws()
+    {
+        var a = new double[] { 0, 1 };
+        var b = new double[] { 2, 2 };
+        var c = new double[] { 1, 0 };
+        var d = new double[] { 1 };
+
+        var action = () => Interpolation.TridiagonalSolver.Solve(a, b, c, d);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*same length*");
+    }
+
+    [Test]
+    public void Solve_SingleEquation_ReturnsQuotient()
+    {
+        var result = Interpolation.TridiagonalSolver.Solve([0], [4], [0], [8]);
+
+        result.Should().HaveCount(1);
+        result[0].Should().BeApproximately(2.0, 1e-12);
+    }
+
+    [Test]
+    public void Solve_SingleEquation_ZeroDiagonal_Throws()
+    {
+        var action = () => Interpolation.TridiagonalSolver.Solve([0], [0], [0], [1]);
+
+        action.Should().Throw<InvalidOperationException>().WithMessage("*zero or near-zero*");
+    }
+
+    [Test]
+    public void Solve_DenominatorZero_Throws()
+    {
+        // b[0]=1 -> cPrime[0] = 1, so denom at i==1 is b[1] - a[1]*cPrime[0] = 1 - 1*1 = 0.
+        var a = new double[] { 0, 1, 0 };
+        var b = new double[] { 1, 1, 1 };
+        var c = new double[] { 1, 0, 0 };
+        var d = new double[] { 1, 1, 1 };
+
+        var action = () => Interpolation.TridiagonalSolver.Solve(a, b, c, d);
+
+        action.Should().Throw<InvalidOperationException>().WithMessage("*Denominator at index 1*");
+    }
+
+    [Test]
+    public void SolveCyclic_EmptyInput_ReturnsEmptyArray()
+    {
+        var result = Interpolation.TridiagonalSolver.SolveCyclic([], [], [], []);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void SolveCyclic_MismatchedLengths_Throws()
+    {
+        var action = () => Interpolation.TridiagonalSolver.SolveCyclic([0, 0, 0], [1, 1], [0, 0, 0], [1, 1, 1]);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*same length*");
+    }
+
+    [Test]
+    public void SolveCyclic_GammaNearZero_FallsBackToOne_AndReturnsFinite()
+    {
+        // gamma = -b[0]; b[0] near-zero forces the gamma = 1.0 fallback branch.
+        var a = new double[] { 1, 1, 1, 1 };
+        var b = new double[] { 0, 4, 4, 4 };
+        var c = new double[] { 1, 1, 1, 1 };
+        var d = new double[] { 1, 2, 3, 4 };
+
+        double[] result = null!;
+        var action = () => result = Interpolation.TridiagonalSolver.SolveCyclic(a, b, c, d);
+
+        action.Should().NotThrow();
+        result.Should().HaveCount(4);
+        result.Should().OnlyContain(v => !double.IsNaN(v) && !double.IsInfinity(v));
+    }
+
+    [Test]
+    public void SplineInterpolator_MismatchedXsYs_Throws()
+    {
+        var action = () => new Interpolation.NaturalSpline([0, 1, 2], [0, 1]);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*same length*");
+    }
+
+    [Test]
+    public void SplineInterpolator_EmptyInput_Throws()
+    {
+        var action = () => new Interpolation.NaturalSpline([], []);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*length of 1 or greater*");
+    }
+
+    [TestCase(0)]
+    [TestCase(-5)]
+    public void SplineInterpolator_InvalidResolution_Throws(int resolution)
+    {
+        var action = () => new Interpolation.NaturalSpline([0, 1, 2], [0, 1, 2], resolution);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*resolution must be 1 or greater*");
+    }
+
+    [Test]
+    public void EndSlopeSpline_NonZeroEndSlopes_ProducesFiniteCurve()
+    {
+        var spline = new Interpolation.EndSlopeSpline([0, 1, 2, 3], [0, 1, 0, 1], resolution: 10, firstSlopeDegrees: 30, lastSlopeDegrees: -30);
+
+        spline.InterpolatedXs.Should().HaveCount((10 * 3) + 1);
+        spline.InterpolatedXs[0].Should().BeApproximately(0, 1e-12);
+        spline.InterpolatedXs[^1].Should().BeApproximately(3, 1e-12);
+        AssertFinite(spline.InterpolatedYs);
+    }
+
+    [Test]
+    public void NaturalSpline_Integrate_ReturnsFiniteValue()
+    {
+        var spline = new Interpolation.NaturalSpline([0, 1, 2, 3], [0, 1, 4, 9], resolution: 10);
+
+        var integral = ((Interpolation.SplineInterpolator)spline).Integrate();
+
+        integral.Should().NotBe(double.NaN);
+        double.IsInfinity(integral).Should().BeFalse();
+        integral.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public void NaturalSpline_DuplicateX_UsesZeroSpacingBranch_AndStaysFinite()
+    {
+        // Two consecutive equal X values make spacing h == 0, driving the guarded zero-spacing branch.
+        var spline = new Interpolation.NaturalSpline([0, 1, 1, 2], [0, 1, 2, 3], resolution: 5);
+
+        AssertFinite(spline.InterpolatedYs);
+        spline.InterpolatedXs[0].Should().BeApproximately(0, 1e-12);
+        spline.InterpolatedXs[^1].Should().BeApproximately(2, 1e-12);
+    }
+
+    [Test]
+    public void EndSlopeSpline_DuplicateX_UsesZeroSpacingBranch_AndStaysFinite()
+    {
+        var spline = new Interpolation.EndSlopeSpline([0, 1, 1, 2], [0, 1, 2, 3], resolution: 5);
+
+        AssertFinite(spline.InterpolatedYs);
+        spline.InterpolatedXs[0].Should().BeApproximately(0, 1e-12);
+        spline.InterpolatedXs[^1].Should().BeApproximately(2, 1e-12);
+    }
+
+    [Test]
+    public void PeriodicSpline_DuplicateX_UsesZeroSpacingBranch_AndStaysFinite()
+    {
+        var spline = new Interpolation.PeriodicSpline([0, 1, 1, 2], [10, 20, 20, 10], resolution: 5);
+
+        AssertFinite(spline.InterpolatedYs);
+        spline.InterpolatedXs[0].Should().BeApproximately(0, 1e-12);
+        spline.InterpolatedXs[^1].Should().BeApproximately(2, 1e-12);
     }
 
     private static Interpolation.ILineInterpolator CreateInterpolator(InterpolationOption option, double[] xs, double[] ys, int resolution = 10)

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -773,6 +773,18 @@ namespace MudBlazor.UnitTests.Charts
 
             yAxisLabels2.Should().HaveCount(3);
             yAxisLabels2.Should().ContainInOrder("0", "80", "160");
+
+            // A huge data range with YAxisTicks=1 and a tight MaxNumYAxisTicks forces the grid-units
+            // safeguard to repeatedly double the unit until the line count fits within the cap.
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.ChartSeries, new List<ChartSeries<double>>() { new() { Name = "Big", Data = new[] { 100_000.0, 250_000.0 } } })
+                .Add(p => p.ChartOptions, new StackedBarChartOptions { YAxisTicks = 1, MaxNumYAxisTicks = 4 }));
+
+            var yAxisLabels3 = comp.FindAll("g.mud-charts-yaxis text").Select(e => e.TextContent).ToList();
+            yAxisLabels3.Count.Should().BeInRange(2, 4);
+            // The top tick must still cover the data max of 250,000.
+            yAxisLabels3.Select(l => double.Parse(l, System.Globalization.CultureInfo.InvariantCulture)).Max()
+                .Should().BeGreaterThanOrEqualTo(250_000);
         }
 
         [Test]
@@ -1022,6 +1034,134 @@ namespace MudBlazor.UnitTests.Charts
             seriesCheckboxes[2].IsChecked().Should().BeTrue("Series 3 checkbox should be checked after showing");
             chartSeries[2].Visible.Should().BeTrue("Series 3 Visible property should be true after showing");
             comp.FindAll($"path.mud-chart-bar{series3}").Count.Should().Be(chartSeries[2].Data.Values.Count, "Series 3 bar segments should be visible");
+        }
+
+        private static List<ChartSeries<double>> TwoSeries() =>
+            new()
+            {
+                new() { Name = "S1", Data = new double[] { 10, 20, 30 } },
+                new() { Name = "S2", Data = new double[] { 5, 15, 25 } },
+            };
+
+        [Test]
+        public async Task StackedBarChart_AsOverlay_InsideBarChart_ShouldShareDataAndProjectSegments()
+        {
+            // A StackedBar nested inside a Bar chart registers itself as an overlay: it renders nothing
+            // of its own, instead projecting its segments into the host Bar's overlay content and sharing
+            // the host's plot data. Hovering an overlay segment surfaces the tooltip through the host.
+            var barSeries = new List<ChartSeries<double>>
+            {
+                new() { Name = "Base", Data = new double[] { 40, 60, 80 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.Bar)
+                .Add(x => x.ChartSeries, barSeries)
+                .Add(x => x.ChartLabels, new[] { "A", "B", "C" })
+                .Add(x => x.ChartOptions, new BarChartOptions { YAxisTicks = 20, ShowToolTips = true })
+                .AddChildContent<StackedBar<double>>(cp => cp
+                    .Add(s => s.ChartSeries, TwoSeries())
+                    .Add(s => s.ChartOptions, new StackedBarChartOptions { YAxisTicks = 20, ShowToolTips = true })));
+
+            var overlay = comp.FindComponent<StackedBar<double>>().Instance;
+            overlay.IsOverlayChart.Should().BeTrue();
+
+            var hostBar = comp.FindComponent<Bar<double>>().Instance;
+            hostBar.OverlayChart.Should().NotBeNull();
+
+            // The JS element-size callback that normally triggers the host rebuild is absent in bUnit,
+            // so force the host to rebuild now to build the shared plot data and project the overlay.
+            await comp.InvokeAsync(() => hostBar.RebuildChart());
+            overlay.SharedData.Should().NotBeNull();
+
+            // Host (1 series x 3 points = 3 bars) plus overlay (2 series x 3 points = 6 bars) = 9 bars
+            // in the combined markup, since the overlay's segments are projected into the host.
+            var bars = comp.FindAll("path.mud-chart-bar");
+            bars.Count.Should().Be(9);
+
+            // Hovering the last (overlay) segment surfaces the tooltip through the host; mousing out clears it.
+            await bars.Last().MouseOverAsync();
+            comp.FindAll("g.svg-tooltip").Count.Should().BeGreaterThan(0);
+
+            await comp.FindAll("path.mud-chart-bar").Last().MouseOutAsync();
+            comp.FindAll("g.svg-tooltip").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void StackedBarChart_FixedBarWidth_ShouldUseFixedWidthAndForceRatioToOne()
+        {
+            var options = new StackedBarChartOptions { FixedBarWidth = 12, BarWidthRatio = 0.3, YAxisTicks = 20 };
+
+            var comp = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, TwoSeries())
+                .Add(x => x.ChartLabels, new[] { "A", "B", "C" })
+                .Add(x => x.ChartOptions, options));
+
+            // FixedBarWidth forces the ratio to 1 and returns the fixed width verbatim (no overlap fix).
+            options.BarWidthRatio.Should().Be(1);
+
+            var bars = comp.FindAll("path.mud-chart-bar");
+            bars.Count.Should().Be(6);
+            bars.First().GetAttribute("stroke-width").Should().Be("12");
+        }
+
+        [Test]
+        public void StackedBarChart_FullBarWidthRatio_ShouldApplyOverlapStrokeFix()
+        {
+            var compFull = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, TwoSeries())
+                .Add(x => x.ChartLabels, new[] { "A", "B", "C" })
+                .Add(x => x.ChartOptions, new StackedBarChartOptions { BarWidthRatio = 1.0, YAxisTicks = 20 }));
+
+            var fullRatioStroke = double.Parse(
+                compFull.FindAll("path.mud-chart-bar").First().GetAttribute("stroke-width")!,
+                System.Globalization.CultureInfo.InvariantCulture);
+
+            // Below the full-ratio threshold the overlap branch is not taken, so the stroke is the plain
+            // rounded width. The full-ratio stroke must be wider thanks to the +0.5 overlap fix.
+            var compNarrow = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, TwoSeries())
+                .Add(x => x.ChartLabels, new[] { "A", "B", "C" })
+                .Add(x => x.ChartOptions, new StackedBarChartOptions { BarWidthRatio = 0.5, YAxisTicks = 20 }));
+
+            var narrowStroke = double.Parse(
+                compNarrow.FindAll("path.mud-chart-bar").First().GetAttribute("stroke-width")!,
+                System.Globalization.CultureInfo.InvariantCulture);
+
+            fullRatioStroke.Should().BeGreaterThan(narrowStroke,
+                "the maximum ratio uses the full bar width plus the 0.5 overlap fix");
+        }
+
+        [Test]
+        public void StackedBarChart_ShowZeroValuesFalse_ShouldSkipZeroSegments()
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Name = "S1", Data = new double[] { 0, 20 } },
+                new() { Name = "S2", Data = new double[] { 10, 0 } },
+            };
+
+            var compHidden = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, series)
+                .Add(x => x.ChartLabels, new[] { "A", "B" })
+                .Add(x => x.ChartOptions, new StackedBarChartOptions { ShowZeroValues = false, YAxisTicks = 10 }));
+
+            // Two of the four segments are zero and are skipped.
+            compHidden.FindAll("path.mud-chart-bar").Count.Should().Be(2);
+
+            // The same data with ShowZeroValues = true (the default) renders all four, proving the
+            // difference is the skip branch, not the data.
+            var compShown = Context.Render<MudChart<double>>(p => p
+                .Add(x => x.ChartType, ChartType.StackedBar)
+                .Add(x => x.ChartSeries, series)
+                .Add(x => x.ChartLabels, new[] { "A", "B" })
+                .Add(x => x.ChartOptions, new StackedBarChartOptions { ShowZeroValues = true, YAxisTicks = 10 }));
+
+            compShown.FindAll("path.mud-chart-bar").Count.Should().Be(4);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
@@ -18,43 +18,54 @@ namespace MudBlazor.UnitTests.Charts
 
         }
 
-        [Test]
-        public void TimeSeriesChartBasicExample()
+        // Mirrors the X/Y axis label measurement that the chart requests via JS during layout so
+        // that the line/area paths are produced with realistic geometry in a headless test.
+        private void SetupBBoxInterop()
         {
-            var mockYAxisLabelSize = new ElementSize
-            {
-                Width = 27.5,
-                Height = 14.8,
-            };
-            var mockXAxisLabelSize = new ElementSize
-            {
-                Width = 670.5,
-                Height = 14.8,
-            };
-
+            var mockYAxisLabelSize = new ElementSize { Width = 27.5, Height = 14.8 };
+            var mockXAxisLabelSize = new ElementSize { Width = 670.5, Height = 14.8 };
             var counter = 1;
 
-            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
+            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", _ =>
             {
                 if (counter % 2 == 0)
                 {
                     counter++;
                     return true;
                 }
-
                 return false;
             }).SetResult(mockXAxisLabelSize);
 
-            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
+            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", _ =>
             {
                 if (counter % 2 == 1)
                 {
                     counter++;
                     return true;
                 }
-
                 return false;
             }).SetResult(mockYAxisLabelSize);
+        }
+
+        private static List<ChartSeries<double>> BuildSeries(DateTime time, int count = 4, double value = 1000, double spacingHours = 1)
+        {
+            return new List<ChartSeries<double>>
+            {
+                new()
+                {
+                    Name = "Series 1",
+                    Data = Enumerable.Range(0, count)
+                        .Select(x => new TimeValue<double>(time.AddHours(x * spacingHours), value))
+                        .ToList(),
+                    Visible = true,
+                }
+            };
+        }
+
+        [Test]
+        public void TimeSeriesChartBasicExample()
+        {
+            SetupBBoxInterop();
 
             var time = new DateTime(2000, 1, 1);
 
@@ -82,40 +93,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void TimeSeriesChartRendersWithIntData()
         {
-            var mockYAxisLabelSize = new ElementSize
-            {
-                Width = 27.5,
-                Height = 14.8,
-            };
-            var mockXAxisLabelSize = new ElementSize
-            {
-                Width = 670.5,
-                Height = 14.8,
-            };
-
-            var counter = 1;
-
-            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
-            {
-                if (counter % 2 == 0)
-                {
-                    counter++;
-                    return true;
-                }
-
-                return false;
-            }).SetResult(mockXAxisLabelSize);
-
-            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
-            {
-                if (counter % 2 == 1)
-                {
-                    counter++;
-                    return true;
-                }
-
-                return false;
-            }).SetResult(mockYAxisLabelSize);
+            SetupBBoxInterop();
 
             var time = new DateTime(2000, 1, 1);
 
@@ -143,40 +121,7 @@ namespace MudBlazor.UnitTests.Charts
         [Test]
         public void TimeSeriesChartMatchBounds()
         {
-            var mockYAxisLabelSize = new ElementSize
-            {
-                Width = 27.5,
-                Height = 14.8,
-            };
-            var mockXAxisLabelSize = new ElementSize
-            {
-                Width = 670.5,
-                Height = 14.8,
-            };
-
-            var counter = 1;
-
-            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
-            {
-                if (counter % 2 == 0)
-                {
-                    counter++;
-                    return true;
-                }
-
-                return false;
-            }).SetResult(mockXAxisLabelSize);
-
-            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", args =>
-            {
-                if (counter % 2 == 1)
-                {
-                    counter++;
-                    return true;
-                }
-
-                return false;
-            }).SetResult(mockYAxisLabelSize);
+            SetupBBoxInterop();
 
             var time = new DateTime(2000, 1, 1);
 
@@ -292,6 +237,105 @@ namespace MudBlazor.UnitTests.Charts
                 var expectedTimeString = time.AddDays(i).ToString(format);
                 comp.Markup.Should().Contain(expectedTimeString);
             }
+        }
+
+        [Test]
+        public async Task TimeSeriesChart_AsOverlay_NestedInLineChart_BecomesOverlayAndRenders()
+        {
+            SetupBBoxInterop();
+            var time = new DateTime(2000, 1, 1);
+
+            var hostSeries = new List<ChartSeries<double>>
+            {
+                new() { Name = "Host", Data = new double[] { 100, 200, 300, 250 }, Visible = true }
+            };
+            var overlaySeries = BuildSeries(time, value: 500);
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartSeries, hostSeries)
+                .Add(p => p.ChartOptions, new ChartOptions())
+                .AddChildContent<TimeSeries<double>>(cp => cp
+                    .Add(l => l.ChartSeries, overlaySeries)
+                    .Add(l => l.ChartOptions, new TimeSeriesChartOptions { TimeLabelSpacing = TimeSpan.FromHours(1) })));
+
+            // The nested TimeSeries registers itself as an overlay child of the Line host.
+            var overlay = comp.FindComponents<TimeSeries<double>>()
+                .Select(c => c.Instance)
+                .First(i => i.IsOverlayChart);
+
+            overlay.IsOverlayChart.Should().BeTrue();
+
+            // Re-rendering the host re-runs RebuildChart, which now propagates SharedData to the
+            // overlay and renders its line alongside the host line.
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartSeries, hostSeries)
+                .Add(p => p.ChartOptions, new ChartOptions())
+                .AddChildContent<TimeSeries<double>>(cp => cp
+                    .Add(l => l.ChartSeries, overlaySeries)
+                    .Add(l => l.ChartOptions, new TimeSeriesChartOptions { TimeLabelSpacing = TimeSpan.FromHours(1) })));
+
+            overlay.SharedData.Should().NotBeNull();
+            comp.FindAll("path.mud-chart-line").Count.Should().BeGreaterThan(1);
+        }
+
+        [Test]
+        public void TimeSeriesChart_AreaDisplayType_RequiresZeroPoint_RendersAreaPath()
+        {
+            SetupBBoxInterop();
+            var time = new DateTime(2000, 1, 1);
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Timeseries)
+                .Add(p => p.ChartSeries, BuildSeries(time, value: 1000))
+                .Add(p => p.ChartOptions, new TimeSeriesChartOptions
+                {
+                    TimeLabelSpacing = TimeSpan.FromHours(1),
+                    LineDisplayType = LineDisplayType.Area,
+                }));
+
+            // Area display closes the path back to the zero baseline (" Z") and adds a second
+            // mud-chart-line path (the fill) on top of the stroke path.
+            comp.Markup.Should().Contain(" Z");
+            comp.FindAll("path.mud-chart-line").Count.Should().BeGreaterThanOrEqualTo(2);
+        }
+
+        [Test]
+        public async Task TimeSeriesChart_HoverDataPoint_ShowsTooltip()
+        {
+            SetupBBoxInterop();
+            var time = new DateTime(2000, 1, 1);
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Timeseries)
+                .Add(p => p.ChartSeries, BuildSeries(time, count: 4))
+                .Add(p => p.ChartOptions, new TimeSeriesChartOptions
+                {
+                    TimeLabelSpacing = TimeSpan.FromHours(1),
+                    ShowToolTips = true,
+                }));
+
+            comp.FindComponents<ChartTooltip>().Count.Should().Be(0);
+
+            var point = comp.FindAll("circle.mud-chart-point").First();
+            await point.MouseOverAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+
+            comp.FindComponents<ChartTooltip>().Count.Should().BeGreaterThan(0);
+
+            await point.MouseOutAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+            comp.FindComponents<ChartTooltip>().Count.Should().Be(0);
+        }
+
+        [Test]
+        public void TimeSeriesChart_CreateInterpolator_Throws()
+        {
+            var comp = Context.Render<TimeSeries<double>>();
+            var instance = comp.Instance;
+
+            Action act = () => instance.CreateInterpolator(0, 0, 20d, 1d, 1d);
+            act.Should().Throw<NotImplementedException>()
+                .WithMessage("*not implemented*");
         }
 
         [Test]


### PR DESCRIPTION
Expands unit-test coverage of the chart components and tidies the existing chart test suite:

- overlay/composite charts (Bar / Line / StackedBar / TimeSeries) and their hover handlers
- Sankey multi-column layout, node/edge interaction, tooltips and options
- HeatMap cell/legend hover, cell selection and pixel-bounds parsing
- area display, clamp-to-zero and tooltip-gating on axis-line charts
- radial chart sizing and option implicit operators
- `TridiagonalSolver` and spline interpolation guard branches
- `ChartData` / `ChartPoint` / `ChartSeries` models
- de-duplicated the triplicated `mudGetSvgBBox` JSInterop setup in `TimeSeriesChartTests` behind a shared helper.

Chart line coverage rises from ~88% to ~97% and chart test count goes from 354 to 464.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests