### PR TITLE
MudForm: Re-apply the form-level Validation to controls on each validate

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormNullChildValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormNullChildValidationTest.razor
@@ -1,16 +1,18 @@
 ﻿<MudForm @ref="Form" Validation="@FormValidation" ValidationDelay="0">
-    <MudTextField T="string" @ref="Field" @bind-Value="_value" For="@(() => _value)" Validation="_childValidation" />
+    <MudTextField T="string" @ref="Field" @bind-Value="_value" For="@(() => _value)"
+                  Validation="@(UseChildValidation ? _childValidation : null)" />
 </MudForm>
 
 @code {
-    public static string __description__ = "#12842: a form-level Validation with a child whose own Validation binds to null must re-apply on every validation, not only the first.";
+    public static string __description__ = "#12842: when a child binds Validation to a conditional that evaluates to null, the form-level Validation must re-apply on every validation, not only the first.";
+
+    // Mirrors a consumer's Validation="@(condition ? someFunc : null)": flipping this to false makes the child's Validation null on the next render, overwriting the copy the form made at registration.
+    [Parameter] public bool UseChildValidation { get; set; } = true;
 
     public MudForm Form { get; set; } = null!;
     public MudTextField<string> Field { get; set; } = null!;
     private string? _value;
-
-    // Always null, mimicking a consumer binding Validation="@(condition ? someFunc : null)" that a parent render keeps overwriting.
-    private readonly object? _childValidation = null;
+    private readonly Func<string?, string?> _childValidation = _ => null;
 
     public Func<string?, string?> FormValidation { get; } = value => string.IsNullOrEmpty(value) ? "form: required" : null;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormNullChildValidationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormNullChildValidationTest.razor
@@ -1,0 +1,16 @@
+﻿<MudForm @ref="Form" Validation="@FormValidation" ValidationDelay="0">
+    <MudTextField T="string" @ref="Field" @bind-Value="_value" For="@(() => _value)" Validation="_childValidation" />
+</MudForm>
+
+@code {
+    public static string __description__ = "#12842: a form-level Validation with a child whose own Validation binds to null must re-apply on every validation, not only the first.";
+
+    public MudForm Form { get; set; } = null!;
+    public MudTextField<string> Field { get; set; } = null!;
+    private string? _value;
+
+    // Always null, mimicking a consumer binding Validation="@(condition ? someFunc : null)" that a parent render keeps overwriting.
+    private readonly object? _childValidation = null;
+
+    public Func<string?, string?> FormValidation { get; } = value => string.IsNullOrEmpty(value) ? "form: required" : null;
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -2137,8 +2137,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => form.ValidateAsync());
             field.HasErrors.Should().BeTrue();
 
-            // A parent re-render overwrites the child's Validation parameter back to null.
-            comp.Render();
+            // The child's Validation expression now evaluates to null, overwriting the copy the form made at registration.
+            // The child's Validation expression now evaluates to null, overwriting the copy the form made at registration.
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.UseChildValidation, false));
 
             await comp.InvokeAsync(() => form.ValidateAsync());
             field.HasErrors.Should().BeTrue();

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -2125,6 +2125,26 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A form-level Validation must keep applying to a child whose own Validation binds to null, even after a parent re-render overwrites the copied default (#12842).
+        /// </summary>
+        [Test]
+        public async Task MudForm_ChildValidationNull_ReappliesFormValidationEachValidate()
+        {
+            var comp = Context.Render<FormNullChildValidationTest>();
+            var form = comp.Instance.Form;
+            var field = comp.Instance.Field;
+
+            await comp.InvokeAsync(() => form.ValidateAsync());
+            field.HasErrors.Should().BeTrue();
+
+            // A parent re-render overwrites the child's Validation parameter back to null.
+            comp.Render();
+
+            await comp.InvokeAsync(() => form.ValidateAsync());
+            field.HasErrors.Should().BeTrue();
+        }
+
+        /// <summary>
         /// When the field is initialised from cache, the value can be set before the cascading parameter "Form",
         /// triggering validation. Validations requiring "Form" or "For" properties should not crash.
         /// </summary>

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -317,14 +317,17 @@ namespace MudBlazor
         /// </remarks>
         public async Task ValidateAsync()
         {
+            // Snapshot the controls so a field registering or unregistering mid-validation can't throw, and the set is enumerated only once.
+            var controls = _formControls.ToArray();
+
             // Re-apply the form-level default Validation before validating.
             // A child that binds Validation to an expression evaluating to null (e.g. a conditional) has the copy made at registration overwritten to null on every parent render, so without this the form's Validation would only run on the first validation (#12842).
-            foreach (var control in _formControls)
+            foreach (var control in controls)
             {
                 SetDefaultControlValidation(control);
             }
 
-            await Task.WhenAll(_formControls.Select(x => x.ValidateAsync()));
+            await Task.WhenAll(controls.Select(x => x.ValidateAsync()));
 
             if (ChildForms.Count > 0)
             {

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -317,6 +317,13 @@ namespace MudBlazor
         /// </remarks>
         public async Task ValidateAsync()
         {
+            // Re-apply the form-level default Validation before validating.
+            // A child that binds Validation to an expression evaluating to null (e.g. a conditional) has the copy made at registration overwritten to null on every parent render, so without this the form's Validation would only run on the first validation (#12842).
+            foreach (var control in _formControls)
+            {
+                SetDefaultControlValidation(control);
+            }
+
             await Task.WhenAll(_formControls.Select(x => x.ValidateAsync()));
 
             if (ChildForms.Count > 0)


### PR DESCRIPTION
Fixes #12842.: A form-level `Validation` is copied into each child's `Validation` only when the child registers. When a child binds `Validation="@(condition ? someFunc : null)"`, Blazor re-applies that null on every parent render, overwriting the copy. After the first validation the form's `Validation` no longer runs on the child, so it appears to validate only once.

- Re-apply the form's default `Validation` to each control at the start of `ValidateAsync`.

Repro: a form with `Validation` set plus a child binding `Validation` to null → validate twice → the child now stays validated on every pass, not just the first.
