### PR TITLE
MudRating: Make Ripple opt-in (default false)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -222,14 +222,28 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task Rating_RippleClass_SuppressedWhenReadOnly()
+        public async Task Rating_RippleOffByDefault()
         {
             var comp = Context.Render<MudRating>();
             IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
 
+            RatingItemsSpans()[0].ClassName.Should().NotContain("mud-ripple");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Ripple, true));
+            RatingItemsSpans()[0].ClassName.Should().Contain("mud-ripple");
+        }
+
+        [Test]
+        public async Task Rating_RippleClass_SuppressedWhenReadOnly()
+        {
+            var comp = Context.Render<MudRating>(parameters => parameters.Add(p => p.Ripple, true));
+            IReadOnlyList<IElement> RatingItemsSpans() => comp.FindAll("span.mud-rating-item");
+
             RatingItemsSpans()[0].ClassName.Should().Contain("mud-ripple");
 
-            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ReadOnly, true));
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.Ripple, true)
+                .Add(p => p.ReadOnly, true));
             RatingItemsSpans()[0].ClassName.Should().NotContain("mud-ripple");
         }
 

--- a/src/MudBlazor/Components/Rating/MudRating.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRating.razor.cs
@@ -138,11 +138,11 @@ namespace MudBlazor
         /// Shows a ripple effect when an item is clicked.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.
+        /// Defaults to <c>false</c>.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Rating.Appearance)]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = false;
 
         /// <summary>
         /// Prevents the user from interacting with this rating and shows a disabled color.

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -67,10 +67,10 @@ namespace MudBlazor
         /// Show a ripple effect when the user clicks the button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.  Can be overridden by <see cref="MudRating.Ripple"/>.
+        /// Defaults to <c>false</c>.  Can be overridden by <see cref="MudRating.Ripple"/>.
         /// </remarks>
         [Parameter]
-        public bool Ripple { get; set; } = true;
+        public bool Ripple { get; set; } = false;
 
         /// <summary>
         /// Prevents the user from interacting with this item, and uses a disabled style.


### PR DESCRIPTION
Default `MudRating.Ripple` (and `MudRatingItem.Ripple`) to `false` so the ripple is opt-in.

The ripple's current styling reads poorly on a rating:

<img width="245" height="85" alt="after" src="https://github.com/user-attachments/assets/abd3182a-7a72-40b1-a2c2-fcfee0fd0698" />

it's a square wash over the star rather than something shaped to the icon. Rather than ship that on by default, this makes it opt-in. The `Ripple` parameter stays fully functional and is intentionally **not** marked `[Obsolete]`, so the ripple can be restyled and re-enabled by default later without any migration for users.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
