### PR TITLE
MudSelect: Validate after the SelectedValues binding commits

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectMultiSelectionValidationOrderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectMultiSelectionValidationOrderTest.razor
@@ -1,0 +1,24 @@
+﻿<MudPopoverProvider />
+
+<MudForm ValidationDelay="0">
+    <MudSelect T="int" MultiSelection="true" @bind-SelectedValues="Selected"
+               Validation="@(new Func<int, string?>(_ => Observe()))" Label="Options">
+        <MudSelectItem Value="1" />
+        <MudSelectItem Value="2" />
+        <MudSelectItem Value="3" />
+    </MudSelect>
+</MudForm>
+
+@code {
+    public static string __description__ = "#11796: the Validation function must observe the already-committed SelectedValues binding.";
+
+    public IReadOnlyCollection<int>? Selected { get; set; } = [];
+
+    public List<int> ObservedCounts { get; } = new();
+
+    private string? Observe()
+    {
+        ObservedCounts.Add(Selected?.Count ?? 0);
+        return null;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectMultiSelectionValidationOrderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectMultiSelectionValidationOrderTest.razor
@@ -1,7 +1,7 @@
 ﻿<MudPopoverProvider />
 
 <MudForm ValidationDelay="0">
-    <MudSelect T="int" MultiSelection="true" @bind-SelectedValues="Selected"
+    <MudSelect T="int" MultiSelection="true" Clearable="true" @bind-SelectedValues="Selected"
                Validation="@(new Func<int, string?>(_ => Observe()))" Label="Options">
         <MudSelectItem Value="1" />
         <MudSelectItem Value="2" />

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1096,6 +1096,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #11796: In multi-selection, the Validation function must run after the SelectedValues
+        /// binding has been committed, so it observes the new selection - exactly once per click.
+        /// </summary>
+        [Test]
+        public async Task MultiSelect_Validation_RunsAfterSelectedValuesCommit()
+        {
+            var comp = Context.Render<SelectMultiSelectionValidationOrderTest>();
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().Be(3));
+            comp.Instance.ObservedCounts.Clear();
+
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+            comp.Instance.ObservedCounts.Should().Equal(new[] { 1 },
+                "validation runs once per selection and sees the committed binding (#11796)");
+
+            await comp.FindAll("div.mud-list-item")[1].ClickAsync();
+            comp.Instance.ObservedCounts.Should().Equal(new[] { 1, 2 });
+
+            // deselect the first option again
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+            comp.Instance.ObservedCounts.Should().Equal(new[] { 1, 2, 1 });
+        }
+
+        /// <summary>
         /// Selected option should be hilighted when drop-down opens
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1095,7 +1095,9 @@ namespace MudBlazor.UnitTests.Components
             select.ValidationErrors.First().Should().Be("Required");
         }
 
-        // #11796: in multi-selection the Validation function runs after SelectedValues commits, so it observes the new selection - once per click.
+        /// <summary>
+        /// #11796: in multi-selection the Validation function runs after SelectedValues commits, so it observes the new selection - once per click.
+        /// </summary>
         [Test]
         public async Task MultiSelect_Validation_RunsAfterSelectedValuesCommit()
         {

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1118,6 +1118,10 @@ namespace MudBlazor.UnitTests.Components
             // deselect the first option again
             await comp.FindAll("div.mud-list-item")[0].ClickAsync();
             comp.Instance.ObservedCounts.Should().Equal(new[] { 1, 2, 1 });
+
+            // the Clearable X button must also validate against the committed (now empty) binding
+            await comp.Find(".mud-input-clear-button").ClickAsync();
+            comp.Instance.ObservedCounts.Should().Equal(new[] { 1, 2, 1, 0 });
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1095,10 +1095,7 @@ namespace MudBlazor.UnitTests.Components
             select.ValidationErrors.First().Should().Be("Required");
         }
 
-        /// <summary>
-        /// #11796: In multi-selection, the Validation function must run after the SelectedValues
-        /// binding has been committed, so it observes the new selection - exactly once per click.
-        /// </summary>
+        // #11796: in multi-selection the Validation function runs after SelectedValues commits, so it observes the new selection - once per click.
         [Test]
         public async Task MultiSelect_Validation_RunsAfterSelectedValuesCommit()
         {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1504,10 +1504,10 @@ namespace MudBlazor
             await SetValueAndUpdateTextAsync(default, false);
             await SetTextAndUpdateValueAsync(null, false);
             _selectedValues.Clear();
-            await BeginValidateAsync();
             StateHasChanged();
             await UpdateSelectedValuesStateAsync();
             FieldChanged(_selectedValues);
+            await BeginValidateAsync();
             await OnClearButtonClick.InvokeAsync(e);
         }
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -621,7 +621,6 @@ namespace MudBlazor
                 }
 
                 UpdateSelectAllChecked();
-                await BeginValidateAsync();
             }
             else
             {
@@ -653,6 +652,13 @@ namespace MudBlazor
             await UpdateSelectedValuesStateAsync(comparer);
 
             FieldChanged(_selectedValues);
+
+            if (MultiSelection)
+            {
+                // Validate only now that SelectedValuesChanged has committed the new selection,
+                // so validation functions observe the updated binding (#11796).
+                await BeginValidateAsync();
+            }
 
             if (MultiSelection && typeof(T) == typeof(string))
             {
@@ -739,10 +745,10 @@ namespace MudBlazor
             await SetValueAndUpdateTextAsync(default, false);
             await SetTextAndUpdateValueAsync(null, false);
             _selectedValues.Clear();
-            await BeginValidateAsync();
             StateHasChanged();
             await UpdateSelectedValuesStateAsync();
             FieldChanged(_selectedValues);
+            await BeginValidateAsync();
         }
 
         /// <summary>
@@ -985,9 +991,9 @@ namespace MudBlazor
 
             UpdateSelectAllChecked();
             _selectedValues = selectedValues; // need to force selected values because Blazor overwrites it under certain circumstances due to changes of Text or Value
-            await BeginValidateAsync();
             await UpdateSelectedValuesStateAsync();
             FieldChanged(_selectedValues);
+            await BeginValidateAsync();
 
             if (MultiSelection && typeof(T) == typeof(string))
             {


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11796. In multi-selection, `BeginValidateAsync()` ran before `UpdateSelectedValuesStateAsync()` raised `SelectedValuesChanged`, so `Validation` functions observed the previous selection: the first selection still failed a not-empty rule, and deselecting the last option still passed it.

**Fix:** Validate after the selection is committed, in all four paths: `SelectOption`, `ClearAsync`, `SelectAllItems`, and the `Clearable` clear button. The built-in `Required` check is unaffected (it reads the internal `_selectedValues` either way), and validation still runs once per interaction.
