### PR TITLE
MudAutocomplete: Validate required fields on blur

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -893,6 +893,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("input").BlurAsync();
             await comp.WaitForAssertionAsync(() =>
             {
+                ac.Touched.Should().BeTrue("leaving the field marks it touched (#9425)");
                 ac.HasErrors.Should().BeFalse("a pre-filled required autocomplete is valid on blur (#9425)");
                 ac.ValidationErrors.Should().BeEmpty();
             });

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -861,7 +861,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Required, true)
                 .Add(x => x.RequiredError, "Required")
                 .Add(x => x.DebounceInterval, 0)
-                .Add(x => x.SearchFunc, (s, t) => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IEnumerable<string>>(new[] { "a", "b" })));
+                .Add(x => x.SearchFunc, (s, t) => Task.FromResult<IEnumerable<string>>(new[] { "a", "b" })));
             var ac = comp.Instance;
 
             ac.Touched.Should().BeFalse();
@@ -887,7 +887,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.RequiredError, "Required")
                 .Add(x => x.Value, "a")
                 .Add(x => x.DebounceInterval, 0)
-                .Add(x => x.SearchFunc, (s, t) => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IEnumerable<string>>(new[] { "a", "b" })));
+                .Add(x => x.SearchFunc, (s, t) => Task.FromResult<IEnumerable<string>>(new[] { "a", "b" })));
             var ac = comp.Instance;
 
             await comp.Find("input").BlurAsync();
@@ -896,6 +896,32 @@ namespace MudBlazor.UnitTests.Components
                 ac.Touched.Should().BeTrue("leaving the field marks it touched (#9425)");
                 ac.HasErrors.Should().BeFalse("a pre-filled required autocomplete is valid on blur (#9425)");
                 ac.ValidationErrors.Should().BeEmpty();
+            });
+        }
+
+        /// <summary>
+        /// #5489: A required autocomplete validates on blur even when Immediate is disabled.
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Required_NonImmediate_ValidatesOnBlur()
+        {
+            var comp = Context.Render<MudAutocomplete<string>>(a => a
+                .Add(x => x.Required, true)
+                .Add(x => x.RequiredError, "Required")
+                .Add(x => x.Immediate, false)
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, (s, t) => Task.FromResult<IEnumerable<string>>(new[] { "a", "b" })));
+            var ac = comp.Instance;
+
+            ac.Touched.Should().BeFalse();
+            ac.HasErrors.Should().BeFalse();
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                ac.Touched.Should().BeTrue("leaving an empty required autocomplete validates it, even when Immediate is off (#5489)");
+                ac.HasErrors.Should().BeTrue();
+                ac.ValidationErrors.Should().Contain("Required");
             });
         }
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -851,6 +851,53 @@ namespace MudBlazor.UnitTests.Components
             calls.Should().Be(1);
         }
 
+        /// <summary>
+        /// #5489: A required autocomplete validates when the user leaves it (blur with the menu closed).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Required_ValidatesOnBlur()
+        {
+            var comp = Context.Render<MudAutocomplete<string>>(a => a
+                .Add(x => x.Required, true)
+                .Add(x => x.RequiredError, "Required")
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, (s, t) => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IEnumerable<string>>(new[] { "a", "b" })));
+            var ac = comp.Instance;
+
+            ac.Touched.Should().BeFalse();
+            ac.HasErrors.Should().BeFalse();
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                ac.Touched.Should().BeTrue("leaving an empty required autocomplete validates it (#5489)");
+                ac.HasErrors.Should().BeTrue();
+                ac.ValidationErrors.Should().Contain("Required");
+            });
+        }
+
+        /// <summary>
+        /// #9425: A required autocomplete pre-filled with a value is valid on blur.
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Required_PreFilledValue_IsValidOnBlur()
+        {
+            var comp = Context.Render<MudAutocomplete<string>>(a => a
+                .Add(x => x.Required, true)
+                .Add(x => x.RequiredError, "Required")
+                .Add(x => x.Value, "a")
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, (s, t) => System.Threading.Tasks.Task.FromResult<System.Collections.Generic.IEnumerable<string>>(new[] { "a", "b" })));
+            var ac = comp.Instance;
+
+            await comp.Find("input").BlurAsync();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                ac.HasErrors.Should().BeFalse("a pre-filled required autocomplete is valid on blur (#9425)");
+                ac.ValidationErrors.Should().BeEmpty();
+            });
+        }
+
         [Test]
         public async Task AutoCompleteClearable()
         {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1148,12 +1148,11 @@ namespace MudBlazor
             _isFocused = false;
             _handleNextFocus = false;
 
-            // When Immediate is enabled, then the CoerceValue is set by TextChanged
-            // So only coerce the value on blur when Immediate is disabled
+            // When Immediate is enabled, then the CoerceValue is set by TextChanged.
+            // So only coerce the value on blur when Immediate is disabled, then fall through to the same validation path.
             if (!Immediate)
             {
                 await CoerceValueToTextAsync();
-                return;
             }
 
             // A blur while the menu is open or a value is being committed is part of selecting an item: the item's mousedown blurs the input before its click lands, so validating now would flag a premature error.

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1156,9 +1156,10 @@ namespace MudBlazor
                 return;
             }
 
-            // A blur while the menu is open (or opening/committing a value) is part of selecting an item: the item's mousedown blurs the input before its click lands, so validating now would flag a premature error.
-            // Only a genuine leave (menu closed, nothing pending) runs the base blur, so a required autocomplete surfaces its error on blur like other inputs (#5489).
-            if (Open || _opening || _isProcessingValue)
+            // A blur while the menu is open or a value is being committed is part of selecting an item: the item's mousedown blurs the input before its click lands, so validating now would flag a premature error.
+            // Only a genuine leave runs the base blur, so a required autocomplete surfaces its error on blur like other inputs (#5489).
+            // A leave while a search is still running (menu not yet open) is genuine, so the in-flight opening flag is intentionally not gated on.
+            if (Open || _isProcessingValue)
             {
                 await OnBlur.InvokeAsync(args);
                 return;

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1156,10 +1156,8 @@ namespace MudBlazor
                 return;
             }
 
-            // A blur while the menu is open (or opening/committing a value) is part of selecting an
-            // item: the item's mousedown blurs the input before its click lands, so validating now
-            // would flag a premature error. Only a genuine leave (menu closed, nothing pending) runs
-            // the base blur, so a required autocomplete surfaces its error on blur like other inputs (#5489).
+            // A blur while the menu is open (or opening/committing a value) is part of selecting an item: the item's mousedown blurs the input before its click lands, so validating now would flag a premature error.
+            // Only a genuine leave (menu closed, nothing pending) runs the base blur, so a required autocomplete surfaces its error on blur like other inputs (#5489).
             if (Open || _opening || _isProcessingValue)
             {
                 await OnBlur.InvokeAsync(args);

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -1143,7 +1143,7 @@ namespace MudBlazor
             }
         }
 
-        private Task OnInputBlurredAsync(FocusEventArgs args)
+        private async Task OnInputBlurredAsync(FocusEventArgs args)
         {
             _isFocused = false;
             _handleNextFocus = false;
@@ -1152,13 +1152,21 @@ namespace MudBlazor
             // So only coerce the value on blur when Immediate is disabled
             if (!Immediate)
             {
-                return CoerceValueToTextAsync();
+                await CoerceValueToTextAsync();
+                return;
             }
 
-            return OnBlur.InvokeAsync(args);
-            // we should not validate on blur in autocomplete, because the user needs to click out of the input to select a value,
-            // resulting in a premature validation. thus, don't call base
-            //base.OnBlurred(args);
+            // A blur while the menu is open (or opening/committing a value) is part of selecting an
+            // item: the item's mousedown blurs the input before its click lands, so validating now
+            // would flag a premature error. Only a genuine leave (menu closed, nothing pending) runs
+            // the base blur, so a required autocomplete surfaces its error on blur like other inputs (#5489).
+            if (Open || _opening || _isProcessingValue)
+            {
+                await OnBlur.InvokeAsync(args);
+                return;
+            }
+
+            await base.OnBlurredAsync(args);
         }
 
         private Task OnOverlayClosedAsync()


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/5489: A required `MudAutocomplete` never showed its error on blur — only on submit. `OnInputBlurredAsync` deliberately skipped the base blur (which sets `Touched` and validates), because selecting an item works by the item's mousedown blurring the input *before* its click lands, so validating on that blur would flag a premature error.

Now gate on the menu state instead of skipping validation entirely:

- A blur while the menu is open (or opening/committing a value) is part of selecting — suppress validation, don't close the dropdown.
- A genuine leave (menu closed, nothing pending) runs the base blur, so a required autocomplete surfaces its error like every other input.

Tab and click-outside both close the menu *before* the blur (Tab → `CloseMenuAsync`; the overlay closes on an outside click), so leaving the field validates. This mirrors how `MudSelect.OnFocusOutAsync` already gates on its open flag.

Also fixes #9425 — a pre-filled required autocomplete now reports valid on blur.
