### PR TITLE
MudSelect: Fire OnKeyDown callback when ReadOnly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1437,6 +1437,37 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(null));
         }
 
+        /// <summary>
+        /// ReadOnly only suppresses value-changing/menu operations, never the user-facing key callbacks.
+        /// Regression for the OnKeyDown gap, mirroring https://github.com/MudBlazor/MudBlazor/issues/11585 (MudNumericField OnKeyUp).
+        /// </summary>
+        [Test]
+        public async Task Select_FiresKeyEvents_WhenReadOnly()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var keyDownKey = "";
+            var keyUpKey = "";
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
+                .Add(p => p.ReadOnly, true)
+                .Add(p => p.Value, "2")
+                .Add(p => p.OnKeyDown, (KeyboardEventArgs e) => keyDownKey = e.Key)
+                .Add(p => p.OnKeyUp, (KeyboardEventArgs e) => keyUpKey = e.Key)
+                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "1"))
+                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "2"))
+                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "3")));
+
+            // Pressing "3" would character-search-select item "3" if the select were editable; ReadOnly must suppress that.
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp.Instance.ElementId, new KeyboardEventArgs { Key = "3", Type = "keydown", }));
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyUp(comp.Instance.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keyup", }));
+
+            // Both user-facing callbacks fire regardless of ReadOnly.
+            await comp.WaitForAssertionAsync(() => keyDownKey.Should().Be("3"));
+            await comp.WaitForAssertionAsync(() => keyUpKey.Should().Be("Enter"));
+
+            // ReadOnly still prevents the selection from changing.
+            comp.Instance.ReadValue.Should().Be("2");
+        }
+
         [Test]
         public async Task MultiSelectWithCustomComparer()
         {

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1437,37 +1437,6 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(null));
         }
 
-        /// <summary>
-        /// ReadOnly only suppresses value-changing/menu operations, never the user-facing key callbacks.
-        /// Regression for the OnKeyDown gap, mirroring https://github.com/MudBlazor/MudBlazor/issues/11585 (MudNumericField OnKeyUp).
-        /// </summary>
-        [Test]
-        public async Task Select_FiresKeyEvents_WhenReadOnly()
-        {
-            var keyInterceptorService = Context.AddKeyInterceptorService();
-            var keyDownKey = "";
-            var keyUpKey = "";
-            var comp = Context.Render<MudSelect<string>>(parameters => parameters
-                .Add(p => p.ReadOnly, true)
-                .Add(p => p.Value, "2")
-                .Add(p => p.OnKeyDown, (KeyboardEventArgs e) => keyDownKey = e.Key)
-                .Add(p => p.OnKeyUp, (KeyboardEventArgs e) => keyUpKey = e.Key)
-                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "1"))
-                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "2"))
-                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "3")));
-
-            // Pressing "3" would character-search-select item "3" if the select were editable; ReadOnly must suppress that.
-            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(comp.Instance.ElementId, new KeyboardEventArgs { Key = "3", Type = "keydown", }));
-            await comp.InvokeAsync(() => keyInterceptorService.OnKeyUp(comp.Instance.ElementId, new KeyboardEventArgs { Key = "Enter", Type = "keyup", }));
-
-            // Both user-facing callbacks fire regardless of ReadOnly.
-            await comp.WaitForAssertionAsync(() => keyDownKey.Should().Be("3"));
-            await comp.WaitForAssertionAsync(() => keyUpKey.Should().Be("Enter"));
-
-            // ReadOnly still prevents the selection from changing.
-            comp.Instance.ReadValue.Should().Be("2");
-        }
-
         [Test]
         public async Task MultiSelectWithCustomComparer()
         {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1410,9 +1410,10 @@ namespace MudBlazor
                     ]);
 
                 await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
+                    // The user-facing OnKeyUp/OnKeyDown callbacks fire unconditionally; readonly only suppresses the value-changing/menu key handlers below.
                     .HookKeyUp(args => OnKeyUp.InvokeAsync(args))
+                    .HookKeyDown(args => OnKeyDown.InvokeAsync(args))
                     .When(CanHandleKeys, builder => builder
-                        .HookKeyDown(args => OnKeyDown.InvokeAsync(args))
                         .OnKeyDown("Tab", () => CloseMenu(false))
                         .OnKeyDown("ArrowUp", HandleArrowUpAsync)
                         .OnKeyDown("ArrowDown", HandleArrowDownAsync)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1410,7 +1410,6 @@ namespace MudBlazor
                     ]);
 
                 await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
-                    // The user-facing OnKeyUp/OnKeyDown callbacks fire unconditionally; readonly only suppresses the value-changing/menu key handlers below.
                     .HookKeyUp(args => OnKeyUp.InvokeAsync(args))
                     .HookKeyDown(args => OnKeyDown.InvokeAsync(args))
                     .When(CanHandleKeys, builder => builder


### PR DESCRIPTION
`MudSelect` does not fire its user-facing `OnKeyDown` `EventCallback` when `ReadOnly=true`. The hook is registered inside the `When(CanHandleKeys, …)` block (`CanHandleKeys()` returns `!Disabled && !ReadOnly`), so it is gated alongside the value-changing key handlers. Meanwhile `OnKeyUp` is registered outside that block and fires unconditionally, so the component was internally inconsistent.

This is the same class of bug as the `MudNumericField` `OnKeyUp` issue (#11585, fixed in #13367). The baseline `MudTextField` (via `MudBaseInput.InvokeKeyDownAsync`/`InvokeKeyUpAsync`) fires both callbacks regardless of readonly. ReadOnly should only suppress value-changing/menu operations, never the user-facing event callbacks.

The fix moves the `OnKeyDown` hook out of the `When(CanHandleKeys)` block so it fires unconditionally, while the value-changing/menu handlers (Tab, ArrowUp/Down, Space, Escape, Home, End, Enter, character search) stay gated. Hook ordering is preserved — the user callback still runs before the internal handlers.
