### PR TITLE
Tests: Cover input display refresh on programmatic value change while focused

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldUpdateViaBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NumericField/NumericFieldUpdateViaBindingTest.razor
@@ -1,0 +1,20 @@
+@using System.Globalization
+@namespace MudBlazor.UnitTests.TestComponents.NumericField
+
+<MudNumericField @bind-Value="_value" Immediate="true" Min="0.0" OnKeyDown="OnKeyDown" Label="Hit Enter to reset to 0" />
+<br />
+<span id="value-display">value: @(_value.ToString(CultureInfo.InvariantCulture))</span>
+
+@code {
+    public static string __description__ = "After hitting Enter both the value and the displayed text should reset to 0 (issues #8565 / #10486).";
+
+    private double _value;
+
+    private void OnKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter" && _value != 0)
+        {
+            _value = 0;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -367,6 +367,39 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Programmatically resetting Value (e.g. from an OnKeyDown handler) while the field is focused must
+        /// update the displayed text, not only the bound Value. Regression test for #8565 / #10486: on Blazor
+        /// Server the rendered input kept the typed text because the old TextUpdateSuppression skipped the
+        /// _internalText refresh while focused. The key assertion is on the rendered value attribute, since
+        /// ReadText already updated correctly even when the bug was present.
+        /// </summary>
+        [Test]
+        public async Task NumericField_Should_UpdateDisplayedTextOnBoundValueChange_WhenFocused()
+        {
+            var comp = Context.Render<NumericFieldUpdateViaBindingTest>();
+            var input = comp.FindComponent<MudInput<string>>();
+
+            // Focus the field (sets _isFocused = true, the condition that used to suppress the text refresh).
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
+
+            // Simulate the user typing a value (Immediate => commits on input).
+            await comp.Find("input").InputAsync(new ChangeEventArgs() { Value = "123" });
+
+            comp.Find("#value-display").TrimmedText().Should().Be("value: 123");
+            input.Instance.ReadText.Should().Be("123");
+            comp.Find("input").GetAttribute("value").Should().Be("123");
+
+            // Hit Enter: the handler resets the bound value to 0 while the field is still focused.
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
+
+            await comp.WaitForAssertionAsync(() => comp.Find("#value-display").TrimmedText().Should().Be("value: 0"));
+            await comp.WaitForAssertionAsync(() => input.Instance.ReadText.Should().Be("0"));
+            // Crucial assertion: the displayed text (rendered value attribute) must reflect the reset and not
+            // keep the typed "123". This is what regressed on Server in #8565 / #10486.
+            await comp.WaitForAssertionAsync(() => comp.Find("input").GetAttribute("value").Should().Be("0"));
+        }
+
+        /// <summary>
         /// KeyDown disabled, should not do anything
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -944,12 +944,16 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("span").TrimmedText().Should().Be("value: The Stormlight Archive");
             input.Instance.ReadValue.Should().Be("The Stormlight Archive");
             input.Instance.ReadText.Should().Be("The Stormlight Archive");
+            comp.Find("input").GetAttribute("value").Should().Be("The Stormlight Archive");
 
             // now hit Enter to cause the clearing of the focused text field
             await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => comp.Find("span").TrimmedText().Should().Be("value:"));
             await comp.WaitForAssertionAsync(() => input.Instance.ReadValue.Should().Be(""));
             await comp.WaitForAssertionAsync(() => input.Instance.ReadText.Should().Be(""));
+            // Assert the rendered value attribute too: the displayed text (not just ReadText) must clear while
+            // focused. This is the user-visible part that regressed on Server in #8565 / #10486.
+            await comp.WaitForAssertionAsync(() => comp.Find("input").GetAttribute("value").Should().Be(""));
         }
 
         [Test]


### PR DESCRIPTION
Adds regression coverage for [#8565](https://github.com/MudBlazor/MudBlazor/issues/8565) and [#10486](https://github.com/MudBlazor/MudBlazor/issues/10486) (the same bug). Both report that on Blazor Server, setting a numeric/text field's `Value` from code while the field is focused (e.g. resetting to `0` inside an `OnKeyDown`/Enter handler) updates the bound value but leaves the displayed text stale until the field loses focus. It worked on `try.mudblazor.com` (WASM) but not on Server.

These issues are already fixed on `dev`. This PR locks the fix in with tests so it can't silently regress, and closes the two issues.

The old `TextUpdateSuppression`-while-focused behavior. `MudInput<T>.SetParametersAsync` used to gate `_internalText = ReadText` behind `if (!_isFocused)`. Because the rendered `<input>` binds to `_internalText` (`@bind:get="@_internalText"`), a programmatic `Value` → `Text` change while focused updated `ReadText` but not the rendered value, so the DOM stayed stale. The v9 input rework made `_internalText = ReadText` unconditional ("Always update internal text (TextUpdateSuppression removed)"), which fixes it. Confirmed by temporarily reintroducing the focus gate on `dev`: the exact bug reappears, then reverted.

The decisive assertion is on the rendered `input` `value` attribute, not `ReadText` — `ReadText` updated correctly even when the bug was present; only the DOM display regressed. These are proven non-vacuous: reintroducing the focus-gated suppression fails both tests at exactly the `GetAttribute("value")` assertion while the earlier `ReadText` checks still pass. On clean `dev`, the full NumericField + TextField + Input suites pass (301/301).

Closes #8565
Closes #10486
