### PR TITLE
Test Viewer: Emit `data-viewer-state=ready` on the rendered surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,8 +319,9 @@ Reproduction loop:
 2. Build the viewer with `dotnet build src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj /p:SkipBunCompile=true`. Components are discovered by reflection at startup, so a newly added file is not visible until the app is rebuilt and reloaded; `dotnet watch` does not reliably pick up added files or routes.
 3. Run it with `dotnet run --project src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj` and open `/viewer/<path>`, where `<path>` is the folder relative to `TestComponents` plus the type name (e.g. `/viewer/Menu/MenuEdgeCasesTest`).
 4. Set visual state through the query string: `theme=light|dark`, `dir=ltr|rtl`, `chrome=full|none`. `chrome=none` hides the viewer UI (drawer and header) while keeping theme, RTL, and the popover/dialog/snackbar providers intact, which is useful for clean screenshots.
-5. Capture the route, query parameters, viewport, and steps as before/after evidence.
-6. Delete the component (and rebuild) when done; a scratch component is removed with a single file delete.
+5. Wait for `data-viewer-state="ready"` on the `.test-viewer-surface` before reading it (`error`/`not-found` mean the component threw or the route was unmatched; the landing page has no marker). On first load the WASM runtime boots for a few seconds before any state appears, so poll with a timeout. The surface also carries `data-viewer-theme`/`-dir`/`-chrome` reflecting the query state.
+6. Capture the route, query parameters, viewport, and steps as before/after evidence.
+7. Delete the component (and rebuild) when done; a scratch component is removed with a single file delete.
 
 Use `@attribute [ViewerHidden]` for helper or sub-components that are not meaningful to open on their own; they stay routable but are kept out of the sidebar listing.
 

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -88,7 +88,6 @@
                         <ErrorBoundary @key="_selectedType">
                             <ChildContent>
                                 @* Positive readiness marker so tooling can wait on a mounted, non-errored component. *@
-                                @* display:contents keeps the wrapper out of layout so the surface renders identically. *@
                                 <div class="test-viewer-ready" data-viewer-state="ready">
                                     @TestComponent()
                                 </div>
@@ -209,7 +208,6 @@
         overflow: auto;
     }
 
-    /* Transparent box: carries the data-viewer-state=ready marker without affecting the surface layout. */
     .test-viewer-ready {
         display: contents;
     }

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -87,7 +87,11 @@
                         @* Keyed by the selected type so switching components starts a fresh, non-errored boundary. *@
                         <ErrorBoundary @key="_selectedType">
                             <ChildContent>
-                                @TestComponent()
+                                @* Positive readiness marker so tooling can wait on a mounted, non-errored component. *@
+                                @* display:contents keeps the wrapper out of layout so the surface renders identically. *@
+                                <div class="test-viewer-ready" data-viewer-state="ready">
+                                    @TestComponent()
+                                </div>
                             </ChildContent>
                             <ErrorContent Context="exception">
                                 <div class="test-viewer-error" data-viewer-state="error">
@@ -203,6 +207,11 @@
     .test-viewer-surface {
         flex: 1;
         overflow: auto;
+    }
+
+    /* Transparent box: carries the data-viewer-state=ready marker without affecting the surface layout. */
+    .test-viewer-ready {
+        display: contents;
     }
 
     .test-viewer-title-row {


### PR DESCRIPTION
## What

The test viewer (`MudBlazor.UnitTests.Viewer`) already exposes `data-viewer-state` on its error and not-found branches, but the success branch rendered the selected component with no positive signal. Automated drivers — browser agents and screenshot/capture tooling — had nothing to wait on to know a component had actually mounted.

This adds a positive `data-viewer-state="ready"` marker so the surface reports every state:

- `ready` — selected component mounted without throwing
- `error` — component threw (existing)
- `not-found` — route matched no component (existing)
- *(no marker)* — landing page, or the WASM runtime is still booting

The marker is wrapped in a `display:contents` element, so it adds the attribute without changing the surface layout, and only one `data-viewer-state` is ever in the DOM at a time.

## Docs

`AGENTS.md`'s viewer repro loop now documents the signal: wait for `ready` before reading the surface, poll through the WASM boot, and the `data-viewer-theme`/`-dir`/`-chrome` attributes the surface reflects.

## Why

Follow-up to the viewer agentic-host series (#13303–#13309), which flagged a render-ready signal as an open gap. It lets a repro/capture tool deterministically wait for a component instead of guessing at timing.

## Verification

- Builds clean (`MudBlazor.UnitTests.Viewer`, no new warnings).
- Verified in a browser across all four states, RTL, dark mode, and `chrome=none`: exactly one `data-viewer-state` present at each step, and the surface layout unchanged.
