### PR TITLE
Services: Skip dispose-time JS interop when never initialized

### DIFF
--- a/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Browser/BrowserViewportServiceTests.cs
@@ -659,4 +659,21 @@ public class BrowserViewportServiceTests
         observer.Notifications.Count.Should().Be(0);
         service.ObserversCount.Should().Be(0);
     }
+
+    [Test]
+    public async Task DisposeAsync_WhenNeverSubscribed_ShouldNotCallJsDispose()
+    {
+        // A scoped service is disposed by the DI scope at the end of a prerender request, before a
+        // circuit exists. With no subscription there is no JS listener to tear down, so DisposeAsync
+        // must not call JS - otherwise it throws a first-chance InvalidOperationException. See #12574.
+        // Arrange
+        var jsRuntimeMock = new Mock<IJSRuntime>();
+        var service = new BrowserViewportService(NullLogger<BrowserViewportService>.Instance, jsRuntimeMock.Object);
+
+        // Act
+        await service.DisposeAsync();
+
+        // Assert
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudResizeListenerFactory.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Never);
+    }
 }

--- a/src/MudBlazor.UnitTests/Services/PointerEvents/PointerEventsNoneServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/PointerEvents/PointerEventsNoneServiceTests.cs
@@ -169,4 +169,21 @@ public class PointerEventsNoneServiceTests
         jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudPointerEventsNone.listenForPointerEvents", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Exactly(5));
         jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudPointerEventsNone.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
     }
+
+    [Test]
+    public async Task DisposeAsync_WhenNeverSubscribed_ShouldNotCallJsDispose()
+    {
+        // A scoped service is disposed by the DI scope at the end of a prerender request, before a
+        // circuit exists. With no subscription there is no JS listener to tear down, so DisposeAsync
+        // must not call JS - otherwise it throws a first-chance InvalidOperationException. See #12574.
+        // Arrange
+        var jsRuntimeMock = new Mock<IJSRuntime>();
+        var service = new PointerEventsNoneService(NullLogger<PointerEventsNoneService>.Instance, jsRuntimeMock.Object);
+
+        // Act
+        await service.DisposeAsync();
+
+        // Assert
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudPointerEventsNone.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Never);
+    }
 }

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -710,6 +710,40 @@ public class PopoverServiceTests
     }
 
     [Test]
+    public async Task DisposeAsync_WhenNeverInitialized_ShouldNotCallJsDispose()
+    {
+        // A scoped service is disposed by the DI scope at the end of a prerender request, before a
+        // circuit exists. With no JS initialization there is nothing to tear down, so DisposeAsync
+        // must not call JS - otherwise it throws a first-chance InvalidOperationException. See #12574.
+        // Arrange
+        var jsRuntimeMock = new Mock<IJSRuntime>();
+        var service = CreateService(jsRuntimeMock.Object);
+
+        // Act
+        await service.DisposeAsync();
+
+        // Assert
+        service.IsInitialized.Should().BeFalse();
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudPopover.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DisposeAsync_WhenInitialized_ShouldCallJsDispose()
+    {
+        // Arrange
+        var jsRuntimeMock = new Mock<IJSRuntime>();
+        var service = CreateService(jsRuntimeMock.Object);
+        await service.UpdatePopoverAsync(new PopoverMock());
+
+        // Act
+        await service.DisposeAsync();
+
+        // Assert
+        service.IsInitialized.Should().BeTrue();
+        jsRuntimeMock.Verify(x => x.InvokeAsync<IJSVoidResult>("mudPopover.dispose", It.IsAny<CancellationToken>(), It.IsAny<object[]>()), Times.Once);
+    }
+
+    [Test]
     public async Task DisposeAsync_ShouldNotAcceptObservers()
     {
         // Arrange

--- a/src/MudBlazor/Services/Browser/BrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/BrowserViewportService.cs
@@ -249,13 +249,16 @@ internal sealed class BrowserViewportService : IBrowserViewportService
             await _cancellationTokenSource.CancelAsync();
             _observerManager.Clear();
 
+            // Only tear down the JS listener if one was ever created. During prerendering the DI scope
+            // disposes this service before a circuit exists; skipping the call avoids a first-chance
+            // InvalidOperationException and cannot leak, since nothing was registered on the JS side.
             if (_dotNetReferenceLazy.IsValueCreated)
             {
                 _dotNetReferenceLazy.Value.Dispose();
-            }
 
-            // Do not send our CancellationTokenSource as it was cancelled.
-            await _resizeListenerInterop.DisposeAsync(CancellationToken.None);
+                // Do not send our CancellationTokenSource as it was cancelled.
+                await _resizeListenerInterop.DisposeAsync(CancellationToken.None);
+            }
 
             _cancellationTokenSource.Dispose();
         }

--- a/src/MudBlazor/Services/PointerEvents/PointerEventsNoneService.cs
+++ b/src/MudBlazor/Services/PointerEvents/PointerEventsNoneService.cs
@@ -143,12 +143,15 @@ internal sealed class PointerEventsNoneService : IPointerEventsNoneService
 
             _observerManager.Clear();
 
+            // Only tear down the JS listener if one was ever created. During prerendering the DI scope
+            // disposes this service before a circuit exists; skipping the call avoids a first-chance
+            // InvalidOperationException and cannot leak, since nothing was registered on the JS side.
             if (_dotNetObjectReference.IsValueCreated)
             {
                 _dotNetObjectReference.Value.Dispose();
-            }
 
-            await _pointerEventsNoneInterop.DisposeAsync(CancellationToken.None);
+                await _pointerEventsNoneInterop.DisposeAsync(CancellationToken.None);
+            }
 
             _cancellationTokenSource.Dispose();
         }

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -228,8 +228,14 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
             // In case someone has custom implementation and didn't unsubscribe
             _observerManager.Clear();
 
-            // Do not send our CancellationTokenSource as it was cancelled.
-            await _popoverJsInterop.DisposeAsync(CancellationToken.None);
+            // Only dispose the JS side if it was ever initialized. During prerendering the DI scope
+            // disposes this service before a circuit exists; skipping the call avoids a first-chance
+            // InvalidOperationException and cannot leak, since the JS module was never set up.
+            if (IsInitialized)
+            {
+                // Do not send our CancellationTokenSource as it was cancelled.
+                await _popoverJsInterop.DisposeAsync(CancellationToken.None);
+            }
 
             _cancellationTokenSource.Dispose();
         }


### PR DESCRIPTION
Fixes #12574

During Blazor Server prerendering, the DI request scope disposes scoped services at the end of the HTTP request, before an interactive circuit exists. `BrowserViewportService`, `PopoverService`, and `PointerEventsNoneService` issued a JS interop call from `DisposeAsync` unconditionally, which throws a first-chance `InvalidOperationException` ("JavaScript interop calls cannot be issued at this time ... statically rendered"). The call is already swallowed by `InvokeVoidAsyncIgnoreErrors`, so nothing breaks, but a caught exception is still a first-chance exception: it surfaces in the debugger, the Output window, and first-chance logging on every prerendered page (`PopoverService` runs on essentially all of them, since `MudPopoverProvider` is in most layouts).

A `try/catch` cannot quiet this since the throw happens before the catch runs. The only way to remove it is to not make the call when nothing was set up on the JS side. This gates each dispose-time JS call on the service's existing "was JS initialized" signal:

- `BrowserViewportService` / `PointerEventsNoneService`: the JS dispose now runs inside the existing `_dotNet*Lazy.IsValueCreated` guard (it previously sat outside it).
- `PopoverService`: the JS dispose is gated on the existing `IsInitialized` flag.

When the signal is false, no JS listener/module was ever created, so the call is a no-op and is skipped, with no leak. This matches the pattern `KeyInterceptorService` already uses (its dispose only disconnects per active observer, of which there are none during prerender), and the established Blazor approach used by Microsoft's docs and other component libraries.

Added regression tests covering each service: dispose without initialization does not call the JS dispose, and (for `PopoverService`) dispose after initialization still does.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests