### PR TITLE
Build: restore all TFMs so packing never fails on missing assets

### DIFF
--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- Build the full set when needed; otherwise build only one for the local Debug inner loop to save time. -->
-    <TargetFrameworks Condition="'$(_IsPacking)' == 'true' Or '$(Configuration)' == 'Release' Or '$(BuildAllTargetFrameworks)' == 'true'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
+    <!-- Always restore every TFM (cheap and cached) so a later build/pack never hits a missing-assets error; only the compile is reduced for speed. Build the full set when needed; otherwise build only one for the local Debug inner loop to save time. -->
+    <TargetFrameworks Condition="'$(MSBuildRestoreSessionId)' != '' Or '$(_IsPacking)' == 'true' Or '$(Configuration)' == 'Release' Or '$(BuildAllTargetFrameworks)' == 'true'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(MudBlazorTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>


### PR DESCRIPTION
## Problem
The nightly build is failing at `Pack nuget package` ([run](https://github.com/MudBlazor/MudBlazor/actions/runs/28347202160)):

```
Assets file '.../src/MudBlazor/obj/project.assets.json' doesn't have a target for 'net8.0'.
Assets file '.../src/MudBlazor/obj/project.assets.json' doesn't have a target for 'net9.0'.
```

Root cause: after the conditional multi-targeting in #13377, `restore` and `pack` evaluate different `TargetFrameworks`. The deploy workflows run `dotnet restore` (Debug → `net10.0` only) and then `dotnet pack -c Release --no-restore` (→ `net8.0;net9.0;net10.0`), so the restored assets file is missing the net8.0/net9.0 targets that pack needs.

This affects two workflows:
- **`deploy-mudblazor-nightly`** — failing now.
- **`deploy-mudblazor-nuget`** — same `restore` + `pack -c Release --no-restore` pattern, so it would fail on the next release tag.

It also affects a local `dotnet restore` followed by `dotnet pack`/`dotnet build -c Release --no-restore`.

## Fix
Restore is cheap and cached, so there's no reason to ever restore a *subset* of TFMs — only the *compile* needs to be reduced. Include all TFMs whenever a restore is running (`MSBuildRestoreSessionId` is set, the standard restore-time signal), so the assets file always covers every TFM a later build or pack might use. The Debug compile is still reduced to net10.0, preserving the local inner-loop speedup. No workflow changes required.

## Verified locally
- Debug `dotnet restore` (no flags) now writes net8.0/net9.0/net10.0 to `project.assets.json`.
- The nightly's exact command, `dotnet pack -c Release --no-restore`, now succeeds and produces `lib/net8.0`, `lib/net9.0`, `lib/net10.0`.
- A normal Debug build still compiles **net10.0 only** (no net8/net9 compilation) — the speedup from #13377 is intact.