### PR TITLE
MudExpansionPanel, MudNavGroup: Obsolete hide icon properties in favor of empty icon

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelDisabledExpandIcon.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelDisabledExpandIcon.razor
@@ -2,15 +2,15 @@
 
 
 <MudExpansionPanels>
-    <MudExpansionPanel Text="Title" HideIcon="true" Disabled="true">
+    <MudExpansionPanel Text="Title" Icon="" Disabled="true">
     </MudExpansionPanel>
     <MudExpansionPanel Text="Panel Two">
         Panel Two Content
     </MudExpansionPanel>
-    <MudExpansionPanel Text="Panel Three" HideIcon="true">
+    <MudExpansionPanel Text="Panel Three" Icon="">
         Panel Three Content
     </MudExpansionPanel>
-    <MudExpansionPanel Text="Panel Four" HideIcon="false">
+    <MudExpansionPanel Text="Panel Four">
         Panel Four Content
     </MudExpansionPanel>
 </MudExpansionPanels>

--- a/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelTitleExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExpansionPanel/Examples/ExpansionPanelTitleExample.razor
@@ -13,10 +13,10 @@
                 Panel Content
             </ChildContent>
         </MudExpansionPanel>
-        <MudExpansionPanel Text="The icon of this panel is hidden" HideIcon="true">
+        <MudExpansionPanel Text="The icon of this panel is hidden" Icon="">
             Panel Content
         </MudExpansionPanel>
-        <MudExpansionPanel HideIcon="true">
+        <MudExpansionPanel Icon="">
             <TitleContent>
                 <div class="d-flex">
                     <MudText Class="mt-1">Inbox</MudText>
@@ -29,7 +29,7 @@
                 Panel Content
             </ChildContent>
         </MudExpansionPanel>
-        <MudExpansionPanel @bind-Expanded="@open" HideIcon="true">
+        <MudExpansionPanel @bind-Expanded="@open" Icon="">
             <TitleContent>
                 <div class="d-flex">
                     <MudText>Overriding standard icon with own icon</MudText>

--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -26,6 +26,23 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The expand icon shows by default, is hidden when Icon is empty, and is still hidden by the obsolete HideIcon flag.
+        /// </summary>
+        [Test]
+        public void MudExpansionPanel_IconVisibility_FollowsIconAndHideIcon()
+        {
+            Context.Render<MudExpansionPanel>().Markup.Should().Contain("mud-expand-panel-icon");
+
+            Context.Render<MudExpansionPanel>(p => p.Add(x => x.Icon, string.Empty))
+                .Markup.Should().NotContain("mud-expand-panel-icon");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Context.Render<MudExpansionPanel>(p => p.Add(x => x.HideIcon, true))
+                .Markup.Should().NotContain("mud-expand-panel-icon");
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        /// <summary>
         /// Expansion panel must expand and collapse in the right order
         /// Here we are open the first, then the third and then the second
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
@@ -58,6 +58,23 @@ namespace MudBlazor.UnitTests.Components
 
             bool GetExpandedState() => comp.FindComponent<MudCollapse>().Instance.Expanded;
         }
+
+        /// <summary>
+        /// The expand/collapse icon shows by default, is hidden when ExpandIcon is empty, and is still hidden by the obsolete HideExpandIcon flag.
+        /// </summary>
+        [Test]
+        public void NavGroup_ExpandIconVisibility_FollowsExpandIconAndHideExpandIcon()
+        {
+            Context.Render<MudNavGroup>().Markup.Should().Contain("mud-nav-link-expand-icon");
+
+            Context.Render<MudNavGroup>(parameters => parameters.Add(p => p.ExpandIcon, string.Empty))
+                .Markup.Should().NotContain("mud-nav-link-expand-icon");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Context.Render<MudNavGroup>(parameters => parameters.Add(p => p.HideExpandIcon, true))
+                .Markup.Should().NotContain("mud-nav-link-expand-icon");
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
     }
 }
 

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -1,6 +1,10 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
+@{
+#pragma warning disable CS0618 // Type or member is obsolete
+}
+
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
     <div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="@(Disabled ? null : "0")" @onkeydown="HandleKeyDownAsync">
         <div class="mud-expand-panel-text">
@@ -13,7 +17,7 @@
                 @Text
             }
         </div>
-        @if (!HideIcon)
+        @if (!HideIcon && !string.IsNullOrEmpty(Icon))
         {
             <MudIcon Icon="@Icon" class="@(_expandedState.Value ? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")" />
         }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -86,6 +86,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
+        [Obsolete("Set Icon to an empty string to hide the expand icon instead. This property will be removed in v10.")]
         [Parameter]
         [Category(CategoryTypes.ExpansionPanel.Appearance)]
         public bool HideIcon { get; set; }
@@ -94,11 +95,11 @@ namespace MudBlazor
         /// The icon for expanding this panel.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Icons.Material.Filled.ExpandMore"/>.
+        /// Defaults to <see cref="Icons.Material.Filled.ExpandMore"/>.  Set to <c>null</c> or an empty string to hide the icon.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.ExpansionPanel.Appearance)]
-        public string Icon { get; set; } = Icons.Material.Filled.ExpandMore;
+        public string? Icon { get; set; } = Icons.Material.Filled.ExpandMore;
 
         /// <summary>
         /// Removes vertical padding from the panel.

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
@@ -4,6 +4,10 @@
 
 @inject InternalMudLocalizer Localizer
 
+@{
+#pragma warning disable CS0618 // Type or member is obsolete
+}
+
 <nav @attributes="UserAttributes"
      class="@Classname"
      disabled="@_navigationContext.Disabled"
@@ -29,7 +33,7 @@
                 @Title
             }
         </div>
-        @if (!HideExpandIcon)
+        @if (!HideExpandIcon && !string.IsNullOrEmpty(ExpandIcon))
         {
             <MudIcon Disabled="@Disabled" Icon="@ExpandIcon" Class="@ExpandIconClassname" />
         }

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -152,6 +152,7 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>.
         /// </remarks>
+        [Obsolete("Set ExpandIcon to an empty string to hide the expand/collapse icon instead. This property will be removed in v10.")]
         [Parameter]
         [Category(CategoryTypes.NavMenu.Appearance)]
         public bool HideExpandIcon { get; set; }
@@ -170,11 +171,11 @@ namespace MudBlazor
         /// The icon for expanding and collapsing this group.
         /// </summary>
         /// <remarks>
-        /// Defaults to <see cref="Icons.Material.Filled.ArrowDropDown"/>.  Only shows when <see cref="HideExpandIcon"/> is <c>false</c>.
+        /// Defaults to <see cref="Icons.Material.Filled.ArrowDropDown"/>.  Set to <c>null</c> or an empty string to hide the expand/collapse icon.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.NavMenu.Appearance)]
-        public string ExpandIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
+        public string? ExpandIcon { get; set; } = Icons.Material.Filled.ArrowDropDown;
 
         /// <summary>
         /// The content within this group.


### PR DESCRIPTION
Part of #12991: covers the two clean cases where the boolean defaults to "shown" and the icon has a static default, so an empty icon can carry visibility with no behavior change:

- `MudExpansionPanel.HideIcon` → set `Icon` to `null`/empty to hide
- `MudNavGroup.HideExpandIcon` → set `ExpandIcon` to `null`/empty to hide

Both flags are marked `[Obsolete]` and remain fully functional. The icon render now also hides when the icon property is null/empty, so the new usage works today; the flags are slated for removal in v10. `Icon`/`ExpandIcon` are now nullable to reflect that empty means hidden. The ExpansionPanel docs examples are migrated to the new usage.
