### PR TITLE
Docs: Refresh SubTitle after navigation

### DIFF
--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor
@@ -4,11 +4,11 @@
     <meta Name="keywords" Content="@GetKeywords()" />
     <meta Property="og:title" Content="@GetTitle()" />
     <meta Name="twitter:title" Content="@GetTitle()" />
-    @if (!string.IsNullOrEmpty(SubTitle))
+    @if (!string.IsNullOrEmpty(ComputedSubTitle))
     {
-        <meta Name="description" Content="@SubTitle" />
-        <meta Property="og:description" Content="@SubTitle" />
-        <meta Name="twitter:description" Content="@SubTitle" />
+        <meta Name="description" Content="@ComputedSubTitle" />
+        <meta Property="og:description" Content="@ComputedSubTitle" />
+        <meta Name="twitter:description" Content="@ComputedSubTitle" />
     }
     <link rel="canonical" href="@GetCanonicalUri()" />
 </HeadContent>

--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor.cs
@@ -58,6 +58,7 @@ public sealed partial class DocsPageHeader
     /// </summary>
     [Parameter]
     public string SubTitle { get; set; }
+    private string ComputedSubTitle { get; set; }
 
     /// <summary>
     /// The description of this page.
@@ -93,11 +94,19 @@ public sealed partial class DocsPageHeader
             DocumentedType = ApiDocumentation.GetType(Component);
             // Look for an example page for this type
             Example = DocumentedType == null ? null : MenuService.GetExample(DocumentedType);
-            // If there is no subtitle set, but we have a component summary, use the component summary
-            if (string.IsNullOrEmpty(SubTitle) && !string.IsNullOrEmpty(DocumentedType.Summary))
-            {
-                SubTitle = DocumentedType.Summary;
-            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(SubTitle))
+        {
+            ComputedSubTitle = SubTitle;
+        }
+        else if (!string.IsNullOrEmpty(DocumentedType.Summary))
+        {
+            ComputedSubTitle = DocumentedType.Summary;
+        }
+        else
+        {
+            ComputedSubTitle = "";
         }
     }
 
@@ -112,9 +121,9 @@ public sealed partial class DocsPageHeader
     /// <returns></returns>
     private string GetSubTitle()
     {
-        if (string.IsNullOrEmpty(SubTitle))
+        if (string.IsNullOrEmpty(ComputedSubTitle))
             return "";
-        return SubTitle.TrimEnd('.') + ".";
+        return ComputedSubTitle.TrimEnd('.') + ".";
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor.cs
@@ -100,7 +100,7 @@ public sealed partial class DocsPageHeader
         {
             ComputedSubTitle = SubTitle;
         }
-        else if (!string.IsNullOrEmpty(DocumentedType.Summary))
+        else if (!string.IsNullOrWhiteSpace(DocumentedType.Summary))
         {
             ComputedSubTitle = DocumentedType.Summary;
         }

--- a/src/MudBlazor.Docs/Components/DocsPageHeader.razor.cs
+++ b/src/MudBlazor.Docs/Components/DocsPageHeader.razor.cs
@@ -100,7 +100,7 @@ public sealed partial class DocsPageHeader
         {
             ComputedSubTitle = SubTitle;
         }
-        else if (!string.IsNullOrWhiteSpace(DocumentedType.Summary))
+        else if (DocumentedType != null && !string.IsNullOrWhiteSpace(DocumentedType.Summary))
         {
             ComputedSubTitle = DocumentedType.Summary;
         }


### PR DESCRIPTION
Closes #13302

As Claude suggested in the issue, an elegant fix is to add a new field which recomputes the subtitle when the parameters change. 
Previously the logic was setting the SubTitle directly which made it impossible to tell on the second render if the parameter was actually supplied or if we just set it in the previous render.

I was in the process of adding a unit tests for this but it seems like the tests for the documentation part aren't that well developed so i had a bit of trouble setting one up (rendering DocsPageHeader also renders a DocsPageSection which then expectes a DocsPage as a cascading parameter and it breaks)..

https://github.com/user-attachments/assets/12ccf637-ce4a-4b46-9020-6f9890d61009

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project