### PR TITLE
MudDateRangePicker: Don't raise DateRangeChanged when DateRange is set from parent

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -927,7 +927,25 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.Date, today));
 
             comp.Instance.Date.Should().Be(today);
-            wasEventCallbackCalled.Should().BeTrue();
+            // A programmatic/parent assignment updates the value but must NOT raise DateChanged (#10834,
+            // follow-up to #13428): the parent set the value, so echoing an event back to it is the bug.
+            wasEventCallbackCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task DateChanged_ShouldNotFire_WhenDateSetFromParent()
+        {
+            var eventCount = 0;
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(x => x.DateChanged, (DateTime? _) => eventCount++));
+
+            // Assigning Date from a parent is programmatic, not user interaction; it must update the display
+            // without raising DateChanged (#10834, follow-up to #13428).
+            var date = new DateTime(2022, 3, 14);
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.Date, date));
+
+            comp.Instance.Date.Should().Be(date);
+            eventCount.Should().Be(0);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -478,7 +478,8 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.DateRange, range));
 
             comp.Instance.DateRange.Should().Be(range);
-            wasEventCallbackCalled.Should().BeTrue();
+            // #10834: assigning DateRange from the parent applies the value but must not raise DateRangeChanged.
+            wasEventCallbackCalled.Should().BeFalse();
         }
 
         [Test]
@@ -544,6 +545,41 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Instance.DateRange.Should().Be(dr2);
             wasEventCallbackCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task DateRangeChanged_ShouldNotFire_WhenDateRangeSetFromParent()
+        {
+            // #10834: a programmatic (parent) assignment of DateRange must NOT raise DateRangeChanged.
+            var invocationCount = 0;
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
+                .Add(x => x.DateRangeChanged, (DateRange _) => invocationCount++));
+
+            var range = new DateRange(new DateTime(2022, 1, 1), new DateTime(2022, 1, 10));
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DateRange, range));
+
+            // The value is applied to the display, but the parent-driven change is not echoed back as an event.
+            comp.Instance.DateRange.Should().Be(range);
+            invocationCount.Should().Be(0);
+        }
+
+        [Test]
+        public async Task DateRangeChanged_ShouldFire_WhenUserSelectsRange()
+        {
+            // No-regression for #10834: a genuine user selection must STILL raise DateRangeChanged.
+            var invocationCount = 0;
+            var comp = Context.Render<DateRangePickerImpl>(parameters => parameters
+                .Add(x => x.PickerVariant, PickerVariant.Static)
+                .Add(x => x.DateRangeChanged, (DateRange _) => invocationCount++));
+            var picker = comp.Instance;
+
+            var start = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 10);
+            var end = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 12);
+            await comp.InvokeAsync(() => picker.ClickDayAsync(start));
+            await comp.InvokeAsync(() => picker.ClickDayAsync(end));
+
+            picker.DateRange.Should().Be(new DateRange(start, end));
+            invocationCount.Should().Be(1);
         }
 
         // new DateRange() chains to new DateRange(null, null), so both produce an all-null range.
@@ -977,8 +1013,10 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.DateRange, new DateRange(twoDaysAgo, today)));
 
+            // The range (which includes a disabled date) is still captured because AllowDisabledDatesInRange is true,
+            // but #10834: assigning DateRange from the parent must not raise DateRangeChanged.
             comp.Instance.DateRange.Should().Be(range);
-            wasEventCallbackCalled.Should().BeTrue();
+            wasEventCallbackCalled.Should().BeFalse();
         }
 
         [Test]
@@ -1394,55 +1432,70 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DateRangePicker_ClearAndReselectSameDateRange_ShouldFireDateRangeChanged()
         {
-            var initialRange = new DateRange(new DateTime(2020, 10, 26), new DateTime(2020, 10, 29));
+            // Regression guarantee from #12775, preserved under #10834: after clearing, reselecting the SAME range
+            // through a genuine user selection must raise DateRangeChanged again. The selection is driven through the
+            // calendar (not a parent parameter assignment) because #10834 makes programmatic assignments silent.
             var changedRanges = new List<DateRange>();
-
-            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
-                .Add(p => p.Clearable, true)
-                .Add(p => p.DateRange, initialRange)
+            var comp = Context.Render<DateRangePickerImpl>(parameters => parameters
+                .Add(p => p.PickerVariant, PickerVariant.Static)
                 .Add(p => p.DateRangeChanged, (DateRange range) => changedRanges.Add(range)));
-
             var picker = comp.Instance;
-            picker.DateRange.Should().Be(initialRange);
 
-            // Clear the date range via the clearable X button
-            await comp.Find("button").ClickAsync();
+            var start = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 10);
+            var end = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 12);
+            var range = new DateRange(start, end);
 
-            // DateRangeChanged should fire on clear
+            // Select the range via the calendar.
+            await comp.InvokeAsync(() => picker.ClickDayAsync(start));
+            await comp.InvokeAsync(() => picker.ClickDayAsync(end));
             changedRanges.Should().HaveCount(1);
+            picker.DateRange.Should().Be(range);
 
-            // Reselect the exact same date range (simulating user reselecting after clearing)
-            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DateRange, initialRange));
-
-            // DateRangeChanged should fire again even when reselecting the same range after clearing
+            // Clear the range.
+            await comp.InvokeAsync(() => picker.ClearAsync());
             changedRanges.Should().HaveCount(2);
+            changedRanges[1].Should().BeNull();
+            picker.DateRange.Should().BeNull();
+
+            // Reselect the exact same range: DateRangeChanged must fire again even though the value equals the one
+            // selected before the clear.
+            await comp.InvokeAsync(() => picker.ClickDayAsync(start));
+            await comp.InvokeAsync(() => picker.ClickDayAsync(end));
+            changedRanges.Should().HaveCount(3);
+            picker.DateRange.Should().Be(range);
         }
 
         [Test]
         public async Task DateRangePicker_ClearViaClearAsync_ShouldFireDateRangeChanged()
         {
-            var initialRange = new DateRange(new DateTime(2020, 10, 26), new DateTime(2020, 10, 29));
+            // Same guarantee as above, clearing through the ClearAsync API instead of the X button.
             var changedRanges = new List<DateRange>();
-
-            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
-                .Add(p => p.Clearable, true)
-                .Add(p => p.DateRange, initialRange)
+            var comp = Context.Render<DateRangePickerImpl>(parameters => parameters
+                .Add(p => p.PickerVariant, PickerVariant.Static)
                 .Add(p => p.DateRangeChanged, (DateRange range) => changedRanges.Add(range)));
-
             var picker = comp.Instance;
-            picker.DateRange.Should().Be(initialRange);
 
-            // Clear the date range via ClearAsync
-            await comp.InvokeAsync(() => picker.ClearAsync());
+            var start = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 10);
+            var end = new DateTime(DateTime.Now.Year, DateTime.Now.Month, 12);
+            var range = new DateRange(start, end);
 
-            // DateRangeChanged should fire on clear
+            // Select the range via the calendar.
+            await comp.InvokeAsync(() => picker.ClickDayAsync(start));
+            await comp.InvokeAsync(() => picker.ClickDayAsync(end));
             changedRanges.Should().HaveCount(1);
+            picker.DateRange.Should().Be(range);
 
-            // Reselect the exact same date range after clearing via ClearAsync
-            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DateRange, initialRange));
-
-            // DateRangeChanged should fire again when reselecting the same range after clearing
+            // Clear the date range via ClearAsync.
+            await comp.InvokeAsync(() => picker.ClearAsync());
             changedRanges.Should().HaveCount(2);
+            changedRanges[1].Should().BeNull();
+            picker.DateRange.Should().BeNull();
+
+            // Reselect the exact same range: DateRangeChanged must fire again.
+            await comp.InvokeAsync(() => picker.ClickDayAsync(start));
+            await comp.InvokeAsync(() => picker.ClickDayAsync(end));
+            changedRanges.Should().HaveCount(3);
+            picker.DateRange.Should().Be(range);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -417,6 +417,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TimeChanged_ShouldNotFire_WhenTimeSetFromParent()
+        {
+            var eventCount = 0;
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(p => p.TimeChanged, (TimeSpan? _) => eventCount++));
+
+            // Assigning Time from a parent is programmatic, not user interaction; it must update the value
+            // without raising TimeChanged (#10834, follow-up to #13428).
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Time, new TimeSpan(9, 15, 0)));
+
+            comp.Instance.Time.Should().Be(new TimeSpan(9, 15, 0));
+            eventCount.Should().Be(0);
+        }
+
+        [Test]
+        public async Task TimeChanged_ShouldFire_WhenUserPicksTime()
+        {
+            var eventCount = 0;
+            TimeSpan? changed = null;
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(p => p.PickerVariant, PickerVariant.Static)
+                .Add(p => p.Time, new TimeSpan(10, 30, 0)) // parent init must NOT count as a change
+                .Add(p => p.TimeChanged, (TimeSpan? t) => { eventCount++; changed = t; }));
+            var picker = comp.Instance;
+
+            // A user clock pick followed by a commit is the user-driven path that MUST notify the parent.
+            await comp.InvokeAsync(() => picker.SelectTimeFromStick(5, false));
+            await comp.InvokeAsync(picker.SubmitAsync);
+
+            eventCount.Should().Be(1);
+            changed.Should().Be(picker.Time);
+            picker.Time.Should().NotBe(new TimeSpan(10, 30, 0));
+        }
+
+        [Test]
         public async Task SelectTimeFromStick_IgnoresSentinelValue()
         {
             var comp = await OpenPicker(parameters => parameters.Add(x => x.Time, new TimeSpan(8, 20, 0)));

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -27,10 +27,12 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _value;
-            // Assigning Date from the parameter is programmatic, not user interaction. Pass the suppression
-            // as an explicit argument (NOT an instance flag) so it cannot leak across the awaits inside
-            // SetDateAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
-            set => SetDateAsync(value, updateValue: true, forceUpdate: false, suppressInteraction: true).CatchAndLog();
+            // Assigning Date from the parameter is programmatic, not user interaction. Pass suppression AND
+            // notify: false as explicit arguments (NOT instance flags) so they cannot leak across the awaits
+            // inside SetDateAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
+            // notify: false stops DateChanged from firing on a parent/programmatic assignment - echoing back an
+            // event the parent never triggered is the feedback loop reported in #10834 (follow-up to #13428).
+            set => SetDateAsync(value, updateValue: true, forceUpdate: false, suppressInteraction: true, notify: false).CatchAndLog();
         }
 
         private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
@@ -39,7 +41,7 @@ namespace MudBlazor
         protected Task SetDateAsync(DateTime? date, bool updateValue)
             => SetDateAsync(date, updateValue, false);
 
-        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate, bool suppressInteraction = false)
+        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate, bool suppressInteraction = false, bool notify = true)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
             {
@@ -92,7 +94,13 @@ namespace MudBlazor
                     await SetTextAsync(ConvertSet(_value), false);
                 }
 
-                await DateChanged.InvokeAsync(_value);
+                // Programmatic/parent assignments pass notify: false and must not raise DateChanged (#10834);
+                // genuine user changes keep the default notify: true. The display update above still runs either
+                // way, so a parent assignment (even null, to clear stale invalid text) is fully reflected.
+                if (notify)
+                {
+                    await DateChanged.InvokeAsync(_value);
+                }
                 await BeginValidateAsync();
                 if (!suppressInteraction)
                 {

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -12,8 +12,10 @@ namespace MudBlazor
     public partial class MudDateRangePicker : MudBaseDatePicker
     {
         private readonly ParameterState<bool> _allowDisabledDatesInCountState;
+        private readonly ParameterState<DateRange?> _dateRangeState;
         private DateTime? _firstDate, _secondDate, _minValidDate, _maxValidDate;
         private DateRange? _dateRange;
+        private DateRange? _dateRangeParameter;
         private Range<string>? _rangeText;
 
         /// <summary>
@@ -25,6 +27,10 @@ namespace MudBlazor
             _allowDisabledDatesInCountState = registerScope.RegisterParameter<bool>(nameof(AllowDisabledDatesInCount))
                 .WithParameter(() => AllowDisabledDatesInCount)
                 .WithChangeHandler(RecalculateValidDays);
+            _dateRangeState = registerScope.RegisterParameter<DateRange?>(nameof(DateRange))
+                .WithParameter(() => _dateRangeParameter)
+                .WithEventCallback(() => DateRangeChanged)
+                .WithChangeHandler(OnDateRangeParameterChangedAsync);
 
             DisplayMonths = 2;
         }
@@ -104,9 +110,15 @@ namespace MudBlazor
         public DateRange? DateRange
         {
             get => _dateRange;
-            // Programmatic parameter assignment; pass suppression explicitly so it cannot leak across the
-            // awaits inside SetDateRangeAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
-            set => SetDateRangeAsync(value, updateValue: true, suppressInteraction: true).CatchAndLog();
+            // DateRange is managed by MudBlazor's ParameterState framework (see _dateRangeState in the constructor).
+            // Blazor stores the assigned parameter value here (raw); the state's change handler
+            // (OnDateRangeParameterChangedAsync) reflects a programmatic/parent assignment in the display WITHOUT
+            // raising DateRangeChanged (#10834). A genuine user selection instead writes through
+            // _dateRangeState.SetValueAsync, which DOES raise DateRangeChanged. The getter keeps returning the
+            // processed value (_dateRange) so normalization and disabled-date filtering remain observable through
+            // the public API. Because assignment no longer starts async work here, the earlier suppression race
+            // (PR #13328) can no longer occur through this setter.
+            set => _dateRangeParameter = value;
         }
 
         /// <summary>
@@ -119,62 +131,99 @@ namespace MudBlazor
         [Category(CategoryTypes.FormComponent.Validation)]
         public bool AllowDisabledDatesInRange { get; set; } = false;
 
+        // Internal value change (user calendar selection, clear, or text edit): update the display AND notify the
+        // parent through DateRangeChanged (two-way binding write-back). Programmatic/parent assignments instead flow
+        // through the ParameterState change handler (OnDateRangeParameterChangedAsync), which never notifies.
         protected async Task SetDateRangeAsync(DateRange? range, bool updateValue, bool suppressInteraction = false)
+        {
+            if (!await UpdateDateRangeDisplayAsync(range, updateValue, suppressInteraction))
+            {
+                return;
+            }
+
+            // Keep the raw parameter mirror aligned with the internally selected value so that change detection in
+            // SetParametersAsync compares a subsequent programmatic assignment against what the user actually sees
+            // (otherwise a parent could re-assign the pre-change value and it would be missed as "unchanged").
+            _dateRangeParameter = _dateRange;
+
+            // Writing through the state raises DateRangeChanged and keeps the tracked ParameterState value in sync,
+            // so a later programmatic assignment of the same value is still detected as "unchanged".
+            await _dateRangeState.SetValueAsync(_dateRange);
+            await BeginValidateAsync();
+            if (!suppressInteraction)
+            {
+                FieldChanged(_value);
+            }
+        }
+
+        // Runs when DateRange is assigned programmatically (from a parent) via the ParameterState framework.
+        // It reflects the new value in the display but must NOT raise DateRangeChanged: echoing back an event the
+        // parent never triggered is exactly the bug reported in #10834. suppressInteraction mirrors the previous
+        // behavior where a parameter assignment was never treated as user interaction.
+        private async Task OnDateRangeParameterChangedAsync(ParameterChangedEventArgs<DateRange?> args)
+        {
+            if (await UpdateDateRangeDisplayAsync(args.Value, updateValue: true, suppressInteraction: true))
+            {
+                await BeginValidateAsync();
+            }
+        }
+
+        // Applies a date range to the picker's display state (normalization, text, highlighted date, picker month,
+        // disabled-date filtering). Returns true when the value was accepted and actually changed, false when it was
+        // unchanged or rejected (e.g. it contains a disabled date). This method never raises DateRangeChanged.
+        private async Task<bool> UpdateDateRangeDisplayAsync(DateRange? range, bool updateValue, bool suppressInteraction)
         {
             // Normalize the DateRange before exception is thrown
             range = NormalizeDateRange(range);
 
-            if (_dateRange != range)
+            if (_dateRange == range)
             {
-                var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
-                    .Range(0, int.MaxValue)
-                    .Select(index => range.Start.Value.AddDays(index))
-                    .TakeWhile(date => date <= range.End.Value)
-                    .Any(date => IsDateDisabledFunc(date.Date));
+                return false;
+            }
 
-                if (doesRangeContainDisabledDates)
+            var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
+                .Range(0, int.MaxValue)
+                .Select(index => range.Start.Value.AddDays(index))
+                .TakeWhile(date => date <= range.End.Value)
+                .Any(date => IsDateDisabledFunc(date.Date));
+
+            if (doesRangeContainDisabledDates)
+            {
+                _rangeText = null;
+                await SetTextAsync(null, false);
+                return false;
+            }
+
+            if (!suppressInteraction)
+            {
+                Touched = true;
+            }
+
+            if (range?.Start is not null && StartMonth == null)
+                PickerMonth = new DateTime(GetCulture().Calendar.GetYear(range.Start.Value), GetCulture().Calendar.GetMonth(range.Start.Value), 1, GetCulture().Calendar);
+
+            _dateRange = range;
+            _value = range?.End;
+            HighlightedDate = range?.Start;
+
+            if (updateValue)
+            {
+                ResetConverterErrors();
+                if (_dateRange == null || (_dateRange.Start == null && _dateRange.End == null))
                 {
                     _rangeText = null;
                     await SetTextAsync(null, false);
-                    return;
                 }
-
-                if (!suppressInteraction)
+                else
                 {
-                    Touched = true;
-                }
-
-                if (range?.Start is not null && StartMonth == null)
-                    PickerMonth = new DateTime(GetCulture().Calendar.GetYear(range.Start.Value), GetCulture().Calendar.GetMonth(range.Start.Value), 1, GetCulture().Calendar);
-
-                _dateRange = range;
-                _value = range?.End;
-                HighlightedDate = range?.Start;
-
-                if (updateValue)
-                {
-                    ResetConverterErrors();
-                    if (_dateRange == null || (_dateRange.Start == null && _dateRange.End == null))
-                    {
-                        _rangeText = null;
-                        await SetTextAsync(null, false);
-                    }
-                    else
-                    {
-                        _rangeText = new Range<string>(
-                            ConvertSet(_dateRange.Start),
-                            ConvertSet(_dateRange.End));
-                        await SetTextAsync(_dateRange.ToString(GetConverter()), false);
-                    }
-                }
-
-                await DateRangeChanged.InvokeAsync(_dateRange);
-                await BeginValidateAsync();
-                if (!suppressInteraction)
-                {
-                    FieldChanged(_value);
+                    _rangeText = new Range<string>(
+                        ConvertSet(_dateRange.Start),
+                        ConvertSet(_dateRange.End));
+                    await SetTextAsync(_dateRange.ToString(GetConverter()), false);
                 }
             }
+
+            return true;
         }
 
         private Range<string>? RangeText

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -140,9 +140,12 @@ namespace MudBlazor
         public TimeSpan? Time
         {
             get => _value;
-            // Programmatic parameter assignment; pass suppression explicitly so it cannot leak across the
-            // awaits inside SetTimeAsync into a concurrent user clock pick on Blazor Server (PR #13328 review).
-            set => SetTimeAsync(value, updateValue: true, suppressInteraction: true).CatchAndLog();
+            // Programmatic parameter assignment; pass suppression AND notify: false explicitly so they cannot
+            // leak across the awaits inside SetTimeAsync into a concurrent user clock pick on Blazor Server
+            // (PR #13328 review). notify: false stops TimeChanged from firing on a parent/programmatic assignment
+            // - echoing back an event the parent never triggered is the feedback loop reported in #10834
+            // (follow-up to #13428).
+            set => SetTimeAsync(value, updateValue: true, suppressInteraction: true, notify: false).CatchAndLog();
         }
 
         /// <summary>
@@ -157,7 +160,8 @@ namespace MudBlazor
         /// <param name="time">The new value to set.</param>
         /// <param name="updateValue">When <c>true</c>, the <c>Text</c> will also be updated.</param>
         /// <param name="suppressInteraction">When <c>true</c>, the change is treated as programmatic and does not mark the picker touched or fire <c>FieldChanged</c>.</param>
-        protected async Task SetTimeAsync(TimeSpan? time, bool updateValue, bool suppressInteraction = false)
+        /// <param name="notify">When <c>false</c>, <c>TimeChanged</c> is not raised (used for programmatic/parent assignments; see <see cref="Time"/>).</param>
+        protected async Task SetTimeAsync(TimeSpan? time, bool updateValue, bool suppressInteraction = false, bool notify = true)
         {
             if (_value != time)
             {
@@ -173,7 +177,12 @@ namespace MudBlazor
                 }
 
                 UpdateTimeSetFromTime();
-                await TimeChanged.InvokeAsync(_value);
+                // Programmatic/parent assignments pass notify: false and must not raise TimeChanged (#10834);
+                // genuine user changes keep the default notify: true.
+                if (notify)
+                {
+                    await TimeChanged.InvokeAsync(_value);
+                }
                 await BeginValidateAsync();
                 if (!suppressInteraction)
                 {


### PR DESCRIPTION
Fixes #10834

## Summary

`MudDateRangePicker` raised `DateRangeChanged` whenever `DateRange` was assigned from a parent (programmatic / bound assignment), not only on genuine user interaction. This produced an event the parent never triggered and could create a feedback loop when the value was pushed down from the parent.

This migrates `DateRange` to MudBlazor's `ParameterState` framework so that a parent-driven assignment updates the display **without** raising `DateRangeChanged`, while a real user change (calendar selection, clear, or text edit) still raises it. This is the approach @ScarletKuro prescribed on the issue ("migrate `DateRange` to `ParameterState`"; no consumer migration is needed since no other component relies on the old behavior).

The public API is unchanged: `DateRange` (getter/setter) and the `DateRangeChanged` `EventCallback` keep the same signatures, and the getter still returns the processed value.

## Root cause

`DateRange` was a manual property whose setter called `SetDateRangeAsync(...)`, and `SetDateRangeAsync` ended with `await DateRangeChanged.InvokeAsync(_dateRange)`. Blazor drives a parent/programmatic parameter assignment through that setter, so `DateRangeChanged` fired on **any** value change — including one that originated from the parent.

## Fix

- `DateRange` is now tracked by a `ParameterState<DateRange?>` registered in the constructor (mirroring the existing `AllowDisabledDatesInCount` registration in the same file), with `.WithEventCallback(() => DateRangeChanged)` and `.WithChangeHandler(OnDateRangeParameterChangedAsync)`.
- **External (parent/programmatic) assignment** is detected by `ParameterState` in `SetParametersAsync` and runs `OnDateRangeParameterChangedAsync`, which updates the display (normalization, text, highlighted date, picker month, disabled-date filtering) but does **not** raise `DateRangeChanged`. ← fixes #10834
- **Internal change** (user calendar selection / clear / text edit) writes through `_dateRangeState.SetValueAsync(...)`, which raises `DateRangeChanged` and performs the two-way-binding write-back. ← preserves current user-facing behavior
- `SetDateRangeAsync` was split into a shared display-update step (`UpdateDateRangeDisplayAsync`) used by both paths and the notify step used only by the internal path, so every existing side-effect and guard is preserved: `NormalizeDateRange`, `SetTextAsync`, `FieldChanged`, `suppressInteraction`, and the concurrency handling from #13328 (assignment no longer starts async work in the setter, so that race can no longer occur through it).

## Validation

- Added `DateRangeChanged_ShouldNotFire_WhenDateRangeSetFromParent` (the fix) and `DateRangeChanged_ShouldFire_WhenUserSelectsRange` (no-regression). Confirmed the first fails on the current code (`invocationCount` was 1) and passes after the change.
- Existing tests that asserted `DateRangeChanged` fired on a **parent** assignment now assert the new contract (the value is still applied, the event is not raised): `IsDateDisabledFunc_SettingRangeToExcludeADisabledDateYieldsTheRange`, `StrictCaptureRange_ShouldCaptureDisabledDates_WhenFalse`.
- The #12775 "clear then reselect the same range fires `DateRangeChanged`" regression tests are preserved, but now drive the reselection through genuine calendar selections rather than a parent parameter re-assignment (which is intentionally silent after this change). The user-facing guarantee they protect still holds.
- Full picker suites green: `DateRangePickerTests` 81/81; `DateRangePickerTests` + `DatePickerTests` + `PickerToolbarTests` 209/209 (0 failed) on `net10.0`.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
