### PR TITLE
MudForm: Aggregate child form errors into Errors

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -2733,6 +2733,44 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Regression test for: https://github.com/MudBlazor/MudBlazor/issues/11193.
+        /// The Errors property should aggregate the errors of child forms, the same way
+        /// that IsValid reflects the validity of child forms.
+        /// </summary>
+        [Test]
+        public async Task ChildForm_ErrorsPropagateToParent()
+        {
+            var comp = Context.Render<FormWithChildFormTest>();
+            var childFormSwitch = comp.Find(".mud-switch-input");
+            var parentForm = comp.FindComponent<MudForm>().Instance;
+            var parentTextFieldCmp = comp.FindComponent<MudTextField<string>>();
+
+            // Satisfy the parent's own required field, so that any error on the
+            // parent form can only have come from the child form.
+            await parentTextFieldCmp.Find("input").ChangeAsync("Marilyn Manson");
+            parentForm.IsValid.Should().BeTrue();
+            parentForm.Errors.Should().BeEmpty();
+
+            // Display the child form, which holds a second required field.
+            await childFormSwitch.ChangeAsync(true);
+            var forms = comp.FindComponents<MudForm>();
+            forms.Count.Should().Be(2);
+            var childForm = forms[1];
+            var childTextFieldCmp = childForm.FindComponent<MudTextField<string>>();
+
+            // Touch the child's required field and clear it, producing an error.
+            await childTextFieldCmp.Find("input").ChangeAsync("Trent Reznor");
+            await childTextFieldCmp.Find("input").ChangeAsync("");
+
+            childForm.Instance.IsValid.Should().BeFalse();
+            childForm.Instance.Errors.Should().BeEquivalentTo(["Required"]);
+
+            // The parent form has no errors of its own, but must surface the child's.
+            parentForm.IsValid.Should().BeFalse();
+            parentForm.Errors.Should().BeEquivalentTo(["Required"]);
+        }
+
+        /// <summary>
         /// Regression test for: https://github.com/MudBlazor/MudBlazor/issues/12012.
         /// When a form has a validation error and the bound property is updated through code,
         /// the validation error should be cleared if the new value is valid, or updated if still invalid.

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -196,7 +196,7 @@ namespace MudBlazor
         public bool? OverrideFieldValidation { get; set; }
 
         /// <summary>
-        /// The validation errors for inputs within this form.
+        /// The validation errors for inputs within this form and any child forms.
         /// </summary>
         /// <remarks>
         /// When this property changes, <see cref="ErrorsChanged"/> occurs.
@@ -205,7 +205,7 @@ namespace MudBlazor
         [Category(CategoryTypes.Form.ValidationResult)]
         public string[] Errors
         {
-            get => _errors.ToArray();
+            get => _errors.Concat(ChildForms.SelectMany(childForm => childForm.Errors)).ToArray();
             set { /* readonly */ }
         }
 


### PR DESCRIPTION
## Description

`MudForm.Errors` only returned the validation errors of the form's own controls. An error raised by an input inside a nested `MudForm` never appeared in the parent's `Errors` array, even though `IsValid` already accounts for child forms.

Fixes #11193

## How Has This Been Tested?

Added `ChildForm_ErrorsPropagateToParent` to `FormTests`, built on the existing `FormWithChildFormTest` component. It fills the parent's required field first, so the parent has no errors of its own and the `"Required"` it reports can only have come from the child form.

- The new test fails on `dev` and passes with this change (I reverted the source change and re-ran it to confirm it isn't vacuous).
- All 103 `FormTests` pass.
- The other suites that assert on `.Errors` also pass: `RowValidatorTests`, `CheckBoxTests`, `NumericFieldTests`, `TextFieldTests` (450 tests total).

## Type of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes

The issue suggested appending the child forms' errors to `_errors` immediately after the loop in `OnEvaluateForm()`. I went a different way, and it's worth explaining why.

A child form's field change does not trigger the parent's `OnEvaluateForm()` — the only place a parent re-evaluates because of a child is `Dispose()`, via `ParentMudForm.EvaluateForm()`. Caching the child's errors into the parent's `_errors` would therefore leave the parent stale whenever a child validated after its parent had already evaluated.

Instead, `Errors` is now computed on read, in the same style as `IsValid` directly above it:

```csharp
public bool IsValid
{
    get => _valid && ChildForms.All(x => x.IsValid);
    ...
}

public string[] Errors
{
    get => _errors.Concat(ChildForms.SelectMany(childForm => childForm.Errors)).ToArray();
    ...
}
```

This is independent of evaluation order and recurses through arbitrarily nested forms, since each child's `Errors` aggregates its own children.

One behavioural detail worth flagging for review: within a single form, `_errors` is a `HashSet<string>`, so two controls failing with the same message yield one entry. Across forms the arrays are concatenated, so a parent and child that both report `"Required"` will surface two entries. That seemed right to me — they're two distinct failing fields — but I'm happy to add a `.Distinct()` if you'd prefer the deduplicating behaviour to extend across the whole tree.

`ErrorsChanged` still fires only when the owning form re-evaluates, exactly as `IsValidChanged` does today. Making child changes bubble up as parent events would be a larger behavioural change, so I left it out of scope.
