### PR TITLE
MudTable: Fix RowsPerPage reset when the parameter is re-applied on re-render

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageParameterReapplyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageParameterReapplyTest.razor
@@ -1,0 +1,10 @@
+﻿<MudTable T="int" @ref="Table" Items="_items" RowsPerPage="100">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudButton OnClick="Rerender" Variant="Variant.Outlined">Rerender</MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageParameterReapplyTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowsPerPageParameterReapplyTest.razor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.UnitTests.TestComponents.Table;
+
+public partial class TableRowsPerPageParameterReapplyTest : ComponentBase
+{
+    public static string __description__ = "Table - Re-applying an unchanged RowsPerPage parameter must not reset the pager (#13462)";
+
+    public MudTable<int> Table { get; set; } = null!;
+
+    private readonly int[] _items = Enumerable.Range(1, 200).ToArray();
+
+    private void Rerender() => StateHasChanged();
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2737,6 +2737,26 @@ namespace MudBlazor.UnitTests.Components
             await testComponent.WaitForAssertionAsync(() => table.RowsPerPage.Should().Be(35));
         }
 
+        // Issue #13462
+        // A one-way RowsPerPage parameter is re-applied on every parent re-render. Re-applying the
+        // same value must not clobber a page size the user picked via the pager.
+        [Test]
+        public async Task RowsPerPageParameterReapplyDoesNotResetPager()
+        {
+            var testComponent = Context.Render<TableRowsPerPageParameterReapplyTest>();
+            var table = testComponent.FindComponent<MudTable<int>>().Instance;
+            var buttonComponent = testComponent.FindComponent<MudButton>();
+            table.RowsPerPage.Should().Be(100);
+
+            // Simulate the user changing the page size through the pager.
+            await testComponent.InvokeAsync(() => table.SetRowsPerPage(25));
+            table.RowsPerPage.Should().Be(25);
+
+            // A parent re-render re-applies the unchanged RowsPerPage="100" parameter; the pager choice must survive.
+            await buttonComponent.Find("button").ClickAsync();
+            table.RowsPerPage.Should().Be(25);
+        }
+
         /// <summary>
         /// Tests whether record type table items are kept track of when edited
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -216,11 +216,7 @@ namespace MudBlazor
             get => _rowsPerPage ?? 10;
             set
             {
-                // React only when the parameter value itself changes between renders.
-                // The pager (and SetRowsPerPage callers) mutate _rowsPerPage directly, so comparing
-                // against _rowsPerPage would let a re-applied but unchanged parameter clobber that
-                // choice on any parent re-render (#13462). Tracking the last parameter value still
-                // honors genuine parameter changes made from code after the first render (#3033, #3244).
+                // React only to real parameter changes; the pager mutates _rowsPerPage directly, so re-applying an unchanged value must not clobber it (#13462, #3033, #3244).
                 if (_rowsPerPageParameterValue == value)
                 {
                     return;

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -13,6 +13,7 @@ namespace MudBlazor
     {
         private int _currentPage = 0;
         internal int? _rowsPerPage;
+        private int? _rowsPerPageParameterValue;
         internal object? _editingItem = null;
         internal bool Editing => _editingItem != null;
 
@@ -215,10 +216,18 @@ namespace MudBlazor
             get => _rowsPerPage ?? 10;
             set
             {
-                if (_rowsPerPage is null || _rowsPerPage != value)
+                // React only when the parameter value itself changes between renders.
+                // The pager (and SetRowsPerPage callers) mutate _rowsPerPage directly, so comparing
+                // against _rowsPerPage would let a re-applied but unchanged parameter clobber that
+                // choice on any parent re-render (#13462). Tracking the last parameter value still
+                // honors genuine parameter changes made from code after the first render (#3033, #3244).
+                if (_rowsPerPageParameterValue == value)
                 {
-                    SetRowsPerPage(value);
+                    return;
                 }
+
+                _rowsPerPageParameterValue = value;
+                SetRowsPerPage(value);
             }
         }
 


### PR DESCRIPTION
On a `MudTable` with a one-way `RowsPerPage` (e.g. `RowsPerPage="100"`), changing the page size via the pager and then triggering any parent re-render (a row-click callback, `ScrollToItemAsync`/`FocusCellAsync` via a `_table` ref, or any other parent event) snapped the page size back to the literal and, with `ServerData`, fired a redundant reload that discarded the user's choice.

Reproduces on the docs `Programmatic Scroll & Focus` example: set rows-per-page to 25, click *Scroll to Element*, the table reloads at 100.

The `RowsPerPage` setter reacted whenever the incoming parameter value differed from the internal `_rowsPerPage` field:

```csharp
if (_rowsPerPage is null || _rowsPerPage != value)
    SetRowsPerPage(value);
```

The pager changes the size by calling `SetRowsPerPage(25)` directly, mutating `_rowsPerPage` without touching the parameter. When the parent re-renders, Blazor re-applies the unchanged literal `RowsPerPage="100"`; the setter sees `_rowsPerPage(25) != 100` and resets. `MudDataGrid` is unaffected because its setter only applies on the first assignment (`if (_rowsPerPage == null)`).

Fixes #13462 by tracking the last value supplied by the parameter and react only when it actually changes between renders. Re-applying the same value is a no-op (the pager choice survives), while a genuine change from code still applies, preserving #3033/#3244.
