### PR TITLE
MudRating: Remove the grey block on click and color the ripple

### DIFF
--- a/src/MudBlazor/Styles/components/_rating.scss
+++ b/src/MudBlazor/Styles/components/_rating.scss
@@ -2,7 +2,8 @@
   display: inline-flex;
   color: #ffb400;
 
-  &:focus-visible, &:active {
+  // Keyboard focus only. :active is excluded so clicking no longer greys the whole block.
+  &:focus-visible {
     outline: none;
 
     &:not(.mud-disabled):not(.mud-readonly) {
@@ -13,6 +14,7 @@
 
 .mud-rating-item {
   cursor: pointer;
+  --mud-ripple-color: currentColor;
   transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
   &.mud-rating-item-active {


### PR DESCRIPTION
Two grey artifacts appear when you click a star:

1. **Whole-block grey.** `.mud-rating-root:active` paints `background-color: var(--mud-palette-action-default-hover)` over the root. CSS `:active` matches the activated element *and its ancestors*, so clicking any star greys the entire group. (It was added in #8256 on top of the keyboard-focus rule from #3399.)
2. **Grey ripple.** The per-item ripple has no `--mud-ripple-color`, so it falls back to `--mud-palette-text-primary` (grey).

Changes

- Drop `:active` from the root background rule; keep `:focus-visible` as the keyboard focus affordance.
- Set `--mud-ripple-color: currentColor` on `.mud-rating-item` so the ripple matches the star color instead of grey.

Clicking a star no longer greys the whole block, and the ripple takes the star's color rather than grey.


Before

<img width="245" height="85" alt="before" src="https://github.com/user-attachments/assets/433d4cf5-7657-4838-9ae8-20045db5ae21" />


After

<img width="245" height="85" alt="after" src="https://github.com/user-attachments/assets/6fb6f188-9f58-477b-be32-01baaeacec20" />


**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests *(CSS-only change; not observable in bUnit — existing tests pass)*
