### PR TITLE
Build: Skip API-doc reflection when the public API is unchanged

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -186,16 +186,16 @@ public class ApiDocumentationBuilder
     /// </summary>
     public bool Execute()
     {
-        // Early exit: if ApiDocumentation.generated.cs exists and is newer than all input assemblies, skip generation
-        if (File.Exists(Paths.ApiDocumentationFilePath))
+        // Early exit: if the generated file exists and our stamp is newer than all input assemblies, skip generation.
+        if (File.Exists(Paths.ApiDocumentationFilePath) && File.Exists(Paths.ApiDocumentationStampFilePath))
         {
-            var outputLastWrite = File.GetLastWriteTimeUtc(Paths.ApiDocumentationFilePath);
+            var stampLastWrite = File.GetLastWriteTimeUtc(Paths.ApiDocumentationStampFilePath);
             var newestInputTime = Assemblies
                 .Select(a => File.GetLastWriteTimeUtc(a.Location))
                 .DefaultIfEmpty(DateTime.MinValue)
                 .Max();
 
-            if (outputLastWrite > newestInputTime)
+            if (stampLastWrite > newestInputTime)
             {
                 Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs is up-to-date, skipping generation.");
                 return true;
@@ -747,10 +747,11 @@ public class ApiDocumentationBuilder
         }
         else
         {
-            // Touch the file to update its timestamp so future checks skip regeneration
-            File.SetLastWriteTimeUtc(Paths.ApiDocumentationFilePath, DateTime.UtcNow);
-            Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs content unchanged, touched timestamp.");
+            Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs content unchanged.");
         }
+
+        // Stamp (not the .cs) so the next build's early-exit works without forcing a recompile.
+        Paths.TouchStamp(Paths.ApiDocumentationStampFilePath);
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -223,8 +223,7 @@ public class ApiDocumentationBuilder
     /// </summary>
     public bool Execute()
     {
-        // Early exit: skip generation when the generated file exists and the public API surface,
-        // XML comments, and generator are unchanged since the stamp was last written.
+        // Early exit: skip generation when the generated file exists and the public API surface, XML comments, and generator are unchanged since the stamp was last written.
         var inputHash = ComputeInputHash();
         if (File.Exists(Paths.ApiDocumentationFilePath) && File.Exists(Paths.ApiDocumentationStampFilePath)
             && File.ReadAllText(Paths.ApiDocumentationStampFilePath).Trim() == inputHash)

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -146,9 +146,8 @@ public class ApiDocumentationBuilder
     public string? ReferenceAssemblyPath { get; set; }
 
     /// <summary>
-    /// Hashes the inputs that the generated API documentation depends on: the public API surface
-    /// (reference assembly), the XML doc comments, and the generator version. Lets the build skip
-    /// the expensive reflection pass when none of them changed.
+    /// Hashes the inputs that the generated API documentation depends on: the public API surface (reference assembly), the XML doc comments, and the generator version.
+    /// Lets the build skip the expensive reflection pass when none of them changed.
     /// </summary>
     private string ComputeInputHash()
     {

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -155,12 +155,12 @@ public class ApiDocumentationBuilder
         var apiSurface = ReferenceAssemblyPath is { Length: > 0 } refPath && File.Exists(refPath)
             ? refPath
             : Assemblies[0].Location;
-        hash.AppendData(File.ReadAllBytes(apiSurface));
+        AppendFile(hash, apiSurface);
 
         var xmlPath = Path.ChangeExtension(Assemblies[0].Location, ".xml");
         if (File.Exists(xmlPath))
         {
-            hash.AppendData(File.ReadAllBytes(xmlPath));
+            AppendFile(hash, xmlPath);
         }
 
         // Generator identity, so changing the compiler invalidates the cache.
@@ -168,6 +168,18 @@ public class ApiDocumentationBuilder
         hash.AppendData(Encoding.UTF8.GetBytes(generator + File.GetLastWriteTimeUtc(generator).Ticks));
 
         return Convert.ToHexString(hash.GetHashAndReset());
+
+        // Stream the file through the hash in chunks instead of allocating the whole file (the reference assembly is several MB).
+        static void AppendFile(IncrementalHash hash, string path)
+        {
+            using var stream = File.OpenRead(path);
+            var buffer = new byte[81920];
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                hash.AppendData(buffer, 0, read);
+            }
+        }
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -139,9 +139,8 @@ public class ApiDocumentationBuilder
     /// Path to MudBlazor's reference assembly, if known (passed by the build).
     /// </summary>
     /// <remarks>
-    /// The reference assembly is byte-stable unless the public API surface changes, so it lets us
-    /// skip regeneration after library edits that only touch method bodies. Falls back to the
-    /// implementation assembly (which changes on every build) when not supplied.
+    /// The reference assembly is byte-stable unless the public API surface changes, so it lets us skip regeneration after library edits that only touch method bodies. 
+    /// Falls back to the implementation assembly (which changes on every build) when not supplied.
     /// </remarks>
     public string? ReferenceAssemblyPath { get; set; }
 

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using LoxSmoke.DocXml;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities.Converter.Base;
@@ -134,6 +136,43 @@ public class ApiDocumentationBuilder
     }
 
     /// <summary>
+    /// Path to MudBlazor's reference assembly, if known (passed by the build).
+    /// </summary>
+    /// <remarks>
+    /// The reference assembly is byte-stable unless the public API surface changes, so it lets us
+    /// skip regeneration after library edits that only touch method bodies. Falls back to the
+    /// implementation assembly (which changes on every build) when not supplied.
+    /// </remarks>
+    public string? ReferenceAssemblyPath { get; set; }
+
+    /// <summary>
+    /// Hashes the inputs that the generated API documentation depends on: the public API surface
+    /// (reference assembly), the XML doc comments, and the generator version. Lets the build skip
+    /// the expensive reflection pass when none of them changed.
+    /// </summary>
+    private string ComputeInputHash()
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        var apiSurface = ReferenceAssemblyPath is { Length: > 0 } refPath && File.Exists(refPath)
+            ? refPath
+            : Assemblies[0].Location;
+        hash.AppendData(File.ReadAllBytes(apiSurface));
+
+        var xmlPath = Path.ChangeExtension(Assemblies[0].Location, ".xml");
+        if (File.Exists(xmlPath))
+        {
+            hash.AppendData(File.ReadAllBytes(xmlPath));
+        }
+
+        // Generator identity, so changing the compiler invalidates the cache.
+        var generator = typeof(ApiDocumentationBuilder).Assembly.Location;
+        hash.AppendData(Encoding.UTF8.GetBytes(generator + File.GetLastWriteTimeUtc(generator).Ticks));
+
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    /// <summary>
     /// Gets whether a type is excluded from documentation.
     /// </summary>
     /// <param name="type">The type to check.</param>
@@ -186,20 +225,14 @@ public class ApiDocumentationBuilder
     /// </summary>
     public bool Execute()
     {
-        // Early exit: if the generated file exists and our stamp is newer than all input assemblies, skip generation.
-        if (File.Exists(Paths.ApiDocumentationFilePath) && File.Exists(Paths.ApiDocumentationStampFilePath))
+        // Early exit: skip generation when the generated file exists and the public API surface,
+        // XML comments, and generator are unchanged since the stamp was last written.
+        var inputHash = ComputeInputHash();
+        if (File.Exists(Paths.ApiDocumentationFilePath) && File.Exists(Paths.ApiDocumentationStampFilePath)
+            && File.ReadAllText(Paths.ApiDocumentationStampFilePath).Trim() == inputHash)
         {
-            var stampLastWrite = File.GetLastWriteTimeUtc(Paths.ApiDocumentationStampFilePath);
-            var newestInputTime = Assemblies
-                .Select(a => File.GetLastWriteTimeUtc(a.Location))
-                .DefaultIfEmpty(DateTime.MinValue)
-                .Max();
-
-            if (stampLastWrite > newestInputTime)
-            {
-                Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs is up-to-date, skipping generation.");
-                return true;
-            }
+            Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs is up-to-date (API surface unchanged), skipping generation.");
+            return true;
         }
 
         AddTypesToDocument();
@@ -208,6 +241,9 @@ public class ApiDocumentationBuilder
         AddGlobalsToDocument();
         ExportApiDocumentation();
         CalculateDocumentationCoverage();
+
+        // Record the inputs we generated from so the next build can skip when nothing changed.
+        Paths.WriteStamp(Paths.ApiDocumentationStampFilePath, inputHash);
         return true;
     }
 
@@ -749,9 +785,6 @@ public class ApiDocumentationBuilder
         {
             Console.WriteLine("ApiDocumentationBuilder: ApiDocumentation.generated.cs content unchanged.");
         }
-
-        // Stamp (not the .cs) so the next build's early-exit works without forcing a recompile.
-        Paths.TouchStamp(Paths.ApiDocumentationStampFilePath);
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs.Compiler/CodeSnippets.cs
+++ b/src/MudBlazor.Docs.Compiler/CodeSnippets.cs
@@ -10,10 +10,10 @@ namespace MudBlazor.Docs.Compiler
             var success = true;
             try
             {
-                // Early exit: if Snippets.generated.cs exists and is newer than all example files, skip generation
-                if (File.Exists(Paths.SnippetsFilePath))
+                // Early exit: if the generated file exists and our stamp is newer than all example files, skip generation.
+                if (File.Exists(Paths.SnippetsFilePath) && File.Exists(Paths.SnippetsStampFilePath))
                 {
-                    var snippetsLastWrite = File.GetLastWriteTimeUtc(Paths.SnippetsFilePath);
+                    var stampLastWrite = File.GetLastWriteTimeUtc(Paths.SnippetsStampFilePath);
                     var exampleFiles = Directory.EnumerateFiles(Paths.DocsDirPath, "*.razor", SearchOption.AllDirectories)
                         .Where(f => Path.GetFileNameWithoutExtension(f).Contains(Paths.ExampleDiscriminator));
                     var newestExampleTime = exampleFiles
@@ -21,7 +21,7 @@ namespace MudBlazor.Docs.Compiler
                         .DefaultIfEmpty(DateTime.MinValue)
                         .Max();
 
-                    if (snippetsLastWrite > newestExampleTime)
+                    if (stampLastWrite > newestExampleTime)
                     {
                         Console.WriteLine("CodeSnippets: Snippets.generated.cs is up-to-date, skipping generation.");
                         return true;
@@ -66,10 +66,11 @@ namespace MudBlazor.Docs.Compiler
                 }
                 else
                 {
-                    // Touch the file to update its timestamp so future checks skip regeneration
-                    File.SetLastWriteTimeUtc(Paths.SnippetsFilePath, DateTime.UtcNow);
-                    Console.WriteLine("CodeSnippets: Snippets.generated.cs content unchanged, touched timestamp.");
+                    Console.WriteLine("CodeSnippets: Snippets.generated.cs content unchanged.");
                 }
+
+                // Stamp (not the .cs) so the next build's early-exit works without forcing a recompile.
+                Paths.TouchStamp(Paths.SnippetsStampFilePath);
             }
             catch (Exception e)
             {

--- a/src/MudBlazor.Docs.Compiler/Paths.cs
+++ b/src/MudBlazor.Docs.Compiler/Paths.cs
@@ -35,4 +35,20 @@ public static class Paths
     public static string ApiDocumentationPath => Path.Join(DocsDirPath, "Models", "Generated");
 
     public static string ApiDocumentationFilePath => Path.Join(ApiDocumentationPath, ApiDocumentationFile);
+
+    // Stamp files live in obj/ (git-ignored, never a Compile input). They record that the generator
+    // validated its output against the current inputs, so the generated .cs keeps its old timestamp
+    // when content is unchanged and does not force a full Docs recompile after every library rebuild.
+    private static string StampDirPath => Path.Join(DocsDirPath, "obj");
+
+    public static string SnippetsStampFilePath => Path.Join(StampDirPath, SnippetsFile + ".stamp");
+
+    public static string ApiDocumentationStampFilePath => Path.Join(StampDirPath, ApiDocumentationFile + ".stamp");
+
+    // Records that the generator has validated its output against the current inputs.
+    public static void TouchStamp(string stampFilePath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(stampFilePath)!);
+        File.WriteAllText(stampFilePath, DateTime.UtcNow.ToString("O"));
+    }
 }

--- a/src/MudBlazor.Docs.Compiler/Paths.cs
+++ b/src/MudBlazor.Docs.Compiler/Paths.cs
@@ -46,9 +46,12 @@ public static class Paths
     public static string ApiDocumentationStampFilePath => Path.Join(StampDirPath, ApiDocumentationFile + ".stamp");
 
     // Records that the generator has validated its output against the current inputs.
-    public static void TouchStamp(string stampFilePath)
+    public static void TouchStamp(string stampFilePath) => WriteStamp(stampFilePath, DateTime.UtcNow.ToString("O"));
+
+    // Writes arbitrary content (e.g. an input hash) to a stamp file, creating the directory if needed.
+    public static void WriteStamp(string stampFilePath, string content)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(stampFilePath)!);
-        File.WriteAllText(stampFilePath, DateTime.UtcNow.ToString("O"));
+        File.WriteAllText(stampFilePath, content);
     }
 }

--- a/src/MudBlazor.Docs.Compiler/Paths.cs
+++ b/src/MudBlazor.Docs.Compiler/Paths.cs
@@ -36,9 +36,7 @@ public static class Paths
 
     public static string ApiDocumentationFilePath => Path.Join(ApiDocumentationPath, ApiDocumentationFile);
 
-    // Stamp files live in obj/ (git-ignored, never a Compile input). They record that the generator
-    // validated its output against the current inputs, so the generated .cs keeps its old timestamp
-    // when content is unchanged and does not force a full Docs recompile after every library rebuild.
+    // Stamp files live in obj/ (git-ignored, never a Compile input). They record that the generator validated its output against the current inputs, so the generated .cs keeps its old timestamp when content is unchanged and does not force a full Docs recompile after every library rebuild.
     private static string StampDirPath => Path.Join(DocsDirPath, "obj");
 
     public static string SnippetsStampFilePath => Path.Join(StampDirPath, SnippetsFile + ".stamp");

--- a/src/MudBlazor.Docs.Compiler/Program.cs
+++ b/src/MudBlazor.Docs.Compiler/Program.cs
@@ -4,12 +4,14 @@ namespace MudBlazor.Docs.Compiler;
 
 public class Program
 {
-    public static int Main()
+    public static int Main(string[] args)
     {
         var stopWatch = Stopwatch.StartNew();
+        // Optional arg 0: path to MudBlazor's reference assembly (stable unless the public API changes).
+        var referenceAssemblyPath = args.Length > 0 ? args[0] : null;
         var success =
             new CodeSnippets().Execute()
-            && new ApiDocumentationBuilder().Execute()
+            && new ApiDocumentationBuilder { ReferenceAssemblyPath = referenceAssemblyPath }.Execute()
             && new ExamplesMarkup().Execute();
 
         Console.WriteLine(@$"Docs.Compiler completed in {stopWatch.ElapsedMilliseconds} milliseconds.");

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -15,9 +15,13 @@
 
   <!--Execute the code generator-->
   <Target Name="GenerateDocs" BeforeTargets="BeforeBuild" DependsOnTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
+    <!--MudBlazor's reference assembly: byte-stable unless the public API changes, so the generator can skip the API-doc reflection after method-body-only edits.-->
+    <PropertyGroup>
+      <_MudBlazorRefAssembly>$(MSBuildThisFileDirectory)../MudBlazor/obj/$(Configuration)/net10.0/ref/MudBlazor.dll</_MudBlazorRefAssembly>
+    </PropertyGroup>
     <!--Command-line for the code generator-->
     <Message Text="Generating Docs" Importance="high" />
-    <Exec Command="dotnet run --configuration $(Configuration) --no-build --project &quot;$(MSBuildThisFileDirectory)../MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj&quot;" />
+    <Exec Command="dotnet run --configuration $(Configuration) --no-build --project &quot;$(MSBuildThisFileDirectory)../MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj&quot; -- &quot;$(_MudBlazorRefAssembly)&quot;" />
   </Target>
 
   <!--Add Content that is being generated as part of the build cycle-->

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -17,7 +17,7 @@
   <Target Name="GenerateDocs" BeforeTargets="BeforeBuild" DependsOnTargets="ResolveProjectReferences" Condition="'$(DesignTimeBuild)' != 'true'">
     <!--MudBlazor's reference assembly: byte-stable unless the public API changes, so the generator can skip the API-doc reflection after method-body-only edits.-->
     <PropertyGroup>
-      <_MudBlazorRefAssembly>$(MSBuildThisFileDirectory)../MudBlazor/obj/$(Configuration)/net10.0/ref/MudBlazor.dll</_MudBlazorRefAssembly>
+      <_MudBlazorRefAssembly>$(MSBuildThisFileDirectory)../MudBlazor/obj/$(Configuration)/$(TargetFramework)/ref/MudBlazor.dll</_MudBlazorRefAssembly>
     </PropertyGroup>
     <!--Command-line for the code generator-->
     <Message Text="Generating Docs" Importance="high" />


### PR DESCRIPTION
The API-documentation generator reflected the whole MudBlazor assembly on every build, because its early-exit compared the generated file's timestamp against the **implementation** assembly — which changes on every compile (new MVID), even for a method-body-only edit.

This replaces the early-exit with a content hash of the inputs the generated docs actually depend on:
- MudBlazor's **reference assembly** — byte-stable unless the public API surface changes (the reference assembly is exactly what MSBuild leaves untouched when only method bodies change),
- the **XML doc comments** file, and
- the generator's own identity.

The reference-assembly path is passed to the generator from the `GenerateDocs` target. When it isn't available the generator falls back to the implementation assembly (degrades to the previous always-regenerate behavior, still correct).

Effect (measured locally, Debug, warm caches)
- `Docs.Compiler` on a method-body-only library edit: ~2.4s -> ~0.1s (reflection skipped); `GenerateDocs` 3.2s -> ~1.2s.

Verified
- Body-only edit: skips ("API surface unchanged").
- Doc-comment-only change: regenerates (XML hash).
- Property type change `bool` -> `bool?`: regenerates with the new type — caught by the reference-assembly hash even though property types never appear in the XML doc file (keyed by name only).
- Deleting the generated files (clean) regenerates them.