### PR TITLE
MudDataGrid: Support sticky aggregate rows in footer

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridAggregationStickyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridAggregationStickyTest.razor
@@ -1,0 +1,22 @@
+﻿<MudDataGrid Items="@_items" HorizontalScrollbar="true" Bordered="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" AggregateDefinition="@(new AggregateDefinition<Model>())" StickyLeft="true">
+            <AggregateTemplate>
+                @context.Count()
+            </AggregateTemplate>
+        </PropertyColumn>
+        <PropertyColumn Property="x => x.Age" AggregateDefinition="@(new AggregateDefinition<Model>{ Type = AggregateType.Avg })" />
+        <PropertyColumn Property="x => x.Salary" AggregateDefinition="@(new AggregateDefinition<Model>{ Type = AggregateType.Sum })" StickyRight="true" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public record Model(string Name, int Age, decimal Salary);
+
+    private readonly IEnumerable<Model> _items = new List<Model>
+    {
+        new("Sam", 56, 50000M),
+        new("Alicia", 54, 75000M),
+        new("Ira", 27, 102000M)
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4726,6 +4726,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DataGridAggregateFooterSticky()
+        {
+            var comp = Context.Render<DataGridAggregationStickyTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridAggregationStickyTest.Model>>();
+
+            var allFooter = dataGrid.FindAll("tfoot td");
+            allFooter.First().ClassList.Should().Contain("sticky-left");
+            allFooter.Last().ClassList.Should().Contain("sticky-right");
+        }
+
+        [Test]
         public void DataGridStickyColumnsResizer()
         {
             var comp = Context.Render<DataGridStickyColumnsResizerTest>();

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -524,6 +524,8 @@ namespace MudBlazor
             new CssBuilder("mud-table-cell")
                 .AddClass("footer-cell")
                 .AddClass("mud-table-cell-hide", HideSmall)
+                .AddClass("sticky-left", StickyLeft)
+                .AddClass("sticky-right", StickyRight)
                 .AddClass(Class)
                 .Build();
 


### PR DESCRIPTION
fixes #13143

the `sticky-left` and `sticky-right` classes just weren't applied to the footer.

<img width="781" height="685" alt="grafik" src="https://github.com/user-attachments/assets/8793e3af-9b29-43e6-9eb0-4efaca3bff0b" />


**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
