### PR TITLE
MudNumericField: Fire OnKeyUp when ReadOnly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -440,32 +440,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// A read-only numeric field must still fire OnKeyDown and OnKeyUp, like MudTextField does.
-        /// ReadOnly only suppresses changes to the value (e.g. arrow-key increment), never the events
-        /// themselves. Regression test for #11585.
-        /// </summary>
-        [Test]
-        public async Task NumericField_FiresKeyEvents_WhenReadOnly()
-        {
-            var keyDowns = 0;
-            var keyUps = 0;
-            var comp = Context.Render<MudNumericField<double>>();
-            await comp.SetParametersAndRenderAsync(parameters => parameters
-                .Add(x => x.Value, 1234.56)
-                .Add(x => x.ReadOnly, true)
-                .Add(x => x.OnKeyDown, EventCallback.Factory.Create<KeyboardEventArgs>(this, () => keyDowns++))
-                .Add(x => x.OnKeyUp, EventCallback.Factory.Create<KeyboardEventArgs>(this, () => keyUps++)));
-
-            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
-            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
-
-            await comp.WaitForAssertionAsync(() => keyDowns.Should().Be(1));
-            await comp.WaitForAssertionAsync(() => keyUps.Should().Be(1));
-            // The value must remain untouched even though the events fired.
-            comp.Instance.ReadValue.Should().Be(1234.56);
-        }
-
-        /// <summary>
         /// MouseWheel actions should work
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -440,6 +440,32 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A read-only numeric field must still fire OnKeyDown and OnKeyUp, like MudTextField does.
+        /// ReadOnly only suppresses changes to the value (e.g. arrow-key increment), never the events
+        /// themselves. Regression test for #11585.
+        /// </summary>
+        [Test]
+        public async Task NumericField_FiresKeyEvents_WhenReadOnly()
+        {
+            var keyDowns = 0;
+            var keyUps = 0;
+            var comp = Context.Render<MudNumericField<double>>();
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Value, 1234.56)
+                .Add(x => x.ReadOnly, true)
+                .Add(x => x.OnKeyDown, EventCallback.Factory.Create<KeyboardEventArgs>(this, () => keyDowns++))
+                .Add(x => x.OnKeyUp, EventCallback.Factory.Create<KeyboardEventArgs>(this, () => keyUps++)));
+
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "a", Type = "keydown", });
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs() { Key = "a", Type = "keyup", });
+
+            await comp.WaitForAssertionAsync(() => keyDowns.Should().Be(1));
+            await comp.WaitForAssertionAsync(() => keyUps.Should().Be(1));
+            // The value must remain untouched even though the events fired.
+            comp.Instance.ReadValue.Should().Be(1234.56);
+        }
+
+        /// <summary>
         /// MouseWheel actions should work
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -1,4 +1,4 @@
-F﻿// Copyright (c) MudBlazor 2022
+﻿// Copyright (c) MudBlazor 2022
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2022
+F﻿// Copyright (c) MudBlazor 2022
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -390,9 +390,6 @@ namespace MudBlazor
 
         protected Task HandleKeyUpAsync(KeyboardEventArgs obj)
         {
-            // Fire OnKeyUp even when disabled/read-only, mirroring HandleKeyDownAsync and
-            // MudBaseInput.InvokeKeyUpAsync (which MudTextField uses). Read-only only suppresses
-            // value changes, never the events themselves (#11585).
             _isFocused = true;
 
             return OnKeyUp.InvokeAsync(obj);

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -390,9 +390,9 @@ namespace MudBlazor
 
         protected Task HandleKeyUpAsync(KeyboardEventArgs obj)
         {
-            if (GetDisabledState() || GetReadOnlyState())
-                return Task.CompletedTask;
-
+            // Fire OnKeyUp even when disabled/read-only, mirroring HandleKeyDownAsync and
+            // MudBaseInput.InvokeKeyUpAsync (which MudTextField uses). Read-only only suppresses
+            // value changes, never the events themselves (#11585).
             _isFocused = true;
 
             return OnKeyUp.InvokeAsync(obj);


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11585

`MudNumericField` did not fire `OnKeyUp` while `ReadOnly` was set, even though `MudTextField` does. `HandleKeyUpAsync` early-returned on disabled/read-only:

```csharp
if (GetDisabledState() || GetReadOnlyState())
    return Task.CompletedTask;
```

`MudBaseInput.InvokeKeyUpAsync`/`InvokeKeyDownAsync` (used by `MudTextField`) fire their callbacks unconditionally, and `HandleKeyDownAsync` already lost its equivalent guard in https://github.com/MudBlazor/MudBlazor/pull/12512. Read-only is meant to suppress value changes, not events, so `OnKeyUp` should fire too.

This removes the guard from `HandleKeyUpAsync` so it mirrors `HandleKeyDownAsync` and the base input. The value still cannot change in read-only mode: arrow-key increment/decrement is dispatched through `KeyInterceptorService`, whose commands are gated by `CanHandleKeys()` (`!GetDisabledState() && !GetReadOnlyState()`).

The reported `OnKeyDown` symptom no longer reproduces on `dev` (fixed as a side effect of #12512); the remaining gap was the symmetric `OnKeyUp`, which this addresses.

Added `NumericField_FiresKeyEvents_WhenReadOnly` asserting both `OnKeyDown` and `OnKeyUp` fire while the value stays unchanged. Existing `NumericField_KeyboardInput_Readonly`/`_Disabled` tests still pass.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests