### PR TITLE
Tests: Improve List component tests

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListItemTabIndexTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListItemTabIndexTest.razor
@@ -1,7 +1,0 @@
-﻿<MudList T="string">
-    <MudListItem tabindex="-1" Text="You cannot tab to this"/>
-</MudList>
-
-@code {
-    public static string __description__ = "tabindex should be able to override the default behavior";
-}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListNestedExpansionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListNestedExpansionTest.razor
@@ -1,0 +1,29 @@
+﻿<MudList T="string">
+    <MudListItem Text="Drinks"
+                 Expanded="_expanded"
+                 ExpandedChanged="OnExpandedChanged"
+                 ExpandMoreIcon="@Icons.Material.Filled.Add"
+                 ExpandLessIcon="@Icons.Material.Filled.Remove"
+                 ExpandIconColor="Color.Secondary">
+        <NestedList>
+            <MudListItem Text="Water" />
+            <MudListItem Text="Coffee" />
+        </NestedList>
+    </MudListItem>
+</MudList>
+
+<p class="expanded">@_expanded</p>
+<p class="changed-count">@_changedCount</p>
+
+@code {
+    public static string __description__ = "Expanding the parent reveals its nested list and raises ExpandedChanged.";
+
+    private bool _expanded;
+    private int _changedCount;
+
+    private void OnExpandedChanged(bool value)
+    {
+        _expanded = value;
+        _changedCount++;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionInitialValueTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/List/ListSelectionInitialValueTest.razor
@@ -30,7 +30,7 @@
     [Parameter]
     public Color Color { get; set; } = Color.Primary;
 
-    public void SetSelectedValue(string value)
+    public void SetSelectedValue(string? value)
     {
         _selectedValue = value;
         StateHasChanged();

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -1,6 +1,9 @@
-﻿using AwesomeAssertions;
+﻿#nullable enable
+using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.UnitTests.TestComponents;
 using MudBlazor.UnitTests.TestComponents.List;
 using NUnit.Framework;
@@ -10,213 +13,164 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class ListTests : BunitTest
     {
-
         [Test]
-        public async Task ListRender()
+        public async Task ListItem_RendersText_AndSecondaryText()
         {
-            var comp = Context.Render<ListSelectionTest>();
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Sparkling Water")));
             var listItem = comp.FindComponent<MudListItem<string>>();
             comp.Markup.Should().Contain("Sparkling Water");
-            comp.Markup.Should().NotContain("Roger Waters");
-            comp.Markup.Should().NotContain("High Hopes");
+            comp.FindAll(".mud-list-item-secondary-text").Should().BeEmpty();
+
             await listItem.SetParametersAndRenderAsync(parameters => parameters
-                .Add(x => x.Text, "Roger Waters")
-                .Add(x => x.SecondaryText, "High Hopes"));
+                .Add(x => x.Text, "Latte")
+                .Add(x => x.SecondaryText, "with oat milk"));
+
             comp.Markup.Should().NotContain("Sparkling Water");
-            comp.Markup.Should().Contain("Roger Waters");
-            comp.Markup.Should().Contain("High Hopes");
+            comp.Markup.Should().Contain("Latte");
+            comp.Find(".mud-list-item-secondary-text").TextContent.Should().Contain("with oat milk");
         }
 
         /// <summary>
-        /// <para>Clicking the drinks selects them. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.</para>
-        /// <para>In this test no item is selected to begin with</para>
+        /// Clicking items selects them, and at most one item is ever highlighted because the child lists
+        /// share the parent's selection. The two modes differ only when an already-selected item is clicked
+        /// again: single-selection keeps it, toggle-selection clears it.
         /// </summary>
         [Test]
-        public async Task ListSelection()
+        [TestCase(SelectionMode.SingleSelection)]
+        [TestCase(SelectionMode.ToggleSelection)]
+        public async Task ClickingItems_HighlightsAtMostOne_AndReclickDependsOnMode(SelectionMode mode)
         {
-            var comp = Context.Render<ListSelectionTest>();
+            var comp = Context.Render<ListSelectionTest>(self => self.Add(x => x.SelectionMode, mode));
             var list = comp.FindComponent<MudList<string>>().Instance;
-            list.SelectedValue.Should().Be(null);
-            // we have seven choices, none is active
-            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
-            // click water
-            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
-            list.SelectedValue.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
-            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
-            await comp.FindAll("div.mud-list-item")[4].ClickAsync();
-            list.SelectedValue.Should().Be("Pu'er");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[4].Markup.Should().Contain("mud-selected-item");
-            // click Cafe Latte
-            await comp.FindAll("div.mud-list-item")[8].ClickAsync();
-            list.SelectedValue.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[8].Markup.Should().Contain("mud-selected-item");
-            // click Cafe Latte again which should NOT deselect it because we are in single-selection mode
-            await comp.FindAll("div.mud-list-item")[8].ClickAsync();
-            list.SelectedValue.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[8].Markup.Should().Contain("mud-selected-item");
-        }
 
-        [Test]
-        public async Task ListToggleSelection()
-        {
-            var comp = Context.Render<ListSelectionTest>(self => self.Add(x => x.SelectionMode, SelectionMode.ToggleSelection));
-            var list = comp.FindComponent<MudList<string>>().Instance;
-            list.SelectedValue.Should().Be(null);
-            // we have seven choices, none is active
-            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
-            // click water
-            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
-            list.SelectedValue.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
-            // click Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
-            await comp.FindAll("div.mud-list-item")[4].ClickAsync();
-            list.SelectedValue.Should().Be("Pu'er");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[4].Markup.Should().Contain("mud-selected-item");
-            // click Cafe Latte
-            await comp.FindAll("div.mud-list-item")[8].ClickAsync();
-            list.SelectedValue.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[8].Markup.Should().Contain("mud-selected-item");
-            // click Cafe Latte again which should deselect it because we are in toggle-selection mode
-            await comp.FindAll("div.mud-list-item")[8].ClickAsync();
-            list.SelectedValue.Should().Be(null);
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
-            comp.FindComponents<MudListItem<string>>()[8].Markup.Should().NotContain("mud-selected-item");
-        }
+            Task ClickItem(string text) => comp.FindComponents<MudListItem<string>>()
+                .Single(x => x.Instance.Text == text).Find("div.mud-list-item").ClickAsync();
+            void AssertOnlySelected(string text)
+            {
+                comp.FindAll("div.mud-selected-item").Should().ContainSingle();
+                list.SelectedValue.Should().Be(text);
+                comp.FindComponents<MudListItem<string>>().Single(x => x.Instance.Text == text)
+                    .Markup.Should().Contain("mud-selected-item");
+            }
 
-        [Test]
-        public void ListMultiSelectionInitialValues()
-        {
-            var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Milk", "Cafe Latte"]));
-            var list = comp.FindComponent<MudList<string>>().Instance;
-            comp.Find("p.selected-values").TrimmedText().Should().Be("Cafe Latte, Milk");
-            var GetCheckBox = (string text) => comp.FindComponents<MudListItem<string>>().FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
-            GetCheckBox("Milk").ReadValue.Should().Be(true);
-            GetCheckBox("Cafe Latte").ReadValue.Should().Be(true);
-        }
+            list.SelectedValue.Should().BeNull();
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 drinks + 2 nested group headers
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty();
 
-        [Test]
-        public async Task ListMultiSelection_DisabledItems_ShouldDisplaySelectedStateAndNotBeClickable()
-        {
-            var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Apple Juice", "Orange Juice"]));
-            var list = comp.FindComponent<MudList<string>>().Instance;
-            var GetCheckBox = (string text) => comp.FindComponents<MudListItem<string>>().FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
-            comp.Find("p.selected-values").TrimmedText().Should().Be("Apple Juice, Orange Juice");
-            GetCheckBox("Apple Juice").ReadValue.Should().Be(true);
-            GetCheckBox("Orange Juice").ReadValue.Should().Be(true);
-            // attempt to click disabled items: selection state must not change
-            var appleItem = comp.FindComponents<MudListItem<string>>()
-                .FirstOrDefault(x => x.Instance.Text == "Apple Juice");
-            var orangeItem = comp.FindComponents<MudListItem<string>>()
-                .FirstOrDefault(x => x.Instance.Text == "Orange Juice");
-            await appleItem.Find("div.mud-list-item").ClickAsync();
-            await orangeItem.Find("div.mud-list-item").ClickAsync();
-            // after click attempts, disabled items should remain selected
-            comp.Find("p.selected-values").TrimmedText().Should().Be("Apple Juice, Orange Juice");
-            GetCheckBox("Apple Juice").ReadValue.Should().Be(true);
-            GetCheckBox("Orange Juice").ReadValue.Should().Be(true);
-        }
+            await ClickItem("Sparkling Water");
+            AssertOnlySelected("Sparkling Water");
 
-        [Test]
-        public async Task ListMultiSelectionBinding()
-        {
-            var comp = Context.Render<ListMultiSelectionBindingTest>();
-            var list1 = comp.FindComponents<MudList<string>>().FirstOrDefault(x => x.Instance.Class == "list-1");
-            var list2 = comp.FindComponents<MudList<string>>().FirstOrDefault(x => x.Instance.Class == "list-2");
-            list1.FindComponents<MudListItem<string>>().Count.Should().Be(8);
-            var GetCheckBox = (IRenderedComponent<MudList<string>> list, string text) => list.FindComponents<MudListItem<string>>()
-                        .FirstOrDefault(x => x.Instance.Text == text)?.FindComponent<MudCheckBox<bool?>>().Instance;
-            var Select = async (IRenderedComponent<MudList<string>> list, string text) =>
-                        await list.FindComponents<MudListItem<string>>()
-                        .FirstOrDefault(x => x.Instance.Text == text).Find("div.mud-list-item").ClickAsync();
-            // click water on list1
-            await Select(list1, "Sparkling Water");
-            comp.Find("p.selected-values").TrimmedText().Should().Be("Carbonated H²O");
-            GetCheckBox(list1, "Milk").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Sparkling Water").ReadValue.Should().Be(true);
-            GetCheckBox(list1, "English Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Chinese Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Irish Coffee").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Double Espresso").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Milk").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Sparkling Water").ReadValue.Should().Be(true);
-            GetCheckBox(list2, "English Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Chinese Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Irish Coffee").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Double Espresso").ReadValue.Should().Be(false);
-            // click Irish on list2
-            await Select(list2, "Irish Coffee");
-            comp.Find("p.selected-values").TrimmedText().Should().Be("Carbonated H²O, Irish Coffee");
-            GetCheckBox(list1, "Milk").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Sparkling Water").ReadValue.Should().Be(true);
-            GetCheckBox(list1, "English Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Chinese Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Irish Coffee").ReadValue.Should().Be(true);
-            GetCheckBox(list1, "Double Espresso").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Milk").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Sparkling Water").ReadValue.Should().Be(true);
-            GetCheckBox(list2, "English Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Chinese Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Irish Coffee").ReadValue.Should().Be(true);
-            GetCheckBox(list2, "Double Espresso").ReadValue.Should().Be(false);
-            // click off water on list2
-            await Select(list2, "Sparkling Water");
-            comp.Find("p.selected-values").TrimmedText().Should().Be("Irish Coffee");
-            GetCheckBox(list1, "Milk").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Sparkling Water").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "English Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Chinese Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list1, "Irish Coffee").ReadValue.Should().Be(true);
-            GetCheckBox(list1, "Double Espresso").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Milk").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Sparkling Water").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "English Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Chinese Tea").ReadValue.Should().Be(false);
-            GetCheckBox(list2, "Irish Coffee").ReadValue.Should().Be(true);
-            GetCheckBox(list2, "Double Espresso").ReadValue.Should().Be(false);
+            // selecting a nested item moves the single selection into the child list
+            await ClickItem("Pu'er");
+            AssertOnlySelected("Pu'er");
+
+            // re-clicking the already-selected item is where the modes diverge
+            await ClickItem("Pu'er");
+            if (mode == SelectionMode.ToggleSelection)
+            {
+                list.SelectedValue.Should().BeNull();
+                comp.FindAll("div.mud-selected-item").Should().BeEmpty();
+            }
+            else
+            {
+                AssertOnlySelected("Pu'er");
+            }
         }
 
         /// <summary>
-        /// <para>Clicking the drinks selects them. The child lists are updated accordingly, meaning, only ever 1 list item can have the active class.</para>
-        /// <para>This test starts with a pre-selected item (by value)</para>
+        /// Changing <see cref="MudList{T}.SelectedValue"/> from outside the component re-targets the highlight,
+        /// including into nested child lists, and clearing it removes the highlight entirely.
         /// </summary>
         [Test]
-        public async Task ListWithPreSelectedValue()
+        public async Task PreSelectedValue_IsHonored_AndExternalChangesMoveSelection()
         {
             var comp = Context.Render<ListSelectionInitialValueTest>();
             var list = comp.FindComponent<MudList<string>>().Instance;
             list.SelectedValue.Should().Be("Sparkling Water");
-            // we have seven choices, 1 is active because of the initial value of SelectedValue
-            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            // set Pu'er, a heavily fermented Chinese tea that tastes like an old leather glove
-            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue("Pu'er"));
-            list.SelectedValue.Should().Be("Pu'er");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[4].Markup.Should().Contain("mud-selected-item");
-            // set Cafe Latte via changing SelectedValue
-            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue("Cafe Latte"));
-            list.SelectedValue.Should().Be("Cafe Latte");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[8].Markup.Should().Contain("mud-selected-item");
-            // set water
-            await comp.InvokeAsync(() => comp.Instance.SetSelectedValue("Sparkling Water"));
-            list.SelectedValue.Should().Be("Sparkling Water");
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(1);
-            comp.FindComponents<MudListItem<string>>()[0].Markup.Should().Contain("mud-selected-item");
-            // set nothing
+            comp.FindAll("div.mud-selected-item").Should().ContainSingle();
+
+            foreach (var drink in new[] { "Pu'er", "Cafe Latte", "Sparkling Water" })
+            {
+                await comp.InvokeAsync(() => comp.Instance.SetSelectedValue(drink));
+                list.SelectedValue.Should().Be(drink);
+                comp.FindAll("div.mud-selected-item").Should().ContainSingle();
+                comp.FindComponents<MudListItem<string>>().Single(x => x.Instance.Text == drink)
+                    .Markup.Should().Contain("mud-selected-item");
+            }
+
             await comp.InvokeAsync(() => comp.Instance.SetSelectedValue(null));
-            list.SelectedValue.Should().Be(null);
-            comp.FindAll("div.mud-selected-item").Count.Should().Be(0);
+            list.SelectedValue.Should().BeNull();
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty();
+        }
+
+        [Test]
+        public void MultiSelection_InitialSelectedValues_CheckTheMatchingItems()
+        {
+            var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Milk", "Cafe Latte"]));
+            comp.Find("p.selected-values").TrimmedText().Should().Be("Cafe Latte, Milk");
+            CheckBoxValue(comp, "Milk").Should().Be(true);
+            CheckBoxValue(comp, "Cafe Latte").Should().Be(true);
+        }
+
+        [Test]
+        public async Task MultiSelection_DisabledItems_IgnoreClicks_WhileEnabledItemsToggle()
+        {
+            // Apple/Orange Juice are disabled in the fixture; Milk is enabled. All three start selected.
+            var comp = Context.Render<ListMultiSelectionTest>(self => self.Add(x => x.SelectedValues, ["Apple Juice", "Orange Juice", "Milk"]));
+            var item = (string text) => comp.FindComponents<MudListItem<string>>().Single(x => x.Instance.Text == text);
+
+            item("Apple Juice").Find("div.mud-list-item").ClassList.Should().Contain("mud-list-item-disabled");
+            CheckBoxValue(comp, "Apple Juice").Should().Be(true);
+            CheckBoxValue(comp, "Milk").Should().Be(true);
+
+            // clicking the enabled, already-selected item deselects it...
+            await item("Milk").Find("div.mud-list-item").ClickAsync();
+            CheckBoxValue(comp, "Milk").Should().Be(false);
+
+            // ...but clicking the disabled items leaves their selection untouched
+            await item("Apple Juice").Find("div.mud-list-item").ClickAsync();
+            await item("Orange Juice").Find("div.mud-list-item").ClickAsync();
+            CheckBoxValue(comp, "Apple Juice").Should().Be(true);
+            CheckBoxValue(comp, "Orange Juice").Should().Be(true);
+        }
+
+        /// <summary>
+        /// Two lists bound to the same collection mirror each other: a click on one updates the other and the
+        /// shared <c>SelectedValues</c>.
+        /// </summary>
+        [Test]
+        public async Task MultiSelection_TwoListsShareBoundCollection()
+        {
+            var comp = Context.Render<ListMultiSelectionBindingTest>();
+            var list1 = comp.FindComponents<MudList<string>>().Single(x => x.Instance.Class == "list-1");
+            var list2 = comp.FindComponents<MudList<string>>().Single(x => x.Instance.Class == "list-2");
+            list1.FindComponents<MudListItem<string>>().Count.Should().Be(8);
+
+            bool? CheckBox(IRenderedComponent<MudList<string>> list, string text) => list
+                .FindComponents<MudListItem<string>>().Single(x => x.Instance.Text == text)
+                .FindComponent<MudCheckBox<bool?>>().Instance.ReadValue;
+            Task Select(IRenderedComponent<MudList<string>> list, string text) => list
+                .FindComponents<MudListItem<string>>().Single(x => x.Instance.Text == text)
+                .Find("div.mud-list-item").ClickAsync();
+
+            // selecting on list1 mirrors onto list2 because both bind the same collection
+            await Select(list1, "Sparkling Water");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("Carbonated H²O");
+            CheckBox(list1, "Sparkling Water").Should().Be(true);
+            CheckBox(list2, "Sparkling Water").Should().Be(true);
+
+            // selecting on list2 adds to the shared collection without disturbing the first selection
+            await Select(list2, "Irish Coffee");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("Carbonated H²O, Irish Coffee");
+            CheckBox(list1, "Irish Coffee").Should().Be(true);
+            CheckBox(list2, "Irish Coffee").Should().Be(true);
+
+            // de-selecting on list2 removes it from both
+            await Select(list2, "Sparkling Water");
+            comp.Find("p.selected-values").TrimmedText().Should().Be("Irish Coffee");
+            CheckBox(list1, "Sparkling Water").Should().Be(false);
+            CheckBox(list2, "Sparkling Water").Should().Be(false);
         }
 
         [Test]
@@ -229,19 +183,16 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(Color.Warning)]
         [TestCase(Color.Error)]
         [TestCase(Color.Dark)]
-        public void ListColor(Color color)
+        public void SelectedItem_UsesListColorClasses(Color color)
         {
             var comp = Context.Render<ListSelectionInitialValueTest>(x => x.Add(c => c.Color, color));
 
-            var list = comp.FindComponent<MudList<string>>().Instance;
-            list.SelectedValue.Should().Be("Sparkling Water");
-
-            var listItemClasses = comp.Find(".mud-selected-item");
-            listItemClasses.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToStringFast(true)}-text", $"mud-{color.ToStringFast(true)}-hover" });
+            var selectedItem = comp.Find(".mud-selected-item");
+            selectedItem.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToStringFast(true)}-text", $"mud-{color.ToStringFast(true)}-hover" });
         }
 
         /// <summary>
-        /// The child lists should honor the Dense property of their parent list if not overridden.
+        /// Child lists honor the parent list's <see cref="MudList{T}.Dense"/> setting unless they override it.
         /// </summary>
         [Test]
         [TestCase(true, null, 9)]
@@ -250,12 +201,42 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(false, false, 0)]
         [TestCase(true, false, 5)]
         [TestCase(false, true, 4)]
-        public void ListDenseInheritance(bool dense, bool? innerListDense, int expectedDenseClassCount)
+        public void DenseInheritance_ChildListsFollowParentUnlessOverridden(bool dense, bool? innerListDense, int expectedDenseClassCount)
         {
             var comp = Context.Render<ListDenseInheritanceTest>(x => x.Add(c => c.Dense, dense).Add(c => c.InnerListDense, innerListDense));
 
-            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 choices, 2 groups
-            comp.FindAll("div.mud-list-item-dense").Count.Should().Be(expectedDenseClassCount); // 7 choices, 2 groups
+            comp.FindAll("div.mud-list-item").Count.Should().Be(9); // 7 drinks + 2 nested group headers
+            comp.FindAll("div.mud-list-item-dense").Count.Should().Be(expectedDenseClassCount);
+        }
+
+        /// <summary>
+        /// Toggling <see cref="MudList{T}.Dense"/> after the first render propagates to every already-registered
+        /// item, including those in nested child lists.
+        /// </summary>
+        [Test]
+        public async Task Dense_ToggledAfterRender_PropagatesToItemsAndNestedLists()
+        {
+            var comp = Context.Render<ListDenseInheritanceTest>();
+            comp.FindAll("div.mud-list-item-dense").Should().BeEmpty();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Dense, true));
+
+            comp.FindAll("div.mud-list-item-dense").Count.Should().Be(9);
+        }
+
+        /// <summary>
+        /// Switching to multi-selection at runtime re-evaluates the container semantics: the list (which owns
+        /// nested child lists) gains <c>aria-multiselectable</c>.
+        /// </summary>
+        [Test]
+        public async Task SelectionMode_SwitchedToMultiSelection_MarksContainerMultiselectable()
+        {
+            var comp = Context.Render<ListSelectionTest>();
+            comp.Find("div.mud-list").HasAttribute("aria-multiselectable").Should().BeFalse();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+
+            comp.Find("div.mud-list").GetAttribute("aria-multiselectable").Should().Be("true");
         }
 
         [Test]
@@ -269,30 +250,256 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void ListItemTabIndex()
+        [TestCase(true, null, true)]
+        [TestCase(true, true, true)]
+        [TestCase(true, false, false)]
+        [TestCase(false, null, false)]
+        [TestCase(false, true, true)]
+        [TestCase(false, false, false)]
+        public void Gutters_OnList_OverrideGuttersOnItemsWithoutTheirOwnSetting(bool listGutters, bool? itemGutters, bool resultingGutters)
         {
-            var comp = Context.Render<ListItemTabIndexTest>();
-            comp.FindAll("div")[1].GetAttribute("tabindex").Should().Be("-1");
+            var comp = Context.Render<ListItemGuttersTest>(self => self
+                .Add(x => x.ListGutters, listGutters)
+                .Add(x => x.ItemGutters, itemGutters)
+            );
+            comp.FindAll("div.mud-list-item-gutters").Should().HaveCount(resultingGutters ? 1 : 0);
         }
 
         [Test]
-        public void ListAccessibility_ReadOnlyUsesListRoles()
+        public void ListItem_Inset_AddsInsetClassToTextWrapper()
         {
-            var comp = Context.Render<ListAccessibilityTest>(x => x.Add(c => c.ReadOnly, true));
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Indented").Add(x => x.Inset, true)));
 
-            var list = comp.Find("div.mud-list");
-            list.GetAttribute("role").Should().Be("list");
-            list.HasAttribute("aria-multiselectable").Should().BeFalse();
+            comp.Find("div.mud-list-item-text").ClassList.Should().Contain("mud-list-item-text-inset");
+        }
 
-            foreach (var item in comp.FindAll("div.mud-list-item"))
+        [Test]
+        public void ListItem_ChildContent_OverridesTextAndSecondaryText()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "ignored-text")
+                    .Add(x => x.SecondaryText, "ignored-secondary")
+                    .AddChildContent("<span class=\"custom-content\">Custom</span>")));
+
+            comp.Find("span.custom-content").TextContent.Should().Be("Custom");
+            comp.Markup.Should().NotContain("ignored");
+        }
+
+        [Test]
+        public void ListItem_AvatarContent_RendersAvatar_AndIgnoresIcon()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "Profile")
+                    .Add(x => x.Icon, Icons.Material.Filled.Inbox)
+                    .Add(x => x.AvatarContent, "<span class=\"avatar-marker\">AV</span>")));
+
+            comp.Find("div.mud-list-item-avatar").TextContent.Should().Contain("AV");
+            comp.FindAll("div.mud-list-item-icon").Should().BeEmpty(); // Icon is ignored when AvatarContent is set
+        }
+
+        [Test]
+        public async Task Subheader_GuttersAndInset_ToggleTheirClasses()
+        {
+            var comp = Context.Render<MudListSubheader>(p => p
+                .Add(x => x.Inset, true)
+                .Add(x => x.Gutters, false)
+                .AddChildContent("Drinks"));
+
+            var header = comp.Find("div.mud-list-subheader");
+            header.ClassList.Should().Contain("mud-list-subheader-inset");
+            header.ClassList.Should().NotContain("mud-list-subheader-gutters");
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Inset, false).Add(x => x.Gutters, true));
+
+            header = comp.Find("div.mud-list-subheader");
+            header.ClassList.Should().NotContain("mud-list-subheader-inset");
+            header.ClassList.Should().Contain("mud-list-subheader-gutters");
+        }
+
+        [Test]
+        public void List_WithHref_RendersAnchorWithHrefAndTarget()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "Docs")
+                    .Add(x => x.Href, "/docs")
+                    .Add(x => x.Target, "_blank"))
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "Plain")));
+
+            var anchor = comp.Find("a.mud-list-item");
+            anchor.GetAttribute("href").Should().Be("/docs");
+            anchor.GetAttribute("target").Should().Be("_blank");
+
+            // the item without an Href stays a div
+            comp.FindAll("div.mud-list-item").Should().ContainSingle();
+        }
+
+        /// <summary>
+        /// A list item only navigates manually (bypassing the router) when it has an <c>Href</c>, <c>ForceLoad</c>
+        /// is set, and no <c>Target</c> is given. In every other case the rendered anchor handles navigation.
+        /// </summary>
+        [Test]
+        [TestCase(true, null, true)]      // ForceLoad + Href + no Target -> manual NavigateTo
+        [TestCase(false, null, false)]    // Href only -> the anchor navigates, no manual call
+        [TestCase(true, "_blank", false)] // ForceLoad + Href + Target -> the anchor navigates
+        public async Task ListItem_ForceLoad_NavigatesManuallyOnlyWithHrefAndNoTarget(bool forceLoad, string? target, bool shouldNavigate)
+        {
+            var nav = Context.Services.GetRequiredService<NavigationManager>();
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "Go")
+                    .Add(x => x.Href, "/list-target")
+                    .Add(x => x.ForceLoad, forceLoad)
+                    .Add(x => x.Target, target)));
+            var before = nav.Uri;
+
+            await comp.Find("a.mud-list-item").ClickAsync();
+
+            if (shouldNavigate)
             {
-                item.GetAttribute("role").Should().Be("listitem");
-                item.HasAttribute("aria-selected").Should().BeFalse();
+                nav.Uri.Should().EndWith("list-target");
+            }
+            else
+            {
+                nav.Uri.Should().Be(before);
             }
         }
 
+        /// <summary>
+        /// <see cref="MudListItem{T}.OnClickPreventDefault"/> renders the item as a div (even with an Href) and
+        /// short-circuits the click to only invoke <c>OnClick</c>; selection and navigation are suppressed.
+        /// </summary>
         [Test]
-        public void ListAccessibility_InteractiveUsesListboxRolesAndRovingTabIndex()
+        public async Task ListItem_OnClickPreventDefault_OnlyInvokesOnClick()
+        {
+            var clicks = 0;
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "Item")
+                    .Add(x => x.Value, "item")
+                    .Add(x => x.Href, "/should-not-follow")
+                    .Add(x => x.OnClickPreventDefault, true)
+                    .Add(x => x.OnClick, () => clicks++)));
+
+            comp.FindAll("a.mud-list-item").Should().BeEmpty(); // forced to a div despite the Href
+            await comp.Find("div.mud-list-item").ClickAsync();
+
+            clicks.Should().Be(1);
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty(); // selection is suppressed
+        }
+
+        [Test]
+        public async Task Disabled_List_DisablesEveryItem_AndSuppressesSelection()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .Add(x => x.Disabled, true)
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "A").Add(x => x.Value, "A"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "B").Add(x => x.Value, "B")));
+
+            comp.FindAll("div.mud-list-item").Should().OnlyContain(item =>
+                item.ClassList.Contains("mud-list-item-disabled") && item.GetAttribute("tabindex") == "-1");
+
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty(); // clicks on a disabled list select nothing
+        }
+
+        [Test]
+        public async Task Disabled_Item_IsNotClickable_ButSiblingsRemainSelectable()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "A").Add(x => x.Value, "A"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "B").Add(x => x.Value, "B").Add(x => x.Disabled, true))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "C").Add(x => x.Value, "C")));
+            var item = (string text) => comp.FindComponents<MudListItem<string>>().Single(x => x.Instance.Text == text);
+
+            var disabled = item("B").Find("div.mud-list-item");
+            disabled.ClassList.Should().Contain("mud-list-item-disabled");
+            disabled.ClassList.Should().NotContain("mud-list-item-clickable");
+
+            await disabled.ClickAsync();
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty(); // the disabled item ignores the click
+
+            await item("C").Find("div.mud-list-item").ClickAsync();
+            item("C").Find("div.mud-list-item").ClassList.Should().Contain("mud-selected-item"); // enabled siblings still work
+        }
+
+        [Test]
+        public void MultiSelection_AppliesCustomCheckBoxIconsAndColor()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
+                .Add(x => x.CheckBoxColor, Color.Secondary)
+                .Add(x => x.CheckedIcon, Icons.Material.Filled.Star)
+                .Add(x => x.UncheckedIcon, Icons.Material.Filled.StarBorder)
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "A").Add(x => x.Value, "A"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "B").Add(x => x.Value, "B")));
+
+            comp.FindComponents<MudCheckBox<bool?>>().Should().AllSatisfy(checkbox =>
+            {
+                checkbox.Instance.CheckedIcon.Should().Be(Icons.Material.Filled.Star);
+                checkbox.Instance.UncheckedIcon.Should().Be(Icons.Material.Filled.StarBorder);
+                checkbox.Instance.Color.Should().Be(Color.Secondary);
+                checkbox.Instance.UncheckedColor.Should().Be(Color.Secondary);
+            });
+        }
+
+        /// <summary>
+        /// Changing the <see cref="MudList{T}.Comparer"/> re-evaluates the single selection, so a value that did
+        /// not match any item under the default comparer can match once a looser comparer is supplied.
+        /// </summary>
+        [Test]
+        public async Task SingleSelection_ChangingComparer_ReevaluatesSelectedItem()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .Add(x => x.SelectedValue, "apple")
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "APPLE").Add(x => x.Value, "APPLE"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Banana").Add(x => x.Value, "Banana")));
+
+            // case-sensitive default: "apple" matches nothing
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty();
+
+            await comp.SetParametersAndRenderAsync(p => p
+                .Add(x => x.Comparer, new CaseInsensitiveStringComparer()));
+
+            // now "apple" matches "APPLE"
+            comp.FindAll("div.mud-selected-item").Should().ContainSingle();
+            comp.FindComponents<MudListItem<string>>().Single(x => x.Instance.Value == "APPLE")
+                .Markup.Should().Contain("mud-selected-item");
+        }
+
+        /// <summary>
+        /// Changing the <see cref="MudList{T}.Comparer"/> in multi-selection rebuilds the selection set with the
+        /// new comparer, so items re-match the selected values under the looser comparison.
+        /// </summary>
+        [Test]
+        public async Task MultiSelection_ChangingComparer_RematchesItemsUnderNewComparer()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
+                .Add(x => x.SelectedValues, ["apple"])
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "APPLE").Add(x => x.Value, "APPLE"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Banana").Add(x => x.Value, "Banana")));
+
+            bool? CheckBox(string text) => comp.FindComponents<MudListItem<string>>()
+                .Single(x => x.Instance.Text == text).FindComponent<MudCheckBox<bool?>>().Instance.ReadValue;
+
+            // "apple" does not match the "APPLE" item under the default comparer
+            CheckBox("APPLE").Should().Be(false);
+
+            await comp.SetParametersAndRenderAsync(p => p
+                .Add(x => x.Comparer, new CaseInsensitiveStringComparer()));
+
+            // the looser comparer now matches "apple" to the "APPLE" item
+            CheckBox("APPLE").Should().Be(true);
+            CheckBox("Banana").Should().Be(false);
+        }
+
+        [Test]
+        public void Interactive_SingleSelection_UsesListboxRoles_WithoutMultiselectable()
         {
             var comp = Context.Render<ListAccessibilityTest>();
 
@@ -308,7 +515,51 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_ArrowDownSkipsDisabledItem()
+        public void Interactive_MultiSelection_MarksContainerMultiselectable()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "A")));
+
+            var list = comp.Find("div.mud-list");
+            list.GetAttribute("role").Should().Be("listbox");
+            list.GetAttribute("aria-multiselectable").Should().Be("true");
+        }
+
+        [Test]
+        public async Task SingleSelection_AriaSelected_ReflectsTheSelectedItem()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "A").Add(x => x.Value, "A"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "B").Add(x => x.Value, "B")));
+
+            comp.FindAll("div.mud-list-item").Should().OnlyContain(item => item.GetAttribute("aria-selected") == "false");
+
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+
+            var items = comp.FindAll("div.mud-list-item");
+            items[0].GetAttribute("aria-selected").Should().Be("true");
+            items[1].GetAttribute("aria-selected").Should().Be("false");
+        }
+
+        [Test]
+        public void ReadOnly_List_UsesPlainListRolesAndNoSelectionState()
+        {
+            var comp = Context.Render<ListAccessibilityTest>(x => x.Add(c => c.ReadOnly, true));
+
+            var list = comp.Find("div.mud-list");
+            list.GetAttribute("role").Should().Be("list");
+            list.HasAttribute("aria-multiselectable").Should().BeFalse();
+
+            foreach (var item in comp.FindAll("div.mud-list-item"))
+            {
+                item.GetAttribute("role").Should().Be("listitem");
+                item.HasAttribute("aria-selected").Should().BeFalse();
+            }
+        }
+
+        [Test]
+        public async Task Keyboard_ArrowDown_SkipsDisabledItem()
         {
             var comp = Context.Render<ListAccessibilityTest>(x => x.Add(c => c.IncludeDisabledItem, true));
             var items = comp.FindAll("div.mud-list-item");
@@ -324,7 +575,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_ArrowUpMovesToPreviousItem()
+        public async Task Keyboard_ArrowUp_MovesToPreviousItem()
         {
             var comp = Context.Render<ListAccessibilityTest>();
             var items = comp.FindAll("div.mud-list-item");
@@ -343,7 +594,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_ArrowUpOnFirstItemStaysOnFirstItem()
+        public async Task Keyboard_ArrowUpOnFirstItem_StaysOnFirstItem()
         {
             var comp = Context.Render<ListAccessibilityTest>();
             var items = comp.FindAll("div.mud-list-item");
@@ -359,7 +610,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_HomeMovesFocusToFirstItem()
+        public async Task Keyboard_Home_MovesFocusToFirstItem()
         {
             var comp = Context.Render<ListAccessibilityTest>();
             var items = comp.FindAll("div.mud-list-item");
@@ -378,7 +629,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_EndMovesFocusToLastItem()
+        public async Task Keyboard_End_MovesFocusToLastItem()
         {
             var comp = Context.Render<ListAccessibilityTest>();
             var items = comp.FindAll("div.mud-list-item");
@@ -393,7 +644,20 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_EnterAndNumpadEnterToggleSelectionInToggleMode()
+        [TestCase(" ")]
+        [TestCase("Enter")]
+        public async Task Keyboard_SingleSelection_ActivatesFocusedItem(string key)
+        {
+            var comp = Context.Render<ListAccessibilityTest>();
+            var items = comp.FindAll("div.mud-list-item");
+
+            await items[0].KeyDownAsync(new KeyboardEventArgs { Key = key });
+
+            await comp.WaitForAssertionAsync(() => comp.Find("p.selected-value").TrimmedText().Should().Be("Alpha"));
+        }
+
+        [Test]
+        public async Task Keyboard_EnterAndNumpadEnter_ToggleSelectionInToggleMode()
         {
             var comp = Context.Render<ListAccessibilityTest>(x => x.Add(c => c.SelectionMode, SelectionMode.ToggleSelection));
             var items = comp.FindAll("div.mud-list-item");
@@ -407,7 +671,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_NonTabbableItemDoesNotHandleKeyCommands()
+        public async Task Keyboard_EnterOnAnchorItem_LeavesNavigationToTheBrowser()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Link").Add(x => x.Value, "Link").Add(x => x.Href, "/somewhere")));
+
+            comp.Find("a.mud-list-item").GetAttribute("aria-selected").Should().Be("false");
+
+            await comp.Find("a.mud-list-item").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            // Enter on an anchor is a no-op in code (the rendered <a> activates itself), so it is not selected
+            comp.Find("a.mud-list-item").GetAttribute("aria-selected").Should().Be("false");
+        }
+
+        [Test]
+        public async Task Keyboard_NonTabbableItem_DoesNotHandleKeyCommands()
         {
             var comp = Context.Render<ListAccessibilityTest>();
             var items = comp.FindAll("div.mud-list-item");
@@ -425,7 +703,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task ListKeyboardNavigation_SpaceTogglesMultiSelectionWithoutTabbableCheckboxes()
+        public async Task Keyboard_Space_TogglesMultiSelection_WithCheckboxesHiddenFromTabOrder()
         {
             var comp = Context.Render<ListAccessibilityTest>(x => x.Add(c => c.SelectionMode, SelectionMode.MultiSelection));
             var items = comp.FindAll("div.mud-list-item");
@@ -443,6 +721,50 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("p.selected-values").TrimmedText().Should().BeEmpty());
         }
 
+        /// <summary>
+        /// Clicking an item that owns a nested list toggles its expansion (and raises <c>ExpandedChanged</c>)
+        /// instead of selecting it; the expand/collapse icon swaps to match.
+        /// </summary>
+        [Test]
+        public async Task NestedItem_Click_TogglesExpansion_AndRaisesExpandedChanged()
+        {
+            var comp = Context.Render<ListNestedExpansionTest>();
+            var parent = comp.Find("div.mud-list-item");
+
+            // the expand chevron is the icon coloured with the fixture's ExpandIconColor (Secondary)
+            string? ExpandIcon() => comp.FindComponents<MudIcon>().Single(i => i.Instance.Color == Color.Secondary).Instance.Icon;
+
+            parent.GetAttribute("aria-expanded").Should().Be("false");
+            comp.Find("p.changed-count").TrimmedText().Should().Be("0");
+            ExpandIcon().Should().Be(Icons.Material.Filled.Add); // ExpandMoreIcon
+
+            await parent.ClickAsync();
+
+            comp.Find("div.mud-list-item").GetAttribute("aria-expanded").Should().Be("true");
+            comp.Find("p.expanded").TrimmedText().Should().Be("True");
+            comp.Find("p.changed-count").TrimmedText().Should().Be("1");
+            comp.FindAll("div.mud-selected-item").Should().BeEmpty(); // expanding is not selecting
+            ExpandIcon().Should().Be(Icons.Material.Filled.Remove); // ExpandLessIcon
+
+            await comp.Find("div.mud-list-item").ClickAsync();
+            comp.Find("div.mud-list-item").GetAttribute("aria-expanded").Should().Be("false");
+            comp.Find("p.changed-count").TrimmedText().Should().Be("2");
+        }
+
+        [Test]
+        [TestCase(" ")]
+        [TestCase("Enter")]
+        public async Task NestedItem_Keyboard_TogglesExpansion(string key)
+        {
+            var comp = Context.Render<ListNestedExpansionTest>();
+            var parent = comp.Find("div.mud-list-item");
+
+            await parent.KeyDownAsync(new KeyboardEventArgs { Key = key });
+
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-list-item").GetAttribute("aria-expanded").Should().Be("true"));
+            comp.Find("p.expanded").TrimmedText().Should().Be("True");
+        }
+
         [Test]
         public void ListItem_UserProvidedIdOverridesGeneratedElementId()
         {
@@ -457,10 +779,11 @@ namespace MudBlazor.UnitTests.Components
             );
 
             var customIdItem = comp.Find("div.mud-list-item[data-test='custom-marker']");
-            var fallbackItem = comp.FindAll("div.mud-list-item")[1];
+            var fallbackItem = comp.FindComponents<MudListItem<string>>()
+                .Single(x => x.Instance.Text == "Default item").Find("div.mud-list-item");
 
             customIdItem.GetAttribute("id").Should().Be("custom-id");
-            customIdItem.GetAttribute("tabindex").Should().Be("-1");
+            customIdItem.GetAttribute("tabindex").Should().Be("-1"); // user value wins over the roving tabindex
             fallbackItem.GetAttribute("id").Should().StartWith("list-item");
         }
 
@@ -477,20 +800,16 @@ namespace MudBlazor.UnitTests.Components
             list.GetAttribute("aria-multiselectable").Should().Be("false");
         }
 
-        [Test]
-        [TestCase(true, null, true)]
-        [TestCase(true, true, true)]
-        [TestCase(true, false, false)]
-        [TestCase(false, null, false)]
-        [TestCase(false, true, true)]
-        [TestCase(false, false, false)]
-        public void SettingGuttersOnList_Should_OverrideGuttersOnItemsWithoutGuttersSetting(bool listGutters, bool? itemGutters, bool resultingGutters)
+        private static bool? CheckBoxValue(IRenderedComponent<ListMultiSelectionTest> comp, string text) =>
+            comp.FindComponents<MudListItem<string>>()
+                .Single(x => x.Instance.Text == text)
+                .FindComponent<MudCheckBox<bool?>>().Instance.ReadValue;
+
+        private sealed class CaseInsensitiveStringComparer : IEqualityComparer<string?>
         {
-            var comp = Context.Render<ListItemGuttersTest>(self => self
-                .Add(x => x.ListGutters, listGutters)
-                .Add(x => x.ItemGutters, itemGutters)
-            );
-            (comp.FindAll("div.mud-list-item-gutters").Count > 0).Should().Be(resultingGutters);
+            public bool Equals(string? x, string? y) => string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+
+            public int GetHashCode(string? obj) => obj is null ? 0 : obj.ToLowerInvariant().GetHashCode();
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -31,11 +31,6 @@ namespace MudBlazor.UnitTests.Components
             comp.Find(".mud-list-item-secondary-text").TextContent.Should().Contain("with oat milk");
         }
 
-        /// <summary>
-        /// Clicking items selects them, and at most one item is ever highlighted because the child lists
-        /// share the parent's selection. The two modes differ only when an already-selected item is clicked
-        /// again: single-selection keeps it, toggle-selection clears it.
-        /// </summary>
         [Test]
         [TestCase(SelectionMode.SingleSelection)]
         [TestCase(SelectionMode.ToggleSelection)]
@@ -78,10 +73,6 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
-        /// <summary>
-        /// Changing <see cref="MudList{T}.SelectedValue"/> from outside the component re-targets the highlight,
-        /// including into nested child lists, and clearing it removes the highlight entirely.
-        /// </summary>
         [Test]
         public async Task PreSelectedValue_IsHonored_AndExternalChangesMoveSelection()
         {
@@ -135,10 +126,6 @@ namespace MudBlazor.UnitTests.Components
             CheckBoxValue(comp, "Orange Juice").Should().Be(true);
         }
 
-        /// <summary>
-        /// Two lists bound to the same collection mirror each other: a click on one updates the other and the
-        /// shared <c>SelectedValues</c>.
-        /// </summary>
         [Test]
         public async Task MultiSelection_TwoListsShareBoundCollection()
         {
@@ -191,9 +178,6 @@ namespace MudBlazor.UnitTests.Components
             selectedItem.ClassList.Should().ContainInOrder(new[] { $"mud-{color.ToStringFast(true)}-text", $"mud-{color.ToStringFast(true)}-hover" });
         }
 
-        /// <summary>
-        /// Child lists honor the parent list's <see cref="MudList{T}.Dense"/> setting unless they override it.
-        /// </summary>
         [Test]
         [TestCase(true, null, 9)]
         [TestCase(false, null, 0)]
@@ -209,10 +193,6 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item-dense").Count.Should().Be(expectedDenseClassCount);
         }
 
-        /// <summary>
-        /// Toggling <see cref="MudList{T}.Dense"/> after the first render propagates to every already-registered
-        /// item, including those in nested child lists.
-        /// </summary>
         [Test]
         public async Task Dense_ToggledAfterRender_PropagatesToItemsAndNestedLists()
         {
@@ -224,10 +204,6 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item-dense").Count.Should().Be(9);
         }
 
-        /// <summary>
-        /// Switching to multi-selection at runtime re-evaluates the container semantics: the list (which owns
-        /// nested child lists) gains <c>aria-multiselectable</c>.
-        /// </summary>
         [Test]
         public async Task SelectionMode_SwitchedToMultiSelection_MarksContainerMultiselectable()
         {
@@ -338,10 +314,6 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-list-item").Should().ContainSingle();
         }
 
-        /// <summary>
-        /// A list item only navigates manually (bypassing the router) when it has an <c>Href</c>, <c>ForceLoad</c>
-        /// is set, and no <c>Target</c> is given. In every other case the rendered anchor handles navigation.
-        /// </summary>
         [Test]
         [TestCase(true, null, true)]      // ForceLoad + Href + no Target -> manual NavigateTo
         [TestCase(false, null, false)]    // Href only -> the anchor navigates, no manual call
@@ -369,10 +341,6 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
-        /// <summary>
-        /// <see cref="MudListItem{T}.OnClickPreventDefault"/> renders the item as a div (even with an Href) and
-        /// short-circuits the click to only invoke <c>OnClick</c>; selection and navigation are suppressed.
-        /// </summary>
         [Test]
         public async Task ListItem_OnClickPreventDefault_OnlyInvokesOnClick()
         {
@@ -447,10 +415,6 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
-        /// <summary>
-        /// Changing the <see cref="MudList{T}.Comparer"/> re-evaluates the single selection, so a value that did
-        /// not match any item under the default comparer can match once a looser comparer is supplied.
-        /// </summary>
         [Test]
         public async Task SingleSelection_ChangingComparer_ReevaluatesSelectedItem()
         {
@@ -471,10 +435,6 @@ namespace MudBlazor.UnitTests.Components
                 .Markup.Should().Contain("mud-selected-item");
         }
 
-        /// <summary>
-        /// Changing the <see cref="MudList{T}.Comparer"/> in multi-selection rebuilds the selection set with the
-        /// new comparer, so items re-match the selected values under the looser comparison.
-        /// </summary>
         [Test]
         public async Task MultiSelection_ChangingComparer_RematchesItemsUnderNewComparer()
         {
@@ -721,10 +681,6 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find("p.selected-values").TrimmedText().Should().BeEmpty());
         }
 
-        /// <summary>
-        /// Clicking an item that owns a nested list toggles its expansion (and raises <c>ExpandedChanged</c>)
-        /// instead of selecting it; the expand/collapse icon swaps to match.
-        /// </summary>
         [Test]
         public async Task NestedItem_Click_TogglesExpansion_AndRaisesExpandedChanged()
         {


### PR DESCRIPTION
Holistic review of the List component test suite (`MudList`, `MudListItem`, `MudListSubheader`). Raises the dedicated suite from 88.6% to 94.3% line coverage (branch 75.6% to 80.9%, method 100%) while tightening existing tests. Test-only; no product source changed.

What changed:
- Merged the near-identical `ListSelection`/`ListToggleSelection` into one parameterized test, dropped dead locals, replaced brittle positional lookups (`FindAll("div")[1]`, hard-coded indices, first-match `MudIcon`) with stable text/colour handles, and trimmed repeated assertions.
- Added tests for previously untested behavior: `Href`/`Target`/`ForceLoad` navigation, `OnClickPreventDefault`, nested expand/collapse via click and keyboard with `ExpandedChanged` and the chevron swap, `Comparer` changes (single and multi selection), disabled list and disabled item, custom checkbox icons/colour, runtime `Dense`/`SelectionMode` changes, `aria-selected`/`aria-multiselectable`, and `Subheader`/`Inset`/`AvatarContent`/`ChildContent`.
- Added the `ListNestedExpansionTest` viewer scaffold and removed the redundant `ListItemTabIndexTest` (its case is already covered by the user-provided-id override test).

The remaining uncovered lines are defensive guards (duplicate register/unregister, internal mode guards, the `Dispose` catch, key handling on disabled items that is blocked upstream by `CanHandleKeys`) that aren't cleanly reachable through bUnit without white-box or contrived setups.

Verification:
- Filtered List tests: 65 passing.
- Full suite: 5176 passing, 0 failed, 2 skipped.
- Ran the full suite three times under 32-worker oversubscription (2.7x on 12 cores) with `--hangdump`; no failures or hangs. Confirmed isolation (no static state, fixed data, no sleeps/sync-over-async, invariant culture).
- `dotnet format --verify-no-changes` clean.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests