### PR TITLE
MudRadioGroup: Correct reset behavior and remove Backspace shortcut

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Radio/RadioPage.razor
@@ -99,12 +99,6 @@
                             </td>
                             <td>Cycle focus between radio buttons</td>
                         </tr>
-                        <tr>
-                            <td>
-                                <CodeInline>Backspace</CodeInline>
-                            </td>
-                            <td>Unselect the focused radio button</td>
-                        </tr>
                         </tbody>
                     </MudSimpleTable>
                     <MudAlert Severity="Severity.Info" Class="my-3">

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -274,10 +274,53 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Enter", Type = "keydown", });
             await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be("1"));
 
+            // Backspace is not a standard radio interaction and no longer clears the selection.
             await comp.Find("input").KeyDownAsync(new KeyboardEventArgs() { Key = "Backspace", Type = "keydown", });
-            await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be(null));
+            await comp.WaitForAssertionAsync(() => radio.Instance.Value.Should().Be("1"));
 
             //Can't tabbed around the radios in test.
+        }
+
+        [Test]
+        public async Task RadioGroup_ResetAsync_ResetsToDefault()
+        {
+            // #11369: ResetAsync must set the group to default(T) consistently across the value, the selected
+            // radio, and the rendered markup - and a fresh selection must still work afterwards.
+
+            // Non-nullable bool: default is false, so resetting selects the "false" radio.
+            var boolGroup = Context.Render<MudRadioGroup<bool>>(self => self
+                .Add(x => x.Value, true)
+                .AddChildContent<MudRadio<bool>>(r => r.Add(x => x.Value, true))
+                .AddChildContent<MudRadio<bool>>(r => r.Add(x => x.Value, false)));
+
+            await boolGroup.InvokeAsync(() => boolGroup.Instance.ResetAsync());
+            boolGroup.Instance.Value.Should().BeFalse();
+            boolGroup.FindAll("input.mud-radio-input[checked]").Count.Should().Be(1);
+
+            // Selecting another option right after a reset still updates the value (the original #11369 symptom).
+            await boolGroup.FindAll("input.mud-radio-input")[0].ClickAsync(new MouseEventArgs());
+            boolGroup.Instance.Value.Should().BeTrue();
+
+            // Nullable with a matching null option: resets to null and selects that option.
+            var nullableWithNull = Context.Render<MudRadioGroup<bool?>>(self => self
+                .Add(x => x.Value, false)
+                .AddChildContent<MudRadio<bool?>>(r => r.Add(x => x.Value, true))
+                .AddChildContent<MudRadio<bool?>>(r => r.Add(x => x.Value, false))
+                .AddChildContent<MudRadio<bool?>>(r => r.Add(x => x.Value, (bool?)null)));
+
+            await nullableWithNull.InvokeAsync(() => nullableWithNull.Instance.ResetAsync());
+            nullableWithNull.Instance.Value.Should().BeNull();
+            nullableWithNull.FindAll("input.mud-radio-input[checked]").Count.Should().Be(1);
+
+            // Nullable without a null option: resets to null and clears the selection entirely.
+            var nullableNoNull = Context.Render<MudRadioGroup<bool?>>(self => self
+                .Add(x => x.Value, false)
+                .AddChildContent<MudRadio<bool?>>(r => r.Add(x => x.Value, true))
+                .AddChildContent<MudRadio<bool?>>(r => r.Add(x => x.Value, false)));
+
+            await nullableNoNull.InvokeAsync(() => nullableNoNull.Instance.ResetAsync());
+            nullableNoNull.Instance.Value.Should().BeNull();
+            nullableNoNull.FindAll("input.mud-radio-input[checked]").Count.Should().Be(0);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -284,8 +284,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RadioGroup_ResetAsync_ResetsToDefault()
         {
-            // #11369: ResetAsync must set the group to default(T) consistently across the value, the selected
-            // radio, and the rendered markup - and a fresh selection must still work afterwards.
+            // #11369: ResetAsync must reset the group to default(T) consistently, and re-selection must still work.
 
             // Non-nullable bool: default is false, so resetting selects the "false" radio.
             var boolGroup = Context.Render<MudRadioGroup<bool>>(self => self
@@ -297,7 +296,7 @@ namespace MudBlazor.UnitTests.Components
             boolGroup.Instance.Value.Should().BeFalse();
             boolGroup.FindAll("input.mud-radio-input[checked]").Count.Should().Be(1);
 
-            // Selecting another option right after a reset still updates the value (the original #11369 symptom).
+            // Re-selecting right after a reset still updates the value (the #11369 symptom).
             await boolGroup.FindAll("input.mud-radio-input")[0].ClickAsync(new MouseEventArgs());
             boolGroup.Instance.Value.Should().BeTrue();
 

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -189,14 +189,6 @@ namespace MudBlazor
 
         private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState() && !(MudRadioGroup?.GetReadOnlyState() ?? false);
 
-        private async Task HandleBackspaceAsync()
-        {
-            if (MudRadioGroup is not null)
-            {
-                await MudRadioGroup.ResetAsync();
-            }
-        }
-
         /// <inheritdoc />
         protected override async Task OnInitializedAsync()
         {
@@ -219,14 +211,12 @@ namespace MudBlazor
                         // prevent scrolling page
                         new(" ", preventDown: "key+none", preventUp: "key+none"),
                         new("Enter", preventDown: "key+none"),
-                        new("NumpadEnter", preventDown: "key+none"),
-                        new("Backspace", preventDown: "key+none")
+                        new("NumpadEnter", preventDown: "key+none")
                     ]);
 
                 await KeyInterceptorService.SubscribeAsync(_elementId, options, keys => keys
                     .When(CanHandleKeys, builder => builder
-                        .OnKeyDownAny(["Enter", "NumpadEnter", " "], SelectAsync)
-                        .OnKeyDown("Backspace", HandleBackspaceAsync)));
+                        .OnKeyDownAny(["Enter", "NumpadEnter", " "], SelectAsync)));
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -195,15 +195,14 @@ namespace MudBlazor
             }
         }
 
-        protected override Task ResetValueAsync()
+        protected override async Task ResetValueAsync()
         {
-            if (_selectedRadio is not null)
-            {
-                _selectedRadio.SetChecked(false);
-                _selectedRadio = null;
-            }
-
-            return base.ResetValueAsync();
+            // Route through SetSelectedOptionAsync so the value, the selected radio, and the checked markup
+            // stay consistent: default(T) selects the matching radio (false for a bool group) or clears the
+            // selection when nothing matches (null for a nullable group).
+            await SetSelectedOptionAsync(default, updateRadio: true);
+            Touched = false;
+            await InvokeAsync(StateHasChanged);
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -197,9 +197,7 @@ namespace MudBlazor
 
         protected override async Task ResetValueAsync()
         {
-            // Route through SetSelectedOptionAsync so the value, the selected radio, and the checked markup
-            // stay consistent: default(T) selects the matching radio (false for a bool group) or clears the
-            // selection when nothing matches (null for a nullable group).
+            // Route through SetSelectedOptionAsync so the value, selected radio, and checked markup stay in sync.
             await SetSelectedOptionAsync(default, updateRadio: true);
             Touched = false;
             await InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -199,8 +199,7 @@ namespace MudBlazor
         {
             // Route through SetSelectedOptionAsync so the value, selected radio, and checked markup stay in sync.
             await SetSelectedOptionAsync(default, updateRadio: true);
-            Touched = false;
-            await InvokeAsync(StateHasChanged);
+            await base.ResetValueAsync();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Closes #11369, Closes #11380.

> Upgrade note: `MudRadioGroup` no longer clears its selection when Backspace/Delete is pressed on a focused radio (that shortcut was non-standard). Reset now clears the selection through the standard path, so `ValueChanged`/`SelectedOptionChanged` fire on reset.

### 1. Fix `MudRadioGroup.ResetValueAsync`.

It updated the value and the selected radio through separate paths, so a reset left inconsistent state:
- `T="bool"`: the UI cleared but `Value` stayed, and re-selecting `false` afterwards did nothing.
- `T="bool?"`: reset did not set the value to `null`.

It now routes through `SetSelectedOptionAsync(default, updateRadio: true)`, so the value, the selected radio, and the checked markup stay consistent, and the reset propagates through `ValueChanged`. Resetting selects the radio matching `default(T)` (e.g. `false` for a `bool` group) or clears the selection when nothing matches (e.g. `null` for a nullable group without a `null` option).

### 2. Remove the Backspace-to-reset keyboard shortcut.

It was never a standard interaction:
- The WAI-ARIA APG radio pattern, native `<input type="radio">`, and Material Design all define the model as Tab / Arrow keys / Space, none bind a key to clear a selection.
- No major library does either (MUI, Angular Material, React Aria, Radix, Ant Design, Carbon, Vuetify, Bootstrap; Radzen / Telerik / Syncfusion / built-in `InputRadioGroup` on the Blazor side).

It silently changed the value on a key that means "back", and the docs row described it as "Unselect" when it actually reset to `default(T)` (i.e. `false` for a `bool` group, never truly unselected). The standard ways to clear a group remain: bind the value to `null`/default, or call `Reset()` / `ResetAsync()`.

## Checklist

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
