### PR TITLE
MudInput: Shrink the floating label when the browser autofills a field

### DIFF
--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -180,7 +180,9 @@
       }
     }
 
-    &.mud-shrink > .mud-input-outlined-border {
+    // Autofill must open the label notch too since mud-shrink is not set (#9050).
+    &.mud-shrink > .mud-input-outlined-border,
+    &:has(:-webkit-autofill) > .mud-input-outlined-border {
       legend {
         width: auto;
         padding: 0 5px;

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -53,7 +53,10 @@
 }
 
 label.mud-input-label.mud-input-label-inputcontrol {
-  .mud-shrink ~ & {
+  // Browser autofill applies :-webkit-autofill without firing an input event, so mud-shrink is never set
+  // and the label would overlap the prefilled value. Treat the autofilled state as shrunk directly in CSS (#9050).
+  .mud-shrink ~ &,
+  .mud-input:has(:-webkit-autofill) ~ & {
     color: var(--mud-palette-text-primary);
   }
 
@@ -62,7 +65,8 @@ label.mud-input-label.mud-input-label-inputcontrol {
   }
 
   .mud-shrink ~ &,
-  .mud-input:focus-within ~ & {
+  .mud-input:focus-within ~ &,
+  .mud-input:has(:-webkit-autofill) ~ & {
     transform: translate(0, 1.5px) scale(0.75);
     transform-origin: top left;
     max-width: calc(100% / 0.75);
@@ -117,7 +121,7 @@ label.mud-input-label.mud-input-label-inputcontrol {
     }
   }
 
-  .mud-shrink, .mud-input:focus-within {
+  .mud-shrink, .mud-input:focus-within, .mud-input:has(:-webkit-autofill) {
     ~ label.mud-input-label.mud-input-label-inputcontrol {
       transform-origin: top right;
 

--- a/src/MudBlazor/Styles/components/_inputlabel.scss
+++ b/src/MudBlazor/Styles/components/_inputlabel.scss
@@ -53,8 +53,7 @@
 }
 
 label.mud-input-label.mud-input-label-inputcontrol {
-  // Browser autofill applies :-webkit-autofill without firing an input event, so mud-shrink is never set
-  // and the label would overlap the prefilled value. Treat the autofilled state as shrunk directly in CSS (#9050).
+  // Browser autofill applies :-webkit-autofill without firing an input event, so mud-shrink is never set and the label would overlap the prefilled value. Treat the autofilled state as shrunk directly in CSS (#9050).
   .mud-shrink ~ &,
   .mud-input:has(:-webkit-autofill) ~ & {
     color: var(--mud-palette-text-primary);


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/9050: When a browser password manager prefills a field on page load / refresh / browser navigation (not SPA navigation), the floating label stays on top of the autofilled text instead of shrinking. Clicking anywhere fixes it.

Autofill applies the `:-webkit-autofill` pseudo-class to the `<input>` but fires no `input`/`change` event. The `mud-shrink` class is only added in C# when a value arrives through those events, so the label never lifts.

We add the autofilled input as a third shrink trigger in CSS, next to the existing `mud-shrink` and `:focus-within`:

- `_inputlabel.scss` — `.mud-input:has(:-webkit-autofill) ~ label` joins the shrink color and transform lists (LTR + RTL, all variants).
- `_input.scss` — the same selector joins the outlined legend-notch rule so the notch opens for the raised label. The border stays default-colored since the field is not focused.

CSS-only, additive, no public API change. Both `:has()` and `input:-webkit-autofill` are already used elsewhere in the stylesheet.
