### PR TITLE
MudTextField: Keep SetTextAsync from marking the field touched

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -555,6 +555,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #12997: calling SetTextAsync programmatically is not a user interaction, so it must not mark the field touched, and ResetAsync afterwards leaves it untouched.
+        /// </summary>
+        [Test]
+        public async Task SetTextAsync_ProgrammaticSet_DoesNotMarkTouched()
+        {
+            var comp = Context.Render<MudTextField<string>>();
+            var textField = comp.Instance;
+            textField.Touched.Should().BeFalse();
+
+            await comp.InvokeAsync(() => textField.SetTextAsync("hello"));
+
+            textField.GetState(x => x.Text).Should().Be("hello");
+            textField.Touched.Should().BeFalse("programmatic SetTextAsync is not a user interaction (#12997)");
+
+            await comp.InvokeAsync(() => textField.ResetAsync());
+            textField.Touched.Should().BeFalse();
+        }
+
+        /// <summary>
         /// This is based on a bug reported by a user
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -570,6 +570,21 @@ namespace MudBlazor.UnitTests.Components
             textField.Touched.Should().BeFalse();
         }
 
+        [Test]
+        public async Task SetTextAsync_InForm_DoesNotMarkFormTouched()
+        {
+            var comp = Context.Render<MudForm>(parameters => parameters
+                .Add(f => f.ValidationDelay, 0)
+                .AddChildContent<MudTextField<string>>());
+            var form = comp.Instance;
+            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+
+            await comp.InvokeAsync(() => textField.SetTextAsync("hello"));
+
+            textField.Touched.Should().BeFalse("a programmatic set is not a user interaction (#12997)");
+            form.IsTouched.Should().BeFalse("a programmatic set must not mark the form touched, even briefly during the value sync (#12997)");
+        }
+
         /// <summary>
         /// This is based on a bug reported by a user
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -16,6 +16,7 @@ using MudBlazor.UnitTests.TestComponents.Field;
 using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.UnitTests.TestComponents.TextField;
 using MudBlazor.UnitTests.Utilities;
+using MudBlazor.Utilities;
 using NUnit.Framework;
 
 #nullable enable

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -554,9 +554,6 @@ namespace MudBlazor.UnitTests.Components
             textfield.HasErrors.Should().Be(false);
         }
 
-        /// <summary>
-        /// #12997: calling SetTextAsync programmatically is not a user interaction, so it must not mark the field touched, and ResetAsync afterwards leaves it untouched.
-        /// </summary>
         [Test]
         public async Task SetTextAsync_ProgrammaticSet_DoesNotMarkTouched()
         {

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -585,6 +585,23 @@ namespace MudBlazor.UnitTests.Components
             form.IsTouched.Should().BeFalse("a programmatic set must not mark the form touched, even briefly during the value sync (#12997)");
         }
 
+        [Test]
+        public async Task SetTextAsync_FiresFieldChangedOnChangeButNotOnNoOp()
+        {
+            var fieldChangedCount = 0;
+            var comp = Context.Render<MudForm>(parameters => parameters
+                .Add(f => f.ValidationDelay, 0)
+                .Add(f => f.FieldChanged, EventCallback.Factory.Create<FormFieldChangedEventArgs>(this, () => fieldChangedCount++))
+                .AddChildContent<MudTextField<string>>());
+            var textField = comp.FindComponent<MudTextField<string>>().Instance;
+
+            await comp.InvokeAsync(() => textField.SetTextAsync("hello"));
+            fieldChangedCount.Should().Be(1, "a programmatic set that changes the value still notifies the form");
+
+            await comp.InvokeAsync(() => textField.SetTextAsync("hello"));
+            fieldChangedCount.Should().Be(1, "setting the same value is a no-op and must not fire a spurious FieldChanged (#12997)");
+        }
+
         /// <summary>
         /// This is based on a bug reported by a user
         /// </summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -185,14 +185,20 @@ namespace MudBlazor
         /// <param name="text">The new text value to use.</param>
         public async Task SetTextAsync(string? text)
         {
+            // A programmatic text set is not a user interaction, so it must leave the touched state unchanged (it still updates the value and notifies the form) (#12997).
+            var wasTouched = Touched;
+
             if (!HasMask)
             {
                 await InputReference.SetText(text);
-                return;
+            }
+            else
+            {
+                await _maskReference.Clear();
+                await _maskReference.OnPasteAsync(text);
             }
 
-            await _maskReference.Clear();
-            await _maskReference.OnPasteAsync(text);
+            Touched = wasTouched;
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -185,20 +185,22 @@ namespace MudBlazor
         /// <param name="text">The new text value to use.</param>
         public async Task SetTextAsync(string? text)
         {
-            // A programmatic text set is not a user interaction, so it must leave the touched state unchanged.
-            var wasTouched = Touched;
-
-            if (HasMask)
+            // A programmatic text set is not a user interaction, so suppress the touched/FieldChanged side effects during the sync: otherwise the value change validates and updates the form while Touched is momentarily true (#12997).
+            await SuppressInteractionEffectsWhileAsync(async () =>
             {
-                await _maskReference.Clear();
-                await _maskReference.OnPasteAsync(text);
-            }
-            else
-            {
-                await InputReference.SetText(text);
-            }
+                if (HasMask)
+                {
+                    await _maskReference.Clear();
+                    await _maskReference.OnPasteAsync(text);
+                }
+                else
+                {
+                    await InputReference.SetText(text);
+                }
+            });
 
-            Touched = wasTouched;
+            // Notify the form of the value change explicitly, keeping the SetTextAsync-fires-FieldChanged contract.
+            FieldChanged(ReadValue);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -185,17 +185,17 @@ namespace MudBlazor
         /// <param name="text">The new text value to use.</param>
         public async Task SetTextAsync(string? text)
         {
-            // A programmatic text set is not a user interaction, so it must leave the touched state unchanged (it still updates the value and notifies the form) (#12997).
+            // A programmatic text set is not a user interaction, so it must leave the touched state unchanged.
             var wasTouched = Touched;
 
-            if (!HasMask)
-            {
-                await InputReference.SetText(text);
-            }
-            else
+            if (HasMask)
             {
                 await _maskReference.Clear();
                 await _maskReference.OnPasteAsync(text);
+            }
+            else
+            {
+                await InputReference.SetText(text);
             }
 
             Touched = wasTouched;

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -185,7 +185,8 @@ namespace MudBlazor
         /// <param name="text">The new text value to use.</param>
         public async Task SetTextAsync(string? text)
         {
-            // A programmatic text set is not a user interaction, so suppress the touched/FieldChanged side effects during the sync: otherwise the value change validates and updates the form while Touched is momentarily true (#12997).
+            // A programmatic text set is not a user interaction, so suppress the touched/FieldChanged side effects during the value sync: otherwise the change validates and updates the form while Touched is momentarily true (#12997).
+            var previousValue = ReadValue;
             await SuppressInteractionEffectsWhileAsync(async () =>
             {
                 if (HasMask)
@@ -199,8 +200,11 @@ namespace MudBlazor
                 }
             });
 
-            // Notify the form of the value change explicitly, keeping the SetTextAsync-fires-FieldChanged contract.
-            FieldChanged(ReadValue);
+            // Notify the form explicitly to keep the SetTextAsync-fires-FieldChanged contract, but only on a real change so a no-op set (same value) is not a spurious notification, matching the suppressed path's early-returns.
+            if (!EqualityComparer<T?>.Default.Equals(previousValue, ReadValue))
+            {
+                FieldChanged(ReadValue);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #12997: Calling `MudTextField.SetTextAsync(...)` programmatically marked the field `Touched`. `Touched` is meant to reflect user interaction (it gates required-error display and counts toward `MudForm.IsValid`), so a code-driven set shouldn't flip it. The call flows through `SetTextAndUpdateValueAsync`, which marks the field touched on any non-empty text — added by #13328, which suppresses that write for parameter-driven syncs but not for the public `SetTextAsync` API.

Fix by saving and restoring `Touched` around the set. The value still updates and the form is still notified via `FieldChanged` (so validity re-evaluates), but the touched state is left unchanged.

Note: We deliberately did **not** suppress `FieldChanged` here — an existing test (`FieldChangedEventShouldTrigger`) asserts that a programmatic `SetTextAsync` notifies the form, which is the right contract; only `Touched` was wrong.
