### PR TITLE
MudRating: Remove dead code and tidy parameter metadata/docs

### DIFF
--- a/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
+++ b/src/MudBlazor.UnitTests/Other/CategoryAttributeTests.cs
@@ -59,8 +59,6 @@ namespace MudBlazor.UnitTests.Other
                 typeof(MudPageContentNavigation),
                 typeof(MudSnackbarElement),
                 typeof(MudBlazor.Charts.Legend<>),
-
-                typeof(MudRatingItem),  // TODO: remove it later; see also: https://github.com/MudBlazor/MudBlazor/discussions/3452
             };
 
             var isTestOK = true;

--- a/src/MudBlazor/Components/Rating/MudRating.razor
+++ b/src/MudBlazor/Components/Rating/MudRating.razor
@@ -7,7 +7,7 @@
 #pragma warning disable CS0618 // Type or member is obsolete
 }
 
-<span tabindex="@(Disabled ? -1 : 0)" role="radiogroup" aria-readonly="@(ReadOnly.ToString().ToLower())"
+<span tabindex="@(Disabled ? -1 : 0)" role="radiogroup" aria-readonly="@(ReadOnly.ToString().ToLowerInvariant())"
       @onkeydown="HandleKeyDownAsync" @attributes="UserAttributes" class="@ClassName" style="@Style">
     <CascadingValue Value="this">
         @for (var i = 1; i <= MaxValue; i++)

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor
@@ -14,7 +14,7 @@
            name="@Rating?.Name"
            disabled="@Disabled"
            checked="@Checked"
-           aria-readonly="@(ReadOnly.ToString().ToLower())" />
+           aria-readonly="@(ReadOnly.ToString().ToLowerInvariant())" />
 
     <MudIcon Icon="@ItemIcon" Color="@ItemColor" Size="@Size" />
 </span>

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor.cs
@@ -21,8 +21,7 @@ namespace MudBlazor
         /// </summary>
         protected string ClassName =>
             new CssBuilder("mud-rating-item")
-                .AddClass("mud-ripple mud-ripple-icon", Ripple && !ReadOnly)
-                .AddClass("yellow-text.text-darken-3", Color == Color.Default)
+                .AddClass("mud-ripple", Ripple && !ReadOnly)
                 .AddClass($"mud-{Color.ToStringFast(true)}-text", Color != Color.Default)
                 .AddClass("mud-rating-item-active", Active)
                 .AddClass("mud-disabled", Disabled)
@@ -43,33 +42,37 @@ namespace MudBlazor
         /// Defaults to the index of this item in the parent <see cref="MudRating"/>.  (e.g. The 3rd item has a value of <c>3</c>.)
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Rating.Data)]
         public int ItemValue { get; set; }
 
         /// <summary>
         /// The size of this item.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Size.Medium"/>.  Can be overridden by <see cref="MudRating.Size"/>.
+        /// Defaults to <see cref="Size.Medium"/>.  When used within a <see cref="MudRating"/>, the value of <see cref="MudRating.Size"/> is applied instead.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Rating.Appearance)]
         public Size Size { get; set; } = Size.Medium;
 
         /// <summary>
         /// The color of this item.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Color.Default"/>.  Can be overridden by <see cref="MudRating.Color"/>.
+        /// Defaults to <see cref="Color.Default"/>.  When used within a <see cref="MudRating"/>, the value of <see cref="MudRating.Color"/> is applied instead.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Rating.Appearance)]
         public Color Color { get; set; } = Color.Default;
 
         /// <summary>
         /// Show a ripple effect when the user clicks the button.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>.  Can be overridden by <see cref="MudRating.Ripple"/>.
+        /// Defaults to <c>false</c>.  When used within a <see cref="MudRating"/>, the value of <see cref="MudRating.Ripple"/> is applied instead.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Rating.Appearance)]
         public bool Ripple { get; set; } = false;
 
         /// <summary>
@@ -79,15 +82,17 @@ namespace MudBlazor
         /// Defaults to <c>false</c>.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Rating.Behavior)]
         public bool Disabled { get; set; }
 
         /// <summary>
-        /// Prevents thid item from being changed.
+        /// Prevents this item from being changed.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Rating.Behavior)]
         public bool ReadOnly { get; set; }
 
         /// <summary>

--- a/src/MudBlazor/Styles/components/_rating.scss
+++ b/src/MudBlazor/Styles/components/_rating.scss
@@ -2,7 +2,6 @@
   display: inline-flex;
   color: #ffb400;
 
-  // Keyboard focus only. :active is excluded so clicking no longer greys the whole block.
   &:focus-visible {
     outline: none;
 
@@ -28,18 +27,6 @@
     & * {
       cursor: default;
       color: var(--mud-palette-text-disabled);
-    }
-  }
-
-  @media(hover: hover) and (pointer: fine) {
-    .mud-disabled:hover {
-      cursor: default;
-      pointer-events: none;
-
-      & * {
-        cursor: default;
-        color: var(--mud-palette-text-disabled);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary

Cleanup-only refactor for `MudRating` / `MudRatingItem`. No behavior change.

## Dead code

- Remove the `.mud-disabled:hover` `@media` block in `_rating.scss`: it was missing the `&`, so it compiled to a descendant selector (`.mud-rating-item .mud-disabled:hover`) that never matched, and it duplicated the already-active `&.mud-disabled` rule.
- Drop the `mud-ripple-icon` class from rating items — the document-delegated ripple only keys off `.mud-ripple`, and the only `.mud-ripple-icon` rule lives in `_buttongroup.scss` and can't match a rating item.
- Remove the malformed Materialize leftover `yellow-text.text-darken-3` (a single bogus class token; no such CSS exists). The default star color comes from `.mud-rating-root { color: #ffb400 }`, so rendering is unchanged.
- Remove a low-value code comment.

## Parameter metadata

- Add the required `[Category]` to every `MudRatingItem` parameter (Data / Appearance / Behavior, matching `MudRating`) and remove its `CategoryAttributeTests` whitelist exception (the TODO referencing discussion #3452).

## Docs

- Fix the "thid" typo in `ReadOnly`'s summary.
- Use `ToLowerInvariant()` for `aria-readonly`, matching the rest of the library.
- Clarify in the `MudRatingItem` `Color` / `Size` / `Ripple` remarks that `MudRating` controls these values when an item is used inside a rating. They previously read "Can be overridden by …", which is misleading — the parent always applies its own value.

## Tests

`RatingTests` and `CategoryAttributeTests` pass (17 total). The category enforcement test now covers `MudRatingItem` with the exception removed.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests *(no behavior change; existing tests pass and category enforcement now covers MudRatingItem)*
