### PR TITLE
Build: Multi-target MudBlazor unconditionally again

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@
 ### Choose the smallest valid verification loop
 - For repository metadata or prose-only changes outside the build inputs, such as `README.md`, `CHANGELOG.md`, or `.github/` text-only edits: do not run `dotnet`.
 - For component `.cs` or `.razor` changes with behavior coverage: prefer a single filtered `dotnet test --project ... -- --filter ...` run against `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` with `/p:SkipBunCompile=true`. Build `src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` first only when you plan to reuse the outputs for multiple test filters.
-- For component `.cs` or `.razor` changes that only need compile validation: build `src/MudBlazor/MudBlazor.csproj` with `/p:SkipBunCompile=true`.
+- For component `.cs` or `.razor` changes that only need compile validation: build one framework with `dotnet build src/MudBlazor/MudBlazor.csproj -f net10.0 /p:SkipBunCompile=true`. The library multi-targets net8.0/net9.0/net10.0; `-f` compiles just one for a faster check (CI covers the rest).
 - For `TScripts` or `Styles`: run a normal scoped project build.
 - For docs changes: build the relevant docs project. Avoid docs host run loops during agent verification.
 - For docs example or API-page changes that need parity with CI, run `dotnet test --project src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,13 @@ Please make sure that you follow our [code of conduct](/CODE_OF_CONDUCT.md)
 
 ## Minimal Prerequisites to Compile from Source
 
--   [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+-   [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (pinned in `global.json`; it can build the older targets too)
+
+The `MudBlazor` library multi-targets net8.0, net9.0, and net10.0. `dotnet test` and IDE builds only compile the framework that is needed (the tests build just net10.0), but a direct `dotnet build src/MudBlazor` compiles all three. For a faster single-framework build while developing, pass `-f`:
+
+```bash
+dotnet build src/MudBlazor -f net10.0
+```
 
 ## Pull Requests
 - Your Pull Request (PR) must only consist of one topic. It is better to split Pull Requests with more than one feature or bug fix in separate Pull Requests

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MudBlazorTargetFramework>net10.0</MudBlazorTargetFramework>
+    <PrimaryTargetFramework>net10.0</PrimaryTargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj
+++ b/src/MudBlazor.Analyzers.TestComponents/MudBlazor.Analyzers.TestComponents.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <RootNamespace>MudBlazor.Analyzers.TestComponents</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/MudBlazor.Benchmarks/MudBlazor.Benchmarks.csproj
+++ b/src/MudBlazor.Benchmarks/MudBlazor.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj
+++ b/src/MudBlazor.Docs.Compiler/MudBlazor.Docs.Compiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
+++ b/src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
+++ b/src/MudBlazor.Docs.Wasm/MudBlazor.Docs.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>

--- a/src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
+++ b/src/MudBlazor.Docs.WasmHost/MudBlazor.Docs.WasmHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <UserSecretsId>8b1bb13d-4e11-4924-b174-cf040d6576ea</UserSecretsId>
   </PropertyGroup>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>
 

--- a/src/MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj
+++ b/src/MudBlazor.Examples.Data/MudBlazor.Examples.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
+++ b/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
   </PropertyGroup>

--- a/src/MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj
+++ b/src/MudBlazor.UnitTests.Docs.Generator/MudBlazor.UnitTests.Docs.Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
+++ b/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
     <!-- Docs tests are generated only in CI to keep local builds fast (set GenerateDocsTests=true to override). -->

--- a/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
+++ b/src/MudBlazor.UnitTests.Shared/MudBlazor.UnitTests.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
+++ b/src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>MudBlazor.UnitTests</RootNamespace>
   </PropertyGroup>

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(MudBlazorTargetFramework)</TargetFramework>
+    <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
   </PropertyGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- Build the full set when needed; otherwise build only one for the local Debug inner loop to save time. -->
-    <TargetFrameworks Condition="'$(_IsPacking)' == 'true' Or '$(Configuration)' == 'Release' Or '$(BuildAllTargetFrameworks)' == 'true'">net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(MudBlazorTargetFramework)</TargetFrameworks>
+    <!-- The package targets all of these. For a fast local build of just one, use `dotnet build -f net10.0` (restore still covers every TFM, so it stays consistent). -->
+    <TargetFrameworks>net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- The package targets all of these. For a fast local build of just one, use `dotnet build -f net10.0` (restore still covers every TFM, so it stays consistent). -->
     <TargetFrameworks>net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;$(PrimaryTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <EnumGenerator_ForceInternal>true</EnumGenerator_ForceInternal>
   </PropertyGroup>


### PR DESCRIPTION
## Why
The conditional `TargetFrameworks` from #13377 gated the framework set on per-command context (`Configuration`, `_IsPacking`, and the `MSBuildRestoreSessionId` follow-up in #13383). That makes `restore` and `pack` resolve **different** frameworks, so the restored assets file is missing targets the build/pack needs:

```
Assets file '.../obj/project.assets.json' doesn't have a target for 'net8.0'.
```

This broke the **nightly** ([run](https://github.com/MudBlazor/MudBlazor/actions/runs/28347202160)) and would have broken the **NuGet release** on the next tag (same `restore` + `pack -c Release --no-restore` pattern). Patching it required progressively more internal/hidden MSBuild properties — a sign the approach was fighting how restore/build/pack are invoked.

## What
Go back to plain, unconditional multi-targeting — the same thing most multi-targeted libraries do — so restore, build, and pack always agree:

```xml
<TargetFrameworks>net8.0;net9.0;$(MudBlazorTargetFramework)</TargetFrameworks>
```

The local-build speed that #13377 aimed for doesn't need the conditional:
- `dotnet test` and IDE builds already compile **only net10.0** for MudBlazor via target-framework negotiation (the test projects are net10.0).
- A fast single-framework build is `dotnet build src/MudBlazor -f net10.0` — the outer multi-target dispatch doesn't run, and restore still covers every TFM so it stays consistent.

Both are now documented in CONTRIBUTING.md (and the stale ".NET 8.0 SDK" prerequisite is corrected to .NET 10, which `global.json` pins).

This **supersedes #13383** (the `MSBuildRestoreSessionId` band-aid) and removes all the contextual TFM conditions. The `$(MudBlazorTargetFramework)` property (one place to define the current TFM, shared across projects) is kept — it's a plain dedup with no restore/build divergence. The trim-analyzer gating from #13382 is unaffected (an analyzer toggle doesn't change the restore graph).

## Verified locally
- `dotnet restore` (Debug) writes net8.0/net9.0/net10.0 assets; `dotnet pack -c Release --no-restore` then succeeds with all three `lib/` folders (the exact nightly command).
- `dotnet build src/MudBlazor -f net10.0` builds net10.0 only.