### PR TITLE
MudPicker: Fix freeze when a literal Text is set with a bound value

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerTextLoopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DatePickerTextLoopTest.razor
@@ -1,0 +1,40 @@
+﻿@* Repro for #13439 on MudDatePicker: a literal Text alongside a bound Date froze the page.
+   Same root cause and guard as TimePickerTextLoopTest; proves the base MudPicker fix covers the
+   DatePicker value/converter path too. *@
+@using System.Globalization
+<MudPopoverProvider />
+
+@if (_showPicker)
+{
+    <MudDatePicker @ref="Picker"
+                   Date="_date"
+                   DateChanged="OnDateChanged"
+                   Text="@Text"
+                   Culture="@(new CultureInfo("en-US"))"
+                   PickerVariant="PickerVariant.Static" />
+}
+
+@code {
+    private DateTime? _date;
+    private bool _showPicker = true;
+    private const int LoopGuardThreshold = 25;
+
+    public MudDatePicker Picker { get; set; } = null!;
+
+    [Parameter]
+    public string? Text { get; set; } = "Broken";
+
+    public int DateChangedCount { get; private set; }
+
+    public bool LoopGuardTripped => DateChangedCount > LoopGuardThreshold;
+
+    private void OnDateChanged(DateTime? value)
+    {
+        _date = value;
+        DateChangedCount++;
+        if (LoopGuardTripped)
+        {
+            _showPicker = false;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/TimePickerTextLoopTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/TimePickerTextLoopTest.razor
@@ -1,0 +1,39 @@
+﻿@* Repro for #13439: a literal Text alongside a bound Time froze the page.
+   The unparseable Text was re-parsed to null on every render and pushed back through TimeChanged,
+   fighting the bound Time and spinning an infinite render loop. LoopGuard stops rendering the picker
+   if TimeChanged runs away, so a regression fails the assertion instead of hanging the test. *@
+<MudPopoverProvider />
+
+@if (_showPicker)
+{
+    <MudTimePicker @ref="Picker"
+                   Time="_time"
+                   TimeChanged="OnTimeChanged"
+                   Text="@Text"
+                   PickerVariant="PickerVariant.Static" />
+}
+
+@code {
+    private TimeSpan? _time;
+    private bool _showPicker = true;
+    private const int LoopGuardThreshold = 25;
+
+    public MudTimePicker Picker { get; set; } = null!;
+
+    [Parameter]
+    public string? Text { get; set; } = "Broken";
+
+    public int TimeChangedCount { get; private set; }
+
+    public bool LoopGuardTripped => TimeChangedCount > LoopGuardThreshold;
+
+    private void OnTimeChanged(TimeSpan? value)
+    {
+        _time = value;
+        TimeChangedCount++;
+        if (LoopGuardTripped)
+        {
+            _showPicker = false;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1115,6 +1115,24 @@ namespace MudBlazor.UnitTests.Components
             picker.Date.Should().Be(initialDate);
         }
 
+        [Test]
+        public async Task LiteralText_WithBoundDate_DoesNotLoopOnSelection()
+        {
+            // #13439: a literal Text ("Broken") alongside a bound Date froze the page. The unparseable Text
+            // was re-parsed to null on every render and pushed back through DateChanged, fighting the bound
+            // Date and spinning an infinite render loop. Picking a date must fire DateChanged a bounded number
+            // of times and leave the picked value in place.
+            var comp = Context.Render<DatePickerTextLoopTest>();
+            var picker = comp.Instance.Picker;
+
+            await comp.SelectDateAsync("15");
+
+            comp.Instance.LoopGuardTripped.Should().BeFalse("a literal Text must not spin an infinite render loop");
+            comp.Instance.DateChangedCount.Should().BeLessThan(5);
+            picker.Date.Should().NotBeNull();
+            picker.Date!.Value.Day.Should().Be(15);
+        }
+
         // In the editable path a month/year click advances the view (Year->Month, Month->Date); the ReadOnly
         // guard must suppress that, so the originally-shown container stays put. Asserting the view (not Date,
         // which a month/year click never commits anyway) is what actually proves the guard.

--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -486,6 +486,24 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task LiteralText_WithBoundTime_DoesNotLoopOnSelection()
+        {
+            // #13439: a literal Text ("Broken") alongside a bound Time froze the page. The unparseable Text
+            // was re-parsed to null on every render and pushed back through TimeChanged, fighting the bound
+            // Time and spinning an infinite render loop. Picking a time must fire TimeChanged a bounded number
+            // of times and leave the picked value in place.
+            var comp = Context.Render<TimePickerTextLoopTest>();
+            var picker = comp.Instance.Picker;
+
+            // Pick an hour as the clock JS would; on a static picker this commits the time.
+            await comp.InvokeAsync(() => picker.SelectTimeFromStick(10, false));
+
+            comp.Instance.LoopGuardTripped.Should().BeFalse("a literal Text must not spin an infinite render loop");
+            comp.Instance.TimeChangedCount.Should().BeLessThan(5);
+            picker.Time.Should().Be(new TimeSpan(10, 0, 0));
+        }
+
+        [Test]
         [TestCase(7, 0)]   // rounds down to 0
         [TestCase(8, 15)]  // rounds up to 15
         [TestCase(22, 15)] // rounds down to 15

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -18,6 +18,8 @@ namespace MudBlazor
     public abstract partial class MudPicker<T> : MudFormComponent<T, string>
     {
         private string? _text;
+        private string? _lastTextParameter;
+        private bool _textParameterInitialized;
         private bool _pickerSquare;
         private ElementReference _pickerInlineRef;
         private bool _keyInterceptorObserving;
@@ -393,7 +395,24 @@ namespace MudBlazor
         public virtual string? Text
         {
             get => _text;
-            set => SetTextAsync(value, true).CatchAndLog();
+            set
+            {
+                // This setter is the parameter-write path (Blazor assigns it during SetParametersAsync).
+                // Only re-parse when the incoming parameter actually differs from the last one supplied.
+                // The old behavior compared against _text, which drifts as the user picks values, so a
+                // parent re-supplying the same literal Text every render re-ran StringValueChanged and
+                // pushed a conflicting value back; combined with a bound Time/Date, that spun an infinite
+                // render loop and froze the page (#13439). This mirrors ParameterState: a parameter the
+                // parent does not change is applied once. User edits go through WriteTextAsync, not here.
+                if (_textParameterInitialized && value == _lastTextParameter)
+                {
+                    return;
+                }
+
+                _lastTextParameter = value;
+                _textParameterInitialized = true;
+                SetTextAsync(value, true).CatchAndLog();
+            }
         }
 
         /// <summary>
@@ -744,11 +763,9 @@ namespace MudBlazor
         // A proxy for components that will utilize ParameterState
         // Since for ParameterState we don't want to write directly from the Text property, but we have other components that inherit from MudPicker
         // In future when all Pickers will use ParameterState, we can remove this.
-        protected virtual Task WriteTextAsync(string? value)
-        {
-            Text = value;
-            return Task.CompletedTask;
-        }
+        // Goes straight to SetTextAsync rather than through the Text parameter setter so a user edit is
+        // never mistaken for a repeated parameter and skipped by that setter's idempotency guard (#13439).
+        protected virtual Task WriteTextAsync(string? value) => SetTextAsync(value, true);
 
         /// <inheritdoc />
         protected override async ValueTask DisposeAsyncCore()


### PR DESCRIPTION
Fixes #13439. Setting a literal `Text` that doesn't parse back to the bound value freezes the page on selection:

```razor
<MudTimePicker @bind-Time="_time" Text="Broken" />
```

Reproduced locally in a Blazor browser harness: a single hour click fired `TimeChanged` **151 times** (an unbounded render loop). Same for `MudDatePicker`.

`MudPicker.Text`'s setter ran `SetTextAsync(value, callback: true)` whenever `_text != value`. But `_text` is the *display* text and drifts as the user picks. So on every render where the parent re-supplied the same literal `Text`, the setter re-parsed it (`"Broken"` → `null`) and pushed the conflicting result back through `TimeChanged`/`DateChanged`, fighting the bound `Time`/`Date` that restores the real value. Each change re-renders the parent, which re-applies the parameters, forever. A valid `Text` that round-trips to the value fires exactly once — no loop.

We can make the `Text` **parameter** setter idempotent, mirroring `ParameterState`: skip re-parsing when the incoming parameter equals the last one supplied. User/field edits are routed through `WriteTextAsync -> SetTextAsync` directly so a real edit never hits the guard.

- One base-class change covers `MudDatePicker`, `MudTimePicker`, and `MudDateRangePicker` (shared `MudPicker` base).
- `MudColorPicker` already overrides `Text` via `ParameterState` and was unaffected.
- This matches the maintainers' stated direction ("In future when all Pickers will use ParameterState") and how `MudBaseInput` already reconciles the Text-vs-Value fight.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
