### PR TITLE
MudTabs: Add lazy loading option when using KeepPanelsAlive

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepAlivePanel.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepAlivePanel.razor
@@ -12,13 +12,13 @@
 
     public int Counter { get; set; } = 0;
 
-    protected override Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            FirstRender.InvokeAsync();
+            await FirstRender.InvokeAsync();
         }
 
-        return base.OnAfterRenderAsync(firstRender);
+        await base.OnAfterRenderAsync(firstRender);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepAlivePanel.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepAlivePanel.razor
@@ -12,12 +12,6 @@
 
     public int Counter { get; set; } = 0;
 
-    protected override async Task OnInitializedAsync()
-    {
-        await Task.Delay(2000);
-        await base.OnInitializedAsync();
-    }
-
     protected override Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepAlivePanel.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepAlivePanel.razor
@@ -1,0 +1,30 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudButton Variant="@Variant.Filled" Color="Color.Primary" OnClick="@(() => Counter++)">@ComponentName Counter: @Counter</MudButton>
+
+@code {
+#nullable enable
+    [Parameter]
+    public string? ComponentName { get; set; }
+
+    [Parameter]
+    public EventCallback FirstRender { get; set; }
+
+    public int Counter { get; set; } = 0;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Delay(2000);
+        await base.OnInitializedAsync();
+    }
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            FirstRender.InvokeAsync();
+        }
+
+        return base.OnAfterRenderAsync(firstRender);
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepPanelsAliveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepPanelsAliveExample.razor
@@ -1,0 +1,45 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTabs @key="@($"{_keepPanelsAlive}-{_lazyLoadPanels}")" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6" KeepPanelsAlive="@_keepPanelsAlive" LazyLoadPanels="@_lazyLoadPanels">
+    <MudTabPanel Text="Item One">
+        <TabsKeepAlivePanel ComponentName="Panel 1" FirstRender="@(x => _firstRenderCounts[0]++)" />
+    </MudTabPanel>
+    <MudTabPanel Text="Item Two">
+        <TabsKeepAlivePanel ComponentName="Panel 2" FirstRender="@(x => _firstRenderCounts[1]++)" />
+    </MudTabPanel>
+    <MudTabPanel Text="Item Three">
+        <TabsKeepAlivePanel ComponentName="Panel 3" FirstRender="@(x => _firstRenderCounts[2]++)" />
+    </MudTabPanel>
+</MudTabs>
+
+<MudText GutterBottom="true" Class="mt-4"><b>Number of first renders per panel:</b></MudText>
+<p>Panel 1: @_firstRenderCounts[0]</p>
+<p>Panel 2: @_firstRenderCounts[1]</p>
+<p>Panel 3: @_firstRenderCounts[2]</p>
+
+<MudSwitch T="bool" Value="@_keepPanelsAlive" ValueChanged="HandleKeepPanelsAliveChanged" Color="Color.Primary">Keep Panels Alive</MudSwitch>
+<MudSwitch T="bool" Value="@_lazyLoadPanels" ValueChanged="HandleLazyLoadPanelsChanged" Color="Color.Primary" Disabled="!_keepPanelsAlive">Lazy Load Panels</MudSwitch>
+
+
+@code {
+    private List<int> _firstRenderCounts = [0, 0, 0];
+
+    bool _keepPanelsAlive = false;
+    bool _lazyLoadPanels = false;
+
+    private void HandleKeepPanelsAliveChanged(bool value)
+    {
+        _keepPanelsAlive = value;
+        _firstRenderCounts = [0, 0, 0];
+        if (!_keepPanelsAlive)
+        {
+            _lazyLoadPanels = false;
+        }
+    }
+
+    private void HandleLazyLoadPanelsChanged(bool value)
+    {
+        _lazyLoadPanels = value;
+        _firstRenderCounts = [0, 0, 0];
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepPanelsAliveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsKeepPanelsAliveExample.razor
@@ -2,13 +2,13 @@
 
 <MudTabs @key="@($"{_keepPanelsAlive}-{_lazyLoadPanels}")" Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6" KeepPanelsAlive="@_keepPanelsAlive" LazyLoadPanels="@_lazyLoadPanels">
     <MudTabPanel Text="Item One">
-        <TabsKeepAlivePanel ComponentName="Panel 1" FirstRender="@(x => _firstRenderCounts[0]++)" />
+        <TabsKeepAlivePanel ComponentName="Panel 1" FirstRender="@(() => _firstRenderCounts[0]++)" />
     </MudTabPanel>
     <MudTabPanel Text="Item Two">
-        <TabsKeepAlivePanel ComponentName="Panel 2" FirstRender="@(x => _firstRenderCounts[1]++)" />
+        <TabsKeepAlivePanel ComponentName="Panel 2" FirstRender="@(() => _firstRenderCounts[1]++)" />
     </MudTabPanel>
     <MudTabPanel Text="Item Three">
-        <TabsKeepAlivePanel ComponentName="Panel 3" FirstRender="@(x => _firstRenderCounts[2]++)" />
+        <TabsKeepAlivePanel ComponentName="Panel 3" FirstRender="@(() => _firstRenderCounts[2]++)" />
     </MudTabPanel>
 </MudTabs>
 

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -226,5 +226,18 @@
             </SectionSubGroups>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Keep Panels Alive">
+                <Description>
+                    By default, tab panels are removed when switching to another tab and rerendered once the tab is selected again.
+                    This behavior can be changed by setting the <CodeInline>KeepPanelsAlive</CodeInline> property to <CodeInline>true</CodeInline>. Then, all tabs are rendered at once and inactive tab panels only get hidden but not destroyed.
+                    The <CodeInline>LazyLoadPanels</CodeInline> property additionally allows rendering tab panels only once they get activated. This property requires <CodeInline>KeepPanelsAlive</CodeInline> to also be <CodeInline>true</CodeInline>.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TabsKeepPanelsAliveExample)" ShowCode="false" Block="true">
+                <TabsKeepPanelsAliveExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAlive/TabsKeepAliveTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/KeepTabsAlive/TabsKeepAliveTest.razor
@@ -1,6 +1,6 @@
-﻿<MudTabs KeepPanelsAlive="@KeepPanelsAlive">
+﻿<MudTabs KeepPanelsAlive="@KeepPanelsAlive" LazyLoadPanels="@LazyLoadPanels">
     <MudTabPanel Text="Item One">
-        <TabsKeepAlivePanel ComponentName="Panel 1" FirstRender="@(x => _firstRenders.Add(x))"/>
+        <TabsKeepAlivePanel ComponentName="Panel 1" FirstRender="@(x => _firstRenders.Add(x))" />
     </MudTabPanel>
     <MudTabPanel Text="Item Two">
         <TabsKeepAlivePanel ComponentName="Panel 2" FirstRender="@(x => _firstRenders.Add(x))" />
@@ -22,4 +22,7 @@
 
     [Parameter]
     public bool KeepPanelsAlive { get; set; } = true;
+
+    [Parameter]
+    public bool LazyLoadPanels { get; set; } = false;
 }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -177,7 +177,7 @@ namespace MudBlazor.UnitTests.Components
 
         /// <summary>
         /// When KeepPanelsAlive="true" the panels are not destroyed and recreated on tab-switch. We prove that by using
-        /// a button click counter on every tab and a callback that is fired only when OnRenderAsync of the tab panel
+        /// a button click counter on every tab and a callback that is fired only when OnAfterRenderAsync of the tab panel
         /// happens the first time (which outputs a message at the bottom).
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -175,6 +175,78 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br>Panel 1<br></p>");
         }
 
+        /// <summary>
+        /// When KeepPanelsAlive="true" the panels are not destroyed and recreated on tab-switch. We prove that by using
+        /// a button click counter on every tab and a callback that is fired only when OnRenderAsync of the tab panel
+        /// happens the first time (which outputs a message at the bottom).
+        /// </summary>
+        [Test]
+        public async Task KeepTabsAliveWithLazyLoadPanels()
+        {
+            var comp = Context.Render<TabsKeepAliveTest>(parameters => parameters.Add(p => p.LazyLoadPanels, true));
+            // only one panel should be evident in the markup
+            comp.FindAll("div.mud-tabs-panels > div").Count.Should().Be(1);
+            // first panel should be active
+            comp.Find("div.mud-tabs-panels > div").ClassList.Should().Contain("mud-tab-panel-active");
+            // only the first panel should be rendered first
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br/></p>");
+            // click first button and check button click counters
+            comp.FindAll("button").Count.Should().Be(1);
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=0");
+            await comp.FindAll("button")[0].ClickAsync();
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
+
+            // switch to the second tab
+            await comp.FindAll("div.mud-tab")[1].ClickAsync();
+            // first and second panel should be evident in the markup
+            comp.FindAll("div.mud-tabs-panels > div").Count.Should().Be(2);
+            // only the second panel should be active
+            comp.FindAll("div.mud-tabs-panels > div")[0].ClassList.Should().NotContain("mud-tab-panel-active");
+            comp.FindAll("div.mud-tabs-panels > div")[1].ClassList.Should().Contain("mud-tab-panel-active");
+            // first and second panel were rendered once with firstRender==true
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br></p>");
+            // first panel text should not have changed
+            comp.FindAll("button").Count.Should().Be(2);
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
+            // click the second button twice and check click counters
+            comp.FindAll("button")[1].TrimmedText().Should().Be("Panel 2=0");
+            await comp.FindAll("button")[1].ClickAsync();
+            await comp.FindAll("button")[1].ClickAsync();
+            comp.FindAll("button")[1].TrimmedText().Should().Be("Panel 2=2");
+
+            // switch to the third tab
+            await comp.FindAll("div.mud-tab")[2].ClickAsync();
+            // all three panels should be evident in the markup
+            comp.FindAll("div.mud-tabs-panels > div").Count.Should().Be(3);
+            // only the third panel should be active
+            comp.FindAll("div.mud-tabs-panels > div")[0].ClassList.Should().NotContain("mud-tab-panel-active");
+            comp.FindAll("div.mud-tabs-panels > div")[1].ClassList.Should().NotContain("mud-tab-panel-active");
+            comp.FindAll("div.mud-tabs-panels > div")[2].ClassList.Should().Contain("mud-tab-panel-active");
+            // all three panels were rendered once with firstRender==true
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            // first and second button texts should not have changed
+            comp.FindAll("button").Count.Should().Be(3);
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
+            comp.FindAll("button")[1].TrimmedText().Should().Be("Panel 2=2");
+            comp.FindAll("button")[2].TrimmedText().Should().Be("Panel 3=0");
+
+            // switch back to the first tab:
+            await comp.FindAll("div.mud-tab")[0].ClickAsync();
+            // all three panels should be evident in the markup
+            comp.FindAll("div.mud-tabs-panels > div").Count.Should().Be(3);
+            // only the first panel should be active
+            comp.FindAll("div.mud-tabs-panels > div")[0].ClassList.Should().Contain("mud-tab-panel-active");
+            comp.FindAll("div.mud-tabs-panels > div")[1].ClassList.Should().NotContain("mud-tab-panel-active");
+            comp.FindAll("div.mud-tabs-panels > div")[2].ClassList.Should().NotContain("mud-tab-panel-active");
+            // all three panels were rendered once with firstRender==true
+            comp.FindAll("p")[^1].MarkupMatches("<p>Panel 1<br>Panel 2<br>Panel 3<br></p>");
+            // all three button texts should not have changed
+            comp.FindAll("button").Count.Should().Be(3);
+            comp.FindAll("button")[0].TrimmedText().Should().Be("Panel 1=1");
+            comp.FindAll("button")[1].TrimmedText().Should().Be("Panel 2=2");
+            comp.FindAll("button")[2].TrimmedText().Should().Be("Panel 3=0");
+        }
+
         [Test]
         public async Task TabHeaderClassPropagated()
         {

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 @implements IAsyncDisposable
 
-@if (Parent?.KeepPanelsAlive == true && (Parent.LazyLoadPanels == false || Parent.ActivePanel == this || _alreadyRendered))
+@if (Parent?.KeepPanelsAlive == true && (!Parent.LazyLoadPanels || Parent.ActivePanel == this || _alreadyRendered))
 {
     _alreadyRendered = true;
     <div @attributes="UserAttributes" class="@PanelClassname" style="@Style" role="tabpanel" id="@Parent.GetTabPanelId(this)" aria-labelledby="@Parent.GetTabId(this)">

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -2,9 +2,11 @@
 @inherits MudComponentBase
 @implements IAsyncDisposable
 
-@if (Parent?.KeepPanelsAlive == true)
+
+@if (Parent?.KeepPanelsAlive == true && (Parent?.LazyLoadPanels == false || Parent?.ActivePanel == this || _alreadyRendered))
 {
-    <div @attributes="UserAttributes" class="@PanelClassname" style="@Style" role="tabpanel" id="@Parent.GetTabPanelId(this)" aria-labelledby="@Parent.GetTabId(this)">
+    _alreadyRendered = true;
+    <div @attributes="UserAttributes" class="@PanelClassname" style="@Style" role="tabpanel" id="@Parent?.GetTabPanelId(this)" aria-labelledby="@Parent?.GetTabId(this)">
         @ChildContent
     </div>
 }

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -2,10 +2,10 @@
 @inherits MudComponentBase
 @implements IAsyncDisposable
 
-@if (Parent?.KeepPanelsAlive == true && (Parent?.LazyLoadPanels == false || Parent?.ActivePanel == this || _alreadyRendered))
+@if (Parent?.KeepPanelsAlive == true && (Parent.LazyLoadPanels == false || Parent.ActivePanel == this || _alreadyRendered))
 {
     _alreadyRendered = true;
-    <div @attributes="UserAttributes" class="@PanelClassname" style="@Style" role="tabpanel" id="@Parent?.GetTabPanelId(this)" aria-labelledby="@Parent?.GetTabId(this)">
+    <div @attributes="UserAttributes" class="@PanelClassname" style="@Style" role="tabpanel" id="@Parent.GetTabPanelId(this)" aria-labelledby="@Parent.GetTabId(this)">
         @ChildContent
     </div>
 }

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor
@@ -2,7 +2,6 @@
 @inherits MudComponentBase
 @implements IAsyncDisposable
 
-
 @if (Parent?.KeepPanelsAlive == true && (Parent?.LazyLoadPanels == false || Parent?.ActivePanel == this || _alreadyRendered))
 {
     _alreadyRendered = true;

--- a/src/MudBlazor/Components/Tabs/MudTabPanel.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabPanel.razor.cs
@@ -15,6 +15,7 @@ namespace MudBlazor;
 public partial class MudTabPanel : MudComponentBase
 {
     private bool _disposed;
+    private bool _alreadyRendered;
 
     internal string Classname =>
         new CssBuilder("mud-tab-panel")

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -98,6 +98,18 @@ namespace MudBlazor
         public bool KeepPanelsAlive { get; set; }
 
         /// <summary>
+        /// Initializes tabs only once visited. Only has an effect if KeepPanelsAlive is true.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.<br />
+        /// When <c>false</c>, all tabs's contents will instantly be initialized.<br />
+        /// When <c>true</c>, a tab's content is initialized only once it is visited.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Tabs.Behavior)]
+        public bool LazyLoadPanels { get; set; }
+
+        /// <summary>
         /// Disables user interaction for all tab panels.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -98,11 +98,11 @@ namespace MudBlazor
         public bool KeepPanelsAlive { get; set; }
 
         /// <summary>
-        /// Initializes tabs only once visited. Only has an effect if KeepPanelsAlive is true.
+        /// Initializes tab panels only once visited. Only has an effect when <see cref="KeepPanelsAlive"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>false</c>.<br />
-        /// When <c>false</c>, all tabs's contents will instantly be initialized.<br />
+        /// When <c>false</c>, all tabs' contents are initialized immediately.<br />
         /// When <c>true</c>, a tab's content is initialized only once it is visited.
         /// </remarks>
         [Parameter]


### PR DESCRIPTION
Closes #6742

## Description

This PR adds a property `LazyLoadPanels` to MudTabs that if combined with `KeepPanelsAlive` makes tab panels only render once they are actually activated, instead of all tab panels being rendered right from the start.

## Changes

- MudTabs: Add `LazyLoadPanels` property
- MudTabPanel: Implement logic to only render once the tab is activated if `KeepPanelsAlive` is true
- Add unit test for `LazyLoadPanels` property
- Add docs section for `KeepPanelsAlive` and `LazyLoadPanels` 

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
