### PR TITLE
MudPopover: Fix duplicate provider false positives when uninitialized

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -647,7 +647,7 @@ window.mudpopoverHelper = {
 
     // returns the count of providers
     countProviders: function () {
-        return document.querySelectorAll(`.${window.mudpopoverHelper.mainContainerClass}`).length;
+        return !window.mudpopoverHelper.mainContainerClass ? 0 : document.querySelectorAll(`.${window.mudpopoverHelper.mainContainerClass}`).length;
     },
 
     // sets popoveroverlay to the right z-index

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -647,7 +647,7 @@ window.mudpopoverHelper = {
 
     // returns the count of providers
     countProviders: function () {
-        return !window.mudpopoverHelper.mainContainerClass ? 0 : document.querySelectorAll(`.${window.mudpopoverHelper.mainContainerClass}`).length;
+        return window.mudpopoverHelper.mainContainerClass ? document.querySelectorAll(`.${window.mudpopoverHelper.mainContainerClass}`).length : 0;
     },
 
     // sets popoveroverlay to the right z-index


### PR DESCRIPTION
Whenever the `mainContainerClass` is null because the `initialize` method was not yet called, the countProviders should return 0.

If any element on the page has a class named `null` then the count will be greater than 0. When the popover provider is not initialized, the `countProviders` method evaluates to `document.querySelectorAll(".null")`. This will return the count of elements having a class named `null`.

This can easily happen when using the the [CodeBeam.MudBlazor.Extensions.Code](https://www.nuget.org/packages/CodeBeam.MudBlazor.Extensions.Code) package and formatting JSON which contains `null` tokens. Here's how `null` tokens are rendered:

```html
<span class="token null keyword">null</span>
```

And we end up with this (false positive) exception:

> InvalidOperationException: Duplicate MudPopoverProvider detected. Please ensure there is only one provider, or disable this warning with PopoverOptions.ThrowOnDuplicateProvider.

<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests
