### PR TITLE
MudDataGrid: Hide columns panel when filtering

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnFilterMenuTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridColumnFilterMenuTest.razor
@@ -1,0 +1,23 @@
+﻿<MudPopoverProvider />
+
+<MudDataGrid T="Model" Items="@_items" Filterable="true" FilterMode="DataGridFilterMode.ColumnFilterMenu" ShowMenuIcon="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Age" />
+        <PropertyColumn Property="x => x.Status" />
+        <PropertyColumn Property="x => x.Hired" />
+        <PropertyColumn Property="x => x.HiredOn" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public record Model(string Name, int? Age, Severity? Status, bool? Hired, DateTime? HiredOn);
+
+    private readonly IEnumerable<Model> _items = new List<Model>
+    {
+        new("Sam", 56, Severity.Normal, false, null),
+        new("Alicia", 54, Severity.Info, null, null),
+        new("Ira", 27, Severity.Success, true, new DateTime(2011, 1, 2)),
+        new("John", 32, Severity.Warning, false, null)
+    };
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4277,6 +4277,49 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("tbody tr").Count.Should().Be(1);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task DataGridColumnFilterMenu_OpeningFilter_ClosesColumnsPanel(bool withExistingFilter)
+        {
+            var comp = Context.Render<DataGridColumnFilterMenuTest>();
+            if (withExistingFilter)
+            {
+                var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterMenuTest.Model>>();
+                var departmentColumn = dataGrid.Instance.RenderedColumns.First(c => c.PropertyName == "Name");
+
+                await comp.InvokeAsync(async () =>
+                {
+                    await dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridColumnFilterMenuTest.Model>
+                    {
+                        Column = departmentColumn,
+                        Operator = FilterOperator.String.Equal,
+                        Value = "Sam"
+                    });
+                });
+            }
+            
+            var buttons = comp.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon");
+            await buttons[0].ClickAsync();
+
+            var menuItem = comp.Find(".mud-menu-item");
+            await menuItem.ClickAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.FindAll(".mud-popover.mud-data-grid-columns-panel").Count.Should().Be(1);
+            });
+
+            var filterButtons = comp.FindAll(".mud-data-grid-columns-panel .filter-button");
+            await filterButtons[0].ClickAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.FindAll(".mud-popover.mud-data-grid-columns-panel").Count.Should().Be(0);
+                comp.FindAll(".mud-popover.column-filter-popup.mud-popover-open").Count.Should().Be(1);
+            });
+        }
+
+
         [Test]
         public async Task DataGridCustomPropertyFilterTemplate()
         {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4285,19 +4285,19 @@ namespace MudBlazor.UnitTests.Components
             if (withExistingFilter)
             {
                 var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterMenuTest.Model>>();
-                var departmentColumn = dataGrid.Instance.RenderedColumns.First(c => c.PropertyName == "Name");
+                var nameColumn = dataGrid.Instance.RenderedColumns.First(c => c.PropertyName == "Name");
 
                 await comp.InvokeAsync(async () =>
                 {
                     await dataGrid.Instance.AddFilterAsync(new FilterDefinition<DataGridColumnFilterMenuTest.Model>
                     {
-                        Column = departmentColumn,
+                        Column = nameColumn,
                         Operator = FilterOperator.String.Equal,
                         Value = "Sam"
                     });
                 });
             }
-            
+
             var buttons = comp.FindAll("button.mud-button-root.mud-icon-button.mud-ripple.mud-ripple-icon");
             await buttons[0].ClickAsync();
 

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -554,6 +554,7 @@ namespace MudBlazor
             {
                 _filtersMenuPosition = (args.PageY, args.PageX);
                 _filtersMenuVisible = true;
+                DataGrid.HideColumnsPanel();
                 DataGrid.DropContainerHasChanged();
             }
         }
@@ -576,6 +577,7 @@ namespace MudBlazor
             {
                 _filtersMenuPosition = (args.PageY, args.PageX);
                 _filtersMenuVisible = true;
+                DataGrid.HideColumnsPanel();
                 DataGrid.DropContainerHasChanged();
             }
         }


### PR DESCRIPTION
Closes #13445

Updated the filter-opening logic (AddFilter / OpenFilters) to close the columns panel when a filter popup is opened. This resolves the overlapping issue, since the columns panel and the filter popup can no longer be open simultaneously.
As a side effect, this also prevents opening multiple filters via the columns panel, since opening a new filter now closes it. 

Note, this is scoped to this specific path - each column still holds its own filter-visibility state, which I haven't changed, so it's possible other paths could still allow overlapping filters. 
I first looked at adjusting the z-index logic in mudPopover.js as the issue suggested, but that code handles nested-popover stacking and is doing more than it looks like at first glance. I think this fix is more targeted and much less likely to introduce new issues.

https://github.com/user-attachments/assets/67e4b4b7-bd84-44fd-9625-183fa3aed90f



**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
