### PR TITLE
MudPopover: Align edge-anchored dropdown popovers with their box

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverEdgeAlignmentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPopoverEdgeAlignmentTest.razor
@@ -1,0 +1,29 @@
+﻿@* Visual regression for #11894. Field dropdowns pinned within the overflow-padding
+   gutter (24px) of the viewport edge must stay aligned with their input box, not shift inward. *@
+<div style="position:fixed; left:8px; top:120px; width:300px; z-index:10;">
+    <MudSelect T="string" @bind-Value="_value" Label="Select 8px from left edge" Variant="Variant.Outlined"
+               PopoverClass="edge-select-popover">
+        @foreach (var state in _states)
+        {
+            <MudSelectItem Value="@state">@state</MudSelectItem>
+        }
+    </MudSelect>
+</div>
+
+<div style="position:fixed; left:8px; top:320px; width:300px; z-index:10;">
+    <MudDatePicker Label="DatePicker 8px from left edge" Variant="Variant.Outlined"
+                   PopoverClass="edge-picker-popover" />
+</div>
+
+@code {
+    public static string __description__ =
+        "Field dropdowns near the left viewport edge should stay left-aligned with their input box (#11894), " +
+        "instead of being pushed to the overflow-padding gutter. The popover left should match the input left.";
+
+    private string? _value;
+
+    private readonly string[] _states =
+    {
+        "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado"
+    };
+}

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -521,10 +521,7 @@ window.mudpopoverHelper = {
                     }
                 }
 
-                // Anchor-aware floor for the edge clamp below: clamp no further than the anchor's
-                // own edge, so a dropdown near the viewport edge stays aligned with its box (#11894).
-                // Bounded to >= 0 so the clamp never targets an off-screen position, unlike the
-                // reverted #13053 which skipped the clamp entirely and let popovers overflow (#13199).
+                // Anchor-aware floor for the edge clamp below: clamp no further than the anchor's own edge, so a dropdown near the viewport edge stays aligned with its box (#11894).
                 const minLeft = Math.max(0, Math.min(window.mudpopoverHelper.overflowPadding, boundingRect.left));
                 const minTop = Math.max(0, Math.min(window.mudpopoverHelper.overflowPadding, boundingRect.top));
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -521,19 +521,25 @@ window.mudpopoverHelper = {
                     }
                 }
 
+                // Pull the popover back on screen, but never past the anchor's own edge, so a
+                // dropdown attached to a box near the viewport edge stays aligned with it (#11894).
+                // Clamped to at least 0 so the popover can never overflow off screen (#13199).
+                const minLeft = Math.max(0, Math.min(window.mudpopoverHelper.overflowPadding, boundingRect.left));
+                const minTop = Math.max(0, Math.min(window.mudpopoverHelper.overflowPadding, boundingRect.top));
+
                 // ensure the left is inside bounds
-                if (left + offsetX < window.mudpopoverHelper.overflowPadding && // it's starting left of the screen
+                if (left + offsetX < minLeft && // it's starting left of the anchor or gutter
                     Math.abs(left + offsetX) < selfRect.width) { // it's not starting so far left the entire box would be hidden
-                    left = window.mudpopoverHelper.overflowPadding;
+                    left = minLeft;
                     // set offsetX to 0 to avoid double offset
                     offsetX = 0;
                 }
 
                 // ensure the top is inside bounds
-                if (top + offsetY < window.mudpopoverHelper.overflowPadding && // it's starting above the screen
+                if (top + offsetY < minTop && // it's starting above the anchor or gutter
                     boundingRect.top >= 0 && // the popoverNode is still on screen
                     Math.abs(top + offsetY) < selfRect.height) { // it's not starting so far above the entire box would be hidden
-                    top = window.mudpopoverHelper.overflowPadding;
+                    top = minTop;
                     // set offsetY to 0 to avoid double offset
                     offsetY = 0;
                 }

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -521,9 +521,10 @@ window.mudpopoverHelper = {
                     }
                 }
 
-                // Pull the popover back on screen, but never past the anchor's own edge, so a
-                // dropdown attached to a box near the viewport edge stays aligned with it (#11894).
-                // Clamped to at least 0 so the popover can never overflow off screen (#13199).
+                // Anchor-aware floor for the edge clamp below: clamp no further than the anchor's
+                // own edge, so a dropdown near the viewport edge stays aligned with its box (#11894).
+                // Bounded to >= 0 so the clamp never targets an off-screen position, unlike the
+                // reverted #13053 which skipped the clamp entirely and let popovers overflow (#13199).
                 const minLeft = Math.max(0, Math.min(window.mudpopoverHelper.overflowPadding, boundingRect.left));
                 const minTop = Math.max(0, Math.min(window.mudpopoverHelper.overflowPadding, boundingRect.top));
 
@@ -537,7 +538,7 @@ window.mudpopoverHelper = {
 
                 // ensure the top is inside bounds
                 if (top + offsetY < minTop && // it's starting above the anchor or gutter
-                    boundingRect.top >= 0 && // the popoverNode is still on screen
+                    boundingRect.top >= 0 && // the anchor hasn't scrolled above the viewport top
                     Math.abs(top + offsetY) < selfRect.height) { // it's not starting so far above the entire box would be hidden
                     top = minTop;
                     // set offsetY to 0 to avoid double offset


### PR DESCRIPTION
Fixes #11894: The left/top overflow clamps in `placePopover` push a popover to a fixed 24px viewport gutter (`overflowPadding`), ignoring the anchor. When a field's input box sits inside that gutter (e.g. a Select at `left:16`), the popover is shoved to `left:24` and detaches from the box.

The earlier fix #13053 skipped the clamp entirely for placement-classified popovers, which let a `CenterLeft` menu near the top edge overflow off-screen (#13199) → reverted by #13200.

This fix keeps the clamp on both axes but makes its floor anchor-aware:

```js
minLeft = Math.max(0, Math.min(overflowPadding, boundingRect.left));
minTop  = Math.max(0, Math.min(overflowPadding, boundingRect.top));
```

When the box is nearer the edge than the gutter, the popover aligns to the box; otherwise the 24px gutter is unchanged. `Math.max(0, …)` keeps it fully on screen, so #13199's off-screen failure mode can't recur. Width-agnostic, so pickers (which default to `RelativeWidth=Ignore`) are covered too.