### PR TITLE
MudTable: Do not show progress bar and loading content together

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -367,9 +367,8 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Regression test for #11514: when Loading is true and LoadingContent is set, the custom content
-        /// replaces the built-in progress bar rather than showing both. The progress bar is still used when
-        /// the current page has items (e.g. a background refresh), where the custom content is not rendered.
+        /// Regression test for #11514: when Loading is true and LoadingContent is set, the custom content replaces the built-in progress bar rather than showing both.
+        /// The progress bar is still used when the current page has items (e.g. a background refresh), where the custom content is not rendered.
         /// </summary>
         [Test]
         public async Task LoadingContentReplacesProgressBar()

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -289,7 +289,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").Count.Should().Be(2);
             comp.FindAll("tr")[1].TextContent.Should().Be("No records");
 
-            // With LoadingContent set and no records, the custom content replaces the progress bar (issue #11514):
+            // LoadingContent replaces the progress bar when there are no records (#11514):
             // 2 rows = header row + loading text
             await switchElement.ChangeAsync(true);
             comp.FindAll("tr").Count.Should().Be(2);
@@ -322,7 +322,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").Count.Should().Be(2);
             comp.FindAll("tr")[1].TextContent.Should().Be("No matching records found");
 
-            // With LoadingContent set and no records, the custom content replaces the progress bar (issue #11514):
+            // LoadingContent replaces the progress bar when there are no records (#11514):
             // 2 rows = header row + loading content row
             await switchElement.ChangeAsync(true);
             comp.FindAll("tr").Count.Should().Be(2);
@@ -356,7 +356,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").Count.Should().Be(2);
             comp.FindAll("tr")[1].TextContent.Should().Be("No matching records found");
 
-            // With LoadingContentBody set and no records, the custom content replaces the progress bar (issue #11514):
+            // LoadingContentBody replaces the progress bar when there are no records (#11514):
             // 5 rows = 4 loading rows + header row
             await switchElement.ChangeAsync(true);
             comp.FindAll("tr").Count.Should().Be(5);

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -289,10 +289,11 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").Count.Should().Be(2);
             comp.FindAll("tr")[1].TextContent.Should().Be("No records");
 
-            // It should be equal to 3 = header row + loading progress row + loading text
+            // With LoadingContent set and no records, the custom content replaces the progress bar (issue #11514):
+            // 2 rows = header row + loading text
             await switchElement.ChangeAsync(true);
-            comp.FindAll("tr").Count.Should().Be(3);
-            comp.FindAll("tr")[2].TextContent.Should().Be("Loading...");
+            comp.FindAll("tr").Count.Should().Be(2);
+            comp.FindAll("tr")[1].TextContent.Should().Be("Loading...");
 
             // Remove filter
             await searchString.ChangeAsync("");
@@ -321,10 +322,12 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").Count.Should().Be(2);
             comp.FindAll("tr")[1].TextContent.Should().Be("No matching records found");
 
-            // It should be equal to 3 = empty row string + header row + loading row
+            // With LoadingContent set and no records, the custom content replaces the progress bar (issue #11514):
+            // 2 rows = header row + loading content row
             await switchElement.ChangeAsync(true);
-            comp.FindAll("tr").Count.Should().Be(3);
-            comp.FindAll("tr")[2].TextContent.Should().Be("Loading...");
+            comp.FindAll("tr").Count.Should().Be(2);
+            comp.FindAll("tr")[1].TextContent.Should().Be("Loading...");
+            comp.FindAll(".mud-table-loading-progress").Count.Should().Be(0);
         }
 
         /// <summary>
@@ -353,12 +356,37 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr").Count.Should().Be(2);
             comp.FindAll("tr")[1].TextContent.Should().Be("No matching records found");
 
-            // It should be equal to 6 = 4 loading rows + header row + loading row
+            // With LoadingContentBody set and no records, the custom content replaces the progress bar (issue #11514):
+            // 5 rows = 4 loading rows + header row
             await switchElement.ChangeAsync(true);
-            comp.FindAll("tr").Count.Should().Be(6);
+            comp.FindAll("tr").Count.Should().Be(5);
+            comp.FindAll(".mud-table-loading-progress").Count.Should().Be(0);
 
             // It should be equal to 20 = 4 rows * 5 columns
             comp.FindAll(".mud-skeleton").Count.Should().Be(20);
+        }
+
+        /// <summary>
+        /// Regression test for #11514: when Loading is true and LoadingContent is set, the custom content
+        /// replaces the built-in progress bar rather than showing both. The progress bar is still used when
+        /// the current page has items (e.g. a background refresh), where the custom content is not rendered.
+        /// </summary>
+        [Test]
+        public async Task LoadingContentReplacesProgressBar()
+        {
+            var comp = Context.Render<TableLoadingTest>();
+            var searchString = comp.Find("#searchString");
+            var switchElement = comp.Find("#switch");
+
+            // Items present + loading => progress bar is shown, custom content is not.
+            await switchElement.ChangeAsync(true);
+            comp.FindAll(".mud-table-loading-progress").Count.Should().Be(1);
+            comp.Markup.Should().NotContain("Loading...");
+
+            // No items + loading => custom content is shown, progress bar is not (the actual bug).
+            await searchString.ChangeAsync("ZZZ");
+            comp.FindAll(".mud-table-loading-progress").Count.Should().Be(0);
+            comp.FindAll("tr").Select(tr => tr.TextContent).Should().Contain("Loading...");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -65,7 +65,7 @@
                                     }
                                 </MudTHeadRow>
                             }
-                            @if (Loading)
+                            @if (ShowLoadingProgress)
                             {
                                 <tr class="mud-table-loading-row">
                                     <th colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
@@ -75,7 +75,7 @@
                             }
                         </thead>
                     }
-                    else if (Loading)
+                    else if (ShowLoadingProgress)
                     {
                         <thead class="@HeadClassname">
                             <tr class="mud-table-loading-row">

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -590,8 +590,7 @@ namespace MudBlazor
         /// Renders the built-in loading progress bar.
         /// </summary>
         /// <remarks>
-        /// Custom loading content (<see cref="LoadingContent"/> or <see cref="LoadingContentBody"/>)
-        /// replaces the progress bar when it is displayed, which is when the current page has no items.
+        /// Custom loading content (<see cref="LoadingContent"/> or <see cref="LoadingContentBody"/>) replaces the progress bar when it is displayed, which is when the current page has no items.
         /// When items are still present, for example during a refresh, the progress bar is shown instead.
         /// </remarks>
         private bool ShowLoadingProgress =>

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -586,6 +586,17 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// Whether the built-in loading progress bar should be rendered.
+        /// </summary>
+        /// <remarks>
+        /// Per the <c>Loading</c> contract, custom loading content (<see cref="LoadingContent"/> or
+        /// <see cref="LoadingContentBody"/>) replaces the progress bar when it is actually displayed, i.e. when the
+        /// current page has no items to show. When the page still has items (e.g. a refresh), the progress bar is used.
+        /// </remarks>
+        private bool ShowLoadingProgress =>
+            Loading && (CurrentPageItems.Any() || (LoadingContent is null && LoadingContentBody is null));
+
         protected IEnumerable<T> CurrentPageItems
         {
             get

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -587,12 +587,12 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Whether the built-in loading progress bar should be rendered.
+        /// Renders the built-in loading progress bar.
         /// </summary>
         /// <remarks>
-        /// Per the <c>Loading</c> contract, custom loading content (<see cref="LoadingContent"/> or
-        /// <see cref="LoadingContentBody"/>) replaces the progress bar when it is actually displayed, i.e. when the
-        /// current page has no items to show. When the page still has items (e.g. a refresh), the progress bar is used.
+        /// Custom loading content (<see cref="LoadingContent"/> or <see cref="LoadingContentBody"/>)
+        /// replaces the progress bar when it is displayed, which is when the current page has no items.
+        /// When items are still present, for example during a refresh, the progress bar is shown instead.
         /// </remarks>
         private bool ShowLoadingProgress =>
             Loading && (CurrentPageItems.Any() || (LoadingContent is null && LoadingContentBody is null));


### PR DESCRIPTION
### Description

When `Loading` was `true` and `LoadingContent` (or `LoadingContentBody`) was set, the built-in `MudProgressLinear` was rendered in the table header **at the same time** as the custom loading content in the body.

This contradicts the documented behavior of `Loading`:
> When `true`, either a `MudProgressLinear` is displayed **or** custom content if `LoadingContent` or `LoadingContentBody` is set.

(and `LoadingProgressColor`: *"Has no effect if `LoadingContent` or `LoadingContentBody` is set."*)

The progress bar is now gated behind a new `ShowLoadingProgress` check, so the custom loading content **replaces** it when it is actually displayed (i.e. when the current page has no items). When the page still has items — e.g. a background refresh where the custom content isn't rendered — the progress bar is still shown, preserving existing behavior.

### Tests

- Updated `TableHeadContent`, `TableHeadContentBody`, and `TableGroupLoadingAndNoRecords`, which had encoded the old both-shown behavior.
- Added `LoadingContentReplacesProgressBar` covering both cases: progress bar shown with items present, custom content (no progress bar) when empty.
- All 142 `TableTests` pass.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

Fixes #11514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
