### PR TITLE
MudTooltip: Fix crash when Chrome Translate mutates text

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ToolTipTests.cs
@@ -65,6 +65,10 @@ namespace MudBlazor.UnitTests.Components
             popoverContentNode().TextContent.Should().Be("my tooltip content text");
             popoverContentNode().ClassList.Should().Contain("d-flex");
 
+            var textWrapper = popoverContentNode().Children.Should().ContainSingle().Subject;
+            textWrapper.ClassList.Should().Contain("mud-tooltip-text");
+            textWrapper.TextContent.Should().Be("my tooltip content text");
+
             tooltipComp.GetState(x => x.Visible).Should().BeTrue();
 
             //trigger pointerleave

--- a/src/MudBlazor/Components/Tooltip/MudTooltip.razor
+++ b/src/MudBlazor/Components/Tooltip/MudTooltip.razor
@@ -14,7 +14,7 @@
             }
             else if (!string.IsNullOrEmpty(Text))
             {
-                @Text
+                <span class="mud-tooltip-text">@Text</span>
             }
         </MudPopover>
     }


### PR DESCRIPTION
Fixes #7556 

This implements the fix proposed in the existing issue discussion: MudTooltip.Text currently renders as a bare text node,
which Chrome Translate can replace with <font> wrappers. When the tooltip closes, Blazor may then try to remove a detached text node and throw removeChild.

This changes the rendered DOM for text-based tooltips from a direct text node to:

`<span class="mud-tooltip-text">...</span>`

Because this is a DOM shape change, this PR may be appropriate for the v10 milestone rather than a patch/minor release.

This intentionally does not use translate="no", because tooltip text should remain translatable.
The fix only gives Blazor a stable element boundary around the tranlated text.