### PR TITLE
MudPopover: Log instead of throw when no provider is in the render scope

### DIFF
--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -121,8 +121,11 @@
                     <SectionHeader Class="mt-6">
                         <Description>
                             <MudAlert Class="mt-4" Severity="Severity.Warning">
-                                If you experience issues such as certain components not responding to user interactions, your render mode may be configured incorrectly.
-                                Static rendering is not supported and the rendering mode must be interactive.
+                                If you experience issues such as certain components not responding to user interactions, or a logged
+                                <CodeInline>Missing &lt;MudPopoverProvider /&gt;</CodeInline> error, your render mode may be configured incorrectly.
+                                Static rendering is not supported: these providers must render in the same interactive render mode as the components that use them.
+                                With global interactivity (the render mode set on <CodeInline>&lt;Routes /&gt;</CodeInline> in <CodeInline>App.razor</CodeInline>) keep them here in <CodeInline>MainLayout.razor</CodeInline>.
+                                With per-page interactivity, <CodeInline>MainLayout.razor</CodeInline> renders statically, so add the providers to each interactive page instead.
                                 <MudLink Href="https://learn.microsoft.com/aspnet/core/blazor/components/render-modes" Target="_blank">Learn about render modes</MudLink>
                                 or
                                 <MudLink Href="https://github.com/MudBlazor/MudBlazor/discussions/7430" Target="_blank">view a related discussion</MudLink>.

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -153,14 +153,7 @@ public class PopoverServiceTests
         // Assert
         await create.Should().NotThrowAsync();
         service.ActivePopovers.Should().ContainSingle(x => x.Id == popover.Id);
-        loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Exactly(checkForPopoverProvider ? 1 : 0));
+        loggerMock.VerifyLogging(PopoverService.MissingProviderMessage, LogLevel.Error, Times.Exactly(checkForPopoverProvider ? 1 : 0));
     }
 
     [Test]
@@ -180,14 +173,7 @@ public class PopoverServiceTests
 
         // Assert
         service.ActivePopovers.Should().HaveCount(2);
-        loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once());
+        loggerMock.VerifyLogging(PopoverService.MissingProviderMessage, LogLevel.Error, Times.Once());
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -145,9 +145,9 @@ public class PopoverServiceTests
         var service = new PopoverService(loggerMock.Object, jsRuntimeMock, new FakeTimeProvider(), new OptionsWrapper<PopoverOptions>(options));
 
         // Act
-        // No MudPopoverProvider is subscribed (ObserversCount == 0). This must never throw: throwing from the
-        // popover's OnInitializedAsync tears down the circuit mid-render and surfaces as a cryptic
-        // ObjectDisposedException on the other components (#11887). With the check on, it logs an error instead.
+        // No MudPopoverProvider is subscribed (ObserversCount == 0).
+        // This must never throw: throwing from the popover's OnInitializedAsync tears down the circuit mid-render and surfaces as a cryptic ObjectDisposedException on the other components (#11887).
+        // With the check on, it logs an error instead.
         var create = () => service.CreatePopoverAsync(popover);
 
         // Assert
@@ -173,8 +173,8 @@ public class PopoverServiceTests
         var service = new PopoverService(loggerMock.Object, jsRuntimeMock, new FakeTimeProvider(), new OptionsWrapper<PopoverOptions>(options));
 
         // Act
-        // Several popovers are created without a provider (e.g. multiple pickers on a page). The actionable error
-        // must be logged only once so the log is not flooded with the same message.
+        // Several popovers are created without a provider (e.g. multiple pickers on a page).
+        // The actionable error must be logged only once so the log is not flooded with the same message.
         await service.CreatePopoverAsync(new PopoverMock());
         await service.CreatePopoverAsync(new PopoverMock());
 

--- a/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Popover/PopoverServiceTests.cs
@@ -4,6 +4,7 @@
 
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -138,22 +139,55 @@ public class PopoverServiceTests
     {
         // Arrange
         var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var loggerMock = new Mock<ILogger<PopoverService>>();
         var popover = new PopoverMock();
         var options = new PopoverOptions { CheckForPopoverProvider = checkForPopoverProvider };
-        var service = CreateService(jsRuntimeMock, options);
+        var service = new PopoverService(loggerMock.Object, jsRuntimeMock, new FakeTimeProvider(), new OptionsWrapper<PopoverOptions>(options));
 
         // Act
+        // No MudPopoverProvider is subscribed (ObserversCount == 0). This must never throw: throwing from the
+        // popover's OnInitializedAsync tears down the circuit mid-render and surfaces as a cryptic
+        // ObjectDisposedException on the other components (#11887). With the check on, it logs an error instead.
         var create = () => service.CreatePopoverAsync(popover);
 
         // Assert
-        if (checkForPopoverProvider)
-        {
-            await create.Should().ThrowAsync<InvalidOperationException>();
-        }
-        else
-        {
-            await create.Should().NotThrowAsync<InvalidOperationException>();
-        }
+        await create.Should().NotThrowAsync();
+        service.ActivePopovers.Should().ContainSingle(x => x.Id == popover.Id);
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Exactly(checkForPopoverProvider ? 1 : 0));
+    }
+
+    [Test]
+    public async Task CreatePopoverAsync_LogsMissingProviderOnlyOnce()
+    {
+        // Arrange
+        var jsRuntimeMock = Mock.Of<IJSRuntime>();
+        var loggerMock = new Mock<ILogger<PopoverService>>();
+        var options = new PopoverOptions { CheckForPopoverProvider = true };
+        var service = new PopoverService(loggerMock.Object, jsRuntimeMock, new FakeTimeProvider(), new OptionsWrapper<PopoverOptions>(options));
+
+        // Act
+        // Several popovers are created without a provider (e.g. multiple pickers on a page). The actionable error
+        // must be logged only once so the log is not flooded with the same message.
+        await service.CreatePopoverAsync(new PopoverMock());
+        await service.CreatePopoverAsync(new PopoverMock());
+
+        // Assert
+        service.ActivePopovers.Should().HaveCount(2);
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once());
     }
 
     [Test]

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -20,8 +20,15 @@ namespace MudBlazor;
 /// </remarks>
 internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHolder>
 {
+    internal const string MissingProviderMessage =
+        "Missing <MudPopoverProvider /> in the active render scope, so popovers cannot be displayed. " +
+        "Add <MudPopoverProvider /> within the same interactive render mode as the components that use it: " +
+        "in your layout for global interactivity, or on each page for per-page interactivity. " +
+        "See https://mudblazor.com/getting-started/installation#manual-install-add-components";
+
     private bool _disposed;
     private bool _isInitializing;
+    private bool _missingProviderLogged;
     private readonly PopoverJsInterop _popoverJsInterop;
     private readonly CancellationToken _cancellationToken;
     private readonly Dictionary<Guid, MudPopoverHolder> _holders;
@@ -29,6 +36,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
     private readonly BatchPeriodicQueue<MudPopoverHolder> _batchExecutor;
     private readonly ObserverManager<Guid, IPopoverObserver> _observerManager;
     private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PopoverService> _logger;
 
     /// <inheritdoc />
     public IEnumerable<IMudPopoverHolder> ActivePopovers => _holders.Values;
@@ -65,6 +73,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
     public PopoverService(ILogger<PopoverService> logger, IJSRuntime jsInterop, TimeProvider timeProvider, IOptions<PopoverOptions>? options = null)
     {
         _timeProvider = timeProvider;
+        _logger = logger;
         PopoverOptions = options?.Value ?? new PopoverOptions();
         _holders = new Dictionary<Guid, MudPopoverHolder>();
         _cancellationTokenSource = new CancellationTokenSource();
@@ -107,12 +116,13 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
             return;
         }
 
-        if (PopoverOptions.CheckForPopoverProvider)
+        if (PopoverOptions.CheckForPopoverProvider && ObserversCount == 0 && !_missingProviderLogged)
         {
-            if (ObserversCount == 0)
-            {
-                throw new InvalidOperationException($"Missing <{nameof(MudPopoverProvider)} />, please add it to your layout. See https://mudblazor.com/getting-started/installation#manual-install-add-components");
-            }
+            // No MudPopoverProvider is subscribed in this render scope. Throwing here (this runs from the popover's
+            // OnInitializedAsync) tears down the circuit mid-render and surfaces as a cryptic ObjectDisposedException
+            // on sibling components (#11887), so log once and continue; the holder is harmless without a provider.
+            _missingProviderLogged = true;
+            _logger.LogError(MissingProviderMessage);
         }
 
         var holder = new MudPopoverHolder(popover.Id, _timeProvider)

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -118,9 +118,8 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
 
         if (PopoverOptions.CheckForPopoverProvider && ObserversCount == 0 && !_missingProviderLogged)
         {
-            // No MudPopoverProvider is subscribed in this render scope. Throwing here (this runs from the popover's
-            // OnInitializedAsync) tears down the circuit mid-render and surfaces as a cryptic ObjectDisposedException
-            // on sibling components (#11887), so log once and continue; the holder is harmless without a provider.
+            // No MudPopoverProvider is subscribed in this render scope.
+            // Throwing here (this runs from the popover's OnInitializedAsync) tears down the circuit mid-render and surfaces as a cryptic ObjectDisposedException on sibling components (#11887), so log once and continue; the holder is harmless without a provider.
             _missingProviderLogged = true;
             _logger.LogError(MissingProviderMessage);
         }

--- a/src/MudBlazor/Services/Popover/PopoverService.cs
+++ b/src/MudBlazor/Services/Popover/PopoverService.cs
@@ -22,8 +22,7 @@ internal class PopoverService : IPopoverService, IBatchTimerHandler<MudPopoverHo
 {
     internal const string MissingProviderMessage =
         "Missing <MudPopoverProvider /> in the active render scope, so popovers cannot be displayed. " +
-        "Add <MudPopoverProvider /> within the same interactive render mode as the components that use it: " +
-        "in your layout for global interactivity, or on each page for per-page interactivity. " +
+        "Add <MudPopoverProvider /> within the same interactive render mode as the components that use it: in your layout for global interactivity, or on each page for per-page interactivity. " +
         "See https://mudblazor.com/getting-started/installation#manual-install-add-components";
 
     private bool _disposed;


### PR DESCRIPTION
When a popover-based component (`MudDatePicker`, `MudDateRangePicker`, `MudSelect`, `MudMenu`, ...) initializes but no `MudPopoverProvider` is subscribed in its render scope, `PopoverService.CreatePopoverAsync` threw an `InvalidOperationException` from the component's `OnInitializedAsync`.

In a Blazor Web App with per-page interactivity this is a common misconfiguration: the providers sit in the static `MainLayout` while the components run on an interactive page, so the circuit-scoped `PopoverService` has no subscribed provider. Throwing from a lifecycle method during the render batch tears down the circuit mid-render, and the sibling components' pending renders then fault with a cryptic `ObjectDisposedException` (`ArrayBuilder.GrowBuffer` -> `RenderTreeDiffBuilder.InsertNewFrame` -> `Renderer.ProcessRenderQueue`) — which is what users actually see, hiding the real cause.

This converts the fatal throw into a single, actionable error log and keeps the popover holder registered, so the app stays usable and the popover renders if a provider becomes present in the scope. The real cure for an affected app is still to place the providers in the same interactive render mode as the components; the logged message and the installation docs now spell this out.

Same root cause as #11168, #12277, #12283.

Before, the circuit crashes:

```
fail: ...Circuits.CircuitHost[111] Missing <MudPopoverProvider />
fail: ...Circuits.CircuitHost[111] System.ObjectDisposedException: Cannot access a disposed object.
   at ArrayBuilder`1.GrowBuffer ... at Renderer.ProcessRenderQueue
```

After, the app keeps running with one actionable log:

```
fail: MudBlazor.PopoverService[0] Missing <MudPopoverProvider /> in the active render scope, so popovers
cannot be displayed. Add <MudPopoverProvider /> within the same interactive render mode as the components
that use it: in your layout for global interactivity, or on each page for per-page interactivity.
See https://mudblazor.com/getting-started/installation#manual-install-add-components
```

Fixes #11887
