### PR TITLE
MudDatePicker: Remove unnecessary `Task.Run` from day-click commit

### DIFF
--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -147,7 +147,7 @@ namespace MudBlazor
             _selectedDate = dateTime;
             if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
-                await Task.Run(() => InvokeAsync(SubmitAsync));
+                await SubmitAsync();
 
                 if (PickerVariant != PickerVariant.Static)
                 {


### PR DESCRIPTION
## Summary

Removes a pointless `Task.Run` thread-pool hop from `MudDatePicker.OnDayClickedAsync`. This is the production root cause behind the flaky autoclose test stabilized in #13339.

## Detail

When a day is clicked, the commit was dispatched as:

```csharp
await Task.Run(() => InvokeAsync(SubmitAsync));
```

`OnDayClickedAsync` is an event handler and already runs on the renderer dispatcher, so this hops to a thread-pool thread only to immediately marshal back to the same dispatcher. The detour serves no purpose, and it defers the commit to a later dispatcher cycle — decoupling the value commit from the `await Task.Delay(ClosingDelay, TimeProvider)` close timer that follows it. That decoupling is what made the autoclose unit test hang under CI load (the test advanced a fake clock after the commit, but the timer had not been registered yet).

The two sibling pickers already commit inline with no `Task.Run`:

- `MudDateRangePicker.OnDayClickedAsync` — `await SubmitAsync();`
- `MudTimePicker.SubmitAndCloseAsync` — `await SubmitAsync();`

The `Task.Run` was introduced in #8382 to make a nested DatePicker show the selected date. At that time the code was a fire-and-forget `Submit();`; the actual fix was awaiting the commit, and the thread-pool hop was incidental. `await SubmitAsync()` keeps the await and matches the other pickers. It is also safer on Blazor Server, which never wants component work running off the circuit's synchronization context.

## Verification

- `Display_SelectedDate_WhenWrapped` (the nested scenario #8382 added) passes.
- Full DatePicker, TimePicker and DateRangePicker fixtures (241 tests) pass.

Companion to #13339 (test-side stabilization); this removes the underlying cause.
