### PR TITLE
MudFormComponent: Preserve consumer-managed Error when no validation source

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -677,6 +677,61 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
+        // #12732/#4593: when a component has no validation source of its own, Error/ErrorText are consumer-managed
+        // and a validate pass (here a value change) must not wipe them.
+        [Test]
+        public async Task ValidateValue_KeepsConsumerManagedError_WhenNoValidationSource()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.Error, true)
+                .Add(x => x.ErrorText, "consumer error"));
+            var textField = comp.Instance;
+
+            textField.GetState(x => x.Error).Should().BeTrue();
+
+            // A value change runs ValidateValue; with no Validation/Required/For it produces no errors of its own.
+            await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "hello" });
+
+            textField.GetState(x => x.Error).Should().BeTrue("a validate pass must not clobber a consumer-managed Error (#12732)");
+            textField.GetState(x => x.ErrorText).Should().Be("consumer error");
+            textField.HasErrors.Should().BeTrue();
+        }
+
+        // #11244: selecting an option must not clear an Error the consumer manages on a MudSelect with no validation source.
+        [Test]
+        public async Task MudSelect_KeepsConsumerManagedError_OnSelection()
+        {
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
+                .Add(x => x.Error, true)
+                .Add(x => x.ErrorText, "consumer error")
+                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "1"))
+                .AddChildContent<MudSelectItem<string>>(item => item.Add(x => x.Value, "2")));
+            var select = comp.Instance;
+
+            select.GetState(x => x.Error).Should().BeTrue();
+
+            await comp.InvokeAsync(() => select.SelectOption("2"));
+
+            select.GetState(x => x.Error).Should().BeTrue("selecting an option must not clobber a consumer-managed Error (#11244)");
+            select.GetState(x => x.ErrorText).Should().Be("consumer error");
+        }
+
+        // The consumer-error guard must still let a component clear its OWN error: a conversion error set on a
+        // bad edit is cleared once the value is corrected, even though no validation source remains configured.
+        [Test]
+        public async Task ValidateValue_ClearsOwnConversionError_AfterCorrection()
+        {
+            var comp = Context.Render<MudTextField<int?>>(parameters => parameters
+                .Add(x => x.Value, 5));
+            var textField = comp.Instance;
+
+            await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "not a number" });
+            textField.HasErrors.Should().BeTrue("an unparseable edit is a conversion error");
+
+            await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "10" });
+            textField.HasErrors.Should().BeFalse("correcting the value must clear the component's own error");
+        }
+
         /// <summary>
         /// #13381: on submit the external validators own the verdict; a blur-staged component-Required error must not linger as stale display.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -732,6 +732,27 @@ namespace MudBlazor.UnitTests.Components
             textField.HasErrors.Should().BeFalse("correcting the value must clear the component's own error");
         }
 
+        // A For whose target property carries no ValidationAttribute is not a validation source (the attribute
+        // enumerable is non-null but empty), so a consumer-managed Error must still survive a validate pass.
+        [Test]
+        public async Task ValidateValue_KeepsConsumerManagedError_WhenForHasNoValidationAttributes()
+        {
+            var model = new { data = "asdf" };
+            Expression<Func<string>> expression = () => model.data;
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.Error, true)
+                .Add(x => x.ErrorText, "consumer error")
+                .Add(x => x.For, expression));
+            var textField = comp.Instance;
+
+            textField.GetState(x => x.Error).Should().BeTrue();
+
+            await comp.Find("input").ChangeAsync(new ChangeEventArgs { Value = "hello" });
+
+            textField.GetState(x => x.Error).Should().BeTrue("a For without validation attributes is not a validation source (#13415 review)");
+            textField.GetState(x => x.ErrorText).Should().Be("consumer error");
+        }
+
         /// <summary>
         /// #13381: on submit the external validators own the verdict; a blur-staged component-Required error must not linger as stale display.
         /// </summary>

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -447,12 +447,18 @@ namespace MudBlazor
                     }
                     else
                     {
-                        // this must be called in any case, because even if Validation is null the user might have set Error and ErrorText manually
-                        // if Error and ErrorText are set by the user, setting them here will have no effect.
-                        // if Error, create an error id that can be used by aria-describedby on input control
-                        ValidationErrors = errors;
-                        await ErrorState.SetValueAsync(errors.Count > 0);
-                        await ErrorTextState.SetValueAsync(errors.FirstOrDefault());
+                        // Error/ErrorText are consumer-managed unless this component has its own validation source; publishing an empty assessment here would wipe a consumer-set error on every validate pass (#12732, #11244, #4593).
+                        // _hasInternalError keeps us writing long enough to clear an error this component previously published (e.g. a resolved conversion error) even after its source goes away.
+                        var hasValidationSource = Validation is not null || Required || _validationAttrsFor is not null || ConversionError;
+                        if (hasValidationSource || _hasInternalError)
+                        {
+                            _hasInternalError = errors.Count > 0;
+                            ValidationErrors = errors;
+                            await ErrorState.SetValueAsync(errors.Count > 0);
+                            await ErrorTextState.SetValueAsync(errors.FirstOrDefault());
+                        }
+
+                        // Refresh the aria-describedby error id and the form/render regardless, so a consumer-managed error stays wired up.
                         await UpdateErrorIdStateAsync(HasErrors);
                         Form?.Update(this);
                         StateHasChanged();
@@ -704,6 +710,7 @@ namespace MudBlazor
             await UpdateErrorIdStateAsync(false);
             ResetConverterErrors();
             _lastInternalErrors = [];
+            _hasInternalError = false;
             RetractStagedEditContextMessages();
 
             await InvokeAsync(StateHasChanged);
@@ -874,6 +881,9 @@ namespace MudBlazor
         private ValidationMessageStore? _editContextValidationMessages;
 
         private bool _hasStagedEditContextMessages;
+
+        // True while this component's own validation (Validation/Required/For/conversion) is the source of ErrorState, so a later empty pass may clear it. Distinguishes internal errors from a consumer-set Error parameter.
+        private bool _hasInternalError;
 
         /// <summary>
         /// The most recent internal assessment, kept so <see cref="EditFormValidate"/> can restore it when the external validators produce nothing for the field.

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -449,7 +449,8 @@ namespace MudBlazor
                     {
                         // Error/ErrorText are consumer-managed unless this component has its own validation source; publishing an empty assessment here would wipe a consumer-set error on every validate pass (#12732, #11244, #4593).
                         // _hasInternalError keeps us writing long enough to clear an error this component previously published (e.g. a resolved conversion error) even after its source goes away.
-                        var hasValidationSource = Validation is not null || Required || _validationAttrsFor is not null || ConversionError;
+                        // _validationAttrsFor is non-null but empty when the For-targeted property carries no ValidationAttribute, so require an actual attribute rather than just a non-null For.
+                        var hasValidationSource = Validation is not null || Required || _validationAttrsFor?.Any() == true || ConversionError;
                         if (hasValidationSource || _hasInternalError)
                         {
                             _hasInternalError = errors.Count > 0;


### PR DESCRIPTION
`MudFormComponent.ValidateValue` (the non-EditContext branch) unconditionally wrote `ErrorState`/`ErrorText` from its own error list on every validate pass. When a component has no validation source of its own, that list is empty, so a blur, submit, or value change wiped any `Error`/`ErrorText` the consumer had set manually.

The stale comment claimed "setting them here will have no effect" — that was true before `Error`/`ErrorText` became `ParameterState`-backed, but the internal write now wins over the parameter, so it clobbers.

We now publish an internal assessment only when the component actually has a validation source: `Validation`, `Required`, `For` attributes, or a conversion error. A small `_hasInternalError` flag keeps us writing long enough to clear an error the component previously published (e.g. a resolved conversion error) even after its source goes away. Otherwise the consumer's `Error`/`ErrorText` are left intact — the aria error-id, form update, and render still run so a consumer-managed error stays wired up.

Fixes #12732
Fixes #11244
Fixes #4593
Likely also relevant to #7518 and #11503 (same clobber); left open for separate confirmation.
