### PR TITLE
Localization: Avoid satellite assembly probing under non-English cultures

### DIFF
--- a/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
@@ -186,6 +186,50 @@ public class DefaultLocalizationInterceptorTests
         result.Value.Should().Be(expectedValue, "The value should be the template string with the provided parameter.");
     }
 
+    [Test]
+    [NonParallelizable]
+    [SetUICulture("sv-SE")]
+    public void DefaultEnglishLookup_NonEnglishUICulture_DoesNotProbeSatelliteAssembly()
+    {
+        // Regression test for #13461. Reading the built-in English resources under a non-English UI culture
+        // must not make the ResourceManager probe for a (non-existent) MudBlazor.resources satellite assembly.
+        // On the Blazor WebAssembly runtime each probe throws a first-chance FileNotFoundException; on the
+        // runtime used by the test host the same probe surfaces as an AssemblyResolve request.
+        // A value-only assertion is not enough: the English fallback resolves correctly either way, so the
+        // test asserts that the probe never happens.
+
+        // Arrange
+        var defaultLocalizationInterceptor = new DefaultLocalizationInterceptor(NullLoggerFactory.Instance, mudLocalizer: null);
+        var internalMudLocalizer = new InternalMudLocalizer(defaultLocalizationInterceptor);
+        var satelliteProbes = 0;
+        ResolveEventHandler handler = (_, args) =>
+        {
+            if (args.Name.StartsWith("MudBlazor.resources", StringComparison.OrdinalIgnoreCase))
+            {
+                Interlocked.Increment(ref satelliteProbes);
+            }
+
+            return null;
+        };
+        AppDomain.CurrentDomain.AssemblyResolve += handler;
+
+        // Act
+        LocalizedString result;
+        try
+        {
+            result = internalMudLocalizer[LanguageResource.MudDataGrid_Clear];
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= handler;
+        }
+
+        // Assert
+        satelliteProbes.Should().Be(0, "the invariant-culture lookup must not probe for a culture-specific satellite assembly");
+        result.ResourceNotFound.Should().BeFalse();
+        result.Value.Should().Be("Clear", "the built-in English fallback is still returned under a non-English UI culture");
+    }
+
     private static string GetResourceString(string key, params object[] parameters)
     {
         var resourceString = LanguageResource.GetResourceString(key) ?? string.Empty;

--- a/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
@@ -191,12 +191,9 @@ public class DefaultLocalizationInterceptorTests
     [SetUICulture("sv-SE")]
     public void DefaultEnglishLookup_NonEnglishUICulture_DoesNotProbeSatelliteAssembly()
     {
-        // Regression test for #13461. Reading the built-in English resources under a non-English UI culture
-        // must not make the ResourceManager probe for a (non-existent) MudBlazor.resources satellite assembly.
-        // On the Blazor WebAssembly runtime each probe throws a first-chance FileNotFoundException; on the
-        // runtime used by the test host the same probe surfaces as an AssemblyResolve request.
-        // A value-only assertion is not enough: the English fallback resolves correctly either way, so the
-        // test asserts that the probe never happens.
+        // Regression test for #13461. Reading the built-in English resources under a non-English UI culture must not make the ResourceManager probe for a (non-existent) MudBlazor.resources satellite assembly.
+        // On the Blazor WebAssembly runtime each probe throws a first-chance FileNotFoundException; on the runtime used by the test host the same probe surfaces as an AssemblyResolve request.
+        // A value-only assertion is not enough: the English fallback resolves correctly either way, so the test asserts that the probe never happens.
 
         // Arrange
         var defaultLocalizationInterceptor = new DefaultLocalizationInterceptor(NullLoggerFactory.Instance, mudLocalizer: null);

--- a/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Localization;
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MudBlazor.Resources;
@@ -56,6 +59,43 @@ public abstract class AbstractLocalizationInterceptor : ILocalizationInterceptor
         var options = Options.Create(new LocalizationOptions());
         var factory = new ResourceManagerStringLocalizerFactory(options, loggerFactory);
 
-        return factory.Create(typeof(LanguageResource));
+        // The built-in resources only contain the neutral (English) strings; MudBlazor ships no satellite assemblies.
+        // Reading them under a non-English UI culture makes the ResourceManager probe for a non-existent
+        // MudBlazor.resources satellite, which throws a first-chance FileNotFoundException on every fresh lookup.
+        // That is mostly invisible at runtime but crippling under the Blazor WebAssembly debugger (see #13461).
+        // Pinning the lookup to the invariant culture returns the embedded neutral resource with no satellite probing.
+        return new InvariantLanguageResourceLocalizer(factory.Create(typeof(LanguageResource)));
+    }
+
+    /// <summary>
+    /// Wraps the built-in English <see cref="IStringLocalizer"/> so lookups resolve under the invariant culture,
+    /// avoiding satellite-assembly probing under non-English UI cultures. Only <see cref="CultureInfo.CurrentUICulture"/>
+    /// is pinned, so <see cref="CultureInfo.CurrentCulture"/> still formats arguments in the user's culture.
+    /// </summary>
+    private sealed class InvariantLanguageResourceLocalizer(IStringLocalizer inner) : IStringLocalizer
+    {
+        public LocalizedString this[string name]
+            => ReadInvariant(() => inner[name]);
+
+        public LocalizedString this[string name, params object[] arguments]
+            => ReadInvariant(() => inner[name, arguments]);
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
+            => ReadInvariant(() => inner.GetAllStrings(includeParentCultures).ToList());
+
+        private static T ReadInvariant<T>(Func<T> read)
+        {
+            // Synchronous swap/restore with no await in between, so the culture never leaks to another flow.
+            var previous = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            try
+            {
+                return read();
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = previous;
+            }
+        }
     }
 }

--- a/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
@@ -59,17 +59,13 @@ public abstract class AbstractLocalizationInterceptor : ILocalizationInterceptor
         var options = Options.Create(new LocalizationOptions());
         var factory = new ResourceManagerStringLocalizerFactory(options, loggerFactory);
 
-        // The built-in resources only contain the neutral (English) strings; MudBlazor ships no satellite assemblies.
-        // Reading them under a non-English UI culture makes the ResourceManager probe for a non-existent
-        // MudBlazor.resources satellite, which throws a first-chance FileNotFoundException on every fresh lookup.
-        // That is mostly invisible at runtime but crippling under the Blazor WebAssembly debugger (see #13461).
-        // Pinning the lookup to the invariant culture returns the embedded neutral resource with no satellite probing.
+        // MudBlazor ships no satellite assemblies, so look up the built-in English strings under the invariant
+        // culture to avoid probing for a non-existent MudBlazor.resources satellite under non-English UI cultures (#13461).
         return new InvariantLanguageResourceLocalizer(factory.Create(typeof(LanguageResource)));
     }
 
     /// <summary>
-    /// Wraps the built-in English <see cref="IStringLocalizer"/> so lookups resolve under the invariant culture,
-    /// avoiding satellite-assembly probing under non-English UI cultures. Only <see cref="CultureInfo.CurrentUICulture"/>
+    /// Resolves the built-in English resources under the invariant culture. Only <see cref="CultureInfo.CurrentUICulture"/>
     /// is pinned, so <see cref="CultureInfo.CurrentCulture"/> still formats arguments in the user's culture.
     /// </summary>
     private sealed class InvariantLanguageResourceLocalizer(IStringLocalizer inner) : IStringLocalizer

--- a/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
@@ -59,14 +59,12 @@ public abstract class AbstractLocalizationInterceptor : ILocalizationInterceptor
         var options = Options.Create(new LocalizationOptions());
         var factory = new ResourceManagerStringLocalizerFactory(options, loggerFactory);
 
-        // MudBlazor ships no satellite assemblies, so look up the built-in English strings under the invariant
-        // culture to avoid probing for a non-existent MudBlazor.resources satellite under non-English UI cultures (#13461).
+        // MudBlazor ships no satellite assemblies, so look up the built-in English strings under the invariant culture to avoid probing for a non-existent MudBlazor.resources satellite under non-English UI cultures (#13461).
         return new InvariantLanguageResourceLocalizer(factory.Create(typeof(LanguageResource)));
     }
 
     /// <summary>
-    /// Resolves the built-in English resources under the invariant culture. Only <see cref="CultureInfo.CurrentUICulture"/>
-    /// is pinned, so <see cref="CultureInfo.CurrentCulture"/> still formats arguments in the user's culture.
+    /// Resolves the built-in English resources under the invariant culture. Only <see cref="CultureInfo.CurrentUICulture"/> is pinned, so <see cref="CultureInfo.CurrentCulture"/> still formats arguments in the user's culture.
     /// </summary>
     private sealed class InvariantLanguageResourceLocalizer(IStringLocalizer inner) : IStringLocalizer
     {


### PR DESCRIPTION
The built-in English resources are looked up through a `ResourceManagerStringLocalizer` that resolves under the ambient `CurrentUICulture`. MudBlazor ships only the neutral `LanguageResource.resx` (no satellite assemblies), so a non-English culture makes `ResourceManager` walk the fallback chain (`sv-SE` → `sv` → invariant) and probe for a missing `MudBlazor.resources` satellite, throwing a caught first-chance `FileNotFoundException` on each fresh lookup.

- Mostly invisible at runtime, but crippling under the Visual Studio managed Blazor WebAssembly debugger: every caught exception stalls the debugger agent, so a small `MudDataGrid` renders in ~14-15s instead of ~100ms.
- The interceptor/localizer are registered transient and injected per component, so each localized component builds a fresh `ResourceManager` and re-probes; the cost scales with the number of localized components.
- Affects any non-English culture, including `en-US` (which probes `en-US` and `en`).

Fixes #13461 by wrapping the built-in localizer in `DefaultLanguageResourceReader` so its lookups resolve under `InvariantCulture`, which reads the embedded neutral resource with no satellite probing.

- Only `CurrentUICulture` is pinned, synchronously with no `await` gap, so `CurrentCulture` still formats arguments in the user's culture.
- Applied only to the built-in English resource; a custom `IStringLocalizer` (other constructor) and a custom `MudLocalizer` keep the app's current UI culture.
