### PR TITLE
MudExpansionPanel: Add focus styling

### DIFF
--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -89,6 +89,11 @@
       cursor: pointer;
     }
 
+    &:focus-visible {
+      outline: 2px solid var(--mud-palette-action-default);
+      outline-offset: -2px;
+    }
+
     & .mud-expand-panel-text {
       flex: 1 1 auto;
     }

--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -83,11 +83,10 @@
     outline: none;
     padding: 16px 0px;
     position: relative;
-    transition: min-height .3s cubic-bezier(.25,.8,.5,1);
+    transition: min-height .3s cubic-bezier(.25,.8,.5,1), border-radius .3s cubic-bezier(.25,.8,.5,1);
     user-select: none;
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
-    transition: border-radius .3s cubic-bezier(.25,.8,.5,1);
 
     &.mud-expand-panel-header-gutters {
       padding-left: 24px;

--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -98,7 +98,7 @@
     }
 
     &:focus-visible {
-      background-color: var(--mud-palette-action-default-hover) !important;
+      background-color: var(--mud-palette-action-default-hover);
     }
 
     & .mud-expand-panel-text {

--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -61,6 +61,12 @@
     }
   }
 
+  &:not(.mud-panel-expanded) {
+    .mud-expand-panel-header {
+      border-radius: inherit;
+    }
+  }
+
   &.mud-panel-next-expanded {
     border-bottom: none;
     border-bottom-left-radius: inherit;
@@ -79,6 +85,9 @@
     position: relative;
     transition: min-height .3s cubic-bezier(.25,.8,.5,1);
     user-select: none;
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+    transition: border-radius .3s cubic-bezier(.25,.8,.5,1);
 
     &.mud-expand-panel-header-gutters {
       padding-left: 24px;
@@ -90,8 +99,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--mud-palette-action-default);
-      outline-offset: -2px;
+      background-color: var(--mud-palette-action-default-hover) !important;
     }
 
     & .mud-expand-panel-text {


### PR DESCRIPTION
Closes #11962

Panels were already keyboard-focusable (tabindex was present), but focus had no visual indicator. I implemented a :focus-visible with an outline so it only shows for keyboard navigation. Kept the header as a div with existing tabindex rather than switching to button to avoid breaking selectors for consumers.

https://github.com/user-attachments/assets/afc4e022-a8c0-49bf-a93d-c3475eb6f78f



**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project