### PR TITLE
MudNavMenu: Allow only one MudNavGroup to be expanded at a time

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuExpandSingleGroupExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuExpandSingleGroupExample.razor
@@ -1,0 +1,20 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudPaper Width="250px" Class="py-3" Elevation="0">
+    <MudNavMenu ExpandSingleGroup="true">
+        <MudNavGroup Title="Projects" Expanded="true">
+            <MudNavLink Href="/active-projects">Active Projects</MudNavLink>
+            <MudNavLink Href="/archived-projects">Archived Projects</MudNavLink>
+        </MudNavGroup>
+
+        <MudNavGroup Title="Team">
+            <MudNavLink Href="/members">Members</MudNavLink>
+            <MudNavLink Href="/permissions">Permissions</MudNavLink>
+        </MudNavGroup>
+
+        <MudNavGroup Title="Settings">
+            <MudNavLink Href="/profile">Profile</MudNavLink>
+            <MudNavLink Href="/notifications">Notifications</MudNavLink>
+        </MudNavGroup>
+    </MudNavMenu>
+</MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuMultiExpansionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/Examples/NavMenuMultiExpansionExample.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Width="250px" Class="py-3" Elevation="0">
-    <MudNavMenu ExpandSingleGroup="true">
+    <MudNavMenu MultiExpansion="false">
         <MudNavGroup Title="Projects" Expanded="true">
             <MudNavLink Href="/active-projects">Active Projects</MudNavLink>
             <MudNavLink Href="/archived-projects">Archived Projects</MudNavLink>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -107,5 +107,17 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="ExpandSingleGroup">
+                <Description>
+                    The <CodeInline>ExpandSingleGroup</CodeInline> property controls whether only one navigation group can be expanded at a time.
+                    Only top-level <CodeInline>MudNavGroup</CodeInline> components participate in this behavior.
+                </Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(NavMenuExpandSingleGroupExample)" DarkenBackground="true" ShowCode="true">
+                <NavMenuExpandSingleGroupExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/NavMenu/NavMenuPage.razor
@@ -108,14 +108,14 @@
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="ExpandSingleGroup">
+            <SectionHeader Title="MultiExpansion">
                 <Description>
-                    The <CodeInline>ExpandSingleGroup</CodeInline> property controls whether only one navigation group can be expanded at a time.
+                    The <CodeInline>MultiExpansion</CodeInline> property controls whether only one navigation group can be expanded at a time.
                     Only top-level <CodeInline>MudNavGroup</CodeInline> components participate in this behavior.
                 </Description>
             </SectionHeader>
-            <SectionContent Code="@nameof(NavMenuExpandSingleGroupExample)" DarkenBackground="true" ShowCode="true">
-                <NavMenuExpandSingleGroupExample />
+            <SectionContent Code="@nameof(NavMenuMultiExpansionExample)" DarkenBackground="true" ShowCode="true">
+                <NavMenuMultiExpansionExample />
             </SectionContent>
         </DocsPageSection>
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuExclusive.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuExclusive.razor
@@ -1,0 +1,13 @@
+﻿<MudNavMenu ExpandSingleGroup="@ExpandSingle">
+    <MudNavGroup Title="Group1">
+        <MudNavLink Href="/a">A</MudNavLink>
+    </MudNavGroup>
+    <MudNavGroup Title="Group2">
+        <MudNavLink Href="/b">B</MudNavLink>
+    </MudNavGroup>
+</MudNavMenu>
+
+@code{
+    [Parameter]
+    public bool ExpandSingle { get; set; } = true;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuExclusive.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/NavMenu/NavMenuExclusive.razor
@@ -1,4 +1,4 @@
-﻿<MudNavMenu ExpandSingleGroup="@ExpandSingle">
+﻿<MudNavMenu MultiExpansion="@MultiExpansion">
     <MudNavGroup Title="Group1">
         <MudNavLink Href="/a">A</MudNavLink>
     </MudNavGroup>
@@ -9,5 +9,5 @@
 
 @code{
     [Parameter]
-    public bool ExpandSingle { get; set; } = true;
+    public bool MultiExpansion { get; set; } = false;
 }

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -40,7 +40,7 @@ namespace MudBlazor.UnitTests.Components
             // Expand first
             await buttons[0].ClickAsync();
             comp.Markup.Should().Contain("mud-expanded");
-            // Expand second. Should collapse first because ExpandSingleGroup==true by default in component
+            // Expand second. Should collapse first because MultiExpansion==false by default in component
             await buttons[1].ClickAsync();
             int expandedCount = comp.FindAll(".mud-expanded").Count;
             expandedCount.Should().Be(1);
@@ -49,14 +49,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NonExclusive_AllowsMultipleOpen()
         {
-            var comp = Context.Render<NavMenuExclusive>(ps => ps.Add(p => p.ExpandSingle, false));
+            var comp = Context.Render<NavMenuExclusive>(ps => ps.Add(p => p.MultiExpansion, true));
 
             var buttons = comp.FindAll(".mud-nav-group>button");
             buttons.Count.Should().BeGreaterThanOrEqualTo(2);
 
             // Expand first
             await buttons[0].ClickAsync();
-            // Expand second. Should not collapse first because ExpandSingleGroup==false
+            // Expand second. Should not collapse first because MultiExpansion==true
             await buttons[1].ClickAsync();
             int expandedCount = comp.FindAll(".mud-expanded").Count;
             expandedCount.Should().Be(2);

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -29,6 +29,39 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("mud-navmenu-rounded").Count.Should().Be(0);
         }
 
+        [Test]
+        public async Task Exclusive_OnlyOneOpen()
+        {
+            var comp = Context.Render<NavMenuExclusive>();
+
+            var buttons = comp.FindAll(".mud-nav-group>button");
+            buttons.Count.Should().BeGreaterThanOrEqualTo(2);
+
+            // Expand first
+            await buttons[0].ClickAsync();
+            comp.Markup.Should().Contain("mud-expanded");
+            // Expand second. Should collapse first because ExpandSingleGroup==true by default in component
+            await buttons[1].ClickAsync();
+            int expandedCount = comp.FindAll(".mud-expanded").Count;
+            expandedCount.Should().Be(1);
+        }
+
+        [Test]
+        public async Task NonExclusive_AllowsMultipleOpen()
+        {
+            var comp = Context.Render<NavMenuExclusive>(ps => ps.Add(p => p.ExpandSingle, false));
+
+            var buttons = comp.FindAll(".mud-nav-group>button");
+            buttons.Count.Should().BeGreaterThanOrEqualTo(2);
+
+            // Expand first
+            await buttons[0].ClickAsync();
+            // Expand second. Should not collapse first because ExpandSingleGroup==false
+            await buttons[1].ClickAsync();
+            int expandedCount = comp.FindAll(".mud-expanded").Count;
+            expandedCount.Should().Be(2);
+        }
+
         /// <summary>
         /// Change all styling parameters from its default values and check that the correct classes are added.
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -1,5 +1,6 @@
 ﻿using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.UnitTests.TestComponents.NavMenu;
 using NUnit.Framework;
 
@@ -60,6 +61,36 @@ namespace MudBlazor.UnitTests.Components
             await buttons[1].ClickAsync();
             int expandedCount = comp.FindAll(".mud-expanded").Count;
             expandedCount.Should().Be(2);
+        }
+
+        [Test]
+        public async Task DefaultMultiExpansion_AllowsMultipleGroupsOpen()
+        {
+            static void CreateGroups(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<MudNavGroup>(0);
+                builder.AddAttribute(1, nameof(MudNavGroup.Title), "Group 1");
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudNavGroup>(2);
+                builder.AddAttribute(3, nameof(MudNavGroup.Title), "Group 2");
+                builder.CloseComponent();
+            }
+
+            // Intentionally omit MultiExpansion. This protects existing menus from
+            // silently becoming exclusive if the component default changes.
+            var comp = Context.Render<MudNavMenu>(parameters =>
+                parameters.Add(p => p.ChildContent, CreateGroups));
+
+            comp.Instance.MultiExpansion.Should().BeTrue();
+
+            var buttons = comp.FindAll(".mud-nav-group > button");
+            await buttons[0].ClickAsync();
+            await buttons[1].ClickAsync();
+
+            comp.FindAll(".mud-nav-group > button.mud-expanded")
+                .Should()
+                .HaveCount(2);
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -213,7 +213,7 @@ namespace MudBlazor
         /// <summary>
         /// Collapse this group programmatically.
         /// </summary>
-        public async Task CollapseAsync()
+        internal async Task CollapseAsync()
         {
             if (!_expandedState.Value)
             {

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor.cs
@@ -14,10 +14,13 @@ namespace MudBlazor
     /// </summary>
     /// <seealso cref="MudNavLink"/>
     /// <seealso cref="MudNavMenu"/>
-    public partial class MudNavGroup : MudComponentBase
+    public partial class MudNavGroup : MudComponentBase, IDisposable
     {
         private readonly ParameterState<bool> _expandedState;
         private NavigationContext _navigationContext = new(false, true);
+
+        [CascadingParameter]
+        private MudNavMenu? ParentMenu { get; set; }
 
         public MudNavGroup()
         {
@@ -37,6 +40,7 @@ namespace MudBlazor
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            ParentMenu?.RegisterGroup(this);
             UpdateNavigationContext();
         }
 
@@ -192,11 +196,37 @@ namespace MudBlazor
         [Parameter]
         public EventCallback<bool> ExpandedChanged { get; set; }
 
+        /// <summary>
+        /// Toggles the expanded state of this group (expand or collapse) and updates the navigation context.
+        /// When expanded, notifies the parent menu so it can collapse other groups if exclusive expansion is enabled.
+        /// </summary>
         private async Task ExpandedToggleAsync()
         {
             await _expandedState.SetValueAsync(!_expandedState.Value);
             UpdateNavigationContext();
+            if (_expandedState.Value && ParentMenu is not null)
+            {
+                await ParentMenu.NotifyGroupExpandedAsync(this);
+            }
         }
+
+        /// <summary>
+        /// Collapse this group programmatically.
+        /// </summary>
+        public async Task CollapseAsync()
+        {
+            if (!_expandedState.Value)
+            {
+                return;
+            }
+
+            await _expandedState.SetValueAsync(false);
+            UpdateNavigationContext();
+            await InvokeAsync(StateHasChanged);
+        }
+
+        public void Dispose()
+            => ParentMenu?.UnregisterGroup(this);
 
         private void UpdateNavigationContext()
             => _navigationContext = _navigationContext with

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
@@ -5,7 +5,7 @@
      id="@NavigationContext?.MenuId"
      class="@Classname"
      style="@Style">
-    <CascadingValue Value="@this">
+    <CascadingValue Value="@this" IsFixed="true">
         <CascadingValue Value="@NavigationContext">
             @ChildContent
         </CascadingValue>

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
@@ -5,7 +5,9 @@
      id="@NavigationContext?.MenuId"
      class="@Classname"
      style="@Style">
-    <CascadingValue Value="@NavigationContext">
-        @ChildContent
+    <CascadingValue Value="@this">
+        <CascadingValue Value="@NavigationContext">
+            @ChildContent
+        </CascadingValue>
     </CascadingValue>
 </nav>

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -26,7 +26,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.NavMenu.Behavior)]
-        public bool MultiExpansion { get; set; }
+        public bool MultiExpansion { get; set; } = true;
 
         internal void RegisterGroup(MudNavGroup group)
         {

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -18,8 +18,12 @@ namespace MudBlazor
         private readonly List<MudNavGroup> _groups = [];
 
         /// <summary>
-        /// Only a single MudNavGroup can be expanded at a time when set to true.
+        /// When <c>true</c>, only a single top-level <see cref="MudNavGroup"/> can be expanded at a time.
         /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>. Expanding a group collapses the others; nested groups are unaffected.
+        /// Only applies when a group is expanded by the user; setting <see cref="MudNavGroup.Expanded"/> programmatically bypasses this.
+        /// </remarks
         [Parameter]
         [Category(CategoryTypes.NavMenu.Behavior)]
         public bool ExpandSingleGroup { get; set; }

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -15,6 +15,43 @@ namespace MudBlazor
     /// <seealso cref="MudNavLink"/>
     public partial class MudNavMenu : MudComponentBase
     {
+        private readonly List<MudNavGroup> _groups = [];
+
+        /// <summary>
+        /// Only a single MudNavGroup can be expanded at a time when set to true.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.Behavior)]
+        public bool ExpandSingleGroup { get; set; }
+
+        internal void RegisterGroup(MudNavGroup group)
+        {
+            if (!_groups.Contains(group))
+            {
+                _groups.Add(group);
+            }
+        }
+
+        internal void UnregisterGroup(MudNavGroup group)
+        {
+            _groups.Remove(group);
+        }
+
+        internal async Task NotifyGroupExpandedAsync(MudNavGroup expandedGroup)
+        {
+            if (!ExpandSingleGroup)
+            {
+                return;
+            }
+
+            foreach (MudNavGroup group in _groups)
+            {
+                if (!ReferenceEquals(group, expandedGroup))
+                {
+                    await group.CollapseAsync();
+                }
+            }
+        }
         protected string Classname =>
             new CssBuilder("mud-navmenu")
                 .AddClass($"mud-navmenu-{Color.ToStringFast(true)}")

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -23,10 +23,10 @@ namespace MudBlazor
         /// <remarks>
         /// Defaults to <c>false</c>. Expanding a group collapses the others; nested groups are unaffected.
         /// Only applies when a group is expanded by the user; setting <see cref="MudNavGroup.Expanded"/> programmatically bypasses this.
-        /// </remarks
+        /// </remarks>
         [Parameter]
         [Category(CategoryTypes.NavMenu.Behavior)]
-        public bool ExpandSingleGroup { get; set; }
+        public bool MultiExpansion { get; set; }
 
         internal void RegisterGroup(MudNavGroup group)
         {
@@ -43,7 +43,7 @@ namespace MudBlazor
 
         internal async Task NotifyGroupExpandedAsync(MudNavGroup expandedGroup)
         {
-            if (!ExpandSingleGroup)
+            if (MultiExpansion)
             {
                 return;
             }

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor.cs
@@ -18,10 +18,10 @@ namespace MudBlazor
         private readonly List<MudNavGroup> _groups = [];
 
         /// <summary>
-        /// When <c>true</c>, only a single top-level <see cref="MudNavGroup"/> can be expanded at a time.
+        /// When <c>true</c>, multiple top-level <see cref="MudNavGroup"/> can be expanded at a time.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>false</c>. Expanding a group collapses the others; nested groups are unaffected.
+        /// Defaults to <c>true</c>. When set to <c>false</c>, expanding one group collapses the other top-level groups; nested groups are unaffected.
         /// Only applies when a group is expanded by the user; setting <see cref="MudNavGroup.Expanded"/> programmatically bypasses this.
         /// </remarks>
         [Parameter]


### PR DESCRIPTION
fixes #11793

Adds a new bool property called `MultiExpansion` to the `MudNavMenu`, so consumers can allow for only 1 expanded `MudNavGroup` at a time by setting it to `false`. It defaults to `true`, which keeps the current behaviour.
Note that this implementation only works for top-level `MudNavGroup`s.

https://github.com/user-attachments/assets/7e032446-74d2-452e-8783-cfe6e40e21a1

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

