### PR TITLE
Build: Run the trim analyzer only in Release and pack

### DIFF
--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -32,11 +32,8 @@
   <PropertyGroup>
     <IsTrimmable>true</IsTrimmable>
     <TrimMode>link</TrimMode>
-    <!-- The trim (IL2xxx) analyzer only matters for consumers who trim the packaged library, so run it
-         only in Release/pack where the package is actually produced; skipping it shaves the local Debug
-         inner loop (~1.6s off the library compile) without losing CI coverage. -->
+    <!-- The trim (IL2xxx) analyzer only matters for consumers who trim the packaged library, so run it only in Release/pack where the package is actually produced; skipping it shaves the local Debug inner loop without losing CI coverage. -->
     <EnableTrimAnalyzer Condition="'$(Configuration)' == 'Release' Or '$(_IsPacking)' == 'true'">true</EnableTrimAnalyzer>
-    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -32,7 +32,11 @@
   <PropertyGroup>
     <IsTrimmable>true</IsTrimmable>
     <TrimMode>link</TrimMode>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <!-- The trim (IL2xxx) analyzer only matters for consumers who trim the packaged library, so run it
+         only in Release/pack where the package is actually produced; skipping it shaves the local Debug
+         inner loop (~1.6s off the library compile) without losing CI coverage. -->
+    <EnableTrimAnalyzer Condition="'$(Configuration)' == 'Release' Or '$(_IsPacking)' == 'true'">true</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The IL trim (IL2xxx) analyzer only matters for consumers who trim the packaged library, so running it on every local Debug compile is wasted work on the dev inner loop. The library is the first link of the test build chain, so this is on the hot path.

This gates `EnableTrimAnalyzer` to `Release`/pack, where the package is actually produced. `IsTrimmable`/`TrimMode` are unchanged, so the packaged library still carries its trimming metadata.

Measured ~1.6s off the library compile on a single-component edit (local Debug, warm caches). CI builds and tests in Release, so trim (IL2xxx) coverage is unchanged. Release and pack output are byte-identical. The analyzer DLL shipped in the NuGet is the separate netstandard2.0 `MudBlazor.Analyzers` project and is unaffected.
