### PR TITLE
MudProgressLinear: Fix striped animation loop jump

### DIFF
--- a/src/MudBlazor/Styles/core/_animations.scss
+++ b/src/MudBlazor/Styles/core/_animations.scss
@@ -244,6 +244,6 @@
   }
 
   100% {
-    background-position: 300px 0;
+    background-position: 320px 0;
   }
 }


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

## Description

Fixes #13444.

The striped `MudProgressLinear` background repeats every `40px`, but the existing animation ended at `300px`. Since `300 % 40 = 20`, the animation loop can restart on a different stripe phase and visibly jump.

This changes the animation end offset to `320px`, which is an exact multiple of the `40px` stripe width. That keeps the existing animation duration while making the loop boundary phase-aligned.

## Visual verification

![MudProgressLinear striped before/after](https://gist.githubusercontent.com/roian6/61daeb09c914056fb1d9b7776d508331/raw/a8a52349ff3c201e523725b1056251c6bffe55e8/mudprogresslinear-striped-before-after.gif)

High-quality MP4: https://gist.githubusercontent.com/roian6/61daeb09c914056fb1d9b7776d508331/raw/50aa73e53d2399a65361cfab4ca9958a6f6de904/mudprogresslinear-striped-before-after.mp4

## Validation

- `cd src && bun install --frozen-lockfile`
- `cd src/MudBlazor && bun run build.mjs`
- `dotnet build src/MudBlazor -f net10.0`
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj -f net10.0 --filter 'FullyQualifiedName~ProgressLinear'`

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] Relevant verification was run. This is a CSS-only styling change, so no new unit test was added.
