### PR TITLE
MudDatePicker, MudDateRangePicker: Fix StartMonth ignored on initial render when Static

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2111,6 +2111,20 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().Contain(comp.Instance.ClearIcon);
         }
 
+        [Test]
+        public void Static_StartMonth_IsShownOnFirstRender()
+        {
+            var startMonth = new DateTime(2025, 12, 3);
+
+            var comp = Context.Render<MudDatePicker>(ps => ps
+                .Add(p => p.PickerVariant, PickerVariant.Static)
+                .Add(p => p.StartMonth, startMonth)
+            );
+
+            var expectedMonthName = new DateTime(2025, 12, 1).ToString(CultureInfo.CurrentCulture.DateTimeFormat.YearMonthPattern, CultureInfo.CurrentCulture);
+            comp.Find(".mud-button-month").TextContent.Trim().Should().Be(expectedMonthName);
+        }
+
         private async Task<IRenderedComponent<SimpleMudDatePickerTest>> OpenPicker(Action<ComponentParameterCollectionBuilder<SimpleMudDatePickerTest>>? parameterBuilder = null)
         {
             IRenderedComponent<SimpleMudDatePickerTest> comp;

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2115,13 +2115,15 @@ namespace MudBlazor.UnitTests.Components
         public void Static_StartMonth_IsShownOnFirstRender()
         {
             var startMonth = new DateTime(2025, 12, 3);
+            var culture = CultureInfo.GetCultureInfo("en-US");
 
             var comp = Context.Render<MudDatePicker>(ps => ps
                 .Add(p => p.PickerVariant, PickerVariant.Static)
                 .Add(p => p.StartMonth, startMonth)
+                .Add(p => p.Culture, culture)
             );
 
-            var expectedMonthName = new DateTime(2025, 12, 1).ToString(CultureInfo.CurrentCulture.DateTimeFormat.YearMonthPattern, CultureInfo.CurrentCulture);
+            var expectedMonthName = new DateTime(2025, 12, 1).ToString(culture.DateTimeFormat.YearMonthPattern, culture);
             comp.Find(".mud-button-month").TextContent.Trim().Should().Be(expectedMonthName);
         }
 

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1488,6 +1488,21 @@ namespace MudBlazor.UnitTests.Components
             picker.DateRange.Should().BeNull();
         }
 
+        [Test]
+        public void Static_StartMonth_IsShownOnFirstRender()
+        {
+            var startMonth = new DateTime(2025, 12, 3);
+
+            var comp = Context.Render<MudDateRangePicker>(ps => ps
+                .Add(p => p.PickerVariant, PickerVariant.Static)
+                .Add(p => p.StartMonth, startMonth)
+                .Add(p => p.DisplayMonths, 1)
+            );
+
+            var expectedMonthName = new DateTime(2025, 12, 1).ToString(CultureInfo.CurrentCulture.DateTimeFormat.YearMonthPattern, CultureInfo.CurrentCulture);
+            comp.Find(".mud-button-month").TextContent.Trim().Should().Be(expectedMonthName);
+        }
+
         private sealed class DateRangePickerImpl : MudDateRangePicker
         {
             public DateTime StartOfMonth() => GetCalendarStartOfMonth();

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1492,14 +1492,16 @@ namespace MudBlazor.UnitTests.Components
         public void Static_StartMonth_IsShownOnFirstRender()
         {
             var startMonth = new DateTime(2025, 12, 3);
+            var culture = CultureInfo.GetCultureInfo("en-US");
 
             var comp = Context.Render<MudDateRangePicker>(ps => ps
                 .Add(p => p.PickerVariant, PickerVariant.Static)
                 .Add(p => p.StartMonth, startMonth)
                 .Add(p => p.DisplayMonths, 1)
+                .Add(p => p.Culture, culture)
             );
 
-            var expectedMonthName = new DateTime(2025, 12, 1).ToString(CultureInfo.CurrentCulture.DateTimeFormat.YearMonthPattern, CultureInfo.CurrentCulture);
+            var expectedMonthName = new DateTime(2025, 12, 1).ToString(culture.DateTimeFormat.YearMonthPattern, culture);
             comp.Find(".mud-button-month").TextContent.Trim().Should().Be(expectedMonthName);
         }
 

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -803,7 +803,7 @@ namespace MudBlazor
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
-            
+
             if (firstRender && CurrentView == OpenTo.Year)
             {
                 ScrollToYearAsync().CatchAndLog();

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -781,34 +781,29 @@ namespace MudBlazor
             AdornmentAriaLabel ??= Localizer[Resources.LanguageResource.MudBaseDatePicker_Open];
             CurrentView = OpenTo;
 
-            if (HighlightedDate is not null)
+            if (HighlightedDate is null)
             {
-                return;
+                var culture = GetCulture();
+                var calendar = culture.Calendar;
+                var today = TimeProvider.GetLocalNow().Date;
+
+                var year = FixYear ?? calendar.GetYear(today);
+                var month = FixMonth ?? (year == calendar.GetYear(today) ? calendar.GetMonth(today) : 1);
+                var day = FixDay ?? 1;
+
+                if (DateTime.TryParseExact($"{year}-{month}-{day}", "yyyy-M-d", GetCulture(), DateTimeStyles.None, out var date))
+                {
+                    HighlightedDate = date;
+                }
             }
 
-            var culture = GetCulture();
-            var calendar = culture.Calendar;
-            var today = TimeProvider.GetLocalNow().Date;
-
-            var year = FixYear ?? calendar.GetYear(today);
-            var month = FixMonth ?? (year == calendar.GetYear(today) ? calendar.GetMonth(today) : 1);
-            var day = FixDay ?? 1;
-
-            if (DateTime.TryParseExact($"{year}-{month}-{day}", "yyyy-M-d", GetCulture(), DateTimeStyles.None, out var date))
-            {
-                HighlightedDate = date;
-            }
+            _picker_month ??= GetCalendarStartOfMonth();
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
-
-            if (firstRender)
-            {
-                _picker_month ??= GetCalendarStartOfMonth();
-            }
-
+            
             if (firstRender && CurrentView == OpenTo.Year)
             {
                 ScrollToYearAsync().CatchAndLog();


### PR DESCRIPTION
## Description

Fixes #11938

`MudDatePicker` and `MudDateRangePicker` ignored `StartMonth` on the first render when `PickerVariant.Static` was used, showing the current month instead — it only corrected itself after the user interacted with the picker.

**Root cause:** the field tracking the displayed month (`_picker_month`) was initialized in `OnAfterRenderAsync`, after the first paint, and without triggering a re-render. Static pickers paint their calendar on that very first render, so the stale value was what showed up.

**Fix:** initialize `_picker_month` in `OnInitialized` instead, so it's correct before the first paint.

**Tests:** added `Static_StartMonth_IsShownOnFirstRender` to `DatePickerTests.cs` and `DateRangePickerTests.cs`, asserting on the rendered calendar header.

##Screenshots
Note that the configured date should be June (Junio),

**Before:**
Renders July (Julio) until we interact with the picker.
<img width="1012" height="520" alt="20260709-2322-20 6961438" src="https://github.com/user-attachments/assets/b5dec7e4-2b04-4f3d-b598-d60080923b4f" />

**After:**
Renders June (Junio) directly.
<img width="1276" height="642" alt="20260709-2324-07 6763569" src="https://github.com/user-attachments/assets/a5bf7fb8-f6fa-4aa9-ace5-5493798cc839" />


**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests