### PR TITLE
MudPagination: Allow BoundaryCount to be zero

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -133,11 +133,10 @@ namespace MudBlazor.UnitTests.Components
         /// <param name="expectedSelectedPage">The expected selected page.</param>
         [TestCase(0, 6, 1)]
         [TestCase(6, 6, 11)]
-        [TestCase(5, 5, 6)]
-        [TestCase(2, 5, 3)]
+        [TestCase(5, 5, 10)]
+        [TestCase(2, 5, 4)]
         [Test]
-        public async Task PaginationPageButtonClick(int clickIndexPage, int initiallySelectedPage,
-            int expectedSelectedPage)
+        public async Task PaginationPageButtonClick(int clickIndexPage, int initiallySelectedPage, int expectedSelectedPage)
         {
             var comp = Context.Render<PaginationButtonTest>();
 
@@ -227,11 +226,12 @@ namespace MudBlazor.UnitTests.Components
         /// <param name="count">The number of total items.</param>
         /// <param name="middleCount">The number of items displayed in the middle.</param>
         /// <param name="boundaryCount">The number of items displayed on the start and end.</param>
-        [TestCase(21, 5, 7)]
-        [TestCase(9, 3, 2)]
-        [TestCase(5, 1, 1)]
-        [TestCase(5, -1, 1)]
-        [TestCase(5, 1, -1)]
+        [TestCase(19, 5, 7)]
+        [TestCase(7, 3, 2)]
+        [TestCase(3, 1, 1)]
+        [TestCase(3, -1, 1)]
+        [TestCase(1, 1, -1)]
+        [TestCase(1, 1, 0)]
         [Test]
         public async Task PaginationCountWithoutEllipsis(int count, int middleCount, int boundaryCount)
         {
@@ -243,14 +243,16 @@ namespace MudBlazor.UnitTests.Components
 
             //Expected values
             pagination.GetState(x => x.MiddleCount).Should().Be(Math.Max(1, middleCount));
-            pagination.GetState(x => x.BoundaryCount).Should().Be(Math.Max(1, boundaryCount));
+            pagination.GetState(x => x.BoundaryCount).Should().Be(Math.Max(0, boundaryCount));
 
             for (var i = 1; i <= count; i++)
             {
                 await comp.Find(".mud-pagination-test-count input").ChangeAsync(i.ToString());
                 var buttons = comp.FindAll(".mud-pagination-item");
                 //Expected values
-                buttons.Count.Should().Be(i);
+                //buttons.Count.Should().Be(i);
+                string.Join(", ", buttons.Select(i => i.TextContent)).Should().BeEquivalentTo(string.Join(", ", Enumerable.Range(1, i).Select(i => i.ToString())));
+
                 for (var j = 0; j < buttons.Count; j++)
                 {
                     buttons[j].TextContent.Should().Be((j + 1).ToString());
@@ -266,19 +268,25 @@ namespace MudBlazor.UnitTests.Components
         /// <param name="boundaryCount">The number of items at the start and end of the pagination.</param>
         /// <param name="expectedValues">The expected content of the items.</param>
         [TestCase(6, 11, 3, 2, new[] { "1", "2", "...", "5", "6", "7", "...", "10", "11" })]
-        [TestCase(7, 11, 3, 2, new[] { "1", "2", "...", "6", "7", "8", "9", "10", "11" })]
-        [TestCase(11, 11, 3, 2, new[] { "1", "2", "...", "6", "7", "8", "9", "10", "11" })]
-        [TestCase(5, 11, 3, 2, new[] { "1", "2", "3", "4", "5", "6", "...", "10", "11" })]
-        [TestCase(3, 11, 3, 2, new[] { "1", "2", "3", "4", "5", "6", "...", "10", "11" })]
+        [TestCase(7, 11, 3, 2, new[] { "1", "2", "...", "6", "7", "8", "...", "10", "11" })]
+        [TestCase(11, 11, 3, 2, new[] { "1", "2", "...", "7", "8", "9", "10", "11" })]
+        [TestCase(5, 11, 3, 2, new[] { "1", "2", "...", "4", "5", "6", "...", "10", "11" })]
+        [TestCase(3, 11, 3, 2, new[] { "1", "2", "3", "4", "5", "...", "10", "11" })]
         [TestCase(11, 22, 1, 1, new[] { "1", "...", "11", "...", "22" })]
-        [TestCase(1, 22, 1, 1, new[] { "1", "2", "3", "...", "22" })]
+        [TestCase(1, 22, 1, 1, new[] { "1", "2", "...", "22" })]
         [TestCase(8, 22, 5, 3, new[] { "1", "2", "3", "...", "6", "7", "8", "9", "10", "...", "20", "21", "22" })]
-        [TestCase(7, 22, 5, 3, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "...", "20", "21", "22" })]
-        [TestCase(16, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
-        [TestCase(22, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
+        [TestCase(7, 22, 5, 3, new[] { "1", "2", "3", "...", "5", "6", "7", "8", "9", "...", "20", "21", "22" })]
+        [TestCase(16, 22, 5, 3, new[] { "1", "2", "3", "...", "14", "15", "16", "17", "18", "...", "20", "21", "22" })]
+        [TestCase(22, 22, 5, 3, new[] { "1", "2", "3", "...", "15", "16", "17", "18", "19", "20", "21", "22" })]
+        [TestCase(8, 30, 11, 0, new[] { "...", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "..." })]
+        [TestCase(1, 30, 11, 0, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "..." })]
+        [TestCase(30, 30, 11, 0, new[] { "...", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
+        [TestCase(28, 30, 11, 0, new[] { "...", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
+        [TestCase(28, 30, 11, 1, new[] { "1", "...", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
+        [TestCase(27, 30, 11, 1, new[] { "1", "...", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
+        [TestCase(26, 30, 11, 1, new[] { "1", "...", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30" })]
         [Test]
-        public async Task PaginationCountWithEllipsis(int selectedPage, int count, int middleCount,
-            int boundaryCount, string[] expectedValues)
+        public async Task PaginationCountWithEllipsis(int selectedPage, int count, int middleCount, int boundaryCount, string[] expectedValues)
         {
             var comp = Context.Render<PaginationCountTest>();
 
@@ -293,11 +301,33 @@ namespace MudBlazor.UnitTests.Components
 
             //Expected values
             var items = comp.FindAll(".mud-pagination-item");
-            items.Count.Should().Be(middleCount + (2 * boundaryCount) + 2);
+            //items.Count.Should().Be(expectedValues.Length);
+            string.Join(", ", items.Select(i => i.TextContent)).Should().BeEquivalentTo(string.Join(", ", expectedValues));
             for (var j = 0; j < items.Count; j++)
             {
                 items[j].TextContent.Should().Be(expectedValues[j]);
             }
+        }
+
+        /// <summary>
+        /// Tests that a <see cref="MudPagination.BoundaryCount"/> of zero set via the initial parameters
+        /// hides the boundary pages instead of being clamped to one.
+        /// Verifies https://github.com/MudBlazor/MudBlazor/issues/13181
+        /// </summary>
+        [Test]
+        public void PaginationBoundaryCountZeroInitialParameter()
+        {
+            var comp = Context.Render<MudPagination>(parameters => parameters
+                .Add(x => x.Count, 30)
+                .Add(x => x.MiddleCount, 11)
+                .Add(x => x.BoundaryCount, 0)
+                .Add(x => x.Selected, 8)
+                .Add(x => x.ShowPreviousButton, false)
+                .Add(x => x.ShowNextButton, false));
+
+            var items = comp.FindAll(".mud-pagination-item");
+            items.Select(x => x.TextContent).Should()
+                .Equal("...", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "...");
         }
 
         /// <summary>
@@ -313,7 +343,7 @@ namespace MudBlazor.UnitTests.Components
             var paginationItems = comp.FindAll("mud-pagination-item");
 
             //test if previous and next buttons are hidden
-            buttons.Count.Should().Be(8);
+            buttons.Count.Should().Be(7);
 
             //test if variant is filled
             pagination.ClassName.Should().Contain("mud-pagination-filled");

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -2,6 +2,7 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -76,8 +77,9 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>1</c>. <br />
+        /// A value of <c>0</c> would hide the page numbers at the edge: <c>&lt; ... 4 5 6 ... &gt;</c> <br />
         /// A value of <c>1</c> would show one-page number at the edge: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c> <br />
-        /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c> 
+        /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c>
         /// </remarks>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Appearance)]
@@ -266,67 +268,60 @@ namespace MudBlazor
          -1 is displayed as "..." in the ui*/
         private int[] GeneratePagination()
         {
-            //return array {1, ..., Count} if Count is small 
-            if (_countState.Value <= 4 || _countState.Value <= (2 * _boundaryCountState.Value) + _middleCountState.Value + 2)
-            {
-                var result = new int[_countState.Value];
-                for (var i = 0; i < _countState.Value; i++)
-                {
-                    result[i] = i + 1;
-                }
+            var totalCount = _countState.Value;
+            var page = _selectedState.Value;
+            var boundary = _boundaryCountState.Value;
 
-                return result;
-            }
+            var totalCountIsEven = totalCount % 2 == 0;
 
-            var length = (2 * _boundaryCountState.Value) + _middleCountState.Value + 2;
+            var leftBoundary = Math.Clamp(boundary, 0, totalCountIsEven ? totalCount / 2 : (totalCount - 1) / 2);
+            var rightBoundary = Math.Clamp(boundary, 0, totalCountIsEven ? totalCount / 2 : (totalCount - 1) / 2);
+
+            var middleCount = Math.Clamp(_middleCountState.Value, 0, totalCount - leftBoundary - rightBoundary);
+
+            var middleCountIsEven = middleCount % 2 == 0;
+
+            var pageIsInLowerBoundary = page <= boundary;
+            var pageIsInUpperBoundary = page >= totalCount - boundary;
+
+            var firstPageOfMiddle =
+                Math.Clamp(
+                    page - ((middleCountIsEven ? middleCount : middleCount - 1) / 2),
+                    leftBoundary + 1,
+                    totalCount - rightBoundary - middleCount + 1);
+
+            var lastPageOfMiddle = firstPageOfMiddle + middleCount - 1;
+
+            var leftElipsis = firstPageOfMiddle > leftBoundary + 1;
+            var rightElipsis = lastPageOfMiddle < totalCount - rightBoundary;
+
+            var length = Math.Min(totalCount, leftBoundary + rightBoundary + middleCount + (leftElipsis ? 1 : 0) + (rightElipsis ? 1 : 0));
+
             var pages = new int[length];
 
-            //set start boundary items, e.g. if BoundaryCount == 3 => [1, 2, 3, ...]
-            for (var i = 0; i < _boundaryCountState.Value; i++)
+            for (var i = 0; i < Math.Min(totalCount, leftBoundary); i++)
             {
                 pages[i] = i + 1;
             }
 
-            //set end boundary items, e.g. if BoundaryCount == 3 and Count == 11 => [..., 9, 10, 11]
-            for (var i = 0; i < _boundaryCountState.Value; i++)
+            for (var i = length - 1; i > length - rightBoundary - 1; i--)
             {
-                pages[length - i - 1] = _countState.Value - i;
+                pages[i] = totalCount - (length - i - 1);
             }
 
-            //calculate start value for middle items
-            int startValue;
-            if (_selectedState.Value <= _boundaryCountState.Value + (_middleCountState.Value / 2) + 1)
+            if (leftElipsis)
             {
-                startValue = _boundaryCountState.Value + 2;
-            }
-            else if (_selectedState.Value >= _countState.Value - _boundaryCountState.Value - (_middleCountState.Value / 2))
-            {
-                startValue = _countState.Value - _boundaryCountState.Value - _middleCountState.Value;
-            }
-            else
-            {
-                startValue = _selectedState.Value - (_middleCountState.Value / 2);
+                pages[leftBoundary] = -1;
             }
 
-            //set middle items, e.g. if MiddleCount == 3 and Selected == 5 and Count == 11 => [..., 4, 5, 6, ...] 
-            for (var i = 0; i < _middleCountState.Value; i++)
+            if (rightElipsis)
             {
-                pages[_boundaryCountState.Value + 1 + i] = startValue + i;
+                pages[length - rightBoundary - 1] = -1;
             }
 
-            //set start delimiter "..." when selected page is far enough to the end, dots are represented as -1
-            pages[_boundaryCountState.Value] = (_boundaryCountState.Value + (_middleCountState.Value / 2) + 1 < _selectedState.Value) ? -1 : _boundaryCountState.Value + 1;
-
-            //set end delimiter "..." when selected page is far enough to the start, dots are represented as -1
-            pages[length - _boundaryCountState.Value - 1] = (_countState.Value - _boundaryCountState.Value - (_middleCountState.Value / 2) > _selectedState.Value) ? -1 : _countState.Value - _boundaryCountState.Value;
-
-            //remove ellipsis if difference is small enough, e.g convert [..., 5 , -1 , 7, ...] to [..., 5, 6, 7, ...]
-            for (var i = 0; i < length - 2; i++)
+            for (var i = 0; i < middleCount; i++)
             {
-                if (pages[i] + 2 == pages[i + 2])
-                {
-                    pages[i + 1] = pages[i] + 1;
-                }
+                pages[leftBoundary + (leftElipsis ? 1 : 0) + i] = firstPageOfMiddle + i;
             }
 
             return pages;
@@ -378,7 +373,7 @@ namespace MudBlazor
 
         private Task SetBoundaryCount(int count)
         {
-            var newCount = Math.Max(1, count);
+            var newCount = Math.Max(0, count);
 
             return _boundaryCountState.SetValueAsync(newCount);
         }

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -274,54 +274,50 @@ namespace MudBlazor
 
             var totalCountIsEven = totalCount % 2 == 0;
 
-            var leftBoundary = Math.Clamp(boundary, 0, totalCountIsEven ? totalCount / 2 : (totalCount - 1) / 2);
-            var rightBoundary = Math.Clamp(boundary, 0, totalCountIsEven ? totalCount / 2 : (totalCount - 1) / 2);
+            var actualBoundary = Math.Clamp(boundary, 0, totalCountIsEven ? totalCount / 2 : (totalCount - 1) / 2);
 
-            var middleCount = Math.Clamp(_middleCountState.Value, 0, totalCount - leftBoundary - rightBoundary);
+            var middleCount = Math.Clamp(_middleCountState.Value, 0, totalCount - actualBoundary - actualBoundary);
 
             var middleCountIsEven = middleCount % 2 == 0;
-
-            var pageIsInLowerBoundary = page <= boundary;
-            var pageIsInUpperBoundary = page >= totalCount - boundary;
 
             var firstPageOfMiddle =
                 Math.Clamp(
                     page - ((middleCountIsEven ? middleCount : middleCount - 1) / 2),
-                    leftBoundary + 1,
-                    totalCount - rightBoundary - middleCount + 1);
+                    actualBoundary + 1,
+                    totalCount - actualBoundary - middleCount + 1);
 
             var lastPageOfMiddle = firstPageOfMiddle + middleCount - 1;
 
-            var leftElipsis = firstPageOfMiddle > leftBoundary + 1;
-            var rightElipsis = lastPageOfMiddle < totalCount - rightBoundary;
+            var leftElipsis = firstPageOfMiddle > actualBoundary + 1;
+            var rightElipsis = lastPageOfMiddle < totalCount - actualBoundary;
 
-            var length = Math.Min(totalCount, leftBoundary + rightBoundary + middleCount + (leftElipsis ? 1 : 0) + (rightElipsis ? 1 : 0));
+            var length = Math.Min(totalCount, actualBoundary + actualBoundary + middleCount + (leftElipsis ? 1 : 0) + (rightElipsis ? 1 : 0));
 
             var pages = new int[length];
 
-            for (var i = 0; i < Math.Min(totalCount, leftBoundary); i++)
+            for (var i = 0; i < Math.Min(totalCount, actualBoundary); i++)
             {
                 pages[i] = i + 1;
             }
 
-            for (var i = length - 1; i > length - rightBoundary - 1; i--)
+            for (var i = length - 1; i > length - actualBoundary - 1; i--)
             {
                 pages[i] = totalCount - (length - i - 1);
             }
 
             if (leftElipsis)
             {
-                pages[leftBoundary] = -1;
+                pages[actualBoundary] = -1;
             }
 
             if (rightElipsis)
             {
-                pages[length - rightBoundary - 1] = -1;
+                pages[length - actualBoundary - 1] = -1;
             }
 
             for (var i = 0; i < middleCount; i++)
             {
-                pages[leftBoundary + (leftElipsis ? 1 : 0) + i] = firstPageOfMiddle + i;
+                pages[actualBoundary + (leftElipsis ? 1 : 0) + i] = firstPageOfMiddle + i;
             }
 
             return pages;


### PR DESCRIPTION
Refactor pagination logic to support hiding boundary pages when BoundaryCount is set to zero. Update and expand unit tests to cover this behaviour, including new cases and adjusted assertions to match the revised pagination output.

Fixes #13181

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
