### PR TITLE
MudDataGrid: Raise FilterChanged for Simple mode set value/operator

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1523,6 +1523,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task DataGridFilterChangedSimpleApplyAndClear()
+        {
+            var comp = Context.Render<DataGridFilterChangedCallbacksTest>(parameters => parameters
+                .Add(x => x.FilterMode, DataGridFilterMode.Simple));
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridFilterChangedCallbacksTest.Item>>();
+
+            // Open the Simple filter panel with a blank filter on the first column.
+            await comp.InvokeAsync(() => dataGrid.Instance.AddFilter());
+
+            // Setting a value fires FilterChanged (previously only clearing did).
+            var filterInput = comp.FindComponents<MudTextField<string>>().Single();
+            await comp.InvokeAsync(async () => await filterInput.Instance.ValueChanged.InvokeAsync("second"));
+            comp.Instance.FilterChanged.Should().BeTrue();
+            comp.Instance.FilterChangedCallCount.Should().Be(1);
+
+            // Changing the operator fires FilterChanged.
+            var operatorSelect = comp.FindComponents<MudSelect<string>>().Single();
+            await comp.InvokeAsync(async () => await operatorSelect.Instance.ValueChanged.InvokeAsync(FilterOperator.String.NotContains));
+            comp.Instance.FilterChangedCallCount.Should().Be(2);
+
+            // Clearing the filter fires FilterChanged.
+            await comp.Find(".remove-filter-button").ClickAsync();
+            comp.Instance.FilterChangedCallCount.Should().Be(3);
+            dataGrid.Instance.FilterDefinitions.Should().BeEmpty();
+        }
+
+        [Test]
         public async Task DataGridCommittedItemChangedOccursAfterSourceItemUpdateInFormEdit()
         {
             var comp = Context.Render<DataGridCommittedItemChangedTest>();
@@ -3318,26 +3345,26 @@ namespace MudBlazor.UnitTests.Components
             // test internal filter class for string data type.
             var internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, stringFilterDefinition, null);
             stringFilterDefinition.Column.dataType.Should().Be(typeof(string));
-            await comp.InvokeAsync(() => internalFilter.StringValueChanged("J"));
+            await comp.InvokeAsync(() => internalFilter.StringValueChangedAsync("J"));
             stringFilterDefinition.Value.Should().Be("J");
 
             // test internal filter class for number data type.
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, intFilterDefinition, null);
             intFilterDefinition.Column.dataType.Should().Be(typeof(int?));
-            await comp.InvokeAsync(() => internalFilter.NumberValueChanged(35));
+            await comp.InvokeAsync(() => internalFilter.NumberValueChangedAsync(35));
             intFilterDefinition.Value.Should().Be(35);
 
             // test internal filter class for enum data type.
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, enumFilterDefinition, null);
             enumFilterDefinition.Column.dataType.Should().Be(typeof(Severity?));
-            await comp.InvokeAsync(() => internalFilter.EnumValueChanged(Severity.Warning));
+            await comp.InvokeAsync(() => internalFilter.EnumValueChangedAsync(Severity.Warning));
             enumFilterDefinition.Value.Should().Be(Severity.Warning);
             enumFilterDefinition.FieldType.IsEnum.Should().Be(true);
 
             // test internal filter class for bool data type.
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, boolFilterDefinition, null);
             boolFilterDefinition.Column.dataType.Should().Be(typeof(bool?));
-            await comp.InvokeAsync(() => internalFilter.BoolValueChanged(false));
+            await comp.InvokeAsync(() => internalFilter.BoolValueChangedAsync(false));
             boolFilterDefinition.Value.Should().Be(false);
 
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(boolFilterDefinitionWithNull)); // Test adding Bool filter with null value
@@ -3348,16 +3375,16 @@ namespace MudBlazor.UnitTests.Components
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, dateTimeFilterDefinition, null);
             dateTimeFilterDefinition.Column.dataType.Should().Be(typeof(DateTime?));
 
-            await comp.InvokeAsync(() => internalFilter.DateValueChanged(date));
+            await comp.InvokeAsync(() => internalFilter.DateValueChangedAsync(date));
             dateTimeFilterDefinition.Value.Should().Be(date.Date);
 
-            await comp.InvokeAsync(() => internalFilter.TimeValueChanged(date.TimeOfDay));
+            await comp.InvokeAsync(() => internalFilter.TimeValueChangedAsync(date.TimeOfDay));
             dateTimeFilterDefinition.Value.Should().Be(date);
 
-            await comp.InvokeAsync(() => internalFilter.TimeValueChanged(null));
+            await comp.InvokeAsync(() => internalFilter.TimeValueChangedAsync(null));
             dateTimeFilterDefinition.Value.Should().Be(date.Date);
 
-            await comp.InvokeAsync(() => internalFilter.DateValueChanged(null));
+            await comp.InvokeAsync(() => internalFilter.DateValueChangedAsync(null));
             dateTimeFilterDefinition.Value.Should().BeNull();
 
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(dateTimeFilterDefinitionWithNull)); // Test adding DateTime filter with null value
@@ -3368,10 +3395,10 @@ namespace MudBlazor.UnitTests.Components
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, dateOnlyFilterDefinition, null);
             dateOnlyFilterDefinition.Column.dataType.Should().Be(typeof(DateOnly?));
 
-            await comp.InvokeAsync(() => internalFilter.DateOnlyValueChanged(dateOnlyDateTimeInput));
+            await comp.InvokeAsync(() => internalFilter.DateOnlyValueChangedAsync(dateOnlyDateTimeInput));
             dateOnlyFilterDefinition.Value.Should().Be(DateOnly.FromDateTime(dateOnlyDateTimeInput));
 
-            await comp.InvokeAsync(() => internalFilter.DateOnlyValueChanged(null));
+            await comp.InvokeAsync(() => internalFilter.DateOnlyValueChangedAsync(null));
             dateOnlyFilterDefinition.Value.Should().BeNull();
 
             await comp.InvokeAsync(() => dataGrid.Instance.AddFilterAsync(dateOnlyFilterDefinitionWithNull)); // Test Adding DateOnly filter with null value
@@ -3381,7 +3408,7 @@ namespace MudBlazor.UnitTests.Components
             var guid = Guid.NewGuid();
             internalFilter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, guidFilterDefinition, null);
             guidFilterDefinition.Column.dataType.Should().Be(typeof(Guid?));
-            await comp.InvokeAsync(() => internalFilter.GuidValueChanged(guid));
+            await comp.InvokeAsync(() => internalFilter.GuidValueChangedAsync(guid));
             guidFilterDefinition.Value.Should().Be(guid);
         }
 
@@ -3408,7 +3435,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void DataGridFilterFieldChanged()
+        public async Task DataGridFilterFieldChanged()
         {
             var comp = Context.Render<DataGridFiltersTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridFiltersTest.Model>>();
@@ -3421,7 +3448,7 @@ namespace MudBlazor.UnitTests.Components
             var filter = new Filter<DataGridFiltersTest.Model>(dataGrid.Instance, filterDefinition, null);
             var newBoolColumn = dataGrid.Instance.GetColumnByPropertyName("Hired");
 
-            filter.FieldChanged(newBoolColumn!);
+            await comp.InvokeAsync(() => filter.FieldChangedAsync(newBoolColumn!));
 
             filterDefinition.Column.Should().Be(newBoolColumn);
             filterDefinition.Operator.Should().Be(FilterOperator.Boolean.Is);

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -62,7 +62,7 @@ namespace MudBlazor
             await _dataGrid.RemoveFilterAsync(_filterDefinition.Id);
         }
 
-        internal void FieldChanged(Column<T> column)
+        internal Task FieldChangedAsync(Column<T> column)
         {
             _filterDefinition.Column = column;
             var operators = column.GetFilterOperators(FieldType.Identify(column.PropertyType));
@@ -73,37 +73,44 @@ namespace MudBlazor
             {
                 filterDefinition.FilterFunction = null;
             }
+            return ApplyChangesAsync();
         }
 
-        internal void StringValueChanged(string value)
+        internal Task OperatorChangedAsync(string? value)
+        {
+            _filterDefinition.Operator = value;
+            return ApplyChangesAsync();
+        }
+
+        internal Task StringValueChangedAsync(string value)
         {
             _valueString = value;
             _filterDefinition.Value = _valueString;
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void NumberValueChanged(double? value)
+        internal Task NumberValueChangedAsync(double? value)
         {
             _valueNumber = value;
             _filterDefinition.Value = _valueNumber;
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void EnumValueChanged(Enum value)
+        internal Task EnumValueChangedAsync(Enum value)
         {
             _valueEnum = value;
             _filterDefinition.Value = _valueEnum;
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void BoolValueChanged(bool? value)
+        internal Task BoolValueChangedAsync(bool? value)
         {
             _valueBool = value;
             _filterDefinition.Value = _valueBool;
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void DateValueChanged(DateTime? value)
+        internal Task DateValueChangedAsync(DateTime? value)
         {
             _valueDateTimeForPicker = value;
 
@@ -122,10 +129,10 @@ namespace MudBlazor
             else
                 _filterDefinition.Value = null;
 
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void TimeValueChanged(TimeSpan? value)
+        internal Task TimeValueChangedAsync(TimeSpan? value)
         {
             _valueTime = value;
 
@@ -142,10 +149,10 @@ namespace MudBlazor
                 _filterDefinition.Value = date;
             }
 
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void DateOnlyValueChanged(DateTime? value)
+        internal Task DateOnlyValueChangedAsync(DateTime? value)
         {
             _valueDateOnlyForPicker = value;
 
@@ -156,14 +163,24 @@ namespace MudBlazor
             else
                 _filterDefinition.Value = null;
 
-            _dataGrid.GroupItems();
+            return ApplyChangesAsync();
         }
 
-        internal void GuidValueChanged(Guid? value)
+        internal Task GuidValueChangedAsync(Guid? value)
         {
             _valueGuid = value;
             _filterDefinition.Value = _valueGuid;
+            return ApplyChangesAsync();
+        }
+
+        // Regroups the data after a filter edit and, in Simple mode, raises FilterChanged.
+        // Simple mode applies filters live, so it notifies here; the row and menu modes notify from their own apply paths instead.
+        private Task ApplyChangesAsync()
+        {
             _dataGrid.GroupItems();
+            return _dataGrid.FilterMode == DataGridFilterMode.Simple
+                ? _dataGrid.NotifyFilterChangedAsync()
+                : Task.CompletedTask;
         }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -441,8 +441,8 @@
                     </MudItem>
                     <MudItem xs="4">
                         <MudSelect T="Column<T>" 
-                                   Value="@filterDefinition.Column" 
-                                   ValueChanged="@filter.FieldChanged" 
+                                   Value="@filterDefinition.Column"
+                                   ValueChanged="@filter.FieldChangedAsync"
                                    FullWidth="true" 
                                    Label="@Localizer[LanguageResource.MudDataGrid_Column]" 
                                    Dense="true" 
@@ -465,7 +465,7 @@
                     else
                     {
                         <MudItem xs="3">
-                            <MudSelect @bind-Value="filterDefinition.Operator" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Operator]" Dense="true" Margin="@Margin.Dense"
+                            <MudSelect T="string" Value="@filterDefinition.Operator" ValueChanged="@filter.OperatorChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Operator]" Dense="true" Margin="@Margin.Dense"
                                        Class="filter-operator">
                                 @foreach (var fieldOperator in filterDefinition.Column!.GetFilterOperators(fieldType))
                                 {
@@ -476,17 +476,17 @@
                         <MudItem xs="4">
                             @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
-                                <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                                <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                               Immediate="true" Class="filter-input" />
                             }
                             else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
-                                <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                                <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                                  Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
                             }
                             else if (fieldType.IsEnum)
                             {
-                                <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                                <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                            Class="filter-input">
                                     <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
                                     @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
@@ -497,7 +497,7 @@
                             }
                             else if (fieldType.IsBoolean)
                             {
-                                <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                                <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                            Class="filter-input">
                                     <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
                                     <MudSelectItem T="bool?" Value="@(true)">@Localizer[LanguageResource.MudDataGrid_True]</MudSelectItem>
@@ -506,22 +506,22 @@
                             }
                             else if (fieldType.IsDateOnly && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
-                                <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChanged" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChangedAsync" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                             }
                             else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
                                 <MudGrid Spacing="0">
                                     <MudItem xs="7">
-                                        <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChanged" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                        <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChangedAsync" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                                     </MudItem>
                                     <MudItem xs="5">
-                                        <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time" />
+                                        <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChangedAsync" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time" />
                                     </MudItem>
                                 </MudGrid>
                             }
                             else if (fieldType.IsGuid)
                             {
-                                <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                                <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                               Immediate="true" Class="filter-input"/>
                             }
                         </MudItem>
@@ -543,17 +543,17 @@
                     <MudItem xs="12">
                         @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
-                            <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                            <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                           Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
                         }
                         else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
-                            <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                            <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                              Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
                         }
                         else if (fieldType.IsEnum)
                         {
-                            <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                            <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                        Class="filter-input">
                                 <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
                                 @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
@@ -564,7 +564,7 @@
                         }
                         else if (fieldType.IsBoolean)
                         {
-                            <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                            <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                        Class="filter-input">
                                 <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
                                 <MudSelectItem T="bool?" Value="@(true)">@Localizer[LanguageResource.MudDataGrid_True]</MudSelectItem>
@@ -573,22 +573,22 @@
                         }
                         else if (fieldType.IsDateOnly && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
-                            <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChanged" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                            <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChangedAsync" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                         }
                         else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
                             <MudGrid Spacing="0">
                                 <MudItem xs="7">
-                                    <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChanged" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                    <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChangedAsync" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                                 </MudItem>
                                 <MudItem xs="5">
-                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time"/>
+                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChangedAsync" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time"/>
                                 </MudItem>
                             </MudGrid>
                         }
                         else if (fieldType.IsGuid)
                         {
-                            <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                            <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                           Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
                         }
                     </MudItem>


### PR DESCRIPTION
Fixes #13446.

In `DataGridFilterMode.Simple`, `FilterChanged` fired only when a filter was **cleared**, never when a value or operator was set — matching the report ("fired when clearing, not when setting").

The Simple filter panel's default fields are wired to the internal `Filter<T>` class, whose value handlers updated the definition and called `GroupItems()` but never `NotifyFilterChangedAsync()`; the operator used plain `@bind-Value` with no callback. Only clearing routed through `RemoveFilterAsync`, which does notify. This is the Simple-mode counterpart to #13182 / #13185, which only covered `ColumnFilterRow` and `ColumnFilterMenu`.

**What changed**
- `Filter<T>`: value, operator, and field-change handlers now route through a shared `ApplyChangesAsync()` that regroups and, **only when `FilterMode == Simple`**, raises `FilterChanged`.
- The Simple-mode operator select moved from `@bind-Value` to `Value` + `ValueChanged`.

**Why the mode gate**
`Filter<T>` (and the `Filter(...)` render fragment) is shared between the Simple panel and the `ColumnFilterMenu` popover. ColumnFilterMenu must keep deferring notification to its Apply button (the definition isn't in `FilterDefinitions` until then), so the gate prevents per-keystroke over-firing there. The ColumnFilterMenu operator stays on `@bind-Value`.

**Note:** for server-data Simple mode, `FilterChanged` now fires per keystroke while the Apply button reloads without firing it — consistent with "Simple = live filtering," but asymmetric with ColumnFilterMenu. Easy to switch to Apply-only/debounced notification if that contract is preferred.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
