### PR TITLE
MudBaseInput: Obsolete `Text` in favor of `Value`

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldFocusExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldFocusExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTextField @ref="multilineReference" T="string" Label="Manual focus" Variant="Variant.Filled" Text="@sampleText" Lines="3" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CenterFocusWeak" OnAdornmentClick="@(() => multilineReference.FocusAsync())"  />
-<MudTextField @ref="singleLineReference" T="string" Label="Manual focus" Variant="Variant.Filled" Text="@sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CenterFocusWeak" OnAdornmentClick="@(() => singleLineReference.FocusAsync())" />
+<MudTextField @ref="multilineReference" T="string" Label="Manual focus" Variant="Variant.Filled" @bind-Value="sampleText" Lines="3" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CenterFocusWeak" OnAdornmentClick="@(() => multilineReference.FocusAsync())"  />
+<MudTextField @ref="singleLineReference" T="string" Label="Manual focus" Variant="Variant.Filled" @bind-Value="sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CenterFocusWeak" OnAdornmentClick="@(() => singleLineReference.FocusAsync())" />
 
 @code
 {

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldMultilineExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldMultilineExample.razor
@@ -9,14 +9,14 @@
                           Variant="Variant.Outlined"
                           Lines="3"
                           Sizing="InputSizing.Fixed"
-                          Text="@_fixedText" />
+                          @bind-Value="_fixedText" />
             
             <MudTextField T="string"
                           Label="Fixed (5 lines)"
                           Variant="Variant.Filled"
                           Lines="5"
                           Sizing="InputSizing.Fixed"
-                          Text="@_fixedText2" />
+                          @bind-Value="_fixedText2" />
         </MudStack>
     </MudItem>
     <MudItem xs="12" sm="6">

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Outlined" Text="@sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => multilineReference.SelectAsync())" />
-<MudTextField @ref="singleLineReference" T="string" Label="Single Select" Variant="Variant.Outlined" Text="@sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => singleLineReference.SelectAsync())" />
+<MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Outlined" @bind-Value="sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => multilineReference.SelectAsync())" />
+<MudTextField @ref="singleLineReference" T="string" Label="Single Select" Variant="Variant.Outlined" @bind-Value="sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => singleLineReference.SelectAsync())" />
 
 @code
 {

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectRangeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldSelectRangeExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Outlined" Text="@sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => multilineReference.SelectRangeAsync(5, 10))" />
-<MudTextField @ref="singleLineReference" T="string" Label="Single Select" Variant="Variant.Outlined" Text="@sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => singleLineReference.SelectRangeAsync(5, 10))" />
+<MudTextField @ref="multilineReference" T="string" Label="Multiline Select" Lines="3" Variant="Variant.Outlined" @bind-Value="sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => multilineReference.SelectRangeAsync(5, 10))" />
+<MudTextField @ref="singleLineReference" T="string" Label="Single Select" Variant="Variant.Outlined" @bind-Value="sampleText" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Api" OnAdornmentClick="@(() => singleLineReference.SelectRangeAsync(5, 10))" />
 
 @code
 {

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldTextInsertionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldTextInsertionExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudTextField @ref="_textField" T="string" Label="Text insertion" Lines="3" Variant="Variant.Outlined" Text="@SampleText" HelperText="@($"Current caret position: {_currentCaretPosition}")"/>
+<MudTextField @ref="_textField" T="string" Label="Text insertion" Lines="3" Variant="Variant.Outlined" Value="@SampleText" HelperText="@($"Current caret position: {_currentCaretPosition}")"/>
 <MudStack Row="true" Justify="Justify.Center">
     <MudButton OnClick="@GetCurrentCaretPositionAsync" Color="Color.Primary">Get caret position</MudButton>
     <MudButton OnClick="@InsertAtCurrentCaretPositionAsync" Color="Color.Primary">Insert at caret position</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldTypoExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TextField/Examples/TextFieldTypoExample.razor
@@ -1,5 +1,9 @@
-﻿@namespace MudBlazor.Docs.Examples
+@namespace MudBlazor.Docs.Examples
 
-<MudTextField T="string" Text="Lorem ipsum dolor" Label="Typo.subtitle1" Typo="Typo.subtitle1"></MudTextField>
-<MudTextField T="string" Text="Lorem ipsum dolor" Label="Typo.caption" Typo="Typo.caption"></MudTextField>
-<MudTextField T="string" Text="Lorem ipsum dolor" Label="Typo.h5" Typo="Typo.h5"></MudTextField>
+<MudTextField T="string" Value="@_text" Label="Typo.subtitle1" Typo="Typo.subtitle1"></MudTextField>
+<MudTextField T="string" Value="@_text" Label="Typo.caption" Typo="Typo.caption"></MudTextField>
+<MudTextField T="string" Value="@_text" Label="Typo.h5" Typo="Typo.h5"></MudTextField>
+
+@code {
+    private string _text = "Lorem ipsum dolor";
+}

--- a/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/TreeView/Examples/TreeViewFilteringExample.razor
@@ -2,7 +2,7 @@
 
 <MudPaper Width="300px" Elevation="0">
     <MudStack AlignItems="AlignItems.Center">
-        <MudTextField T="string" Label="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" TextChanged="OnTextChanged" Immediate="true" Clearable="true" />
+        <MudTextField T="string" Label="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" @bind-Value="_searchPhrase" @bind-Value:after="OnSearchChanged" Immediate="true" Clearable="true" />
         <MudTreeView Items="@_treeItemData" @ref="_treeView" FilterFunc="MatchesName">
             <ItemTemplate>
                 <MudTreeViewItem @bind-Expanded="@context.Expanded" Items="@context.Children" Value="@context.Value"
@@ -46,9 +46,8 @@
         _treeItemData.Add(new TreeItemPresenter("History", Icons.Material.Filled.Label));
     }
 
-    private async void OnTextChanged(string searchPhrase) 
+    private async Task OnSearchChanged()
     {
-        _searchPhrase = searchPhrase;
         await _treeView.FilterAsync();
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteHandleClearButtonAsyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteHandleClearButtonAsyncTest.razor
@@ -1,4 +1,7 @@
-﻿<MudPopoverProvider />
+﻿@{
+#pragma warning disable CS0618 // Fixture exercises the obsolete @bind-Text (removed in v10, #13320), still supported in v9
+}
+<MudPopoverProvider />
 
 <MudText>@StatusMessage</MudText>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteInitialTextComplexTypeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteInitialTextComplexTypeTest.razor
@@ -1,4 +1,7 @@
-﻿<MudPopoverProvider />
+﻿@{
+#pragma warning disable CS0618 // Fixture exercises the obsolete Text parameter (removed in v10, #13320), still supported in v9
+}
+<MudPopoverProvider />
 
 <MudAutocomplete T="ComplexItem"
                  Text="InitialValue"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallback.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogWithEventCallback.razor
@@ -1,5 +1,7 @@
 ﻿@attribute [ViewerHidden]
-
+@{
+#pragma warning disable CS0618 // Fixture exercises the obsolete TextChanged (removed in v10, #13320), still supported in v9
+}
 <MudDialog>
     <DialogContent>
         Dialog Content

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialValuesNotTouchedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormInitialValuesNotTouchedTest.razor
@@ -1,5 +1,7 @@
 @using MudBlazor.Utilities
-
+@{
+#pragma warning disable CS0618 // Fixture exercises the obsolete @bind-Text (removed in v10, #13320) to reproduce #13246/#13064; still supported in v9
+}
 <MudForm @ref="Form" FieldChanged="v => FormFieldChangedEventArgs = v">
     <MudNumericField T="int" @bind-Value="_number" />
     <MudSelect T="Fruit?" @bind-Value="_fruit">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipFlexScenariosTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipFlexScenariosTest.razor
@@ -1,4 +1,7 @@
-﻿<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6">
+﻿@{
+#pragma warning disable CS0618 // Fixture seeds inputs via the obsolete Text parameter (removed in v10, #13320), still supported in v9
+}
+<MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6">
     <MudTabPanel Text="Simple Tooltip">
         <MudTooltip Text="Delete">
             <MudIconButton Icon="@Icons.Material.Filled.Delete" />

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipInlineTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipInlineTest.razor
@@ -1,4 +1,7 @@
-﻿<MudGrid>
+﻿@{
+#pragma warning disable CS0618 // Fixture seeds inputs via the obsolete Text parameter (removed in v10, #13320), still supported in v9
+}
+<MudGrid>
     <MudItem xs="12">
         <MudTextField T="string" Text="Nice and flexy" Variant="Variant.Outlined"></MudTextField>
     </MudItem>

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -16,6 +16,9 @@ using MudBlazor.UnitTests.TestComponents.Autocomplete;
 using NUnit.Framework;
 using static MudBlazor.UnitTests.TestComponents.Autocomplete.AutocompleteSetParametersInitialization;
 
+// Tests cover the obsolete Text/TextChanged (removed in v10, #13320) which is still supported in v9.
+#pragma warning disable CS0618
+
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -5,6 +5,10 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components;
 
 #nullable enable
+
+// Tests cover the obsolete Text/TextChanged (removed in v10, #13320) which is still supported in v9.
+#pragma warning disable CS0618
+
 [TestFixture]
 public class InputTests : BunitTest
 {

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -8,6 +8,9 @@ using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Mask;
 using NUnit.Framework;
 
+// Tests cover the obsolete Text/TextChanged (removed in v10, #13320) which is still supported in v9.
+#pragma warning disable CS0618
+
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -14,6 +14,9 @@ using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.NumericField;
 using NUnit.Framework;
 
+// Tests cover the obsolete Text/TextChanged (removed in v10, #13320) which is still supported in v9.
+#pragma warning disable CS0618
+
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -9,6 +9,9 @@ using MudBlazor.UnitTests.TestData;
 using NUnit.Framework;
 using static MudBlazor.UnitTests.TestComponents.Select.SelectWithEnumTest;
 
+// Tests cover the obsolete Text/TextChanged (removed in v10, #13320) which is still supported in v9.
+#pragma warning disable CS0618
+
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -19,6 +19,10 @@ using MudBlazor.UnitTests.Utilities;
 using NUnit.Framework;
 
 #nullable enable
+
+// Tests cover the obsolete Text/TextChanged (removed in v10, #13320) which is still supported in v9.
+#pragma warning disable CS0618
+
 namespace MudBlazor.UnitTests.Components
 {
     [TestFixture]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -36,10 +36,12 @@ namespace MudBlazor
         protected MudBaseInput()
         {
             using var registerScope = CreateRegisterScope();
+#pragma warning disable CS0618 // Text/TextChanged are obsolete but remain wired up for v9 back-compat; removed in v10 (#13320)
             _textState = registerScope.RegisterParameter<string?>(nameof(Text))
                 .WithParameter(() => Text)
                 .WithEventCallback(() => TextChanged)
                 .WithChangeHandler(OnTextParameterChangedAsync);
+#pragma warning restore CS0618
             _valueState = registerScope.RegisterParameter<T?>(nameof(Value))
                 .WithParameter(() => Value)
                 .WithEventCallback(() => ValueChanged)
@@ -304,6 +306,10 @@ namespace MudBlazor
         /// <summary>
         /// The text displayed in the input.
         /// </summary>
+        /// <remarks>
+        /// Deprecated and removed in v10. <see cref="Value"/> (with a <c>Converter</c>/<see cref="Format"/> for display) becomes the single source of truth; bind <c>@bind-Value</c> instead, and observe typed text via <see cref="OnInternalInputChanged"/>. See https://github.com/MudBlazor/MudBlazor/issues/13320.
+        /// </remarks>
+        [Obsolete("Text is being removed in v10; Value (with a Converter/Format for display) becomes the single source of truth. Bind @bind-Value instead, and observe typed text via OnInternalInputChanged. https://github.com/MudBlazor/MudBlazor/issues/13320")]
         [Parameter, ParameterState]
         [Category(CategoryTypes.FormComponent.Data)]
         public string? Text { get; set; }
@@ -342,6 +348,10 @@ namespace MudBlazor
         /// <summary>
         /// Occurs when the <see cref="Text"/> property has changed.
         /// </summary>
+        /// <remarks>
+        /// Deprecated and removed in v10 along with the settable <see cref="Text"/>. Observe typed text via <see cref="OnInternalInputChanged"/>, or bind <c>@bind-Value</c> to react to value changes. See https://github.com/MudBlazor/MudBlazor/issues/13320.
+        /// </remarks>
+        [Obsolete("TextChanged is being removed in v10 along with the settable Text. Observe typed text via OnInternalInputChanged, or bind @bind-Value to react to value changes. https://github.com/MudBlazor/MudBlazor/issues/13320")]
         [Parameter]
         public EventCallback<string?> TextChanged { get; set; }
 
@@ -558,7 +568,9 @@ namespace MudBlazor
             // When Value changes from parent, update Text from Value
             // But only if Text is not also being set in the same parameter update
             // Check ParameterView to see if Text is also present
+#pragma warning disable CS0618 // Text is obsolete (removed in v10, #13320); referenced here only for v9 back-compat
             if (!arg.ParameterView.Contains<string?>(nameof(Text)))
+#pragma warning restore CS0618
             {
                 var forceTextUpdate = _forceTextUpdate;
                 _forceTextUpdate = false;
@@ -681,7 +693,9 @@ namespace MudBlazor
         /// <inheritdoc />
         public override async Task SetParametersAsync(ParameterView parameters)
         {
+#pragma warning disable CS0618 // Text is obsolete (removed in v10, #13320); referenced here only for v9 back-compat
             var hasText = parameters.Contains<string>(nameof(Text));
+#pragma warning restore CS0618
             var hasValue = parameters.Contains<T>(nameof(Value));
             var currentValue = ReadValue;
             await base.SetParametersAsync(parameters);

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -1,6 +1,10 @@
 ﻿@namespace MudBlazor
 @inherits MudBaseInput<T>
 @typeparam T
+@* TextChanged on the inner MudInput is obsolete (removed in v10, #13320) but still used here for v9 back-compat. *@
+@{
+#pragma warning disable CS0618
+}
 
 <CascadingValue Name="SubscribeToParentForm" Value="false" IsFixed="true">
     <div id="@_componentId" class="@AutocompleteClassname" @onclick:stopPropagation @onmousedown:stopPropagation>


### PR DESCRIPTION
Marks the settable `Text` parameter and the `TextChanged` event on `MudBaseInput<T>` as `[Obsolete]` so the deprecation ships in v9. The full removal stays a v10 breaking change, as tracked in #12556.
