### PR TITLE
Build: Stamp generated files to stop spurious Docs recompiles

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -186,16 +186,16 @@ public class ApiDocumentationBuilder
     /// </summary>
     public bool Execute()
     {
-        // Early exit: if ApiDocumentation.generated.cs exists and is newer than all input assemblies, skip generation
-        if (File.Exists(Paths.ApiDocumentationFilePath))
+        // Early exit: if the generated file exists and our stamp is newer than all input assemblies, skip generation.
+        if (File.Exists(Paths.ApiDocumentationFilePath) && File.Exists(Paths.ApiDocumentationStampFilePath))
         {
-            var outputLastWrite = File.GetLastWriteTimeUtc(Paths.ApiDocumentationFilePath);
+            var stampLastWrite = File.GetLastWriteTimeUtc(Paths.ApiDocumentationStampFilePath);
             var newestInputTime = Assemblies
                 .Select(a => File.GetLastWriteTimeUtc(a.Location))
                 .DefaultIfEmpty(DateTime.MinValue)
                 .Max();
 
-            if (outputLastWrite > newestInputTime)
+            if (stampLastWrite > newestInputTime)
             {
                 Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs is up-to-date, skipping generation.");
                 return true;
@@ -747,10 +747,11 @@ public class ApiDocumentationBuilder
         }
         else
         {
-            // Touch the file to update its timestamp so future checks skip regeneration
-            File.SetLastWriteTimeUtc(Paths.ApiDocumentationFilePath, DateTime.UtcNow);
-            Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs content unchanged, touched timestamp.");
+            Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs content unchanged.");
         }
+
+        // Stamp (not the .cs) so the next build's early-exit works without forcing a recompile.
+        Paths.TouchStamp(Paths.ApiDocumentationStampFilePath);
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs.Compiler/CodeSnippets.cs
+++ b/src/MudBlazor.Docs.Compiler/CodeSnippets.cs
@@ -10,10 +10,10 @@ namespace MudBlazor.Docs.Compiler
             var success = true;
             try
             {
-                // Early exit: if Snippets.generated.cs exists and is newer than all example files, skip generation
-                if (File.Exists(Paths.SnippetsFilePath))
+                // Early exit: if the generated file exists and our stamp is newer than all example files, skip generation.
+                if (File.Exists(Paths.SnippetsFilePath) && File.Exists(Paths.SnippetsStampFilePath))
                 {
-                    var snippetsLastWrite = File.GetLastWriteTimeUtc(Paths.SnippetsFilePath);
+                    var stampLastWrite = File.GetLastWriteTimeUtc(Paths.SnippetsStampFilePath);
                     var exampleFiles = Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
                         .Where(f => Path.GetFileNameWithoutExtension(f).Contains(Paths.ExampleDiscriminator));
                     var newestExampleTime = exampleFiles
@@ -21,7 +21,7 @@ namespace MudBlazor.Docs.Compiler
                         .DefaultIfEmpty(DateTime.MinValue)
                         .Max();
 
-                    if (snippetsLastWrite > newestExampleTime)
+                    if (stampLastWrite > newestExampleTime)
                     {
                         Console.WriteLine("CodeSnippets: Snippets.generated.cs is up-to-date, skipping generation.");
                         return true;
@@ -66,10 +66,11 @@ namespace MudBlazor.Docs.Compiler
                 }
                 else
                 {
-                    // Touch the file to update its timestamp so future checks skip regeneration
-                    File.SetLastWriteTimeUtc(Paths.SnippetsFilePath, DateTime.UtcNow);
-                    Console.WriteLine("CodeSnippets: Snippets.generated.cs content unchanged, touched timestamp.");
+                    Console.WriteLine("CodeSnippets: Snippets.generated.cs content unchanged.");
                 }
+
+                // Stamp (not the .cs) so the next build's early-exit works without forcing a recompile.
+                Paths.TouchStamp(Paths.SnippetsStampFilePath);
             }
             catch (Exception e)
             {

--- a/src/MudBlazor.Docs.Compiler/Paths.cs
+++ b/src/MudBlazor.Docs.Compiler/Paths.cs
@@ -35,4 +35,20 @@ public static class Paths
     public static string ApiDocumentationPath => Path.Join(DocsDirPath, "Models", "Generated");
 
     public static string ApiDocumentationFilePath => Path.Join(ApiDocumentationPath, ApiDocumentationFile);
+
+    // Stamp files live in obj/ (git-ignored, never a Compile input). They record that the generator
+    // validated its output against the current inputs, so the generated .cs keeps its old timestamp
+    // when content is unchanged and does not force a full Docs recompile after every library rebuild.
+    private static string StampDirPath => Path.Join(DocsDirPath, "obj");
+
+    public static string SnippetsStampFilePath => Path.Join(StampDirPath, SnippetsFile + ".stamp");
+
+    public static string ApiDocumentationStampFilePath => Path.Join(StampDirPath, ApiDocumentationFile + ".stamp");
+
+    // Records that the generator has validated its output against the current inputs.
+    public static void TouchStamp(string stampFilePath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(stampFilePath)!);
+        File.WriteAllText(stampFilePath, DateTime.UtcNow.ToString("O"));
+    }
 }

--- a/src/MudBlazor.Docs.Compiler/Paths.cs
+++ b/src/MudBlazor.Docs.Compiler/Paths.cs
@@ -36,16 +36,12 @@ public static class Paths
 
     public static string ApiDocumentationFilePath => Path.Join(ApiDocumentationPath, ApiDocumentationFile);
 
-    // Stamp files live in obj/ (git-ignored, never a Compile input). They record that the generator
-    // validated its output against the current inputs, so the generated .cs keeps its old timestamp
-    // when content is unchanged and does not force a full Docs recompile after every library rebuild.
     private static string StampDirPath => Path.Join(DocsDirPath, "obj");
 
     public static string SnippetsStampFilePath => Path.Join(StampDirPath, SnippetsFile + ".stamp");
 
     public static string ApiDocumentationStampFilePath => Path.Join(StampDirPath, ApiDocumentationFile + ".stamp");
 
-    // Records that the generator has validated its output against the current inputs.
     public static void TouchStamp(string stampFilePath)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(stampFilePath)!);


### PR DESCRIPTION
The doc compiler touched the timestamp of the generated files (`Snippets.generated.cs`, `ApiDocumentation.generated.cs`) whenever their content was unchanged, to keep its own timestamp-based early-exit working. That touch also makes MSBuild treat the generated files as newer than the `MudBlazor.Docs` assembly, so `MudBlazor.Docs` fully recompiled after every library build even when the public API never changed.

This writes a sidecar `.stamp` file under `obj/` (git-ignored) instead. The early-exit reads the stamp and additionally requires the generated `.cs` to exist (so a clean still regenerates), and the generated `.cs` only changes when its content actually changes, leaving the Docs assembly up to date.

Effect (measured locally, Debug, warm caches)
- Building `MudBlazor.Docs` after a library edit: 18.7s -> 14.1s (the full Docs assembly recompile is eliminated)
- Full-solution incremental rebuild after a library edit: 29.8s -> 20.9s
