### PR TITLE
MudTable: Fix one-way CurrentPage reset by parent re-render

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterReapplyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterReapplyTest.razor
@@ -1,0 +1,11 @@
+﻿<MudTable T="int" @ref="Table" Items="_items" CurrentPage="_currentPage">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudButton OnClick="Rerender" Variant="Variant.Outlined">Rerender</MudButton>
+<MudButton OnClick="SetPageFromCode" Variant="Variant.Outlined">Set page from code</MudButton>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterReapplyTest.razor.cs
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageParameterReapplyTest.razor.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.UnitTests.TestComponents.Table;
+
+public partial class TableCurrentPageParameterReapplyTest : ComponentBase
+{
+    public static string __description__ = "Table - Re-applying an unchanged CurrentPage parameter must not reset the pager (same class as #13462)";
+
+    public MudTable<int> Table { get; set; } = null!;
+
+    private readonly int[] _items = Enumerable.Range(1, 200).ToArray();
+
+    // One-way bound: the pager mutates the table's page without writing back here, so a plain
+    // re-render re-applies this unchanged value. Changing it from code drives a genuine navigation.
+    private int _currentPage;
+
+    private void Rerender() => StateHasChanged();
+
+    private void SetPageFromCode() => _currentPage = 5;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageServerDataReapplyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableCurrentPageServerDataReapplyTest.razor
@@ -1,0 +1,42 @@
+﻿<MudTable T="int" @ref="Table" ServerData="ServerReload" CurrentPage="_currentPage">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<button id="rerender" @onclick="Rerender">Rerender</button>
+<button id="setcode" @onclick="SetPageFromCode">Set page from code</button>
+
+@code {
+    public static string __description__ = "Table - Re-applying an unchanged CurrentPage parameter must not trigger a redundant ServerData load (same class as #13462)";
+
+    public MudTable<int> Table { get; set; } = null!;
+
+    public int LoadCount { get; private set; }
+
+    public int LastRequestedPage { get; private set; }
+
+    private int _currentPage;
+    private int _totalItems = 200;
+
+    // Lets a test shrink the dataset so the current page overflows and the server-reset path runs.
+    public void ShrinkTo(int totalItems) => _totalItems = totalItems;
+
+    private Task<TableData<int>> ServerReload(TableState state, CancellationToken token)
+    {
+        LoadCount++;
+        LastRequestedPage = state.Page;
+        var start = state.Page * state.PageSize;
+        var count = Math.Clamp(_totalItems - start, 0, state.PageSize);
+        var items = Enumerable.Range(start + 1, count);
+
+        return Task.FromResult(new TableData<int> { TotalItems = _totalItems, Items = items });
+    }
+
+    private void Rerender() => StateHasChanged();
+
+    private void SetPageFromCode() => _currentPage = 5;
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2870,6 +2870,30 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Find(".mud-table-body .mud-table-row .mud-table-cell").TextContent.Should().Be("3"));
         }
 
+        // A one-way CurrentPage parameter is re-applied on every parent re-render. Re-applying the
+        // same value must not clobber a page the user navigated to via the pager (same class as #13462).
+        // A genuine parameter change from code must still navigate.
+        [Test]
+        public async Task CurrentPageParameterReapplyDoesNotResetPager()
+        {
+            var testComponent = Context.Render<TableCurrentPageParameterReapplyTest>();
+            var table = testComponent.FindComponent<MudTable<int>>().Instance;
+            var buttons = testComponent.FindComponents<MudButton>();
+            table.CurrentPage.Should().Be(0);
+
+            // Simulate the user navigating with the pager (the one-way parameter is not written back).
+            await testComponent.InvokeAsync(() => table.NavigateTo(3));
+            table.CurrentPage.Should().Be(3);
+
+            // A parent re-render re-applies the unchanged CurrentPage parameter; the pager choice must survive.
+            await buttons[0].Find("button").ClickAsync();
+            table.CurrentPage.Should().Be(3);
+
+            // A genuine parameter change from code must still navigate.
+            await buttons[1].Find("button").ClickAsync();
+            table.CurrentPage.Should().Be(5);
+        }
+
         /// <summary>
         /// Table initialized to display the third page
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2894,6 +2894,71 @@ namespace MudBlazor.UnitTests.Components
             table.CurrentPage.Should().Be(5);
         }
 
+        // With ServerData, re-applying an unchanged one-way CurrentPage on a parent re-render must not
+        // trigger a redundant server load (#13462); a genuine code-driven change still loads the new page.
+        [Test]
+        public async Task CurrentPageParameterReapplyDoesNotTriggerRedundantServerLoad()
+        {
+            var testComponent = Context.Render<TableCurrentPageServerDataReapplyTest>();
+            var component = testComponent.Instance;
+            var table = testComponent.FindComponent<MudTable<int>>().Instance;
+
+            // Wait for the initial server load to render the first page.
+            await testComponent.WaitForAssertionAsync(() => testComponent.FindAll("tbody tr.mud-table-row").Count.Should().BeGreaterThan(0));
+            table.CurrentPage.Should().Be(0);
+            var loadsAfterInit = component.LoadCount;
+
+            // Internal navigation triggers exactly one load for the requested page.
+            await testComponent.InvokeAsync(() => table.NavigateTo(3));
+            await testComponent.WaitForAssertionAsync(() =>
+            {
+                table.CurrentPage.Should().Be(3);
+                component.LastRequestedPage.Should().Be(3);
+                component.LoadCount.Should().Be(loadsAfterInit + 1);
+            });
+
+            // A parent re-render re-applies the unchanged CurrentPage: the page must stay selected.
+            await testComponent.Find("#rerender").ClickAsync();
+            table.CurrentPage.Should().Be(3);
+
+            // A genuine code-driven change navigates with exactly one more load; the re-render added none
+            // (otherwise this total would be loadsAfterInit + 3).
+            await testComponent.Find("#setcode").ClickAsync();
+            await testComponent.WaitForAssertionAsync(() =>
+            {
+                table.CurrentPage.Should().Be(5);
+                component.LastRequestedPage.Should().Be(5);
+                component.LoadCount.Should().Be(loadsAfterInit + 2);
+            });
+        }
+
+        // The ServerData reset path: when a load reveals the current page no longer exists, the table
+        // resets to page 0 through SetCurrentPage (MudTable.InvokeServerLoadFunc).
+        [Test]
+        public async Task ServerDataResetsToFirstPageWhenCurrentPageOverflows()
+        {
+            var testComponent = Context.Render<TableCurrentPageServerDataReapplyTest>();
+            var component = testComponent.Instance;
+            var table = testComponent.FindComponent<MudTable<int>>().Instance;
+
+            await testComponent.WaitForAssertionAsync(() => testComponent.FindAll("tbody tr.mud-table-row").Count.Should().BeGreaterThan(0));
+
+            await testComponent.InvokeAsync(() => table.NavigateTo(5));
+            await testComponent.WaitForAssertionAsync(() => table.CurrentPage.Should().Be(5));
+
+            // Data shrinks so page 5 no longer exists; the next load must snap back to page 0.
+            await testComponent.InvokeAsync(() =>
+            {
+                component.ShrinkTo(20);
+                return table.ReloadServerData();
+            });
+            await testComponent.WaitForAssertionAsync(() =>
+            {
+                table.CurrentPage.Should().Be(0);
+                component.LastRequestedPage.Should().Be(0);
+            });
+        }
+
         /// <summary>
         /// Table initialized to display the third page
         /// </summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -605,7 +605,7 @@ namespace MudBlazor
                     {
                         lastPageNo -= 1;
                     }
-                    CurrentPage = lastPageNo < CurrentPage ? lastPageNo : CurrentPage;
+                    SetCurrentPage(lastPageNo < CurrentPage ? lastPageNo : CurrentPage);
                 }
 
                 return GetItemsOfPage(CurrentPage, RowsPerPage);
@@ -798,7 +798,7 @@ namespace MudBlazor
 
             if (CurrentPage * RowsPerPage > _serverData.TotalItems)
             {
-                CurrentPage = 0;
+                SetCurrentPage(0);
             }
 
             Loading = false;

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -12,6 +12,7 @@ namespace MudBlazor
     public abstract class MudTableBase : MudComponentBase
     {
         private int _currentPage = 0;
+        private int? _currentPageParameterValue;
         internal int? _rowsPerPage;
         internal object? _editingItem = null;
         internal bool Editing => _editingItem != null;
@@ -241,18 +242,14 @@ namespace MudBlazor
             get => _currentPage;
             set
             {
-                if (_currentPage == value)
+                // React only to genuine parameter changes: internal nav mutates the page via SetCurrentPage, so a re-applied but unchanged CurrentPage must not clobber it on a parent re-render (#13462).
+                if (_currentPageParameterValue == value)
                 {
                     return;
                 }
 
-                _currentPage = value;
-                InvokeAsync(StateHasChanged);
-                CurrentPageChanged.InvokeAsync(_currentPage);
-                if (HasRendered)
-                {
-                    InvokeServerLoadFunc();
-                }
+                _currentPageParameterValue = value;
+                SetCurrentPage(value);
             }
         }
 
@@ -654,16 +651,16 @@ namespace MudBlazor
             switch (page)
             {
                 case Page.First:
-                    CurrentPage = 0;
+                    SetCurrentPage(0);
                     break;
                 case Page.Last:
-                    CurrentPage = Math.Max(0, NumPages - 1);
+                    SetCurrentPage(Math.Max(0, NumPages - 1));
                     break;
                 case Page.Next:
-                    CurrentPage = Math.Min(NumPages - 1, CurrentPage + 1);
+                    SetCurrentPage(Math.Min(NumPages - 1, CurrentPage + 1));
                     break;
                 case Page.Previous:
-                    CurrentPage = Math.Max(0, CurrentPage - 1);
+                    SetCurrentPage(Math.Max(0, CurrentPage - 1));
                     break;
             }
         }
@@ -673,7 +670,24 @@ namespace MudBlazor
         /// <param name="pageIndex">The index of the page to navigate to.</param>
         public void NavigateTo(int pageIndex)
         {
-            CurrentPage = Math.Min(Math.Max(0, pageIndex), NumPages - 1);
+            SetCurrentPage(Math.Min(Math.Max(0, pageIndex), NumPages - 1));
+        }
+
+        // Applies an internal page change (pager/NavigateTo/clamp/reset); must not update _currentPageParameterValue or it would be mistaken for a parameter change (#13462).
+        internal void SetCurrentPage(int page)
+        {
+            if (_currentPage == page)
+            {
+                return;
+            }
+
+            _currentPage = page;
+            InvokeAsync(StateHasChanged);
+            CurrentPageChanged.InvokeAsync(_currentPage);
+            if (HasRendered)
+            {
+                InvokeServerLoadFunc();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
A one-way `CurrentPage="N"` on `MudTable` is re-applied on every parent re-render. Internal navigation (the pager, `NavigateTo`, the `CurrentPageItems` clamp, and the `ServerData` reset) all mutated the page through the `CurrentPage` property setter, which compared the incoming value against the internal `_currentPage`. So a re-applied but unchanged parameter looked like a change: it snapped the page back to `N` and re-fired `ServerData`.

Any parent-hosted event (a button, an `OnRowClick` callback, `ScrollToItemAsync`) triggers the re-render that surfaces this. Same class of bug as RowsPerPage in https://github.com/MudBlazor/MudBlazor/issues/13462.

Fix:

- Extract `internal SetCurrentPage(int)` and route all internal navigation through it instead of the public parameter setter.
- Make the `CurrentPage` parameter setter react only when the parameter value actually changes between renders (track `_currentPageParameterValue`), mirroring the RowsPerPage approach.
- Code-driven `CurrentPage` changes still navigate; two-way `@bind-CurrentPage` is unaffected.
