### PR TITLE
MudTable, MudDataGrid: Fix async row validation bypass; obsolete Validate for ValidateAsync

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditAsyncValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditAsyncValidationTest.razor
@@ -1,0 +1,44 @@
+﻿@using System.Threading.Tasks
+
+<MudTable @ref="Table" T="Item" Items="_items" Editable="true" CanCancelEdit="true"
+          EditTrigger="TableEditTrigger.EditButton"
+          ApplyButtonPosition="TableApplyButtonPosition.End"
+          EditButtonPosition="TableEditButtonPosition.End"
+          RowEditCommit="OnRowCommit">
+    <HeaderContent>
+        <MudTh>Name</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context.Name</MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd>
+            <MudTextField @bind-Value="@context.Name"
+                          Validation="@(new Func<string, Task<string?>>(ValidateNameAsync))" />
+        </MudTd>
+    </RowEditingTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "Inline Edit Table: an async validator must block the commit";
+
+    private readonly List<Item> _items = [new Item { Name = "A" }];
+
+    public MudTable<Item> Table { get; private set; } = null!;
+
+    public int CommitCount { get; private set; }
+
+    // Only produces its error after an awaited continuation, so a fire-and-forget caller reads it stale.
+    private async Task<string?> ValidateNameAsync(string value)
+    {
+        await Task.Yield();
+        return "always invalid (async)";
+    }
+
+    private void OnRowCommit(object? item) => CommitCount++;
+
+    public class Item
+    {
+        public string Name { get; set; } = "";
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditAsyncValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditAsyncValidationTest.razor
@@ -20,7 +20,7 @@
 </MudTable>
 
 @code {
-    public static string __description__ = "Inline Edit Table: an async validator must block the commit";
+    public static string __description__ = "Inline Edit Table: async validation gates the commit";
 
     private readonly List<Item> _items = [new Item { Name = "A" }];
 
@@ -28,11 +28,11 @@
 
     public int CommitCount { get; private set; }
 
-    // Only produces its error after an awaited continuation, so a fire-and-forget caller reads it stale.
+    // Only produces its result after an awaited continuation, so a fire-and-forget caller reads it stale.
     private async Task<string?> ValidateNameAsync(string value)
     {
         await Task.Yield();
-        return "always invalid (async)";
+        return value == "B" ? null : "invalid (async)";
     }
 
     private void OnRowCommit(object? item) => CommitCount++;

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -62,8 +62,7 @@ public class RowValidatorTests
     }
 
     /// <summary>
-    /// An <see cref="IForm"/> implementation that predates <see cref="IForm.ValidateAsync"/> must keep
-    /// compiling and running: the default implementation completes without validating anything.
+    /// An <see cref="IForm"/> implementation that predates <see cref="IForm.ValidateAsync"/> must keep compiling and running: the default implementation completes without validating anything.
     /// </summary>
     [Test]
     public async Task IForm_ValidateAsync_DefaultImplementation_IsANoOp()
@@ -105,8 +104,7 @@ public class RowValidatorTests
     }
 
     /// <summary>
-    /// A form component whose async validation only produces its errors after the
-    /// awaited continuation resumes, so a fire-and-forget caller would miss them.
+    /// A form component whose async validation only produces its errors after the awaited continuation resumes, so a fire-and-forget caller would miss them.
     /// </summary>
     private sealed class TestFormComponent : IFormComponent
     {

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -62,6 +62,49 @@ public class RowValidatorTests
     }
 
     /// <summary>
+    /// An <see cref="IForm"/> implementation that predates <see cref="IForm.ValidateAsync"/> must keep
+    /// compiling and running: the default implementation completes without validating anything.
+    /// </summary>
+    [Test]
+    public async Task IForm_ValidateAsync_DefaultImplementation_IsANoOp()
+    {
+        IForm form = new LegacyForm();
+
+        await form.ValidateAsync();
+
+        form.IsValid.Should().BeTrue();
+        form.Errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A minimal external implementer from before ValidateAsync was added to IForm.
+    /// </summary>
+    private sealed class LegacyForm : IForm
+    {
+        public bool IsValid => Errors.Length <= 0;
+
+        public string[] Errors => [];
+
+        public object? Model { get; set; }
+
+        public void FieldChanged(IFormComponent formControl, object? newValue)
+        {
+        }
+
+        void IForm.Add(IFormComponent formControl)
+        {
+        }
+
+        void IForm.Remove(IFormComponent formControl)
+        {
+        }
+
+        void IForm.Update(IFormComponent formControl)
+        {
+        }
+    }
+
+    /// <summary>
     /// A form component whose async validation only produces its errors after the
     /// awaited continuation resumes, so a fire-and-forget caller would miss them.
     /// </summary>

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using MudBlazor.Interfaces;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components;
+
+#nullable enable
+[TestFixture]
+public class RowValidatorTests
+{
+    [Test]
+    public async Task TableRowValidator_ValidateAsync_CollectsErrorsFromAsyncValidation()
+    {
+        var validator = new TableRowValidator();
+        ((IForm)validator).Add(new TestFormComponent(isAsync: true, "async error"));
+
+        await validator.ValidateAsync();
+
+        validator.Errors.Should().BeEquivalentTo("async error");
+    }
+
+    [Test]
+    public async Task TableRowValidator_ValidateAsync_WithoutErrors_IsValid()
+    {
+        var validator = new TableRowValidator();
+        ((IForm)validator).Add(new TestFormComponent(isAsync: false));
+
+        await validator.ValidateAsync();
+
+        validator.Errors.Should().BeEmpty();
+        validator.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task DataGridRowValidator_ValidateAsync_CollectsErrorsFromAsyncValidation()
+    {
+        var validator = new DataGridRowValidator();
+        ((IForm)validator).Add(new TestFormComponent(isAsync: true, "async error"));
+
+        await validator.ValidateAsync();
+
+        validator.Errors.Should().BeEquivalentTo("async error");
+    }
+
+    [Test]
+    public async Task DataGridRowValidator_ValidateAsync_WithoutErrors_IsValid()
+    {
+        var validator = new DataGridRowValidator();
+        ((IForm)validator).Add(new TestFormComponent(isAsync: false));
+
+        await validator.ValidateAsync();
+
+        validator.Errors.Should().BeEmpty();
+        validator.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A form component whose async validation only produces its errors after the
+    /// awaited continuation resumes, so a fire-and-forget caller would miss them.
+    /// </summary>
+    private sealed class TestFormComponent : IFormComponent
+    {
+        private readonly bool _isAsync;
+        private readonly string[] _errorsToRaise;
+
+        public TestFormComponent(bool isAsync, params string[] errorsToRaise)
+        {
+            _isAsync = isAsync;
+            _errorsToRaise = errorsToRaise;
+        }
+
+        public bool Required { get; set; }
+
+        public bool Error { get; set; }
+
+        public bool HasErrors => ValidationErrors.Count > 0;
+
+        public bool Touched => false;
+
+        public object? Validation { get; set; }
+
+        public bool IsForNull => false;
+
+        public List<string> ValidationErrors { get; set; } = new();
+
+        public async Task ValidateAsync()
+        {
+            if (_isAsync)
+            {
+                await Task.Yield();
+            }
+
+            ValidationErrors = _errorsToRaise.ToList();
+        }
+
+        public Task ResetAsync()
+        {
+            ValidationErrors = new List<string>();
+            return Task.CompletedTask;
+        }
+
+        public Task ResetValidationAsync()
+        {
+            ValidationErrors = new List<string>();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1598,24 +1598,26 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// A row whose editor uses an asynchronous validation function must not commit while invalid.
-        /// The commit path awaits <see cref="TableRowValidator.ValidateAsync"/> instead of reading the
-        /// synchronous <c>IsValid</c>, which used to report async validators as valid.
+        /// A row whose editor uses an asynchronous validation function must not commit while invalid, and must commit once valid.
+        /// The commit path awaits <see cref="TableRowValidator.ValidateAsync"/> instead of reading the synchronous <c>IsValid</c>, which reported async validators as valid.
         /// </summary>
         [Test]
-        public async Task TableInlineEdit_AsyncValidation_BlocksCommit()
+        public async Task TableInlineEdit_AsyncValidation_GatesCommit()
         {
             var comp = Context.Render<TableInlineEditAsyncValidationTest>();
 
-            // Enter edit mode.
             await comp.Find("button[aria-label=\"Edit row\"]").ClickAsync();
 
-            // The async validator always fails, so committing must be rejected.
+            // The initial value fails the async rule, so committing is rejected and the row stays in edit mode.
             await comp.Find("button[aria-label=\"Commit edit\"]").ClickAsync();
-
             comp.Instance.CommitCount.Should().Be(0);
-            // The row is still being edited (its input is still present).
-            comp.FindAll("input").Count.Should().BeGreaterThan(0);
+            comp.FindAll("input").Should().NotBeEmpty();
+
+            // A value that passes the async rule commits and leaves edit mode.
+            await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "B" });
+            await comp.Find("button[aria-label=\"Commit edit\"]").ClickAsync();
+            comp.Instance.CommitCount.Should().Be(1);
+            comp.FindAll("input").Should().BeEmpty();
         }
 
         [Theory]

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -1597,6 +1597,27 @@ namespace MudBlazor.UnitTests.Components
             validator.ControlCount.Should().Be(1);
         }
 
+        /// <summary>
+        /// A row whose editor uses an asynchronous validation function must not commit while invalid.
+        /// The commit path awaits <see cref="TableRowValidator.ValidateAsync"/> instead of reading the
+        /// synchronous <c>IsValid</c>, which used to report async validators as valid.
+        /// </summary>
+        [Test]
+        public async Task TableInlineEdit_AsyncValidation_BlocksCommit()
+        {
+            var comp = Context.Render<TableInlineEditAsyncValidationTest>();
+
+            // Enter edit mode.
+            await comp.Find("button[aria-label=\"Edit row\"]").ClickAsync();
+
+            // The async validator always fails, so committing must be rejected.
+            await comp.Find("button[aria-label=\"Commit edit\"]").ClickAsync();
+
+            comp.Instance.CommitCount.Should().Be(0);
+            // The row is still being edited (its input is still present).
+            comp.FindAll("input").Count.Should().BeGreaterThan(0);
+        }
+
         [Theory]
         [TestCase(TableApplyButtonPosition.StartAndEnd)]
         [TestCase(TableApplyButtonPosition.Start)]

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -18,11 +18,19 @@ namespace MudBlazor
         /// Indicates whether the row is valid.
         /// </summary>
         /// <remarks>
-        /// A pure read of the last <see cref="ValidateAsync"/> result; it no longer drives validation.
-        /// A synchronous getter cannot await async validators, so it reported invalid rows as valid.
-        /// Await <see cref="ValidateAsync"/> before reading this.
+        /// Reading this drives a validation pass that only completes inline for synchronous validators.
+        /// Callers that must respect asynchronous validators should await <see cref="ValidateAsync"/> and read <see cref="Errors"/>.
         /// </remarks>
-        public bool IsValid => Errors.Length <= 0;
+        public bool IsValid
+        {
+            get
+            {
+                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
+                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
+                ValidateAsync().CatchAndLog();
+                return Errors.Length <= 0;
+            }
+        }
 
         /// <summary>
         /// Any validation errors for this row.

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -25,8 +25,7 @@ namespace MudBlazor
         {
             get
             {
-                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
-                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
+                // IForm.IsValid must remain synchronous, so drive validation without awaiting; exceptions are forwarded to MudGlobal.UnhandledExceptionHandler.
                 ValidateAsync().CatchAndLog();
                 return Errors.Length <= 0;
             }
@@ -81,7 +80,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Checks this row for any validation errors.
+        /// Checks this row for any validation errors, awaiting asynchronous validators before collecting their errors.
         /// </summary>
         public async Task ValidateAsync()
         {

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -17,16 +17,12 @@ namespace MudBlazor
         /// <summary>
         /// Indicates whether the row is valid.
         /// </summary>
-        public bool IsValid
-        {
-            get
-            {
-                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
-                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
-                ValidateAsync().CatchAndLog();
-                return Errors.Length <= 0;
-            }
-        }
+        /// <remarks>
+        /// A pure read of the last <see cref="ValidateAsync"/> result; it no longer drives validation.
+        /// A synchronous getter cannot await async validators, so it reported invalid rows as valid.
+        /// Await <see cref="ValidateAsync"/> before reading this.
+        /// </remarks>
+        public bool IsValid => Errors.Length <= 0;
 
         /// <summary>
         /// Any validation errors for this row.

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -21,9 +21,9 @@ namespace MudBlazor
         {
             get
             {
-                // IForm.IsValid is synchronous, so drive validation without awaiting.
-                // Synchronous validators complete inline; asynchronous ones should use ValidateAsync.
-                _ = ValidateAsync();
+                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
+                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
+                ValidateAsync().CatchAndLog();
                 return Errors.Length <= 0;
             }
         }
@@ -73,7 +73,7 @@ namespace MudBlazor
         [ExcludeFromCodeCoverage]
         public void Validate()
         {
-            _ = ValidateAsync();
+            ValidateAsync().CatchAndLog();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -21,7 +21,9 @@ namespace MudBlazor
         {
             get
             {
-                Validate();
+                // IForm.IsValid is synchronous, so drive validation without awaiting.
+                // Synchronous validators complete inline; asynchronous ones should use ValidateAsync.
+                _ = ValidateAsync();
                 return Errors.Length <= 0;
             }
         }
@@ -67,19 +69,27 @@ namespace MudBlazor
         /// <summary>
         /// Checks this row for any validation errors.
         /// </summary>
+        [Obsolete("Use ValidateAsync instead.")]
         [ExcludeFromCodeCoverage]
         public void Validate()
+        {
+            _ = ValidateAsync();
+        }
+
+        /// <summary>
+        /// Checks this row for any validation errors.
+        /// </summary>
+        public async Task ValidateAsync()
         {
             _errors.Clear();
             foreach (var formControl in _formControls.ToArray())
             {
-                formControl.ValidateAsync();
+                await formControl.ValidateAsync();
                 foreach (var err in formControl.ValidationErrors)
                 {
                     _errors.Add(err);
                 }
             }
         }
-
     }
 }

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -303,10 +303,17 @@ namespace MudBlazor
             }
         }
 
-        private void FinishEdit(MouseEventArgs ev)
+        private async Task FinishEdit(MouseEventArgs ev)
         {
-            // Check the validity of the item
-            if (!(Context?.Table?.Validator.IsValid ?? true)) return;
+            // Validate the row, awaiting any async validators, before reading validity.
+            // IsValid is a synchronous getter, so gating the commit on it alone let an async validator's
+            // errors arrive too late and an invalid row could commit.
+            var validator = Context?.Table?.Validator;
+            if (validator is not null)
+            {
+                await validator.ValidateAsync();
+                if (!validator.IsValid) return;
+            }
 
             // Set the item value to cancel edit mode
             Context?.Table?.SetEditingItem(null);

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -305,10 +305,8 @@ namespace MudBlazor
 
         private async Task FinishEdit(MouseEventArgs ev)
         {
-            // Await the row's validation so async validators finish before validity is read.
-            // Gating on the synchronous IsValid let an async validator's errors arrive after the check,
-            // committing an invalid row. Read Errors directly: the IsValid getter starts a fresh
-            // fire-and-forget validation pass, which would clear the errors gathered here.
+            // Gating the commit on the synchronous IsValid alone let an async validator's errors arrive after the check, committing an invalid row.
+            // Read Errors directly: the IsValid getter starts a fresh fire-and-forget validation pass, which would clear the errors just gathered.
             var validator = Context?.Table?.Validator;
             if (validator is not null)
             {

--- a/src/MudBlazor/Components/Table/MudTr.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTr.razor.cs
@@ -305,14 +305,15 @@ namespace MudBlazor
 
         private async Task FinishEdit(MouseEventArgs ev)
         {
-            // Validate the row, awaiting any async validators, before reading validity.
-            // IsValid is a synchronous getter, so gating the commit on it alone let an async validator's
-            // errors arrive too late and an invalid row could commit.
+            // Await the row's validation so async validators finish before validity is read.
+            // Gating on the synchronous IsValid let an async validator's errors arrive after the check,
+            // committing an invalid row. Read Errors directly: the IsValid getter starts a fresh
+            // fire-and-forget validation pass, which would clear the errors gathered here.
             var validator = Context?.Table?.Validator;
             if (validator is not null)
             {
                 await validator.ValidateAsync();
-                if (!validator.IsValid) return;
+                if (validator.Errors.Length > 0) return;
             }
 
             // Set the item value to cancel edit mode

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using MudBlazor.Interfaces;
 
@@ -17,7 +18,9 @@ namespace MudBlazor
         {
             get
             {
-                Validate();
+                // IForm.IsValid is synchronous, so drive validation without awaiting.
+                // Synchronous validators complete inline; asynchronous ones should use ValidateAsync.
+                _ = ValidateAsync();
                 return Errors.Length <= 0;
             }
         }
@@ -58,12 +61,22 @@ namespace MudBlazor
         /// <summary>
         /// Checks for data errors within this row.
         /// </summary>
+        [Obsolete("Use ValidateAsync instead.")]
+        [ExcludeFromCodeCoverage]
         public void Validate()
+        {
+            _ = ValidateAsync();
+        }
+
+        /// <summary>
+        /// Checks for data errors within this row.
+        /// </summary>
+        public async Task ValidateAsync()
         {
             _errors.Clear();
             foreach (var formControl in _formControls.ToArray())
             {
-                formControl.ValidateAsync();
+                await formControl.ValidateAsync();
                 foreach (var err in formControl.ValidationErrors)
                 {
                     _errors.Add(err);

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -14,16 +14,12 @@ namespace MudBlazor
         /// <summary>
         /// Whether the table row is valid.
         /// </summary>
-        public bool IsValid
-        {
-            get
-            {
-                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
-                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
-                ValidateAsync().CatchAndLog();
-                return Errors.Length <= 0;
-            }
-        }
+        /// <remarks>
+        /// A pure read of the last <see cref="ValidateAsync"/> result; it no longer drives validation.
+        /// A synchronous getter cannot await async validators, so it reported invalid rows as valid.
+        /// Await <see cref="ValidateAsync"/> before reading this.
+        /// </remarks>
+        public bool IsValid => Errors.Length <= 0;
 
         /// <summary>
         /// The validation errors for this row.

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -18,9 +18,9 @@ namespace MudBlazor
         {
             get
             {
-                // IForm.IsValid is synchronous, so drive validation without awaiting.
-                // Synchronous validators complete inline; asynchronous ones should use ValidateAsync.
-                _ = ValidateAsync();
+                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
+                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
+                ValidateAsync().CatchAndLog();
                 return Errors.Length <= 0;
             }
         }
@@ -65,7 +65,7 @@ namespace MudBlazor
         [ExcludeFromCodeCoverage]
         public void Validate()
         {
-            _ = ValidateAsync();
+            ValidateAsync().CatchAndLog();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -22,8 +22,7 @@ namespace MudBlazor
         {
             get
             {
-                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
-                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
+                // IForm.IsValid must remain synchronous, so drive validation without awaiting; exceptions are forwarded to MudGlobal.UnhandledExceptionHandler.
                 ValidateAsync().CatchAndLog();
                 return Errors.Length <= 0;
             }
@@ -73,7 +72,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Checks for data errors within this row.
+        /// Checks for data errors within this row, awaiting asynchronous validators before collecting their errors.
         /// </summary>
         public async Task ValidateAsync()
         {

--- a/src/MudBlazor/Components/Table/TableRowValidator.cs
+++ b/src/MudBlazor/Components/Table/TableRowValidator.cs
@@ -15,11 +15,19 @@ namespace MudBlazor
         /// Whether the table row is valid.
         /// </summary>
         /// <remarks>
-        /// A pure read of the last <see cref="ValidateAsync"/> result; it no longer drives validation.
-        /// A synchronous getter cannot await async validators, so it reported invalid rows as valid.
-        /// Await <see cref="ValidateAsync"/> before reading this.
+        /// Reading this drives a validation pass that only completes inline for synchronous validators.
+        /// Callers that must respect asynchronous validators should await <see cref="ValidateAsync"/> and read <see cref="Errors"/>.
         /// </remarks>
-        public bool IsValid => Errors.Length <= 0;
+        public bool IsValid
+        {
+            get
+            {
+                // IForm.IsValid is synchronous. Drive validation without awaiting; synchronous validators
+                // complete inline, and any exception is forwarded to MudGlobal.UnhandledExceptionHandler.
+                ValidateAsync().CatchAndLog();
+                return Errors.Length <= 0;
+            }
+        }
 
         /// <summary>
         /// The validation errors for this row.

--- a/src/MudBlazor/Interfaces/IForm.cs
+++ b/src/MudBlazor/Interfaces/IForm.cs
@@ -15,7 +15,7 @@ namespace MudBlazor.Interfaces
         /// </summary>
         /// <remarks>
         /// The synchronous <see cref="IsValid"/> getter cannot await, so callers that must react to async
-        /// validation (such as gating a commit) should await this first, then read <see cref="IsValid"/>.
+        /// validation (such as gating a commit) should await this first, then read <see cref="Errors"/>.
         /// The default keeps existing external implementers source-compatible.
         /// </remarks>
         public Task ValidateAsync() => Task.CompletedTask;

--- a/src/MudBlazor/Interfaces/IForm.cs
+++ b/src/MudBlazor/Interfaces/IForm.cs
@@ -14,9 +14,8 @@ namespace MudBlazor.Interfaces
         /// Validates every form control, awaiting async validators, then refreshes <see cref="IsValid"/> and <see cref="Errors"/>.
         /// </summary>
         /// <remarks>
-        /// The synchronous <see cref="IsValid"/> getter cannot await, so callers that must react to async
-        /// validation (such as gating a commit) should await this first, then read <see cref="Errors"/>.
-        /// The default keeps existing external implementers source-compatible.
+        /// The synchronous <see cref="IsValid"/> getter cannot await, so callers that must react to async validation should await this first, then read <see cref="Errors"/>.
+        /// The default implementation keeps existing external implementers source-compatible.
         /// </remarks>
         public Task ValidateAsync() => Task.CompletedTask;
 

--- a/src/MudBlazor/Interfaces/IForm.cs
+++ b/src/MudBlazor/Interfaces/IForm.cs
@@ -1,4 +1,6 @@
-﻿namespace MudBlazor.Interfaces
+﻿using System.Threading.Tasks;
+
+namespace MudBlazor.Interfaces
 {
     public interface IForm
     {
@@ -7,6 +9,16 @@
         public string[] Errors { get; }
 
         public object? Model { get; set; }
+
+        /// <summary>
+        /// Validates every form control, awaiting async validators, then refreshes <see cref="IsValid"/> and <see cref="Errors"/>.
+        /// </summary>
+        /// <remarks>
+        /// The synchronous <see cref="IsValid"/> getter cannot await, so callers that must react to async
+        /// validation (such as gating a commit) should await this first, then read <see cref="IsValid"/>.
+        /// The default keeps existing external implementers source-compatible.
+        /// </remarks>
+        public Task ValidateAsync() => Task.CompletedTask;
 
         public void FieldChanged(IFormComponent formControl, object? newValue);
 


### PR DESCRIPTION
The synchronous `Validate()` on `TableRowValidator`/`DataGridRowValidator` started each field's `IFormComponent.ValidateAsync()` without awaiting it, then read `ValidationErrors` immediately. Synchronous validators complete inline, but an asynchronous validation function had not produced its errors yet, so the row was reported valid. In a `MudTable` inline edit this let an invalid row commit, because `MudTr` gates the commit on the synchronous `IForm.IsValid`.

Breaking changes

- `IForm` gains `ValidateAsync()` (a default interface method).
- `TableRowValidator.Validate()` / `DataGridRowValidator.Validate()` are `[Obsolete]`; use `ValidateAsync()`.
