### PR TITLE
MudAutocomplete: Dispose previous CTS on each search

### DIFF
--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -661,14 +661,21 @@ namespace MudBlazor
 
         private void CancelToken()
         {
+            // Swap in a fresh source before cancelling so the next search never observes the cancelled one.
+            // The previous source must be disposed or it leaks along with its registrations on every search.
+            var previous = _cancellationTokenSrc;
+            _cancellationTokenSrc = new CancellationTokenSource();
             try
             {
-                _cancellationTokenSrc?.Cancel();
+                previous?.Cancel();
             }
-            catch { /*ignored*/ }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed, such as when the component was disposed mid-search.
+            }
             finally
             {
-                _cancellationTokenSrc = new CancellationTokenSource();
+                previous?.Dispose();
             }
         }
 


### PR DESCRIPTION
`CancelToken()` cancelled the previous `CancellationTokenSource` but never disposed it, then unconditionally allocated a new one. It runs on every search keystroke, menu open, and menu close, so each interaction leaked a source and its registrations for the component's lifetime.