### PR TITLE
MudSelect: Fix infinite render loop with inline new item Value

### DIFF
--- a/src/MudBlazor/Components/Select/MudSelectContext.cs
+++ b/src/MudBlazor/Components/Select/MudSelectContext.cs
@@ -168,7 +168,18 @@ internal sealed class MudSelectContext<T>
 
         _shadowLookup[newValue] = item;
         _select.InvalidateFitContent();
-        ((IMudStateHasChanged)_select).StateHasChanged();
+
+        // Re-render only when the changed value is the one shown by the selected-value presenter
+        // (single selection only). An unconditional StateHasChanged loops forever when an item's
+        // Value is a fresh reference each render, e.g. an inline Value="@(new ...)" (#13281).
+        if (!_select.MultiSelection)
+        {
+            var comparer = Comparer ?? EqualityComparer<T?>.Default;
+            if (comparer.Equals(oldValue, _select.ReadValue) || comparer.Equals(newValue, _select.ReadValue))
+            {
+                ((IMudStateHasChanged)_select).StateHasChanged();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #13281.

A `MudSelectItem` whose `Value` is an inline `new` expression — e.g. `Value="@(new StringKeyValueItem("-", "(New Item)"))"` — allocates a **fresh reference on every render**. When the type has no value-equality and no `Comparer` is set, the default reference comparer reports the value as *changed* every render.

`MudSelect` renders its `ChildContent` twice: once as visible items and once as hidden "shadow" items used to resolve the selected-value presenter. The shadow item's value-change handler (`MudSelectContext.OnShadowItemValueChanged`) called `StateHasChanged()` **unconditionally**, so: render → inline `new` (fresh ref) → shadow value "changed" → StateHasChanged → render → …∞.

This is an infinite render loop that spikes memory and hangs the browser tab. The unconditional `StateHasChanged` was introduced in #13034 to refresh the presenter after a keyless-`@foreach` value swap — correct for stable references, but unbounded for an inline `new`.

We now gate the re-render so it only fires when the changed value is the one currently shown by the selected-value presenter (single selection; the presenter is not used in multi-selection). Comparing both the old and new value against `ReadValue` keeps the value-swap refresh working while breaking the loop, since an inline `new` item is virtually never the selected value.