### PR TITLE
Tests: Stabilize flaky picker autoclose tests

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutocompleteDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutocompleteDatePickerTest.razor
@@ -1,6 +1,6 @@
 ﻿<MudPopoverProvider />
 
-<MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="_date" AutoClose="AutoClose">
+<MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="_date" AutoClose="AutoClose" ClosingDelay="ClosingDelay">
     <PickerActions>
         <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
         <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
@@ -16,4 +16,8 @@
 
     [Parameter]
     public bool AutoClose { get; set; }
+
+    // Mirrors MudBaseDatePicker.ClosingDelay; tests set 0 to remove the post-commit close timer.
+    [Parameter]
+    public int ClosingDelay { get; set; } = 100;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
@@ -6,6 +6,7 @@
 			   AmPm="AmPm"
 			   TimeEditMode="TimeEditMode"
 			   MinuteSelectionStep="MinuteSelectionStep"
+			   ClosingDelay="ClosingDelay"
 			   InputId="@InputId" />
 
 @code {
@@ -25,6 +26,10 @@
 
 	[Parameter]
     public int MinuteSelectionStep { get; set; } = 1;
+
+	// Mirrors MudTimePicker.ClosingDelay; tests set 0 to remove the post-commit close timer.
+	[Parameter]
+    public int ClosingDelay { get; set; } = 200;
 
 	[Parameter]
 	public string? InputId { get; set; }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -995,22 +995,25 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DatePicker_WithAutoClose_DayClickCommitsAndCloses()
         {
-            var timeProvider = Context.AddFakeTimeProvider();
-            var comp = Context.Render<AutocompleteDatePickerTest>(parameters => parameters.Add(p => p.AutoClose, true));
+            // ClosingDelay = 0 removes the post-commit close timer so the day click commits the value
+            // and closes the popover deterministically, without depending on a timer settling (the commit
+            // runs on a pooled thread, so advancing a fake clock after the commit races the timer and hangs).
+            var comp = Context.Render<AutocompleteDatePickerTest>(parameters => parameters
+                .Add(p => p.AutoClose, true)
+                .Add(p => p.ClosingDelay, 0));
             var datePicker = comp.FindComponent<MudDatePicker>();
 
             await comp.InvokeAsync(datePicker.Instance.OpenAsync);
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
 
-            // AutoClose commits the clicked day, then waits ClosingDelay before closing.
-            // Hold the click task and release the (fake) delay so the close is deterministic.
             // The initial date is the 10th, so committing the 15th is an observable change.
-            var clickTask = comp.SelectDateAsync("15");
-            await comp.WaitForAssertionAsync(() => datePicker.Instance.Date.Should().Be(new DateTime(2025, 6, 15)));
+            await comp.SelectDateAsync("15");
 
-            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(datePicker.Instance.ClosingDelay)));
-            await clickTask;
-            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(0));
+            await comp.WaitForAssertionAsync(() =>
+            {
+                datePicker.Instance.Date.Should().Be(new DateTime(2025, 6, 15));
+                comp.FindAll("div.mud-popover-open").Count.Should().Be(0);
+            });
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -443,40 +443,46 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task OnStickClick_OnMinute_SubmitsAndClosesPicker()
         {
-            var timeProvider = Context.AddFakeTimeProvider();
-            var comp = await OpenPicker(parameters => parameters.Add(x => x.OpenTo, OpenTo.Minutes));
+            // ClosingDelay = 0 removes the post-commit close timer so the minute click commits and closes
+            // deterministically, without depending on a timer settling (advancing a fake clock after the
+            // commit races the timer registration and hangs under CI load).
+            var comp = await OpenPicker(parameters => parameters
+                .Add(x => x.OpenTo, OpenTo.Minutes)
+                .Add(x => x.ClosingDelay, 0));
             var picker = comp.FindComponent<MudTimePicker>().Instance;
 
             await comp.InvokeAsync(() => picker.SelectTimeFromStick(20, false));
 
-            // OnStickClick commits the minute, then waits ClosingDelay before closing.
-            // Hold the task and release the (fake) delay so the close is deterministic.
-            var closeTask = comp.InvokeAsync(() => picker.OnStickClick(20));
-            await comp.WaitForAssertionAsync(() => picker.Time.Should().Be(new TimeSpan(0, 20, 0)));
+            await comp.InvokeAsync(() => picker.OnStickClick(20));
 
-            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(picker.ClosingDelay)));
-            await closeTask;
-            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            await comp.WaitForAssertionAsync(() =>
+            {
+                picker.Time.Should().Be(new TimeSpan(0, 20, 0));
+                comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            });
         }
 
         [Test]
         public async Task OnStickClick_OnHour_InOnlyHoursMode_SubmitsAndCloses()
         {
-            var timeProvider = Context.AddFakeTimeProvider();
+            // OnlyHours mode has nothing left to pick, so the hour click commits and closes. ClosingDelay = 0
+            // removes the post-commit close timer so the close is deterministic, without depending on a timer
+            // settling (advancing a fake clock after the commit races the timer registration and hangs).
             var comp = await OpenPicker(parameters => parameters
                 .Add(x => x.OpenTo, OpenTo.Hours)
-                .Add(x => x.TimeEditMode, TimeEditMode.OnlyHours));
+                .Add(x => x.TimeEditMode, TimeEditMode.OnlyHours)
+                .Add(x => x.ClosingDelay, 0));
             var picker = comp.FindComponent<MudTimePicker>().Instance;
 
             await comp.InvokeAsync(() => picker.SelectTimeFromStick(9, false));
 
-            // OnlyHours mode has nothing left to pick, so the hour click commits and closes after ClosingDelay.
-            var closeTask = comp.InvokeAsync(() => picker.OnStickClick(9));
-            await comp.WaitForAssertionAsync(() => picker.Time.Should().Be(new TimeSpan(9, 0, 0)));
+            await comp.InvokeAsync(() => picker.OnStickClick(9));
 
-            await comp.InvokeAsync(() => timeProvider.Advance(TimeSpan.FromMilliseconds(picker.ClosingDelay)));
-            await closeTask;
-            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            await comp.WaitForAssertionAsync(() =>
+            {
+                picker.Time.Should().Be(new TimeSpan(9, 0, 0));
+                comp.FindAll("div.mud-picker-open").Count.Should().Be(0);
+            });
         }
 
         [Test]


### PR DESCRIPTION
`DatePicker_WithAutoClose_DayClickCommitsAndCloses` and the two TimePicker `OnStickClick` autoclose tests hang under CI load (MTP hang-dump watchdog, exit 137) while passing locally in ~1.5s. This stabilizes them.

`MudDatePicker.OnDayClickedAsync` commits the value on a thread-pool thread (`await Task.Run(() => InvokeAsync(SubmitAsync))`) and only afterward registers the close timer (`await Task.Delay(ClosingDelay, TimeProvider)`). The tests used a `FakeTimeProvider`: they waited for the commit, then called `Advance(ClosingDelay)` and awaited the held click task. Because the commit runs off the dispatcher, the `Advance` can be queued onto the renderer before the `Task.Delay` timer is registered, scheduling the timer past the advanced clock so it never fires and the awaited task hangs forever. It is load-dependent, hence green locally and on re-runs.

Fix by setting `ClosingDelay = 0` so `Task.Delay(TimeSpan.Zero, ...)` returns a completed task with no timer to register or advance. Drop the fake clock, fully await the click (commit + immediate close), and assert the committed value and closed popover via `WaitForAssertion`. A `ClosingDelay` parameter is added to the two test wrappers, defaulting to the component defaults so other tests are unchanged.

The same held-task + advance-after-commit race affected the two TimePicker siblings, so they get the same treatment. A suite-wide sweep found no other tests with this hangable shape (the safe pattern advances then asserts via `WaitForAssertion` without awaiting a held task).
