### PR TITLE
Tests: Enable Server GC for the unit test runner

### DIFF
--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -4,9 +4,8 @@
     <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
-    <!-- bUnit tests allocate heavily (component trees, AngleSharp DOM, a DI container per test). The
-         default Workstation GC serializes those allocations across the parallel fixtures on a single
-         heap; Server GC gives each core its own heap, cutting that contention (~35s to ~30s on 12 cores). -->
+    <!-- bUnit tests allocate heavily (component trees, AngleSharp DOM, a DI container per test).
+         The default Workstation GC serializes those allocations across the parallel fixtures on a single heap; Server GC gives each core its own heap. -->
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>$(PrimaryTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableNUnitRunner>true</EnableNUnitRunner>
+    <!-- bUnit tests allocate heavily (component trees, AngleSharp DOM, a DI container per test). The
+         default Workstation GC serializes those allocations across the parallel fixtures on a single
+         heap; Server GC gives each core its own heap, cutting that contention (~35s to ~30s on 12 cores). -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
The unit test suite is parallel and allocation-heavy: every test renders a fresh component tree, builds an AngleSharp DOM, and spins up its own DI container. Under the default Workstation GC those allocations from all the parallel fixtures serialize on a single heap, so the suite scales poorly with cores. Enabling Server GC (one heap per core) removes that contention.

Measured locally (12-core, net10 Debug, 5375 tests): the suite drops from ~35s to ~30s wall-clock, with no change to test behavior. The gain scales with core count, so CI benefits too.

This was the safe, isolated win from a broader investigation. Also prototyped test-level parallelism (`ParallelScope.All`), which is faster still (~24s) but was set aside: under heavy CPU contention it makes a few timing-sensitive debounce tests flaky, and Server GC alone keeps the suite fully deterministic.

**Verification:** Ran the suite repeatedly under heavy CPU oversubscription, with no new failures or flakiness.
