### PR TITLE
MudGlobal: Restore static UnhandledExceptionHandler

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
@@ -1,112 +1,118 @@
-﻿using AwesomeAssertions;
+﻿using System.Diagnostics;
+using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Extensions
 {
+
     [TestFixture]
+    [NonParallelizable]
     public class TaskExtensionsTests
     {
-        private static async Task AsyncTaskExceptionGenerator(string errorMessage)
+        private Action<Exception> _originalExceptionHandler = null!;
+
+        [SetUp]
+        public void SetUp()
         {
-            await Task.Yield();
+            _originalExceptionHandler = MudGlobal.UnhandledExceptionHandler;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            MudGlobal.UnhandledExceptionHandler = _originalExceptionHandler;
+        }
+
+        private async Task AsyncTaskExceptionGenerator(string errorMessage)
+        {
+            await Task.Delay(10);
             throw new Exception(errorMessage);
         }
 
-        private static async ValueTask AsyncValueTaskExceptionGenerator(string errorMessage)
+        private async ValueTask AsyncValueTaskExceptionGenerator(string errorMessage)
         {
-            await Task.Yield();
+            await Task.Delay(10);
             throw new Exception(errorMessage);
         }
 
-        private static async ValueTask<TValue> AsyncValueTaskExceptionGenerator<TValue>(string errorMessage)
+        private async ValueTask<TValue> AsyncValueTaskExceptionGenerator<TValue>(string errorMessage)
         {
-            await Task.Yield();
+            await Task.Delay(10);
             throw new Exception(errorMessage);
         }
 
         [Test]
-        [CancelAfter(5000)]
         public async Task Task_AndForget_ShouldForwardExceptionToGlobalHandler()
         {
-            var handled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            MudGlobal.UnhandledExceptionHandler = ex => handled.TrySetResult(ex.Message);
-
-            AsyncTaskExceptionGenerator("Something bad is about to happen ...").CatchAndLog();
-
-            var errorMessage = await handled.Task.WaitAsync(TestContext.CurrentContext.CancellationToken);
+            string errorMessage = null;
+            MudGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
+            var task = AsyncTaskExceptionGenerator("Something bad is about to happen ...");
+            task.CatchAndLog();
+            var t = Stopwatch.StartNew();
+            while (errorMessage == null)
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                {
+                    Assert.Fail("The exception wasn't forwarded to the global exception handler in time!");
+                }
+            }
             errorMessage.Should().Be("Something bad is about to happen ...");
         }
 
         [Test]
-        [CancelAfter(5000)]
         public async Task ValueTask_AndForget_ShouldForwardExceptionToGlobalHandler()
         {
-            var handled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            MudGlobal.UnhandledExceptionHandler = ex => handled.TrySetResult(ex.Message);
-
-            AsyncValueTaskExceptionGenerator("Something bad is about to happen ...").CatchAndLog();
-
-            var errorMessage = await handled.Task.WaitAsync(TestContext.CurrentContext.CancellationToken);
+            string errorMessage = null;
+            MudGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
+            var task = AsyncValueTaskExceptionGenerator("Something bad is about to happen ...");
+            task.CatchAndLog();
+            var t = Stopwatch.StartNew();
+            while (errorMessage == null)
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                {
+                    Assert.Fail("The exception wasn't forwarded to the global exception handler in time!");
+                }
+            }
             errorMessage.Should().Be("Something bad is about to happen ...");
         }
 
         [Test]
-        [CancelAfter(5000)]
         public async Task ValueTask_T_AndForget_ShouldForwardExceptionToGlobalHandler()
         {
-            var handled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            MudGlobal.UnhandledExceptionHandler = ex => handled.TrySetResult(ex.Message);
-
-            AsyncValueTaskExceptionGenerator<bool>("Something bad is about to happen ...").CatchAndLog();
-
-            var errorMessage = await handled.Task.WaitAsync(TestContext.CurrentContext.CancellationToken);
+            string errorMessage = null;
+            MudGlobal.UnhandledExceptionHandler = ex => errorMessage = ex.Message;
+            var task = AsyncValueTaskExceptionGenerator<bool>("Something bad is about to happen ...");
+            task.CatchAndLog();
+            var t = Stopwatch.StartNew();
+            while (errorMessage == null)
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                {
+                    Assert.Fail("The exception wasn't forwarded to the global exception handler in time!");
+                }
+            }
             errorMessage.Should().Be("Something bad is about to happen ...");
         }
 
         [Test]
-        public void UnhandledExceptionHandler_ShouldFallBackToDefaultWhenUnset()
+        public async Task Task_AndForget_ShouldNotFailIfGlobalHandlerIsNull()
         {
-            // No handler is set in this flow, so the getter resolves to the default console handler.
-            var handler = MudGlobal.UnhandledExceptionHandler;
-            handler.Should().NotBeNull();
-
-            // The default handler writes the exception to the console and must not throw.
-            var invokeDefault = () => handler.Invoke(new InvalidOperationException("default handler smoke test"));
-            invokeDefault.Should().NotThrow();
-        }
-
-        [Test]
-        [CancelAfter(5000)]
-        public async Task CatchAndLog_ShouldUseHandlerFromCurrentAsyncFlow()
-        {
-            // The handler is async-local, so concurrent flows each see their own value with no cross-talk.
-            // Both flows install their handler before either exception is raised, so a shared (non-isolated)
-            // handler would route both exceptions to whichever flow wrote last and hang the other.
-            var cancellationToken = TestContext.CurrentContext.CancellationToken;
-            var flow1Ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var flow2Ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            Task<string> CaptureInOwnFlow(string errorMessage, TaskCompletionSource ready, Task otherReady) => Task.Run(async () =>
+            MudGlobal.UnhandledExceptionHandler = null;
+            var task = AsyncTaskExceptionGenerator("Something bad is about to happen ...");
+            task.CatchAndLog();
+            var t = Stopwatch.StartNew();
+            while (!(task.IsCompleted || task.IsCanceled || task.IsFaulted))
             {
-                var handled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-                MudGlobal.UnhandledExceptionHandler = ex => handled.TrySetResult(ex.Message);
-                ready.SetResult();
-                await otherReady.WaitAsync(cancellationToken);
-
-                AsyncTaskExceptionGenerator(errorMessage).CatchAndLog();
-
-                return await handled.Task.WaitAsync(cancellationToken);
-            }, cancellationToken);
-
-            var results = await Task.WhenAll(
-                CaptureInOwnFlow("Something bad is about to happen in flow 1 ...", flow1Ready, flow2Ready.Task),
-                CaptureInOwnFlow("Something bad is about to happen in flow 2 ...", flow2Ready, flow1Ready.Task));
-
-            results.Should().BeEquivalentTo(new[]
-            {
-                "Something bad is about to happen in flow 1 ...",
-                "Something bad is about to happen in flow 2 ..."
-            });
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                {
+                    Assert.Fail("The test task did not end in time, this should not happen!");
+                }
+            }
         }
     }
 }

--- a/src/MudBlazor/Services/MudGlobal.cs
+++ b/src/MudBlazor/Services/MudGlobal.cs
@@ -46,22 +46,13 @@ public static class MudGlobal
         public static TimeSpan Duration { get; set; } = TimeSpan.FromMilliseconds(251);
     }
 
-    private static readonly AsyncLocal<Action<Exception>?> _unhandledExceptionHandler = new();
-
     /// <summary>
     /// The handler for unhandled MudBlazor component exceptions.
     /// </summary>
     /// <remarks>
     /// Exceptions which use this handler are typically rare, such as errors which occur during a "fire-and-forget" <see cref="Task"/> which cannot be awaited.<br />
     /// By default, exceptions are logged to the console via <see cref="Console.Write(object?)"/>.<br />
-    /// The handler is resolved per async flow, so a value set in one flow does not affect others; unset flows use the default console handler.<br />
     /// To handle all .NET exceptions, see: <see href="https://learn.microsoft.com/aspnet/core/fundamentals/error-handling">Handle errors in ASP.NET Core</see>.
     /// </remarks>
-    public static Action<Exception> UnhandledExceptionHandler
-    {
-        get => _unhandledExceptionHandler.Value ?? DefaultUnhandledExceptionHandler;
-        set => _unhandledExceptionHandler.Value = value;
-    }
-
-    private static void DefaultUnhandledExceptionHandler(Exception exception) => Console.Write(exception);
+    public static Action<Exception> UnhandledExceptionHandler { get; set; } = (exception) => Console.Write(exception);
 }


### PR DESCRIPTION
Reverts #13192, which changed `MudGlobal.UnhandledExceptionHandler` from a process-wide `static` property to one backed by `AsyncLocal<Action<Exception>?>`:

```csharp
get => _unhandledExceptionHandler.Value ?? DefaultUnhandledExceptionHandler;
set => _unhandledExceptionHandler.Value = value;
```

`AsyncLocal<T>` values only flow downward through async continuations from the point they're set. The handler is invoked from `TaskExtensions.CatchAndLog()` fire-and-forget continuations, which on Blazor Server run inside a SignalR circuit's `ExecutionContext` — *not* one descended from `Program.Main`. ASP.NET Core does not flow startup ambient `ExecutionContext` into request/circuit processing, so a handler assigned once in `Program.cs` (the documented pattern) is invisible to circuit code and silently falls back to the console default.

The parallel test that motivated the original PR only passes because it sets and reads the handler within a single async flow — which is exactly the property that breaks the production set-once-at-startup contract. Net effect: a silent behavioral regression of a public API versus v9.5.0, affecting apps that route MudBlazor's rare fire-and-forget exceptions to a custom logger/telemetry sink on Server.

A future parallel-safe approach (if desired) should keep a `static` field as the global fallback and resolve `AsyncLocal.Value ?? staticFallback ?? Default`, so a startup `set` still works in production while tests can isolate per-flow.