### PR TITLE
Build: Skip bun SCSS when sources are unchanged

### DIFF
--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -92,7 +92,9 @@
           Condition="'$(IsCrossTargetingBuild)' != 'true'
                 AND '$(DesignTimeBuild)' != 'true'
                 AND '$(WebAssetsBuilt)' != 'true'
-                AND '$(SkipBunCompile)' != 'true'">
+                AND '$(SkipBunCompile)' != 'true'"
+          Inputs="@(WebAssetInputs)"
+          Outputs="wwwroot/MudBlazorDocs.min.css">
 
     <PropertyGroup>
       <WebAssetsBuilt>true</WebAssetsBuilt>


### PR DESCRIPTION
`MudBlazor.Docs`'s `BuildWebAssets` target had a comment saying it should "only rebuild web assets if any of the source files have changed", but it had no `Inputs`/`Outputs`, so it ran bun — and a `dotnet tool restore` — on every build regardless.

This adds `Inputs="@(WebAssetInputs)"` / `Outputs="wwwroot/MudBlazorDocs.min.css"`, matching the pattern the main `MudBlazor` project's asset targets already use, so the SCSS bundle is only rebuilt when a `.scss` file actually changes.

Effect (measured locally, Debug, warm caches)
- Contributes ~1s per no-op/unrelated build; full-solution no-op rebuild dropped from 7.4s to ~6.4s on its own (4.4s combined with the other build PRs).