### PR TITLE
MudBaseInput: Add in-flight edit window for Immediate inputs

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -475,6 +475,64 @@ namespace MudBlazor.UnitTests.Components
             changed_text.Should().Be("B");
         }
 
+        // ---- #12796: in-flight edit window (Immediate inputs must not lose characters to stale echoes) ----
+
+        [Test]
+        public async Task TextField_Immediate_StaleParentEcho_Should_NotClobberInFlightText()
+        {
+            // #12796: the user is typing on an Immediate input. A stale parent value (an earlier
+            // keystroke's @bind echo arriving late on a high-latency circuit) must NOT overwrite the
+            // text the user has since typed. Before the in-flight window, the stale value reformatted
+            // the field and ate characters.
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Immediate, true)
+                .Add(p => p.Value, "a"));
+            var input = comp.Find("input");
+            comp.Instance.ReadText.Should().Be("a");
+
+            // user focuses (keydown opens focus tracking) and types ahead to "abc"
+            await input.KeyDownAsync(new KeyboardEventArgs { Key = "b" });
+            await input.InputAsync(new ChangeEventArgs { Value = "abc" });
+            comp.Instance.ReadText.Should().Be("abc");
+
+            // a STALE echo lands: the parent re-renders with the earlier value "a" while "abc" is in flight
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, "a"));
+
+            // the in-flight window suppresses the stale echo, so the typed text survives
+            comp.Instance.ReadText.Should().Be("abc");
+        }
+
+        [Test]
+        public async Task TextField_Immediate_ExternalChange_Should_SyncAfterEditingEnds()
+        {
+            // #12796 contract: once the edit settles (here, on blur) the window closes and genuine
+            // external/programmatic updates sync to the text again, even though it was just edited.
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Immediate, true)
+                .Add(p => p.Value, "a"));
+            var input = comp.Find("input");
+            await input.KeyDownAsync(new KeyboardEventArgs { Key = "b" });
+            await input.InputAsync(new ChangeEventArgs { Value = "abc" });
+            await input.BlurAsync(); // editing ends → window closes
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, "external"));
+            comp.Instance.ReadText.Should().Be("external");
+        }
+
+        [Test]
+        public async Task TextField_NonImmediate_ExternalChange_Should_SyncText_Unchanged()
+        {
+            // #12796 contract: Immediate=false behavior is unchanged — the window never engages, so an
+            // external value change always refreshes the displayed text.
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Immediate, false)
+                .Add(p => p.Value, "a"));
+            comp.Instance.ReadText.Should().Be("a");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Value, "b"));
+            comp.Instance.ReadText.Should().Be("b");
+        }
+
         /// <summary>
         /// Instead of RequiredError it should show the conversion error, because typing something (even if not a number) should
         /// already fulfill the requirement of Required="true". If it is a valid value is a different question.

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -22,6 +22,14 @@ namespace MudBlazor
         protected bool _isFocused;
         protected bool _forceTextUpdate;
 
+        // In-flight edit window (#12796): while a user keystroke's @bind echo is still round-tripping
+        // through the parent, stale value echoes from earlier keystrokes must not clobber the
+        // in-progress text. The window opens on user input (Immediate + focused) and closes the instant
+        // the echo of the most recent user value arrives, so genuine external changes resume syncing
+        // even while the input stays focused. Non-Immediate inputs never open it.
+        private bool _editInFlight;
+        private T? _latestUserValue;
+
         /// <summary>
         /// The resolved input element ID.
         /// </summary>
@@ -469,6 +477,9 @@ namespace MudBlazor
         protected internal virtual async Task OnBlurredAsync(FocusEventArgs obj)
         {
             _isFocused = false;
+            // Editing has ended: close the in-flight edit window so the next Value change derives text
+            // normally and the committed/formatted value can be shown (#12796).
+            _editInFlight = false;
 
             if (ReadOnly)
             {
@@ -530,6 +541,15 @@ namespace MudBlazor
             _isDirty = true;
             _validated = false;
 
+            // Open the in-flight edit window (#12796): record the value this keystroke produced so a
+            // stale echo arriving mid-typing can be told apart from the settling echo and from a genuine
+            // external change. Only Immediate, focused user input needs the window.
+            if (Immediate && _isFocused)
+            {
+                _latestUserValue = value;
+                _editInFlight = true;
+            }
+
             // Use ParameterState to set Value instead of direct assignment
             // This ensures proper parameter lifecycle management
             await _valueState.SetValueAsync(value);
@@ -562,12 +582,18 @@ namespace MudBlazor
             {
                 var forceTextUpdate = _forceTextUpdate;
                 _forceTextUpdate = false;
-                // Do not reformat the displayed text from Value on this input's own Immediate ValueChanged
-                // echo (the @bind round-trip mid-typing). On Blazor Server the echo can land between
-                // keystrokes and would reformat while the user is typing, corrupting input (#13002; also
-                // completes #13266/#13250 on Server, which #13311 only fixed for the synchronous case).
-                // External value changes, non-Immediate commits, and explicit forced updates still refresh.
-                if (forceTextUpdate || !(Immediate && arg.IsChildOriginatedChange))
+                if (forceTextUpdate)
+                {
+                    _editInFlight = false;
+                }
+                // Governed by the in-flight edit window (#12796): while a user edit is awaiting its echo,
+                // suppress the value->text derive so a stale echo from an earlier keystroke can't reformat
+                // (and corrupt) the in-progress text on a high-latency Blazor Server circuit. The window
+                // closes the moment the latest user value echoes back, so genuine external value changes
+                // resume refreshing the text even while the input stays focused. This supersedes the prior
+                // `Immediate && IsChildOriginatedChange` guard, which let stale echoes through because their
+                // value differs from the current working value (so IsChildOriginatedChange was false).
+                if (forceTextUpdate || ShouldDeriveTextFromValue(arg.Value))
                 {
                     await UpdateTextPropertyAsync(false);
                 }
@@ -585,6 +611,35 @@ namespace MudBlazor
                 FieldChanged(arg.Value);
                 await BeginValidateAsync();
             }
+        }
+
+        /// <summary>
+        /// Decides whether an incoming <see cref="Value"/> change should refresh the derived display
+        /// text, implementing the in-flight edit window (#12796).
+        /// </summary>
+        /// <remarks>
+        /// While a user edit is awaiting its <see cref="ValueChanged"/> echo, derivation is suppressed so
+        /// a stale echo from an earlier keystroke cannot overwrite the in-flight text. As soon as the echo
+        /// of the most recent user value arrives, the window closes so subsequent genuine external changes
+        /// resume syncing normally — even while the input is still focused. The settling echo itself does
+        /// not reformat, so the user's in-progress text is preserved until they commit (blur).
+        /// </remarks>
+        private bool ShouldDeriveTextFromValue(T? incomingValue)
+        {
+            if (!_editInFlight)
+            {
+                return true;
+            }
+
+            if (EqualityComparer<T?>.Default.Equals(incomingValue, _latestUserValue))
+            {
+                // The latest user keystroke's echo has caught up: the window has settled.
+                _editInFlight = false;
+                return false; // the display already shows the user's in-flight text
+            }
+
+            // A stale echo from an earlier keystroke (or an external change mid-edit). Don't clobber.
+            return false;
         }
 
         /// <summary>
@@ -674,6 +729,7 @@ namespace MudBlazor
         public virtual void ForceRender(bool forceTextUpdate)
         {
             _forceTextUpdate = true;
+            _editInFlight = false;
             UpdateTextPropertyAsync(false).CatchAndLog();
             StateHasChanged();
         }
@@ -694,14 +750,24 @@ namespace MudBlazor
             {
                 var valueChanged = !EqualityComparer<T?>.Default.Equals(currentValue, ReadValue);
 
-                // Preserve in-progress user text across parent rerenders until Value actually changes.
-                if (_isFocused && !valueChanged && !_forceTextUpdate)
+                // An explicit forced refresh always wins and closes any in-flight edit window.
+                if (_forceTextUpdate)
+                {
+                    _forceTextUpdate = false;
+                    _editInFlight = false;
+                    await UpdateTextPropertyAsync(false);
+                    return;
+                }
+
+                // Preserve in-progress user text across parent rerenders. While a user edit is in flight,
+                // suppress the value->text derive here too so a stale echo on a high-latency circuit can't
+                // clobber typed text via this path (the value-changed echo bypasses the focused/unchanged
+                // guard below) (#12796). Also keep preserving focused text when the value is unchanged.
+                if (_editInFlight || (_isFocused && !valueChanged))
                 {
                     return;
                 }
 
-                // Always update text when Value changes (TextUpdateSuppression removed)
-                _forceTextUpdate = false;
                 await UpdateTextPropertyAsync(false);
             }
         }


### PR DESCRIPTION
## Description

Implements the in-flight edit window behavioral contract from #12796 for `MudBaseInput<T>`. **No public API changes.**

While a user types on an `Immediate` input, a stale parent value — an earlier keystroke's `@bind` echo arriving late on a high-latency Blazor Server circuit — could overwrite the text the user had since typed, eating characters. The previous `Immediate && IsChildOriginatedChange` guard only suppressed the input's echo of its *current* value; a stale echo carries an *earlier* value, so `IsChildOriginatedChange` was `false`, the value→text derive ran, and it reformatted/clobbered the in-flight text.

### What changed
An explicit in-flight edit window in `MudBaseInput<T>`:
- Opens when a focused `Immediate` input produces a new value (records that value as the latest).
- Suppresses the value→text derive for any incoming value that isn't the latest user value (i.e. stale echoes), in **both** derive paths (`OnValueParameterChangedAsync` and `SetParametersAsync`).
- Closes the instant the latest user value echoes back (settles) or on blur, so genuine external/programmatic changes resume syncing the displayed text **even while focused** — the "resume once settled" half of the contract that a blunt "suppress while focused" guard misses.

This replaces the `Immediate && IsChildOriginatedChange` guard. Non-`Immediate` behavior is unchanged (the window never opens).

### Behavioral contract (from #12796)
- ✅ Immediate + focused + updates in flight: don't overwrite displayed text with stale parent values.
- ✅ No updates in flight: resume normal syncing (parent/programmatic changes update the input again).
- ✅ Non-immediate behavior: unchanged.
- ✅ No public API changes.

## How tested
- All input/form bUnit suites pass (TextField, NumericField, Select, Mask, Autocomplete, Form, pickers) — no regressions.
- Added contract tests in `TextFieldTests`: typed text survives a stale echo, external changes sync once editing ends, and `Immediate=false` syncing is unchanged.
- Exercised on a real Blazor Server (interactive SignalR) host with simulated latency.

> **Validation caveat (please read):** the race itself is **circuit-/latency-only** and is *not* reproducible in bUnit's synchronous render model (as noted in the #13320 epic), and I could not reliably reproduce it on a localhost Server harness either (low latency + the existing guards mask it under synthetic input). So the added tests assert the **behavioral contract / invariants** rather than failing-without-the-change. The change is validated structurally (matches the contract, no regressions across ~1060 input tests); a maintainer confirming on a genuinely high-latency Server connection would be the final word.

Part of #13320. Fixes #12796.
