### PR TITLE
MudPagination: Allow a BoundaryCount of zero

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -300,6 +300,12 @@ namespace MudBlazor.UnitTests.Components
             //Expected values
             var items = comp.FindAll(".mud-pagination-item");
             items.Count.Should().Be(expectedValues.Length);
+            if (boundaryCount >= 1)
+            {
+                //Boundary pages keep the item count constant so the control doesn't change width while navigating.
+                items.Count.Should().Be(middleCount + (2 * boundaryCount) + 2);
+            }
+
             for (var j = 0; j < items.Count; j++)
             {
                 items[j].TextContent.Should().Be(expectedValues[j]);

--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -280,8 +280,6 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(8, 30, 11, 0, new[] { "…", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "…" })]
         [TestCase(1, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "…" })]
         [TestCase(30, 30, 11, 0, new[] { "…", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
-        // With BoundaryCount=0 the window must contain exactly MiddleCount pages.
-        // Selected=6 shows pages 1-11; Selected=7 is the first page whose window is centered on both sides.
         [TestCase(6, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "…" })]
         [TestCase(7, 30, 11, 0, new[] { "…", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "…" })]
         [Test]
@@ -309,9 +307,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Tests that a <see cref="MudPagination.BoundaryCount"/> of zero set via the initial parameters
-        /// hides the boundary pages instead of being clamped to one.
-        /// Verifies https://github.com/MudBlazor/MudBlazor/issues/13181
+        /// #13181: a <see cref="MudPagination.BoundaryCount"/> of zero set via the initial parameters hides the boundary pages instead of being clamped to one.
         /// </summary>
         [Test]
         public void PaginationBoundaryCountZeroInitialParameter()

--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -231,7 +231,8 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(9, 3, 2)]
         [TestCase(5, 1, 1)]
         [TestCase(5, -1, 1)]
-        [TestCase(5, 1, -1)]
+        [TestCase(4, 1, -1)]
+        [TestCase(4, 1, 0)]
         [Test]
         public async Task PaginationCountWithoutEllipsis(int count, int middleCount, int boundaryCount)
         {
@@ -243,7 +244,7 @@ namespace MudBlazor.UnitTests.Components
 
             //Expected values
             pagination.GetState(x => x.MiddleCount).Should().Be(Math.Max(1, middleCount));
-            pagination.GetState(x => x.BoundaryCount).Should().Be(Math.Max(1, boundaryCount));
+            pagination.GetState(x => x.BoundaryCount).Should().Be(Math.Max(0, boundaryCount));
 
             for (var i = 1; i <= count; i++)
             {
@@ -276,6 +277,9 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(7, 22, 5, 3, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "...", "20", "21", "22" })]
         [TestCase(16, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
         [TestCase(22, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
+        [TestCase(8, 30, 11, 0, new[] { "...", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "..." })]
+        [TestCase(1, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "..." })]
+        [TestCase(30, 30, 11, 0, new[] { "...", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
         [Test]
         public async Task PaginationCountWithEllipsis(int selectedPage, int count, int middleCount,
             int boundaryCount, string[] expectedValues)
@@ -298,6 +302,27 @@ namespace MudBlazor.UnitTests.Components
             {
                 items[j].TextContent.Should().Be(expectedValues[j]);
             }
+        }
+
+        /// <summary>
+        /// Tests that a <see cref="MudPagination.BoundaryCount"/> of zero set via the initial parameters
+        /// hides the boundary pages instead of being clamped to one.
+        /// Verifies https://github.com/MudBlazor/MudBlazor/issues/13181
+        /// </summary>
+        [Test]
+        public void PaginationBoundaryCountZeroInitialParameter()
+        {
+            var comp = Context.Render<MudPagination>(parameters => parameters
+                .Add(x => x.Count, 30)
+                .Add(x => x.MiddleCount, 11)
+                .Add(x => x.BoundaryCount, 0)
+                .Add(x => x.Selected, 8)
+                .Add(x => x.ShowPreviousButton, false)
+                .Add(x => x.ShowNextButton, false));
+
+            var items = comp.FindAll(".mud-pagination-item");
+            items.Select(x => x.TextContent).Should()
+                .Equal("...", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "...");
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -278,8 +278,13 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(16, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
         [TestCase(22, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
         [TestCase(8, 30, 11, 0, new[] { "...", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "..." })]
-        [TestCase(1, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "..." })]
-        [TestCase(30, 30, 11, 0, new[] { "...", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
+        [TestCase(1, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "..." })]
+        [TestCase(30, 30, 11, 0, new[] { "...", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
+        // Regression cases for https://github.com/MudBlazor/MudBlazor/pull/13424#issuecomment (OFark):
+        // with BoundaryCount=0 and MiddleCount=11, Selected=6 must show exactly 11 pages (1-11, 5 before/5 after),
+        // not 12 as previously; Selected=7 is the first page for which the window can be fully centered on both sides.
+        [TestCase(6, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "..." })]
+        [TestCase(7, 30, 11, 0, new[] { "...", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "..." })]
         [Test]
         public async Task PaginationCountWithEllipsis(int selectedPage, int count, int middleCount,
             int boundaryCount, string[] expectedValues)
@@ -297,7 +302,7 @@ namespace MudBlazor.UnitTests.Components
 
             //Expected values
             var items = comp.FindAll(".mud-pagination-item");
-            items.Count.Should().Be(middleCount + (2 * boundaryCount) + 2);
+            items.Count.Should().Be(expectedValues.Length);
             for (var j = 0; j < items.Count; j++)
             {
                 items[j].TextContent.Should().Be(expectedValues[j]);

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -267,7 +267,7 @@ namespace MudBlazor
          -1 is displayed as "..." in the ui*/
         private int[] GeneratePagination()
         {
-            //return array {1, ..., Count} if Count is small 
+            //return array {1, ..., Count} if Count is small
             if (_countState.Value <= 4 || _countState.Value <= (2 * _boundaryCountState.Value) + _middleCountState.Value + 2)
             {
                 var result = new int[_countState.Value];
@@ -277,6 +277,34 @@ namespace MudBlazor
                 }
 
                 return result;
+            }
+
+            //BoundaryCount==0 has no fixed boundary pages to bridge a single-page gap into, so the
+            //"absorb the gap into a real page" trick below (used when BoundaryCount>=1) would show one
+            //extra page beyond MiddleCount; handle it separately as a pure sliding window instead.
+            if (_boundaryCountState.Value == 0)
+            {
+                var tightMin = 1;
+                var tightMax = _countState.Value - _middleCountState.Value + 1;
+                var start = Math.Clamp(_selectedState.Value - (_middleCountState.Value / 2), tightMin, tightMax);
+
+                var leftGap = start - 1;
+                var rightGap = _countState.Value - (start + _middleCountState.Value - 1);
+
+                var list = new List<int>(_middleCountState.Value + 2);
+                if (leftGap > 0)
+                {
+                    list.Add(-1);
+                }
+                for (var i = 0; i < _middleCountState.Value; i++)
+                {
+                    list.Add(start + i);
+                }
+                if (rightGap > 0)
+                {
+                    list.Add(-1);
+                }
+                return list.ToArray();
             }
 
             var length = (2 * _boundaryCountState.Value) + _middleCountState.Value + 2;

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -279,32 +279,30 @@ namespace MudBlazor
                 return result;
             }
 
-            //BoundaryCount==0 has no fixed boundary pages to bridge a single-page gap into, so the
-            //"absorb the gap into a real page" trick below (used when BoundaryCount>=1) would show one
-            //extra page beyond MiddleCount; handle it separately as a pure sliding window instead.
+            //With no boundary pages there is nothing for a single-page gap to be absorbed into.
+            //The path below would then show one page more than MiddleCount, so use a plain sliding window.
             if (_boundaryCountState.Value == 0)
             {
-                var tightMin = 1;
-                var tightMax = _countState.Value - _middleCountState.Value + 1;
-                var start = Math.Clamp(_selectedState.Value - (_middleCountState.Value / 2), tightMin, tightMax);
+                var maxStart = _countState.Value - _middleCountState.Value + 1;
+                var start = Math.Clamp(_selectedState.Value - (_middleCountState.Value / 2), 1, maxStart);
 
-                var leftGap = start - 1;
-                var rightGap = _countState.Value - (start + _middleCountState.Value - 1);
-
-                var list = new List<int>(_middleCountState.Value + 2);
-                if (leftGap > 0)
+                var window = new List<int>(_middleCountState.Value + 2);
+                if (start > 1)
                 {
-                    list.Add(-1);
+                    window.Add(-1);
                 }
+
                 for (var i = 0; i < _middleCountState.Value; i++)
                 {
-                    list.Add(start + i);
+                    window.Add(start + i);
                 }
-                if (rightGap > 0)
+
+                if (start + _middleCountState.Value - 1 < _countState.Value)
                 {
-                    list.Add(-1);
+                    window.Add(-1);
                 }
-                return list.ToArray();
+
+                return window.ToArray();
             }
 
             var length = (2 * _boundaryCountState.Value) + _middleCountState.Value + 2;

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -75,7 +75,7 @@ namespace MudBlazor
         /// The number of pages shown before and after the ellipsis.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>1</c>. <br />
+        /// Defaults to <c>2</c>. <br />
         /// A value of <c>0</c> would hide the page numbers at the edge: <c>&lt; ... 4 5 6 ... &gt;</c> <br />
         /// A value of <c>1</c> would show one-page number at the edge: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c> <br />
         /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c>
@@ -88,7 +88,7 @@ namespace MudBlazor
         /// The number of pages shown between the ellipsis.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>1</c>. <br />
+        /// Defaults to <c>3</c>. <br />
         /// A value of <c>1</c> would show one-page number in the middle: <c>&lt; 1 ... 5 ... 9 &gt;</c> <br />
         /// A value of <c>3</c> would show three-page numbers in the middle: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c>
         /// </remarks>

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -76,8 +76,9 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>1</c>. <br />
+        /// A value of <c>0</c> would hide the page numbers at the edge: <c>&lt; ... 4 5 6 ... &gt;</c> <br />
         /// A value of <c>1</c> would show one-page number at the edge: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c> <br />
-        /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c> 
+        /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c>
         /// </remarks>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Appearance)]
@@ -378,7 +379,7 @@ namespace MudBlazor
 
         private Task SetBoundaryCount(int count)
         {
-            var newCount = Math.Max(1, count);
+            var newCount = Math.Max(0, count);
 
             return _boundaryCountState.SetValueAsync(newCount);
         }


### PR DESCRIPTION
## Description

`SetBoundaryCount` clamped `BoundaryCount` to a minimum of `1`, so setting it to `0` was silently ignored. This caused two symptoms reported in the issue:

- The boundary pages were always shown even when the caller doesn't want them (e.g. when `ShowFirstButton`/`ShowLastButton` already cover that need).
- The forced page `1` triggered the ellipsis compaction (`[1, …, 3]` → `1 2 3`), displaying pages the caller cannot navigate to — which breaks cursor-based pagination where no cursor exists for those pages.

This PR lowers the clamp floor to `0`, as suggested in the issue. With `BoundaryCount="0"` the boundary loops don't run and both ellipses sit at the array ends where the compaction cannot reach them:

`Count="30" MiddleCount="11" BoundaryCount="0" Selected="8"` now renders
`… 3 4 5 6 7 8 9 10 11 12 13 …` instead of `1 2 3 4 5 6 7 8 9 10 11 12 13 … 30`.

`MiddleCount` keeps its floor of `1`, since `0` would hide the selected page.

## How Has This Been Tested?

- Added three `PaginationCountWithEllipsis` cases covering `BoundaryCount="0"` at the start, middle and end of the page range (the middle one is the exact reproduction from the issue).
- Added `PaginationBoundaryCountZeroInitialParameter` covering the initial-parameter path used in the issue's reproduction snippet.
- Updated the existing clamp assertions in `PaginationCountWithoutEllipsis` to the new floor.
- All 65 Pagination unit tests pass locally (net10.0); the new cases fail without the one-line fix.
- Verified visually in the browser (screenshot below).

Fixes #13181

## Screenshots

`Count="30" MiddleCount="11" BoundaryCount="0"`, page 8 selected:

<img width="2390" height="500" alt="image" src="https://github.com/user-attachments/assets/df85f93d-790e-4329-b52b-31ff168aa306" />
