### PR TITLE
MudCheckBox, MudSwitch, MudRadio: Honor Color/UncheckedColor when ReadOnly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -373,6 +373,58 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [TestCase(Color.Secondary, Color.Error)]
+        [TestCase(Color.Info, Color.Warning)]
+        public void CheckBoxColor_ReadOnly_ShouldKeepColor(Color color, Color uncheckedColor)
+        {
+            // #9524: a read-only checkbox keeps Color/UncheckedColor (only Disabled greys out),
+            // while the interactive hover class stays suppressed.
+            var uncheckedComp = Context.Render<MudCheckBox<bool>>(x => x
+                .Add(c => c.Color, color)
+                .Add(c => c.UncheckedColor, uncheckedColor)
+                .Add(c => c.ReadOnly, true)
+                .Add(c => c.Value, false));
+            var uncheckedIcon = uncheckedComp.Find(".mud-button-root.mud-icon-button");
+            uncheckedIcon.ClassList.Should().Contain($"mud-{uncheckedColor.ToStringFast(true)}-text");
+            uncheckedIcon.ClassList.Should().NotContain($"hover:mud-{uncheckedColor.ToStringFast(true)}-hover");
+
+            var checkedComp = Context.Render<MudCheckBox<bool>>(x => x
+                .Add(c => c.Color, color)
+                .Add(c => c.UncheckedColor, uncheckedColor)
+                .Add(c => c.ReadOnly, true)
+                .Add(c => c.Value, true));
+            var checkedIcon = checkedComp.Find(".mud-button-root.mud-icon-button");
+            checkedIcon.ClassList.Should().Contain($"mud-{color.ToStringFast(true)}-text");
+            checkedIcon.ClassList.Should().NotContain($"hover:mud-{color.ToStringFast(true)}-hover");
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void CheckBoxColor_ReadOnlyWithoutUncheckedColor_ShouldKeepColor(bool value)
+        {
+            // #9524: with only Color set, a read-only checkbox keeps that color in both states.
+            var comp = Context.Render<MudCheckBox<bool>>(x => x
+                .Add(c => c.Color, Color.Success)
+                .Add(c => c.ReadOnly, true)
+                .Add(c => c.Value, value));
+            comp.Find(".mud-button-root.mud-icon-button").ClassList.Should().Contain("mud-success-text");
+        }
+
+        [Test]
+        public void CheckBoxColor_Disabled_ShouldDropColorClass()
+        {
+            // #9524: Disabled (unlike ReadOnly) greys out, so no color utility class is emitted.
+            var comp = Context.Render<MudCheckBox<bool>>(x => x
+                .Add(c => c.Color, Color.Success)
+                .Add(c => c.UncheckedColor, Color.Error)
+                .Add(c => c.Disabled, true));
+            var icon = comp.Find(".mud-button-root.mud-icon-button");
+            icon.ClassList.Should().NotContain("mud-error-text");
+            icon.ClassList.Should().NotContain("mud-success-text");
+        }
+
+        [Test]
         public void CheckBoxDisabled()
         {
             var comp = Context.Render<CheckBoxLabelTest>();

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -412,15 +412,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void CheckBoxColor_Disabled_ShouldDropColorClass()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void CheckBoxColor_Disabled_ShouldDropColorClass(bool value)
         {
-            // #9524: Disabled (unlike ReadOnly) greys out, so no color utility class is emitted.
+            // #9524: Disabled (unlike ReadOnly) greys out, so no color utility class is emitted in either state.
             var comp = Context.Render<MudCheckBox<bool>>(x => x
                 .Add(c => c.Color, Color.Success)
                 .Add(c => c.UncheckedColor, Color.Error)
-                .Add(c => c.Disabled, true));
+                .Add(c => c.Disabled, true)
+                .Add(c => c.Value, value));
             var icon = comp.Find(".mud-button-root.mud-icon-button");
             icon.ClassList.Should().NotContain("mud-error-text");
+            icon.ClassList.Should().NotContain("mud-success-text");
+        }
+
+        [Test]
+        public void CheckBoxColor_Indeterminate_ShouldUseUncheckedColor()
+        {
+            // #9524: UncheckedColor is documented to apply when Value is false or null, so the
+            // indeterminate (null) tri-state must use UncheckedColor rather than no color at all.
+            var comp = Context.Render<MudCheckBox<bool?>>(x => x
+                .Add(c => c.TriState, true)
+                .Add(c => c.Color, Color.Success)
+                .Add(c => c.UncheckedColor, Color.Error)
+                .Add(c => c.Value, null));
+            var icon = comp.Find(".mud-button-root.mud-icon-button");
+            icon.ClassList.Should().Contain("mud-error-text");
             icon.ClassList.Should().NotContain("mud-success-text");
         }
 

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -456,6 +456,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void RadioColor_ReadOnly_ShouldKeepColor()
+        {
+            // #9524: a read-only radio keeps Color/UncheckedColor (only Disabled greys out),
+            // while the interactive hover class stays suppressed.
+            var comp = Context.Render<MudRadioGroup<int>>(self => self
+                .Add(x => x.ReadOnly, true)
+                .Add(x => x.Value, 1)
+                .AddChildContent<MudRadio<int>>(r => r
+                    .Add(x => x.Value, 1)
+                    .Add(x => x.Color, Color.Success)
+                    .Add(x => x.UncheckedColor, Color.Error))
+                .AddChildContent<MudRadio<int>>(r => r
+                    .Add(x => x.Value, 2)
+                    .Add(x => x.Color, Color.Success)
+                    .Add(x => x.UncheckedColor, Color.Error)));
+
+            var icons = comp.FindAll("span.mud-button-root");
+            // first radio is checked -> Color; second is unchecked -> UncheckedColor
+            icons[0].ClassList.Should().Contain("mud-success-text");
+            icons[0].ClassList.Should().NotContain("hover:mud-success-hover");
+            icons[1].ClassList.Should().Contain("mud-error-text");
+            icons[1].ClassList.Should().NotContain("hover:mud-error-hover");
+        }
+
+        [Test]
         public void RadioLabel()
         {
             var value = new DisplayNameLabelClass();

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -112,6 +112,32 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        [TestCase(Color.Success, Color.Error)]
+        [TestCase(Color.Info, Color.Warning)]
+        public void SwitchColor_ReadOnly_ShouldKeepColor(Color color, Color uncheckedColor)
+        {
+            // #9524: a read-only switch keeps Color/UncheckedColor (only Disabled greys out),
+            // while the interactive hover class stays suppressed.
+            var offComp = Context.Render<MudSwitch<bool>>(x => x
+                .Add(c => c.Color, color)
+                .Add(c => c.UncheckedColor, uncheckedColor)
+                .Add(c => c.ReadOnly, true)
+                .Add(c => c.Value, false));
+            var offBase = offComp.Find(".mud-button-root.mud-icon-button.mud-switch-base");
+            offBase.ClassList.Should().Contain($"mud-{uncheckedColor.ToStringFast(true)}-text");
+            offBase.ClassList.Should().NotContain($"hover:mud-{uncheckedColor.ToStringFast(true)}-hover");
+
+            var onComp = Context.Render<MudSwitch<bool>>(x => x
+                .Add(c => c.Color, color)
+                .Add(c => c.UncheckedColor, uncheckedColor)
+                .Add(c => c.ReadOnly, true)
+                .Add(c => c.Value, true));
+            var onBase = onComp.Find(".mud-button-root.mud-icon-button.mud-switch-base");
+            onBase.ClassList.Should().Contain($"mud-{color.ToStringFast(true)}-text");
+            onBase.ClassList.Should().NotContain($"hover:mud-{color.ToStringFast(true)}-hover");
+        }
+
+        [Test]
         public void SwitchDisabled()
         {
             var comp = Context.Render<SwitchWithLabelTest>();

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -33,8 +33,6 @@ namespace MudBlazor
             .Build();
 
         protected override string IconClassname => new CssBuilder("mud-button-root mud-icon-button")
-            // The text color is kept when read-only; only Disabled greys the checkbox out.
-            // The hover effect is separated out so it can be suppressed whenever the checkbox is not interactive.
             .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && (UncheckedColor == null || BoolValue == true))
             .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text", !GetDisabledState() && UncheckedColor != null && BoolValue == false)
             .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && (UncheckedColor == null || BoolValue == true))

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -33,8 +33,12 @@ namespace MudBlazor
             .Build();
 
         protected override string IconClassname => new CssBuilder("mud-button-root mud-icon-button")
-            .AddClass($"mud-{Color.ToStringFast(true)}-text hover:mud-{Color.ToStringFast(true)}-hover", (!GetReadOnlyState() && !GetDisabledState() && UncheckedColor == null) || (UncheckedColor != null && BoolValue == true))
-            .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text hover:mud-{UncheckedColor?.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue == false)
+            // The text color is kept when read-only; only Disabled greys the checkbox out.
+            // The hover effect is separated out so it can be suppressed whenever the checkbox is not interactive.
+            .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && (UncheckedColor == null || BoolValue == true))
+            .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text", !GetDisabledState() && UncheckedColor != null && BoolValue == false)
+            .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && (UncheckedColor == null || BoolValue == true))
+            .AddClass($"hover:mud-{UncheckedColor?.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue == false)
             .AddClass($"mud-checkbox-dense", Dense)
             .AddClass($"mud-ripple mud-ripple-checkbox", Ripple && !GetReadOnlyState() && !GetDisabledState())
             .AddClass($"mud-disabled", GetDisabledState())

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -34,9 +34,9 @@ namespace MudBlazor
 
         protected override string IconClassname => new CssBuilder("mud-button-root mud-icon-button")
             .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && (UncheckedColor == null || BoolValue == true))
-            .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text", !GetDisabledState() && UncheckedColor != null && BoolValue == false)
+            .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text", !GetDisabledState() && UncheckedColor != null && BoolValue != true)
             .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && (UncheckedColor == null || BoolValue == true))
-            .AddClass($"hover:mud-{UncheckedColor?.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue == false)
+            .AddClass($"hover:mud-{UncheckedColor?.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && BoolValue != true)
             .AddClass($"mud-checkbox-dense", Dense)
             .AddClass($"mud-ripple mud-ripple-checkbox", Ripple && !GetReadOnlyState() && !GetDisabledState())
             .AddClass($"mud-disabled", GetDisabledState())

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -38,8 +38,6 @@ namespace MudBlazor
 
         protected override string IconClassname => new CssBuilder("mud-button-root mud-icon-button")
             .AddClass("mud-ripple mud-ripple-radio", Ripple && !GetDisabledState() && !GetReadOnlyState())
-            // The text color is kept when read-only; only Disabled greys the radio out.
-            // The hover effect is separated out so it can be suppressed whenever the radio is not interactive.
             .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && (UncheckedColor == null || Checked))
             .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text", !GetDisabledState() && UncheckedColor != null && !Checked)
             .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && (UncheckedColor == null || Checked))

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -38,8 +38,12 @@ namespace MudBlazor
 
         protected override string IconClassname => new CssBuilder("mud-button-root mud-icon-button")
             .AddClass("mud-ripple mud-ripple-radio", Ripple && !GetDisabledState() && !GetReadOnlyState())
-            .AddClass($"mud-{Color.ToStringFast(true)}-text hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && (UncheckedColor == null || (UncheckedColor != null && Checked)))
-            .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text hover:mud-{UncheckedColor?.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && Checked == false)
+            // The text color is kept when read-only; only Disabled greys the radio out.
+            // The hover effect is separated out so it can be suppressed whenever the radio is not interactive.
+            .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && (UncheckedColor == null || Checked))
+            .AddClass($"mud-{UncheckedColor?.ToStringFast(true)}-text", !GetDisabledState() && UncheckedColor != null && !Checked)
+            .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && (UncheckedColor == null || Checked))
+            .AddClass($"hover:mud-{UncheckedColor?.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && UncheckedColor != null && !Checked)
             .AddClass("mud-radio-dense", Dense)
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass("mud-readonly", GetReadOnlyState())

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -32,8 +32,12 @@ namespace MudBlazor
 
         protected string SwitchClassname => new CssBuilder("mud-button-root mud-icon-button mud-switch-base")
             .AddClass($"mud-ripple mud-ripple-switch", Ripple && !GetReadOnlyState() && !GetDisabledState())
-            .AddClass($"mud-{Color.ToStringFast(true)}-text hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && BoolValue == true)
-            .AddClass($"mud-{UncheckedColor.ToStringFast(true)}-text hover:mud-{UncheckedColor.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && BoolValue == false)
+            // The text color is kept when read-only; only Disabled greys the switch out.
+            // The hover effect is separated out so it can be suppressed whenever the switch is not interactive.
+            .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && BoolValue == true)
+            .AddClass($"mud-{UncheckedColor.ToStringFast(true)}-text", !GetDisabledState() && BoolValue == false)
+            .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && BoolValue == true)
+            .AddClass($"hover:mud-{UncheckedColor.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && BoolValue == false)
             .AddClass($"mud-switch-disabled", GetDisabledState())
             .AddClass($"mud-readonly", GetReadOnlyState())
             .AddClass($"mud-checked", BoolValue)

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor.cs
@@ -32,8 +32,6 @@ namespace MudBlazor
 
         protected string SwitchClassname => new CssBuilder("mud-button-root mud-icon-button mud-switch-base")
             .AddClass($"mud-ripple mud-ripple-switch", Ripple && !GetReadOnlyState() && !GetDisabledState())
-            // The text color is kept when read-only; only Disabled greys the switch out.
-            // The hover effect is separated out so it can be suppressed whenever the switch is not interactive.
             .AddClass($"mud-{Color.ToStringFast(true)}-text", !GetDisabledState() && BoolValue == true)
             .AddClass($"mud-{UncheckedColor.ToStringFast(true)}-text", !GetDisabledState() && BoolValue == false)
             .AddClass($"hover:mud-{Color.ToStringFast(true)}-hover", !GetReadOnlyState() && !GetDisabledState() && BoolValue == true)


### PR DESCRIPTION
Fixes #9524: A read-only `MudCheckBox` (and `MudSwitch`/`MudRadio`) was greyed out like a disabled one, ignoring `Color`/`UncheckedColor`. Read-only should keep its color — it's still a meaningful value; only interactivity should be suppressed.

The text-color and hover classes shared one gate that included `!GetReadOnlyState()`, so read-only stripped the color along with the hover effect. This is a regression from #9472, which re-merged the split that #9904 had introduced to fix this exact issue. The three components were unified into the same broken shape.

> Also note (beyond the title): this changes the indeterminate (`null`) state of a tri-state `MudCheckBox`. The `UncheckedColor` gate moved from `value == false` to `value != true`, so a tri-state checkbox with `UncheckedColor` set now paints its indeterminate state with `UncheckedColor` instead of the default color.

### Fix
Split color from hover in each `IconClassname`/`SwitchClassname`:
- `mud-{Color}-text` — gated by `!Disabled` only, so read-only keeps its color.
- `hover:mud-{Color}-hover` — gated by `!ReadOnly && !Disabled`, so hover stays suppressed when not interactive.

Disabled still greys out (via the existing `.mud-disabled` / `.mud-switch-disabled` CSS). This also aligns the switch thumb with its track, which already stayed colored when read-only.

Applied to `MudCheckBox`, `MudSwitch`, and `MudRadio` since they share the pattern — fixing one alone would leave the others broken.

### Behavior (measured, `Color=Success` / `UncheckedColor=Error`)
| State | Before | After |
| --- | --- | --- |
| ReadOnly, unchecked | grey `rgba(0,0,0,.537)` | error red `rgb(244,67,54)` |
| ReadOnly, checked | success green | success green |
| Disabled | disabled grey | disabled grey (unchanged) |
| Normal, hover class | present | present (unchanged) |
| ReadOnly, hover class | absent | absent (unchanged) |

**Checklist:**
- [x] I've read the contribution guidelines
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
