### PR TITLE
Tests: Strengthen Extensions unit test coverage

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/ConverterExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ConverterExtensionsTests.cs
@@ -23,7 +23,6 @@ public class ConverterExtensionsTests
         res.Value.Should().Be("5");
         res.ExceptionError.Should().BeNull();
         res.ErrorMessageKey.Should().BeNull();
-        res.ErrorMessageArgs.Should().BeEmpty();
     }
 
     [Test]
@@ -72,19 +71,6 @@ public class ConverterExtensionsTests
         res.Success.Should().BeFalse();
         res.ExceptionError.Should().BeOfType<InvalidOperationException>();
         res.ErrorMessageKey.Should().BeNull();
-        res.ErrorMessageArgs.Should().BeEmpty();
-    }
-
-    [Test]
-    public void TryConvert_AggregateExceptionWithoutConversionException_IsCapturedAsGenericFailure()
-    {
-        var conv = new ThrowAggregateWithoutConversionExceptionConverter();
-        var res = conv.TryConvert(1);
-
-        res.Success.Should().BeFalse();
-        res.ExceptionError.Should().BeOfType<AggregateException>();
-        res.ErrorMessageKey.Should().BeNull();
-        res.ErrorMessageArgs.Should().BeEmpty();
     }
 
     [Test]
@@ -183,11 +169,6 @@ public class ConverterExtensionsTests
     private sealed class ThrowAggregateWithConversionExceptionConverter : IConverter<int, string>
     {
         public string Convert(int input) => throw new AggregateException(new ConversionException("AGG_KEY", ["x", 2]));
-    }
-
-    private sealed class ThrowAggregateWithoutConversionExceptionConverter : IConverter<int, string>
-    {
-        public string Convert(int input) => throw new AggregateException(new InvalidOperationException("a"), new FormatException("b"));
     }
 
     private sealed class ThrowUnknownExceptionConverter : IConverter<int, string>

--- a/src/MudBlazor.UnitTests/Extensions/ConverterExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ConverterExtensionsTests.cs
@@ -88,17 +88,6 @@ public class ConverterExtensionsTests
     }
 
     [Test]
-    public void TryConvert_AggregateExceptionWithMultipleConversionExceptions_CapturesFirst()
-    {
-        var conv = new ThrowAggregateWithMultipleConversionExceptionsConverter();
-        var res = conv.TryConvert(1);
-
-        res.Success.Should().BeFalse();
-        res.ExceptionError.Should().BeOfType<ConversionException>();
-        res.ErrorMessageKey.Should().Be("FIRST_KEY");
-    }
-
-    [Test]
     public void TryConvertBack_OnReversibleConverter_Works()
     {
         var rev = new ReversibleIntString();
@@ -199,11 +188,6 @@ public class ConverterExtensionsTests
     private sealed class ThrowAggregateWithoutConversionExceptionConverter : IConverter<int, string>
     {
         public string Convert(int input) => throw new AggregateException(new InvalidOperationException("a"), new FormatException("b"));
-    }
-
-    private sealed class ThrowAggregateWithMultipleConversionExceptionsConverter : IConverter<int, string>
-    {
-        public string Convert(int input) => throw new AggregateException(new ConversionException("FIRST_KEY"), new ConversionException("SECOND_KEY"));
     }
 
     private sealed class ThrowUnknownExceptionConverter : IConverter<int, string>

--- a/src/MudBlazor.UnitTests/Extensions/ConverterExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ConverterExtensionsTests.cs
@@ -23,6 +23,7 @@ public class ConverterExtensionsTests
         res.Value.Should().Be("5");
         res.ExceptionError.Should().BeNull();
         res.ErrorMessageKey.Should().BeNull();
+        res.ErrorMessageArgs.Should().BeEmpty();
     }
 
     [Test]
@@ -71,6 +72,30 @@ public class ConverterExtensionsTests
         res.Success.Should().BeFalse();
         res.ExceptionError.Should().BeOfType<InvalidOperationException>();
         res.ErrorMessageKey.Should().BeNull();
+        res.ErrorMessageArgs.Should().BeEmpty();
+    }
+
+    [Test]
+    public void TryConvert_AggregateExceptionWithoutConversionException_IsCapturedAsGenericFailure()
+    {
+        var conv = new ThrowAggregateWithoutConversionExceptionConverter();
+        var res = conv.TryConvert(1);
+
+        res.Success.Should().BeFalse();
+        res.ExceptionError.Should().BeOfType<AggregateException>();
+        res.ErrorMessageKey.Should().BeNull();
+        res.ErrorMessageArgs.Should().BeEmpty();
+    }
+
+    [Test]
+    public void TryConvert_AggregateExceptionWithMultipleConversionExceptions_CapturesFirst()
+    {
+        var conv = new ThrowAggregateWithMultipleConversionExceptionsConverter();
+        var res = conv.TryConvert(1);
+
+        res.Success.Should().BeFalse();
+        res.ExceptionError.Should().BeOfType<ConversionException>();
+        res.ErrorMessageKey.Should().Be("FIRST_KEY");
     }
 
     [Test]
@@ -92,6 +117,30 @@ public class ConverterExtensionsTests
 
         res.Success.Should().BeTrue();
         res.Value.Should().Be(101);
+    }
+
+    [Test]
+    public void TryConvertBack_OnReversible_WhenConvertBackThrowsConversionException_IsCaptured()
+    {
+        var rev = new ThrowOnConvertBackConverter();
+        var res = rev.TryConvertBack("anything");
+
+        res.Success.Should().BeFalse();
+        res.ExceptionError.Should().BeOfType<ConversionException>();
+        res.ErrorMessageKey.Should().Be("BACK_KEY");
+        res.ErrorMessageArgs.Should().Contain("b");
+    }
+
+    [Test]
+    public void TryConvertBack_OnNonReversibleIConverter_CapturesInvalidOperationException()
+    {
+        // The IConverter overload routes through the ConvertBack extension, which throws for non-reversible converters.
+        IConverter<int, string> conv = new NoBackwardConverter();
+        var res = conv.TryConvertBack("test");
+
+        res.Success.Should().BeFalse();
+        res.ExceptionError.Should().BeOfType<InvalidOperationException>();
+        res.ErrorMessageKey.Should().BeNull();
     }
 
     [Test]
@@ -147,6 +196,16 @@ public class ConverterExtensionsTests
         public string Convert(int input) => throw new AggregateException(new ConversionException("AGG_KEY", ["x", 2]));
     }
 
+    private sealed class ThrowAggregateWithoutConversionExceptionConverter : IConverter<int, string>
+    {
+        public string Convert(int input) => throw new AggregateException(new InvalidOperationException("a"), new FormatException("b"));
+    }
+
+    private sealed class ThrowAggregateWithMultipleConversionExceptionsConverter : IConverter<int, string>
+    {
+        public string Convert(int input) => throw new AggregateException(new ConversionException("FIRST_KEY"), new ConversionException("SECOND_KEY"));
+    }
+
     private sealed class ThrowUnknownExceptionConverter : IConverter<int, string>
     {
         public string Convert(int input) => throw new InvalidOperationException("boom");
@@ -156,6 +215,12 @@ public class ConverterExtensionsTests
     {
         public string Convert(int input) => (input + 100).ToString();
         public int ConvertBack(string input) => int.Parse(input) - 100;
+    }
+
+    private sealed class ThrowOnConvertBackConverter : IReversibleConverter<int, string>
+    {
+        public string Convert(int input) => input.ToString();
+        public int ConvertBack(string input) => throw new ConversionException("BACK_KEY", ["b"]);
     }
 
     private sealed class NoBackwardConverter : IConverter<int, string>

--- a/src/MudBlazor.UnitTests/Extensions/DataGridExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DataGridExtensionsTests.cs
@@ -127,5 +127,69 @@ namespace MudBlazor.UnitTests.Extensions
             var result = source.OrderBySortDefinitions(vstate).ToList();
             result.Select(x => x.Name).Should().ContainInOrder("Alpha", "Beta");
         }
+
+        [Test]
+        public void OrderBy_IReadOnlyCollection_NoDefinitions_ReturnsOriginalOrder()
+        {
+            var p1 = new Person { Name = "B", Age = 2 };
+            var p2 = new Person { Name = "A", Age = 1 };
+            var source = new[] { p1, p2 };
+            IReadOnlyCollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>();
+            var result = source.OrderBySortDefinitions(sortDefs);
+            result.Should().Equal(source);
+        }
+
+        [Test]
+        public void OrderBy_SingleDefinition_CustomComparer_IsApplied()
+        {
+            // Comparer orders by string length; alphabetical order would give "a","mmm","zz".
+            var byNameLength = Comparer<object>.Create((a, b) => ((string)a!).Length.CompareTo(((string)b!).Length));
+            var p1 = new Person { Name = "mmm", Age = 1 };
+            var p2 = new Person { Name = "a", Age = 2 };
+            var p3 = new Person { Name = "zz", Age = 3 };
+            var source = new[] { p1, p2, p3 };
+            ICollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>
+            {
+                new SortDefinition<Person>("Name", false, 0, p => p.Name, byNameLength)
+            };
+            var result = source.OrderBySortDefinitions(sortDefs).ToList();
+            result.Select(x => x.Name).Should().ContainInOrder("a", "zz", "mmm");
+        }
+
+        [Test]
+        public void OrderBy_SingleDefinitionDescending_CustomComparer_IsApplied()
+        {
+            // Descending by length; alphabetical descending would give "zz","mmm","a".
+            var byNameLength = Comparer<object>.Create((a, b) => ((string)a!).Length.CompareTo(((string)b!).Length));
+            var p1 = new Person { Name = "a", Age = 1 };
+            var p2 = new Person { Name = "mmm", Age = 2 };
+            var p3 = new Person { Name = "zz", Age = 3 };
+            var source = new[] { p1, p2, p3 };
+            ICollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>
+            {
+                new SortDefinition<Person>("Name", true, 0, p => p.Name, byNameLength)
+            };
+            var result = source.OrderBySortDefinitions(sortDefs).ToList();
+            result.Select(x => x.Name).Should().ContainInOrder("mmm", "zz", "a");
+        }
+
+        [Test]
+        public void OrderBy_SecondDefinition_CustomComparer_IsAppliedToThenBy()
+        {
+            // All ages equal, so the length-based comparer on the ThenBy decides order;
+            // alphabetical ThenBy would give "a","mmm","zz".
+            var byNameLength = Comparer<object>.Create((a, b) => ((string)a!).Length.CompareTo(((string)b!).Length));
+            var p1 = new Person { Name = "mmm", Age = 10 };
+            var p2 = new Person { Name = "a", Age = 10 };
+            var p3 = new Person { Name = "zz", Age = 10 };
+            var source = new[] { p1, p2, p3 };
+            ICollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>
+            {
+                ByAge(),
+                new SortDefinition<Person>("Name", false, 0, p => p.Name, byNameLength)
+            };
+            var result = source.OrderBySortDefinitions(sortDefs).ToList();
+            result.Select(x => x.Name).Should().ContainInOrder("a", "zz", "mmm");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/DataGridExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DataGridExtensionsTests.cs
@@ -144,24 +144,5 @@ namespace MudBlazor.UnitTests.Extensions
             var result = source.OrderBySortDefinitions(sortDefs).ToList();
             result.Select(x => x.Name).Should().ContainInOrder("a", "zz", "mmm");
         }
-
-        [Test]
-        public void OrderBy_SecondDefinition_CustomComparer_IsAppliedToThenBy()
-        {
-            // All ages equal, so the length-based comparer on the ThenBy decides order;
-            // alphabetical ThenBy would give "a","mmm","zz".
-            var byNameLength = Comparer<object>.Create((a, b) => ((string)a!).Length.CompareTo(((string)b!).Length));
-            var p1 = new Person { Name = "mmm", Age = 10 };
-            var p2 = new Person { Name = "a", Age = 10 };
-            var p3 = new Person { Name = "zz", Age = 10 };
-            var source = new[] { p1, p2, p3 };
-            ICollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>
-            {
-                ByAge(),
-                new SortDefinition<Person>("Name", false, 0, p => p.Name, byNameLength)
-            };
-            var result = source.OrderBySortDefinitions(sortDefs).ToList();
-            result.Select(x => x.Name).Should().ContainInOrder("a", "zz", "mmm");
-        }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/DataGridExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DataGridExtensionsTests.cs
@@ -129,17 +129,6 @@ namespace MudBlazor.UnitTests.Extensions
         }
 
         [Test]
-        public void OrderBy_IReadOnlyCollection_NoDefinitions_ReturnsOriginalOrder()
-        {
-            var p1 = new Person { Name = "B", Age = 2 };
-            var p2 = new Person { Name = "A", Age = 1 };
-            var source = new[] { p1, p2 };
-            IReadOnlyCollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>();
-            var result = source.OrderBySortDefinitions(sortDefs);
-            result.Should().Equal(source);
-        }
-
-        [Test]
         public void OrderBy_SingleDefinition_CustomComparer_IsApplied()
         {
             // Comparer orders by string length; alphabetical order would give "a","mmm","zz".
@@ -154,23 +143,6 @@ namespace MudBlazor.UnitTests.Extensions
             };
             var result = source.OrderBySortDefinitions(sortDefs).ToList();
             result.Select(x => x.Name).Should().ContainInOrder("a", "zz", "mmm");
-        }
-
-        [Test]
-        public void OrderBy_SingleDefinitionDescending_CustomComparer_IsApplied()
-        {
-            // Descending by length; alphabetical descending would give "zz","mmm","a".
-            var byNameLength = Comparer<object>.Create((a, b) => ((string)a!).Length.CompareTo(((string)b!).Length));
-            var p1 = new Person { Name = "a", Age = 1 };
-            var p2 = new Person { Name = "mmm", Age = 2 };
-            var p3 = new Person { Name = "zz", Age = 3 };
-            var source = new[] { p1, p2, p3 };
-            ICollection<SortDefinition<Person>> sortDefs = new List<SortDefinition<Person>>
-            {
-                new SortDefinition<Person>("Name", true, 0, p => p.Name, byNameLength)
-            };
-            var result = source.OrderBySortDefinitions(sortDefs).ToList();
-            result.Select(x => x.Name).Should().ContainInOrder("mmm", "zz", "a");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
@@ -53,6 +53,19 @@ public class DateTimeExtensionTests
     }
 
     [Test]
+    public void ToIsoDateString_ShouldZeroPad_WhenComponentsAreSingleDigit()
+    {
+        // Arrange
+        var dateTime = new DateTime(7, 1, 9); // Year 7, January 9th.
+
+        // Act
+        var result = dateTime.ToIsoDateString();
+
+        // Assert
+        result.Should().Be("0007-01-09");
+    }
+
+    [Test]
     public void StartOfMonth_ShouldReturnFirstDayOfMonth()
     {
         // Arrange
@@ -78,6 +91,68 @@ public class DateTimeExtensionTests
 
         // Assert
         result.Should().Be(new DateTime(2023, 10, 31));
+    }
+
+    [Test]
+    public void EndOfMonth_ShouldReturn29Days_ForFebruaryInLeapYear()
+    {
+        // Arrange
+        var dateTime = new DateTime(2024, 2, 10); // 2024 is a leap year.
+        var culture = CultureInfo.InvariantCulture;
+
+        // Act
+        var result = dateTime.EndOfMonth(culture);
+
+        // Assert
+        result.Should().Be(new DateTime(2024, 2, 29));
+    }
+
+    [Test]
+    public void EndOfMonth_ShouldReturn28Days_ForFebruaryInNonLeapYear()
+    {
+        // Arrange
+        var dateTime = new DateTime(2023, 2, 10); // 2023 is not a leap year.
+        var culture = CultureInfo.InvariantCulture;
+
+        // Act
+        var result = dateTime.EndOfMonth(culture);
+
+        // Assert
+        result.Should().Be(new DateTime(2023, 2, 28));
+    }
+
+    [Test]
+    public void StartOfMonth_ShouldUseCultureCalendar_WhenNotGregorian()
+    {
+        // Arrange
+        var culture = new CultureInfo("fa-IR"); // Uses the Persian calendar.
+        var dateTime = new DateTime(2021, 2, 14); // Mid-month in the Persian calendar (Bahman 1399).
+
+        // Act
+        var result = dateTime.StartOfMonth(culture);
+
+        // Assert: result is the first day of the Persian month, not the Gregorian month.
+        culture.Calendar.GetDayOfMonth(result).Should().Be(1);
+        result.Should().NotBe(new DateTime(2021, 2, 1)); // A Gregorian start-of-month would land here.
+        result.Should().BeBefore(dateTime); // Persian Bahman begins in January, before this date.
+    }
+
+    [Test]
+    public void EndOfMonth_ShouldUseCultureCalendar_WhenNotGregorian()
+    {
+        // Arrange
+        var culture = new CultureInfo("fa-IR"); // Uses the Persian calendar.
+        var dateTime = new DateTime(2021, 2, 14); // Mid-month in the Persian calendar (Bahman 1399).
+
+        // Act
+        var result = dateTime.EndOfMonth(culture);
+
+        // Assert: result is the last day of the Persian month, not the Gregorian month.
+        var year = culture.Calendar.GetYear(result);
+        var month = culture.Calendar.GetMonth(result);
+        culture.Calendar.GetDayOfMonth(result).Should().Be(culture.Calendar.GetDaysInMonth(year, month));
+        result.Should().NotBe(new DateTime(2021, 2, 28)); // A Gregorian end-of-month would land here.
+        result.Should().BeAfter(dateTime); // Persian Bahman ends in February, after this date.
     }
 
     [Test]
@@ -137,6 +212,20 @@ public class DateTimeExtensionTests
     }
 
     [Test]
+    public void LastWeekDayOfMonth_ShouldReturnLastDay_WhenItMatchesTargetDay()
+    {
+        // Arrange: October 2023 ends on Tuesday the 31st, so no loop iterations are needed.
+        var dateTime = new DateTime(2023, 10, 15);
+        var culture = CultureInfo.InvariantCulture;
+
+        // Act
+        var result = dateTime.LastWeekDayOfMonth(DayOfWeek.Tuesday, culture);
+
+        // Assert
+        result.Should().Be(new DateTime(2023, 10, 31));
+    }
+
+    [Test]
     public void FirstWeekDayOfMonth_ShouldReturnFirstWeekDayOfMonth()
     {
         // Arrange
@@ -148,5 +237,19 @@ public class DateTimeExtensionTests
 
         // Assert
         result.Should().Be(new DateTime(2023, 9, 4)); // September 4, 2023 (Monday)
+    }
+
+    [Test]
+    public void FirstWeekDayOfMonth_ShouldReturnFirstDay_WhenItMatchesTargetDay()
+    {
+        // Arrange: October 2023 starts on Sunday the 1st, so no loop iterations are needed.
+        var dateTime = new DateTime(2023, 10, 15);
+        var culture = CultureInfo.InvariantCulture;
+
+        // Act
+        var result = dateTime.FirstWeekDayOfMonth(DayOfWeek.Sunday, culture);
+
+        // Assert
+        result.Should().Be(new DateTime(2023, 10, 1));
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
@@ -108,20 +108,6 @@ public class DateTimeExtensionTests
     }
 
     [Test]
-    public void EndOfMonth_ShouldReturn28Days_ForFebruaryInNonLeapYear()
-    {
-        // Arrange
-        var dateTime = new DateTime(2023, 2, 10); // 2023 is not a leap year.
-        var culture = CultureInfo.InvariantCulture;
-
-        // Act
-        var result = dateTime.EndOfMonth(culture);
-
-        // Assert
-        result.Should().Be(new DateTime(2023, 2, 28));
-    }
-
-    [Test]
     public void StartOfMonth_ShouldUseCultureCalendar_WhenNotGregorian()
     {
         // Arrange
@@ -212,20 +198,6 @@ public class DateTimeExtensionTests
     }
 
     [Test]
-    public void LastWeekDayOfMonth_ShouldReturnLastDay_WhenItMatchesTargetDay()
-    {
-        // Arrange: October 2023 ends on Tuesday the 31st, so no loop iterations are needed.
-        var dateTime = new DateTime(2023, 10, 15);
-        var culture = CultureInfo.InvariantCulture;
-
-        // Act
-        var result = dateTime.LastWeekDayOfMonth(DayOfWeek.Tuesday, culture);
-
-        // Assert
-        result.Should().Be(new DateTime(2023, 10, 31));
-    }
-
-    [Test]
     public void FirstWeekDayOfMonth_ShouldReturnFirstWeekDayOfMonth()
     {
         // Arrange
@@ -237,19 +209,5 @@ public class DateTimeExtensionTests
 
         // Assert
         result.Should().Be(new DateTime(2023, 9, 4)); // September 4, 2023 (Monday)
-    }
-
-    [Test]
-    public void FirstWeekDayOfMonth_ShouldReturnFirstDay_WhenItMatchesTargetDay()
-    {
-        // Arrange: October 2023 starts on Sunday the 1st, so no loop iterations are needed.
-        var dateTime = new DateTime(2023, 10, 15);
-        var culture = CultureInfo.InvariantCulture;
-
-        // Act
-        var result = dateTime.FirstWeekDayOfMonth(DayOfWeek.Sunday, culture);
-
-        // Assert
-        result.Should().Be(new DateTime(2023, 10, 1));
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/DateTimeExtensionTests.cs
@@ -108,40 +108,6 @@ public class DateTimeExtensionTests
     }
 
     [Test]
-    public void StartOfMonth_ShouldUseCultureCalendar_WhenNotGregorian()
-    {
-        // Arrange
-        var culture = new CultureInfo("fa-IR"); // Uses the Persian calendar.
-        var dateTime = new DateTime(2021, 2, 14); // Mid-month in the Persian calendar (Bahman 1399).
-
-        // Act
-        var result = dateTime.StartOfMonth(culture);
-
-        // Assert: result is the first day of the Persian month, not the Gregorian month.
-        culture.Calendar.GetDayOfMonth(result).Should().Be(1);
-        result.Should().NotBe(new DateTime(2021, 2, 1)); // A Gregorian start-of-month would land here.
-        result.Should().BeBefore(dateTime); // Persian Bahman begins in January, before this date.
-    }
-
-    [Test]
-    public void EndOfMonth_ShouldUseCultureCalendar_WhenNotGregorian()
-    {
-        // Arrange
-        var culture = new CultureInfo("fa-IR"); // Uses the Persian calendar.
-        var dateTime = new DateTime(2021, 2, 14); // Mid-month in the Persian calendar (Bahman 1399).
-
-        // Act
-        var result = dateTime.EndOfMonth(culture);
-
-        // Assert: result is the last day of the Persian month, not the Gregorian month.
-        var year = culture.Calendar.GetYear(result);
-        var month = culture.Calendar.GetMonth(result);
-        culture.Calendar.GetDayOfMonth(result).Should().Be(culture.Calendar.GetDaysInMonth(year, month));
-        result.Should().NotBe(new DateTime(2021, 2, 28)); // A Gregorian end-of-month would land here.
-        result.Should().BeAfter(dateTime); // Persian Bahman ends in February, after this date.
-    }
-
-    [Test]
     public void StartOfWeek_ShouldReturnFirstDayOfWeek()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -12,11 +12,21 @@ namespace MudBlazor.UnitTests.Extensions
         [TestCase(typeof(Adornment), new[] { "None", "Start", "End" })]
         [TestCase(typeof(Adornment?), new[] { "None", "Start", "End" })]
         [TestCase(typeof(string), new string[0])]
+        [TestCase(typeof(int), new string[0])] // Non-enum value type
+        [TestCase(typeof(List<int>), new string[0])] // Generic but not Nullable<>
         public void GetSafeEnumValues(Type type, string[] expectedNames)
         {
             var values = EnumExtensions.GetSafeEnumValues(type);
             var stringValues = values.Select(x => x.ToString());
             stringValues.Should().BeEquivalentTo(expectedNames);
+        }
+
+        [Test]
+        public void GetSafeEnumValues_ShouldReturnTypedEnumValues()
+        {
+            // Returns the actual boxed enum values, not just their names.
+            EnumExtensions.GetSafeEnumValues(typeof(Adornment))
+                .Should().Equal(Adornment.None, Adornment.Start, Adornment.End);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumExtensionsTests.cs
@@ -12,7 +12,6 @@ namespace MudBlazor.UnitTests.Extensions
         [TestCase(typeof(Adornment), new[] { "None", "Start", "End" })]
         [TestCase(typeof(Adornment?), new[] { "None", "Start", "End" })]
         [TestCase(typeof(string), new string[0])]
-        [TestCase(typeof(int), new string[0])] // Non-enum value type
         [TestCase(typeof(List<int>), new string[0])] // Generic but not Nullable<>
         public void GetSafeEnumValues(Type type, string[] expectedNames)
         {

--- a/src/MudBlazor.UnitTests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/EnumerableExtensionsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+using System.Collections;
 using AwesomeAssertions;
 using MudBlazor.Extensions;
 using NUnit.Framework;
@@ -39,44 +40,52 @@ public class EnumerableExtensionsTests
     }
 
     [Test]
-    public void AsReadOnlyCollection_ICollectionSource_ReflectsCount()
+    public void AsReadOnlyCollection_ListSource_ReturnsSameInstance()
     {
-        // Arrange
-        ICollection<string> source = new List<string> { "a", "b", "c" };
+        // List<T> implements IReadOnlyCollection<T>, so the fast path must return it directly (not wrap or copy).
+        var source = new List<int> { 1, 2, 3 };
 
-        // Act
         var result = source.AsReadOnlyCollection();
 
-        // Assert
-        result.Count.Should().Be(3);
+        result.Should().BeSameAs(source);
     }
 
     [Test]
-    public void AsReadOnlyCollection_ICollectionSource_ReflectsEnumeration()
+    public void AsReadOnlyCollection_PlainCollectionSource_WrapsWithoutCopying()
     {
-        // Arrange
-        ICollection<string> source = new List<string> { "a", "b", "c" };
+        // A type that is ICollection<T> but NOT IReadOnlyCollection<T> hits the wrapper path.
+        var inner = new PlainCollection<string> { "a", "b", "c" };
 
-        // Act
-        var result = source.AsReadOnlyCollection();
+        var result = inner.AsReadOnlyCollection();
 
-        // Assert
+        // Wrapped, not the same instance and not a materialized copy.
+        result.Should().NotBeSameAs(inner);
+        result.Count.Should().Be(3);
         result.Should().Equal("a", "b", "c");
     }
 
     [Test]
-    public void AsReadOnlyCollection_ICollectionSource_ReflectsLiveCount()
+    public void AsReadOnlyCollection_PlainCollectionSource_ReflectsLiveMutations()
     {
-        // Arrange
-        var inner = new List<int> { 1, 2 };
-        ICollection<int> source = inner;
-        var result = source.AsReadOnlyCollection();
+        // The wrapper must adapt the live collection rather than snapshot it.
+        var inner = new PlainCollection<int> { 1, 2 };
+        var result = inner.AsReadOnlyCollection();
 
-        // Act – mutate the underlying collection
         inner.Add(3);
 
-        // Assert – the wrapper reflects the live count
         result.Count.Should().Be(3);
+        result.Should().Equal(1, 2, 3);
+    }
+
+    [Test]
+    public void AsReadOnlyCollection_EmptyEnumerable_ReturnsEmptyCollection()
+    {
+        // Empty non-collection sequence still materializes to an empty result.
+        static IEnumerable<int> Source() { yield break; }
+
+        var result = Source().AsReadOnlyCollection();
+
+        result.Should().BeEmpty();
     }
 
     [Test]
@@ -102,5 +111,21 @@ public class EnumerableExtensionsTests
         // Assert
         enumerationCount.Should().Be(1);
         result.Should().Equal(1, 2, 3);
+    }
+
+    // ICollection<T> that intentionally does NOT implement IReadOnlyCollection<T>, forcing the wrapper path.
+    private sealed class PlainCollection<T> : ICollection<T>
+    {
+        private readonly List<T> _items = [];
+
+        public int Count => _items.Count;
+        public bool IsReadOnly => false;
+        public void Add(T item) => _items.Add(item);
+        public void Clear() => _items.Clear();
+        public bool Contains(T item) => _items.Contains(item);
+        public void CopyTo(T[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+        public bool Remove(T item) => _items.Remove(item);
+        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ExpressionExtensionsTests.cs
@@ -18,6 +18,9 @@ namespace MudBlazor.UnitTests.Extensions
         {
             public string Field1 { get; set; }
 
+            [Label("Nested Label")]
+            public string Field2 { get; set; }
+
             public TestClass2 TestClass2 { get; set; }
         }
 
@@ -74,6 +77,26 @@ namespace MudBlazor.UnitTests.Extensions
             Expression<Func<string>> expression = () => model.Field1;
 
             expression.GetLabelString().Should().Be("");
+        }
+
+        [Test]
+        public void GetFullPathOfMember_ConstantBody_ReturnsEmpty()
+        {
+            // Body is not a MemberExpression, so there is no member path to resolve.
+            Expression<Func<string>> expression = () => "literal";
+
+            expression.GetFullPathOfMember().Should().Be("");
+        }
+
+        [Test]
+        public void GetLabelString_NestedMember_ResolvesAttributeOnDeclaringType()
+        {
+            var model = new TestClass();
+
+            // The label is resolved against the leaf member's declaring type (TestClass1), not the root.
+            Expression<Func<string>> expression = () => model.TestClass1.Field2;
+
+            expression.GetLabelString().Should().Be("Nested Label");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
@@ -23,42 +23,6 @@ namespace MudBlazor.UnitTests
             new object[] { new JSDisconnectedException("only testing") },
         };
 
-        [Test]
-        public async Task InvokeVoidAsyncIgnoreErrors_NoException_InvokesUnderlyingCall()
-        {
-            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
-
-            runtimeMock
-                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
-                .ReturnsAsync(Mock.Of<IJSVoidResult>())
-                .Verifiable();
-
-            var runtime = runtimeMock.Object;
-
-            await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", 42, "blub");
-
-            runtimeMock.Verify();
-        }
-
-        [Test]
-        public async Task InvokeVoidAsyncIgnoreErrors_WithToken_NoException_InvokesUnderlyingCall()
-        {
-            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            runtimeMock
-                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", cancellationToken, It.IsAny<object[]>()))
-                .ReturnsAsync(Mock.Of<IJSVoidResult>())
-                .Verifiable();
-
-            var runtime = runtimeMock.Object;
-
-            await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", cancellationToken, 42, "blub");
-
-            runtimeMock.Verify();
-        }
-
         [TestCaseSource(nameof(_caughtExceptions))]
         public async Task InvokeVoidAsyncIgnoreErrors_Exception_Swallowed<T>(T ex) where T : Exception
         {
@@ -72,26 +36,6 @@ namespace MudBlazor.UnitTests
             var runtime = runtimeMock.Object;
 
             var act = async () => await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", 42, "blub");
-
-            await act.Should().NotThrowAsync();
-            runtimeMock.Verify();
-        }
-
-        [TestCaseSource(nameof(_caughtExceptions))]
-        public async Task InvokeVoidAsyncIgnoreErrors_WithToken_Exception_Swallowed<T>(T ex) where T : Exception
-        {
-            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            runtimeMock
-                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", cancellationToken, It.IsAny<object[]>()))
-                .Throws(ex)
-                .Verifiable();
-
-            var runtime = runtimeMock.Object;
-
-            var act = async () => await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", cancellationToken, 42, "blub");
 
             await act.Should().NotThrowAsync();
             runtimeMock.Verify();
@@ -317,27 +261,6 @@ namespace MudBlazor.UnitTests
 
             success.Should().Be(false);
             value.Should().Be(37.5);
-            runtimeMock.Verify();
-        }
-
-        [TestCaseSource(nameof(_caughtExceptions))]
-        public async Task InvokeAsyncWithErrorHandling_WithToken_Exception_WithDefaultValue<T>(T ex) where T : Exception
-        {
-            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var cancellationToken = cancellationTokenSource.Token;
-
-            runtimeMock
-                .Setup(x => x.InvokeAsync<double>("myMethod", cancellationToken, It.IsAny<object[]>()))
-                .Throws(ex)
-                .Verifiable();
-
-            var runtime = runtimeMock.Object;
-
-            var (success, value) = await runtime.InvokeAsyncWithErrorHandling<double>("myMethod", cancellationToken, 42, "blub");
-
-            success.Should().Be(false);
-            value.Should().Be(0.0);
             runtimeMock.Verify();
         }
 

--- a/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/IJSRuntimeExtensionsTests.cs
@@ -24,6 +24,118 @@ namespace MudBlazor.UnitTests
         };
 
         [Test]
+        public async Task InvokeVoidAsyncIgnoreErrors_NoException_InvokesUnderlyingCall()
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock
+                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>())
+                .Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", 42, "blub");
+
+            runtimeMock.Verify();
+        }
+
+        [Test]
+        public async Task InvokeVoidAsyncIgnoreErrors_WithToken_NoException_InvokesUnderlyingCall()
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken = cancellationTokenSource.Token;
+
+            runtimeMock
+                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", cancellationToken, It.IsAny<object[]>()))
+                .ReturnsAsync(Mock.Of<IJSVoidResult>())
+                .Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", cancellationToken, 42, "blub");
+
+            runtimeMock.Verify();
+        }
+
+        [TestCaseSource(nameof(_caughtExceptions))]
+        public async Task InvokeVoidAsyncIgnoreErrors_Exception_Swallowed<T>(T ex) where T : Exception
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock
+                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
+                .Throws(ex)
+                .Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var act = async () => await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", 42, "blub");
+
+            await act.Should().NotThrowAsync();
+            runtimeMock.Verify();
+        }
+
+        [TestCaseSource(nameof(_caughtExceptions))]
+        public async Task InvokeVoidAsyncIgnoreErrors_WithToken_Exception_Swallowed<T>(T ex) where T : Exception
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken = cancellationTokenSource.Token;
+
+            runtimeMock
+                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", cancellationToken, It.IsAny<object[]>()))
+                .Throws(ex)
+                .Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var act = async () => await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", cancellationToken, 42, "blub");
+
+            await act.Should().NotThrowAsync();
+            runtimeMock.Verify();
+        }
+
+        [Test]
+        public async Task InvokeVoidAsyncIgnoreErrors_ShouldSwallow_WhenUnsupportedJavaScriptRuntime()
+        {
+            // InvalidOperationException is only swallowed for the unsupported/remote prerender runtimes.
+            var jsRuntime1 = new UnsupportedJavaScriptRuntime();
+            var jsRuntime2 = new RemoteJSRuntime();
+            var cancellationToken = CancellationToken.None;
+
+            var act1 = async () => await jsRuntime1.InvokeVoidAsyncIgnoreErrors("myMethod1", 42, "blub1");
+            var act2 = async () => await jsRuntime2.InvokeVoidAsyncIgnoreErrors("myMethod2", 43, "blub2");
+            var act3 = async () => await jsRuntime1.InvokeVoidAsyncIgnoreErrors("myMethod3", cancellationToken, 44, "blub3");
+            var act4 = async () => await jsRuntime2.InvokeVoidAsyncIgnoreErrors("myMethod4", cancellationToken, 45, "blub4");
+
+            await act1.Should().NotThrowAsync();
+            await act2.Should().NotThrowAsync();
+            await act3.Should().NotThrowAsync();
+            await act4.Should().NotThrowAsync();
+        }
+
+        [Test]
+        public async Task InvokeVoidAsyncIgnoreErrors_ShouldRethrow_WhenUncaughtException()
+        {
+            // A plain InvalidOperationException from a supported runtime is not swallowed.
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+
+            runtimeMock
+                .Setup(x => x.InvokeAsync<IJSVoidResult>("myMethod", It.IsAny<object[]>()))
+                .Throws(new InvalidOperationException("mhh that is odd"))
+                .Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var act = async () => await runtime.InvokeVoidAsyncIgnoreErrors("myMethod", 42, "blub");
+
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("mhh that is odd");
+            runtimeMock.Verify();
+        }
+
+        [Test]
         public async Task InvokeVoidAsyncWithErrorHandling_NoException()
         {
             var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
@@ -205,6 +317,27 @@ namespace MudBlazor.UnitTests
 
             success.Should().Be(false);
             value.Should().Be(37.5);
+            runtimeMock.Verify();
+        }
+
+        [TestCaseSource(nameof(_caughtExceptions))]
+        public async Task InvokeAsyncWithErrorHandling_WithToken_Exception_WithDefaultValue<T>(T ex) where T : Exception
+        {
+            var runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken = cancellationTokenSource.Token;
+
+            runtimeMock
+                .Setup(x => x.InvokeAsync<double>("myMethod", cancellationToken, It.IsAny<object[]>()))
+                .Throws(ex)
+                .Verifiable();
+
+            var runtime = runtimeMock.Object;
+
+            var (success, value) = await runtime.InvokeAsyncWithErrorHandling<double>("myMethod", cancellationToken, 42, "blub");
+
+            success.Should().Be(false);
+            value.Should().Be(0.0);
             runtimeMock.Verify();
         }
 

--- a/src/MudBlazor.UnitTests/Extensions/KeepInRangeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/KeepInRangeExtensionsTests.cs
@@ -34,6 +34,19 @@ public class KeepInRangeExtensionsTests
     }
 
     [Test]
+    public void EnsureRange_DoubleMax_UsesZeroAsLowerBound()
+    {
+        // Arrange
+        const double input = -2.5;
+
+        // Act
+        var result = input.EnsureRange(5.0);
+
+        // Assert
+        result.Should().Be(0.0);
+    }
+
+    [Test]
     public void EnsureRange_DoubleMinMax_ReturnsInputWhenInBounds()
     {
         // Arrange
@@ -94,6 +107,31 @@ public class KeepInRangeExtensionsTests
 
         // Assert
         result.Should().Be(0);
+    }
+
+    [Test]
+    public void EnsureRange_IntMinMax_ReturnsInputWhenInBounds()
+    {
+        // Arrange
+        const int input = 5;
+
+        // Act
+        var result = input.EnsureRange(0, 10);
+
+        // Assert
+        result.Should().Be(5);
+    }
+
+    [Test]
+    public void EnsureRangeToByte_KeepsBoundaryValues()
+    {
+        // Act
+        var lowerBound = 0.EnsureRangeToByte();
+        var upperBound = 255.EnsureRangeToByte();
+
+        // Assert
+        lowerBound.Should().Be(byte.MinValue);
+        upperBound.Should().Be(byte.MaxValue);
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Extensions/KeepInRangeExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/KeepInRangeExtensionsTests.cs
@@ -34,19 +34,6 @@ public class KeepInRangeExtensionsTests
     }
 
     [Test]
-    public void EnsureRange_DoubleMax_UsesZeroAsLowerBound()
-    {
-        // Arrange
-        const double input = -2.5;
-
-        // Act
-        var result = input.EnsureRange(5.0);
-
-        // Assert
-        result.Should().Be(0.0);
-    }
-
-    [Test]
     public void EnsureRange_DoubleMinMax_ReturnsInputWhenInBounds()
     {
         // Arrange
@@ -107,31 +94,6 @@ public class KeepInRangeExtensionsTests
 
         // Assert
         result.Should().Be(0);
-    }
-
-    [Test]
-    public void EnsureRange_IntMinMax_ReturnsInputWhenInBounds()
-    {
-        // Arrange
-        const int input = 5;
-
-        // Act
-        var result = input.EnsureRange(0, 10);
-
-        // Assert
-        result.Should().Be(5);
-    }
-
-    [Test]
-    public void EnsureRangeToByte_KeepsBoundaryValues()
-    {
-        // Act
-        var lowerBound = 0.EnsureRangeToByte();
-        var upperBound = 255.EnsureRangeToByte();
-
-        // Assert
-        lowerBound.Should().Be(byte.MinValue);
-        upperBound.Should().Be(byte.MaxValue);
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Extensions/MathExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/MathExtensionsTests.cs
@@ -26,6 +26,41 @@ public class MathExtensionsTests
     }
 
     [Test]
+    public void Map_IgnoresSourceMinOffset_WhenSourceRangeDoesNotStartAtZero()
+    {
+        // Arrange
+        const double sourceMin = 20;
+        const double sourceMax = 70;
+        const double targetMin = 0;
+        const double targetMax = 100;
+        const double value = 45;
+
+        // Act
+        var result = MathExtensions.Map(sourceMin, sourceMax, targetMin, targetMax, value);
+
+        // Assert
+        // Formula uses only the range widths: 45 / (70-20) * (100-0). A true linear remap of 45 would be 50.
+        result.Should().Be(90);
+    }
+
+    [Test]
+    public void Map_ReturnsInfinity_WhenSourceRangeIsZero()
+    {
+        // Arrange
+        const double sourceMin = 50;
+        const double sourceMax = 50;
+        const double targetMin = 0;
+        const double targetMax = 10;
+        const double value = 5;
+
+        // Act
+        var result = MathExtensions.Map(sourceMin, sourceMax, targetMin, targetMax, value);
+
+        // Assert
+        result.Should().Be(double.PositiveInfinity);
+    }
+
+    [Test]
     public void SumGeneric_ReturnsZero_WhenListIsNull()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
@@ -170,41 +170,4 @@ public class ParameterViewExtensionsTests
         result.Should().BeFalse();
         newValue.Should().Be(default(int));
     }
-
-    [Test]
-    public void HasParameterChanged_ReferenceType_NullToValue_ReturnsTrue()
-    {
-        // Arrange
-        const string ParameterName = "Parameter";
-        var parameters = new Dictionary<string, object?>
-        {
-            [ParameterName] = null
-        };
-        var parameterView = ParameterView.FromDictionary(parameters);
-
-        // Act
-        var result = parameterView.HasParameterChanged(ParameterName, "value", out var newValue);
-
-        // Assert
-        result.Should().BeTrue();
-        newValue.Should().BeNull();
-    }
-
-    [Test]
-    public void Contains_ParameterPresent_ReturnsTrue()
-    {
-        // Arrange
-        const string ParameterName = "Parameter";
-        var parameters = new Dictionary<string, object?>
-        {
-            [ParameterName] = 10
-        };
-        var parameterView = ParameterView.FromDictionary(parameters);
-
-        // Act
-        var result = parameterView.Contains<int>(ParameterName);
-
-        // Assert
-        result.Should().BeTrue();
-    }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
@@ -156,4 +156,87 @@ public class ParameterViewExtensionsTests
         newValue.Should().Be(10);
         result.Should().BeTrue();
     }
+
+    [Test]
+    public void HasParameterChanged_ParameterMissing_ReturnsFalse()
+    {
+        // Arrange
+        var parameterView = ParameterView.FromDictionary(new Dictionary<string, object?>());
+
+        // Act
+        var result = parameterView.HasParameterChanged("Missing", 20, out var newValue);
+
+        // Assert
+        result.Should().BeFalse();
+        newValue.Should().Be(default(int));
+    }
+
+    [Test]
+    public void HasParameterChanged_ReferenceType_NullToValue_ReturnsTrue()
+    {
+        // Arrange
+        const string ParameterName = "Parameter";
+        var parameters = new Dictionary<string, object?>
+        {
+            [ParameterName] = null
+        };
+        var parameterView = ParameterView.FromDictionary(parameters);
+
+        // Act
+        var result = parameterView.HasParameterChanged(ParameterName, "value", out var newValue);
+
+        // Assert
+        result.Should().BeTrue();
+        newValue.Should().BeNull();
+    }
+
+    [Test]
+    public void HasParameterChanged_ReferenceType_SameValue_ReturnsFalse()
+    {
+        // Arrange
+        const string ParameterName = "Parameter";
+        var parameters = new Dictionary<string, object?>
+        {
+            [ParameterName] = "value"
+        };
+        var parameterView = ParameterView.FromDictionary(parameters);
+
+        // Act
+        var result = parameterView.HasParameterChanged(ParameterName, "value", out var newValue);
+
+        // Assert
+        result.Should().BeFalse();
+        newValue.Should().Be("value");
+    }
+
+    [Test]
+    public void Contains_ParameterPresent_ReturnsTrue()
+    {
+        // Arrange
+        const string ParameterName = "Parameter";
+        var parameters = new Dictionary<string, object?>
+        {
+            [ParameterName] = 10
+        };
+        var parameterView = ParameterView.FromDictionary(parameters);
+
+        // Act
+        var result = parameterView.Contains<int>(ParameterName);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Contains_ParameterMissing_ReturnsFalse()
+    {
+        // Arrange
+        var parameterView = ParameterView.FromDictionary(new Dictionary<string, object?>());
+
+        // Act
+        var result = parameterView.Contains<int>("Missing");
+
+        // Assert
+        result.Should().BeFalse();
+    }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ParameterViewExtensionsTests.cs
@@ -191,25 +191,6 @@ public class ParameterViewExtensionsTests
     }
 
     [Test]
-    public void HasParameterChanged_ReferenceType_SameValue_ReturnsFalse()
-    {
-        // Arrange
-        const string ParameterName = "Parameter";
-        var parameters = new Dictionary<string, object?>
-        {
-            [ParameterName] = "value"
-        };
-        var parameterView = ParameterView.FromDictionary(parameters);
-
-        // Act
-        var result = parameterView.HasParameterChanged(ParameterName, "value", out var newValue);
-
-        // Assert
-        result.Should().BeFalse();
-        newValue.Should().Be("value");
-    }
-
-    [Test]
     public void Contains_ParameterPresent_ReturnsTrue()
     {
         // Arrange
@@ -225,18 +206,5 @@ public class ParameterViewExtensionsTests
 
         // Assert
         result.Should().BeTrue();
-    }
-
-    [Test]
-    public void Contains_ParameterMissing_ReturnsFalse()
-    {
-        // Arrange
-        var parameterView = ParameterView.FromDictionary(new Dictionary<string, object?>());
-
-        // Act
-        var result = parameterView.Contains<int>("Missing");
-
-        // Assert
-        result.Should().BeFalse();
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ResizeOptionsExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ResizeOptionsExtensionsTests.cs
@@ -79,17 +79,4 @@ public class ResizeOptionsExtensionsTests
         // Assert - the null source is replaced with a non-null empty dictionary.
         clonedOptions.BreakpointDefinitions.Should().NotBeNull().And.BeEmpty();
     }
-
-    [Test]
-    public void Clone_NullOptions_ShouldThrowArgumentNullException()
-    {
-        // Arrange
-        ResizeOptions options = null!;
-
-        // Act
-        var act = () => options.Clone();
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>();
-    }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ResizeOptionsExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ResizeOptionsExtensionsTests.cs
@@ -46,4 +46,50 @@ public class ResizeOptionsExtensionsTests
         clonedOptions.NotifyOnBreakpointOnly.Should().Be(originalOptions.NotifyOnBreakpointOnly);
         clonedOptions.BreakpointDefinitions.Should().BeEquivalentTo(originalOptions.BreakpointDefinitions);
     }
+
+    [Test]
+    public void Clone_ShouldDeepCopyBreakpointDefinitions()
+    {
+        // Arrange
+        var originalOptions = new ResizeOptions
+        {
+            BreakpointDefinitions = new Dictionary<Breakpoint, int> { { Breakpoint.Md, 960 } }
+        };
+
+        // Act
+        var clonedOptions = originalOptions.Clone();
+        clonedOptions.BreakpointDefinitions![Breakpoint.Md] = 1;
+        clonedOptions.BreakpointDefinitions.Add(Breakpoint.Sm, 600);
+
+        // Assert - mutating the clone's dictionary must not affect the original.
+        clonedOptions.BreakpointDefinitions.Should().NotBeSameAs(originalOptions.BreakpointDefinitions);
+        originalOptions.BreakpointDefinitions.Should().BeEquivalentTo(
+            new Dictionary<Breakpoint, int> { { Breakpoint.Md, 960 } });
+    }
+
+    [Test]
+    public void Clone_NullBreakpointDefinitions_ShouldProduceEmptyDictionary()
+    {
+        // Arrange
+        var originalOptions = new ResizeOptions { BreakpointDefinitions = null };
+
+        // Act
+        var clonedOptions = originalOptions.Clone();
+
+        // Assert - the null source is replaced with a non-null empty dictionary.
+        clonedOptions.BreakpointDefinitions.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Test]
+    public void Clone_NullOptions_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        ResizeOptions options = null!;
+
+        // Act
+        var act = () => options.Clone();
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -7,6 +7,7 @@ using Bunit;
 using Bunit.TestDoubles;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using MudBlazor.Services;
@@ -604,5 +605,132 @@ public class ServiceCollectionExtensionsTests
         actualSnackBarOptions.SuccessIcon.Should().Be(expectedOptions.SnackbarConfiguration.SuccessIcon);
         actualSnackBarOptions.WarningIcon.Should().Be(expectedOptions.SnackbarConfiguration.WarningIcon);
         actualSnackBarOptions.ErrorIcon.Should().Be(expectedOptions.SnackbarConfiguration.ErrorIcon);
+    }
+
+    [Test]
+    public void AddMudServices_WithNullConfiguration_ShouldThrow()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var act = () => services.AddMudServices(configuration: null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void AddMudBlazorDialog_WhenServiceAlreadyRegistered_ShouldNotOverwrite()
+    {
+        // Arrange: registration uses TryAddScoped so a pre-registered service must survive.
+        var existing = new StubDialogService();
+        var services = new ServiceCollection();
+        services.AddSingleton<IDialogService>(existing);
+
+        // Act
+        services.AddMudBlazorDialog();
+        var serviceProvider = services.BuildServiceProvider();
+        var dialogService = serviceProvider.GetService<IDialogService>();
+
+        // Assert
+        dialogService.Should().BeSameAs(existing);
+    }
+
+    [Test]
+    public void AddMudLocalization_WhenInterceptorAlreadyRegistered_ShouldNotOverwrite()
+    {
+        // Arrange: registration uses TryAddTransient so a pre-registered interceptor must survive.
+        var services = new ServiceCollection();
+        services.AddTransient<ILocalizationInterceptor, StubLocalizationInterceptor>();
+
+        // Act
+        services.AddMudLocalization();
+
+        // Assert
+        var descriptor = services.Single(x => x.ServiceType == typeof(ILocalizationInterceptor));
+        descriptor.ImplementationType.Should().Be<StubLocalizationInterceptor>();
+    }
+
+    [Test]
+    public void AddLocalizationInterceptor_ShouldReplaceDefaultInterceptor()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddMudLocalization();
+
+        // Act
+        services.AddLocalizationInterceptor<StubLocalizationInterceptor>();
+
+        // Assert: Replace keeps a single registration but swaps the implementation.
+        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationInterceptor)).ToList();
+        descriptors.Should().ContainSingle();
+        descriptors[0].ImplementationType.Should().Be<StubLocalizationInterceptor>();
+    }
+
+    [Test]
+    public void AddLocalizationEnumInterceptor_ShouldReplaceDefaultInterceptor()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddMudLocalization();
+
+        // Act
+        services.AddLocalizationEnumInterceptor<StubLocalizationEnumInterceptor>();
+
+        // Assert
+        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationEnumInterceptor)).ToList();
+        descriptors.Should().ContainSingle();
+        descriptors[0].ImplementationType.Should().Be<StubLocalizationEnumInterceptor>();
+    }
+
+    [Test]
+    public void AddLocalizationInterceptor_WithFactory_ShouldReplaceDefaultInterceptorWithFactory()
+    {
+        // Arrange
+        var instance = new StubLocalizationInterceptor();
+        var services = new ServiceCollection();
+        services.AddMudLocalization();
+
+        // Act
+        services.AddLocalizationInterceptor(_ => instance);
+
+        // Assert: factory overload registers an ImplementationFactory, not a type, and resolves to it.
+        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationInterceptor)).ToList();
+        descriptors.Should().ContainSingle();
+        descriptors[0].ImplementationFactory.Should().NotBeNull();
+        var serviceProvider = services.BuildServiceProvider();
+        serviceProvider.GetService<ILocalizationInterceptor>().Should().BeSameAs(instance);
+    }
+
+    [Test]
+    public void AddLocalizationEnumInterceptor_WithFactory_ShouldReplaceDefaultInterceptorWithFactory()
+    {
+        // Arrange
+        var instance = new StubLocalizationEnumInterceptor();
+        var services = new ServiceCollection();
+        services.AddMudLocalization();
+
+        // Act
+        services.AddLocalizationEnumInterceptor(_ => instance);
+
+        // Assert
+        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationEnumInterceptor)).ToList();
+        descriptors.Should().ContainSingle();
+        descriptors[0].ImplementationFactory.Should().NotBeNull();
+        var serviceProvider = services.BuildServiceProvider();
+        serviceProvider.GetService<ILocalizationEnumInterceptor>().Should().BeSameAs(instance);
+    }
+
+    private sealed class StubDialogService : DialogService;
+
+    private sealed class StubLocalizationInterceptor : ILocalizationInterceptor
+    {
+        public LocalizedString Handle(string key, params object[] arguments) => new(key, key, resourceNotFound: true);
+    }
+
+    private sealed class StubLocalizationEnumInterceptor : ILocalizationEnumInterceptor
+    {
+        public string Handle(Enum enumeration) => enumeration.ToString();
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -608,19 +608,6 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Test]
-    public void AddMudServices_WithNullConfiguration_ShouldThrow()
-    {
-        // Arrange
-        var services = new ServiceCollection();
-
-        // Act
-        var act = () => services.AddMudServices(configuration: null!);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>();
-    }
-
-    [Test]
     public void AddMudBlazorDialog_WhenServiceAlreadyRegistered_ShouldNotOverwrite()
     {
         // Arrange: registration uses TryAddScoped so a pre-registered service must survive.
@@ -638,21 +625,6 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Test]
-    public void AddMudLocalization_WhenInterceptorAlreadyRegistered_ShouldNotOverwrite()
-    {
-        // Arrange: registration uses TryAddTransient so a pre-registered interceptor must survive.
-        var services = new ServiceCollection();
-        services.AddTransient<ILocalizationInterceptor, StubLocalizationInterceptor>();
-
-        // Act
-        services.AddMudLocalization();
-
-        // Assert
-        var descriptor = services.Single(x => x.ServiceType == typeof(ILocalizationInterceptor));
-        descriptor.ImplementationType.Should().Be<StubLocalizationInterceptor>();
-    }
-
-    [Test]
     public void AddLocalizationInterceptor_ShouldReplaceDefaultInterceptor()
     {
         // Arrange
@@ -666,22 +638,6 @@ public class ServiceCollectionExtensionsTests
         var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationInterceptor)).ToList();
         descriptors.Should().ContainSingle();
         descriptors[0].ImplementationType.Should().Be<StubLocalizationInterceptor>();
-    }
-
-    [Test]
-    public void AddLocalizationEnumInterceptor_ShouldReplaceDefaultInterceptor()
-    {
-        // Arrange
-        var services = new ServiceCollection();
-        services.AddMudLocalization();
-
-        // Act
-        services.AddLocalizationEnumInterceptor<StubLocalizationEnumInterceptor>();
-
-        // Assert
-        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationEnumInterceptor)).ToList();
-        descriptors.Should().ContainSingle();
-        descriptors[0].ImplementationType.Should().Be<StubLocalizationEnumInterceptor>();
     }
 
     [Test]
@@ -703,34 +659,10 @@ public class ServiceCollectionExtensionsTests
         serviceProvider.GetService<ILocalizationInterceptor>().Should().BeSameAs(instance);
     }
 
-    [Test]
-    public void AddLocalizationEnumInterceptor_WithFactory_ShouldReplaceDefaultInterceptorWithFactory()
-    {
-        // Arrange
-        var instance = new StubLocalizationEnumInterceptor();
-        var services = new ServiceCollection();
-        services.AddMudLocalization();
-
-        // Act
-        services.AddLocalizationEnumInterceptor(_ => instance);
-
-        // Assert
-        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationEnumInterceptor)).ToList();
-        descriptors.Should().ContainSingle();
-        descriptors[0].ImplementationFactory.Should().NotBeNull();
-        var serviceProvider = services.BuildServiceProvider();
-        serviceProvider.GetService<ILocalizationEnumInterceptor>().Should().BeSameAs(instance);
-    }
-
     private sealed class StubDialogService : DialogService;
 
     private sealed class StubLocalizationInterceptor : ILocalizationInterceptor
     {
         public LocalizedString Handle(string key, params object[] arguments) => new(key, key, resourceNotFound: true);
-    }
-
-    private sealed class StubLocalizationEnumInterceptor : ILocalizationEnumInterceptor
-    {
-        public string Handle(Enum enumeration) => enumeration.ToString();
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -640,25 +640,6 @@ public class ServiceCollectionExtensionsTests
         descriptors[0].ImplementationType.Should().Be<StubLocalizationInterceptor>();
     }
 
-    [Test]
-    public void AddLocalizationInterceptor_WithFactory_ShouldReplaceDefaultInterceptorWithFactory()
-    {
-        // Arrange
-        var instance = new StubLocalizationInterceptor();
-        var services = new ServiceCollection();
-        services.AddMudLocalization();
-
-        // Act
-        services.AddLocalizationInterceptor(_ => instance);
-
-        // Assert: factory overload registers an ImplementationFactory, not a type, and resolves to it.
-        var descriptors = services.Where(x => x.ServiceType == typeof(ILocalizationInterceptor)).ToList();
-        descriptors.Should().ContainSingle();
-        descriptors[0].ImplementationFactory.Should().NotBeNull();
-        var serviceProvider = services.BuildServiceProvider();
-        serviceProvider.GetService<ILocalizationInterceptor>().Should().BeSameAs(instance);
-    }
-
     private sealed class StubDialogService : DialogService;
 
     private sealed class StubLocalizationInterceptor : ILocalizationInterceptor

--- a/src/MudBlazor.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/StringExtensionsTests.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using AwesomeAssertions;
 using NUnit.Framework;
 
@@ -139,6 +140,41 @@ public class StringExtensionsTests
 
         // Assert
         result.Should().Be("12");
+    }
+
+    [Test]
+    public void ToPercentage_ShouldStripTrailingZeros_WhenDecimalHasSingleSignificantPlace()
+    {
+        // "0.##" omits trailing zeros, so 12.50 collapses to a single decimal place.
+        const decimal Value = 12.50m;
+
+        // Act
+        var result = Value.ToPercentage();
+
+        // Assert
+        result.Should().Be("12.5");
+    }
+
+    [Test]
+    public void ToPercentage_ShouldUseInvariantCulture_WhenCurrentCultureUsesCommaSeparator()
+    {
+        // Guards the explicit CultureInfo.InvariantCulture: the separator must stay a period
+        // even under a culture that uses a comma as the decimal separator.
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            // Act
+            var result = 12.34m.ToPercentage();
+
+            // Assert
+            result.Should().Be("12.34");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 }
 

--- a/src/MudBlazor.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/StringExtensionsTests.cs
@@ -143,19 +143,6 @@ public class StringExtensionsTests
     }
 
     [Test]
-    public void ToPercentage_ShouldStripTrailingZeros_WhenDecimalHasSingleSignificantPlace()
-    {
-        // "0.##" omits trailing zeros, so 12.50 collapses to a single decimal place.
-        const decimal Value = 12.50m;
-
-        // Act
-        var result = Value.ToPercentage();
-
-        // Assert
-        result.Should().Be("12.5");
-    }
-
-    [Test]
     public void ToPercentage_ShouldUseInvariantCulture_WhenCurrentCultureUsesCommaSeparator()
     {
         // Guards the explicit CultureInfo.InvariantCulture: the separator must stay a period

--- a/src/MudBlazor.UnitTests/Extensions/TableExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TableExtensionsTests.cs
@@ -84,6 +84,35 @@ public class TableExtensionsTests
     }
 
     [Test]
+    public void OrderByDirection_ShouldSortAscending_WhenDirectionIsNone_ForIEnumerable()
+    {
+        // Arrange
+        var direction = SortDirection.None;
+        string KeySelector(TestItem item) => item.Name;
+
+        // Act
+        var result = _testData.OrderByDirection(direction, KeySelector).ToList();
+
+        // Assert
+        result.Should().BeInAscendingOrder(item => item.Name);
+    }
+
+    [Test]
+    public void OrderByDirection_ShouldSortAscending_WhenDirectionIsNone_ForIQueryable()
+    {
+        // Arrange
+        var direction = SortDirection.None;
+        Expression<Func<TestItem, string>> keySelector = item => item.Name;
+        var queryableData = _testData.AsQueryable();
+
+        // Act
+        var result = queryableData.OrderByDirection(direction, keySelector).ToList();
+
+        // Assert
+        result.Should().BeInAscendingOrder(item => item.Name);
+    }
+
+    [Test]
     public void EditButtonDisabled_ShouldReturnFalse_WhenContextIsNull()
     {
         // Arrange
@@ -118,6 +147,63 @@ public class TableExtensionsTests
         var tableMock = new Mock<MudTable<TestItem>>();
         var context = new TableContext<TestItem> { Table = tableMock.Object };
         var item = new TestItem("B");
+
+        // Act
+        var result = context.EditButtonDisabled(item);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void EditButtonDisabled_ShouldReturnFalse_WhenBlockedButNoItemIsEditing()
+    {
+        // Arrange
+        var tableMock = new Mock<MudTable<TestItem>>();
+#pragma warning disable BL0005
+        tableMock.Object.IsEditRowSwitchingBlocked = true;
+#pragma warning restore BL0005
+        tableMock.Object._editingItem = null;
+        var context = new TableContext<TestItem> { Table = tableMock.Object };
+        var item = new TestItem("B");
+
+        // Act
+        var result = context.EditButtonDisabled(item);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void EditButtonDisabled_ShouldReturnTrue_WhenBlockedAndAnotherItemIsEditing()
+    {
+        // Arrange
+        var tableMock = new Mock<MudTable<TestItem>>();
+#pragma warning disable BL0005
+        tableMock.Object.IsEditRowSwitchingBlocked = true;
+#pragma warning restore BL0005
+        tableMock.Object._editingItem = new TestItem("A");
+        var context = new TableContext<TestItem> { Table = tableMock.Object };
+        var item = new TestItem("B");
+
+        // Act
+        var result = context.EditButtonDisabled(item);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void EditButtonDisabled_ShouldReturnFalse_WhenBlockedAndItemIsTheEditingItem()
+    {
+        // Arrange
+        var item = new TestItem("B");
+        var tableMock = new Mock<MudTable<TestItem>>();
+#pragma warning disable BL0005
+        tableMock.Object.IsEditRowSwitchingBlocked = true;
+#pragma warning restore BL0005
+        tableMock.Object._editingItem = item;
+        var context = new TableContext<TestItem> { Table = tableMock.Object };
 
         // Act
         var result = context.EditButtonDisabled(item);

--- a/src/MudBlazor.UnitTests/Extensions/TableExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TableExtensionsTests.cs
@@ -84,35 +84,6 @@ public class TableExtensionsTests
     }
 
     [Test]
-    public void OrderByDirection_ShouldSortAscending_WhenDirectionIsNone_ForIEnumerable()
-    {
-        // Arrange
-        var direction = SortDirection.None;
-        string KeySelector(TestItem item) => item.Name;
-
-        // Act
-        var result = _testData.OrderByDirection(direction, KeySelector).ToList();
-
-        // Assert
-        result.Should().BeInAscendingOrder(item => item.Name);
-    }
-
-    [Test]
-    public void OrderByDirection_ShouldSortAscending_WhenDirectionIsNone_ForIQueryable()
-    {
-        // Arrange
-        var direction = SortDirection.None;
-        Expression<Func<TestItem, string>> keySelector = item => item.Name;
-        var queryableData = _testData.AsQueryable();
-
-        // Act
-        var result = queryableData.OrderByDirection(direction, keySelector).ToList();
-
-        // Assert
-        result.Should().BeInAscendingOrder(item => item.Name);
-    }
-
-    [Test]
     public void EditButtonDisabled_ShouldReturnFalse_WhenContextIsNull()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/TableExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TableExtensionsTests.cs
@@ -127,25 +127,6 @@ public class TableExtensionsTests
     }
 
     [Test]
-    public void EditButtonDisabled_ShouldReturnFalse_WhenBlockedButNoItemIsEditing()
-    {
-        // Arrange
-        var tableMock = new Mock<MudTable<TestItem>>();
-#pragma warning disable BL0005
-        tableMock.Object.IsEditRowSwitchingBlocked = true;
-#pragma warning restore BL0005
-        tableMock.Object._editingItem = null;
-        var context = new TableContext<TestItem> { Table = tableMock.Object };
-        var item = new TestItem("B");
-
-        // Act
-        var result = context.EditButtonDisabled(item);
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Test]
     public void EditButtonDisabled_ShouldReturnTrue_WhenBlockedAndAnotherItemIsEditing()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
@@ -135,27 +135,5 @@ namespace MudBlazor.UnitTests.Extensions
             await Task.Delay(100);
             handlerInvoked.Should().BeFalse();
         }
-
-        [Test]
-        public async Task ValueTask_AndForget_ShouldNotForwardExceptionWhenIgnoreExceptions()
-        {
-            var handlerInvoked = false;
-            MudGlobal.UnhandledExceptionHandler = _ => handlerInvoked = true;
-            var task = AsyncValueTaskExceptionGenerator("Something bad is about to happen ...");
-            task.CatchAndLog(ignoreExceptions: true);
-            await Task.Delay(100);
-            handlerInvoked.Should().BeFalse();
-        }
-
-        [Test]
-        public async Task ValueTask_T_AndForget_ShouldNotForwardExceptionWhenIgnoreExceptions()
-        {
-            var handlerInvoked = false;
-            MudGlobal.UnhandledExceptionHandler = _ => handlerInvoked = true;
-            var task = AsyncValueTaskExceptionGenerator<bool>("Something bad is about to happen ...");
-            task.CatchAndLog(ignoreExceptions: true);
-            await Task.Delay(100);
-            handlerInvoked.Should().BeFalse();
-        }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TaskExtensionsTests.cs
@@ -114,5 +114,48 @@ namespace MudBlazor.UnitTests.Extensions
                 }
             }
         }
+
+        [Test]
+        public async Task Task_AndForget_ShouldNotForwardExceptionWhenIgnoreExceptions()
+        {
+            var handlerInvoked = false;
+            MudGlobal.UnhandledExceptionHandler = _ => handlerInvoked = true;
+            var task = AsyncTaskExceptionGenerator("Something bad is about to happen ...");
+            task.CatchAndLog(ignoreExceptions: true);
+            var t = Stopwatch.StartNew();
+            while (!(task.IsCompleted || task.IsCanceled || task.IsFaulted))
+            {
+                await Task.Delay(10);
+                if (t.Elapsed > TimeSpan.FromSeconds(5))
+                {
+                    Assert.Fail("The test task did not end in time, this should not happen!");
+                }
+            }
+            // Give the fire-and-forget continuation a chance to run before asserting the handler stayed untouched.
+            await Task.Delay(100);
+            handlerInvoked.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task ValueTask_AndForget_ShouldNotForwardExceptionWhenIgnoreExceptions()
+        {
+            var handlerInvoked = false;
+            MudGlobal.UnhandledExceptionHandler = _ => handlerInvoked = true;
+            var task = AsyncValueTaskExceptionGenerator("Something bad is about to happen ...");
+            task.CatchAndLog(ignoreExceptions: true);
+            await Task.Delay(100);
+            handlerInvoked.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task ValueTask_T_AndForget_ShouldNotForwardExceptionWhenIgnoreExceptions()
+        {
+            var handlerInvoked = false;
+            MudGlobal.UnhandledExceptionHandler = _ => handlerInvoked = true;
+            var task = AsyncValueTaskExceptionGenerator<bool>("Something bad is about to happen ...");
+            task.CatchAndLog(ignoreExceptions: true);
+            await Task.Delay(100);
+            handlerInvoked.Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
@@ -64,32 +64,6 @@ public class TimeSpanExtensionsTests
     }
 
     [Test]
-    public void ToIsoString_ShouldNotZeroPadMilliseconds_WhenMillisecondsIsSingleDigit()
-    {
-        // Arrange
-        var timeSpan = new TimeSpan(0, 10, 30, 45, 5);
-
-        // Act
-        var result = timeSpan.ToIsoString(seconds: true, ms: true);
-
-        // Assert
-        result.Should().Be("10:30-45,5");
-    }
-
-    [Test]
-    public void ToAmPmHour_ShouldUseHourComponent_WhenTimeSpanExceedsOneDay()
-    {
-        // Arrange
-        var timeSpan = new TimeSpan(2, 13, 0, 0);
-
-        // Act
-        var result = timeSpan.ToAmPmHour();
-
-        // Assert
-        result.Should().Be(1);
-    }
-
-    [Test]
     public void ToAmPmHour_ShouldReturnCorrectAmPmHour_WhenTimeIsIn24HourFormat()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
@@ -77,32 +77,6 @@ public class TimeSpanExtensionsTests
     }
 
     [Test]
-    public void ToIsoString_ShouldZeroPadSingleDigitParts()
-    {
-        // Arrange
-        var timeSpan = new TimeSpan(1, 2, 3);
-
-        // Act
-        var result = timeSpan.ToIsoString(seconds: true, ms: false);
-
-        // Assert
-        result.Should().Be("01:02-03");
-    }
-
-    [Test]
-    public void ToAmPmHour_ShouldWrapPmHours_WhenHourIsGreaterThan12()
-    {
-        // Arrange
-        var timeSpan = new TimeSpan(23, 0, 0);
-
-        // Act
-        var result = timeSpan.ToAmPmHour();
-
-        // Assert
-        result.Should().Be(11);
-    }
-
-    [Test]
     public void ToAmPmHour_ShouldUseHourComponent_WhenTimeSpanExceedsOneDay()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/TimeSpanExtensionsTests.cs
@@ -51,6 +51,71 @@ public class TimeSpanExtensionsTests
     }
 
     [Test]
+    public void ToIsoString_ShouldIgnoreMilliseconds_WhenSecondsIsFalse()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(0, 10, 30, 45, 123);
+
+        // Act
+        var result = timeSpan.ToIsoString(seconds: false, ms: true);
+
+        // Assert
+        result.Should().Be("10:30");
+    }
+
+    [Test]
+    public void ToIsoString_ShouldNotZeroPadMilliseconds_WhenMillisecondsIsSingleDigit()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(0, 10, 30, 45, 5);
+
+        // Act
+        var result = timeSpan.ToIsoString(seconds: true, ms: true);
+
+        // Assert
+        result.Should().Be("10:30-45,5");
+    }
+
+    [Test]
+    public void ToIsoString_ShouldZeroPadSingleDigitParts()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(1, 2, 3);
+
+        // Act
+        var result = timeSpan.ToIsoString(seconds: true, ms: false);
+
+        // Assert
+        result.Should().Be("01:02-03");
+    }
+
+    [Test]
+    public void ToAmPmHour_ShouldWrapPmHours_WhenHourIsGreaterThan12()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(23, 0, 0);
+
+        // Act
+        var result = timeSpan.ToAmPmHour();
+
+        // Assert
+        result.Should().Be(11);
+    }
+
+    [Test]
+    public void ToAmPmHour_ShouldUseHourComponent_WhenTimeSpanExceedsOneDay()
+    {
+        // Arrange
+        var timeSpan = new TimeSpan(2, 13, 0, 0);
+
+        // Act
+        var result = timeSpan.ToAmPmHour();
+
+        // Assert
+        result.Should().Be(1);
+    }
+
+    [Test]
     public void ToAmPmHour_ShouldReturnCorrectAmPmHour_WhenTimeIsIn24HourFormat()
     {
         // Arrange

--- a/src/MudBlazor.UnitTests/Extensions/WebUnitsExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/WebUnitsExtensionsTests.cs
@@ -2,7 +2,6 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using AwesomeAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;
@@ -64,28 +63,6 @@ namespace MudBlazor.UnitTests.Extensions
         public void ToPx_Double_RoundsToTwoDecimalsAndTrimsZeros(double value, string expected)
         {
             value.ToPx().Should().Be(expected);
-        }
-
-        // de-DE uses ',' as the decimal separator; the output must stay invariant ('.').
-        [Test]
-        public void ToPx_Double_UsesInvariantCulture()
-        {
-            var originalCulture = CultureInfo.CurrentCulture;
-            var originalUiCulture = CultureInfo.CurrentUICulture;
-
-            try
-            {
-                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
-                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
-
-                3.3333.ToPx().Should().Be("3.33px");
-                ((double?)3.3333).ToPx().Should().Be("3.33px");
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = originalCulture;
-                CultureInfo.CurrentUICulture = originalUiCulture;
-            }
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Extensions/WebUnitsExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/WebUnitsExtensionsTests.cs
@@ -66,15 +66,6 @@ namespace MudBlazor.UnitTests.Extensions
             value.ToPx().Should().Be(expected);
         }
 
-        [TestCase(3.0, "3%")]
-        [TestCase(3.5, "3.5%")]
-        [TestCase(3.05, "3.05%")]
-        [TestCase(1234.5678, "1234.57%")]
-        public void ToPercent_Double_RoundsToTwoDecimalsAndTrimsZeros(double value, string expected)
-        {
-            value.ToPercent().Should().Be(expected);
-        }
-
         // de-DE uses ',' as the decimal separator; the output must stay invariant ('.').
         [Test]
         public void ToPx_Double_UsesInvariantCulture()
@@ -89,27 +80,6 @@ namespace MudBlazor.UnitTests.Extensions
 
                 3.3333.ToPx().Should().Be("3.33px");
                 ((double?)3.3333).ToPx().Should().Be("3.33px");
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = originalCulture;
-                CultureInfo.CurrentUICulture = originalUiCulture;
-            }
-        }
-
-        [Test]
-        public void ToPercent_Double_UsesInvariantCulture()
-        {
-            var originalCulture = CultureInfo.CurrentCulture;
-            var originalUiCulture = CultureInfo.CurrentUICulture;
-
-            try
-            {
-                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
-                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
-
-                3.3333.ToPercent().Should().Be("3.33%");
-                ((double?)3.3333).ToPercent().Should().Be("3.33%");
             }
             finally
             {

--- a/src/MudBlazor.UnitTests/Extensions/WebUnitsExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/WebUnitsExtensionsTests.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using AwesomeAssertions;
 using MudBlazor.Utilities;
 using NUnit.Framework;
@@ -53,6 +54,68 @@ namespace MudBlazor.UnitTests.Extensions
             (-3L).ToPercent().Should().Be("-3%");
             ((long?)3L).ToPercent().Should().Be("3%");
             ((long?)null).ToPercent().Should().Be(string.Empty);
+        }
+
+        // The "0.##" format trims trailing zeros and rounds anything past the second decimal.
+        [TestCase(3.0, "3px")]
+        [TestCase(3.5, "3.5px")]
+        [TestCase(3.05, "3.05px")]
+        [TestCase(1234.5678, "1234.57px")]
+        public void ToPx_Double_RoundsToTwoDecimalsAndTrimsZeros(double value, string expected)
+        {
+            value.ToPx().Should().Be(expected);
+        }
+
+        [TestCase(3.0, "3%")]
+        [TestCase(3.5, "3.5%")]
+        [TestCase(3.05, "3.05%")]
+        [TestCase(1234.5678, "1234.57%")]
+        public void ToPercent_Double_RoundsToTwoDecimalsAndTrimsZeros(double value, string expected)
+        {
+            value.ToPercent().Should().Be(expected);
+        }
+
+        // de-DE uses ',' as the decimal separator; the output must stay invariant ('.').
+        [Test]
+        public void ToPx_Double_UsesInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUiCulture = CultureInfo.CurrentUICulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+
+                3.3333.ToPx().Should().Be("3.33px");
+                ((double?)3.3333).ToPx().Should().Be("3.33px");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUiCulture;
+            }
+        }
+
+        [Test]
+        public void ToPercent_Double_UsesInvariantCulture()
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUiCulture = CultureInfo.CurrentUICulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+                CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+
+                3.3333.ToPercent().Should().Be("3.33%");
+                ((double?)3.3333).ToPercent().Should().Be("3.33%");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUiCulture;
+            }
         }
     }
 }


### PR DESCRIPTION
Shores up weak spots in the Extensions namespace. Curated to the highest-impact cases; this is not a full-coverage pass.

- Conversions and DI: TryConvertBack error paths, ServiceCollection TryAdd-does-not-overwrite and type-based interceptor Replace.
- Collections: AsReadOnlyCollection wrapper vs same-instance and live-mutation behavior, DataGrid custom-comparer OrderBy.
- DateTime and time: ISO date zero-padding, leap-year EndOfMonth, TimeSpan millisecond handling.
- JS interop and math: IJSRuntime swallow/rethrow branches, MathExtensions Map offset and divide-by-zero.
- Misc: culture-invariant ToPercentage/ToPx, ResizeOptions deep-copy, ParameterView change detection, EditButtonDisabled branches.

Test-only; no production code changed.
