### PR TITLE
MudBaseInput: Mark touched on first change even when text already in sync

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWrappedRequiredSelectTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormWrappedRequiredSelectTest.razor
@@ -1,0 +1,15 @@
+﻿<MudPopoverProvider />
+
+<MudForm @ref="Form" ValidationDelay="0">
+    <RequiredSelectWrapper T="string" @bind-Value="_value" Required="true" RequiredError="required">
+        <MudSelectItem T="string" Value="@("1")">1</MudSelectItem>
+        <MudSelectItem T="string" Value="@("2")">2</MudSelectItem>
+    </RequiredSelectWrapper>
+</MudForm>
+
+@code {
+    public static string __description__ = "#13389: a Required MudSelect wrapped by a one-way forwarding component inside a MudForm.";
+
+    public MudForm Form { get; set; } = null!;
+    private string? _value;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/RequiredSelectWrapper.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/RequiredSelectWrapper.razor
@@ -1,5 +1,5 @@
-﻿@typeparam T
-
+@typeparam T
+@attribute [ViewerHidden]
 <MudSelect T="T" Value="Value" ValueChanged="OnValueChanged" Required="Required" RequiredError="@RequiredError">
     @ChildContent
 </MudSelect>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/RequiredSelectWrapper.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/RequiredSelectWrapper.razor
@@ -1,0 +1,17 @@
+﻿@typeparam T
+
+<MudSelect T="T" Value="Value" ValueChanged="OnValueChanged" Required="Required" RequiredError="@RequiredError">
+    @ChildContent
+</MudSelect>
+
+@code {
+    public static string __description__ = "#13389: forwards Value/ValueChanged one-way into an inner MudSelect to reproduce the wrapper case.";
+
+    [Parameter] public T? Value { get; set; }
+    [Parameter] public EventCallback<T?> ValueChanged { get; set; }
+    [Parameter] public bool Required { get; set; }
+    [Parameter] public string? RequiredError { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    private Task OnValueChanged(T? value) => ValueChanged.InvokeAsync(value);
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -759,6 +759,29 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #13389: selecting a value in a Required MudSelect (wrapped by a one-way forwarding component) marks the field touched and the form valid on the first selection.
+        /// </summary>
+        [Test]
+        public async Task MudForm_FirstSelectionOnWrappedRequiredSelect_MarksTouchedAndValid()
+        {
+            var comp = Context.Render<FormWrappedRequiredSelectTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var select = comp.FindComponent<MudSelect<string>>().Instance;
+
+            form.IsValid.Should().BeFalse();
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                select.Touched.Should().BeTrue("the first selection is a user interaction and must touch the field (#13389)");
+                form.IsValid.Should().BeTrue("selecting a value in the only required field makes the form valid (#13389)");
+            });
+        }
+
+        /// <summary>
         /// #13381: on submit the external validators own the verdict; a blur-staged component-Required error must not linger as stale display.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -677,8 +677,9 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
-        // #12732/#4593: when a component has no validation source of its own, Error/ErrorText are consumer-managed
-        // and a validate pass (here a value change) must not wipe them.
+        /// <summary>
+        /// #12732/#4593: when a component has no validation source of its own, Error/ErrorText are consumer-managed and a validate pass (here a value change) must not wipe them.
+        /// </summary>
         [Test]
         public async Task ValidateValue_KeepsConsumerManagedError_WhenNoValidationSource()
         {
@@ -697,7 +698,9 @@ namespace MudBlazor.UnitTests.Components
             textField.HasErrors.Should().BeTrue();
         }
 
-        // #11244: selecting an option must not clear an Error the consumer manages on a MudSelect with no validation source.
+        /// <summary>
+        /// #11244: selecting an option must not clear an Error the consumer manages on a MudSelect with no validation source.
+        /// </summary>
         [Test]
         public async Task MudSelect_KeepsConsumerManagedError_OnSelection()
         {
@@ -716,8 +719,9 @@ namespace MudBlazor.UnitTests.Components
             select.GetState(x => x.ErrorText).Should().Be("consumer error");
         }
 
-        // The consumer-error guard must still let a component clear its OWN error: a conversion error set on a
-        // bad edit is cleared once the value is corrected, even though no validation source remains configured.
+        /// <summary>
+        /// The consumer-error guard must still let a component clear its own error: a conversion error set on a bad edit is cleared once the value is corrected, even though no validation source remains configured.
+        /// </summary>
         [Test]
         public async Task ValidateValue_ClearsOwnConversionError_AfterCorrection()
         {
@@ -732,8 +736,9 @@ namespace MudBlazor.UnitTests.Components
             textField.HasErrors.Should().BeFalse("correcting the value must clear the component's own error");
         }
 
-        // A For whose target property carries no ValidationAttribute is not a validation source (the attribute
-        // enumerable is non-null but empty), so a consumer-managed Error must still survive a validate pass.
+        /// <summary>
+        /// A For whose target property carries no ValidationAttribute is not a validation source (the attribute enumerable is non-null but empty), so a consumer-managed Error must still survive a validate pass.
+        /// </summary>
         [Test]
         public async Task ValidateValue_KeepsConsumerManagedError_WhenForHasNoValidationAttributes()
         {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -793,17 +793,18 @@ namespace MudBlazor
 
         protected virtual async Task SetTextAndUpdateValueAsync(string? text, bool updateValue = true)
         {
+            // Mark touched before the equality short-circuit: on Blazor Server the suppressed ValueChanged echo can set the text first, so a genuine interaction that arrives with the text already in sync would otherwise skip the Touched write and leave a required field untouched on its first change (#13389).
+            if (!string.IsNullOrEmpty(text) && !_suppressInteractionEffects)
+            {
+                Touched = true;
+            }
+
             if (ReadText == text)
             {
                 return;
             }
 
             _validated = false;
-
-            if (!string.IsNullOrEmpty(text) && !_suppressInteractionEffects)
-            {
-                Touched = true;
-            }
 
             await _textState.SetValueAsync(text);
             if (updateValue)

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -883,7 +883,6 @@ namespace MudBlazor
 
         private bool _hasStagedEditContextMessages;
 
-        // True while this component's own validation (Validation/Required/For/conversion) is the source of ErrorState, so a later empty pass may clear it. Distinguishes internal errors from a consumer-set Error parameter.
         private bool _hasInternalError;
 
         /// <summary>


### PR DESCRIPTION
Fixes #13389. A Required `MudSelect` inside a `MudForm` did not flip `IsValid` on the **first** selection when the select is wrapped by a component that forwards `Value`/`ValueChanged` (the reporter's case). The second and later selections worked. New in v9.6.0, from #13328.

Root cause: `MudBaseInput.SetTextAndUpdateValueAsync` only marked the field touched *after* its `ReadText == text` short-circuit. On Blazor Server the suppressed `ValueChanged` echo (the parent `@bind` round-trip) can set the text first, so the genuine `SelectOption` → value→text sync arrives with the text already in sync and returns before the `Touched = true` write. The field stays untouched, so `MudForm.IsValid` (which requires all Required fields touched) never flips on the first change.

Fixed by moving the `Touched` write ahead of the equality short-circuit, so a real (unsuppressed) interaction always marks the field touched regardless of whether the echo set the text first. Suppressed/programmatic paths still don't touch.