### PR TITLE
Docs: Document the RegexMask partial-match requirement

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskProgressiveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskProgressiveExample.razor
@@ -1,0 +1,24 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudGrid Class="justify-space-between" Style="max-width: 800px;">
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@blocked" Label="Blocks input: ^[0-9]{5}$"
+                      HelperText="Exact length {5} never matches a shorter prefix, so every keystroke is rejected."
+                      @bind-Value="a" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@works" Label="Accepts input: ^[0-9]{0,5}$"
+                      HelperText="Bounded-from-zero matches every prefix, so up to 5 digits can be typed."
+                      @bind-Value="b" Variant="@Variant.Text" Clearable />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public string a, b;
+
+    // Blocks all input: prefixes "1", "12" do not match ^[0-9]{5}$
+    public IMask blocked = new RegexMask(@"^[0-9]{5}$");
+
+    // Works: every prefix ("", "1", ... "12345") matches ^[0-9]{0,5}$
+    public IMask works = new RegexMask(@"^[0-9]{0,5}$");
+}

--- a/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
@@ -98,6 +98,27 @@
             </SectionContent>
             <SectionSubGroups>
                 <DocsPageSection>
+                    <SectionHeader Title="Writing a progressive regex">
+                        <Description>
+                            <CodeInline>RegexMask</CodeInline> validates input as it grows, one character at a time, so your
+                            expression must match <b>every partial input</b> — the empty string, then <CodeInline>1</CodeInline>,
+                            then <CodeInline>12</CodeInline>, and so on. If a prefix doesn't match, that keystroke is rejected,
+                            which is the most common cause of a mask that appears to block all input.
+                            <br /><br />
+                            Avoid exact (<CodeInline>{5}</CodeInline>) and lower-bounded (<CodeInline>{6,14}</CodeInline>)
+                            quantifiers, which never match shorter prefixes. Use open-ended or zero-bounded quantifiers instead:
+                            <ul>
+                                <li><CodeInline>^[0-9]{5}$</CodeInline> blocks input → use <CodeInline>^[0-9]{0,5}$</CodeInline></li>
+                                <li><CodeInline>^\+[0-9]{6,14}$</CodeInline> blocks input → use <CodeInline>^\+?[0-9]{0,14}$</CodeInline></li>
+                            </ul>
+                            The left field below won't accept any input; the right field accepts up to five digits.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(RegexMaskProgressiveExample)" ShowCode="false">
+                        <RegexMaskProgressiveExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
                     <SectionHeader Title="RegexMask.IPv4">
                         <Description>
                             <CodeInline>RegexMask.IPv4()</CodeInline> is a predefined <CodeInline>RegexMask</CodeInline> for an <b>IPv4</b> Address with or without port masking. 

--- a/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
@@ -39,7 +39,7 @@ public class RegexMask : BaseMask
     /// <param name="regex">The regular expression used to validate inputs.  Must begin with <c>^</c> and end with <c>$</c>.</param>
     /// <param name="mask">The structure of the accepted input.  When <c>null</c>, the regular expression is used for the mask.</param>
     /// <remarks>
-    /// The regular expression must be able to match partial inputs, must begin with <c>^</c>, and must end with <c>$</c> to work properly (e.g. <c>^[0-9]+$</c>).<br />
+    /// The regular expression must be able to match partial inputs, must begin with <c>^</c>, and must end with <c>$</c> to work properly (e.g. <c>^[0-9]+$</c>). Use open-ended quantifiers like <c>^[0-9]{0,5}$</c>, not exact ones like <c>^[0-9]{5}$</c>, which never match a shorter prefix and block all input.<br />
     /// Consider using <see cref="BlockMask"/> to generate the regular expression automatically.
     /// </remarks>
     public RegexMask(string regex, string? mask = null)


### PR DESCRIPTION
RegexMask validates input prefix-by-prefix as it grows, so the regular expression must match every partial input — the empty string, then the first character, then the first two, and so on. A non-progressive quantifier such as `{5}` or `{6,14}` never matches a shorter prefix, so every keystroke is rejected and the mask silently blocks all input. This is a common footgun.

This PR documents the requirement:

- Adds a runnable progressive-vs-non-progressive example (`RegexMaskProgressiveExample.razor`): a left field with `^[0-9]{5}$` that accepts nothing, next to a right field with `^[0-9]{0,5}$` that accepts up to five digits.
- Adds a "Writing a progressive regex" section to the masking docs explaining the prefix-matching rule and how to convert exact/lower-bounded quantifiers to open-ended or zero-bounded ones.
- Clarifies the `RegexMask` constructor XML-doc remark to call out open-ended vs exact quantifiers.

Addresses the recurring confusion in #4840, #8993, and the zip+4 portion of #3937.