### PR TITLE
Build: Skip other TFMs for local Debug

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- The .NET version every project here targets. Defined once so bumping it is a single edit.
-         (The analyzers are netstandard2.0 and MudBlazor additionally packs older runtimes; both set
-         their own TargetFramework(s).) -->
     <MudBlazorTargetFramework>net10.0</MudBlazorTargetFramework>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- The .NET version every project here targets. Defined once so bumping it is a single edit.
+         (The analyzers are netstandard2.0 and MudBlazor additionally packs older runtimes; both set
+         their own TargetFramework(s).) -->
+    <MudBlazorTargetFramework>net10.0</MudBlazorTargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- NetEscapades.EnumGenerators.Generators uses DescriptionAttribute to generate the enum values -->
     <EnumGenerator_EnumMetadataSource>DescriptionAttribute</EnumGenerator_EnumMetadataSource>
   </PropertyGroup>

--- a/src/MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj
+++ b/src/MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <RootNamespace>MudBlazor.Analyzers.TestComponents</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/MudBlazor.Benchmarks/MudBlazor.Benchmarks.csproj
+++ b/src/MudBlazor.Benchmarks/MudBlazor.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj
+++ b/src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
+++ b/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
+++ b/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>

--- a/src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
+++ b/src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <UserSecretsId>8b1bb13d-4e11-4924-b174-cf040d6576ea</UserSecretsId>
   </PropertyGroup>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>
 

--- a/src/MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj
+++ b/src/MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
+++ b/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
   </PropertyGroup>

--- a/src/MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj
+++ b/src/MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
+++ b/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
     <!-- Docs tests are generated only in CI to keep local builds fast (set GenerateDocsTests=true to override). -->

--- a/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
+++ b/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>MudBlazor.UnitTests</RootNamespace>
   </PropertyGroup>

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
   </PropertyGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- Build the full set for any Release build (dotnet pack and CI both use -c Release) or when BuildAllTargetFrameworks=true is passed; otherwise build only one for the local Debug inner loop. -->
-    <TargetFrameworks Condition="'$(BuildAllTargetFrameworks)' == 'true' Or '$(Configuration)' == 'Release'">net8.0;net9.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargetFrameworks)' == 'true' Or '$(Configuration)' == 'Release'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(MudBlazorTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- Build the full set when packing (any configuration, so `dotnet pack` is never net10-only), for any Release build, or when BuildAllTargetFrameworks=true is passed; otherwise build only one for the local Debug inner loop. -->
+    <!-- Build the full set when needed; otherwise build only one for the local Debug inner loop to save time. -->
     <TargetFrameworks Condition="'$(_IsPacking)' == 'true' Or '$(Configuration)' == 'Release' Or '$(BuildAllTargetFrameworks)' == 'true'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(MudBlazorTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,16 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!--
-      The shipped NuGet package targets net8.0;net9.0;net10.0. Compiling all three on every local
-      build is wasteful: nothing in this repository consumes the net8.0/net9.0 assets (every other
-      project is net10.0), so they only matter when packing the NuGet. Build the full set for any
-      Release build (dotnet pack and CI both use -c Release, so the package can never accidentally
-      ship net10-only) or when BuildAllTargetFrameworks=true is passed; otherwise (local Debug inner
-      loop) build only net10.0. Pass -p:BuildAllTargetFrameworks=true to force all TFMs in Debug.
-    -->
-    <MudBlazorAllTargetFrameworks>net8.0;net9.0;net10.0</MudBlazorAllTargetFrameworks>
-    <TargetFrameworks Condition="'$(BuildAllTargetFrameworks)' == 'true' Or '$(Configuration)' == 'Release'">$(MudBlazorAllTargetFrameworks)</TargetFrameworks>
+    <!-- Build the full set for any Release build (dotnet pack and CI both use -c Release) or when BuildAllTargetFrameworks=true is passed; otherwise build only one for the local Debug inner loop. -->
+    <TargetFrameworks Condition="'$(BuildAllTargetFrameworks)' == 'true' Or '$(Configuration)' == 'Release'">net8.0;net9.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,7 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <!--
+      The shipped NuGet package targets net8.0;net9.0;net10.0. Compiling all three on every local
+      build is wasteful: nothing in this repository consumes the net8.0/net9.0 assets (every other
+      project is net10.0), so they only matter when packing the NuGet. Build the full set for any
+      Release build (dotnet pack and CI both use -c Release, so the package can never accidentally
+      ship net10-only) or when BuildAllTargetFrameworks=true is passed; otherwise (local Debug inner
+      loop) build only net10.0. Pass -p:BuildAllTargetFrameworks=true to force all TFMs in Debug.
+    -->
+    <MudBlazorAllTargetFrameworks>net8.0;net9.0;net10.0</MudBlazorAllTargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildAllTargetFrameworks)' == 'true' Or '$(Configuration)' == 'Release'">$(MudBlazorAllTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- Build the full set for any Release build (dotnet pack and CI both use -c Release) or when BuildAllTargetFrameworks=true is passed; otherwise build only one for the local Debug inner loop. -->
-    <TargetFrameworks Condition="'$(BuildAllTargetFrameworks)' == 'true' Or '$(Configuration)' == 'Release'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
+    <!-- Build the full set when packing (any configuration, so `dotnet pack` is never net10-only), for any Release build, or when BuildAllTargetFrameworks=true is passed; otherwise build only one for the local Debug inner loop. -->
+    <TargetFrameworks Condition="'$(_IsPacking)' == 'true' Or '$(Configuration)' == 'Release' Or '$(BuildAllTargetFrameworks)' == 'true'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(MudBlazorTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>


### PR DESCRIPTION
`MudBlazor` multi-targets `net8.0;net9.0;net10.0`, but nothing in this repository consumes the net8.0/net9.0 assets — every other project (docs, tests, examples, WASM host) is net10.0. Those targets only matter when packing the NuGet package, yet they are compiled on every local build, tripling the library compile.

This builds the full target set for any Release build (both `dotnet pack` and CI use `-c Release`, so the published package can never accidentally ship net10-only) or when `-p:BuildAllTargetFrameworks=true` is passed, and otherwise builds only net10.0 for the local Debug inner loop.

Effect (measured locally, Debug, warm caches)
- Direct `MudBlazor` library build: 10.3s -> 6.2s
- Full-solution incremental rebuild after a component edit: 29.8s -> 20.2s