### PR TITLE
Inputs, Pickers: Only mark Touched and fire FieldChanged on user interaction

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialPickerValuesNotTouchedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialPickerValuesNotTouchedTest.razor
@@ -1,0 +1,47 @@
+@using MudBlazor.Utilities
+
+<MudForm @ref="Form" FieldChanged="v => FormFieldChangedEventArgs = v">
+    <MudDatePicker @bind-Date="_date" />
+    <MudTimePicker @bind-Time="_time" />
+    <MudDateRangePicker @bind-DateRange="_dateRange" />
+    <MudColorPicker @bind-Value="_color" />
+</MudForm>
+
+@code {
+    public static string __description__ =
+        "Pickers with non-default initial (or async-loaded) values must NOT become Touched and must NOT fire FieldChanged without user interaction (#13246, #13064).";
+
+    public MudForm Form = null!;
+    public FormFieldChangedEventArgs? FormFieldChangedEventArgs { get; private set; }
+
+    private DateTime? _date;
+    private TimeSpan? _time;
+    private DateRange? _dateRange;
+    private MudColor _color = "#594ae2"; // default-ish; changed by ApplyValues
+
+    /// <summary>When true, the pickers start with non-default values (#13246 initial-load case).</summary>
+    [Parameter] public bool Preloaded { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (Preloaded)
+        {
+            ApplyValues();
+        }
+    }
+
+    /// <summary>Simulates a data load that arrives after the first render (#13064 async-load case).</summary>
+    public Task LoadValuesAsync()
+    {
+        ApplyValues();
+        return InvokeAsync(StateHasChanged);
+    }
+
+    private void ApplyValues()
+    {
+        _date = new DateTime(2020, 1, 15);
+        _time = new TimeSpan(10, 30, 0);
+        _dateRange = new DateRange(new DateTime(2020, 1, 1), new DateTime(2020, 1, 5));
+        _color = "#ff0000";
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialValuesNotTouchedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialValuesNotTouchedTest.razor
@@ -7,6 +7,10 @@
         <MudSelectItem T="Fruit?" Value="@((Fruit?)Fruit.Banana)">Banana</MudSelectItem>
     </MudSelect>
     <MudTextField T="string" @bind-Text="_text" />
+    <MudSelect T="string" MultiSelection="true" @bind-SelectedValues="_multiSelected">
+        <MudSelectItem T="string" Value="@("a")">A</MudSelectItem>
+        <MudSelectItem T="string" Value="@("b")">B</MudSelectItem>
+    </MudSelect>
 </MudForm>
 
 @code {
@@ -22,6 +26,7 @@
     private int _number;
     private Fruit? _fruit;
     private string? _text;
+    private IReadOnlyCollection<string> _multiSelected = [];
 
     public enum Fruit { Apple, Banana }
 
@@ -48,5 +53,6 @@
         _number = 5;
         _fruit = Fruit.Banana;
         _text = "hello";
+        _multiSelected = ["a"];
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialValuesNotTouchedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialValuesNotTouchedTest.razor
@@ -1,0 +1,52 @@
+@using MudBlazor.Utilities
+
+<MudForm @ref="Form" FieldChanged="v => FormFieldChangedEventArgs = v">
+    <MudNumericField T="int" @bind-Value="_number" />
+    <MudSelect T="Fruit?" @bind-Value="_fruit">
+        <MudSelectItem T="Fruit?" Value="@((Fruit?)Fruit.Apple)">Apple</MudSelectItem>
+        <MudSelectItem T="Fruit?" Value="@((Fruit?)Fruit.Banana)">Banana</MudSelectItem>
+    </MudSelect>
+    <MudTextField T="string" @bind-Text="_text" />
+</MudForm>
+
+@code {
+    public static string __description__ =
+        "A MudForm whose inputs receive non-default initial (or async-loaded) values must NOT become Touched and must NOT fire FieldChanged without user interaction (#13246, #13064).";
+
+    public MudForm Form = null!;
+    public FormFieldChangedEventArgs? FormFieldChangedEventArgs { get; private set; }
+
+    // Non-string T (int / nullable enum) is required to reproduce: MudBaseInput.OnInitializedAsync
+    // only syncs Text from Value when typeof(T) != typeof(string). A non-empty bound Text also
+    // reproduces via OnTextParameterChangedAsync regardless of T.
+    private int _number;
+    private Fruit? _fruit;
+    private string? _text;
+
+    public enum Fruit { Apple, Banana }
+
+    /// <summary>When true, the inputs start with non-default values (#13246 initial-load case).</summary>
+    [Parameter] public bool Preloaded { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (Preloaded)
+        {
+            ApplyValues();
+        }
+    }
+
+    /// <summary>Simulates a data load that arrives after the first render (#13064 async-load case).</summary>
+    public Task LoadValuesAsync()
+    {
+        ApplyValues();
+        return InvokeAsync(StateHasChanged);
+    }
+
+    private void ApplyValues()
+    {
+        _number = 5;
+        _fruit = Fruit.Banana;
+        _text = "hello";
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/FormTimePickerSubmitTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/FormTimePickerSubmitTest.razor
@@ -1,0 +1,16 @@
+@using MudBlazor.Utilities
+<MudPopoverProvider />
+
+<MudForm @ref="Form" FieldChanged="v => FormFieldChangedEventArgs = v">
+    <MudTimePicker @bind-Time="_time" />
+</MudForm>
+
+@code {
+    public static string __description__ =
+        "Submitting a user-picked time (Enter) must mark the picker Touched and fire FieldChanged, even though the Time parameter setter is suppressed for programmatic changes (#13328 review).";
+
+    public MudForm Form = null!;
+    public FormFieldChangedEventArgs? FormFieldChangedEventArgs { get; private set; }
+
+    private TimeSpan? _time;
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -180,6 +180,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponent<MudNumericField<int>>().Instance.Touched.Should().BeFalse("numeric");
             comp.FindComponent<MudTextField<string>>().Instance.Touched.Should().BeFalse("textfield");
             comp.FindComponent<MudSelect<FormInitialValuesNotTouchedTest.Fruit?>>().Instance.Touched.Should().BeFalse("select");
+            comp.FindComponent<MudSelect<string>>().Instance.Touched.Should().BeFalse("multiselect");
             comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged");
             form.IsTouched.Should().BeFalse("form.IsTouched");
         }
@@ -207,6 +208,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponent<MudNumericField<int>>().Instance.Touched.Should().BeFalse("numeric");
             comp.FindComponent<MudTextField<string>>().Instance.Touched.Should().BeFalse("textfield");
             comp.FindComponent<MudSelect<FormInitialValuesNotTouchedTest.Fruit?>>().Instance.Touched.Should().BeFalse("select");
+            comp.FindComponent<MudSelect<string>>().Instance.Touched.Should().BeFalse("multiselect");
             comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged");
             form.IsTouched.Should().BeFalse("form.IsTouched");
         }

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -286,10 +286,13 @@ namespace MudBlazor.UnitTests.Components
             // check initial state: form should not be touched
             form.IsTouched.Should().Be(false);
             nestedForm.IsTouched.Should().Be(false);
-            // input a date, istouched should be true
+            // input a date into the OUTER form's date picker (textCompFields[1] is that picker's inner
+            // input); only the outer form becomes touched. The nested form stays untouched - previously it
+            // appeared touched only because its date picker was erroneously marked touched on initial load
+            // by its bound value (#13246/#13064), which this fix corrects.
             await textCompFields[1].Find("input").ChangeAsync("2001-01-31");
             form.IsTouched.Should().Be(true);
-            nestedForm.IsTouched.Should().Be(true);
+            nestedForm.IsTouched.Should().Be(false);
 
             //reset should set touched to false
             await comp.InvokeAsync(() => form.ResetAsync());
@@ -1808,6 +1811,61 @@ namespace MudBlazor.UnitTests.Components
             textFieldComp.Find("input").GetAttribute("value").Should().Be("programmatic", "the text is still set");
             textField.Touched.Should().BeFalse("no user interaction occurred");
             comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged must not fire for a programmatic set");
+        }
+
+        /// <summary>
+        /// Regression test for #13246 / #13064 for pickers. A picker that receives a non-default value via
+        /// its value parameter (Date/Time/DateRange) on initial render must not become touched or fire
+        /// FieldChanged.
+        /// </summary>
+        [Test]
+        public void FormWithNonDefaultInitialPickerValuesIsNotTouched()
+        {
+            var comp = Context.Render<FormInitialPickerValuesNotTouchedTest>(parameters => parameters
+                .Add(p => p.Preloaded, true));
+
+            using var _ = new AssertionScope();
+            comp.FindComponent<MudDatePicker>().Instance.Touched.Should().BeFalse("date");
+            comp.FindComponent<MudTimePicker>().Instance.Touched.Should().BeFalse("time");
+            comp.FindComponent<MudDateRangePicker>().Instance.Touched.Should().BeFalse("daterange");
+            comp.FindComponent<MudColorPicker>().Instance.Touched.Should().BeFalse("color");
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged");
+        }
+
+        /// <summary>
+        /// Regression test for #13064 for pickers. Values that arrive after the first render (e.g. an async
+        /// data load), including an external MudColorPicker Value change, must leave the pickers untouched.
+        /// </summary>
+        [Test]
+        public async Task FormPickersRemainUntouchedWhenValuesLoadedAfterRender()
+        {
+            var comp = Context.Render<FormInitialPickerValuesNotTouchedTest>();
+
+            await comp.InvokeAsync(() => comp.Instance.LoadValuesAsync());
+
+            using var _ = new AssertionScope();
+            comp.FindComponent<MudDatePicker>().Instance.Touched.Should().BeFalse("date");
+            comp.FindComponent<MudTimePicker>().Instance.Touched.Should().BeFalse("time");
+            comp.FindComponent<MudDateRangePicker>().Instance.Touched.Should().BeFalse("daterange");
+            comp.FindComponent<MudColorPicker>().Instance.Touched.Should().BeFalse("color");
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged");
+        }
+
+        /// <summary>
+        /// The picker Touched suppression must not leak into user interaction: typing a date into the
+        /// picker's input must still touch it.
+        /// </summary>
+        [Test]
+        public async Task DatePickerStillTouchesOnUserTextInput()
+        {
+            var comp = Context.Render<FormInitialPickerValuesNotTouchedTest>(parameters => parameters
+                .Add(p => p.Preloaded, true));
+            var datePicker = comp.FindComponent<MudDatePicker>();
+            datePicker.Instance.Touched.Should().BeFalse();
+
+            await datePicker.Find("input").ChangeAsync(new ChangeEventArgs { Value = "2020-02-20" });
+
+            datePicker.Instance.Touched.Should().BeTrue();
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using AngleSharp.Dom;
 using AwesomeAssertions;
+using AwesomeAssertions.Execution;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -159,6 +160,77 @@ namespace MudBlazor.UnitTests.Components
 
             await input.InputAsync(new ChangeEventArgs { Value = "ABC" });
             await comp.WaitForAssertionAsync(() => comp.Instance.ValidationCount.Should().Be(3));
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/13246 and
+        /// https://github.com/MudBlazor/MudBlazor/issues/13064.
+        /// Inputs that receive a non-default value via @bind-Value / @bind-Text must NOT mark the form
+        /// touched and must NOT fire FieldChanged on the initial render (no user interaction occurred).
+        /// Regressed in 9.3.0 by PR #12892: the programmatic value->text sync sets Touched=true.
+        /// </summary>
+        [Test]
+        public async Task FormWithNonDefaultInitialValuesIsNotTouchedAndDoesNotFireFieldChanged()
+        {
+            var comp = Context.Render<FormInitialValuesNotTouchedTest>(parameters => parameters
+                .Add(p => p.Preloaded, true));
+            var form = comp.Instance.Form;
+
+            using var _ = new AssertionScope();
+            comp.FindComponent<MudNumericField<int>>().Instance.Touched.Should().BeFalse("numeric");
+            comp.FindComponent<MudTextField<string>>().Instance.Touched.Should().BeFalse("textfield");
+            comp.FindComponent<MudSelect<FormInitialValuesNotTouchedTest.Fruit?>>().Instance.Touched.Should().BeFalse("select");
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged");
+            form.IsTouched.Should().BeFalse("form.IsTouched");
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/13064.
+        /// When values arrive after the first render (e.g. an async data load), the form must remain
+        /// untouched and FieldChanged must not fire.
+        /// </summary>
+        [Test]
+        public async Task FormFieldsRemainUntouchedWhenValuesLoadedAfterRender()
+        {
+            var comp = Context.Render<FormInitialValuesNotTouchedTest>();
+            var form = comp.Instance.Form;
+
+            // Baseline: empty form is not touched.
+            form.IsTouched.Should().BeFalse();
+
+            // Simulate an async data load arriving after the first render.
+            await comp.InvokeAsync(() => comp.Instance.LoadValuesAsync());
+
+            using var _ = new AssertionScope();
+            // Per-field Touched is the source of truth for MudForm.IsTouched and is reliable in bUnit;
+            // the form-level _touched aggregation is recomputed on a later cycle.
+            comp.FindComponent<MudNumericField<int>>().Instance.Touched.Should().BeFalse("numeric");
+            comp.FindComponent<MudTextField<string>>().Instance.Touched.Should().BeFalse("textfield");
+            comp.FindComponent<MudSelect<FormInitialValuesNotTouchedTest.Fruit?>>().Instance.Touched.Should().BeFalse("select");
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged");
+            form.IsTouched.Should().BeFalse("form.IsTouched");
+        }
+
+        /// <summary>
+        /// The Touched suppression for programmatic/parameter sync must not leak into genuine user
+        /// interaction: a real user edit after a non-default value was loaded must still touch the form
+        /// and fire FieldChanged.
+        /// </summary>
+        [Test]
+        public async Task FormBecomesTouchedAfterUserInteractionWithPreloadedValues()
+        {
+            var comp = Context.Render<FormInitialValuesNotTouchedTest>(parameters => parameters
+                .Add(p => p.Preloaded, true));
+            var form = comp.Instance.Form;
+            var textField = comp.FindComponent<MudTextField<string>>();
+            textField.Instance.Touched.Should().BeFalse();
+
+            // A real user edit (DOM change) must still touch the field and raise FieldChanged: the
+            // suppression must not leak past the programmatic sync into genuine user interaction.
+            await textField.Find("input").ChangeAsync(new ChangeEventArgs { Value = "user typed" });
+
+            textField.Instance.Touched.Should().BeTrue();
+            comp.Instance.FormFieldChangedEventArgs.Should().NotBeNull();
         }
 
         /// <summary>
@@ -1679,7 +1751,8 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<FormFieldChangedTest>();
 
-            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+            var textFieldComp = comp.FindComponent<MudTextField<string>>();
+            var textField = textFieldComp.Instance;
             var numeric = comp.FindComponent<MudNumericField<int>>().Instance;
             var radioGroup = comp.FindComponent<MudRadioGroup<string>>().Instance;
 
@@ -1687,7 +1760,8 @@ namespace MudBlazor.UnitTests.Components
 
             //in all below cases, the event args should switch to an instance of the field changed and contain the new value that was set
 
-            await comp.InvokeAsync(() => textField.SetTextAsync("new value"));
+            // A genuine user edit (DOM change) must raise FieldChanged. (Programmatic SetTextAsync does not — see #12997.)
+            await textFieldComp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "new value" });
             comp.Instance.FormFieldChangedEventArgs!.NewValue.Should().Be("new value");
             textField.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);
 
@@ -1713,6 +1787,27 @@ namespace MudBlazor.UnitTests.Components
 
             (comp.Instance.FormFieldChangedEventArgs.NewValue is IBrowserFile).Should().BeTrue();
             mudFile.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/12997.
+        /// Programmatically setting the text via <see cref="MudTextField{T}.SetTextAsync"/> must update the
+        /// text but must NOT mark the field touched nor fire FieldChanged — Touched reflects user
+        /// interaction only.
+        /// </summary>
+        [Test]
+        public async Task SetTextAsyncDoesNotTouchOrFireFieldChanged()
+        {
+            var comp = Context.Render<FormFieldChangedTest>();
+            var textFieldComp = comp.FindComponent<MudTextField<string>>();
+            var textField = textFieldComp.Instance;
+
+            await comp.InvokeAsync(() => textField.SetTextAsync("programmatic"));
+
+            using var _ = new AssertionScope();
+            textFieldComp.Find("input").GetAttribute("value").Should().Be("programmatic", "the text is still set");
+            textField.Touched.Should().BeFalse("no user interaction occurred");
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged must not fire for a programmatic set");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1756,8 +1756,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<FormFieldChangedTest>();
 
-            var textFieldComp = comp.FindComponent<MudTextField<string>>();
-            var textField = textFieldComp.Instance;
+            var textField = comp.FindComponent<MudTextField<string>>().Instance;
             var numeric = comp.FindComponent<MudNumericField<int>>().Instance;
             var radioGroup = comp.FindComponent<MudRadioGroup<string>>().Instance;
 
@@ -1765,8 +1764,7 @@ namespace MudBlazor.UnitTests.Components
 
             //in all below cases, the event args should switch to an instance of the field changed and contain the new value that was set
 
-            // A genuine user edit (DOM change) must raise FieldChanged. (Programmatic SetTextAsync does not — see #12997.)
-            await textFieldComp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "new value" });
+            await comp.InvokeAsync(() => textField.SetTextAsync("new value"));
             comp.Instance.FormFieldChangedEventArgs!.NewValue.Should().Be("new value");
             textField.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);
 
@@ -1792,27 +1790,6 @@ namespace MudBlazor.UnitTests.Components
 
             (comp.Instance.FormFieldChangedEventArgs.NewValue is IBrowserFile).Should().BeTrue();
             mudFile.Should().Be(comp.Instance.FormFieldChangedEventArgs.Field);
-        }
-
-        /// <summary>
-        /// Regression test for https://github.com/MudBlazor/MudBlazor/issues/12997.
-        /// Programmatically setting the text via <see cref="MudTextField{T}.SetTextAsync"/> must update the
-        /// text but must NOT mark the field touched nor fire FieldChanged — Touched reflects user
-        /// interaction only.
-        /// </summary>
-        [Test]
-        public async Task SetTextAsyncDoesNotTouchOrFireFieldChanged()
-        {
-            var comp = Context.Render<FormFieldChangedTest>();
-            var textFieldComp = comp.FindComponent<MudTextField<string>>();
-            var textField = textFieldComp.Instance;
-
-            await comp.InvokeAsync(() => textField.SetTextAsync("programmatic"));
-
-            using var _ = new AssertionScope();
-            textFieldComp.Find("input").GetAttribute("value").Should().Be("programmatic", "the text is still set");
-            textField.Touched.Should().BeFalse("no user interaction occurred");
-            comp.Instance.FormFieldChangedEventArgs.Should().BeNull("FieldChanged must not fire for a programmatic set");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -328,6 +328,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Regression test for the PR #13328 review: the Time parameter setter is suppressed so a
+        /// parameter-driven value does not touch the picker, but a genuine user submit (Enter) must still
+        /// mark the picker Touched and fire MudForm.FieldChanged.
+        /// </summary>
+        [Test]
+        public async Task TimePicker_UserSubmit_TouchesAndFiresFieldChanged()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<FormTimePickerSubmitTest>();
+            var timePicker = comp.FindComponent<MudTimePicker>().Instance;
+
+            timePicker.Touched.Should().BeFalse();
+            comp.Instance.FormFieldChangedEventArgs.Should().BeNull();
+
+            // Open the picker and change the time with the keyboard.
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keydown" }));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs { Key = "ArrowUp", Type = "keydown" }));
+            await comp.WaitForAssertionAsync(() => timePicker.TimeIntermediate.Should().NotBeNull());
+
+            // Submit the user-picked time.
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(timePicker.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keydown" }));
+
+            await comp.WaitForAssertionAsync(() => timePicker.Touched.Should().BeTrue());
+            comp.Instance.FormFieldChangedEventArgs.Should().NotBeNull();
+        }
+
+        /// <summary>
         /// A time picker with a label should auto-generate an id and use that id on the input element and the label's for attribute.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -22,16 +22,6 @@ namespace MudBlazor
         protected bool _isFocused;
         protected bool _forceTextUpdate;
 
-        // Suppresses user-interaction side effects (marking Touched, firing FieldChanged) while a
-        // programmatic / parameter-driven value<->text synchronization runs. These must reflect genuine
-        // user interaction (typing, selecting, blur) only, never values that arrive from parameters or
-        // are set programmatically. Without this, supplying a non-default initial (or async-loaded)
-        // Value/Text marks the input — and its surrounding MudForm — touched on load and fires
-        // FieldChanged with no interaction (#13064, #13246, #12997). It is a plain instance bool, set and
-        // cleared synchronously around each parameter-sync entry point via SuppressInteractionEffectsWhileAsync,
-        // so it can never leak across an await into a user event. Validation is intentionally NOT suppressed.
-        private protected bool _suppressInteractionEffects;
-
         /// <summary>
         /// The resolved input element ID.
         /// </summary>
@@ -448,30 +438,6 @@ namespace MudBlazor
         protected virtual Task UpdateTextPropertyAsync(bool updateValue)
         {
             return SetTextAndUpdateValueAsync(ConvertSet(ReadValue), updateValue);
-        }
-
-        /// <summary>
-        /// Runs a programmatic or parameter-driven value/text synchronization without marking this
-        /// input as <see cref="MudFormComponent{T, U}.Touched"/>.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="MudFormComponent{T, U}.Touched"/> must reflect genuine user interaction only.
-        /// Use this wrapper around any sync that is triggered by a parameter change or a programmatic
-        /// call (initial value load, external <c>Value</c>/<c>Text</c> changes, culture/format/converter
-        /// changes) so the resulting text update does not spuriously touch the input or its form.
-        /// </remarks>
-        private protected async Task SuppressInteractionEffectsWhileAsync(Func<Task> synchronize)
-        {
-            var previous = _suppressInteractionEffects;
-            _suppressInteractionEffects = true;
-            try
-            {
-                await synchronize();
-            }
-            finally
-            {
-                _suppressInteractionEffects = previous;
-            }
         }
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -678,7 +678,7 @@ namespace MudBlazor
         public virtual void ForceRender(bool forceTextUpdate)
         {
             _forceTextUpdate = true;
-            SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false)).CatchAndLog();
+            UpdateTextPropertyAsync(false).CatchAndLog();
             StateHasChanged();
         }
 
@@ -815,15 +815,11 @@ namespace MudBlazor
         private Task OnTextParameterChangedAsync(ParameterChangedEventArgs<string?> arg)
         {
             // A Text parameter change is always parameter-driven (a user edit updates Text via the internal
-            // state without re-triggering this handler).
+            // state without re-triggering this handler), so it must not touch the input. The whole handler
+            // runs suppressed, so the gated Touched write in UpdateValuePropertyAsync's chain is skipped.
             return SuppressInteractionEffectsWhileAsync(async () =>
             {
                 _validated = false;
-
-                if (!string.IsNullOrEmpty(arg.Value) && !_suppressInteractionEffects)
-                {
-                    Touched = true;
-                }
 
                 // When Text changes from parent, update Value from Text using UpdateValuePropertyAsync
                 // But only if Value is not also being set in the same parameter update

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -22,6 +22,16 @@ namespace MudBlazor
         protected bool _isFocused;
         protected bool _forceTextUpdate;
 
+        // Suppresses user-interaction side effects (marking Touched, firing FieldChanged) while a
+        // programmatic / parameter-driven value<->text synchronization runs. These must reflect genuine
+        // user interaction (typing, selecting, blur) only, never values that arrive from parameters or
+        // are set programmatically. Without this, supplying a non-default initial (or async-loaded)
+        // Value/Text marks the input — and its surrounding MudForm — touched on load and fires
+        // FieldChanged with no interaction (#13064, #13246, #12997). It is a plain instance bool, set and
+        // cleared synchronously around each parameter-sync entry point via SuppressInteractionEffectsWhileAsync,
+        // so it can never leak across an await into a user event. Validation is intentionally NOT suppressed.
+        private protected bool _suppressInteractionEffects;
+
         /// <summary>
         /// The resolved input element ID.
         /// </summary>
@@ -441,6 +451,30 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Runs a programmatic or parameter-driven value/text synchronization without marking this
+        /// input as <see cref="MudFormComponent{T, U}.Touched"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="MudFormComponent{T, U}.Touched"/> must reflect genuine user interaction only.
+        /// Use this wrapper around any sync that is triggered by a parameter change or a programmatic
+        /// call (initial value load, external <c>Value</c>/<c>Text</c> changes, culture/format/converter
+        /// changes) so the resulting text update does not spuriously touch the input or its form.
+        /// </remarks>
+        private protected async Task SuppressInteractionEffectsWhileAsync(Func<Task> synchronize)
+        {
+            var previous = _suppressInteractionEffects;
+            _suppressInteractionEffects = true;
+            try
+            {
+                await synchronize();
+            }
+            finally
+            {
+                _suppressInteractionEffects = previous;
+            }
+        }
+
+        /// <summary>
         /// When overridden, obtains focus for this input.
         /// </summary>
         /// <returns>A <see cref="ValueTask" /> object.</returns>
@@ -546,7 +580,15 @@ namespace MudBlazor
                 await UpdateTextPropertyAsync(false);
             }
 
-            FieldChanged(value);
+            // Only notify the form of a change that originates from user interaction. Programmatic /
+            // parameter-driven syncs (e.g. an initial @bind-Text value, or an async-loaded selection)
+            // run under SuppressInteractionEffectsWhileAsync and must not fire FieldChanged (#13246).
+            // Validation still runs below so externally-set values are validated; an untouched field
+            // simply shows no required error.
+            if (!_suppressInteractionEffects)
+            {
+                FieldChanged(value);
+            }
             await BeginValidateAsync();
         }
 
@@ -569,7 +611,10 @@ namespace MudBlazor
                 // External value changes, non-Immediate commits, and explicit forced updates still refresh.
                 if (forceTextUpdate || !(Immediate && arg.IsChildOriginatedChange))
                 {
-                    await UpdateTextPropertyAsync(false);
+                    // External/programmatic Value change: refresh the displayed text, but do not touch
+                    // the input — only user interaction touches (#13064, #13246). wasTouched (captured
+                    // above) still governs the FieldChanged below, preserving the #12012 behavior.
+                    await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
                 }
             }
 
@@ -624,14 +669,16 @@ namespace MudBlazor
         protected override async Task OnCultureAndFormatChangedAsync()
         {
             await base.OnCultureAndFormatChangedAsync();
-            await UpdateTextPropertyAsync(false);
+            // Reformatting the text on a culture/format parameter change must not touch the input.
+            await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
         }
 
         /// <inheritdoc />
         protected override async Task OnConverterChangedAsync()
         {
             await base.OnConverterChangedAsync();
-            await UpdateTextPropertyAsync(false);
+            // Reformatting the text on a converter parameter change must not touch the input.
+            await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
         }
 
         protected override async Task ValidateValue()
@@ -649,9 +696,10 @@ namespace MudBlazor
 
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
             // equal to the initial value. This is why we force an update to the Text property here.
+            // This is a programmatic sync, so it must not mark the input touched (#13246, #13064).
             if (typeof(T) != typeof(string) && string.IsNullOrWhiteSpace(ReadText))
             {
-                await UpdateTextPropertyAsync(false);
+                await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
             }
 
             if (Label == null && For != null)
@@ -674,7 +722,8 @@ namespace MudBlazor
         public virtual void ForceRender(bool forceTextUpdate)
         {
             _forceTextUpdate = true;
-            UpdateTextPropertyAsync(false).CatchAndLog();
+            // A programmatic re-render must not mark the input touched (#13246).
+            SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false)).CatchAndLog();
             StateHasChanged();
         }
 
@@ -700,9 +749,10 @@ namespace MudBlazor
                     return;
                 }
 
-                // Always update text when Value changes (TextUpdateSuppression removed)
+                // Always update text when Value changes (TextUpdateSuppression removed).
+                // This sync is parameter-driven, so it must not mark the input touched (#13064, #13246).
                 _forceTextUpdate = false;
-                await UpdateTextPropertyAsync(false);
+                await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
             }
         }
 
@@ -796,7 +846,9 @@ namespace MudBlazor
 
             _validated = false;
 
-            if (!string.IsNullOrEmpty(text))
+            // Only a genuine user interaction marks the input touched. Programmatic / parameter-driven
+            // syncs run under SuppressInteractionEffectsWhileAsync and must not touch the input (#13064, #13246).
+            if (!string.IsNullOrEmpty(text) && !_suppressInteractionEffects)
             {
                 Touched = true;
             }
@@ -808,22 +860,27 @@ namespace MudBlazor
             }
         }
 
-        private async Task OnTextParameterChangedAsync(ParameterChangedEventArgs<string?> arg)
+        private Task OnTextParameterChangedAsync(ParameterChangedEventArgs<string?> arg)
         {
-            _validated = false;
-
-            if (!string.IsNullOrEmpty(arg.Value))
+            // A change to the Text parameter is always parameter-driven (a user edit updates Text via the
+            // internal state without re-triggering this handler), so it must not touch the input (#13246).
+            return SuppressInteractionEffectsWhileAsync(async () =>
             {
-                Touched = true;
-            }
+                _validated = false;
 
-            // When Text changes from parent, update Value from Text using UpdateValuePropertyAsync
-            // But only if Value is not also being set in the same parameter update
-            // Check ParameterView to see if Value is also present
-            if (!arg.ParameterView.Contains<T?>(nameof(Value)))
-            {
-                await UpdateValuePropertyAsync(updateText: false);
-            }
+                if (!string.IsNullOrEmpty(arg.Value) && !_suppressInteractionEffects)
+                {
+                    Touched = true;
+                }
+
+                // When Text changes from parent, update Value from Text using UpdateValuePropertyAsync
+                // But only if Value is not also being set in the same parameter update
+                // Check ParameterView to see if Value is also present
+                if (!arg.ParameterView.Contains<T?>(nameof(Value)))
+                {
+                    await UpdateValuePropertyAsync(updateText: false);
+                }
+            });
         }
 
         private async Task UpdateInputIdStateAsync()

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -546,11 +546,7 @@ namespace MudBlazor
                 await UpdateTextPropertyAsync(false);
             }
 
-            // Only notify the form of a change that originates from user interaction. Programmatic /
-            // parameter-driven syncs (e.g. an initial @bind-Text value, or an async-loaded selection)
-            // run under SuppressInteractionEffectsWhileAsync and must not fire FieldChanged (#13246).
-            // Validation still runs below so externally-set values are validated; an untouched field
-            // simply shows no required error.
+            // Only user interaction notifies the form; the validation below runs either way.
             if (!_suppressInteractionEffects)
             {
                 FieldChanged(value);
@@ -577,9 +573,6 @@ namespace MudBlazor
                 // External value changes, non-Immediate commits, and explicit forced updates still refresh.
                 if (forceTextUpdate || !(Immediate && arg.IsChildOriginatedChange))
                 {
-                    // External/programmatic Value change: refresh the displayed text, but do not touch
-                    // the input — only user interaction touches (#13064, #13246). wasTouched (captured
-                    // above) still governs the FieldChanged below, preserving the #12012 behavior.
                     await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
                 }
             }
@@ -635,7 +628,6 @@ namespace MudBlazor
         protected override async Task OnCultureAndFormatChangedAsync()
         {
             await base.OnCultureAndFormatChangedAsync();
-            // Reformatting the text on a culture/format parameter change must not touch the input.
             await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
         }
 
@@ -643,7 +635,6 @@ namespace MudBlazor
         protected override async Task OnConverterChangedAsync()
         {
             await base.OnConverterChangedAsync();
-            // Reformatting the text on a converter parameter change must not touch the input.
             await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
         }
 
@@ -662,7 +653,6 @@ namespace MudBlazor
 
             // Because the way the Value setter is built, it won't cause an update if the incoming Value is
             // equal to the initial value. This is why we force an update to the Text property here.
-            // This is a programmatic sync, so it must not mark the input touched (#13246, #13064).
             if (typeof(T) != typeof(string) && string.IsNullOrWhiteSpace(ReadText))
             {
                 await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
@@ -688,7 +678,6 @@ namespace MudBlazor
         public virtual void ForceRender(bool forceTextUpdate)
         {
             _forceTextUpdate = true;
-            // A programmatic re-render must not mark the input touched (#13246).
             SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false)).CatchAndLog();
             StateHasChanged();
         }
@@ -715,8 +704,7 @@ namespace MudBlazor
                     return;
                 }
 
-                // Always update text when Value changes (TextUpdateSuppression removed).
-                // This sync is parameter-driven, so it must not mark the input touched (#13064, #13246).
+                // Always update text when Value changes (TextUpdateSuppression removed)
                 _forceTextUpdate = false;
                 await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
             }
@@ -812,8 +800,6 @@ namespace MudBlazor
 
             _validated = false;
 
-            // Only a genuine user interaction marks the input touched. Programmatic / parameter-driven
-            // syncs run under SuppressInteractionEffectsWhileAsync and must not touch the input (#13064, #13246).
             if (!string.IsNullOrEmpty(text) && !_suppressInteractionEffects)
             {
                 Touched = true;
@@ -828,8 +814,8 @@ namespace MudBlazor
 
         private Task OnTextParameterChangedAsync(ParameterChangedEventArgs<string?> arg)
         {
-            // A change to the Text parameter is always parameter-driven (a user edit updates Text via the
-            // internal state without re-triggering this handler), so it must not touch the input (#13246).
+            // A Text parameter change is always parameter-driven (a user edit updates Text via the internal
+            // state without re-triggering this handler).
             return SuppressInteractionEffectsWhileAsync(async () =>
             {
                 _validated = false;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -242,11 +242,14 @@ namespace MudBlazor
         /// </remarks>
         public bool Touched { get; protected set; }
 
-        // While set, a programmatic / parameter-driven value sync is running and must not mark the input
-        // Touched or fire FieldChanged - those reflect genuine user interaction only. This stops a
+        // While set, a programmatic / parameter-driven value sync is running and the gated Touched /
+        // FieldChanged writes are skipped - those reflect genuine user interaction only. This stops a
         // non-default initial or async-loaded value from touching the input (and its MudForm) on load
-        // (#13064, #13246). Toggle it only via SuppressInteractionEffectsWhileAsync, which sets and clears
-        // it synchronously so it never leaks across an await. Validation is intentionally not suppressed.
+        // (#13064, #13246). It is toggled ONLY by SuppressInteractionEffectsWhileAsync, and only around
+        // AWAITED parameter-change handlers, so it is always restored before the awaiting caller resumes.
+        // Fire-and-forget value setters (the date/time pickers) deliberately do NOT use this flag - they
+        // pass suppression as an explicit argument instead, so it can never be left set across their awaits
+        // and swallow a concurrent user interaction. Validation is intentionally not suppressed.
         private protected bool _suppressInteractionEffects;
 
         /// <summary>

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -247,7 +247,7 @@ namespace MudBlazor
         // must reflect genuine user interaction (typing, selecting, blur) only, never values that arrive
         // from parameters or are set programmatically. Without this, supplying a non-default initial (or
         // async-loaded) value marks the input — and its surrounding MudForm — touched on load and fires
-        // FieldChanged with no interaction (#13064, #13246, #12997). It is a plain instance bool, set and
+        // FieldChanged with no interaction (#13064, #13246). It is a plain instance bool, set and
         // cleared synchronously around each parameter-sync entry point via SuppressInteractionEffectsWhileAsync,
         // so it can never leak across an await into a user event. Validation is intentionally NOT suppressed.
         private protected bool _suppressInteractionEffects;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -242,26 +242,17 @@ namespace MudBlazor
         /// </remarks>
         public bool Touched { get; protected set; }
 
-        // Suppresses user-interaction side effects (marking Touched, firing FieldChanged) while a
-        // programmatic / parameter-driven value<->text synchronization runs. Touched and FieldChanged
-        // must reflect genuine user interaction (typing, selecting, blur) only, never values that arrive
-        // from parameters or are set programmatically. Without this, supplying a non-default initial (or
-        // async-loaded) value marks the input — and its surrounding MudForm — touched on load and fires
-        // FieldChanged with no interaction (#13064, #13246). It is a plain instance bool, set and
-        // cleared synchronously around each parameter-sync entry point via SuppressInteractionEffectsWhileAsync,
-        // so it can never leak across an await into a user event. Validation is intentionally NOT suppressed.
+        // While set, a programmatic / parameter-driven value sync is running and must not mark the input
+        // Touched or fire FieldChanged - those reflect genuine user interaction only. This stops a
+        // non-default initial or async-loaded value from touching the input (and its MudForm) on load
+        // (#13064, #13246). Toggle it only via SuppressInteractionEffectsWhileAsync, which sets and clears
+        // it synchronously so it never leaks across an await. Validation is intentionally not suppressed.
         private protected bool _suppressInteractionEffects;
 
         /// <summary>
-        /// Runs a programmatic or parameter-driven value/text synchronization without marking this
-        /// component as <see cref="Touched"/> or firing <see cref="FieldChanged"/>.
+        /// Runs a programmatic or parameter-driven value/text sync without marking this component
+        /// <see cref="Touched"/> or firing <see cref="FieldChanged"/> - those reflect user interaction only.
         /// </summary>
-        /// <remarks>
-        /// <see cref="Touched"/> and <see cref="FieldChanged"/> must reflect genuine user interaction only.
-        /// Use this wrapper around any sync triggered by a parameter change or a programmatic call (initial
-        /// value load, external value/text changes, culture/format/converter changes) so the resulting
-        /// update does not spuriously touch the component or notify its form.
-        /// </remarks>
         private protected async Task SuppressInteractionEffectsWhileAsync(Func<Task> synchronize)
         {
             var previous = _suppressInteractionEffects;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -242,6 +242,40 @@ namespace MudBlazor
         /// </remarks>
         public bool Touched { get; protected set; }
 
+        // Suppresses user-interaction side effects (marking Touched, firing FieldChanged) while a
+        // programmatic / parameter-driven value<->text synchronization runs. Touched and FieldChanged
+        // must reflect genuine user interaction (typing, selecting, blur) only, never values that arrive
+        // from parameters or are set programmatically. Without this, supplying a non-default initial (or
+        // async-loaded) value marks the input — and its surrounding MudForm — touched on load and fires
+        // FieldChanged with no interaction (#13064, #13246, #12997). It is a plain instance bool, set and
+        // cleared synchronously around each parameter-sync entry point via SuppressInteractionEffectsWhileAsync,
+        // so it can never leak across an await into a user event. Validation is intentionally NOT suppressed.
+        private protected bool _suppressInteractionEffects;
+
+        /// <summary>
+        /// Runs a programmatic or parameter-driven value/text synchronization without marking this
+        /// component as <see cref="Touched"/> or firing <see cref="FieldChanged"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Touched"/> and <see cref="FieldChanged"/> must reflect genuine user interaction only.
+        /// Use this wrapper around any sync triggered by a parameter change or a programmatic call (initial
+        /// value load, external value/text changes, culture/format/converter changes) so the resulting
+        /// update does not spuriously touch the component or notify its form.
+        /// </remarks>
+        private protected async Task SuppressInteractionEffectsWhileAsync(Func<Task> synchronize)
+        {
+            var previous = _suppressInteractionEffects;
+            _suppressInteractionEffects = true;
+            try
+            {
+                await synchronize();
+            }
+            finally
+            {
+                _suppressInteractionEffects = previous;
+            }
+        }
+
         #region MudForm Validation
 
         /// <summary>

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -94,9 +94,6 @@ namespace MudBlazor
         {
             // TODO: Revisit this when the state of input components / validation improves, for now mimic old behavior
             var forceUpdate = _valueState.IsInitialized && HasRendered;
-            // An external Value parameter change is not user interaction, so it must not touch the picker
-            // or fire FieldChanged (#13246, #13064). User selector / RGB / HSL edits call SetColorAsync
-            // directly (without the flag) and touch normally.
             return SuppressInteractionEffectsWhileAsync(() => SetColorAsync(args.Value, forceUpdate));
         }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -94,7 +94,10 @@ namespace MudBlazor
         {
             // TODO: Revisit this when the state of input components / validation improves, for now mimic old behavior
             var forceUpdate = _valueState.IsInitialized && HasRendered;
-            return SetColorAsync(args.Value, forceUpdate);
+            // An external Value parameter change is not user interaction, so it must not touch the picker
+            // or fire FieldChanged (#13246, #13064). User selector / RGB / HSL edits call SetColorAsync
+            // directly (without the flag) and touch normally.
+            return SuppressInteractionEffectsWhileAsync(() => SetColorAsync(args.Value, forceUpdate));
         }
 
         private async Task OnAlphaChangeHandlerAsync(ParameterChangedEventArgs<bool> args)
@@ -436,11 +439,17 @@ namespace MudBlazor
 
             if (shouldUpdateBinding || forceUpdate)
             {
-                Touched = true;
+                if (!_suppressInteractionEffects)
+                {
+                    Touched = true;
+                }
                 await SetTextAsync(GetColorTextValue(newColor), false);
                 await _valueState.SetValueAsync(newColor);
                 await BeginValidateAsync();
-                FieldChanged(newColor);
+                if (!_suppressInteractionEffects)
+                {
+                    FieldChanged(newColor);
+                }
             }
             else if (colorChanged)
             {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -27,7 +27,10 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _value;
-            set => SuppressInteractionEffectsWhileAsync(() => SetDateAsync(value, true)).CatchAndLog();
+            // Assigning Date from the parameter is programmatic, not user interaction. Pass the suppression
+            // as an explicit argument (NOT an instance flag) so it cannot leak across the awaits inside
+            // SetDateAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
+            set => SetDateAsync(value, updateValue: true, forceUpdate: false, suppressInteraction: true).CatchAndLog();
         }
 
         private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
@@ -36,7 +39,7 @@ namespace MudBlazor
         protected Task SetDateAsync(DateTime? date, bool updateValue)
             => SetDateAsync(date, updateValue, false);
 
-        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate)
+        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate, bool suppressInteraction = false)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
             {
@@ -62,7 +65,7 @@ namespace MudBlazor
             // without this the UI doesn't display a validation error correctly
             if (_value != date || (date is null && Text != null))
             {
-                if (!_suppressInteractionEffects)
+                if (!suppressInteraction)
                 {
                     Touched = true;
                 }
@@ -91,7 +94,7 @@ namespace MudBlazor
 
                 await DateChanged.InvokeAsync(_value);
                 await BeginValidateAsync();
-                if (!_suppressInteractionEffects)
+                if (!suppressInteraction)
                 {
                     FieldChanged(_value);
                 }

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -27,7 +27,10 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _value;
-            set => SetDateAsync(value, true).CatchAndLog();
+            // Setting Date from the parameter is not user interaction, so it must not touch the picker
+            // or fire FieldChanged (#13246, #13064). User calendar/text input goes through other callers
+            // of SetDateAsync, which run without the flag and touch normally.
+            set => SuppressInteractionEffectsWhileAsync(() => SetDateAsync(value, true)).CatchAndLog();
         }
 
         private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
@@ -62,7 +65,10 @@ namespace MudBlazor
             // without this the UI doesn't display a validation error correctly
             if (_value != date || (date is null && Text != null))
             {
-                Touched = true;
+                if (!_suppressInteractionEffects)
+                {
+                    Touched = true;
+                }
 
                 HighlightedDate = date;
 
@@ -88,7 +94,10 @@ namespace MudBlazor
 
                 await DateChanged.InvokeAsync(_value);
                 await BeginValidateAsync();
-                FieldChanged(_value);
+                if (!_suppressInteractionEffects)
+                {
+                    FieldChanged(_value);
+                }
             }
             else if (forceUpdate)
             {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -27,9 +27,6 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _value;
-            // Setting Date from the parameter is not user interaction, so it must not touch the picker
-            // or fire FieldChanged (#13246, #13064). User calendar/text input goes through other callers
-            // of SetDateAsync, which run without the flag and touch normally.
             set => SuppressInteractionEffectsWhileAsync(() => SetDateAsync(value, true)).CatchAndLog();
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -104,7 +104,10 @@ namespace MudBlazor
         public DateRange? DateRange
         {
             get => _dateRange;
-            set => SetDateRangeAsync(value, true).CatchAndLog();
+            // Setting DateRange from the parameter is not user interaction, so it must not touch the
+            // picker or fire FieldChanged (#13246, #13064). User calendar/text input goes through other
+            // callers of SetDateRangeAsync, which run without the flag and touch normally.
+            set => SuppressInteractionEffectsWhileAsync(() => SetDateRangeAsync(value, true)).CatchAndLog();
         }
 
         /// <summary>
@@ -137,7 +140,10 @@ namespace MudBlazor
                     return;
                 }
 
-                Touched = true;
+                if (!_suppressInteractionEffects)
+                {
+                    Touched = true;
+                }
 
                 if (range?.Start is not null && StartMonth == null)
                     PickerMonth = new DateTime(GetCulture().Calendar.GetYear(range.Start.Value), GetCulture().Calendar.GetMonth(range.Start.Value), 1, GetCulture().Calendar);
@@ -165,7 +171,10 @@ namespace MudBlazor
 
                 await DateRangeChanged.InvokeAsync(_dateRange);
                 await BeginValidateAsync();
-                FieldChanged(_value);
+                if (!_suppressInteractionEffects)
+                {
+                    FieldChanged(_value);
+                }
             }
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -104,7 +104,9 @@ namespace MudBlazor
         public DateRange? DateRange
         {
             get => _dateRange;
-            set => SuppressInteractionEffectsWhileAsync(() => SetDateRangeAsync(value, true)).CatchAndLog();
+            // Programmatic parameter assignment; pass suppression explicitly so it cannot leak across the
+            // awaits inside SetDateRangeAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
+            set => SetDateRangeAsync(value, updateValue: true, suppressInteraction: true).CatchAndLog();
         }
 
         /// <summary>
@@ -117,7 +119,7 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool AllowDisabledDatesInRange { get; set; } = false;
 
-        protected async Task SetDateRangeAsync(DateRange? range, bool updateValue)
+        protected async Task SetDateRangeAsync(DateRange? range, bool updateValue, bool suppressInteraction = false)
         {
             // Normalize the DateRange before exception is thrown
             range = NormalizeDateRange(range);
@@ -137,7 +139,7 @@ namespace MudBlazor
                     return;
                 }
 
-                if (!_suppressInteractionEffects)
+                if (!suppressInteraction)
                 {
                     Touched = true;
                 }
@@ -168,7 +170,7 @@ namespace MudBlazor
 
                 await DateRangeChanged.InvokeAsync(_dateRange);
                 await BeginValidateAsync();
-                if (!_suppressInteractionEffects)
+                if (!suppressInteraction)
                 {
                     FieldChanged(_value);
                 }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -104,9 +104,6 @@ namespace MudBlazor
         public DateRange? DateRange
         {
             get => _dateRange;
-            // Setting DateRange from the parameter is not user interaction, so it must not touch the
-            // picker or fire FieldChanged (#13246, #13064). User calendar/text input goes through other
-            // callers of SetDateRangeAsync, which run without the flag and touch normally.
             set => SuppressInteractionEffectsWhileAsync(() => SetDateRangeAsync(value, true)).CatchAndLog();
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -52,7 +52,6 @@ namespace MudBlazor
             using var registerScope = CreateRegisterScope();
             registerScope.RegisterParameter<bool>(nameof(MultiSelection))
                 .WithParameter(() => MultiSelection)
-                // Re-syncing the text on a MultiSelection parameter change must not touch the input (#13064).
                 .WithChangeHandler(() => SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false)));
             registerScope.RegisterParameter<IEqualityComparer<T?>?>(nameof(Comparer))
                 .WithParameter(() => Comparer)
@@ -793,10 +792,8 @@ namespace MudBlazor
 
         private Task OnSelectedValuesChangedAsync(ParameterChangedEventArgs<IReadOnlyCollection<T?>?> arg)
         {
-            // A SelectedValues parameter change is always programmatic (an initial or async-loaded
-            // selection); user selection goes through SelectOption, not this handler. So the entire
-            // handler runs suppressed: syncing the text must not mark the input touched, and the
-            // value->text sinks below must not fire FieldChanged on load (#13064, #13246).
+            // A SelectedValues parameter change is always programmatic; user selection goes through
+            // SelectOption, not this handler. The whole handler therefore runs suppressed.
             return SuppressInteractionEffectsWhileAsync(async () =>
             {
                 var wasTouched = Touched;
@@ -828,10 +825,9 @@ namespace MudBlazor
                     }
                 }
 
-                // Notify the form only when this external change occurs on a select the user has already
-                // touched (mirrors MudBaseInput.OnValueParameterChangedAsync's wasTouched gate, preserving
-                // the #12012 behavior). An initial or async-loaded selection on an untouched select - and
-                // this input's own ValueChanged echo - must not fire FieldChanged. User selection notifies
+                // Mirror MudBaseInput.OnValueParameterChangedAsync's wasTouched gate: an external change
+                // only notifies the form if the select was already touched (an initial/async-loaded
+                // selection on an untouched select must not fire FieldChanged). User selection notifies
                 // via SelectOption.
                 if (HasRendered && wasTouched && !arg.IsChildOriginatedChange)
                 {
@@ -1527,8 +1523,6 @@ namespace MudBlazor
             if (_multiSelectionText != text)
             {
                 _multiSelectionText = text;
-                // Only a user selection touches the input; a programmatic / parameter-driven text sync
-                // (e.g. an initial or async-loaded SelectedValues) runs under SuppressInteractionEffectsWhileAsync (#13064).
                 if (!string.IsNullOrWhiteSpace(_multiSelectionText) && !_suppressInteractionEffects)
                 {
                     Touched = true;

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -791,22 +791,24 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
-        private async Task OnSelectedValuesChangedAsync(ParameterChangedEventArgs<IReadOnlyCollection<T?>?> arg)
+        private Task OnSelectedValuesChangedAsync(ParameterChangedEventArgs<IReadOnlyCollection<T?>?> arg)
         {
-            var value = arg.Value;
-
-            // Update internal HashSet with new values - make a defensive copy to avoid shared references
-            // The HashSet uses the Comparer for equality checks and ensures uniqueness
-            _selectedValues = value != null ? new HashSet<T?>(value, Comparer) : new HashSet<T?>(Comparer);
-
-            // Notify all subscribed items of the selection change
-            await _context.NotifySelectionChangedAsync();
-
-            // A SelectedValues parameter change is programmatic (an initial or async-loaded selection),
-            // so syncing the text from it must not mark the input touched (#13064). User selection touches
-            // via SelectOption, which does not go through this handler.
-            await SuppressInteractionEffectsWhileAsync(async () =>
+            // A SelectedValues parameter change is always programmatic (an initial or async-loaded
+            // selection); user selection goes through SelectOption, not this handler. So the entire
+            // handler runs suppressed: syncing the text must not mark the input touched, and the
+            // value->text sinks below must not fire FieldChanged on load (#13064, #13246).
+            return SuppressInteractionEffectsWhileAsync(async () =>
             {
+                var wasTouched = Touched;
+                var value = arg.Value;
+
+                // Update internal HashSet with new values - make a defensive copy to avoid shared references
+                // The HashSet uses the Comparer for equality checks and ensures uniqueness
+                _selectedValues = value != null ? new HashSet<T?>(value, Comparer) : new HashSet<T?>(Comparer);
+
+                // Notify all subscribed items of the selection change
+                await _context.NotifySelectionChangedAsync();
+
                 if (!MultiSelection)
                 {
                     await SetValueAndUpdateTextAsync(_selectedValues.FirstOrDefault());
@@ -825,18 +827,22 @@ namespace MudBlazor
                         await SetTextAndUpdateValueAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)), updateValue: false);
                     }
                 }
+
+                // Notify the form only when this external change occurs on a select the user has already
+                // touched (mirrors MudBaseInput.OnValueParameterChangedAsync's wasTouched gate, preserving
+                // the #12012 behavior). An initial or async-loaded selection on an untouched select - and
+                // this input's own ValueChanged echo - must not fire FieldChanged. User selection notifies
+                // via SelectOption.
+                if (HasRendered && wasTouched && !arg.IsChildOriginatedChange)
+                {
+                    FieldChanged(_selectedValues);
+                }
+
+                if (MultiSelection && typeof(T) == typeof(string))
+                {
+                    await SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false);
+                }
             });
-
-            // Only fire FieldChanged after the first render to avoid triggering during initialization
-            if (HasRendered)
-            {
-                FieldChanged(_selectedValues);
-            }
-
-            if (MultiSelection && typeof(T) == typeof(string))
-            {
-                await SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false);
-            }
         }
 
         internal void UpdateFitContent()

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -52,7 +52,8 @@ namespace MudBlazor
             using var registerScope = CreateRegisterScope();
             registerScope.RegisterParameter<bool>(nameof(MultiSelection))
                 .WithParameter(() => MultiSelection)
-                .WithChangeHandler(() => UpdateTextPropertyAsync(false));
+                // Re-syncing the text on a MultiSelection parameter change must not touch the input (#13064).
+                .WithChangeHandler(() => SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false)));
             registerScope.RegisterParameter<IEqualityComparer<T?>?>(nameof(Comparer))
                 .WithParameter(() => Comparer)
                 .WithChangeHandler(OnComparerChangedAsync);
@@ -801,24 +802,30 @@ namespace MudBlazor
             // Notify all subscribed items of the selection change
             await _context.NotifySelectionChangedAsync();
 
-            if (!MultiSelection)
+            // A SelectedValues parameter change is programmatic (an initial or async-loaded selection),
+            // so syncing the text from it must not mark the input touched (#13064). User selection touches
+            // via SelectOption, which does not go through this handler.
+            await SuppressInteractionEffectsWhileAsync(async () =>
             {
-                await SetValueAndUpdateTextAsync(_selectedValues.FirstOrDefault());
-            }
-            else
-            {
-                //Warning. Here the Converter was not set yet
-                if (MultiSelectionTextFunc != null)
+                if (!MultiSelection)
                 {
-                    await SetCustomizedTextAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)),
-                        selectedConvertedValues: _selectedValues.Select(ConvertSet).ToList(),
-                        multiSelectionTextFunc: MultiSelectionTextFunc);
+                    await SetValueAndUpdateTextAsync(_selectedValues.FirstOrDefault());
                 }
                 else
                 {
-                    await SetTextAndUpdateValueAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)), updateValue: false);
+                    //Warning. Here the Converter was not set yet
+                    if (MultiSelectionTextFunc != null)
+                    {
+                        await SetCustomizedTextAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)),
+                            selectedConvertedValues: _selectedValues.Select(ConvertSet).ToList(),
+                            multiSelectionTextFunc: MultiSelectionTextFunc);
+                    }
+                    else
+                    {
+                        await SetTextAndUpdateValueAsync(string.Join(Delimiter, _selectedValues.Select(ConvertSet)), updateValue: false);
+                    }
                 }
-            }
+            });
 
             // Only fire FieldChanged after the first render to avoid triggering during initialization
             if (HasRendered)
@@ -1514,7 +1521,9 @@ namespace MudBlazor
             if (_multiSelectionText != text)
             {
                 _multiSelectionText = text;
-                if (!string.IsNullOrWhiteSpace(_multiSelectionText))
+                // Only a user selection touches the input; a programmatic / parameter-driven text sync
+                // (e.g. an initial or async-loaded SelectedValues) runs under SuppressInteractionEffectsWhileAsync (#13064).
+                if (!string.IsNullOrWhiteSpace(_multiSelectionText) && !_suppressInteractionEffects)
                 {
                     Touched = true;
                 }

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -183,16 +183,22 @@ namespace MudBlazor
         /// Sets the <see cref="MudBaseInput{T}.Text"/> to the specified value.
         /// </summary>
         /// <param name="text">The new text value to use.</param>
-        public async Task SetTextAsync(string? text)
+        public Task SetTextAsync(string? text)
         {
-            if (!HasMask)
+            // SetTextAsync is a programmatic API, not user input, so it must not mark the field touched
+            // or fire FieldChanged (#12997). The flag spans the inner-input value echo (ValueChanged ->
+            // OnInnerValueChangedAsync) and the masked path, which are awaited synchronously here.
+            return SuppressInteractionEffectsWhileAsync(async () =>
             {
-                await InputReference.SetText(text);
-                return;
-            }
+                if (!HasMask)
+                {
+                    await InputReference.SetText(text);
+                    return;
+                }
 
-            await _maskReference.Clear();
-            await _maskReference.OnPasteAsync(text);
+                await _maskReference.Clear();
+                await _maskReference.OnPasteAsync(text);
+            });
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -183,22 +183,16 @@ namespace MudBlazor
         /// Sets the <see cref="MudBaseInput{T}.Text"/> to the specified value.
         /// </summary>
         /// <param name="text">The new text value to use.</param>
-        public Task SetTextAsync(string? text)
+        public async Task SetTextAsync(string? text)
         {
-            // SetTextAsync is a programmatic API, not user input, so it must not mark the field touched
-            // or fire FieldChanged (#12997). The flag spans the inner-input value echo (ValueChanged ->
-            // OnInnerValueChangedAsync) and the masked path, which are awaited synchronously here.
-            return SuppressInteractionEffectsWhileAsync(async () =>
+            if (!HasMask)
             {
-                if (!HasMask)
-                {
-                    await InputReference.SetText(text);
-                    return;
-                }
+                await InputReference.SetText(text);
+                return;
+            }
 
-                await _maskReference.Clear();
-                await _maskReference.OnPasteAsync(text);
-            });
+            await _maskReference.Clear();
+            await _maskReference.OnPasteAsync(text);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -140,9 +140,6 @@ namespace MudBlazor
         public TimeSpan? Time
         {
             get => _value;
-            // Setting Time from the parameter is not user interaction, so it must not touch the picker
-            // or fire FieldChanged (#13246, #13064). User clock/text input goes through other callers of
-            // SetTimeAsync, which run without the flag and touch normally.
             set => SuppressInteractionEffectsWhileAsync(() => SetTimeAsync(value, true)).CatchAndLog();
         }
 
@@ -213,11 +210,8 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            // Commit via SetTimeAsync directly, NOT through the Time parameter setter: the setter runs
-            // under SuppressInteractionEffectsWhileAsync (so a parameter-driven value does not touch the
-            // picker), but a submit is a genuine user commit and must mark Touched and fire FieldChanged.
-            // This matches MudDatePicker/MudDateRangePicker, whose submit paths call SetDateAsync/
-            // SetDateRangeAsync directly.
+            // Commit via SetTimeAsync directly, NOT the Time setter: the setter is suppressed, but a submit
+            // is a user commit that must touch and fire FieldChanged (as MudDatePicker/MudDateRangePicker do).
             return SetTimeAsync(TimeIntermediate, updateValue: true);
         }
 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -140,7 +140,10 @@ namespace MudBlazor
         public TimeSpan? Time
         {
             get => _value;
-            set => SetTimeAsync(value, true).CatchAndLog();
+            // Setting Time from the parameter is not user interaction, so it must not touch the picker
+            // or fire FieldChanged (#13246, #13064). User clock/text input goes through other callers of
+            // SetTimeAsync, which run without the flag and touch normally.
+            set => SuppressInteractionEffectsWhileAsync(() => SetTimeAsync(value, true)).CatchAndLog();
         }
 
         /// <summary>
@@ -158,7 +161,10 @@ namespace MudBlazor
         {
             if (_value != time)
             {
-                Touched = true;
+                if (!_suppressInteractionEffects)
+                {
+                    Touched = true;
+                }
                 TimeIntermediate = time;
                 _value = time;
                 if (updateValue)
@@ -169,7 +175,10 @@ namespace MudBlazor
                 UpdateTimeSetFromTime();
                 await TimeChanged.InvokeAsync(_value);
                 await BeginValidateAsync();
-                FieldChanged(_value);
+                if (!_suppressInteractionEffects)
+                {
+                    FieldChanged(_value);
+                }
             }
         }
 

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -213,9 +213,12 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
-            Time = TimeIntermediate;
-
-            return Task.CompletedTask;
+            // Commit via SetTimeAsync directly, NOT through the Time parameter setter: the setter runs
+            // under SuppressInteractionEffectsWhileAsync (so a parameter-driven value does not touch the
+            // picker), but a submit is a genuine user commit and must mark Touched and fire FieldChanged.
+            // This matches MudDatePicker/MudDateRangePicker, whose submit paths call SetDateAsync/
+            // SetDateRangeAsync directly.
+            return SetTimeAsync(TimeIntermediate, updateValue: true);
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -140,7 +140,9 @@ namespace MudBlazor
         public TimeSpan? Time
         {
             get => _value;
-            set => SuppressInteractionEffectsWhileAsync(() => SetTimeAsync(value, true)).CatchAndLog();
+            // Programmatic parameter assignment; pass suppression explicitly so it cannot leak across the
+            // awaits inside SetTimeAsync into a concurrent user clock pick on Blazor Server (PR #13328 review).
+            set => SetTimeAsync(value, updateValue: true, suppressInteraction: true).CatchAndLog();
         }
 
         /// <summary>
@@ -154,11 +156,12 @@ namespace MudBlazor
         /// </summary>
         /// <param name="time">The new value to set.</param>
         /// <param name="updateValue">When <c>true</c>, the <c>Text</c> will also be updated.</param>
-        protected async Task SetTimeAsync(TimeSpan? time, bool updateValue)
+        /// <param name="suppressInteraction">When <c>true</c>, the change is treated as programmatic and does not mark the picker touched or fire <c>FieldChanged</c>.</param>
+        protected async Task SetTimeAsync(TimeSpan? time, bool updateValue, bool suppressInteraction = false)
         {
             if (_value != time)
             {
-                if (!_suppressInteractionEffects)
+                if (!suppressInteraction)
                 {
                     Touched = true;
                 }
@@ -172,7 +175,7 @@ namespace MudBlazor
                 UpdateTimeSetFromTime();
                 await TimeChanged.InvokeAsync(_value);
                 await BeginValidateAsync();
-                if (!_suppressInteractionEffects)
+                if (!suppressInteraction)
                 {
                     FieldChanged(_value);
                 }


### PR DESCRIPTION
Since v9.3.0 (#12892), supplying a non-default initial or async-loaded `Value` / `Text` / `SelectedValues` (or `Date` / `Time` / `DateRange` / color) to a form input marked it — and its surrounding `MudForm` — touched on load and fired `FieldChanged`, with no user interaction. Symptoms reported:

- `MudForm.IsTouched` is `true` on initial load when a `MudSelect`/`MudAutocomplete` gets an initial or async-loaded value (#13064) — breaks the common "enable Save/Cancel only once the user changed something" pattern.
- `MudNumericField` (non-zero), `MudSelect` (enum), and `MudTextField` (bound to `Text`) fire `FieldChanged` on initial render so you can't tell whether the field *actually* changed (#13246).

### References

- Fixes #13246
- Fixes #13064
- Closes #13067

The pickers (`MudDatePicker`/`MudTimePicker`/`MudDateRangePicker`/`MudColorPicker`) exhibit the identical defect via their value parameters, so they're fixed here too.

### Cause

The shared value→text sync (`SetTextAndUpdateValueAsync`, `OnTextParameterChangedAsync`, `MudSelect.SetCustomizedTextAsync`, and the pickers' `SetDateAsync`/`SetTimeAsync`/`SetDateRangeAsync`/`SetColorAsync`) sets `Touched = true` whenever the resulting value/text is non-empty, and the `@bind-Text` path additionally fires the ungated `FieldChanged` in `SetValueAndUpdateTextAsync`. These sinks are reached by both programmatic/parameter-driven syncs and genuine user input, so they can't self-discriminate (which is also why gating on `updateValue` is wrong — user multiselect selection uses `updateValue: false` too).

### Fix

A synchronous, instance-scoped `_suppressInteractionEffects` flag on `MudFormComponent` (where `Touched` is defined, so both `MudBaseInput` and `MudPicker` share it), set via `SuppressInteractionEffectsWhileAsync(...)` (try/finally) **only** around parameter-sync entry points — `OnInitializedAsync`, `SetParametersAsync`, `OnValueParameterChangedAsync`, culture/format/converter changes, `ForceRender`, `OnTextParameterChangedAsync`, `MudSelect`'s `SelectedValues`/`MultiSelection` handlers, and each picker's value-property setter (`Date`/`Time`/`DateRange`) and external value-change handler (color) — and checked at the `Touched` and `FieldChanged` write sites.

- User paths (typing, Select clicks, calendar/clock/selector picks, blur) are untouched and keep marking `Touched`/firing `FieldChanged`.
- For `MudSelect.OnSelectedValuesChangedAsync` (programmatic only — user selection goes through `SelectOption`), `FieldChanged` now fires only on a `wasTouched && !IsChildOriginatedChange` external change, mirroring `MudBaseInput.OnValueParameterChangedAsync` — so an async-loaded multiselect no longer fires it.
- Validation is **never** suppressed (externally-set values still validate; an untouched field just shows no required error).
- This is a **gate**, not a relocation of `FieldChanged`/`BeginValidateAsync` out of the shared sinks — so it does not reintroduce the regressions that caused #13179 to be reverted.
