### PR TITLE
MudDatePicker, MudTimePicker: Prevent raising DateChanged and TimeChanged when set from parent

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -927,7 +927,25 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.Date, today));
 
             comp.Instance.Date.Should().Be(today);
-            wasEventCallbackCalled.Should().BeTrue();
+            // A programmatic/parent assignment updates the value but must NOT raise DateChanged (#10834,
+            // follow-up to #13428): the parent set the value, so echoing an event back to it is the bug.
+            wasEventCallbackCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task DateChanged_ShouldNotFire_WhenDateSetFromParent()
+        {
+            var eventCount = 0;
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(x => x.DateChanged, (DateTime? _) => eventCount++));
+
+            // Assigning Date from a parent is programmatic, not user interaction; it must update the display
+            // without raising DateChanged (#10834, follow-up to #13428).
+            var date = new DateTime(2022, 3, 14);
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(picker => picker.Date, date));
+
+            comp.Instance.Date.Should().Be(date);
+            eventCount.Should().Be(0);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -417,6 +417,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task TimeChanged_ShouldNotFire_WhenTimeSetFromParent()
+        {
+            var eventCount = 0;
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(p => p.TimeChanged, (TimeSpan? _) => eventCount++));
+
+            // Assigning Time from a parent is programmatic, not user interaction; it must update the value
+            // without raising TimeChanged (#10834, follow-up to #13428).
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Time, new TimeSpan(9, 15, 0)));
+
+            comp.Instance.Time.Should().Be(new TimeSpan(9, 15, 0));
+            eventCount.Should().Be(0);
+        }
+
+        [Test]
+        public async Task TimeChanged_ShouldFire_WhenUserPicksTime()
+        {
+            var eventCount = 0;
+            TimeSpan? changed = null;
+            var comp = Context.Render<MudTimePicker>(parameters => parameters
+                .Add(p => p.PickerVariant, PickerVariant.Static)
+                .Add(p => p.Time, new TimeSpan(10, 30, 0)) // parent init must NOT count as a change
+                .Add(p => p.TimeChanged, (TimeSpan? t) => { eventCount++; changed = t; }));
+            var picker = comp.Instance;
+
+            // A user clock pick followed by a commit is the user-driven path that MUST notify the parent.
+            await comp.InvokeAsync(() => picker.SelectTimeFromStick(5, false));
+            await comp.InvokeAsync(picker.SubmitAsync);
+
+            eventCount.Should().Be(1);
+            changed.Should().Be(picker.Time);
+            picker.Time.Should().NotBe(new TimeSpan(10, 30, 0));
+        }
+
+        [Test]
         public async Task SelectTimeFromStick_IgnoresSentinelValue()
         {
             var comp = await OpenPicker(parameters => parameters.Add(x => x.Time, new TimeSpan(8, 20, 0)));

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -27,10 +27,12 @@ namespace MudBlazor
         public DateTime? Date
         {
             get => _value;
-            // Assigning Date from the parameter is programmatic, not user interaction. Pass the suppression
-            // as an explicit argument (NOT an instance flag) so it cannot leak across the awaits inside
-            // SetDateAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
-            set => SetDateAsync(value, updateValue: true, forceUpdate: false, suppressInteraction: true).CatchAndLog();
+            // Assigning Date from the parameter is programmatic, not user interaction. Pass suppression AND
+            // notify: false as explicit arguments (NOT instance flags) so they cannot leak across the awaits
+            // inside SetDateAsync into a concurrent user calendar pick on Blazor Server (PR #13328 review).
+            // notify: false stops DateChanged from firing on a parent/programmatic assignment - echoing back an
+            // event the parent never triggered is the feedback loop reported in #10834 (follow-up to #13428).
+            set => SetDateAsync(value, updateValue: true, forceUpdate: false, suppressInteraction: true, notify: false).CatchAndLog();
         }
 
         private DateTimeOffset _lastSetTime = DateTimeOffset.MinValue;
@@ -39,7 +41,7 @@ namespace MudBlazor
         protected Task SetDateAsync(DateTime? date, bool updateValue)
             => SetDateAsync(date, updateValue, false);
 
-        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate, bool suppressInteraction = false)
+        protected async Task SetDateAsync(DateTime? date, bool updateValue, bool forceUpdate, bool suppressInteraction = false, bool notify = true)
         {
             if (_value != null && date != null && date.Value.Kind == DateTimeKind.Unspecified)
             {
@@ -92,7 +94,13 @@ namespace MudBlazor
                     await SetTextAsync(ConvertSet(_value), false);
                 }
 
-                await DateChanged.InvokeAsync(_value);
+                // Programmatic/parent assignments pass notify: false and must not raise DateChanged (#10834);
+                // genuine user changes keep the default notify: true. The display update above still runs either
+                // way, so a parent assignment (even null, to clear stale invalid text) is fully reflected.
+                if (notify)
+                {
+                    await DateChanged.InvokeAsync(_value);
+                }
                 await BeginValidateAsync();
                 if (!suppressInteraction)
                 {

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -140,9 +140,12 @@ namespace MudBlazor
         public TimeSpan? Time
         {
             get => _value;
-            // Programmatic parameter assignment; pass suppression explicitly so it cannot leak across the
-            // awaits inside SetTimeAsync into a concurrent user clock pick on Blazor Server (PR #13328 review).
-            set => SetTimeAsync(value, updateValue: true, suppressInteraction: true).CatchAndLog();
+            // Programmatic parameter assignment; pass suppression AND notify: false explicitly so they cannot
+            // leak across the awaits inside SetTimeAsync into a concurrent user clock pick on Blazor Server
+            // (PR #13328 review). notify: false stops TimeChanged from firing on a parent/programmatic assignment
+            // - echoing back an event the parent never triggered is the feedback loop reported in #10834
+            // (follow-up to #13428).
+            set => SetTimeAsync(value, updateValue: true, suppressInteraction: true, notify: false).CatchAndLog();
         }
 
         /// <summary>
@@ -157,7 +160,8 @@ namespace MudBlazor
         /// <param name="time">The new value to set.</param>
         /// <param name="updateValue">When <c>true</c>, the <c>Text</c> will also be updated.</param>
         /// <param name="suppressInteraction">When <c>true</c>, the change is treated as programmatic and does not mark the picker touched or fire <c>FieldChanged</c>.</param>
-        protected async Task SetTimeAsync(TimeSpan? time, bool updateValue, bool suppressInteraction = false)
+        /// <param name="notify">When <c>false</c>, <c>TimeChanged</c> is not raised (used for programmatic/parent assignments; see <see cref="Time"/>).</param>
+        protected async Task SetTimeAsync(TimeSpan? time, bool updateValue, bool suppressInteraction = false, bool notify = true)
         {
             if (_value != time)
             {
@@ -173,7 +177,12 @@ namespace MudBlazor
                 }
 
                 UpdateTimeSetFromTime();
-                await TimeChanged.InvokeAsync(_value);
+                // Programmatic/parent assignments pass notify: false and must not raise TimeChanged (#10834);
+                // genuine user changes keep the default notify: true.
+                if (notify)
+                {
+                    await TimeChanged.InvokeAsync(_value);
+                }
                 await BeginValidateAsync();
                 if (!suppressInteraction)
                 {


### PR DESCRIPTION
## Description

Follow-up to #13428 (per @danielchalmers' review question there: *"Should we update `MudDatePicker.Date` too? (And `MudTimePicker.Time`?)"*).

`MudDatePicker.Date` and `MudTimePicker.Time` have the same feedback-loop bug that #13428 fixes for `MudDateRangePicker.DateRange`:

- Their setters call `SetDateAsync` / `SetTimeAsync`, which always invoked `DateChanged.InvokeAsync` / `TimeChanged.InvokeAsync`.
- Because Blazor drives a **parent/programmatic** parameter assignment through the property setter, the change event fired even when the value came from the parent — echoing back an event the parent never triggered (a feedback loop), which is the class of issue in #10834.

The `suppressInteraction: true` flag those setters already pass only guards `Touched` / `FieldChanged`; it never gated the change callback.

## Fix

The setters already pass `suppressInteraction: true` as an **explicit argument** (not an instance flag) specifically so it can't leak across the `await`s into a concurrent user pick on Blazor Server (PR #13328). This change adds a second explicit argument in the same spirit:

- `Set{Date,Time}Async` gains `bool notify = true`; the change event is raised only when `notify` is `true`.
- The `Date` / `Time` setters pass `notify: false`, so a parent/programmatic assignment updates the display (value, text, highlighted date / intermediate time) **without** raising `DateChanged` / `TimeChanged`.
- Every other caller — user calendar/clock selection, clear, text edit, submit — keeps the default `notify: true`, preserving the two-way-binding write-back and all existing user-facing behavior.

The public API (`Date` / `Time` getter+setter and `DateChanged` / `TimeChanged`) is unchanged.

### Why the explicit `notify` argument instead of the `ParameterState` migration used in #13428

I started with the same `ParameterState` migration as #13428, but on `MudDatePicker` it regresses `DataPicker_ShouldClearText_WhenDateSetNull`: `ParameterState` gates its change handler on value-equality, so a parent assignment of `Date = null` while `Date` is *already* `null` (with stale invalid `Text`) is not detected as a change, and the existing `(date is null && Text != null)` text-clear branch never runs. The explicit-`notify` approach keeps the setter's display update running unconditionally (so a parent assignment — including a `null` that clears stale invalid text — is fully reflected) while suppressing only the event, and it reuses the pattern the code already established for `suppressInteraction`. Happy to switch both pickers to `ParameterState` for consistency if you'd prefer — just flag it.

## Tests

- `DateChanged_ShouldNotFire_WhenDateSetFromParent`
- `TimeChanged_ShouldNotFire_WhenTimeSetFromParent`
- `TimeChanged_ShouldFire_WhenUserPicksTime` (real clock pick + submit)
- Updated `IsDateDisabledFunc_SettingDateToAnEnabledDateYieldsTheDate` to assert the new contract (a parent assignment sets the value but does not fire `DateChanged`).

All `DatePickerTests` (165), `TimePickerTests`, and `DateRangePickerTests` (79) pass locally.
