### PR TITLE
MudMask: Isolate per-component mask state to fix shared-instance corruption

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -1176,5 +1176,115 @@ namespace MudBlazor.UnitTests.Components
             // The second keystroke must survive the parent Value echo triggered by the first forwarded callback.
             mask.ReadText.Should().Be("(1)2-_)");
         }
+
+        /// <summary>
+        /// Two MudMask components bound to one non-PatternMask instance must not share input state (#7583, #8299).
+        /// </summary>
+        [Test]
+        public async Task SharedMaskInstance_MudMasksAreIndependent()
+        {
+            // Arrange : one mask instance bound to two MudMask components
+            var sharedMask = new RegexMask("^[0-9]+$");
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp1 = Context.Render<MudMask>(parameters => parameters.Add(x => x.Mask, sharedMask));
+            var comp2 = Context.Render<MudMask>(parameters => parameters.Add(x => x.Mask, sharedMask));
+
+            // Act : drive different input into each
+            await comp1.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp1.Instance.ElementId, new KeyboardEventArgs { Key = "1" }));
+            await comp2.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp2.Instance.ElementId, new KeyboardEventArgs { Key = "9" }));
+            await comp1.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp1.Instance.ElementId, new KeyboardEventArgs { Key = "2" }));
+
+            // Assert : the two components hold independent values and own different instances
+            await comp1.WaitForAssertionAsync(() => comp1.Instance.ReadText.Should().Be("12"));
+            await comp2.WaitForAssertionAsync(() => comp2.Instance.ReadText.Should().Be("9"));
+            comp1.Instance.Mask.Should().NotBeSameAs(comp2.Instance.Mask);
+            comp1.Instance.Mask.Should().NotBeSameAs(sharedMask);
+        }
+
+        /// <summary>
+        /// Two MudTextField components bound to one mask instance must not corrupt each other's value (#7583, #8299).
+        /// This is the gap the original fix missed: MudTextField mutated the bound instance directly.
+        /// </summary>
+        [Test]
+        public async Task SharedMaskInstance_TextFieldsAreIndependent()
+        {
+            // Arrange : one mask instance bound to two MudTextField components. MudTextField mutates the mask
+            // directly in SetValueAndUpdateTextAsync/SetTextAndUpdateValueAsync, so without a defensive copy the
+            // value set on one field would leak into the shared instance the other field reads from.
+            var sharedMask = new PatternMask("0000");
+            var comp1 = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.Mask, sharedMask)
+                .Add(x => x.Value, "1111"));
+            var comp2 = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.Mask, sharedMask)
+                .Add(x => x.Value, "2222"));
+
+            // Act : change one field's value
+            await comp1.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, "3333"));
+
+            // Assert : each field owns its own instance, the other field keeps its value, and the caller's instance
+            // was never mutated by either field.
+            comp1.Instance.ReadText.Should().Be("3333");
+            comp2.Instance.ReadText.Should().Be("2222");
+            comp1.Instance.Mask.Should().NotBeSameAs(comp2.Instance.Mask);
+            comp1.Instance.Mask.Should().NotBeSameAs(sharedMask);
+            comp2.Instance.Mask.Should().NotBeSameAs(sharedMask);
+            sharedMask.Text.Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// A masked MudTextField must keep its typed state when the parent re-renders with the same mask instance.
+        /// Verifies the defensive copy does not reset the live mask on every parameter set.
+        /// </summary>
+        [Test]
+        public async Task MaskedTextField_RetainsState_AcrossParentRerender()
+        {
+            // Arrange
+            var mask = new PatternMask("0000");
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.Mask, mask)
+                .Add(x => x.Value, "1234"));
+
+            comp.Instance.ReadText.Should().Be("1234");
+
+            // Act : re-render with the same mask instance and value (a typical parent StateHasChanged)
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Mask, mask));
+
+            // Assert : state survives
+            comp.Instance.ReadText.Should().Be("1234");
+        }
+
+        /// <summary>
+        /// Switching the bound mask to a different type must adopt the new configuration.
+        /// </summary>
+        [Test]
+        public async Task SharedMaskInstance_NonBaseMask_IsAdoptedDirectly()
+        {
+            // Arrange : a third-party IMask that does not derive from BaseMask cannot be safely copied
+            var custom = new PassthroughMask();
+            var comp = Context.Render<MudMask>(parameters => parameters.Add(x => x.Mask, custom));
+
+            // Assert : adopted directly so custom behavior is preserved
+            comp.Instance.Mask.Should().BeSameAs(custom);
+        }
+
+#nullable enable
+        /// <summary>
+        /// A minimal third-party <see cref="IMask"/> for exercising the non-BaseMask adoption path.
+        /// </summary>
+        private sealed class PassthroughMask : IMask
+        {
+            public string? Mask => null;
+            public string? Text { get; private set; }
+            public int CaretPos { get; set; }
+            public (int, int)? Selection { get; set; }
+            public void Insert(string? input) => Text += input;
+            public void Delete() { }
+            public void Backspace() { }
+            public void Clear() => Text = null;
+            public void SetText(string? text) => Text = text;
+            public void UpdateFrom(IMask? mask) { }
+        }
+#nullable restore
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/Mask/BaseMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/BaseMaskTests.cs
@@ -285,4 +285,129 @@ public class BaseMaskTests
         // Assert
         mask.Text.Should().Be(originalText);
     }
+
+    [Test]
+    public void Adopt_StartsEmpty_AndIsIndependentOfOriginal()
+    {
+        // Arrange
+        var original = new RegexMask("^[0-9]+$");
+        original.SetText("123");
+
+        // Act : a different/absent current forces a defensive copy
+        var copy = (RegexMask)BaseMask.Adopt(null, original);
+        copy.SetText("9");
+        original.Insert("4");
+
+        // Assert : the copy starts empty and the two never share state
+        copy.Should().NotBeSameAs(original);
+        copy.Text.Should().Be("9");
+        original.Text.Should().Be("1234");
+    }
+
+    [Test]
+    public void Adopt_SameType_UpdatesInPlace_RetainingState()
+    {
+        // Arrange
+        var current = new PatternMask("0000");
+        current.SetText("12");
+        var incoming = new PatternMask("0000") { Placeholder = '_' };
+
+        // Act
+        var owned = (PatternMask)BaseMask.Adopt(current, incoming);
+
+        // Assert : same instance is reused (typed input retained) and the new config is copied in
+        owned.Should().BeSameAs(current);
+        owned.GetCleanText().Should().Be("12");
+        owned.Placeholder.Should().Be('_');
+    }
+
+    [Test]
+    public void Adopt_PatternMask_PreservesConfiguration()
+    {
+        // Arrange
+        var original = new PatternMask("(000) 000") { Placeholder = '_', CleanDelimiters = true };
+
+        // Act
+        var copy = (PatternMask)BaseMask.Adopt(null, original);
+        copy.SetText("12");
+
+        // Assert : placeholder fills the remaining slots, proving the config survived the copy
+        copy.Placeholder.Should().Be('_');
+        copy.CleanDelimiters.Should().BeTrue();
+        copy.Text.Should().Be("(12_) ___");
+    }
+
+    [Test]
+    public void Adopt_RegexMask_PreservesPattern()
+    {
+        // Arrange
+        var original = new RegexMask("^[0-9]+$");
+
+        // Act
+        var copy = (RegexMask)BaseMask.Adopt(null, original);
+
+        // Assert : the regex still validates (only digits accepted), so _regexPattern was carried via the constructor
+        copy.SetText("12ab34");
+        copy.GetCleanText().Should().Be("1234");
+    }
+
+    [Test]
+    public void Adopt_RegexMask_PreservesAllowOnlyDelimiters()
+    {
+        // Arrange : RegexMask.IPv6 sets AllowOnlyDelimiters, which UpdateFrom must carry over
+        var original = RegexMask.IPv6();
+
+        // Act
+        var copy = (RegexMask)BaseMask.Adopt(null, original);
+
+        // Assert
+        copy.AllowOnlyDelimiters.Should().BeTrue();
+    }
+
+    [Test]
+    public void Adopt_DateMask_PreservesFormat()
+    {
+        // Arrange
+        var original = new DateMask("MM/dd/yyyy");
+
+        // Act
+        var copy = (DateMask)BaseMask.Adopt(null, original);
+        copy.SetText("12312024");
+
+        // Assert : day/month/year alignment still applies, so the date format survived the copy
+        copy.Text.Should().Be("12/31/2024");
+    }
+
+    [Test]
+    public void Adopt_MultiMask_PreservesOptions_AndResetsDetectedOption()
+    {
+        // Arrange
+        var original = new MultiMask("0000 0000 0000 0000",
+            new MaskOption("American Express", "0000 000000 00000", @"^(34|37)"));
+        original.Insert("3712");
+        original.DetectedOption.Should().NotBeNull();
+
+        // Act
+        var copy = (MultiMask)BaseMask.Adopt(null, original);
+
+        // Assert : copy starts with no detected option, but option detection still works
+        copy.DetectedOption.Should().BeNull();
+        copy.Insert("3712");
+        copy.DetectedOption.Should().NotBeNull();
+        copy.Mask.Should().Be("0000 000000 00000");
+    }
+
+    [Test]
+    public void Adopt_BlockMask_PreservesPattern()
+    {
+        // Arrange
+        var original = new BlockMask("-", new Block('0', 1, 4), new Block('a', 1, 4));
+
+        // Act
+        var copy = (BlockMask)BaseMask.Adopt(null, original);
+        copy.SetText("12ab");
+
+        // Assert : the block pattern (digits then letters, '-' delimiter) survived the copy
+        copy.Text.Should().Be("12-ab");
+    }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -466,17 +466,16 @@ namespace MudBlazor
                 return;
             }
 
-            if (_mask.GetType() == other.GetType())
-            {
-                // update mask while retaining current state
-                _mask.UpdateFrom(other);
+            // Resolve the instance this component owns. Same-type masks are updated in place to retain typed state;
+            // a different type yields a fresh defensive copy so two components binding one instance don't corrupt
+            // each other's input state (#7583, #8299).
+            var owned = BaseMask.Adopt(_mask, other);
+            if (ReferenceEquals(owned, _mask))
                 return;
-            }
 
-            // swap masks while retaining text
-            // note: this is required for `BaseMask` instances other than `PatternMask` to work as expected
-            other.SetText(ReadText);
-            _mask = other;
+            // Swapped to a new instance; seed it with the currently displayed text.
+            owned.SetText(ReadText);
+            _mask = owned;
         }
 
         private async Task OnCutAsync()

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -80,7 +80,16 @@ namespace MudBlazor
         public IMask? Mask
         {
             get => _maskReference?.Mask ?? _mask; // this might look strange, but it is absolutely necessary due to how MudMask works.
-            set => _mask = value;
+            set => SetMask(value);
+        }
+
+        // Own a defensive copy of the bound mask instead of storing the caller's instance directly. Otherwise two
+        // text fields (or pickers) bound to one mask would corrupt each other's input state through the direct
+        // SetText calls in SetValueAndUpdateTextAsync/SetTextAndUpdateValueAsync (#7583, #8299). Same-type masks are
+        // updated in place so typed state is retained across re-renders; only a different type yields a fresh copy.
+        private void SetMask(IMask? value)
+        {
+            _mask = value is null ? null : BaseMask.Adopt(_mask, value);
         }
 
         /// <summary>

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BaseMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BaseMask.cs
@@ -172,6 +172,46 @@ public abstract class BaseMask : IMask
         return Delimiters.Contains(maskChar);
     }
 
+    /// <summary>
+    /// Creates an empty mask of the same runtime type, capturing this mask's constructor-supplied configuration.
+    /// </summary>
+    /// <remarks>
+    /// Used to make a defensive copy so that components don't share the mutable per-edit state of a single mask
+    /// instance. <see cref="UpdateFrom"/> is called on the result afterward to copy the remaining configuration.
+    /// </remarks>
+    protected internal abstract BaseMask CreateBlank();
+
+    /// <summary>
+    /// Resolves which mask instance a component should own, given its current mask and an incoming bound mask.
+    /// </summary>
+    /// <param name="current">The mask the component currently owns.</param>
+    /// <param name="incoming">The mask the component was just bound to.</param>
+    /// <returns>
+    /// The instance the component should own. When <paramref name="incoming"/> is the same runtime type as a
+    /// non-null <paramref name="current"/>, the current instance is updated in place and returned so typed input is
+    /// retained across re-renders. Otherwise a fresh defensive copy is returned so two components bound to one
+    /// instance never share mutable per-edit state (#7583, #8299). A third-party <see cref="IMask"/> that does not
+    /// derive from <see cref="BaseMask"/> cannot be safely copied and is adopted directly; such implementations
+    /// should derive from <see cref="BaseMask"/> to be shareable across components.
+    /// </returns>
+    internal static IMask Adopt(IMask? current, IMask incoming)
+    {
+        if (current is not null && current.GetType() == incoming.GetType())
+        {
+            current.UpdateFrom(incoming);
+            return current;
+        }
+
+        if (incoming is BaseMask baseMask)
+        {
+            var copy = baseMask.CreateBlank();
+            copy.UpdateFrom(baseMask);
+            return copy;
+        }
+
+        return incoming;
+    }
+
     /// <inheritdoc />
     public virtual void UpdateFrom(IMask? mask)
     {
@@ -189,6 +229,8 @@ public abstract class BaseMask : IMask
                 _maskChars = baseMask.MaskChars;
                 _initialized = false;
             }
+
+            AllowOnlyDelimiters = baseMask.AllowOnlyDelimiters;
 
             Refresh();
         }

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
@@ -157,6 +157,9 @@ public class BlockMask : RegexMask
     }
 
     /// <inheritdoc />
+    protected internal override BaseMask CreateBlank() => new BlockMask(Blocks ?? []);
+
+    /// <inheritdoc />
     public override void UpdateFrom(IMask? mask)
     {
         base.UpdateFrom(mask);

--- a/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
@@ -248,6 +248,9 @@ public partial class DateMask : PatternMask
     }
 
     /// <inheritdoc />
+    protected internal override BaseMask CreateBlank() => new DateMask(Mask ?? string.Empty);
+
+    /// <inheritdoc />
     public override void UpdateFrom(IMask? mask)
     {
         base.UpdateFrom(mask);

--- a/src/MudBlazor/Utilities/MaskAlgorithms/MultiMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/MultiMask.cs
@@ -121,6 +121,9 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
+        protected internal override BaseMask CreateBlank() => new MultiMask(_defaultMask, _options);
+
+        /// <inheritdoc />
         public override void UpdateFrom(IMask? mask)
         {
             base.UpdateFrom(mask);

--- a/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
@@ -290,6 +290,9 @@ public class PatternMask : BaseMask
     }
 
     /// <inheritdoc />
+    protected internal override BaseMask CreateBlank() => new PatternMask(Mask ?? string.Empty);
+
+    /// <inheritdoc />
     public override void UpdateFrom(IMask? mask)
     {
         base.UpdateFrom(mask);

--- a/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
@@ -190,6 +190,10 @@ public class RegexMask : BaseMask
     }
 
     /// <inheritdoc />
+    // Pass _regexPattern through the constructor because UpdateFrom does not copy it.
+    protected internal override BaseMask CreateBlank() => new RegexMask(_regexPattern, Mask);
+
+    /// <inheritdoc />
     public override void UpdateFrom(IMask? other)
     {
         base.UpdateFrom(other);


### PR DESCRIPTION
Binding one `IMask` instance to multiple components (or reusing a `Mask` variable, #8299) corrupted input, because a mask holds mutable per-edit state (`Text`/`CaretPos`/`Selection`, plus `DateMask` date parts and `MultiMask.DetectedOption`). `MudMask.SetMask`'s cross-type branch stored the caller's instance (`_mask = other`), so two components shared one mutable buffer. `MudTextField` had the same problem on its own `_mask`, which it mutates directly outside `SetMask`.

Fix: each component owns its mask instance.

- `BaseMask` gains an abstract `CreateBlank()` — a one-line override per subtype that returns a fresh instance of the same type.
- An internal `BaseMask.Adopt(current, incoming)` helper returns a component-owned mask: same runtime type as the current one -> in-place `UpdateFrom` (retains typed state across re-renders); different type -> `CreateBlank()` + `UpdateFrom` (fresh owned copy); a non-`BaseMask` custom `IMask` -> used as-is (derive from `BaseMask` for safe sharing).
- `MudMask.SetMask` and `MudTextField`'s `Mask` setter both route through `Adopt`, so the caller's instance is never mutated.

`UpdateFrom` is now a complete config copy: added `AllowOnlyDelimiters` (used by `RegexMask.IPv6()`), which nothing copied before.

This replaces the earlier `IMask.Clone()` approach: no new interface member, no `MemberwiseClone`, and no per-field state-reset list — a fresh instance is blank by construction and configuration flows through the existing `UpdateFrom`. `CreateBlank` is `abstract`, so the compiler forces every subtype to provide it.

Closes #7583
Closes #8299
