### PR TITLE
MudChart: Add value labels (ShowValues) to Bar and StackedBar charts

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/BarChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/BarChartPage.razor
@@ -16,6 +16,15 @@
         </DocsPageSection>
 
         <DocsPageSection>
+            <SectionHeader Title="Value Labels">
+                <Description>Set <CodeInline>ShowValues</CodeInline> in <CodeInline>BarChartOptions</CodeInline> to display the value above each bar.</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(BarValueLabelsExample)">
+                <BarValueLabelsExample />
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Custom SVG Content" />
             <SectionContent Code="@nameof(BarCustomGraphicsExample)">
                 <BarCustomGraphicsExample />

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarValueLabelsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarValueLabelsExample.razor
@@ -1,0 +1,16 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudChart ChartType="ChartType.Bar" ChartSeries="@_series" ChartLabels="@_xAxisLabels"
+          ChartOptions="@_options" Width="100%" Height="350px" />
+
+@code {
+    private readonly BarChartOptions _options = new() { ShowValues = true };
+
+    private readonly List<ChartSeries<double>> _series =
+    [
+        new() { Name = "United States", Data = new double[] { 40, 20, 25, 27, 46 } },
+        new() { Name = "Germany", Data = new double[] { 19, 24, 35, 13, 28 } },
+    ];
+
+    private readonly string[] _xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May" };
+}

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarValueLabelsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarValueLabelsExample.razor
@@ -1,0 +1,17 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudChart ChartType="ChartType.StackedBar" ChartSeries="@_series" ChartLabels="@_xAxisLabels"
+          ChartOptions="@_options" Width="100%" Height="350px" />
+
+@code {
+    private readonly StackedBarChartOptions _options = new() { ShowValues = true };
+
+    private readonly List<ChartSeries<double>> _series =
+    [
+        new() { Name = "United States", Data = new double[] { 40, 20, 25, 27, 46 } },
+        new() { Name = "Germany", Data = new double[] { 19, 24, 35, 13, 28 } },
+        new() { Name = "Sweden", Data = new double[] { 8, 6, 11, 13, 4 } },
+    ];
+
+    private readonly string[] _xAxisLabels = { "Jan", "Feb", "Mar", "Apr", "May" };
+}

--- a/src/MudBlazor.Docs/Pages/Components/Charts/StackedBarChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/StackedBarChartPage.razor
@@ -16,6 +16,15 @@
         </DocsPageSection>
         
         <DocsPageSection>
+            <SectionHeader Title="Value Labels">
+                <Description>Set <CodeInline>ShowValues</CodeInline> in <CodeInline>StackedBarChartOptions</CodeInline> to display the total of all visible series above each bar.</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(StackedBarValueLabelsExample)">
+                <StackedBarValueLabelsExample/>
+            </SectionContent>
+        </DocsPageSection>
+
+        <DocsPageSection>
             <SectionHeader Title="Custom SVG Content">
                 <Description></Description>
             </SectionHeader>

--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -443,5 +443,63 @@ namespace MudBlazor.UnitTests.Charts
 
             comp.FindAll("path.mud-chart-bar").Count.Should().Be(2, because: "both data points render as bars");
         }
+
+        [Test]
+        public void BarChart_ShowValues_ShouldRenderValueLabels()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20 } },
+                new () { Name = "Series 2", Data = new double[] { 15, 25 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels)
+                .Add(p => p.ChartOptions, new BarChartOptions { ShowValues = true }));
+
+            var labels = comp.FindAll("text.mud-chart-value-label");
+            labels.Should().HaveCount(4, because: "each bar renders its own value label");
+            labels.Select(l => l.TextContent).Should().ContainInOrder("10", "20", "15", "25");
+        }
+
+        [Test]
+        public void BarChart_ShowValues_Default_ShouldNotRenderValueLabels()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels));
+
+            comp.FindAll("text.mud-chart-value-label").Should().BeEmpty(because: "ShowValues defaults to false");
+        }
+
+        [Test]
+        public void BarChart_ShowValues_YAxisFormat_ShouldFormatValueLabels()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 1000, 2000 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels)
+                .Add(p => p.ChartOptions, new BarChartOptions { ShowValues = true, YAxisFormat = "N0", YAxisTicks = 1000 }));
+
+            var labels = comp.FindAll("text.mud-chart-value-label");
+            labels.Should().HaveCount(2);
+            labels.Select(l => l.TextContent).Should().ContainInOrder(1000.ToString("N0"), 2000.ToString("N0"));
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/StackedBarChartTests.cs
@@ -1163,5 +1163,90 @@ namespace MudBlazor.UnitTests.Charts
 
             compShown.FindAll("path.mud-chart-bar").Count.Should().Be(4);
         }
+
+        [Test]
+        public void StackedBarChart_ShowValues_ShouldRenderTotalLabels()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20 } },
+                new () { Name = "Series 2", Data = new double[] { 15, 25 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels)
+                .Add(p => p.ChartOptions, new StackedBarChartOptions { ShowValues = true }));
+
+            var labels = comp.FindAll("text.mud-chart-value-label");
+            labels.Should().HaveCount(2, because: "one total label renders above each stacked bar");
+            labels.Select(l => l.TextContent).Should().ContainInOrder("25", "45");
+        }
+
+        [Test]
+        public void StackedBarChart_ShowValues_Default_ShouldNotRenderTotalLabels()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels));
+
+            comp.FindAll("text.mud-chart-value-label").Should().BeEmpty(because: "ShowValues defaults to false");
+        }
+
+        [Test]
+        public async Task StackedBarChart_ShowValues_HiddenSeries_ShouldExcludeFromTotals()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20 } },
+                new () { Name = "Series 2", Data = new double[] { 15, 25 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels)
+                .Add(p => p.CanHideSeries, true)
+                .Add(p => p.ChartOptions, new StackedBarChartOptions { ShowValues = true }));
+
+            comp.FindAll("text.mud-chart-value-label").Select(l => l.TextContent).Should().ContainInOrder("25", "45");
+
+            // Hide the second series; totals must recalculate from the visible series only.
+            var seriesCheckboxes = comp.FindAll(".mud-checkbox-input");
+            await seriesCheckboxes[1].ChangeAsync(false);
+
+            comp.FindAll("text.mud-chart-value-label").Select(l => l.TextContent).Should().ContainInOrder("10", "20");
+        }
+
+        [Test]
+        public void StackedBarChart_ShowValues_NegativeTotals_ShouldRenderBelowBars()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { -10, 20 } },
+                new () { Name = "Series 2", Data = new double[] { -15, 25 } }
+            };
+            string[] xAxisLabels = { "A", "B" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.StackedBar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels)
+                .Add(p => p.ChartOptions, new StackedBarChartOptions { ShowValues = true, YAxisTicks = 10 }));
+
+            var labels = comp.FindAll("text.mud-chart-value-label");
+            labels.Should().HaveCount(2);
+            labels.Select(l => l.TextContent).Should().ContainInOrder("-25", "45");
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor
@@ -66,6 +66,26 @@
             builder.AddAttribute(seq++, "onmouseout", EventCallback.Factory.Create(this, OnBarMouseOut));
             builder.CloseElement();
         }
+
+        if (ChartOptions!.ShowValues)
+        {
+            builder.OpenElement(seq++, "g");
+            builder.AddAttribute(seq++, "class", "mud-charts-value-labels");
+
+            foreach (var label in _valueLabels)
+            {
+                builder.OpenElement(seq++, "text");
+                builder.AddAttribute(seq++, "class", "mud-chart-value-label");
+                builder.AddAttribute(seq++, "x", ToS(label.X));
+                builder.AddAttribute(seq++, "y", ToS(label.Y));
+                builder.AddAttribute(seq++, "font-size", $"{ToS(ValueLabelFontSize)}px");
+                builder.AddAttribute(seq++, "text-anchor", "middle");
+                builder.AddContent(seq++, label.Value);
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+        }
     };
 
     private RenderFragment RenderTooltip() => builder =>

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor.cs
@@ -20,6 +20,7 @@ namespace MudBlazor.Charts
         public override RenderFragment? OverlayContent { get; set; }
 
         private readonly List<SvgPath> _bars = [];
+        private readonly List<SvgText> _valueLabels = [];
         private SvgPath? _hoveredBar;
 
         private double _barGroupWidth;
@@ -28,6 +29,8 @@ namespace MudBlazor.Charts
 
         private const double MinBarWidth = 6;
         private const double BarWidthFactor = 0.25;
+        private const double ValueLabelOffset = 5;
+        private const double ValueLabelFontSize = 12;
 
         protected override void OnInitialized()
         {
@@ -165,6 +168,7 @@ namespace MudBlazor.Charts
         private void GenerateBars(int lowestHorizontalLine, T gridYUnits, double horizontalSpace, double verticalSpace, int numVerticalLines)
         {
             _bars.Clear();
+            _valueLabels.Clear();
 
             var barGroupPositions = CalculateBarGroupPositions(horizontalSpace, numVerticalLines);
 
@@ -194,6 +198,21 @@ namespace MudBlazor.Charts
                         LabelY = dataValue <= T.Zero ? gridValueY : gridValue
                     };
                     _bars.Add(bar);
+
+                    if (ChartOptions!.ShowValues && series.Visible)
+                    {
+                        // Positive values render above the bar, negative values below it.
+                        var labelY = dataValue < T.Zero
+                            ? gridValue + ValueLabelOffset + ValueLabelFontSize
+                            : gridValue - ValueLabelOffset;
+
+                        _valueLabels.Add(new SvgText
+                        {
+                            X = gridValueX,
+                            Y = labelY,
+                            Value = BuildYAxisValueString(dataValue),
+                        });
+                    }
                 }
             }
         }

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
@@ -67,6 +67,26 @@
             builder.AddAttribute(seq++, "onmouseout", EventCallback.Factory.Create(this, OnBarMouseOut));
             builder.CloseElement();
         }
+
+        if (ChartOptions!.ShowValues)
+        {
+            builder.OpenElement(seq++, "g");
+            builder.AddAttribute(seq++, "class", "mud-charts-value-labels");
+
+            foreach (var label in _valueLabels)
+            {
+                builder.OpenElement(seq++, "text");
+                builder.AddAttribute(seq++, "class", "mud-chart-value-label");
+                builder.AddAttribute(seq++, "x", ToS(label.X));
+                builder.AddAttribute(seq++, "y", ToS(label.Y));
+                builder.AddAttribute(seq++, "font-size", $"{ToS(ValueLabelFontSize)}px");
+                builder.AddAttribute(seq++, "text-anchor", "middle");
+                builder.AddContent(seq++, label.Value);
+                builder.CloseElement();
+            }
+
+            builder.CloseElement();
+        }
     };
 
     private RenderFragment RenderTooltip() => builder =>

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor.cs
@@ -21,11 +21,14 @@ namespace MudBlazor.Charts
         private const double BarOverlapAmountFix = 0.5; // used to trigger slight overlap so the bars don't have gaps due to floating point rounding
 
         private readonly List<SvgPath> _bars = [];
+        private readonly List<SvgText> _valueLabels = [];
         private double _barWidth;
         private double _barWidthStroke;
         private SvgPath? _hoveredBar;
 
         private const double MinBarWidth = 6;
+        private const double ValueLabelOffset = 5;
+        private const double ValueLabelFontSize = 12;
 
         protected override void OnInitialized()
         {
@@ -249,6 +252,7 @@ namespace MudBlazor.Charts
         private void GenerateStackedBars(int lowestHorizontalLine, T gridYUnits, double horizontalSpace, double verticalSpace)
         {
             _bars.Clear();
+            _valueLabels.Clear();
 
             var maxSeriesLength = Series.Count != 0 ? Series.Max(series => series.Data.Values.Count) : 0;
             var barPositions = CalculateBarGroupPositions(horizontalSpace, maxSeriesLength);
@@ -259,6 +263,8 @@ namespace MudBlazor.Charts
                 var baseY = _boundHeight - VerticalStartSpace + (lowestHorizontalLine * verticalSpace);
                 var positiveStack = baseY;
                 var negativeStack = baseY;
+                var barTotal = T.Zero;
+                var hasVisibleSegment = false;
 
                 foreach (var (series, seriesIndex) in Series.Select((s, i) => (s, i)))
                 {
@@ -267,7 +273,13 @@ namespace MudBlazor.Charts
                         continue;
                     }
 
+                    if (series.Visible)
+                    {
+                        hasVisibleSegment = true;
+                    }
+
                     var dataValue = series.Visible ? series.Data[dataIndex].Y : T.Zero;
+                    barTotal += dataValue;
 
                     if (dataValue == T.Zero && !ChartOptions!.ShowZeroValues)
                     {
@@ -298,6 +310,21 @@ namespace MudBlazor.Charts
                     {
                         positiveStack = yEnd;
                     }
+                }
+
+                if (ChartOptions!.ShowValues && hasVisibleSegment)
+                {
+                    // Positive totals render above the stack, negative totals below it.
+                    var labelY = barTotal < T.Zero
+                        ? negativeStack + ValueLabelOffset + ValueLabelFontSize
+                        : positiveStack - ValueLabelOffset;
+
+                    _valueLabels.Add(new SvgText
+                    {
+                        X = x,
+                        Y = labelY,
+                        Value = BuildYAxisValueString(barTotal),
+                    });
                 }
             }
         }

--- a/src/MudBlazor/Components/Chart/Models/Options/BarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/BarChartOptions.cs
@@ -9,9 +9,18 @@ namespace MudBlazor;
 /// <summary>
 /// Options specific to bar charts, extending <see cref="DefaultBarChartOptions"/>.
 /// </summary>
-public class BarChartOptions : DefaultBarChartOptions
+public class BarChartOptions : DefaultBarChartOptions, IHasValueLabelOptions
 {
     private double _barSpacingRatio = 0.20;
+
+    /// <summary>
+    /// Whether to show value labels above each bar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// Labels are formatted using <see cref="DefaultAxisChartOptions.YAxisFormat"/> or <see cref="DefaultAxisChartOptions.YAxisToStringFunc"/>.
+    /// </remarks>
+    public bool ShowValues { get; set; }
     /// <summary>
     /// Defines the spacing between bars as a ratio of the group width, with a value between 0.0 and 1.0.
     /// </summary>

--- a/src/MudBlazor/Components/Chart/Models/Options/StackedBarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/StackedBarChartOptions.cs
@@ -9,10 +9,19 @@ namespace MudBlazor;
 /// <summary>
 /// Options specific to stacked bar charts, extending <see cref="DefaultBarChartOptions"/>.
 /// </summary>
-public class StackedBarChartOptions : DefaultBarChartOptions
+public class StackedBarChartOptions : DefaultBarChartOptions, IHasValueLabelOptions
 {
     /// <inheritdoc />
     public override double SeriesSpacingRatio { get; set; } = 0.8;
+
+    /// <summary>
+    /// Whether to show the total of all visible series above each bar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// Labels are formatted using <see cref="DefaultAxisChartOptions.YAxisFormat"/> or <see cref="DefaultAxisChartOptions.YAxisToStringFunc"/>.
+    /// </remarks>
+    public bool ShowValues { get; set; }
 
     /// <summary>
     /// Determines whether to show zero values

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -109,6 +109,11 @@
   fill: var(--mud-palette-text-primary);
 }
 
+.mud-chart-value-label {
+  fill: var(--mud-palette-text-primary);
+  user-select: none;
+}
+
 .mud-chart-donut {
   & .mud-donut-hole {
     fill: transparent;


### PR DESCRIPTION
Closes #13449

## Description
Implements `IHasValueLabelOptions` on `BarChartOptions` and `StackedBarChartOptions`,
bringing value labels to bar charts in line with Pie, Rose and ScatterPlot:

- **Bar**: renders the value above each bar (below it for negative values).
- **StackedBar**: renders the **total of all visible series** above each bar
  (below it for negative totals). Totals recalculate when series are hidden
  via the legend (`CanHideSeries`).
- Labels are formatted using the existing `YAxisFormat` / `YAxisToStringFunc`
  options and use a new `.mud-chart-value-label` CSS class bound to
  `--mud-palette-text-primary`, so they follow the active theme.
- `ShowValues` defaults to `false` — no change for existing users.

## Screenshots
<img width="1238" height="609" alt="Screenshot 2026-07-09 134909" src="https://github.com/user-attachments/assets/9ac996da-4e1a-4d13-909a-5c4aedc8aedd" />
<img width="1233" height="605" alt="Screenshot 2026-07-09 134948" src="https://github.com/user-attachments/assets/ff528775-7e46-48f2-bb64-bf2f1e5a5ac0" />


## Checklist
- [x] Unit tests added (7 new tests in `BarChartTests` / `StackedBarChartTests`, all 61 chart tests passing)
- [x] Docs examples added (`BarValueLabelsExample`, `StackedBarValueLabelsExample`) with new "Value Labels" sections
- [x] XML documentation on new public properties