### PR TITLE
MudTimeline: Render the Icon property on timeline items

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineDotIconExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/Examples/TimelineDotIconExample.razor
@@ -1,0 +1,16 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudTimeline>
+    <MudTimelineItem Icon="@Icons.Material.Filled.Rocket" Color="Color.Primary" Variant="Variant.Filled" Size="Size.Large">
+        <MudText>Kickoff</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem Icon="@Icons.Material.Filled.Code" Color="Color.Info" Variant="Variant.Filled" Size="Size.Large">
+        <MudText Align="Align.End">Development</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem Icon="@Icons.Material.Filled.BugReport" Color="Color.Warning" Variant="Variant.Filled" Size="Size.Large">
+        <MudText>Testing</MudText>
+    </MudTimelineItem>
+    <MudTimelineItem Icon="@Icons.Material.Filled.Verified" Color="Color.Success" Variant="Variant.Filled" Size="Size.Large">
+        <MudText Align="Align.End">Release</MudText>
+    </MudTimelineItem>
+</MudTimeline>

--- a/src/MudBlazor.Docs/Pages/Components/Timeline/TimelinePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Timeline/TimelinePage.razor
@@ -23,6 +23,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Dot Icon">
+                <Description>Set the <CodeInline>Icon</CodeInline> property on a <CodeInline>TimelineItem</CodeInline> to display an icon inside its dot. For full control, use the <CodeInline>ItemDot</CodeInline> render fragment instead, which takes precedence over <CodeInline>Icon</CodeInline>.</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(TimelineDotIconExample)" Block="true" FullWidth="true">
+                <TimelineDotIconExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Dot class">
                 <Description>The style of each <CodeInline>TimelineItem</CodeInline> dot can be set individually using the <CodeInline>DotClass</CodeInline> attribute with CSS classes.</Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/TimelineTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimelineTests.cs
@@ -166,6 +166,75 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-timeline-item-dot-inner").GetStyle()["background-color"].Should().Be("rgba(255, 0, 0, 1)");
         }
 
+        [Test]
+        public async Task Timeline_Icon()
+        {
+            var comp = Context.Render<TimelineTest>();
+            var firstItem = comp.FindComponent<MudTimelineItem>();
+
+            // No icon by default.
+            comp.FindAll(".mud-timeline-item-dot-inner .mud-icon-root").Should().BeEmpty();
+
+            await firstItem.SetParametersAndRenderAsync(p =>
+            {
+                p.Add(t => t.Icon, Icons.Material.Filled.Groups);
+            });
+
+            var icon = comp.Find(".mud-timeline-item-dot-inner .mud-icon-root");
+            icon.ClassList.Should().Contain("mud-timeline-item-dot-icon");
+            comp.Markup.Should().Contain(Icons.Material.Filled.Groups);
+            // Only the item with an icon set renders one.
+            comp.FindAll(".mud-icon-root").Count.Should().Be(1);
+        }
+
+        [Test]
+        public async Task Timeline_Icon_EmptyRendersNoIcon()
+        {
+            var comp = Context.Render<TimelineTest>();
+            var firstItem = comp.FindComponent<MudTimelineItem>();
+
+            await firstItem.SetParametersAndRenderAsync(p =>
+            {
+                p.Add(t => t.Icon, string.Empty);
+            });
+
+            comp.FindAll(".mud-icon-root").Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task Timeline_ItemDotTakesPrecedenceOverIcon()
+        {
+            var comp = Context.Render<TimelineTest>();
+            var firstItem = comp.FindComponent<MudTimelineItem>();
+
+            await firstItem.SetParametersAndRenderAsync(p =>
+            {
+                p.Add(t => t.Icon, Icons.Material.Filled.Groups);
+                p.Add(t => t.ItemDot, "<span class=\"custom-dot\">X</span>");
+            });
+
+            comp.FindAll(".mud-timeline-item-dot-inner .custom-dot").Should().ContainSingle();
+            comp.FindAll(".mud-timeline-item-dot-icon").Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task Timeline_HideDotHidesIcon()
+        {
+            var comp = Context.Render<TimelineTest>();
+            var firstItem = comp.FindComponent<MudTimelineItem>();
+
+            await firstItem.SetParametersAndRenderAsync(p =>
+            {
+                p.Add(t => t.Icon, Icons.Material.Filled.Groups);
+                p.Add(t => t.HideDot, true);
+            });
+
+            // The whole dot (and therefore the icon) is gone for that item.
+            comp.FindAll(".mud-timeline-item").Count.Should().Be(5);
+            comp.FindAll(".mud-timeline-item-dot").Count.Should().Be(4);
+            comp.FindAll(".mud-icon-root").Should().BeEmpty();
+        }
+
         /// <summary>
         /// Test horizontal timeline inside vertical timeline.
         /// </summary>

--- a/src/MudBlazor/Components/Timeline/MudTimelineItem.razor
+++ b/src/MudBlazor/Components/Timeline/MudTimelineItem.razor
@@ -21,6 +21,10 @@
                     {
                         @ItemDot
                     }
+                    else if (!string.IsNullOrEmpty(Icon))
+                    {
+                        <MudIcon Icon="@Icon" Class="mud-timeline-item-dot-icon" />
+                    }
                 </div>
             </div>
         }

--- a/src/MudBlazor/Components/Timeline/MudTimelineItem.razor.cs
+++ b/src/MudBlazor/Components/Timeline/MudTimelineItem.razor.cs
@@ -41,8 +41,11 @@ namespace MudBlazor
         protected internal MudBaseItemsControl<MudTimelineItem>? Parent { get; set; }
 
         /// <summary>
-        /// The icon displayed for the dot.
+        /// The icon displayed inside the dot.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. Ignored when <see cref="ItemDot"/> is set.
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.Timeline.Dot)]
         public string? Icon { get; set; }

--- a/src/MudBlazor/Styles/components/_timeline.scss
+++ b/src/MudBlazor/Styles/components/_timeline.scss
@@ -316,6 +316,10 @@
       height: 18px;
       width: 18px;
     }
+
+    .mud-timeline-item-dot-icon {
+      font-size: 14px;
+    }
   }
 
   &.mud-timeline-dot-size-medium {
@@ -326,6 +330,10 @@
       height: 30px;
       width: 30px;
     }
+
+    .mud-timeline-item-dot-icon {
+      font-size: 22px;
+    }
   }
 
   &.mud-timeline-dot-size-large {
@@ -335,6 +343,10 @@
     .mud-timeline-item-dot-inner {
       height: 42px;
       width: 42px;
+    }
+
+    .mud-timeline-item-dot-icon {
+      font-size: 30px;
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/MudBlazor/MudBlazor/issues/9213: `MudTimelineItem.Icon` has existed since the component was added (#2323) but was never rendered. This makes it work by setting `Icon` now displays that icon inside the item's dot.

Behavior:
- `Icon` renders a `MudIcon` inside the dot — a shorthand for the common single-icon case.
- Precedence: `HideDot` > `ItemDot` > `Icon` > plain dot. `ItemDot` still wins when both are set, so existing usages are unaffected.
- Empty/null `Icon` renders nothing.

Notes:
- Icon size is clamped per dot size in CSS (14/22/30px for Small/Medium/Large) rather than mapping to `MudIcon.Size`, whose steps overflow the small dot. Fits both Outlined and Filled without clipping.
- No `Color` is set on the icon; it inherits the dot's `{color}-text` via `currentColor`, so contrast is automatic on colored dots.
- No public API change.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
