### PR TITLE
Tests: Strengthen Other unit test coverage

### DIFF
--- a/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
@@ -88,15 +88,6 @@ namespace MudBlazor.UnitTests.Other
             isTestOK.Should().BeTrue();
         }
 
-        [Test]
-        public void Constructor_ValidName_SetsNameAndOrder()
-        {
-            var attribute = new CategoryAttribute(CategoryTypes.General.Behavior);
-
-            attribute.Name.Should().Be("Behavior");
-            attribute.Order.Should().Be(100);
-        }
-
         [TestCase(null)]
         [TestCase("")]
         public void Constructor_NullOrEmptyName_Throws(string name)
@@ -127,14 +118,6 @@ namespace MudBlazor.UnitTests.Other
             data.Should().BeLessThan(behavior);
             behavior.Should().BeLessThan(appearance);
             appearance.Should().BeLessThan(common);
-        }
-
-        [Test]
-        public void Order_Common_IsLast()
-        {
-            var common = new CategoryAttribute(CategoryTypes.ComponentBase.Common).Order;
-
-            common.Should().Be(int.MaxValue);
         }
 
         // Returns the class that declares the specified method.

--- a/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
@@ -88,6 +88,55 @@ namespace MudBlazor.UnitTests.Other
             isTestOK.Should().BeTrue();
         }
 
+        [Test]
+        public void Constructor_ValidName_SetsNameAndOrder()
+        {
+            var attribute = new CategoryAttribute(CategoryTypes.General.Behavior);
+
+            attribute.Name.Should().Be("Behavior");
+            attribute.Order.Should().Be(100);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void Constructor_NullOrEmptyName_Throws(string name)
+        {
+            var construct = () => new CategoryAttribute(name);
+
+            construct.Should().Throw<ArgumentException>().WithMessage("The category name cannot be null nor empty.");
+        }
+
+        [Test]
+        public void Constructor_UnknownName_Throws()
+        {
+            // A typo or a category that isn't registered in the order table must be rejected.
+            var construct = () => new CategoryAttribute("Behaviour");
+
+            construct.Should().Throw<ArgumentException>().WithMessage("*isn't in the categoryOrder field*");
+        }
+
+        [Test]
+        public void Order_GeneralCategories_AscendingByImportance()
+        {
+            // Documentation ordering contract: Data before Behavior before Appearance before Common.
+            var data = new CategoryAttribute(CategoryTypes.General.Data).Order;
+            var behavior = new CategoryAttribute(CategoryTypes.General.Behavior).Order;
+            var appearance = new CategoryAttribute(CategoryTypes.General.Appearance).Order;
+            var common = new CategoryAttribute(CategoryTypes.ComponentBase.Common).Order;
+
+            data.Should().BeLessThan(behavior);
+            behavior.Should().BeLessThan(appearance);
+            appearance.Should().BeLessThan(common);
+        }
+
+        [Test]
+        public void Order_Common_IsLast()
+        {
+            var common = new CategoryAttribute(CategoryTypes.ComponentBase.Common).Order;
+
+            common.Should().Be(int.MaxValue);
+        }
+
         // Returns the class that declares the specified method.
         private static Type GetBaseDefinitionClass(MethodInfo m) => m.GetBaseDefinition().DeclaringType;
 

--- a/src/MudBlazor.UnitTests/Other/DateRangeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/DateRangeTests.cs
@@ -146,22 +146,6 @@ public class DateRangeTests
     }
 
     [Test]
-    public void EqualityOperator_EqualRanges_ReturnsTrue()
-    {
-        var a = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
-        var b = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
-        (a == b).Should().BeTrue();
-    }
-
-    [Test]
-    public void EqualityOperator_SameReference_ReturnsTrue()
-    {
-        var a = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
-        var b = a;
-        (a == b).Should().BeTrue();
-    }
-
-    [Test]
     public void Equals_BothEndpointsNull_ReturnsTrue()
     {
         // DateRange.Equals (unlike base Range<T>.Equals) treats two ranges with null endpoints as equal.

--- a/src/MudBlazor.UnitTests/Other/DateRangeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/DateRangeTests.cs
@@ -99,6 +99,20 @@ public class DateRangeTests
     }
 
     [Test]
+    public void TryParse_CanonicalRangeString_RoundTrips()
+    {
+        var range = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
+        var converter = new DateTimeConverter();
+
+        var ok = DateRange.TryParse(range.ToString(converter), converter, out var result);
+
+        ok.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Start.Should().Be(range.Start);
+        result.End.Should().Be(range.End);
+    }
+
+    [Test]
     public void EqualityOperator_BothNull_ReturnsTrue()
     {
         DateRange? a = null;
@@ -132,11 +146,45 @@ public class DateRangeTests
     }
 
     [Test]
+    public void EqualityOperator_EqualRanges_ReturnsTrue()
+    {
+        var a = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
+        var b = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
+        (a == b).Should().BeTrue();
+    }
+
+    [Test]
+    public void EqualityOperator_SameReference_ReturnsTrue()
+    {
+        var a = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
+        var b = a;
+        (a == b).Should().BeTrue();
+    }
+
+    [Test]
+    public void Equals_BothEndpointsNull_ReturnsTrue()
+    {
+        // DateRange.Equals (unlike base Range<T>.Equals) treats two ranges with null endpoints as equal.
+        var a = new DateRange(null, null);
+        var b = new DateRange(null, null);
+        a.Equals(b).Should().BeTrue();
+        (a == b).Should().BeTrue();
+    }
+
+    [Test]
     public void Equals_NonDateRangeObject_ReturnsFalse()
     {
         var range = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
         range.Equals("not a range").Should().BeFalse();
         range.Equals(null).Should().BeFalse();
+    }
+
+    [Test]
+    public void Equals_DifferentEndpoints_ReturnsFalse()
+    {
+        var range = new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 6, 1));
+        new DateRange(new DateTime(2024, 1, 1), new DateTime(2024, 7, 1)).Equals(range).Should().BeFalse();
+        new DateRange(new DateTime(2023, 1, 1), new DateTime(2024, 6, 1)).Equals(range).Should().BeFalse();
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Other/GroupKeyPathTests.cs
+++ b/src/MudBlazor.UnitTests/Other/GroupKeyPathTests.cs
@@ -64,19 +64,44 @@ namespace MudBlazor.UnitTests.Other
         }
 
         [Test]
-        public void GetHashCode_EqualObjects_ReturnsSameHash()
-        {
-            var keys1 = new GroupKeyPath(["A", 1, null]);
-            var keys2 = new GroupKeyPath(["A", 1, null]);
-            Assert.That(keys1.GetHashCode(), Is.EqualTo(keys2.GetHashCode()));
-        }
-
-        [Test]
         public void GetHashCode_DifferentObjects_ReturnsDifferentHash()
         {
             var keys1 = new GroupKeyPath(["A", 1, null]);
             var keys2 = new GroupKeyPath(["A", 2, null]);
             Assert.That(keys1.GetHashCode(), Is.Not.EqualTo(keys2.GetHashCode()));
+        }
+
+        [Test]
+        public void Equals_BothEmpty_ReturnsTrue()
+        {
+            // MudDataGrid creates root group definitions with an empty path, so empty paths must compare equal.
+            var keys1 = new GroupKeyPath([]);
+            var keys2 = new GroupKeyPath([]);
+            Assert.That(keys1.Equals(keys2), Is.True);
+            Assert.That(keys1.GetHashCode(), Is.EqualTo(keys2.GetHashCode()));
+        }
+
+        [Test]
+        public void Equals_EmptyVsNonEmpty_ReturnsFalse()
+        {
+            var empty = new GroupKeyPath([]);
+            var nonEmpty = new GroupKeyPath(["A"]);
+            Assert.That(empty.Equals(nonEmpty), Is.False);
+            Assert.That(nonEmpty.Equals(empty), Is.False);
+        }
+
+        [Test]
+        public void UsedAsDictionaryKey_EqualContentDistinctInstance_FindsValue()
+        {
+            // Equal-content paths from distinct instances must collide correctly so hash-based lookups succeed.
+            var dictionary = new Dictionary<GroupKeyPath, bool>
+            {
+                [new GroupKeyPath(["A", 1, null])] = true
+            };
+            var lookup = new GroupKeyPath(["A", 1, null]);
+            Assert.That(dictionary.TryGetValue(lookup, out var value), Is.True);
+            Assert.That(value, Is.True);
+            Assert.That(dictionary.ContainsKey(new GroupKeyPath(["A", 2, null])), Is.False);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Other/GroupKeyPathTests.cs
+++ b/src/MudBlazor.UnitTests/Other/GroupKeyPathTests.cs
@@ -82,15 +82,6 @@ namespace MudBlazor.UnitTests.Other
         }
 
         [Test]
-        public void Equals_EmptyVsNonEmpty_ReturnsFalse()
-        {
-            var empty = new GroupKeyPath([]);
-            var nonEmpty = new GroupKeyPath(["A"]);
-            Assert.That(empty.Equals(nonEmpty), Is.False);
-            Assert.That(nonEmpty.Equals(empty), Is.False);
-        }
-
-        [Test]
         public void UsedAsDictionaryKey_EqualContentDistinctInstance_FindsValue()
         {
             // Equal-content paths from distinct instances must collide correctly so hash-based lookups succeed.

--- a/src/MudBlazor.UnitTests/Other/LanguageResourceTests.cs
+++ b/src/MudBlazor.UnitTests/Other/LanguageResourceTests.cs
@@ -28,4 +28,42 @@ public class LanguageResourceTests
             char.IsAsciiLetterUpper(key![0]).Should().BeTrue("because keys must start with an uppercase letter");
         }
     }
+
+    [Test]
+    public void ResourceValues_ShouldNotBeNullOrWhiteSpace()
+    {
+        var manager = LanguageResource.ResourceManager;
+        var resourceSet = manager.GetResourceSet(CultureInfo.InvariantCulture, true, true);
+
+        foreach (DictionaryEntry entry in resourceSet!)
+        {
+            var key = entry.Key.ToString();
+            var value = entry.Value as string;
+
+            value.Should().NotBeNullOrWhiteSpace(
+                $"because the translation for '{key}' would render as blank text in the UI");
+        }
+    }
+
+    [Test]
+    public void ResourceValues_ShouldBeValidCompositeFormatStrings()
+    {
+        var manager = LanguageResource.ResourceManager;
+        var resourceSet = manager.GetResourceSet(CultureInfo.InvariantCulture, true, true);
+
+        // Several values are used as string.Format templates (e.g. "Page {0}", "{0}-{1} of {2}").
+        // A malformed placeholder such as an unbalanced brace would throw FormatException at runtime.
+        var arguments = new object[10];
+
+        foreach (DictionaryEntry entry in resourceSet!)
+        {
+            var key = entry.Key.ToString();
+            var value = (string)entry.Value!;
+
+            var format = () => string.Format(CultureInfo.InvariantCulture, value, arguments);
+
+            format.Should().NotThrow<FormatException>(
+                $"because the translation for '{key}' must be a valid composite format string");
+        }
+    }
 }

--- a/src/MudBlazor.UnitTests/Other/LanguageResourceTests.cs
+++ b/src/MudBlazor.UnitTests/Other/LanguageResourceTests.cs
@@ -30,22 +30,6 @@ public class LanguageResourceTests
     }
 
     [Test]
-    public void ResourceValues_ShouldNotBeNullOrWhiteSpace()
-    {
-        var manager = LanguageResource.ResourceManager;
-        var resourceSet = manager.GetResourceSet(CultureInfo.InvariantCulture, true, true);
-
-        foreach (DictionaryEntry entry in resourceSet!)
-        {
-            var key = entry.Key.ToString();
-            var value = entry.Value as string;
-
-            value.Should().NotBeNullOrWhiteSpace(
-                $"because the translation for '{key}' would render as blank text in the UI");
-        }
-    }
-
-    [Test]
     public void ResourceValues_ShouldBeValidCompositeFormatStrings()
     {
         var manager = LanguageResource.ResourceManager;


### PR DESCRIPTION
Adds focused unit tests across the Other namespace, curated to the highest-value cases.

- CategoryAttribute: null/empty and unknown-name guards, and the documented API-doc ordering contract.
- DateRange: ToString/TryParse round-trip, the both-endpoints-null special case, and endpoint-comparison branches.
- GroupKeyPath: empty-path equality and dictionary-key usage.
- LanguageResource: composite-format-string validation guarding a runtime FormatException.

Test-only; no production code changed.
