### PR TITLE
MudTabs: Anchor notification badge to top corner

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithBadgesAndLongTabNamesTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithBadgesAndLongTabNamesTest.razor
@@ -1,0 +1,23 @@
+<MudText Typo="Typo.subtitle2">Text badge</MudText>
+<MudTabs>
+    <MudTabPanel Text="A long Text" BadgeData='"live"' BadgeColor="Color.Info" />
+    <MudTabPanel Text="Even much longer Text" BadgeData='"live"' BadgeColor="Color.Info" />
+    <MudTabPanel Text="Short" BadgeData='"live"' BadgeColor="Color.Info" />
+</MudTabs>
+
+<MudText Typo="Typo.subtitle2" Class="mt-4">Numeric badge</MudText>
+<MudTabs>
+    <MudTabPanel Text="Deliveries and returns" BadgeData="27" BadgeColor="Color.Error" />
+    <MudTabPanel Text="Outstanding invoices" BadgeData="4" BadgeColor="Color.Error" />
+    <MudTabPanel Text="Archive" BadgeData="99" BadgeColor="Color.Error" />
+</MudTabs>
+
+<MudText Typo="Typo.subtitle2" Class="mt-4">Icon and text</MudText>
+<MudTabs>
+    <MudTabPanel Text="Notifications and alerts" Icon="@Icons.Material.Filled.Notifications" BadgeData="99" BadgeColor="Color.Error" />
+    <MudTabPanel Text="Chat" Icon="@Icons.Material.Filled.Chat" BadgeDot="true" BadgeColor="Color.Error" />
+</MudTabs>
+
+@code {
+    public static string __description__ = "Badges stay inside the tab and do not change its width, even with long tab names.";
+}

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -152,8 +152,6 @@
 
 .mud-tab {
   width: 100%;
-  // Positioning context for the notification badge.
-  // mud-ripple also sets this, but the badge must stay anchored when Ripple is off.
   position: relative;
   display: inline-flex;
   padding: 6px 12px;
@@ -203,9 +201,7 @@
     display: none;
   }
 
-  // Keep the notification badge out of the layout flow so adding one never changes the
-  // tab's width, but anchor it to the tab's own box instead of a zero-width point after
-  // the label, so it can no longer spill past the edge and get clipped (#1668).
+  // Keep the notification badge out of the layout flow so adding one never changes the tab's width, but anchor it to the tab's own box instead of a zero-width point after the label, so it can no longer spill past the edge and get clipped (#1668).
   .mud-tab-badge.mud-badge-root {
     position: static;
     margin: 0;

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -152,6 +152,9 @@
 
 .mud-tab {
   width: 100%;
+  // Positioning context for the notification badge.
+  // mud-ripple also sets this, but the badge must stay anchored when Ripple is off.
+  position: relative;
   display: inline-flex;
   padding: 6px 12px;
   min-height: 48px;
@@ -199,6 +202,21 @@
   &.mud-tab-panel-hidden {
     display: none;
   }
+
+  // Keep the notification badge out of the layout flow so adding one never changes the
+  // tab's width, but anchor it to the tab's own box instead of a zero-width point after
+  // the label, so it can no longer spill past the edge and get clipped (#1668).
+  .mud-tab-badge.mud-badge-root {
+    position: static;
+    margin: 0;
+
+    .mud-badge {
+      inset-block-start: 3px;
+      inset-block-end: auto;
+      inset-inline-start: auto;
+      inset-inline-end: 3px;
+    }
+  }
 }
 
 .mud-tab-slider {
@@ -228,12 +246,6 @@
       right: unset;
     }
   }
-}
-
-.mud-tab-badge {
-  margin-left: 8px;
-  margin-inline-start: 8px;
-  margin-inline-end: unset;
 }
 
 .mud-tab-slider.mud-default {
@@ -320,6 +332,11 @@
         padding-left: 8px;
         padding-inline-start: 8px;
         padding-inline-end: unset;
+      }
+
+      // Shift the badge clear of the close button, which sits at the tab's inline end.
+      .mud-tab-badge.mud-badge-root .mud-badge {
+        inset-inline-end: 45px;
       }
     }
   }


### PR DESCRIPTION
Fixes #1668 (and the duplicates #4408, #11849). Badges on tabs with long text were clipped at the tab edge and bled onto the next tab.

The badge is rendered as a zero-width anchor after the label, so with long text it lands at the tab's edge and paints outside, where the tab's own overflow clips it. As a side effect, adding a badge also nudged the tab 8px wider.

This PR fixes it by anchoring the badge to the tab's box and pin it to the top inline-end corner. It stays out of the layout flow, so adding a badge no longer changes the tab's width (the concern that closed #10099). Dynamic tabs shift it clear of the close button.

This is how Material Design places tab/nav badges: a top-end corner overlay that reserves no width. Android ([BadgeDrawable](https://github.com/material-components/material-components-android/blob/master/docs/components/BadgeDrawable.md)), Compose, Flutter, and MUI all do the same, and Android even auto-moves the badge "within the bounds of [the] first ancestor that does not clip its children, to ensure that the badge is not clipped".

## Screenshots

Before

<img width="1640" height="720" alt="image" src="https://github.com/user-attachments/assets/dcfddcc3-153b-4b57-ba26-07b1e97f7ccb" />


After

<img width="1640" height="720" alt="image" src="https://github.com/user-attachments/assets/35f020fe-520f-43a9-9122-70aec8c9b924" />

This is a visual change: the badge now pins to the tab's top-end corner. For short labels in the default 160px-min-width tab that places the badge at the tab corner rather than beside the text (visible on the `CHAT` dot above). That matches Material Design's tab/nav badge, but if we'd prefer to keep it beside the label we can anchor to the label instead — easy follow-up.

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
