### PR TITLE
MudInput, MudMask: Do not apply user Class to input adornment

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1488,6 +1488,26 @@ namespace MudBlazor.UnitTests.Components
             picker.DateRange.Should().BeNull();
         }
 
+        /// <summary>
+        /// Regression test for: https://github.com/MudBlazor/MudBlazor/issues/11564.
+        /// The user supplied <see cref="MudComponentBase.Class"/> should style the picker's
+        /// input, but must not be copied onto the adornment (the calendar icon).
+        /// </summary>
+        [Test]
+        public void Class_IsNotAppliedToAdornment()
+        {
+            const string customClass = "__custom_picker_class__";
+
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
+                .Add(p => p.Class, customClass));
+
+            // The class is still applied to the input itself.
+            comp.Find("div.mud-input").ClassList.Should().Contain(customClass);
+
+            // But not to the adornment that holds the calendar icon.
+            comp.Find("div.mud-input-adornment-end").ClassList.Should().NotContain(customClass);
+        }
+
         private sealed class DateRangePickerImpl : MudDateRangePicker
         {
             public DateTime StartOfMonth() => GetCalendarStartOfMonth();

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -1176,5 +1176,27 @@ namespace MudBlazor.UnitTests.Components
             // The second keystroke must survive the parent Value echo triggered by the first forwarded callback.
             mask.ReadText.Should().Be("(1)2-_)");
         }
+
+        /// <summary>
+        /// Regression test for: https://github.com/MudBlazor/MudBlazor/issues/11564.
+        /// The user supplied Class should style the mask input, but must not be
+        /// copied onto the adornment (the icon at the end of the input).
+        /// </summary>
+        [Test]
+        public void Class_IsNotAppliedToAdornment()
+        {
+            const string customClass = "__custom_mask_class__";
+
+            var comp = Context.Render<MudMask>(parameters => parameters
+                .Add(p => p.Class, customClass)
+                .Add(p => p.Adornment, Adornment.End)
+                .Add(p => p.AdornmentIcon, Icons.Material.Filled.Search));
+
+            // The class is still applied to the input itself.
+            comp.Find("div.mud-input").ClassList.Should().Contain(customClass);
+
+            // But not to the adornment that holds the icon.
+            comp.Find("div.mud-input-adornment-end").ClassList.Should().NotContain(customClass);
+        }
     }
 }

--- a/src/MudBlazor/Components/Input/MudInputCssHelper.cs
+++ b/src/MudBlazor/Components/Input/MudInputCssHelper.cs
@@ -55,6 +55,5 @@ internal static class MudInputCssHelper
             .AddClass($"mud-input-adornment-{baseInput.Adornment.ToStringFast(true)}", baseInput.Adornment != Adornment.None)
             .AddClass($"mud-text", !string.IsNullOrEmpty(baseInput.AdornmentText))
             .AddClass($"mud-input-root-filled-shrink", baseInput.Variant == Variant.Filled)
-            .AddClass(baseInput.Class)
             .Build();
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -59,7 +59,6 @@ namespace MudBlazor
                 .AddClass($"mud-input-adornment-{Adornment.ToStringFast(true)}", Adornment != Adornment.None)
                 .AddClass($"mud-text", !string.IsNullOrEmpty(AdornmentText))
                 .AddClass($"mud-input-root-filled-shrink", Variant == Variant.Filled)
-                .AddClass(Class)
                 .Build();
 
         protected string ClearButtonClassname =>


### PR DESCRIPTION
## Description

The user-supplied `Class` was being copied onto the input's **adornment** element (the icon or text rendered at the end of the input), in addition to the input itself. Passing a class such as `mud-width-full` to a `MudDateRangePicker` therefore also stretched/misplaced the calendar adornment.

The class reaches the adornment through the shared `MudInputCssHelper.GetAdornmentClassname`, which is used by `MudInput` and `MudRangeInput` (and thus the pickers). Notably, `MudField.AdornmentClassname` already omits `Class` from its adornment — so this change simply makes the input helper consistent with the field.

Fixes #11564

## How Has This Been Tested?

Added `Class_IsNotAppliedToAdornment` to `DateRangePickerTests`, using the exact scenario from the issue: a `MudDateRangePicker` with a custom `Class`.

- The test asserts the class is still applied to the input (`div.mud-input`) but not to the adornment (`div.mud-input-adornment-end`).
- It fails on `dev` and passes with this change. I reverted just the one-line source change and re-ran it to confirm it is a real regression test — the failure output shows the leaked class on the adornment's class list (`{..., "mud-input-input-control", "__custom_picker_class__"}`).
- Ran every suite that renders an adornment through this helper — `DateRangePicker`, `DatePicker`, `TimePicker`, `TextField`, `NumericField`, `Select`, `Autocomplete`, `ColorPicker`, `Mask`, `Field` — **949 tests, all passing**.

## Type of Changes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Notes

`MudMask` has its own `AdornmentClassname` (in `MudMask.razor.cs`) with the same `.AddClass(Class)` line, so it had the same issue and is fixed here too, with an equivalent test in `MaskTests`.

Anything relying on the user `Class` reaching the adornment will stop receiving it, which is why this is marked as a breaking change rather than a plain bug fix.

