### PR TITLE
MudRadioGroup: Don't sever nested inputs from the parent form

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRadioGroupNestedInputTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRadioGroupNestedInputTest.razor
@@ -1,0 +1,20 @@
+﻿@using MudBlazor.Utilities
+<MudForm ValidationDelay="0" FieldChanged="OnFieldChanged">
+    <MudRadioGroup T="string" @bind-Value="_choice">
+        <MudRadio Value="@("A")">Option A</MudRadio>
+        <MudRadio Value="@("B")">Option B</MudRadio>
+        <MudTextField T="string" @bind-Value="_detail" Required="true" RequiredError="Detail is required" Label="Detail" />
+    </MudRadioGroup>
+</MudForm>
+
+@code {
+    public static string __description__ = "#11540: an input nested inside a MudRadioGroup must register with the surrounding MudForm; individual radios must not.";
+
+    public List<string> FieldChangedFieldTypes { get; } = new();
+
+    private string? _choice;
+    private string? _detail;
+
+    private void OnFieldChanged(FormFieldChangedEventArgs args)
+        => FieldChangedFieldTypes.Add(args.Field?.GetType().Name ?? "(null)");
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRadioGroupNestedInputTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRadioGroupNestedInputTest.razor
@@ -1,11 +1,11 @@
 ﻿@using MudBlazor.Utilities
-<MudForm ValidationDelay="0" FieldChanged="OnFieldChanged">
+<MudFormTestable ValidationDelay="0" FieldChanged="OnFieldChanged">
     <MudRadioGroup T="string" @bind-Value="_choice">
         <MudRadio Value="@("A")">Option A</MudRadio>
         <MudRadio Value="@("B")">Option B</MudRadio>
         <MudTextField T="string" @bind-Value="_detail" Required="true" RequiredError="Detail is required" Label="Detail" />
     </MudRadioGroup>
-</MudForm>
+</MudFormTestable>
 
 @code {
     public static string __description__ = "#11540: an input nested inside a MudRadioGroup must register with the surrounding MudForm; individual radios must not.";

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -703,7 +703,9 @@ namespace MudBlazor.UnitTests.Components
             // TODO: fill out the form with errors, field after field, check how fields get validation errors after blur
         }
 
-        // #11540: an input nested inside a MudRadioGroup must register with the surrounding MudForm.
+        /// <summary>
+        /// #11540: an input nested inside a MudRadioGroup must register with the surrounding MudForm.
+        /// </summary>
         [Test]
         public async Task FormRadioGroup_NestedInput_ParticipatesInValidation()
         {
@@ -721,7 +723,9 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Should().BeEmpty();
         }
 
-        // #11540 guard: radios must still not register with the form (#9472); only the group and the nested input do.
+        /// <summary>
+        /// #11540 guard: radios must still not register with the form (#9472); only the group and the nested input do.
+        /// </summary>
         [Test]
         public async Task FormRadioGroup_RadioSelection_DoesNotRegisterRadiosWithForm()
         {

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -708,7 +708,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task FormRadioGroup_NestedInput_ParticipatesInValidation()
         {
             var comp = Context.Render<FormRadioGroupNestedInputTest>();
-            var form = comp.FindComponent<MudForm>().Instance;
+            var form = comp.FindComponent<MudFormTestable>().Instance;
 
             form.IsValid.Should().BeFalse("the nested required text field must count against form validity (#11540)");
 
@@ -726,7 +726,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task FormRadioGroup_RadioSelection_DoesNotRegisterRadiosWithForm()
         {
             var comp = Context.Render<FormRadioGroupNestedInputTest>();
-            var form = comp.FindComponent<MudForm>().Instance;
+            var form = comp.FindComponent<MudFormTestable>().Instance;
 
             await comp.Find("input[type=radio]").ClickAsync();
 
@@ -735,10 +735,7 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert registration directly - a click cannot reveal it (the radio's own
             // FieldChanged is unreachable from markup even when wrongly registered).
-            var formControls = (System.Collections.IEnumerable)typeof(MudForm)
-                .GetField("_formControls", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-                .GetValue(form)!;
-            var registeredTypes = formControls.Cast<object>().Select(c => c.GetType()).ToList();
+            var registeredTypes = form.FormControls.Select(c => c.GetType()).ToList();
             registeredTypes.Should().NotContain(typeof(MudRadio<string>));
             registeredTypes.Should().Contain(typeof(MudRadioGroup<string>));
             registeredTypes.Should().Contain(typeof(MudTextField<string>), "the nested input registers (#11540)");

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -704,6 +704,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #11540: An input nested inside a MudRadioGroup must register with the surrounding MudForm.
+        /// </summary>
+        [Test]
+        public async Task FormRadioGroup_NestedInput_ParticipatesInValidation()
+        {
+            var comp = Context.Render<FormRadioGroupNestedInputTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+
+            form.IsValid.Should().BeFalse("the nested required text field must count against form validity (#11540)");
+
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.Errors.Should().Contain("Detail is required");
+
+            await comp.Find("input[type=text]").ChangeAsync(new ChangeEventArgs { Value = "some detail" });
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.IsValid.Should().BeTrue();
+            form.Errors.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// #11540 guard: individual radios must still not register with the form (#9472);
+        /// selecting one must not raise FieldChanged for the radio itself.
+        /// </summary>
+        [Test]
+        public async Task FormRadioGroup_RadioSelection_DoesNotRegisterRadiosWithForm()
+        {
+            var comp = Context.Render<FormRadioGroupNestedInputTest>();
+
+            await comp.Find("input[type=radio]").ClickAsync();
+
+            comp.Instance.FieldChangedFieldTypes.Should().NotContain("MudRadio`1",
+                "radios participate through their group, not as form fields themselves");
+        }
+
+        /// <summary>
         /// Setting the required radiogroup value should set IsValid true
         /// Clearing the value of a required radiogroup should set form's IsValid to false.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -703,9 +703,7 @@ namespace MudBlazor.UnitTests.Components
             // TODO: fill out the form with errors, field after field, check how fields get validation errors after blur
         }
 
-        /// <summary>
-        /// #11540: An input nested inside a MudRadioGroup must register with the surrounding MudForm.
-        /// </summary>
+        // #11540: an input nested inside a MudRadioGroup must register with the surrounding MudForm.
         [Test]
         public async Task FormRadioGroup_NestedInput_ParticipatesInValidation()
         {
@@ -723,10 +721,7 @@ namespace MudBlazor.UnitTests.Components
             form.Errors.Should().BeEmpty();
         }
 
-        /// <summary>
-        /// #11540 guard: individual radios must still not register with the form (#9472);
-        /// only the group and the nested input are form fields.
-        /// </summary>
+        // #11540 guard: radios must still not register with the form (#9472); only the group and the nested input do.
         [Test]
         public async Task FormRadioGroup_RadioSelection_DoesNotRegisterRadiosWithForm()
         {

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -725,17 +725,28 @@ namespace MudBlazor.UnitTests.Components
 
         /// <summary>
         /// #11540 guard: individual radios must still not register with the form (#9472);
-        /// selecting one must not raise FieldChanged for the radio itself.
+        /// only the group and the nested input are form fields.
         /// </summary>
         [Test]
         public async Task FormRadioGroup_RadioSelection_DoesNotRegisterRadiosWithForm()
         {
             var comp = Context.Render<FormRadioGroupNestedInputTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
 
             await comp.Find("input[type=radio]").ClickAsync();
 
             comp.Instance.FieldChangedFieldTypes.Should().NotContain("MudRadio`1",
                 "radios participate through their group, not as form fields themselves");
+
+            // Assert registration directly - a click cannot reveal it (the radio's own
+            // FieldChanged is unreachable from markup even when wrongly registered).
+            var formControls = (System.Collections.IEnumerable)typeof(MudForm)
+                .GetField("_formControls", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                .GetValue(form)!;
+            var registeredTypes = formControls.Cast<object>().Select(c => c.GetType()).ToList();
+            registeredTypes.Should().NotContain(typeof(MudRadio<string>));
+            registeredTypes.Should().Contain(typeof(MudRadioGroup<string>));
+            registeredTypes.Should().Contain(typeof(MudTextField<string>), "the nested input registers (#11540)");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -29,16 +29,6 @@ namespace MudBlazor
             SubscribeToParentForm = false;
         }
 
-        /// <inheritdoc />
-        protected override async Task ValidateValue()
-        {
-            // The group owns validation; a radio must not notify the form itself.
-            if (SubscribeToParentForm)
-            {
-                await base.ValidateValue();
-            }
-        }
-
         protected override string Classname => new CssBuilder("mud-input-control-boolean-input")
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass("mud-readonly", GetReadOnlyState())

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -23,6 +23,22 @@ namespace MudBlazor
         private readonly string _elementId = Identifier.Create("radio");
         private readonly string _ariaId = Identifier.Create("radio-aria-");
 
+        public MudRadio()
+        {
+            // The MudRadioGroup is the form participant; individual radios must not register (#11540).
+            SubscribeToParentForm = false;
+        }
+
+        /// <inheritdoc />
+        protected override async Task ValidateValue()
+        {
+            // The group owns validation; a radio must not notify the form itself.
+            if (SubscribeToParentForm)
+            {
+                await base.ValidateValue();
+            }
+        }
+
         protected override string Classname => new CssBuilder("mud-input-control-boolean-input")
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass("mud-readonly", GetReadOnlyState())

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -1,5 +1,4 @@
 ﻿@namespace MudBlazor
-@using MudBlazor.Interfaces
 @typeparam T
 @inherits MudFormComponent<T, T>
 
@@ -10,14 +9,11 @@
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorId="@ErrorIdState.Value" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
         <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="false">
-            @* Form should be cascaded as null so the childs are not registered to the Form *@
-            <CascadingValue TValue="IForm" Value="null">
-                <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
-                    <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
-                        <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" aria-required="@Required.ToString().ToLowerInvariant()">
-                            @ChildContent
-                        </div>
-                    </CascadingValue>
+            <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
+                <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
+                    <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" aria-required="@Required.ToString().ToLowerInvariant()">
+                        @ChildContent
+                    </div>
                 </CascadingValue>
             </CascadingValue>
         </CascadingValue>


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11540. Since #9472, `MudRadioGroup` wraps its `ChildContent` in `<CascadingValue TValue="IForm" Value="null">` so its radios don't register with the form. That also unregisters every other input nested in the group — a `MudTextField` inside a radio group is invisible to `MudForm` validation.

**Fix:** Move the opt-out onto `MudRadio` instead of severing the subtree:

- `MudRadio` sets `SubscribeToParentForm = false` in its constructor — the same opt-out wrapped inner inputs already use.
- `MudRadio.ValidateValue` is gated on it (like `MudBaseInput`) so a selection doesn't ping the form.
- The null-`IForm` cascade is removed from `MudRadioGroup.razor`.

Nested inputs (including checkbox/switch) register again, as before #9472. A standalone radio outside a group no longer registers with a form; it was unselectable anyway, so such a form could never become valid.
