### PR TITLE
MudListItem: Fire OnClick for items with a NestedList

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -361,6 +361,32 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task ListItem_WithNestedList_InvokesOnClick_AndExpands()
+        {
+            var clicks = 0;
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item
+                    .Add(x => x.Text, "Parent")
+                    .Add(x => x.Value, "parent")
+                    .Add(x => x.OnClick, () => clicks++)
+                    .Add(x => x.NestedList, nested =>
+                    {
+                        nested.OpenComponent<MudListItem<string>>(0);
+                        nested.AddAttribute(1, nameof(MudListItem<string>.Text), "Child");
+                        nested.AddAttribute(2, nameof(MudListItem<string>.Value), "child");
+                        nested.CloseComponent();
+                    })));
+
+            var parent = comp.FindComponents<MudListItem<string>>().First(x => x.Instance.Text == "Parent");
+            parent.Find("div.mud-list-item").GetAttribute("aria-expanded").Should().Be("false");
+
+            await parent.Find("div.mud-list-item").ClickAsync();
+
+            clicks.Should().Be(1); // OnClick fires even though there is a NestedList
+            parent.Find("div.mud-list-item").GetAttribute("aria-expanded").Should().Be("true"); // and the nested list still expands
+        }
+
+        [Test]
         public async Task Disabled_List_DisablesEveryItem_AndSuppressesSelection()
         {
             var comp = Context.Render<MudList<string>>(builder => builder

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -354,6 +354,8 @@ namespace MudBlazor
             if (NestedList != null)
             {
                 await _expandedState.SetValueAsync(!_expandedState.Value);
+                // still fire OnClick so a nested-list item behaves like any other clickable item
+                await OnClick.InvokeAsync(eventArgs);
                 return;
             }
             if (TopLevelList is not null && !GetReadOnly())
@@ -522,6 +524,8 @@ namespace MudBlazor
             if (NestedList is not null)
             {
                 await _expandedState.SetValueAsync(!_expandedState.Value);
+                // still fire OnClick so a nested-list item behaves like any other clickable item
+                await OnClick.InvokeAsync(new MouseEventArgs());
                 return;
             }
 

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -354,7 +354,6 @@ namespace MudBlazor
             if (NestedList != null)
             {
                 await _expandedState.SetValueAsync(!_expandedState.Value);
-                // still fire OnClick so a nested-list item behaves like any other clickable item
                 await OnClick.InvokeAsync(eventArgs);
                 return;
             }
@@ -524,7 +523,6 @@ namespace MudBlazor
             if (NestedList is not null)
             {
                 await _expandedState.SetValueAsync(!_expandedState.Value);
-                // still fire OnClick so a nested-list item behaves like any other clickable item
                 await OnClick.InvokeAsync(new MouseEventArgs());
                 return;
             }


### PR DESCRIPTION
Fixes #6875.

`MudListItem.OnClick` never fired when the item had a `NestedList`. `OnClickHandlerAsync` (and `OnKeyboardActivateAsync`) toggled the expand state and returned early, before reaching `OnClick.InvokeAsync`. This forwards `OnClick` in both the pointer and keyboard activation paths, so an item with a nested list now both expands/collapses and raises `OnClick`.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
