### PR TITLE
MudTable: Fix nested group checkbox state after expansion

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2398,6 +2398,40 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
+        [Test]
+        public async Task TableGrouping_NestedGroupCheckboxesUpdateWhenParentExpandsAfterSelection()
+        {
+            // Regression for https://github.com/MudBlazor/MudBlazor/issues/9474
+            var comp = Context.Render<TableGroupingNestedTest>();
+            var tableComponent = comp.FindComponent<MudTable<TableGroupingNestedTest.Item>>();
+            await tableComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.MultiSelection, true));
+            var table = tableComponent.Instance;
+
+            IRenderedComponent<MudTableGroupRow<TableGroupingNestedTest.Item>> FindGroup(string key)
+            {
+                return comp.FindComponents<MudTableGroupRow<TableGroupingNestedTest.Item>>()
+                    .Single(group => group.Instance.Items?.Key.ToString() == key);
+            }
+
+            // Control: expanding an unselected parent creates unchecked child groups.
+            var unselectedParent = FindGroup("G2");
+            await unselectedParent.FindComponent<MudIconButton>().Find("button").ClickAsync();
+            table.Context.GroupRows.Single(group => group.Items?.Key.ToString() == "G2 > N1").Checked.Should().BeFalse();
+            table.Context.GroupRows.Single(group => group.Items?.Key.ToString() == "G2 > N2").Checked.Should().BeFalse();
+
+            // Select a different parent while its child groups have not been rendered.
+            table.Context.GroupRows.Should().NotContain(group => group.Items != null && group.Items.Key.ToString().StartsWith("G1 >"));
+            var selectedParent = FindGroup("G1");
+            await selectedParent.FindComponent<MudCheckBox<bool?>>().Find("input").ChangeAsync(true);
+            table.SelectedItems.Should().HaveCount(3);
+            table.SelectedItems.Should().OnlyContain(item => item.Group == "G1");
+
+            // Expanding the selected parent must immediately initialize its child checkboxes.
+            await selectedParent.FindComponent<MudIconButton>().Find("button").ClickAsync();
+            table.Context.GroupRows.Single(group => group.Items?.Key.ToString() == "G1 > N1").Checked.Should().BeTrue();
+            table.Context.GroupRows.Single(group => group.Items?.Key.ToString() == "G1 > N2").Checked.Should().BeTrue();
+        }
+
         /// <summary>
         /// Tests the grouping behavior and ensure that it won't break anything else.
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -182,7 +182,15 @@ namespace MudBlazor
             if (GroupDefinition != null)
             {
                 Expanded = GroupDefinition.IsInitiallyExpanded;
-                ((TableContext<T>?)Context)?.GroupRows.Add(this);
+                var context = (TableContext<T>?)Context;
+                if (context is not null)
+                {
+                    context.GroupRows.Add(this);
+                    if (Checkable && Items is not null)
+                    {
+                        _checked = context.GetGroupCheckedState(Items);
+                    }
+                }
                 SyncInnerGroupItems();
             }
             return base.OnInitializedAsync();

--- a/src/MudBlazor/Components/Table/TableContext.cs
+++ b/src/MudBlazor/Components/Table/TableContext.cs
@@ -132,6 +132,15 @@ namespace MudBlazor
         /// </summary>
         public List<MudTableSortLabel<T>> SortLabels { get; set; } = new();
 
+        internal bool? GetGroupCheckedState(IEnumerable<T>? items)
+        {
+            var rowGroupItems = items?.ToList() ?? new List<T>();
+            var itemsCount = Selection.Intersect(rowGroupItems).Count();
+            var selectAll = itemsCount == rowGroupItems.Count;
+            var indeterminate = !selectAll && itemsCount > 0 && Selection.Count > 0;
+            return indeterminate ? null : selectAll;
+        }
+
         /// <inheritdoc />
         public override void UpdateRowCheckBoxes(bool updateGroups = true, bool updateHeaderFooter = true)
         {
@@ -158,12 +167,7 @@ namespace MudBlazor
                 // Update group checkboxes
                 foreach (var groupRow in GroupRows)
                 {
-                    var rowGroupItems = groupRow.Items?.ToList() ?? new List<T>();
-                    var itemsCount = Selection.Intersect(rowGroupItems).Count();
-                    var selectAll = itemsCount == rowGroupItems.Count;
-                    var indeterminate = !selectAll && itemsCount > 0 && Selection.Count > 0;
-                    var state = indeterminate && !selectAll ? (bool?)null : selectAll;
-                    groupRow.SetChecked(state, notify: false);
+                    groupRow.SetChecked(GetGroupCheckedState(groupRow.Items), notify: false);
                 }
             }
 


### PR DESCRIPTION
## Description
Fixes #9474.
Centralize the group checkbox state calculation in `TableContext` and use it
to initialize newly registered checkable groups before their first render.
This ensures nested groups immediately reflect an existing parent selection
when they are rendered after expansion, without triggering a table-wide
checkbox recalculation for every registered group.
## Tests
- Added a regression test covering selection before nested groups are rendered.
- Verified the relevant table grouping tests.
- Ran the complete `MudBlazor.UnitTests` project:
  - 5376 passed
  - 2 skipped
  - 0 failed