### PR TITLE
Docs: Point mobile nav Learn More link to the Team page

### DIFF
--- a/src/MudBlazor.Docs/Shared/DocsLayout.razor
+++ b/src/MudBlazor.Docs/Shared/DocsLayout.razor
@@ -19,7 +19,7 @@
                 <MudNavMenu Color="Color.Primary" Margin="Margin.Dense" Rounded="true" Class="pa-2">
                     <MudNavLink Href="/getting-started/installation">Get Started</MudNavLink>
                     <MudNavLink Href="/docs/overview">Docs</MudNavLink>
-                    <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Learn More</MudNavLink>
+                    <MudNavLink Href="/mud/project/team" Match="NavLinkMatch.All">Learn More</MudNavLink>
                     <MudNavGroup Title="Projects" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                         <MudListSubheader Class="mt-4 pl-8 pb-2"><b>Official</b></MudListSubheader>
                         <MudNavLink Href="https://mudblazor.com/">MudBlazor</MudNavLink>

--- a/src/MudBlazor.Docs/Shared/LandingLayout.razor
+++ b/src/MudBlazor.Docs/Shared/LandingLayout.razor
@@ -14,7 +14,7 @@
         <MudNavMenu Color="Color.Primary" Margin="Margin.Dense" Rounded="true" Class="pa-2">
             <MudNavLink Href="/getting-started/installation">Get Started</MudNavLink>
             <MudNavLink Href="/docs/overview">Docs</MudNavLink>
-            <MudNavLink Href="/mud/introduction" Match="NavLinkMatch.All">Learn More</MudNavLink>
+            <MudNavLink Href="/mud/project/team" Match="NavLinkMatch.All">Learn More</MudNavLink>
             <MudNavGroup Title="Projects" ExpandIcon="@Icons.Material.Filled.ExpandMore">
                 <MudListSubheader Class="mt-4 pl-8 pb-2"><b>Official</b></MudListSubheader>
                 <MudNavLink Href="https://mudblazor.com/">MudBlazor</MudNavLink>


### PR DESCRIPTION
The "Learn More" entry in the mobile navigation drawer opened `/mud/introduction`, while the desktop app bar button opens `/mud/project/team`.

[#11534](https://github.com/MudBlazor/MudBlazor/pull/11534) repointed the desktop app bar "Learn More" button to the Team page but left the two mobile drawer copies on the old `/mud/introduction` target.

Changes:
- `DocsLayout.razor` — mobile drawer "Learn More" now links to `/mud/project/team`
- `LandingLayout.razor` — mobile drawer "Learn More" now links to `/mud/project/team`

Both drawers mirror the same shared desktop app bar button, so both now match desktop behavior.
