### PR TITLE
Build: Tighten AutoTriage rules

### DIFF
--- a/.github/AutoTriage.prompt
+++ b/.github/AutoTriage.prompt
@@ -205,7 +205,7 @@ General Inactivity Rules:
 Mark issues as `stale` when ONE of these inactivity thresholds are met. For the time-based thresholds, only a comment by a human (non-bot) account counts as activity: bot comments, bot actions, and labeled/unlabeled/renamed/assigned/unassigned events never reset the clock. Measure elapsed time from the last human comment, or from the issue's creation date if there are none.
 - Bug: >=18 months since the last human activity
 - Feature: >=36 months since the last human activity
-- Has `question`, `answered`, `not a bug`, `not planned`, `duplicate`, `invalid`, `fixed`, or any `needs:` label for >=28 consecutive days. This trigger-label list is exhaustive; labels not named here (for example `has workaround`, `regression`, `breaking change`, or environment labels) do not trigger staleness.
+- Has `question`, `answered`, `not a bug`, `not planned`, `duplicate`, `invalid`, `fixed`, or any `needs:` label for >=28 consecutive days.
 
 Post this comment verbatim (exclude default footer) when marking an issue stale:
 ```

--- a/.github/AutoTriage.prompt
+++ b/.github/AutoTriage.prompt
@@ -81,8 +81,8 @@ Apply `help wanted` when ALL conditions are met:
 - Has no `needs:` labels
 - Does not qualify for `good first issue`
 - At least one of the following is true:
-  - There have been repeated requests to move the issue forward
-  - There are explicit signals that outside contributions are welcome
+  - Two or more distinct users who are neither the author nor a maintainer have explicitly asked for the issue to be fixed or moved forward (a single extra "+1"/"same here" does not qualify)
+  - A maintainer has explicitly invited outside contributions on this issue
 
 ### Awaiting Triage
 Apply `awaiting triage` while ALL conditions are met:
@@ -130,7 +130,7 @@ Rules for `needs:` labels:
 - When you post an information request as the first triager, add the matching `needs:` label(s) if they are not already present.
 - When mirroring a maintainer's explicit request, add the corresponding `needs:` label only if their comment is the latest human guidance and the information is still outstanding.
 - `needs: example`, `needs: visuals`, and `needs: info` may be cleared when any human comment or update provides the missing material; it does not need to come from the original author.
-- Remove `needs:` labels as soon as the requested information or changes arrive, or if a newer human comment explicitly supersedes the request (for example: "no repro needed", "closing as duplicate", or equivalent clear direction).
+- Remove `needs:` labels only when the timeline contains an explicit, citable event that resolves them: the requested information or changes have actually arrived in a human comment, commit, or update, or a newer human comment explicitly supersedes the request (for example: "no repro needed", "closing as duplicate", or equivalent clear direction). Do not remove a `needs:` label on the inference that the requirement is probably satisfied.
 
 ## 5. Questions
 
@@ -202,10 +202,10 @@ General Inactivity Rules:
 ### Issues Only
 - Set `state: not_planned` on issues that have been stale for >=84 consecutive days
 
-Mark issues as `stale` when ONE of these inactivity thresholds are met:
-- Bug: >=18 months without a timeline event (excluding labeled/unlabeled/renamed/unassigned)
-- Feature: >=36 months without a timeline event (excluding labeled/unlabeled/renamed/unassigned)
-- Has `question`, `answered`, `not a bug`, `not planned`, `duplicate`, `invalid`, `fixed`, or any `needs:` label for >=28 consecutive days
+Mark issues as `stale` when ONE of these inactivity thresholds are met. For the time-based thresholds, only a comment by a human (non-bot) account counts as activity: bot comments, bot actions, and labeled/unlabeled/renamed/assigned/unassigned events never reset the clock. Measure elapsed time from the last human comment, or from the issue's creation date if there are none.
+- Bug: >=18 months since the last human activity
+- Feature: >=36 months since the last human activity
+- Has `question`, `answered`, `not a bug`, `not planned`, `duplicate`, `invalid`, `fixed`, or any `needs:` label for >=28 consecutive days. This trigger-label list is exhaustive; labels not named here (for example `has workaround`, `regression`, `breaking change`, or environment labels) do not trigger staleness.
 
 Post this comment verbatim (exclude default footer) when marking an issue stale:
 ```


### PR DESCRIPTION
## Summary

Three precision fixes to `.github/AutoTriage.prompt`, found by auditing MudBot's own recent triage runs (downloaded run artifacts + reasoning traces). They reduce wasted model escalations **and** fix real decision bugs. No change to tone, footer, or any other policy.

## 1. Define the inactivity clock (fixes a real false-negative)

The stale-marking thresholds said *"N months without a timeline event (excluding labeled/unlabeled/renamed/unassigned)"*, which conflicts with the general rule above it (*"only a human comment resets the timer"*). A **bot comment** isn't in that exclusion list, so the two rules disagree about whether bot activity counts.

This actually misfired: on **#4559** (a `new component` feature request) MudBot reasoned *"last activity was the bot label change in 2025 – still well under the limit"* and took no action — but the last **human** comment was 2023-03-15 (~39 months, past the 36-month feature threshold). It should have been marked stale.

Fix: state explicitly that only a human (non-bot) comment counts as activity; bot comments/actions and label/rename/assign events never reset the clock; measure from the last human comment (or creation date if none).

## 2. Make the 28-day stale-label list exhaustive

The 28-day trigger lists specific status/`needs:` labels, but MudBot occasionally applied it to labels **not** in the list (e.g. proposed stale on an issue because it had `has workaround` for >28 days — #11650). Added one clause stating the list is exhaustive and naming the labels that do **not** trigger it (`has workaround`, `regression`, `breaking change`, environment labels).

## 3. Quantify `help wanted` triggers

*"Repeated requests to move the issue forward"* / *"explicit signals that outside contributions are welcome"* were subjective, and the fast triage pass over-fired on them: **3 of 4** `help wanted` proposals in the sampled runs were a single "+1"-style comment and were rejected on review. Tightened to: **≥2 distinct non-author, non-maintainer users** explicitly asking for a fix, **or** a maintainer explicitly inviting contributions.

## 4. Require explicit evidence before removing `needs:` labels

The remove rule said "as soon as the requested information/changes arrive," which the model sometimes satisfied by *inferring* the requirement was probably met (removing `needs: info`/`needs: changes` without a clear triggering event). Tightened to require an explicit, citable timeline event (a human comment, commit, or update) and to forbid inference-based removal.

---

These came out of an efficiency/quality review of AutoTriage against MudBlazor's live usage. The behavior is unchanged everywhere the policy was already unambiguous; these just close the gaps where MudBot had to guess.
