### PR TITLE
MudInput: Fix ObjectDisposedException when disposed before first render

### DIFF
--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -409,8 +409,7 @@ namespace MudBlazor
                     SyncAutoSizingTextSnapshot();
                 }
             }
-            // Skip when disposed: a teardown during the await above disposes _dotNetReferenceLazy.Value,
-            // and serializing a disposed DotNetObjectReference throws ObjectDisposedException, crashing the circuit.
+
             if (firstRender && !_disposed)
             {
                 // Attach a JS blur fallback for cases where focus is dismissed without Blazor observing the native blur event.

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
         private bool _shouldInitSizing;
         private bool _shouldUpdateSizingParams;
         private bool _shouldAdjustSizingAfterRender;
+        private bool _disposed;
         private ElementReference _elementReference1;
         private readonly Lazy<DotNetObjectReference<MudInput<T>>> _dotNetReferenceLazy;
 
@@ -408,7 +409,9 @@ namespace MudBlazor
                     SyncAutoSizingTextSnapshot();
                 }
             }
-            if (firstRender)
+            // Skip when disposed: a teardown during the await above disposes _dotNetReferenceLazy.Value,
+            // and serializing a disposed DotNetObjectReference throws ObjectDisposedException, crashing the circuit.
+            if (firstRender && !_disposed)
             {
                 // Attach a JS blur fallback for cases where focus is dismissed without Blazor observing the native blur event.
                 await ElementReference.MudAttachBlurEventWithJS(_dotNetReferenceLazy.Value);
@@ -447,6 +450,9 @@ namespace MudBlazor
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()
         {
+            // Set before disposing the reference so a racing first-render blur attach skips.
+            _disposed = true;
+
             if (IsJSRuntimeAvailable)
             {
                 await JsRuntime.InvokeVoidAsyncWithErrorHandling("mudElementRef.removeOnBlurEvent", ElementReference);


### PR DESCRIPTION
Fixes #13426.

`MudInput.OnAfterRenderAsync` attaches the JS blur fallback on first render via an unguarded `InvokeVoidAsync` that passes the lazy `DotNetObjectReference`. With `Sizing="Auto"` / `AutoGrow`, the `mudInputSizing.init` interop round-trip is awaited **before** that attach. If the component is disposed during that await (navigation, dialog close, stepper step removed), `DisposeAsyncCore` disposes the reference; when the continuation resumes, serializing the disposed reference throws `ObjectDisposedException` synchronously in `JSRuntime.TrackObjectReference` and tears down the Blazor Server circuit.

Default `Sizing="Fixed"` is not affected — there is no await before the synchronous serialization, so nothing can dispose the reference in between.

### Fix

- Track a `_disposed` flag, set at the start of `DisposeAsyncCore` before the reference is disposed.
- Guard the first-render blur attach with `!_disposed`.

The guard check and the synchronous argument serialization are atomic on the renderer's single-threaded sync context, so this closes the race in both Debug and Release. Mirrors the existing `_disposed` pattern in `MudFocusTrap`.

### How Has This Been Tested?

On a Blazor Server harness, with the `mudInputSizing.init` round-trip artificially widened to make the race deterministic: mounting a batch of auto-grow fields and disposing them mid-await reproduces the reported stack trace and disconnects the circuit on `dev`, and no longer crashes with this change.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests
