### PR TITLE
MudSelect: Forward consumer attributes to the selected-value presenter

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectOnFocusTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectOnFocusTest.razor
@@ -1,0 +1,35 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents.Select
+
+@* Repro for #13086: a rich-item MudSelect with a preselected value renders the
+   hidden-input presenter, so the consumer @onfocus splat must still fire there. *@
+<MudSelect T="string"
+           @ref="_select"
+           Label="Vehicle"
+           Value="@_value"
+           @onfocus="OnFocusAsync"
+           data-testid="vehicle-select">
+    <MudSelectItem Value="@("car")">
+        <span class="item-content">Car</span>
+    </MudSelectItem>
+    <MudSelectItem Value="@("truck")">
+        <span class="item-content">Truck</span>
+    </MudSelectItem>
+    <MudSelectItem Value="@("van")">
+        <span class="item-content">Van</span>
+    </MudSelectItem>
+</MudSelect>
+
+<p>Focus handler fired <b id="focus-count">@_focusCount</b> time(s).</p>
+
+@code {
+    private MudSelect<string> _select = null!;
+    private string _value = "car";
+    private int _focusCount;
+
+    // Mirrors the issue's usage: the consumer reacts to focus, e.g. by opening the menu.
+    private async Task OnFocusAsync(FocusEventArgs args)
+    {
+        _focusCount++;
+        await _select.OpenMenu();
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPresenterAttributeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPresenterAttributeTest.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents.Select
+
+@* Guards the #13086 fix: forwarding consumer attributes to the presenter must not
+   duplicate the id (owned by the hidden input) nor add tabindex to a disabled presenter. *@
+<MudSelect T="string" Value="@("car")" id="select-with-id" Label="With id">
+    <MudSelectItem Value="@("car")"><span>Car</span></MudSelectItem>
+    <MudSelectItem Value="@("van")"><span>Van</span></MudSelectItem>
+</MudSelect>
+
+<MudSelect T="string" Value="@("car")" Disabled="true" tabindex="0" data-scenario="disabled" Label="Disabled">
+    <MudSelectItem Value="@("car")"><span>Car</span></MudSelectItem>
+    <MudSelectItem Value="@("van")"><span>Van</span></MudSelectItem>
+</MudSelect>

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -2262,6 +2262,36 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task Select_UserAttributes_ForwardedToSelectedValuePresenter()
+        {
+            // A value is preselected and its item renders child content, so the hidden input
+            // is swapped for the focusable presenter div (#13086).
+            var comp = Context.Render<SelectOnFocusTest>();
+            IElement Presenter() => comp.Find("div.mud-select-input[tabindex='0']");
+
+            // Arbitrary consumer attributes reach the presenter, not just role/aria.
+            Presenter().GetAttribute("data-testid").Should().Be("vehicle-select");
+
+            // The consumer @onfocus splat fires when the presenter receives focus.
+            comp.Find("#focus-count").TextContent.Should().Be("0");
+            await Presenter().TriggerEventAsync("onfocus", new FocusEventArgs());
+            await comp.WaitForAssertionAsync(() => comp.Find("#focus-count").TextContent.Should().Be("1"));
+        }
+
+        [Test]
+        public void Select_PresenterAttributes_DoNotDuplicateIdOrFocusDisabled()
+        {
+            var comp = Context.Render<SelectPresenterAttributeTest>();
+
+            // The consumer id stays on the hidden input only; forwarding it to the presenter too would duplicate the DOM id.
+            comp.FindAll("[id='select-with-id']").Count.Should().Be(1);
+            comp.FindAll("div.mud-select-input[id='select-with-id']").Should().BeEmpty();
+
+            // A forwarded tabindex must not make the disabled presenter focusable.
+            comp.Find("div.mud-select-input[data-scenario='disabled']").HasAttribute("tabindex").Should().BeFalse();
+        }
+
+        [Test]
         public async Task Select_MultiSelect_ShouldKeepSelectionStateIndependentOfActiveDescendant()
         {
             var comp = Context.Render<MultiSelectTest6>();

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -243,7 +243,7 @@ namespace MudBlazor
         /// <remarks>
         /// In this render the <c>&lt;input&gt;</c> is <c>type="hidden"</c> and the display <c>div</c> is what actually receives focus and clicks.
         /// Every consumer-supplied attribute must move there — event handlers such as <c>@onfocus</c>, <c>data-*</c>, and accessibility attributes alike — or it silently stops working once a value is selected.
-        // The hidden input can no longer fire them, so forwarding them here does not double up.
+        /// The hidden input can no longer fire them, so forwarding them here does not double up.
         /// Caller-provided <c>UserAttributes</c> take precedence over the computed accessibility fallbacks. Returns <c>null</c> for every other render so the always-emitted (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
         /// </remarks>
         private Dictionary<string, object?>? GetDisplayUserAttributes()

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -241,9 +241,11 @@ namespace MudBlazor
         /// Builds the attributes mirrored onto the focusable display element for hidden-input rendering.
         /// </summary>
         /// <remarks>
-        /// This path keeps focus on the display element instead of the hidden input, so the display element needs the same accessibility-facing attributes.
-        /// Caller-provided <c>UserAttributes</c> take precedence. Returns <c>null</c> for every other render so the always-emitted
-        /// (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
+        /// In this render the <c>&lt;input&gt;</c> is <c>type="hidden"</c> and the display <c>div</c> is what actually receives focus and clicks.
+        /// Every consumer-supplied attribute must move there — event handlers such as <c>@onfocus</c>, <c>data-*</c>, and accessibility attributes alike —
+        /// or it silently stops working once a value is selected. The hidden input can no longer fire them, so forwarding them here does not double up.
+        /// Caller-provided <c>UserAttributes</c> take precedence over the computed accessibility fallbacks. Returns <c>null</c> for every other render so the
+        /// always-emitted (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
         /// </remarks>
         private Dictionary<string, object?>? GetDisplayUserAttributes()
         {
@@ -252,15 +254,13 @@ namespace MudBlazor
                 return null;
             }
 
-            var attributes = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase);
 
-            foreach (var attribute in UserAttributes)
-            {
-                if (attribute.Key.Equals("role", StringComparison.OrdinalIgnoreCase) || attribute.Key.StartsWith("aria-", StringComparison.OrdinalIgnoreCase))
-                {
-                    attributes[attribute.Key] = attribute.Value;
-                }
-            }
+            // The hidden input still owns the id, and the presenter markup owns tabindex (the disabled branch deliberately omits it
+            // so a disabled control cannot take focus). Forwarding either would duplicate the id across both elements or make a
+            // disabled presenter focusable again.
+            attributes.Remove("id");
+            attributes.Remove("tabindex");
 
             var describedBy = GetAriaDescribedByString();
             if (describedBy is not null)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -242,10 +242,9 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// In this render the <c>&lt;input&gt;</c> is <c>type="hidden"</c> and the display <c>div</c> is what actually receives focus and clicks.
-        /// Every consumer-supplied attribute must move there — event handlers such as <c>@onfocus</c>, <c>data-*</c>, and accessibility attributes alike —
-        /// or it silently stops working once a value is selected. The hidden input can no longer fire them, so forwarding them here does not double up.
-        /// Caller-provided <c>UserAttributes</c> take precedence over the computed accessibility fallbacks. Returns <c>null</c> for every other render so the
-        /// always-emitted (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
+        /// Every consumer-supplied attribute must move there — event handlers such as <c>@onfocus</c>, <c>data-*</c>, and accessibility attributes alike — or it silently stops working once a value is selected.
+        // The hidden input can no longer fire them, so forwarding them here does not double up.
+        /// Caller-provided <c>UserAttributes</c> take precedence over the computed accessibility fallbacks. Returns <c>null</c> for every other render so the always-emitted (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
         /// </remarks>
         private Dictionary<string, object?>? GetDisplayUserAttributes()
         {
@@ -256,9 +255,8 @@ namespace MudBlazor
 
             var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase);
 
-            // The hidden input still owns the id, and the presenter markup owns tabindex (the disabled branch deliberately omits it
-            // so a disabled control cannot take focus). Forwarding either would duplicate the id across both elements or make a
-            // disabled presenter focusable again.
+            // The hidden input still owns the id, and the presenter markup owns tabindex (the disabled branch deliberately omits it so a disabled control cannot take focus).
+            // Forwarding either would duplicate the id across both elements or make a disabled presenter focusable again.
             attributes.Remove("id");
             attributes.Remove("tabindex");
 


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/13086: A consumer `@onfocus` — and every other splatted attribute — on a `MudSelect` stops working once a value is selected.

Cause
- When a selected `MudSelectItem` renders child content, `MudSelect` sets its internal `MudInput` to `InputType.Hidden`: the `<input>` becomes `type="hidden"` and a `<div class="mud-select-input" tabindex="0">` presenter becomes the focus/click target.
- Consumer attributes are splatted onto the now-hidden input, so `@onfocus`, `@onclick`, `data-*`, etc. go dead in that state.
- https://github.com/MudBlazor/MudBlazor/pull/13080 already forwards `role`/`aria-*` to the presenter; this extends the same mechanism to the rest.

Change
- `GetDisplayUserAttributes()` now forwards the full `UserAttributes` to the presenter, minus:
  - `id` — owned by the hidden input via `InputElementId`; forwarding it too would duplicate the DOM id.
  - `tabindex` — owned by the presenter markup, which deliberately omits it in the disabled branch so a disabled control stays unfocusable.
- No double-firing: the hidden input is `type="hidden"` and inert.

Supersedes https://github.com/MudBlazor/MudBlazor/pull/13100.
