### PR TITLE
MudHotkey: Pass HotkeyEventArgs to OnHotkeyPressed

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Hotkey/Examples/HotkeyExampleEventCallback.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hotkey/Examples/HotkeyExampleEventCallback.razor
@@ -27,8 +27,10 @@
     private JsKey _selectedKey = JsKey.KeyB;
     private IReadOnlyCollection<JsKeyModifier> _selectedKeyModifiers = [JsKeyModifier.ControlLeft];
 
-    private void OnHotKey()
+    private void OnHotKey(HotkeyEventArgs args)
     {
-        SnackbarService.Add("Hotkey pressed", Severity.Success);
+        var modifiers = string.Join(" + ", args.KeyModifiers);
+        var combination = string.IsNullOrEmpty(modifiers) ? $"{args.Key}" : $"{modifiers} + {args.Key}";
+        SnackbarService.Add($"Hotkey pressed: {combination}", Severity.Success);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Hotkey/HotkeyPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hotkey/HotkeyPage.razor
@@ -25,7 +25,15 @@
                 </SectionContent>
             </DocsPageSection>
             <DocsPageSection>
-                <SectionHeader Title="Event callback"/>
+                <SectionHeader Title="Event callback">
+                    <Description>
+                        The handler receives a <CodeInline>HotkeyEventArgs</CodeInline> identifying the
+                        <CodeInline>Key</CodeInline> and <CodeInline>KeyModifiers</CodeInline> that triggered it,
+                        plus the <CodeInline>MudHotkey</CodeInline> that raised it via <CodeInline>Sender</CodeInline>,
+                        so several hotkeys can share a single handler. Handlers that don't need it can stay
+                        parameterless.
+                    </Description>
+                </SectionHeader>
                 <SectionContent Code="@nameof(HotkeyExampleEventCallback)">
                     <HotkeyExampleEventCallback/>
                 </SectionContent>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyEventArgsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyEventArgsTest.razor
@@ -1,0 +1,20 @@
+@using MudBlazor.Utilities
+
+@* Several hotkeys wired to a single handler that tells them apart via HotkeyEventArgs.
+   Includes two hotkeys on the SAME Key distinguished only by modifiers (issue #13125's motivation). *@
+<MudHotkey Key="JsKey.KeyA" OnHotkeyPressed="OnHotKey" />
+<MudHotkey Key="JsKey.KeyB" KeyModifiers="@(new[] { JsKeyModifier.ShiftLeft })" OnHotkeyPressed="OnHotKey" />
+<MudHotkey Key="JsKey.KeyB" KeyModifiers="@(new[] { JsKeyModifier.ControlLeft, JsKeyModifier.ShiftLeft })" OnHotkeyPressed="OnHotKey" />
+
+@code {
+    public HotkeyEventArgs? LastArgs { get; private set; }
+
+    public int PressedCount { get; private set; }
+
+    // Single handler for every hotkey; the args identify which one fired.
+    private void OnHotKey(HotkeyEventArgs args)
+    {
+        LastArgs = args;
+        PressedCount++;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyTest.razor
@@ -1,7 +1,5 @@
 ﻿@using MudBlazor.Utilities
 
-@* OnHotKey is intentionally parameterless: this proves a handler written against the old
-   non-generic EventCallback still binds to EventCallback<HotkeyEventArgs> with no source change. *@
 <MudHotkey Key="Key" KeyModifiers="KeyModifiers" OnHotkeyPressed="OnHotKey" HideChildContentOnRepress="HideChildContentOnRepress" Disabled="Disabled" PreventEventPropagation="PreventEventPropagation">
     @if (ChildContent == null)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyTest.razor
@@ -1,5 +1,7 @@
 ﻿@using MudBlazor.Utilities
 
+@* OnHotKey is intentionally parameterless: this proves a handler written against the old
+   non-generic EventCallback still binds to EventCallback<HotkeyEventArgs> with no source change. *@
 <MudHotkey Key="Key" KeyModifiers="KeyModifiers" OnHotkeyPressed="OnHotKey" HideChildContentOnRepress="HideChildContentOnRepress" Disabled="Disabled" PreventEventPropagation="PreventEventPropagation">
     @if (ChildContent == null)
     {

--- a/src/MudBlazor.UnitTests/Components/MudHotkeyTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MudHotkeyTests.cs
@@ -51,6 +51,34 @@ public class MudHotkeyTests : BunitTest
     }
 
     [Test]
+    public async Task Hotkey_ShouldPassEventArgsIdentifyingWhichHotkeyFired()
+    {
+        // Arrange: several hotkeys share a single handler that tells them apart via HotkeyEventArgs.
+        var comp = Context.Render<MudHotkeyEventArgsTest>();
+        var hotkeys = comp.FindComponents<MudHotkey>();
+
+        // The first hotkey: KeyA, no modifiers.
+        await comp.InvokeAsync(hotkeys[0].Instance.MudHotkeyProviderJsCallback);
+        comp.Instance.LastArgs!.Key.Should().Be(JsKey.KeyA);
+        comp.Instance.LastArgs!.KeyModifiers.Should().BeEmpty();
+        comp.Instance.LastArgs!.Sender.Should().BeSameAs(hotkeys[0].Instance);
+
+        // The second hotkey: KeyB + ShiftLeft.
+        await comp.InvokeAsync(hotkeys[1].Instance.MudHotkeyProviderJsCallback);
+        comp.Instance.LastArgs!.Key.Should().Be(JsKey.KeyB);
+        comp.Instance.LastArgs!.KeyModifiers.Should().ContainSingle().Which.Should().Be(JsKeyModifier.ShiftLeft);
+        comp.Instance.LastArgs!.Sender.Should().BeSameAs(hotkeys[1].Instance);
+
+        // The third hotkey: SAME Key as the second, distinguished only by its (multiple) modifiers.
+        await comp.InvokeAsync(hotkeys[2].Instance.MudHotkeyProviderJsCallback);
+        comp.Instance.LastArgs!.Key.Should().Be(JsKey.KeyB);
+        comp.Instance.LastArgs!.KeyModifiers.Should().BeEquivalentTo([JsKeyModifier.ControlLeft, JsKeyModifier.ShiftLeft]);
+        comp.Instance.LastArgs!.Sender.Should().BeSameAs(hotkeys[2].Instance);
+
+        comp.Instance.PressedCount.Should().Be(3);
+    }
+
+    [Test]
     public async Task Hotkey_JsTestComponentLifetimeCycle()
     {
         var jsRuntimeMock = new Mock<IJSRuntime>();

--- a/src/MudBlazor/Components/Hotkey/HotkeyEventArgs.cs
+++ b/src/MudBlazor/Components/Hotkey/HotkeyEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/Hotkey/HotkeyEventArgs.cs
+++ b/src/MudBlazor/Components/Hotkey/HotkeyEventArgs.cs
@@ -1,0 +1,42 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using MudBlazor.Utilities;
+
+namespace MudBlazor;
+
+/// <summary>
+/// The information passed when a <see cref="MudHotkey"/> is pressed.
+/// </summary>
+public class HotkeyEventArgs : EventArgs
+{
+    /// <summary>
+    /// The key which triggered the hotkey.
+    /// </summary>
+    public JsKey Key { get; }
+
+    /// <summary>
+    /// The modifiers which were pressed together with <see cref="Key"/>.
+    /// </summary>
+    public IReadOnlyCollection<JsKeyModifier> KeyModifiers { get; }
+
+    /// <summary>
+    /// The <see cref="MudHotkey"/> which raised the event.
+    /// </summary>
+    public MudHotkey Sender { get; }
+
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    /// <param name="key">The key which triggered the hotkey.</param>
+    /// <param name="keyModifiers">The modifiers which were pressed together with <paramref name="key"/>.</param>
+    /// <param name="sender">The <see cref="MudHotkey"/> which raised the event.</param>
+    public HotkeyEventArgs(JsKey key, IReadOnlyCollection<JsKeyModifier> keyModifiers, MudHotkey sender)
+    {
+        Key = key;
+        KeyModifiers = keyModifiers;
+        Sender = sender;
+    }
+}

--- a/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
+++ b/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
@@ -45,11 +45,6 @@ public partial class MudHotkey : MudComponentBase, IAsyncDisposable
     /// <summary>
     /// Occurs when <see cref="Key"/> and <see cref="KeyModifiers"/> are pressed.
     /// </summary>
-    /// <remarks>
-    /// The <see cref="HotkeyEventArgs"/> identifies which hotkey was pressed, which is useful when
-    /// multiple hotkeys share a single handler. Handlers that do not need the arguments can keep
-    /// using a parameterless method or lambda.
-    /// </remarks>
     [Parameter, Category(CategoryTypes.Hotkey.Behavior)]
     public EventCallback<HotkeyEventArgs> OnHotkeyPressed { get; set; }
 

--- a/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
+++ b/src/MudBlazor/Components/Hotkey/MudHotkey.razor.cs
@@ -45,8 +45,13 @@ public partial class MudHotkey : MudComponentBase, IAsyncDisposable
     /// <summary>
     /// Occurs when <see cref="Key"/> and <see cref="KeyModifiers"/> are pressed.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="HotkeyEventArgs"/> identifies which hotkey was pressed, which is useful when
+    /// multiple hotkeys share a single handler. Handlers that do not need the arguments can keep
+    /// using a parameterless method or lambda.
+    /// </remarks>
     [Parameter, Category(CategoryTypes.Hotkey.Behavior)]
-    public EventCallback OnHotkeyPressed { get; set; }
+    public EventCallback<HotkeyEventArgs> OnHotkeyPressed { get; set; }
 
     /// <summary>
     /// Whether to hide the child content when the hotkey is pressed again, allowing for a toggle behavior.
@@ -151,7 +156,7 @@ public partial class MudHotkey : MudComponentBase, IAsyncDisposable
             await InvokeAsync(StateHasChanged);
         }
 
-        await OnHotkeyPressed.InvokeAsync();
+        await OnHotkeyPressed.InvokeAsync(new HotkeyEventArgs(Key, KeyModifiers.ToArray(), this));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Closes #13125

Adds a `HotkeyEventArgs` payload to `MudHotkey.OnHotkeyPressed` so a single handler can tell which hotkey fired.

Existing Razor markup keeps compiling untouched. When you assign a handler to a typed event-callback parameter, the Razor compiler routes it through `EventCallbackFactory.Create<HotkeyEventArgs>(...)`, and the factory has overloads that take a parameterless `Action` and a parameterless `Func<Task>` — those two are what keep existing method-group / lambda handlers binding with no edits.

The property's accessor signature changes (`set_OnHotkeyPressed(EventCallback)` -> `set_OnHotkeyPressed(EventCallback<HotkeyEventArgs>)`), so a *precompiled* downstream assembly that references `OnHotkeyPressed` and isn't rebuilt can fail at load/bind time (e.g. `MissingMethodException`) until recompiled.