### PR TITLE
MudDialog: Fix open dialogs being recreated when another dialog closes

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogReinstantiationInner.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogReinstantiationInner.razor
@@ -1,0 +1,23 @@
+@namespace MudBlazor.UnitTests.TestComponents.Dialog
+
+<MudDialog>
+    <DialogContent>
+        Inner dialog instance @InstanceId
+    </DialogContent>
+</MudDialog>
+
+@code {
+    // Incremented every time a new instance of this component is constructed/initialized.
+    public static int InitCount;
+
+    private int InstanceId;
+
+    [CascadingParameter]
+    public IMudDialogInstance MudDialog { get; set; } = null!;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        InstanceId = ++InitCount;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1732,6 +1732,36 @@ namespace MudBlazor.UnitTests.Components
             var changedFragment = navigationManager.ToAbsoluteUri($"{currentRoute}#{Guid.NewGuid()}").AbsolutePath;
             provider.Instance.HasRouteChanged(changedFragment).Should().BeFalse();
         }
+
+        /// <summary>
+        /// Closing an earlier dialog must not re-instantiate later dialogs that remain open.
+        /// Reproduces #13231 (closing a parent dialog reopens/re-renders a still-open child dialog).
+        /// </summary>
+        [Test]
+        public async Task ClosingEarlierDialog_ShouldNotReinstantiateLaterDialogs()
+        {
+            DialogReinstantiationInner.InitCount = 0;
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            IDialogReference first = null;
+            IDialogReference second = null;
+            await comp.InvokeAsync(async () => first = await service.ShowAsync<DialogOkCancel>("First"));
+            await comp.InvokeAsync(async () => second = await service.ShowAsync<DialogReinstantiationInner>("Second"));
+
+            // Both dialogs are open and the inner dialog has been constructed exactly once.
+            comp.FindAll("div.mud-dialog-container").Count.Should().Be(2);
+            DialogReinstantiationInner.InitCount.Should().Be(1);
+
+            // Close the FIRST (earlier) dialog while the second remains open.
+            await comp.InvokeAsync(() => first.Close());
+
+            // The second dialog must still be open and must NOT have been reconstructed.
+            comp.FindAll("div.mud-dialog-container").Count.Should().Be(1);
+            DialogReinstantiationInner.InitCount.Should().Be(1);
+
+            second.Should().NotBeNull();
+        }
     }
     internal class CustomDialogService : DialogService
     {

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor
@@ -4,7 +4,9 @@
     <CascadingValue Value="_globalDialogOptions">
         @foreach (var dialogReference in _dialogs.ToArray().Where(x => !x.Result.IsCompleted))
         {
-            @dialogReference.RenderFragment
+            <MudRender @key="dialogReference.Id">
+                @dialogReference.RenderFragment
+            </MudRender>
         }
     </CascadingValue>
 </CascadingValue>


### PR DESCRIPTION
Fixes #13231 — a regression where closing one dialog tears down and **recreates** other dialogs that are still open. In the reported scenario, a child dialog opened from a parent visibly *reopens and resets its state* when the parent closes.

### Root cause

`MudDialogProvider` rendered each open dialog as a bare `@dialogReference.RenderFragment` inside a `@foreach`:

```razor
@foreach (var dialogReference in _dialogs.ToArray().Where(x => !x.Result.IsCompleted))
{
    @dialogReference.RenderFragment
}
```

In Razor, `@<renderFragment>` compiles to `RenderTreeBuilder.AddContent(seq, fragment)`, which wraps the fragment in a **positional region**. The per-dialog `builder.SetKey(dialogReference.Id)` (applied to the `MudDialogContainer` in `DialogService`) therefore lived *inside* that region instead of as a direct sibling in the provider's render tree. Blazor's keyed reconciliation only matches keys among **direct siblings**, so when an earlier dialog was removed, the later dialogs shifted position, the keys could no longer be matched, and each affected `MudDialogContainer` (and its entire content subtree) was disposed and recreated.

The dialog rendering code is identical between v8.9.0 (working) and v9.4.0 (broken); the latent defect surfaced as a regression when the Blazor renderer's keyed-diff/region handling changed across .NET versions.

### Fix

Wrap each dialog in a keyed, DOM-neutral `<MudRender>` so the `@key` sits on a real sibling component and keyed reconciliation works:

```razor
@foreach (var dialogReference in _dialogs.ToArray().Where(x => !x.Result.IsCompleted))
{
    <MudRender @key="dialogReference.Id">
        @dialogReference.RenderFragment
    </MudRender>
}
```

`MudRender` renders only its `ChildContent`, so there is **no DOM change**. This is the same fix that was applied to `MudPopoverProvider` for the equivalent problem in #4479, which keys its fragment list the same way (`<MudRender @key="handler.Id">`). Preserving (rather than recreating) the containers is also strictly better for the key-interceptor subscription, focus trap, and element-id stability.

### Before/After

Before


https://github.com/user-attachments/assets/3ed7849f-6fa8-43b4-a1f7-a5c3afb0646b



After


https://github.com/user-attachments/assets/a2a7e4af-8c81-4824-9ccf-cc17b56182e4

