### PR TITLE
MudForm: Exclude disabled inputs from required validation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -564,6 +564,77 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #2341: A disabled required input must not block form validity nor show a required error.
+        /// </summary>
+        [Test]
+        public async Task DisabledRequiredField_DoesNotBlockFormValidity()
+        {
+            var comp = Context.Render<FormDisabledRequiredTest>(p => p.Add(x => x.Disabled, true));
+            var form = comp.FindComponent<MudForm>().Instance;
+            var guarded = comp.FindComponents<MudTextField<string>>()[0].Instance;
+
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.IsValid.Should().BeTrue("a disabled required field is excluded from validation (#2341)");
+            form.Errors.Should().BeEmpty();
+            guarded.HasErrors.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// #2341: Enabling a previously-disabled required field re-introduces the requirement.
+        /// </summary>
+        [Test]
+        public async Task EnablingDisabledRequiredField_ReintroducesRequirement()
+        {
+            var comp = Context.Render<FormDisabledRequiredTest>(p => p.Add(x => x.Disabled, true));
+            var form = comp.FindComponent<MudForm>().Instance;
+
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.IsValid.Should().BeTrue();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Disabled, false));
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.IsValid.Should().BeFalse("enabling the field re-introduces its requirement (#2341)");
+            form.Errors.Should().Contain("Required");
+        }
+
+        /// <summary>
+        /// #2341: Disabling a field that is currently showing a required error re-validates it live -
+        /// the error clears and the form becomes valid without an explicit re-validation.
+        /// </summary>
+        [Test]
+        public async Task DisablingErroredField_LiveClearsErrorAndValidatesForm()
+        {
+            var comp = Context.Render<FormDisabledRequiredTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var guarded = comp.FindComponents<MudTextField<string>>()[0].Instance;
+
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.IsValid.Should().BeFalse();
+            guarded.HasErrors.Should().BeTrue();
+
+            await comp.SetParametersAndRenderAsync(p => p.Add(x => x.Disabled, true));
+            await comp.WaitForAssertionAsync(() =>
+            {
+                guarded.HasErrors.Should().BeFalse("disabling re-validates and drops the required error (#2341)");
+                form.IsValid.Should().BeTrue("the form re-evaluates when a field's disabled state changes (#2341)");
+            });
+        }
+
+        /// <summary>
+        /// #2341: ReadOnly (unlike Disabled) does not exclude a required field from validation.
+        /// </summary>
+        [Test]
+        public async Task ReadOnlyRequiredField_StillValidates()
+        {
+            var comp = Context.Render<FormDisabledRequiredTest>(p => p.Add(x => x.ReadOnly, true));
+            var form = comp.FindComponent<MudForm>().Instance;
+
+            await comp.InvokeAsync(form.ValidateAsync);
+            form.IsValid.Should().BeFalse("ReadOnly inputs still validate (#2341)");
+            form.Errors.Should().Contain("Required");
+        }
+
+        /// <summary>
         /// Based on error report. Clicking the checkbox should not influence the other form fields.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -427,6 +427,9 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
+        /// <inheritdoc />
+        public override bool IsDisabled => GetDisabledState();
+
         protected bool GetReadOnlyState() => ReadOnly || ParentReadOnly;
 
         /// <summary>

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -42,6 +42,9 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
+        /// <inheritdoc />
+        public override bool IsDisabled => GetDisabledState();
+
         /// <summary>
         /// Prevents the user from changing the input.
         /// </summary>

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -242,6 +242,14 @@ namespace MudBlazor
         /// </remarks>
         public bool Touched { get; protected set; }
 
+        /// <summary>
+        /// Indicates whether this input is disabled, so a <see cref="MudForm"/> can exclude it from validation.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  Overridden by inputs that support a <c>Disabled</c> parameter.
+        /// </remarks>
+        public virtual bool IsDisabled => false;
+
         // While set, a programmatic / parameter-driven value sync is running and the gated Touched /
         // FieldChanged writes are skipped - those reflect genuine user interaction only. This stops a
         // non-default initial or async-loaded value from touching the input (and its MudForm) on load
@@ -433,7 +441,8 @@ namespace MudBlazor
                 }
 
                 // required error (must be last, because it is least important!)
-                if (Required)
+                // a disabled input is barred from constraint validation, matching the HTML standard (#2341).
+                if (Required && !IsDisabled)
                 {
                     if (Touched && !HasValue(ReadValue))
                     {
@@ -798,9 +807,26 @@ namespace MudBlazor
         /// </summary>
         private EditContext? _currentEditContext;
 
+        /// <summary>
+        /// Tracks the disabled state so a change can re-run validation (#2341).
+        /// </summary>
+        private bool? _lastIsDisabled;
+
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
+
+            // When the disabled state changes, re-validate: a disabled input drops its (now excluded)
+            // required error, an enabled one regains it, and the form re-evaluates its validity (#2341).
+            if (_lastIsDisabled is null)
+            {
+                _lastIsDisabled = IsDisabled;
+            }
+            else if (_lastIsDisabled != IsDisabled)
+            {
+                _lastIsDisabled = IsDisabled;
+                ValidateValue().CatchAndLog();
+            }
 
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
             if (For is not null && For != _currentFor)

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -285,6 +285,9 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled || ParentReadOnly;
 
+        /// <inheritdoc />
+        public override bool IsDisabled => GetDisabledState();
+
         private async Task OnDragResetAsync()
         {
             await _draggingState.SetValueAsync(false);

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -244,7 +244,8 @@ namespace MudBlazor
             // - none have an error
             // - all required fields have been touched (and thus validated)
             var noErrors = _formControls.All(x => x.HasErrors == false);
-            var requiredAllTouched = _formControls.Where(x => x.Required).All(x => x.Touched);
+            // disabled inputs are excluded from validation, matching the HTML standard (#2341).
+            var requiredAllTouched = _formControls.Where(x => x.Required && !x.IsDisabled).All(x => x.Touched);
             var valid = noErrors && requiredAllTouched;
 
             var oldTouched = _touched;
@@ -278,7 +279,7 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                var valid = _formControls.All(x => x.Required == false);
+                var valid = _formControls.All(x => x.Required == false || x.IsDisabled);
                 if (valid != IsValid)
                 {
                     // the user probably bound a variable to IsValid, and it conflicts with our state.
@@ -426,7 +427,7 @@ namespace MudBlazor
 
         void IForm.Add(IFormComponent formControl)
         {
-            if (formControl.Required)
+            if (formControl.Required && !formControl.IsDisabled)
                 SetIsValid(false);
             _formControls.Add(formControl);
             SetDefaultControlValidation(formControl);

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -495,6 +495,9 @@ namespace MudBlazor
 
         protected bool GetDisabledState() => Disabled || ParentDisabled;
 
+        /// <inheritdoc />
+        public override bool IsDisabled => GetDisabledState();
+
         protected bool GetReadOnlyState() => ReadOnly || ParentReadOnly;
 
         protected virtual async Task SetTextAsync(string? value, bool callback)

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -111,6 +111,9 @@ namespace MudBlazor
 
         internal bool GetDisabledState() => Disabled || ParentDisabled; //internal because the MudRadio reads this value directly
 
+        /// <inheritdoc />
+        public override bool IsDisabled => GetDisabledState();
+
         internal bool GetReadOnlyState() => ReadOnly || ParentReadOnly; //internal because the MudRadio reads this value directly
 
         protected async Task SetSelectedOptionAsync(T? option, bool updateRadio, bool updateValue = true)

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -10,6 +10,7 @@ namespace MudBlazor.Interfaces
         public bool Error { get; set; }
         public bool HasErrors { get; }
         public bool Touched { get; }
+        public bool IsDisabled { get; }
         public object? Validation { get; set; }
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }


### PR DESCRIPTION
Resolves https://github.com/MudBlazor/MudBlazor/issues/2341: A disabled required input still shows a required error and keeps the `MudForm` invalid, so a form can never be submitted while a disabled field is empty.

Now treats a disabled input as barred from constraint validation, matching the HTML standard.

- Expose `IsDisabled` on `IFormComponent` (overridden by every input that has a `Disabled` parameter).
- Skip the required check for a disabled input, and exclude disabled inputs from `MudForm`'s validity computation.
- Re-run validation when the disabled state changes, so the field's error and the form's validity update live in both directions (disable clears it, enable restores it) without an explicit re-validation.

`ReadOnly` is unaffected and still validates. Scoped to the required check — a custom `Validation` delegate on a disabled field still runs.