### PR TITLE
MudFormComponent: Validate required fields on blur under EditContext

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormDisposedFieldValidationSummaryTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormDisposedFieldValidationSummaryTest.razor
@@ -1,0 +1,34 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+<EditForm EditContext="@EditContext">
+    <ValidationSummary />
+    @if (ShowField)
+    {
+        <MudTextField @bind-Value="_model.Name" For="@(() => _model.Name)" Required="true" RequiredError="Name is required" Label="Name" />
+    }
+</EditForm>
+
+@code {
+    public static string __description__ = "#13381: disposing a field that staged a blur error must refresh the ValidationSummary, not leave the message stale.";
+
+    public EditContext EditContext { get; private set; } = null!;
+    public bool ShowField { get; set; } = true;
+
+    private readonly TestModel _model = new();
+
+    protected override void OnInitialized()
+    {
+        EditContext = new EditContext(_model);
+    }
+
+    public void HideField()
+    {
+        ShowField = false;
+        StateHasChanged();
+    }
+
+    public sealed class TestModel
+    {
+        public string? Name { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormEditContextRemovedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormEditContextRemovedTest.razor
@@ -1,6 +1,4 @@
-﻿@using System.ComponentModel.DataAnnotations
-
-<CascadingValue Value="@CurrentEditContext">
+﻿<CascadingValue Value="@CurrentEditContext">
     <MudTextField @bind-Value="_model.Name" For="@(() => _model.Name)" Required="true" RequiredError="Name is required" Label="Name" />
 </CascadingValue>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormEditContextRemovedTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormEditContextRemovedTest.razor
@@ -1,0 +1,29 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+<CascadingValue Value="@CurrentEditContext">
+    <MudTextField @bind-Value="_model.Name" For="@(() => _model.Name)" Required="true" RequiredError="Name is required" Label="Name" />
+</CascadingValue>
+
+@code {
+    public static string __description__ = "#13381: removing a cascaded EditContext after a field staged a blur error must not crash on the next value change.";
+
+    private readonly TestModel _model = new();
+
+    public EditContext? CurrentEditContext { get; private set; }
+
+    protected override void OnInitialized()
+    {
+        CurrentEditContext = new EditContext(_model);
+    }
+
+    public void RemoveEditContext()
+    {
+        CurrentEditContext = null;
+        StateHasChanged();
+    }
+
+    public sealed class TestModel
+    {
+        public string? Name { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredValidationEditContextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredValidationEditContextTest.razor
@@ -1,0 +1,31 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+<EditForm EditContext="@EditContext">
+    <DataAnnotationsValidator />
+    <MudTextField @bind-Value="_model.Name" For="@(() => _model.Name)" Label="Name" />
+    <MudTextField @bind-Value="_model.Other" For="@(() => _model.Other)" Required="true" RequiredError="Other is required" Label="Other" />
+</EditForm>
+
+@code {
+    public static string __description__ = "#13381: blurring an empty required field under an EditContext should validate it (data-annotations [Required] and the component's own Required parameter), without marking the form dirty.";
+
+    public EditContext EditContext { get; private set; } = null!;
+    public int FieldChangedCount { get; private set; }
+
+    private readonly TestModel _model = new();
+
+    protected override void OnInitialized()
+    {
+        EditContext = new EditContext(_model);
+        EditContext.OnFieldChanged += (_, _) => FieldChangedCount++;
+    }
+
+    public sealed class TestModel
+    {
+        [Required(ErrorMessage = "Name is required")]
+        public string? Name { get; set; }
+
+        // No data-annotation here: only the component's own Required parameter guards it.
+        public string? Other { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -563,11 +563,8 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("span.mud-chip-content")[2].TextContent.Trim().Should().EndWith("Field3 changed");
         }
 
-        /// <summary>
-        /// #13381: Blurring an empty required field inside an EditForm/EditContext must validate it -
-        /// both a data-annotation [Required] (via For) and the component's own Required parameter -
-        /// without marking the form dirty or firing OnFieldChanged (the #12790 contract).
-        /// </summary>
+        // #13381: blurring an empty required field under an EditContext validates it (both [Required] via For and the
+        // Required parameter) without dirtying the form or firing OnFieldChanged (the #12790 contract).
         [Test]
         public async Task EditForm_BlurEmptyRequiredField_Validates_WithoutDirtying()
         {
@@ -594,9 +591,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.FieldChangedCount.Should().Be(0, "blur validation must not fire OnFieldChanged (#12790)");
         }
 
-        /// <summary>
-        /// #13381: After a blur-triggered required error, entering a valid value clears the error.
-        /// </summary>
+        // #13381: after a blur-triggered required error, entering a valid value clears it.
         [Test]
         public async Task EditForm_BlurRequired_ThenValidInput_ClearsError()
         {
@@ -610,9 +605,7 @@ namespace MudBlazor.UnitTests.Components
             nameField.HasErrors.Should().BeFalse("a valid value clears the blur-triggered required error (#13381)");
         }
 
-        /// <summary>
-        /// #13381: A blur-staged message must not duplicate the external validator's message on submit.
-        /// </summary>
+        // #13381: a blur-staged message must not duplicate the external validator's message on submit.
         [Test]
         public async Task EditForm_BlurThenSubmit_NoDuplicateMessage()
         {
@@ -627,10 +620,7 @@ namespace MudBlazor.UnitTests.Components
                 .Should().Be(1, "the blur-staged message must be handed back to the external validator, not duplicated (#13381)");
         }
 
-        /// <summary>
-        /// #13381: Blurring after a failed submit must not duplicate the external validator's message,
-        /// which would show twice in a ValidationSummary.
-        /// </summary>
+        // #13381: blurring after a failed submit must not duplicate the external validator's message (would double in a ValidationSummary).
         [Test]
         public async Task EditForm_SubmitThenBlur_NoDuplicateMessage()
         {
@@ -646,10 +636,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTextField<string>>()[0].Instance.HasErrors.Should().BeTrue();
         }
 
-        /// <summary>
-        /// #13381: ResetValidationAsync must clear a blur-staged message so it cannot resurface
-        /// on the next validation-state notification from another field.
-        /// </summary>
+        // #13381: ResetValidationAsync clears a blur-staged message so it can't resurface on the next validation-state notification.
         [Test]
         public async Task EditForm_ResetValidation_ClearsStagedMessage()
         {
@@ -668,10 +655,7 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.EditContext.GetValidationMessages().Should().NotContain("Name is required");
         }
 
-        /// <summary>
-        /// #13381: On submit the external validators own the verdict; a blur-staged component-Required
-        /// error must not linger as a stale display after a successful submit.
-        /// </summary>
+        // #13381: on submit the external validators own the verdict; a blur-staged component-Required error must not linger as stale display.
         [Test]
         public async Task EditForm_SubmitWithComponentRequiredError_ReconcilesDisplay()
         {
@@ -686,10 +670,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => otherField.HasErrors.Should().BeFalse("the staged error must be reconciled, not left as a stale display"));
         }
 
-        /// <summary>
-        /// #13381: Emptying a field guarded only by the component's Required parameter keeps its error
-        /// even though the external validators have nothing to say about it.
-        /// </summary>
+        // #13381: emptying a field guarded only by the Required parameter keeps its error, though external validators say nothing.
         [Test]
         public async Task EditForm_ComponentRequired_EmptiedValue_ShowsError()
         {

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -564,8 +564,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// #13381: blurring an empty required field under an EditContext validates it (both [Required] via For and the
-        /// Required parameter) without dirtying the form or firing OnFieldChanged (the #12790 contract).
+        /// #13381: blurring an empty required field under an EditContext validates it (both [Required] via For and the Required parameter) without dirtying the form or firing OnFieldChanged (the #12790 contract).
         /// </summary>
         [Test]
         public async Task EditForm_BlurEmptyRequiredField_Validates_WithoutDirtying()

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -628,6 +628,83 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #13381: Blurring after a failed submit must not duplicate the external validator's message,
+        /// which would show twice in a ValidationSummary.
+        /// </summary>
+        [Test]
+        public async Task EditForm_SubmitThenBlur_NoDuplicateMessage()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var editContext = comp.Instance.EditContext;
+
+            editContext.Validate().Should().BeFalse();
+            editContext.GetValidationMessages().Count(m => m == "Name is required").Should().Be(1);
+
+            // The external message is still in its store; blur must defer to it instead of staging a copy.
+            await comp.FindAll("input")[0].BlurAsync();
+            editContext.GetValidationMessages().Count(m => m == "Name is required").Should().Be(1);
+            comp.FindComponents<MudTextField<string>>()[0].Instance.HasErrors.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// #13381: ResetValidationAsync must clear a blur-staged message so it cannot resurface
+        /// on the next validation-state notification from another field.
+        /// </summary>
+        [Test]
+        public async Task EditForm_ResetValidation_ClearsStagedMessage()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var nameField = comp.FindComponents<MudTextField<string>>()[0].Instance;
+
+            await comp.FindAll("input")[0].BlurAsync();
+            nameField.HasErrors.Should().BeTrue();
+
+            await comp.InvokeAsync(() => nameField.ResetValidationAsync());
+            nameField.HasErrors.Should().BeFalse();
+
+            // A validation-state event from another field must not resurrect the reset error.
+            await comp.FindAll("input")[1].BlurAsync();
+            nameField.HasErrors.Should().BeFalse();
+            comp.Instance.EditContext.GetValidationMessages().Should().NotContain("Name is required");
+        }
+
+        /// <summary>
+        /// #13381: On submit the external validators own the verdict; a blur-staged component-Required
+        /// error must not linger as a stale display after a successful submit.
+        /// </summary>
+        [Test]
+        public async Task EditForm_SubmitWithComponentRequiredError_ReconcilesDisplay()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var otherField = comp.FindComponents<MudTextField<string>>()[1].Instance;
+
+            await comp.FindAll("input")[0].ChangeAsync(new ChangeEventArgs { Value = "Sam" });
+            await comp.FindAll("input")[1].BlurAsync();
+            otherField.HasErrors.Should().BeTrue();
+
+            comp.Instance.EditContext.Validate().Should().BeTrue("only external validators decide the submit verdict");
+            await comp.WaitForAssertionAsync(() => otherField.HasErrors.Should().BeFalse("the staged error must be reconciled, not left as a stale display"));
+        }
+
+        /// <summary>
+        /// #13381: Emptying a field guarded only by the component's Required parameter keeps its error
+        /// even though the external validators have nothing to say about it.
+        /// </summary>
+        [Test]
+        public async Task EditForm_ComponentRequired_EmptiedValue_ShowsError()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var otherField = comp.FindComponents<MudTextField<string>>()[1].Instance;
+
+            await comp.FindAll("input")[1].ChangeAsync(new ChangeEventArgs { Value = "x" });
+            otherField.HasErrors.Should().BeFalse();
+
+            await comp.FindAll("input")[1].ChangeAsync(new ChangeEventArgs { Value = "" });
+            await comp.WaitForAssertionAsync(() => otherField.HasErrors.Should().BeTrue());
+            otherField.GetState(x => x.ErrorText).Should().Be("Other is required");
+        }
+
+        /// <summary>
         /// Based on error report. Clicking the checkbox should not influence the other form fields.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -733,6 +733,24 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #13381: disposing a field that staged a blur error refreshes the ValidationSummary instead of leaving it stale.
+        /// </summary>
+        [Test]
+        public async Task EditForm_DisposeFieldWithStagedError_RefreshesValidationSummary()
+        {
+            var comp = Context.Render<FormDisposedFieldValidationSummaryTest>();
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() =>
+                comp.FindAll("li.validation-message").Select(x => x.TextContent).Should().Contain("Name is required"));
+
+            // Removing the field disposes it; its staged message must not linger in the summary.
+            await comp.InvokeAsync(() => comp.Instance.HideField());
+            await comp.WaitForAssertionAsync(() =>
+                comp.FindAll("li.validation-message").Should().BeEmpty("disposing the field must refresh the summary (#13381)"));
+        }
+
+        /// <summary>
         /// Based on error report. Clicking the checkbox should not influence the other form fields.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -564,6 +564,70 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #13381: Blurring an empty required field inside an EditForm/EditContext must validate it -
+        /// both a data-annotation [Required] (via For) and the component's own Required parameter -
+        /// without marking the form dirty or firing OnFieldChanged (the #12790 contract).
+        /// </summary>
+        [Test]
+        public async Task EditForm_BlurEmptyRequiredField_Validates_WithoutDirtying()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var textFields = comp.FindComponents<MudTextField<string>>();
+            var nameField = textFields[0].Instance;   // guarded by data-annotation [Required]
+            var otherField = textFields[1].Instance;  // guarded by the component's Required parameter
+
+            nameField.HasErrors.Should().BeFalse();
+            otherField.HasErrors.Should().BeFalse();
+
+            // Blur the empty [Required] (data-annotation) field.
+            await comp.FindAll("input")[0].BlurAsync();
+            nameField.HasErrors.Should().BeTrue("blurring an empty [Required] field under an EditContext should validate it (#13381)");
+            nameField.GetState(x => x.ErrorText).Should().Be("Name is required");
+
+            // Blur the empty component-Required field (no data-annotation).
+            await comp.FindAll("input")[1].BlurAsync();
+            otherField.HasErrors.Should().BeTrue("blurring an empty Required field under an EditContext should validate it (#13381)");
+            otherField.GetState(x => x.ErrorText).Should().Be("Other is required");
+
+            // #12790: blur must not dirty the form nor fire OnFieldChanged.
+            comp.Instance.EditContext.IsModified().Should().BeFalse("blur validation must not mark the form dirty (#12790)");
+            comp.Instance.FieldChangedCount.Should().Be(0, "blur validation must not fire OnFieldChanged (#12790)");
+        }
+
+        /// <summary>
+        /// #13381: After a blur-triggered required error, entering a valid value clears the error.
+        /// </summary>
+        [Test]
+        public async Task EditForm_BlurRequired_ThenValidInput_ClearsError()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var nameField = comp.FindComponents<MudTextField<string>>()[0].Instance;
+
+            await comp.FindAll("input")[0].BlurAsync();
+            nameField.HasErrors.Should().BeTrue();
+
+            await comp.FindAll("input")[0].ChangeAsync(new ChangeEventArgs { Value = "Sam" });
+            nameField.HasErrors.Should().BeFalse("a valid value clears the blur-triggered required error (#13381)");
+        }
+
+        /// <summary>
+        /// #13381: A blur-staged message must not duplicate the external validator's message on submit.
+        /// </summary>
+        [Test]
+        public async Task EditForm_BlurThenSubmit_NoDuplicateMessage()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+            var editContext = comp.Instance.EditContext;
+
+            await comp.FindAll("input")[0].BlurAsync();
+
+            // Simulate submit: full-form validation runs the external DataAnnotationsValidator.
+            editContext.Validate().Should().BeFalse();
+            editContext.GetValidationMessages().Count(m => m == "Name is required")
+                .Should().Be(1, "the blur-staged message must be handed back to the external validator, not duplicated (#13381)");
+        }
+
+        /// <summary>
         /// Based on error report. Clicking the checkbox should not influence the other form fields.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -563,8 +563,10 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("span.mud-chip-content")[2].TextContent.Trim().Should().EndWith("Field3 changed");
         }
 
-        // #13381: blurring an empty required field under an EditContext validates it (both [Required] via For and the
-        // Required parameter) without dirtying the form or firing OnFieldChanged (the #12790 contract).
+        /// <summary>
+        /// #13381: blurring an empty required field under an EditContext validates it (both [Required] via For and the
+        /// Required parameter) without dirtying the form or firing OnFieldChanged (the #12790 contract).
+        /// </summary>
         [Test]
         public async Task EditForm_BlurEmptyRequiredField_Validates_WithoutDirtying()
         {
@@ -591,7 +593,9 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.FieldChangedCount.Should().Be(0, "blur validation must not fire OnFieldChanged (#12790)");
         }
 
-        // #13381: after a blur-triggered required error, entering a valid value clears it.
+        /// <summary>
+        /// #13381: after a blur-triggered required error, entering a valid value clears it.
+        /// </summary>
         [Test]
         public async Task EditForm_BlurRequired_ThenValidInput_ClearsError()
         {
@@ -605,7 +609,9 @@ namespace MudBlazor.UnitTests.Components
             nameField.HasErrors.Should().BeFalse("a valid value clears the blur-triggered required error (#13381)");
         }
 
-        // #13381: a blur-staged message must not duplicate the external validator's message on submit.
+        /// <summary>
+        /// #13381: a blur-staged message must not duplicate the external validator's message on submit.
+        /// </summary>
         [Test]
         public async Task EditForm_BlurThenSubmit_NoDuplicateMessage()
         {
@@ -620,7 +626,9 @@ namespace MudBlazor.UnitTests.Components
                 .Should().Be(1, "the blur-staged message must be handed back to the external validator, not duplicated (#13381)");
         }
 
-        // #13381: blurring after a failed submit must not duplicate the external validator's message (would double in a ValidationSummary).
+        /// <summary>
+        /// #13381: blurring after a failed submit must not duplicate the external validator's message (would double in a ValidationSummary).
+        /// </summary>
         [Test]
         public async Task EditForm_SubmitThenBlur_NoDuplicateMessage()
         {
@@ -636,7 +644,9 @@ namespace MudBlazor.UnitTests.Components
             comp.FindComponents<MudTextField<string>>()[0].Instance.HasErrors.Should().BeTrue();
         }
 
-        // #13381: ResetValidationAsync clears a blur-staged message so it can't resurface on the next validation-state notification.
+        /// <summary>
+        /// #13381: ResetValidationAsync clears a blur-staged message so it can't resurface on the next validation-state notification.
+        /// </summary>
         [Test]
         public async Task EditForm_ResetValidation_ClearsStagedMessage()
         {
@@ -655,7 +665,9 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.EditContext.GetValidationMessages().Should().NotContain("Name is required");
         }
 
-        // #13381: on submit the external validators own the verdict; a blur-staged component-Required error must not linger as stale display.
+        /// <summary>
+        /// #13381: on submit the external validators own the verdict; a blur-staged component-Required error must not linger as stale display.
+        /// </summary>
         [Test]
         public async Task EditForm_SubmitWithComponentRequiredError_ReconcilesDisplay()
         {
@@ -670,7 +682,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => otherField.HasErrors.Should().BeFalse("the staged error must be reconciled, not left as a stale display"));
         }
 
-        // #13381: emptying a field guarded only by the Required parameter keeps its error, though external validators say nothing.
+        /// <summary>
+        /// #13381: emptying a field guarded only by the Required parameter keeps its error, though external validators say nothing.
+        /// </summary>
         [Test]
         public async Task EditForm_ComponentRequired_EmptiedValue_ShowsError()
         {

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -578,15 +578,22 @@ namespace MudBlazor.UnitTests.Components
             nameField.HasErrors.Should().BeFalse();
             otherField.HasErrors.Should().BeFalse();
 
-            // Blur the empty [Required] (data-annotation) field.
+            // Blur the empty [Required] (data-annotation) field. The error state is applied via
+            // EditContext.OnValidationStateChanged (async), so wait for it.
             await comp.FindAll("input")[0].BlurAsync();
-            nameField.HasErrors.Should().BeTrue("blurring an empty [Required] field under an EditContext should validate it (#13381)");
-            nameField.GetState(x => x.ErrorText).Should().Be("Name is required");
+            await comp.WaitForAssertionAsync(() =>
+            {
+                nameField.HasErrors.Should().BeTrue("blurring an empty [Required] field under an EditContext should validate it (#13381)");
+                nameField.GetState(x => x.ErrorText).Should().Be("Name is required");
+            });
 
             // Blur the empty component-Required field (no data-annotation).
             await comp.FindAll("input")[1].BlurAsync();
-            otherField.HasErrors.Should().BeTrue("blurring an empty Required field under an EditContext should validate it (#13381)");
-            otherField.GetState(x => x.ErrorText).Should().Be("Other is required");
+            await comp.WaitForAssertionAsync(() =>
+            {
+                otherField.HasErrors.Should().BeTrue("blurring an empty Required field under an EditContext should validate it (#13381)");
+                otherField.GetState(x => x.ErrorText).Should().Be("Other is required");
+            });
 
             // #12790: blur must not dirty the form nor fire OnFieldChanged.
             comp.Instance.EditContext.IsModified().Should().BeFalse("blur validation must not mark the form dirty (#12790)");
@@ -603,10 +610,10 @@ namespace MudBlazor.UnitTests.Components
             var nameField = comp.FindComponents<MudTextField<string>>()[0].Instance;
 
             await comp.FindAll("input")[0].BlurAsync();
-            nameField.HasErrors.Should().BeTrue();
+            await comp.WaitForAssertionAsync(() => nameField.HasErrors.Should().BeTrue());
 
             await comp.FindAll("input")[0].ChangeAsync(new ChangeEventArgs { Value = "Sam" });
-            nameField.HasErrors.Should().BeFalse("a valid value clears the blur-triggered required error (#13381)");
+            await comp.WaitForAssertionAsync(() => nameField.HasErrors.Should().BeFalse("a valid value clears the blur-triggered required error (#13381)"));
         }
 
         /// <summary>
@@ -640,8 +647,11 @@ namespace MudBlazor.UnitTests.Components
 
             // The external message is still in its store; blur must defer to it instead of staging a copy.
             await comp.FindAll("input")[0].BlurAsync();
-            editContext.GetValidationMessages().Count(m => m == "Name is required").Should().Be(1);
-            comp.FindComponents<MudTextField<string>>()[0].Instance.HasErrors.Should().BeTrue();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                editContext.GetValidationMessages().Count(m => m == "Name is required").Should().Be(1);
+                comp.FindComponents<MudTextField<string>>()[0].Instance.HasErrors.Should().BeTrue();
+            });
         }
 
         /// <summary>
@@ -654,15 +664,18 @@ namespace MudBlazor.UnitTests.Components
             var nameField = comp.FindComponents<MudTextField<string>>()[0].Instance;
 
             await comp.FindAll("input")[0].BlurAsync();
-            nameField.HasErrors.Should().BeTrue();
+            await comp.WaitForAssertionAsync(() => nameField.HasErrors.Should().BeTrue());
 
             await comp.InvokeAsync(() => nameField.ResetValidationAsync());
             nameField.HasErrors.Should().BeFalse();
 
             // A validation-state event from another field must not resurrect the reset error.
             await comp.FindAll("input")[1].BlurAsync();
-            nameField.HasErrors.Should().BeFalse();
-            comp.Instance.EditContext.GetValidationMessages().Should().NotContain("Name is required");
+            await comp.WaitForAssertionAsync(() =>
+            {
+                nameField.HasErrors.Should().BeFalse();
+                comp.Instance.EditContext.GetValidationMessages().Should().NotContain("Name is required");
+            });
         }
 
         /// <summary>
@@ -676,7 +689,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.FindAll("input")[0].ChangeAsync(new ChangeEventArgs { Value = "Sam" });
             await comp.FindAll("input")[1].BlurAsync();
-            otherField.HasErrors.Should().BeTrue();
+            await comp.WaitForAssertionAsync(() => otherField.HasErrors.Should().BeTrue());
 
             comp.Instance.EditContext.Validate().Should().BeTrue("only external validators decide the submit verdict");
             await comp.WaitForAssertionAsync(() => otherField.HasErrors.Should().BeFalse("the staged error must be reconciled, not left as a stale display"));

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -713,6 +713,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #13381: staged state must not outlive a removed cascaded EditContext; the next value change must not throw.
+        /// </summary>
+        [Test]
+        public async Task EditForm_EditContextRemovedAfterBlur_DoesNotThrow()
+        {
+            var comp = Context.Render<FormEditContextRemovedTest>();
+            var field = comp.FindComponent<MudTextField<string>>().Instance;
+
+            // Blur the empty Required field so it stages an error against the cascaded EditContext.
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() => field.HasErrors.Should().BeTrue());
+
+            // Remove the cascaded EditContext while the field stays alive.
+            await comp.InvokeAsync(() => comp.Instance.RemoveEditContext());
+
+            // A later value change once ran EditContext!.GetValidationMessages on the now-null context (NRE).
+            await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "Sam" });
+            field.HasErrors.Should().BeFalse();
+        }
+
+        /// <summary>
         /// Based on error report. Clicking the checkbox should not influence the other form fields.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -744,8 +744,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Publishes this component's own validation errors to the EditContext through its message store.
-        /// NotifyValidationStateChanged shows them without setting IsModified or raising OnFieldChanged (#13381, #12790).
+        /// Surfaces this component's own errors to the EditContext without dirtying the form (#13381, #12790).
         /// </summary>
         private void StageEditContextValidationMessages(List<string> errors)
         {

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -363,12 +363,6 @@ namespace MudBlazor
 
         protected virtual async Task ValidateValue()
         {
-            // if there is an EditContext, there is no need for internal validation as it will get overwritten by 'OnValidationStateChanged'
-            if (EditContext is not null)
-            {
-                return;
-            }
-
             var changed = false;
             var errors = new List<string>();
             try
@@ -446,15 +440,28 @@ namespace MudBlazor
                 // If Value has changed while we were validating it, ignore results and exit
                 if (!changed)
                 {
-                    // this must be called in any case, because even if Validation is null the user might have set Error and ErrorText manually
-                    // if Error and ErrorText are set by the user, setting them here will have no effect.
-                    // if Error, create an error id that can be used by aria-describedby on input control
-                    ValidationErrors = errors;
-                    await ErrorState.SetValueAsync(errors.Count > 0);
-                    await ErrorTextState.SetValueAsync(errors.FirstOrDefault());
-                    await UpdateErrorIdStateAsync(HasErrors);
-                    Form?.Update(this);
-                    StateHasChanged();
+                    if (EditContext is not null)
+                    {
+                        // Under a cascaded EditContext, surface MudBlazor's own assessment (Required, the
+                        // Validation delegate, For data-annotations, conversion errors) through our message
+                        // store + NotifyValidationStateChanged instead of writing ErrorState directly.
+                        // This validates on blur without marking the form dirty or firing OnFieldChanged
+                        // (#13381/#12790); OnValidationStateChanged then writes ErrorState from the merged
+                        // messages.
+                        StageEditContextValidationMessages(errors);
+                    }
+                    else
+                    {
+                        // this must be called in any case, because even if Validation is null the user might have set Error and ErrorText manually
+                        // if Error and ErrorText are set by the user, setting them here will have no effect.
+                        // if Error, create an error id that can be used by aria-describedby on input control
+                        ValidationErrors = errors;
+                        await ErrorState.SetValueAsync(errors.Count > 0);
+                        await ErrorTextState.SetValueAsync(errors.FirstOrDefault());
+                        await UpdateErrorIdStateAsync(HasErrors);
+                        Form?.Update(this);
+                        StateHasChanged();
+                    }
                 }
             }
         }
@@ -724,8 +731,41 @@ namespace MudBlazor
         {
             if (!IsNullOrEmpty(_fieldIdentifier.FieldName))
             {
+                // A genuine value change hands the field back to the external validators: drop our
+                // staged messages first so they can never duplicate what NotifyFieldChanged produces.
+                _editContextValidationMessages?.Clear(_fieldIdentifier);
                 EditContext?.NotifyFieldChanged(_fieldIdentifier);
             }
+        }
+
+        /// <summary>
+        /// Stages this component's own validation errors into the EditContext-bound message store and
+        /// surfaces them via <see cref="EditContext.NotifyValidationStateChanged"/>. Unlike
+        /// <see cref="EditContext.NotifyFieldChanged"/>, this does not set <c>IsModified</c> or raise
+        /// <c>OnFieldChanged</c>, so a field validates on blur without the form becoming dirty (#13381/#12790).
+        /// </summary>
+        private void StageEditContextValidationMessages(List<string> errors)
+        {
+            // Without a field identity (no For / no bound member) there is nothing to key the store on.
+            if (_editContextValidationMessages is null || _fieldIdentifier.Equals(default(FieldIdentifier)))
+            {
+                return;
+            }
+
+            _editContextValidationMessages.Clear(_fieldIdentifier);
+            foreach (var error in errors)
+            {
+                _editContextValidationMessages.Add(_fieldIdentifier, error);
+            }
+
+            EditContext!.NotifyValidationStateChanged();
+        }
+
+        private void OnValidationRequested(object? sender, ValidationRequestedEventArgs e)
+        {
+            // Full-form validation (submit) re-runs the external validators over every field, so drop
+            // our staged messages to avoid duplicating theirs in the input and the ValidationSummary.
+            _editContextValidationMessages?.Clear();
         }
 
         /// <summary>
@@ -755,7 +795,9 @@ namespace MudBlazor
             {
                 if (EditContext is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
                 {
-                    var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
+                    // Distinct(): an external validator and our own staged assessment can momentarily
+                    // hold the same message for a field; show it once.
+                    var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).Distinct().ToArray();
                     var hasError = errorMessages.Length > 0;
                     //TODO: v9 there no async API, but just make it async void (acceptable for EventHandler) 
                     await ErrorState.SetValueAsync(hasError);
@@ -798,6 +840,13 @@ namespace MudBlazor
         /// </summary>
         private EditContext? _currentEditContext;
 
+        /// <summary>
+        /// MudBlazor-owned message store used to surface this component's own validation assessment
+        /// (Required, the Validation delegate, For data-annotations, conversion errors) to a cascaded
+        /// EditContext without marking the form dirty. Created when an EditContext attaches.
+        /// </summary>
+        private ValidationMessageStore? _editContextValidationMessages;
+
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
@@ -805,21 +854,19 @@ namespace MudBlazor
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
             if (For is not null && For != _currentFor)
             {
-                // if there is an EditContext, there is no need for internal validation as it will get overwritten by 'OnValidationStateChanged'
-                if (EditContext is null)
-                {
-                    // Extract validation attributes
-                    // Sourced from https://stackoverflow.com/a/43076222/4839162
-                    // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
-                    var expression = (MemberExpression)For.Body;
+                // Extract validation attributes so MudBlazor can assess them itself. This now runs even
+                // under an EditContext so blur validation can stage the For data-annotations
+                // ([Required]/[MinLength]/...) without a value change (#13381).
+                // Sourced from https://stackoverflow.com/a/43076222/4839162
+                // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
+                var expression = (MemberExpression)For.Body;
 
-                    // Currently we have no solution for this which is trimming incompatible
-                    // A possible solution is to use source gen
+                // Currently we have no solution for this which is trimming incompatible
+                // A possible solution is to use source gen
 #pragma warning disable IL2075
-                    var propertyInfo = expression.Expression?.Type.GetProperty(expression.Member.Name);
+                var propertyInfo = expression.Expression?.Type.GetProperty(expression.Member.Name);
 #pragma warning restore IL2075
-                    _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
-                }
+                _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
 
                 _fieldIdentifier = FieldIdentifier.Create(For);
                 _currentFor = For;
@@ -829,6 +876,8 @@ namespace MudBlazor
             {
                 DetachValidationStateChangedListener();
                 EditContext.OnValidationStateChanged += OnValidationStateChanged;
+                EditContext.OnValidationRequested += OnValidationRequested;
+                _editContextValidationMessages = new ValidationMessageStore(EditContext);
                 _currentEditContext = EditContext;
             }
         }
@@ -838,6 +887,9 @@ namespace MudBlazor
             if (_currentEditContext is not null)
             {
                 _currentEditContext.OnValidationStateChanged -= OnValidationStateChanged;
+                _currentEditContext.OnValidationRequested -= OnValidationRequested;
+                _editContextValidationMessages?.Clear();
+                _editContextValidationMessages = null;
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -442,12 +442,8 @@ namespace MudBlazor
                 {
                     if (EditContext is not null)
                     {
-                        // Under a cascaded EditContext, surface MudBlazor's own assessment (Required, the
-                        // Validation delegate, For data-annotations, conversion errors) through our message
-                        // store + NotifyValidationStateChanged instead of writing ErrorState directly.
-                        // This validates on blur without marking the form dirty or firing OnFieldChanged
-                        // (#13381/#12790); OnValidationStateChanged then writes ErrorState from the merged
-                        // messages.
+                        // Surface the assessment through the message store instead of writing ErrorState directly.
+                        // OnValidationStateChanged then applies the merged messages (#13381).
                         StageEditContextValidationMessages(errors);
                     }
                     else
@@ -708,6 +704,14 @@ namespace MudBlazor
             await ErrorTextState.SetValueAsync(null);
             await UpdateErrorIdStateAsync(false);
             ResetConverterErrors();
+            _lastInternalErrors = [];
+            if (_hasStagedEditContextMessages)
+            {
+                // Otherwise the staged messages resurface on the next validation-state notification.
+                ClearStagedEditContextMessages();
+                EditContext?.NotifyValidationStateChanged();
+            }
+
             await InvokeAsync(StateHasChanged);
         }
 
@@ -731,41 +735,63 @@ namespace MudBlazor
         {
             if (!IsNullOrEmpty(_fieldIdentifier.FieldName))
             {
-                // A genuine value change hands the field back to the external validators: drop our
-                // staged messages first so they can never duplicate what NotifyFieldChanged produces.
-                _editContextValidationMessages?.Clear(_fieldIdentifier);
+                // A genuine value change hands the field to the external validators.
+                // If they stay silent for it, restore our own assessment so it isn't lost.
+                ClearStagedEditContextMessages();
                 EditContext?.NotifyFieldChanged(_fieldIdentifier);
+                StageEditContextValidationMessages(_lastInternalErrors);
             }
         }
 
         /// <summary>
-        /// Stages this component's own validation errors into the EditContext-bound message store and
-        /// surfaces them via <see cref="EditContext.NotifyValidationStateChanged"/>. Unlike
-        /// <see cref="EditContext.NotifyFieldChanged"/>, this does not set <c>IsModified</c> or raise
-        /// <c>OnFieldChanged</c>, so a field validates on blur without the form becoming dirty (#13381/#12790).
+        /// Publishes this component's own validation errors to the EditContext through its message store.
+        /// NotifyValidationStateChanged shows them without setting IsModified or raising OnFieldChanged (#13381, #12790).
         /// </summary>
         private void StageEditContextValidationMessages(List<string> errors)
         {
-            // Without a field identity (no For / no bound member) there is nothing to key the store on.
+            // Without a field identity (no For) there is nothing to key the store on.
             if (_editContextValidationMessages is null || _fieldIdentifier.Equals(default(FieldIdentifier)))
             {
                 return;
             }
 
-            _editContextValidationMessages.Clear(_fieldIdentifier);
-            foreach (var error in errors)
+            var changed = _hasStagedEditContextMessages;
+            ClearStagedEditContextMessages();
+            _lastInternalErrors = errors;
+
+            // While an external validator holds messages for this field it is authoritative;
+            // staging ours alongside would duplicate them in a ValidationSummary.
+            if (errors.Count > 0 && !EditContext!.GetValidationMessages(_fieldIdentifier).Any())
             {
-                _editContextValidationMessages.Add(_fieldIdentifier, error);
+                foreach (var error in errors)
+                {
+                    _editContextValidationMessages.Add(_fieldIdentifier, error);
+                }
+
+                _hasStagedEditContextMessages = true;
+                changed = true;
             }
 
-            EditContext!.NotifyValidationStateChanged();
+            if (changed)
+            {
+                EditContext!.NotifyValidationStateChanged();
+            }
+        }
+
+        private void ClearStagedEditContextMessages()
+        {
+            _editContextValidationMessages?.Clear(_fieldIdentifier);
+            _hasStagedEditContextMessages = false;
         }
 
         private void OnValidationRequested(object? sender, ValidationRequestedEventArgs e)
         {
-            // Full-form validation (submit) re-runs the external validators over every field, so drop
-            // our staged messages to avoid duplicating theirs in the input and the ValidationSummary.
-            _editContextValidationMessages?.Clear();
+            // Submit re-runs the external validators over every field; ours must not duplicate theirs.
+            if (_hasStagedEditContextMessages)
+            {
+                ClearStagedEditContextMessages();
+                EditContext?.NotifyValidationStateChanged();
+            }
         }
 
         /// <summary>
@@ -795,9 +821,7 @@ namespace MudBlazor
             {
                 if (EditContext is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
                 {
-                    // Distinct(): an external validator and our own staged assessment can momentarily
-                    // hold the same message for a field; show it once.
-                    var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).Distinct().ToArray();
+                    var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
                     var hasError = errorMessages.Length > 0;
                     //TODO: v9 there no async API, but just make it async void (acceptable for EventHandler) 
                     await ErrorState.SetValueAsync(hasError);
@@ -841,11 +865,17 @@ namespace MudBlazor
         private EditContext? _currentEditContext;
 
         /// <summary>
-        /// MudBlazor-owned message store used to surface this component's own validation assessment
-        /// (Required, the Validation delegate, For data-annotations, conversion errors) to a cascaded
-        /// EditContext without marking the form dirty. Created when an EditContext attaches.
+        /// Surfaces this component's own validation assessment to a cascaded EditContext (#13381).
         /// </summary>
         private ValidationMessageStore? _editContextValidationMessages;
+
+        private bool _hasStagedEditContextMessages;
+
+        /// <summary>
+        /// The most recent internal assessment, kept so <see cref="EditFormValidate"/> can restore it
+        /// when the external validators produce nothing for the field.
+        /// </summary>
+        private List<string> _lastInternalErrors = [];
 
         protected override void OnParametersSet()
         {
@@ -854,9 +884,7 @@ namespace MudBlazor
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
             if (For is not null && For != _currentFor)
             {
-                // Extract validation attributes so MudBlazor can assess them itself. This now runs even
-                // under an EditContext so blur validation can stage the For data-annotations
-                // ([Required]/[MinLength]/...) without a value change (#13381).
+                // Extract validation attributes
                 // Sourced from https://stackoverflow.com/a/43076222/4839162
                 // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
                 var expression = (MemberExpression)For.Body;
@@ -868,7 +896,14 @@ namespace MudBlazor
 #pragma warning restore IL2075
                 _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
 
-                _fieldIdentifier = FieldIdentifier.Create(For);
+                var fieldIdentifier = FieldIdentifier.Create(For);
+                if (!_fieldIdentifier.Equals(fieldIdentifier))
+                {
+                    // Drop staged messages keyed on the previous field before rebinding.
+                    ClearStagedEditContextMessages();
+                }
+
+                _fieldIdentifier = fieldIdentifier;
                 _currentFor = For;
             }
 
@@ -890,6 +925,7 @@ namespace MudBlazor
                 _currentEditContext.OnValidationRequested -= OnValidationRequested;
                 _editContextValidationMessages?.Clear();
                 _editContextValidationMessages = null;
+                _hasStagedEditContextMessages = false;
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -939,9 +939,16 @@ namespace MudBlazor
             {
                 _currentEditContext.OnValidationStateChanged -= OnValidationStateChanged;
                 _currentEditContext.OnValidationRequested -= OnValidationRequested;
+                var hadStagedMessages = _hasStagedEditContextMessages;
                 _editContextValidationMessages?.Clear();
                 _editContextValidationMessages = null;
                 _hasStagedEditContextMessages = false;
+                if (hadStagedMessages)
+                {
+                    // We just removed our staged messages from the context (on dispose or an EditContext
+                    // swap); refresh subscribers like a ValidationSummary so a cleared error can't linger.
+                    _currentEditContext.NotifyValidationStateChanged();
+                }
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -945,8 +945,7 @@ namespace MudBlazor
                 _hasStagedEditContextMessages = false;
                 if (hadStagedMessages)
                 {
-                    // We just removed our staged messages from the context (on dispose or an EditContext
-                    // swap); refresh subscribers like a ValidationSummary so a cleared error can't linger.
+                    // We just removed our staged messages from the context (on dispose or an EditContext swap); refresh subscribers like a ValidationSummary so a cleared error can't linger.
                     _currentEditContext.NotifyValidationStateChanged();
                 }
             }

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -705,12 +705,8 @@ namespace MudBlazor
             await UpdateErrorIdStateAsync(false);
             ResetConverterErrors();
             _lastInternalErrors = [];
-            if (_hasStagedEditContextMessages)
-            {
-                // Otherwise the staged messages resurface on the next validation-state notification.
-                ClearStagedEditContextMessages();
-                EditContext?.NotifyValidationStateChanged();
-            }
+            // Otherwise the staged messages resurface on the next validation-state notification.
+            RetractStagedEditContextMessages();
 
             await InvokeAsync(StateHasChanged);
         }
@@ -748,8 +744,9 @@ namespace MudBlazor
         /// </summary>
         private void StageEditContextValidationMessages(List<string> errors)
         {
-            // Without a field identity (no For) there is nothing to key the store on.
-            if (_editContextValidationMessages is null || _fieldIdentifier.Equals(default(FieldIdentifier)))
+            // Without an EditContext or a field identity (no For) there is nothing to stage against.
+            var editContext = EditContext;
+            if (editContext is null || _editContextValidationMessages is null || _fieldIdentifier.Equals(default(FieldIdentifier)))
             {
                 return;
             }
@@ -760,7 +757,7 @@ namespace MudBlazor
 
             // While an external validator holds messages for this field it is authoritative;
             // staging ours alongside would duplicate them in a ValidationSummary.
-            if (errors.Count > 0 && !EditContext!.GetValidationMessages(_fieldIdentifier).Any())
+            if (errors.Count > 0 && !editContext.GetValidationMessages(_fieldIdentifier).Any())
             {
                 foreach (var error in errors)
                 {
@@ -773,19 +770,32 @@ namespace MudBlazor
 
             if (changed)
             {
-                EditContext!.NotifyValidationStateChanged();
+                editContext.NotifyValidationStateChanged();
             }
         }
 
         private void ClearStagedEditContextMessages()
         {
-            _editContextValidationMessages?.Clear(_fieldIdentifier);
+            // Clear(default) would hash a null field name and throw, so guard the empty identity.
+            if (_editContextValidationMessages is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
+            {
+                _editContextValidationMessages.Clear(_fieldIdentifier);
+            }
+
             _hasStagedEditContextMessages = false;
         }
 
         private void OnValidationRequested(object? sender, ValidationRequestedEventArgs e)
         {
             // Submit re-runs the external validators over every field; ours must not duplicate theirs.
+            RetractStagedEditContextMessages();
+        }
+
+        /// <summary>
+        /// Clears any staged messages and refreshes the display so a retracted error can't linger.
+        /// </summary>
+        private void RetractStagedEditContextMessages()
+        {
             if (_hasStagedEditContextMessages)
             {
                 ClearStagedEditContextMessages();
@@ -883,26 +893,35 @@ namespace MudBlazor
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
             if (For is not null && For != _currentFor)
             {
-                // Extract validation attributes
-                // Sourced from https://stackoverflow.com/a/43076222/4839162
-                // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
-                var expression = (MemberExpression)For.Body;
-
-                // Currently we have no solution for this which is trimming incompatible
-                // A possible solution is to use source gen
-#pragma warning disable IL2075
-                var propertyInfo = expression.Expression?.Type.GetProperty(expression.Member.Name);
-#pragma warning restore IL2075
-                _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
-
+                // For is a fresh expression instance on every render for an inline lambda, so only
+                // do the reflection and rebinding work when the field it points at actually changed.
                 var fieldIdentifier = FieldIdentifier.Create(For);
                 if (!_fieldIdentifier.Equals(fieldIdentifier))
                 {
-                    // Drop staged messages keyed on the previous field before rebinding.
+                    // Extract validation attributes
+                    // Sourced from https://stackoverflow.com/a/43076222/4839162
+                    // and also https://stackoverflow.com/questions/59407225/getting-a-custom-attribute-from-a-property-using-an-expression
+                    var expression = (MemberExpression)For.Body;
+
+                    // Currently we have no solution for this which is trimming incompatible
+                    // A possible solution is to use source gen
+#pragma warning disable IL2075
+                    var propertyInfo = expression.Expression?.Type.GetProperty(expression.Member.Name);
+#pragma warning restore IL2075
+                    _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
+
+                    // Drop anything staged for the previous field and reconcile the display so its
+                    // error can't linger on the newly bound field.
+                    var wasStaged = _hasStagedEditContextMessages;
                     ClearStagedEditContextMessages();
+                    _lastInternalErrors = [];
+                    _fieldIdentifier = fieldIdentifier;
+                    if (wasStaged)
+                    {
+                        EditContext?.NotifyValidationStateChanged();
+                    }
                 }
 
-                _fieldIdentifier = fieldIdentifier;
                 _currentFor = For;
             }
 
@@ -913,6 +932,12 @@ namespace MudBlazor
                 EditContext.OnValidationRequested += OnValidationRequested;
                 _editContextValidationMessages = new ValidationMessageStore(EditContext);
                 _currentEditContext = EditContext;
+            }
+            else if (EditContext is null && _currentEditContext is not null)
+            {
+                // The cascaded EditContext was removed; detach so staged state can't outlive it.
+                DetachValidationStateChangedListener();
+                _currentEditContext = null;
             }
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -442,8 +442,7 @@ namespace MudBlazor
                 {
                     if (EditContext is not null)
                     {
-                        // Surface the assessment through the message store instead of writing ErrorState directly.
-                        // OnValidationStateChanged then applies the merged messages (#13381).
+                        // Surface the assessment through the message store instead of writing ErrorState directly. OnValidationStateChanged then applies the merged messages (#13381).
                         StageEditContextValidationMessages(errors);
                     }
                     else
@@ -705,7 +704,6 @@ namespace MudBlazor
             await UpdateErrorIdStateAsync(false);
             ResetConverterErrors();
             _lastInternalErrors = [];
-            // Otherwise the staged messages resurface on the next validation-state notification.
             RetractStagedEditContextMessages();
 
             await InvokeAsync(StateHasChanged);
@@ -731,8 +729,7 @@ namespace MudBlazor
         {
             if (!IsNullOrEmpty(_fieldIdentifier.FieldName))
             {
-                // A genuine value change hands the field to the external validators.
-                // If they stay silent for it, restore our own assessment so it isn't lost.
+                // A genuine value change hands the field to the external validators. If they stay silent for it, restore our own assessment so it isn't lost.
                 ClearStagedEditContextMessages();
                 EditContext?.NotifyFieldChanged(_fieldIdentifier);
                 StageEditContextValidationMessages(_lastInternalErrors);
@@ -740,7 +737,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Surfaces this component's own errors to the EditContext without dirtying the form (#13381, #12790).
+        /// Surfaces this component's own errors to the EditContext without dirtying the form.
         /// </summary>
         private void StageEditContextValidationMessages(List<string> errors)
         {
@@ -755,8 +752,7 @@ namespace MudBlazor
             ClearStagedEditContextMessages();
             _lastInternalErrors = errors;
 
-            // While an external validator holds messages for this field it is authoritative;
-            // staging ours alongside would duplicate them in a ValidationSummary.
+            // While an external validator holds messages for this field it is authoritative; staging ours alongside would duplicate them in a ValidationSummary.
             if (errors.Count > 0 && !editContext.GetValidationMessages(_fieldIdentifier).Any())
             {
                 foreach (var error in errors)
@@ -776,7 +772,6 @@ namespace MudBlazor
 
         private void ClearStagedEditContextMessages()
         {
-            // Clear(default) would hash a null field name and throw, so guard the empty identity.
             if (_editContextValidationMessages is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
             {
                 _editContextValidationMessages.Clear(_fieldIdentifier);
@@ -881,8 +876,7 @@ namespace MudBlazor
         private bool _hasStagedEditContextMessages;
 
         /// <summary>
-        /// The most recent internal assessment, kept so <see cref="EditFormValidate"/> can restore it
-        /// when the external validators produce nothing for the field.
+        /// The most recent internal assessment, kept so <see cref="EditFormValidate"/> can restore it when the external validators produce nothing for the field.
         /// </summary>
         private List<string> _lastInternalErrors = [];
 
@@ -893,8 +887,7 @@ namespace MudBlazor
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
             if (For is not null && For != _currentFor)
             {
-                // For is a fresh expression instance on every render for an inline lambda, so only
-                // do the reflection and rebinding work when the field it points at actually changed.
+                // For is a fresh expression instance on every render for an inline lambda, so only do the reflection and rebinding work when the field it points at actually changed.
                 var fieldIdentifier = FieldIdentifier.Create(For);
                 if (!_fieldIdentifier.Equals(fieldIdentifier))
                 {
@@ -910,8 +903,7 @@ namespace MudBlazor
 #pragma warning restore IL2075
                     _validationAttrsFor = propertyInfo?.GetCustomAttributes(typeof(ValidationAttribute), true).Cast<ValidationAttribute>();
 
-                    // Drop anything staged for the previous field and reconcile the display so its
-                    // error can't linger on the newly bound field.
+                    // Drop anything staged for the previous field and reconcile the display so its error can't linger on the newly bound field.
                     var wasStaged = _hasStagedEditContextMessages;
                     ClearStagedEditContextMessages();
                     _lastInternalErrors = [];

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -743,7 +743,7 @@ namespace MudBlazor
         {
             // Without an EditContext or a field identity (no For) there is nothing to stage against.
             var editContext = EditContext;
-            if (editContext is null || _editContextValidationMessages is null || _fieldIdentifier.Equals(default(FieldIdentifier)))
+            if (editContext is null || _editContextValidationMessages is null || _fieldIdentifier.Equals(default))
             {
                 return;
             }
@@ -772,7 +772,7 @@ namespace MudBlazor
 
         private void ClearStagedEditContextMessages()
         {
-            if (_editContextValidationMessages is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
+            if (_editContextValidationMessages is not null && !_fieldIdentifier.Equals(default))
             {
                 _editContextValidationMessages.Clear(_fieldIdentifier);
             }
@@ -823,7 +823,7 @@ namespace MudBlazor
         {
             try
             {
-                if (EditContext is not null && !_fieldIdentifier.Equals(default(FieldIdentifier)))
+                if (EditContext is not null && !_fieldIdentifier.Equals(default))
                 {
                     var errorMessages = EditContext.GetValidationMessages(_fieldIdentifier).ToArray();
                     var hasError = errorMessages.Length > 0;


### PR DESCRIPTION
Fixes #13381: Under a Blazor `EditForm`/`EditContext`, blurring an untouched required field didn't show its error until submit, while the `MudForm` + `Validation`-delegate path validates on blur. The two behaved inconsistently.

## Cause

`MudFormComponent.ValidateValue()` early-returned whenever an `EditContext` was present, so the input's own assessment (`Required`, the `Validation` delegate, `For` data-annotations, conversion errors) never ran on blur.

The external validators (`DataAnnotationsValidator`, FluentValidation) only run on a real value change (`NotifyFieldChanged`) or submit (`Validate()`), and an untouched empty field is neither.

Regressed from #12817, which switched blur to `ValidateValue()` to fix false dirty-state signals (#12790).

## Fix

On blur, run the assessment and stage the results into a MudBlazor-owned `ValidationMessageStore`, then raise `NotifyValidationStateChanged()`.

Unlike `NotifyFieldChanged`, this surfaces the error without setting `IsModified` or firing `OnFieldChanged`, so blur no longer dirties the form (the #12790 contract holds). `For` data-annotations are now also extracted under an `EditContext`.

## Who wins ties
External validators are authoritative; MudBlazor fills the silence:
- External store already holds messages for the field → MudBlazor stages nothing (no duplicates in the field or a `ValidationSummary`).
- Real value change → the field goes to the external validators; if they say nothing, the component's own assessment is restored.
- Submit → staged messages are cleared; `Validate()` / `OnValidSubmit` are decided by the external validators alone. The component's `Required` shows errors on interaction but does not gate submit; a model-side `[Required]` still does.
- `ResetValidationAsync`, a `For` rebind, or removal of the `EditContext` clear staged messages so a cleared error can't resurface.

## Upgrade note

inside an `EditForm`/`EditContext`, a field's `Required` and any `Validation` delegate now run on blur and surface their error immediately (this restores behavior that #12817 had disabled). The submit verdict is still owned entirely by the external validators (`DataAnnotationsValidator`, FluentValidation) — exactly as in v9.6.0. A field guarded only by the component's `Required` (with no model-level `[Required]`) will show a blur error that is intentionally reconciled away on submit; to block submission, add a `[Required]` (or equivalent validator rule) on the model.

