### PR TITLE
MudTabs: Fix nested tabs clipping in vertical parent

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsNestedFitTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsNestedFitTest.razor
@@ -1,0 +1,33 @@
+<div style="max-width: 520px; border: 1px solid var(--mud-palette-lines-default);">
+    <MudTabs Position="Position.Left" Elevation="1">
+        <MudTabPanel Text="Outer 1">
+            <MudTabs>
+                @foreach (var tab in _tabs)
+                {
+                    <MudTabPanel @key="tab" Text="@tab">
+                        <MudText>@tab content</MudText>
+                    </MudTabPanel>
+                }
+            </MudTabs>
+        </MudTabPanel>
+        <MudTabPanel Text="Outer 2">
+            <MudText>Second outer tab</MudText>
+        </MudTabPanel>
+    </MudTabs>
+</div>
+
+@code {
+    public static string __description__ = "nested tabs should fit inside a left-positioned parent tab";
+
+    private readonly List<string> _tabs =
+    [
+        "Accounts",
+        "Billing",
+        "Documents",
+        "Notifications",
+        "Permissions",
+        "Audit history",
+        "Integrations",
+        "Advanced settings"
+    ];
+}

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -134,6 +134,10 @@
     display: flex;
     flex-grow: 1;
     min-width: 0;
+
+    > .mud-tab-panel-active > * {
+      min-width: 0;
+    }
   }
 }
 

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -133,6 +133,7 @@
   &.mud-tabs-vertical {
     display: flex;
     flex-grow: 1;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
Fixes #10207

## Description

This PR fixes nested `MudTabs` content being clipped when the parent `MudTabs` uses `Position="Position.Left"` or `Position="Position.Right"`.

The vertical tabs panel container now allows its content area to shrink inside the flex layout, so an inner horizontal `MudTabs` can use its available width and show scroll buttons instead of overflowing behind the parent layout.

A UnitTests Viewer scenario was added for the nested tabs case.

## Verification

- `dotnet build src\MudBlazor.UnitTests.Viewer\MudBlazor.UnitTests.Viewer.csproj --no-restore --nologo`

## Screenshots
<img width="1900" height="798" alt="Screenshot 2026-06-23 223450" src="https://github.com/user-attachments/assets/4e029332-225a-4ac9-8a0c-b95dced628c9" />

Before: issue reproduction in #10207  
After: `TabsNestedFitTest` in MudBlazor.UnitTests.Viewer

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests