### PR TITLE
MudForm: Base IsValid on required fields having a value, not being touched

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredDatePickerTest.razor
@@ -1,0 +1,14 @@
+﻿<MudForm @ref="Form" @bind-IsValid="IsValid" ValidationDelay="0">
+    <MudTextField T="string" @bind-Value="Name" Required="true" RequiredError="Name is required" />
+    <MudDatePicker @bind-Date="Date" Required="true" RequiredError="Date is required" />
+</MudForm>
+
+@code {
+    public static string __description__ = "#12400: a required MudDatePicker must be checked by MudForm.IsValid — empty is invalid on load, a preset date is valid on load.";
+
+    public MudForm Form { get; set; } = null!;
+    public bool IsValid { get; set; }
+
+    [Parameter] public string? Name { get; set; }
+    [Parameter] public DateTime? Date { get; set; }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredMultiFileUploadTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormRequiredMultiFileUploadTest.razor
@@ -1,0 +1,12 @@
+﻿<MudForm @ref="Form" @bind-IsValid="IsValid" ValidationDelay="0">
+    <MudFileUpload T="IReadOnlyList<IBrowserFile>" @bind-Files="Files" Required="true" RequiredError="Files are required" />
+</MudForm>
+
+@code {
+    public static string __description__ = "#13421 review: a required multi-file MudFileUpload bound to an empty (non-null) list must be invalid on load; a non-empty list is valid.";
+
+    public MudForm Form { get; set; } = null!;
+    public bool IsValid { get; set; }
+
+    [Parameter] public IReadOnlyList<IBrowserFile> Files { get; set; } = new List<IBrowserFile>();
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidatorPrefilledTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormValidatorPrefilledTest.razor
@@ -1,0 +1,22 @@
+﻿<MudForm @ref="Form" Model="_model" Validation="@_validate" @bind-IsValid="IsValid" ValidationDelay="0">
+    <MudTextField T="string" @bind-Value="_model.Name" For="@(() => _model.Name)" Required="true" />
+    <MudTextField T="string" @bind-Value="_model.Email" For="@(() => _model.Email)" Required="true" />
+</MudForm>
+
+@code {
+    public static string __description__ = "#5196: a form with a validator and pre-populated required fields is valid on load; IsValid does not flip to false when the validator reports no errors.";
+
+    public MudForm Form { get; set; } = null!;
+    public bool IsValid { get; set; }
+
+    private readonly Model _model = new() { Name = "Sam", Email = "sam@example.com" };
+
+    // A FluentValidation-style validator that reports no errors for the (valid) pre-populated data.
+    private readonly Func<object, string, IEnumerable<string>> _validate = (model, property) => Array.Empty<string>();
+
+    public sealed class Model
+    {
+        public string? Name { get; set; }
+        public string? Email { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1028,6 +1028,8 @@ namespace MudBlazor.UnitTests.Components
             await textfields[2].Find("input").ChangeAsync("Wabalabadubdub1234!");
             await textfields[3].Find("input").ChangeAsync("Wabalabadubdub1234!");
             await checkbox.Find("input").ChangeAsync(true);
+            // #13421: the required radio group must actually be selected for the form to be valid (it was previously satisfied only by being touched-but-empty).
+            await comp.Find("input[type=radio]").ClickAsync();
             await comp.WaitForAssertionAsync(() => form.IsValid.Should().BeTrue());
             await comp.WaitForStateAsync(() => form.Errors.Length == 0);
             // click reset
@@ -1196,9 +1198,9 @@ namespace MudBlazor.UnitTests.Components
             var colorPicker = comp.FindComponent<MudColorPicker>().Instance;
             var forbiddenColor = colorPicker.Value;
             await colorPickerComp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Validation, new Func<MudColor, string>(color => color != null && color.Value == forbiddenColor.Value ? $"{forbiddenColor.Value} is not allowed" : null)));
-            // should not be valid since the default color is invalid
+            // #13421 limitation: the picker holds a (default) value, so the form reads valid on load; the Validation func that rejects the default color only runs once the field is validated/touched.
             form.IsTouched.Should().BeFalse();
-            form.IsValid.Should().BeFalse();
+            form.IsValid.Should().BeTrue();
             colorPicker.GetState(x => x.Error).Should().BeFalse();
             colorPicker.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
             // input a valid color
@@ -1229,9 +1231,9 @@ namespace MudBlazor.UnitTests.Components
             var colorPicker = comp.FindComponent<MudColorPicker>().Instance;
             var forbiddenColor = colorPicker.Palette.First();
             await colorPickerComp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Validation, new Func<MudColor, string>(color => color != null && color.Value == forbiddenColor.Value ? $"{forbiddenColor.Value} is not allowed" : null)));
-            // initial form state
+            // initial form state (#13421 limitation: the picker holds a default value, so the form reads valid until the field is validated)
             form.IsTouched.Should().BeFalse();
-            form.IsValid.Should().BeFalse();
+            form.IsValid.Should().BeTrue();
 
             await comp.InvokeAsync(() => comp.Find("input").Click());
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
@@ -1494,8 +1496,8 @@ namespace MudBlazor.UnitTests.Components
             var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
             var input = fileUploadComp.FindComponent<InputFile>();
 
-            // check initial state: form should not be valid because form is untouched
-            form.IsValid.Should().BeFalse();
+            // #13421: a pre-populated file satisfies the required field, so the form is valid on load even though it is untouched
+            form.IsValid.Should().BeTrue();
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.GetState(x => x.Error).Should().BeFalse();
             fileUploadInstance.GetState(x => x.ErrorText).Should().BeNullOrEmpty();
@@ -1538,8 +1540,8 @@ namespace MudBlazor.UnitTests.Components
             var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
             var input = fileUploadComp.FindComponent<InputFile>();
 
-            // check initial state: form should not be valid because form is untouched
-            form.IsValid.Should().BeFalse();
+            // #13421: a pre-populated file satisfies the required field, so the form is valid on load even though it is untouched
+            form.IsValid.Should().BeTrue();
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.Files.Should().NotBeNull();
             fileUploadInstance.GetState(x => x.Error).Should().BeFalse();
@@ -1580,8 +1582,8 @@ namespace MudBlazor.UnitTests.Components
             var fileUploadInstance = comp.FindComponent<MudFileUpload<IBrowserFile>>().Instance;
             var input = fileUploadComp.FindComponent<InputFile>();
 
-            // check initial state: form should not be valid because form is untouched
-            form.IsValid.Should().BeFalse();
+            // #13421: a pre-populated file satisfies the required field, so the form is valid on load even though it is untouched
+            form.IsValid.Should().BeTrue();
             form.IsTouched.Should().BeFalse();
             fileUploadInstance.Files.Should().NotBeNull();
             fileUploadInstance.GetState(x => x.Error).Should().BeFalse();

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1187,6 +1187,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// #12400: a required MudDatePicker participates in MudForm.IsValid — an empty one is invalid on load, and a preset date is valid on load.
+        /// </summary>
+        [Test]
+        public async Task MudForm_RequiredDatePicker_EmptyIsInvalid_PresetIsValid()
+        {
+            var empty = Context.Render<FormRequiredDatePickerTest>();
+            await empty.WaitForAssertionAsync(() => empty.Instance.Form.IsValid.Should().BeFalse("an empty required date picker (and text field) is invalid on load"));
+
+            var preset = Context.Render<FormRequiredDatePickerTest>(parameters => parameters
+                .Add(x => x.Name, "Sam")
+                .Add(x => x.Date, new DateTime(2020, 1, 1)));
+            await preset.WaitForAssertionAsync(() => preset.Instance.Form.IsValid.Should().BeTrue("a preset required date picker and text field are valid on load (#12400)"));
+        }
+
+        /// <summary>
+        /// #5196: a form with a validator and pre-populated required fields is valid on load and does not flip IsValid to false.
+        /// </summary>
+        [Test]
+        public async Task MudForm_ValidatorWithPrefilledRequiredFields_IsValidOnLoad()
+        {
+            var comp = Context.Render<FormValidatorPrefilledTest>();
+            await comp.WaitForAssertionAsync(() => comp.Instance.Form.IsValid.Should().BeTrue("pre-populated required fields with a passing validator are valid on load (#5196)"));
+        }
+
+        /// <summary>
         /// ColorPicker should be validated like every other form component when color is changed via inputs
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1212,6 +1212,20 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A required multi-file MudFileUpload bound to an empty (non-null) collection is not satisfied, so the form is invalid until a file is present.
+        /// </summary>
+        [Test]
+        public async Task MudForm_RequiredMultiFileUpload_EmptyCollectionIsInvalid()
+        {
+            var empty = Context.Render<FormRequiredMultiFileUploadTest>();
+            await empty.WaitForAssertionAsync(() => empty.Instance.Form.IsValid.Should().BeFalse("a required multi-file upload bound to an empty list is invalid on load"));
+
+            var withFile = Context.Render<FormRequiredMultiFileUploadTest>(parameters => parameters
+                .Add(x => x.Files, new List<IBrowserFile> { new DummyBrowserFile("cat.jpg", DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>()) }));
+            await withFile.WaitForAssertionAsync(() => withFile.Instance.Form.IsValid.Should().BeTrue("a required multi-file upload holding a file is valid on load"));
+        }
+
+        /// <summary>
         /// ColorPicker should be validated like every other form component when color is changed via inputs
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -76,6 +76,19 @@ public class RowValidatorTests
     }
 
     /// <summary>
+    /// An <see cref="IFormComponent"/> implementation that predates <see cref="IFormComponent.HasValue"/> must keep compiling and running: the default implementation falls back to <see cref="IFormComponent.Touched"/>.
+    /// </summary>
+    [Test]
+    public void IFormComponent_HasValue_DefaultImplementation_FallsBackToTouched()
+    {
+        var component = new TestFormComponent(isAsync: false) { Touched = false };
+        ((IFormComponent)component).HasValue().Should().BeFalse();
+
+        component.Touched = true;
+        ((IFormComponent)component).HasValue().Should().BeTrue();
+    }
+
+    /// <summary>
     /// A minimal external implementer from before ValidateAsync was added to IForm.
     /// </summary>
     private sealed class LegacyForm : IForm
@@ -123,7 +136,7 @@ public class RowValidatorTests
 
         public bool HasErrors => ValidationErrors.Count > 0;
 
-        public bool Touched => false;
+        public bool Touched { get; set; }
 
         public object? Validation { get; set; }
 

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -125,6 +125,8 @@ public class RowValidatorTests
 
         public bool Touched => false;
 
+        public bool HasValue() => true;
+
         public object? Validation { get; set; }
 
         public bool IsForNull => false;

--- a/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RowValidatorTests.cs
@@ -125,8 +125,6 @@ public class RowValidatorTests
 
         public bool Touched => false;
 
-        public bool HasValue() => true;
-
         public object? Validation { get; set; }
 
         public bool IsForNull => false;

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -283,7 +283,8 @@ namespace MudBlazor.UnitTests.Components
             textField[1].Instance.ReadText.Should().Be("password");
             textField[1].Instance.ReadValue.Should().Be("password");
             comp.Instance.Model.Password.Should().Be("password");
-            form.IsValid.Should().BeTrue();
+            // #13421: the debounced Username's value has not committed yet (ReadValue is null), so its required field is not yet satisfied and the form stays invalid until the pending value commits (on validate below).
+            form.IsValid.Should().BeFalse();
 
             await comp.Find("#validate-button").ClickAsync();
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -475,6 +475,12 @@ namespace MudBlazor
                 return !IsNullOrWhiteSpace(valueString);
             }
 
+            // A collection value (e.g. a multi-file MudFileUpload bound to an empty list) only counts as a value when it holds at least one element.
+            if (value is System.Collections.IEnumerable enumerable)
+            {
+                return enumerable.Cast<object?>().Any();
+            }
+
             return value is not null;
         }
 

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -478,7 +478,17 @@ namespace MudBlazor
             // A collection value (e.g. a multi-file MudFileUpload bound to an empty list) only counts as a value when it holds at least one element.
             if (value is System.Collections.IEnumerable enumerable)
             {
-                return enumerable.Cast<object?>().Any();
+                if (enumerable is System.Collections.ICollection collection)
+                {
+                    return collection.Count > 0;
+                }
+
+                foreach (var _ in enumerable)
+                {
+                    return true;
+                }
+
+                return false;
             }
 
             return value is not null;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -478,17 +478,7 @@ namespace MudBlazor
             // A collection value (e.g. a multi-file MudFileUpload bound to an empty list) only counts as a value when it holds at least one element.
             if (value is System.Collections.IEnumerable enumerable)
             {
-                if (enumerable is System.Collections.ICollection collection)
-                {
-                    return collection.Count > 0;
-                }
-
-                foreach (var _ in enumerable)
-                {
-                    return true;
-                }
-
-                return false;
+                return enumerable.Cast<object?>().Any();
             }
 
             return value is not null;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -478,6 +478,9 @@ namespace MudBlazor
             return value is not null;
         }
 
+        /// <inheritdoc />
+        bool IFormComponent.HasValue() => HasValue(ReadValue);
+
         [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "In the context of EditContext.Model / FieldIdentifier.Model they won't get trimmed.")]
         protected virtual void ValidateWithAttribute(ValidationAttribute attr, T? value, List<string> errors)
         {

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -240,12 +240,7 @@ namespace MudBlazor
             _errors.Clear();
             foreach (var error in _formControls.SelectMany(control => control.ValidationErrors))
                 _errors.Add(error);
-            // form can only be valid if:
-            // - none have an error
-            // - all required fields have been touched (and thus validated)
-            var noErrors = _formControls.All(x => x.HasErrors == false);
-            var requiredAllTouched = _formControls.Where(x => x.Required).All(x => x.Touched);
-            var valid = noErrors && requiredAllTouched;
+            var valid = EvaluateIsValid();
 
             var oldTouched = _touched;
             _touched = _formControls.Any(x => x.Touched);
@@ -269,6 +264,15 @@ namespace MudBlazor
             }
         }
 
+        // The form is valid when no control has an error and every required control holds a value.
+        // A required field is satisfied by having a value, not by being touched: #13328 stopped marking Touched on parameter-driven value sets, which left pre-populated forms reporting invalid on load (#13421).
+        private bool EvaluateIsValid()
+        {
+            var noErrors = _formControls.All(x => x.HasErrors == false);
+            var requiredAllHaveValue = _formControls.Where(x => x.Required).All(x => x.HasValue());
+            return noErrors && requiredAllHaveValue;
+        }
+
         protected override bool ShouldRender()
         {
             return !SuppressRenderingOnValidation || _shouldRender;
@@ -278,7 +282,7 @@ namespace MudBlazor
         {
             if (firstRender)
             {
-                var valid = _formControls.All(x => x.Required == false);
+                var valid = EvaluateIsValid();
                 if (valid != IsValid)
                 {
                     // the user probably bound a variable to IsValid, and it conflicts with our state.

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -264,10 +264,10 @@ namespace MudBlazor
             }
         }
 
-        // The form is valid when no control has an error and every required control holds a value.
-        // A required field is satisfied by having a value, not by being touched: #13328 stopped marking Touched on parameter-driven value sets, which left pre-populated forms reporting invalid on load (#13421).
         private bool EvaluateIsValid()
         {
+            // The form is valid when no control has an error and every required control holds a value.
+            // A required field is satisfied by having a value, not by being touched.
             var noErrors = _formControls.All(x => x.HasErrors == false);
             var requiredAllHaveValue = _formControls.Where(x => x.Required).All(x => x.HasValue());
             return noErrors && requiredAllHaveValue;

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -10,7 +10,9 @@ namespace MudBlazor.Interfaces
         public bool Error { get; set; }
         public bool HasErrors { get; }
         public bool Touched { get; }
-        public bool HasValue();
+
+        // Defaults to Touched so existing external IFormComponent implementers keep compiling and behaving as before; the built-in inputs override this to report actual value presence (#13421).
+        public bool HasValue() => Touched;
         public object? Validation { get; set; }
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -10,6 +10,11 @@ namespace MudBlazor.Interfaces
         public bool Error { get; set; }
         public bool HasErrors { get; }
         public bool Touched { get; }
+
+        /// <summary>
+        /// Whether this component currently holds a value (used by <see cref="MudForm"/> to tell a satisfied required field from an empty one without relying on <see cref="Touched"/>).
+        /// </summary>
+        public bool HasValue();
         public object? Validation { get; set; }
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -10,7 +10,7 @@ namespace MudBlazor.Interfaces
         public bool Error { get; set; }
         public bool HasErrors { get; }
         public bool Touched { get; }
-        public bool HasValue() => Touched; // Default implementation for backwards compatability; the built-in inputs override this to report actual value presence.
+        public bool HasValue() => Touched; // Default implementation for backwards compatibility; built-in inputs override this to report actual value presence.
         public object? Validation { get; set; }
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -10,10 +10,6 @@ namespace MudBlazor.Interfaces
         public bool Error { get; set; }
         public bool HasErrors { get; }
         public bool Touched { get; }
-
-        /// <summary>
-        /// Whether this component currently holds a value (used by <see cref="MudForm"/> to tell a satisfied required field from an empty one without relying on <see cref="Touched"/>).
-        /// </summary>
         public bool HasValue();
         public object? Validation { get; set; }
         public bool IsForNull { get; }

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -10,9 +10,7 @@ namespace MudBlazor.Interfaces
         public bool Error { get; set; }
         public bool HasErrors { get; }
         public bool Touched { get; }
-
-        // Defaults to Touched so existing external IFormComponent implementers keep compiling and behaving as before; the built-in inputs override this to report actual value presence (#13421).
-        public bool HasValue() => Touched;
+        public bool HasValue() => Touched; // Default implementation for backwards compatability; the built-in inputs override this to report actual value presence.
         public object? Validation { get; set; }
         public bool IsForNull { get; }
         public List<string> ValidationErrors { get; set; }


### PR DESCRIPTION
MudForm decided validity from `requiredAllTouched`, using `Touched` as a proxy for "required field satisfied". 

**Fix:** base validity on whether each required field holds a value.
- `IFormComponent.HasValue()` — a default interface method (returns `Touched`, so existing external implementers are unaffected), overridden on MudFormComponent; empty strings and empty collections count as no value.
- MudForm uses `noErrors && required.All(x => x.HasValue())` in both `OnEvaluateForm` and first-render init.

**Behavior notes for upgraders:**
- A pre-populated valid form is now valid on load; an empty required field is still invalid (no error shown until touched); an unselected required `MudRadioGroup` is now correctly invalid.
- A pre-populated value that would fail a custom `Validation` delegate reads as valid until it is validated (the delegate runs on interaction), and a debounced field with an uncommitted value is treated as having no value until it commits.

## Related issues

- #13328 (9.6.0) stopped marking `Touched` on parameter-driven value sets, so a pre-populated required field became `HasValue`=true but `Touched`=false — and the form read invalid on load (regressed from 9.5.0).
- Closes #13421.
- Closes #5196.
- Closes #12400.
- Closes #9793.
- Closes #12664.