### PR TITLE
Components: Stop losing exceptions from fire-and-forget async paths

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -197,6 +197,34 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// An exception thrown by the debounced update must reach <see cref="MudGlobal.UnhandledExceptionHandler"/> instead of vanishing with the fire-and-forget task.
+        /// </summary>
+        [Test]
+        public async Task DebouncedTextField_CallbackException_ReachesUnhandledExceptionHandler()
+        {
+            var originalHandler = MudGlobal.UnhandledExceptionHandler;
+            try
+            {
+                Exception observed = null;
+                MudGlobal.UnhandledExceptionHandler = ex => observed = ex;
+
+                var timeProvider = Context.AddFakeTimeProvider();
+                var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                    .Add(p => p.DebounceInterval, 200d)
+                    .Add(p => p.OnDebounceIntervalElapsed, (string _) => throw new InvalidOperationException("from debounced callback")));
+
+                await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Some Value" });
+                timeProvider.Advance(TimeSpan.FromMilliseconds(200));
+
+                await comp.WaitForAssertionAsync(() => observed.Should().BeOfType<InvalidOperationException>());
+            }
+            finally
+            {
+                MudGlobal.UnhandledExceptionHandler = originalHandler;
+            }
+        }
+
+        /// <summary>
         /// DebounceInterval updates with epsilon-equivalent values should not break debouncing
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -205,7 +205,7 @@ namespace MudBlazor.UnitTests.Components
             var originalHandler = MudGlobal.UnhandledExceptionHandler;
             try
             {
-                Exception observed = null;
+                Exception? observed = null;
                 MudGlobal.UnhandledExceptionHandler = ex => observed = ex;
 
                 var timeProvider = Context.AddFakeTimeProvider();
@@ -214,9 +214,15 @@ namespace MudBlazor.UnitTests.Components
                     .Add(p => p.OnDebounceIntervalElapsed, (string _) => throw new InvalidOperationException("from debounced callback")));
 
                 await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "Some Value" });
-                timeProvider.Advance(TimeSpan.FromMilliseconds(200));
 
-                await comp.WaitForAssertionAsync(() => observed.Should().BeOfType<InvalidOperationException>());
+                // The debounce delay registers with the time provider asynchronously, so keep advancing until the callback has run.
+                for (var i = 0; i < 100 && observed is null; i++)
+                {
+                    timeProvider.Advance(TimeSpan.FromMilliseconds(200));
+                    await Task.Delay(10);
+                }
+
+                observed.Should().BeOfType<InvalidOperationException>();
             }
             finally
             {

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -235,11 +235,16 @@ namespace MudBlazor
 
                 await _visibleState.SetValueAsync(true);
 
-                // Do not await this!
-                _reference.Result.ContinueWith(t =>
+                // Reset the visible state when the dialog closes; not awaited so ShowAsync doesn't block on the dialog's lifetime.
+                // The old ContinueWith produced a Task<Task> whose inner task was never observed, so exceptions from SetValueAsync were lost.
+                var reference = _reference;
+                HideWhenClosedAsync().CatchAndLog();
+
+                async Task HideWhenClosedAsync()
                 {
-                    return InvokeAsync(() => _visibleState.SetValueAsync(false));
-                }).CatchAndLog();
+                    await reference.Result;
+                    await InvokeAsync(() => _visibleState.SetValueAsync(false));
+                }
             }
             finally
             {

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -71,8 +71,9 @@ namespace MudBlazor
                 return base.UpdateValuePropertyAsync(updateText);
             }
 
-            // Debounce the update - use fire-and-forget pattern to match the old Timer implementation.
-            _ = _debouncer.DebounceAsync(OnDebouncedUpdate);
+            // Debounce the update; kept fire-and-forget to match the old Timer implementation.
+            // CatchAndLog forwards exceptions from the debounced callback to MudGlobal.UnhandledExceptionHandler instead of discarding them.
+            _debouncer.DebounceAsync(OnDebouncedUpdate).CatchAndLog();
             return Task.CompletedTask;
         }
 

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -127,7 +127,13 @@ namespace MudBlazor
         /// </summary>
         /// <param name="sender">The <see cref="ScrollListener"/> instance.</param>
         /// <param name="e">Information about the position of the scrolled element.</param>
-        private async void ScrollListener_OnScroll(object? sender, ScrollEventArgs e)
+        private void ScrollListener_OnScroll(object? sender, ScrollEventArgs e)
+        {
+            // The event requires a void handler; CatchAndLog forwards exceptions to MudGlobal.UnhandledExceptionHandler instead of letting async void lose them.
+            OnScrollAsync(e).CatchAndLog();
+        }
+
+        private async Task OnScrollAsync(ScrollEventArgs e)
         {
             await OnScroll.InvokeAsync(e);
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -991,7 +991,7 @@ namespace MudBlazor
 
             if (MultiSelection && typeof(T) == typeof(string))
             {
-                SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false).CatchAndLog();
+                await SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false);
             }
         }
 


### PR DESCRIPTION
Four spots started async work and dropped the task, so exceptions vanished and completion order was lost:

- `MudSelect.SelectAllItems` fired `SetValueAndUpdateTextAsync(...).CatchAndLog()` inside an already-async method while the identical call in `SelectOption` is awaited. Now awaited.
- `MudDebouncedInput` discarded the debounce task with a bare `_ =`, so exceptions from `OnDebounceIntervalElapsed` and the value update vanished. The call stays detached (awaiting would defeat debouncing) but now routes exceptions through `CatchAndLog` to `MudGlobal.UnhandledExceptionHandler`, like the library's other fire-and-forget sites.
- `MudScrollToTop`'s scroll handler was `async void` with no guard, so an exception from the `OnScroll` callback or re-render escaped the synchronization context and could crash the circuit. The event now uses a void adapter over an async method with `CatchAndLog`.
- `MudDialog`'s inline auto-hide used `Result.ContinueWith(...)`, producing a `Task<Task>` whose inner task was never observed, so exceptions from resetting the visible state were lost. Rewritten as an awaited local function, with the reference captured locally.
