### PR TITLE
MudRipple: Clip orphaned ripple to fix scrollbar on disabled items

### DIFF
--- a/src/MudBlazor/Styles/core/_ripple.scss
+++ b/src/MudBlazor/Styles/core/_ripple.scss
@@ -4,16 +4,8 @@
   overflow: hidden;
 }
 
-// Fallback clip for an orphaned ripple. The ripple span is created in JS and lives
-// for a short while after pointer-up; a host can drop the `.mud-ripple` class during
-// that window (e.g. a list item becomes Disabled the moment it is selected, as in a
-// MultiSelection MudSelect whose SelectedValuesChanged disables items), taking the
-// `overflow: hidden` above with it. The leftover absolutely-positioned span (sized
-// max(w,h)*2 with negative offsets) is then unclipped and overflows, forcing a
-// scrollbar (#13283). This rule re-applies the clip ONLY while such an orphaned span
-// is present and the host is no longer a `.mud-ripple` — so it never touches normal
-// elements. position:relative is required so overflow:hidden clips the absolutely-
-// positioned span.
+// If a host loses `.mud-ripple` while its ripple span is still animating (e.g. an
+// item disabled on click), keep clipping the span so it can't overflow (#13283).
 :not(.mud-ripple):has(> .mud-ripple-effect) {
   position: relative;
   overflow: hidden;

--- a/src/MudBlazor/Styles/core/_ripple.scss
+++ b/src/MudBlazor/Styles/core/_ripple.scss
@@ -4,6 +4,21 @@
   overflow: hidden;
 }
 
+// Fallback clip for an orphaned ripple. The ripple span is created in JS and lives
+// for a short while after pointer-up; a host can drop the `.mud-ripple` class during
+// that window (e.g. a list item becomes Disabled the moment it is selected, as in a
+// MultiSelection MudSelect whose SelectedValuesChanged disables items), taking the
+// `overflow: hidden` above with it. The leftover absolutely-positioned span (sized
+// max(w,h)*2 with negative offsets) is then unclipped and overflows, forcing a
+// scrollbar (#13283). This rule re-applies the clip ONLY while such an orphaned span
+// is present and the host is no longer a `.mud-ripple` — so it never touches normal
+// elements. position:relative is required so overflow:hidden clips the absolutely-
+// positioned span.
+:not(.mud-ripple):has(> .mud-ripple-effect) {
+  position: relative;
+  overflow: hidden;
+}
+
 // Individual ripple effect element (created dynamically by JS)
 .mud-ripple-effect {
   position: absolute;

--- a/src/MudBlazor/Styles/core/_ripple.scss
+++ b/src/MudBlazor/Styles/core/_ripple.scss
@@ -4,8 +4,7 @@
   overflow: hidden;
 }
 
-// If a host loses `.mud-ripple` while its ripple span is still animating (e.g. an
-// item disabled on click), keep clipping the span so it can't overflow (#13283).
+// If a host loses `.mud-ripple` while its ripple span is still animating (e.g. an item disabled on click), keep clipping the span so it can't overflow (#13283).
 :not(.mud-ripple):has(> .mud-ripple-effect) {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
Closes #13283

Ripple was changed in #12409 from a CSS `::after` (which disappeared with the `.mud-ripple` class) to a JS-created `.mud-ripple-effect` span that lives ~900ms after pointer-up. The only thing clipping that span is `.mud-ripple { overflow: hidden }`.

Components like MudListItem add `.mud-ripple` conditionally (`Ripple && GetClickable()`) and drop it when the element stops being interactive. In the repro, a MultiSelection MudSelect disables its items in `SelectedValuesChanged`, so clicking an option strips `.mud-ripple` from the just-clicked item while its ripple span is still alive. The item keeps `position: relative` from `.mud-list-item` but loses `overflow: hidden`, so the leftover span (sized `max(w,h)*2` with negative offsets) overflows the popover and adds a scrollbar.

Now we re-apply the clip when an element holds a ripple span but is no longer a `.mud-ripple` host.


https://github.com/user-attachments/assets/12f781e2-7b84-4c3a-af02-8457d4bc2d13

