### PR TITLE
MudBaseInput: Reset validated flag on ResetValidation so blur re-validates

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -125,6 +125,27 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Not a valid number");
         }
 
+        /// <summary>
+        /// After ResetValidationAsync, blurring an empty required field must re-run validation and show the required error again (#11503).
+        /// </summary>
+        [Test]
+        public async Task TextField_ResetValidation_ThenBlur_RevalidatesRequired()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Required, true)
+                .Add(p => p.RequiredError, "required"));
+
+            await comp.Find("input").BlurAsync();
+            comp.FindAll("div.mud-input-error").Count.Should().BeGreaterThan(0);
+
+            await comp.InvokeAsync(() => comp.Instance.ResetValidationAsync());
+            comp.FindAll("div.mud-input-error").Count.Should().Be(0);
+
+            // Without resetting _validated, this blur short-circuits and the error never returns.
+            await comp.Find("input").BlurAsync();
+            comp.FindAll("div.mud-input-error").Count.Should().BeGreaterThan(0);
+        }
+
         [Test]
         public async Task TextField_Should_PreserveInvalidTextOnKeyRerender()
         {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -752,12 +752,12 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        public override async Task ResetValidationAsync()
+        public override Task ResetValidationAsync()
         {
             // Clear _validated so the next blur re-runs validation.
             // Otherwise OnBlurredAsync short-circuits on the stale flag and a required error never reappears (#11503).
             _validated = false;
-            await base.ResetValidationAsync();
+            return base.ResetValidationAsync();
         }
 
         protected string? GetHelperId()

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -751,6 +751,15 @@ namespace MudBlazor
             await base.ResetValueAsync();
         }
 
+        /// <inheritdoc />
+        public override async Task ResetValidationAsync()
+        {
+            // Clear _validated so the next blur re-runs validation.
+            // Otherwise OnBlurredAsync short-circuits on the stale flag and a required error never reappears (#11503).
+            _validated = false;
+            await base.ResetValidationAsync();
+        }
+
         protected string? GetHelperId()
         {
             if (HelperId is not null)


### PR DESCRIPTION
Fixes #11503.: `ResetValidationAsync` cleared the error state but not `MudBaseInput._validated`. On the next blur, `OnBlurredAsync` short-circuits on that stale flag, so a required field's error never reappears after a reset.

- Override `ResetValidationAsync` in `MudBaseInput` to reset `_validated`, then call base.
- Applies to every input; does not change `Touched`.

Repro: blur an empty required field (error shows) → `ResetValidation` (error clears) → blur again → the required error now returns. A value change already reset `_validated`, which is why typing-then-blur worked but reset-then-blur did not.
