### PR TITLE
Tests: Cover fixed validation regressions

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormRequiredSelectTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/EditFormRequiredSelectTest.razor
@@ -1,0 +1,30 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+<MudPopoverProvider />
+
+<EditForm EditContext="EditContext" OnValidSubmit="@(() => ValidSubmits++)" OnInvalidSubmit="@(() => InvalidSubmits++)">
+    <DataAnnotationsValidator />
+    <MudSelect T="int?" @bind-Value="_model.Sel" Required="true" RequiredError="required" For="@(() => _model.Sel)">
+        <MudSelectItem T="int?" Value="1">1</MudSelectItem>
+        <MudSelectItem T="int?" Value="2">2</MudSelectItem>
+    </MudSelect>
+    <button type="submit">Submit</button>
+</EditForm>
+
+@code {
+    public static string __description__ = "#12406: a Required MudSelect under an EditForm/DataAnnotationsValidator.";
+
+    public EditContext EditContext { get; private set; } = null!;
+    public int ValidSubmits { get; private set; }
+    public int InvalidSubmits { get; private set; }
+
+    private readonly Model _model = new();
+
+    protected override void OnInitialized() => EditContext = new EditContext(_model);
+
+    public class Model
+    {
+        [Required(ErrorMessage = "required")]
+        public int? Sel { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAutocompleteRequiredTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormAutocompleteRequiredTest.razor
@@ -1,0 +1,16 @@
+﻿<MudPopoverProvider />
+
+<MudForm @ref="Form" ValidationDelay="0">
+    <MudAutocomplete T="string" @bind-Value="_value" Required="true" RequiredError="required"
+                     SearchFunc="Search" DebounceInterval="0" />
+</MudForm>
+
+@code {
+    public static string __description__ = "#11946: a Required MudAutocomplete inside a MudForm.";
+
+    public MudForm Form { get; set; } = null!;
+    private string? _value;
+
+    private Task<IEnumerable<string>> Search(string value, CancellationToken ct)
+        => Task.FromResult<IEnumerable<string>>(new[] { "Alpha", "Beta" }.Where(x => string.IsNullOrEmpty(value) || x.Contains(value, StringComparison.OrdinalIgnoreCase)));
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -564,6 +564,61 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #12406: an empty Required MudSelect under an EditForm/DataAnnotationsValidator fails validation on submit and shows the error, like other inputs.
+        /// </summary>
+        [Test]
+        public async Task EditForm_RequiredSelect_EmptySubmit_IsInvalidAndShowsError()
+        {
+            var comp = Context.Render<EditFormRequiredSelectTest>();
+            var select = comp.FindComponent<MudSelect<int?>>().Instance;
+
+            await comp.Find("button[type=submit]").ClickAsync();
+
+            comp.Instance.InvalidSubmits.Should().Be(1);
+            comp.Instance.ValidSubmits.Should().Be(0);
+            select.HasErrors.Should().BeTrue("an empty required select fails EditForm validation on submit (#12406)");
+        }
+
+        /// <summary>
+        /// #11946: selecting a value in a Required MudAutocomplete inside a MudForm updates the form to touched and valid.
+        /// </summary>
+        [Test]
+        public async Task MudForm_AutocompleteSelection_UpdatesFormValidity()
+        {
+            var comp = Context.Render<FormAutocompleteRequiredTest>();
+            var form = comp.FindComponent<MudForm>().Instance;
+            var autocomplete = comp.FindComponent<MudAutocomplete<string>>();
+
+            form.IsValid.Should().BeFalse();
+
+            await autocomplete.Find("div.mud-input-control").FocusAsync();
+            await autocomplete.Find("input").InputAsync(new ChangeEventArgs { Value = "Al" });
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                form.IsTouched.Should().BeTrue("typing then selecting is a user interaction (#11946)");
+                form.IsValid.Should().BeTrue("selecting a valid value makes the required form valid (#11946)");
+            });
+        }
+
+        /// <summary>
+        /// #6127: a MudTextField with For under an EditContext raises OnFieldChanged exactly once per change, including the second and later changes.
+        /// </summary>
+        [Test]
+        public async Task EditForm_FieldChange_RaisesOnFieldChangedOncePerChange()
+        {
+            var comp = Context.Render<FormRequiredValidationEditContextTest>();
+
+            await comp.FindAll("input")[0].ChangeAsync(new ChangeEventArgs { Value = "first" });
+            comp.Instance.FieldChangedCount.Should().Be(1, "the first change raises OnFieldChanged once");
+
+            await comp.FindAll("input")[0].ChangeAsync(new ChangeEventArgs { Value = "second" });
+            comp.Instance.FieldChangedCount.Should().Be(2, "the second change raises OnFieldChanged once more, not twice (#6127)");
+        }
+
+        /// <summary>
         /// #13381: blurring an empty required field under an EditContext validates it (both [Required] via For and the Required parameter) without dirtying the form or firing OnFieldChanged (the #12790 contract).
         /// </summary>
         [Test]


### PR DESCRIPTION
Regression tests for three reported validation issues that no longer reproduce on dev:

- Closes #11946 — selecting a value in a Required `MudAutocomplete` inside a `MudForm` updates the form to touched and valid on the first selection. (The earlier failure — the form not reflecting the selection — is gone.)
- Closes #12406 — an empty Required `MudSelect` under an `EditForm`/`DataAnnotationsValidator` fails validation on submit (`OnInvalidSubmit` fires, `OnValidSubmit` does not) and the select shows the error, like other inputs.
- Closes #6127 — a `MudTextField` with `For` raises `EditContext.OnFieldChanged` exactly once per change, including the second and later changes (the "raised twice" report).
