### PR TITLE
MudMenu: Invoke OnClick before closing the menu

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -1477,5 +1477,37 @@ namespace MudBlazor.UnitTests.Components
 
             secondDispose.Should().NotThrow();
         }
+
+        [Test]
+        public async Task OnClick_InvokedBeforeMenuCloses()
+        {
+            // https://github.com/MudBlazor/MudBlazor/issues/6349
+            var popoverOpenDuringClick = false;
+
+            // Render the provider separately so it hosts the menu's popover content.
+            var provider = Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<MudMenu>(parameters => parameters
+                .Add(p => p.Label, "Menu")
+                .Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudMenuItem>(0);
+                    builder.AddAttribute(1, nameof(MudMenuItem.Label), "Item");
+                    builder.AddAttribute(2, nameof(MudMenuItem.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, async () =>
+                    {
+                        // Yield so a wrong ordering would dispose the menu mid-await.
+                        await Task.Yield();
+                        popoverOpenDuringClick = provider.FindAll("div.mud-popover-open").Count > 0;
+                    }));
+                    builder.CloseComponent();
+                }));
+
+            await comp.Find("button.mud-button-root").ClickAsync();
+            await provider.WaitForAssertionAsync(() => provider.FindAll("div.mud-menu-item").Count.Should().Be(1));
+
+            await provider.Find("div.mud-menu-item").ClickAsync();
+
+            popoverOpenDuringClick.Should().BeTrue();
+            await provider.WaitForAssertionAsync(() => provider.FindAll("div.mud-popover-open").Count.Should().Be(0));
+        }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -150,21 +150,24 @@ namespace MudBlazor
                 return;
             }
 
-            if (AutoClose && ParentMenu is not null)
+            // Invoke the user's handler first, before navigating or closing the menu.
+            // A forced reload would otherwise interrupt the handler, and closing tears down
+            // the popover (and any component wrapping this item), disposing it mid-await of an
+            // async OnClick. This matches HTML anchor and MudListItem click semantics.
+            if (OnClick.HasDelegate)
             {
-                await ParentMenu.CloseAllMenusAsync();
+                await OnClick.InvokeAsync(ev);
             }
 
-            // Manual navigation is only required when the target is empty and a
-            // forced reload is necessary; all other scenarios are managed by the HTML anchor.
+            // Manual navigation is only required when the target is empty and a forced reload is necessary; all other scenarios are managed by the HTML anchor.
             if (ForceLoad && !string.IsNullOrEmpty(Href) && string.IsNullOrEmpty(Target))
             {
                 UriHelper.NavigateTo(Href, forceLoad: ForceLoad);
             }
 
-            if (OnClick.HasDelegate)
+            if (AutoClose && ParentMenu is not null)
             {
-                await OnClick.InvokeAsync(ev);
+                await ParentMenu.CloseAllMenusAsync();
             }
         }
 

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -151,9 +151,6 @@ namespace MudBlazor
             }
 
             // Invoke the user's handler first, before navigating or closing the menu.
-            // A forced reload would otherwise interrupt the handler, and closing tears down
-            // the popover (and any component wrapping this item), disposing it mid-await of an
-            // async OnClick. This matches HTML anchor and MudListItem click semantics.
             if (OnClick.HasDelegate)
             {
                 await OnClick.InvokeAsync(ev);


### PR DESCRIPTION
Fixes #6349.

`MudMenuItem.OnClickHandlerAsync` closed the menu (`ParentMenu.CloseAllMenusAsync`) before awaiting the user's `OnClick` (and `Href` navigation). A component wrapping the item could therefore be disposed while the user's async `OnClick` was still awaiting, so the continuation ran on a disposed component or never completed. This invokes `OnClick`/navigation first and closes the menu afterwards.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
