### PR TITLE
MudRating: Stop interaction effects when ReadOnly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -222,6 +222,39 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task Rating_RippleClass_SuppressedWhenReadOnly()
+        {
+            var comp = Context.Render<MudRating>();
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+
+            RatingItemsSpans()[0].ClassName.Should().Contain("mud-ripple");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ReadOnly, true));
+            RatingItemsSpans()[0].ClassName.Should().NotContain("mud-ripple");
+        }
+
+        [Test]
+        public async Task Rating_RootGetsReadOnlyClassWhenReadOnly()
+        {
+            var comp = Context.Render<MudRating>();
+            comp.Find("span.mud-rating-root").ClassName.Should().NotContain("mud-readonly");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ReadOnly, true));
+            comp.Find("span.mud-rating-root").ClassName.Should().Contain("mud-readonly");
+        }
+
+        [Test]
+        public void Rating_ReadOnly_DoesNotActivateItemOnHover()
+        {
+            var comp = Context.Render<MudRating>(parameters => parameters.Add(p => p.ReadOnly, true));
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+
+            RatingItemsSpans()[2].PointerOver();
+            comp.Instance.HoveredValue.Should().BeNull();
+            RatingItemsSpans()[2].ClassName.Should().NotContain("mud-rating-item-active");
+        }
+
+        [Test]
         public async Task Rating_KeyboardNavigation()
         {
             var comp = Context.Render<MudRating>(parameters => parameters

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -29,6 +29,7 @@ namespace MudBlazor
         protected string ClassName =>
             new CssBuilder("mud-rating-root")
                 .AddClass("mud-disabled", Disabled)
+                .AddClass("mud-readonly", ReadOnly)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -21,7 +21,7 @@ namespace MudBlazor
         /// </summary>
         protected string ClassName =>
             new CssBuilder("mud-rating-item")
-                .AddClass("mud-ripple mud-ripple-icon", Ripple)
+                .AddClass("mud-ripple mud-ripple-icon", Ripple && !ReadOnly)
                 .AddClass("yellow-text.text-darken-3", Color == Color.Default)
                 .AddClass($"mud-{Color.ToStringFast(true)}-text", Color != Color.Default)
                 .AddClass("mud-rating-item-active", Active)
@@ -191,7 +191,7 @@ namespace MudBlazor
         // rating item lose hover
         internal Task HandlePointerOutAsync(PointerEventArgs e)
         {
-            if (Disabled || Rating is null)
+            if (Disabled || ReadOnly || Rating is null)
             {
                 return Task.CompletedTask;
             }
@@ -203,7 +203,7 @@ namespace MudBlazor
 
         internal Task HandlePointerOverAsync(PointerEventArgs e)
         {
-            if (Disabled)
+            if (Disabled || ReadOnly)
             {
                 return Task.CompletedTask;
             }

--- a/src/MudBlazor/Styles/components/_rating.scss
+++ b/src/MudBlazor/Styles/components/_rating.scss
@@ -5,7 +5,7 @@
   &:focus-visible, &:active {
     outline: none;
 
-    &:not(.mud-disabled) {
+    &:not(.mud-disabled):not(.mud-readonly) {
       background-color: var(--mud-palette-action-default-hover);
     }
   }


### PR DESCRIPTION
A `ReadOnly` rating still reacted to pointer interaction, even though its value can't be changed:

- Hovering an item grew it (`transform: scale(1.2)`).
- Clicking fired the ripple.
- The `:focus-visible` / `:active` grey background appeared.

Only `Disabled` was guarded. Issue #13265 ("Rating control still applies hover CSS when ReadOnly=true") was partially fixed by #13267, which stopped the hover *fill* (via the parent-side `HandleItemHoveredAsync` guard) — but the child-side `Active` flag that drives the `scale(1.2)` was still guarded only on `Disabled`, and the ripple and grey background were never gated on `ReadOnly` at all.

Changes

- `MudRatingItem.razor.cs`: add `ReadOnly` to the `HandlePointerOver/Out` guards so the `Active` flag (the scale) never sets when readonly; gate the ripple class on `!ReadOnly`.
- `MudRating.razor.cs`: add `mud-readonly` to the root so the stylesheet can target it.
- `_rating.scss`: exclude `.mud-readonly` from the `:focus-visible` / `:active` background rule.

Result: a readonly rating is inert — no hover scale, no ripple, no grey background — while interactive ratings are unchanged.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
