### PR TITLE
Build: Revert dependency Microsoft.NET.Test.Sdk to 18.7.0

### DIFF
--- a/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
+++ b/src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
+++ b/src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj
@@ -70,7 +70,7 @@
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
+++ b/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts MudBlazor/MudBlazor#13471

Accidentally merged with failing CI:

```
Error: /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs(50,30): error CS0103: The name 'Newtonsoft' does not exist in the current context [/home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj]
Error: /home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/Utilities/MudColorTests.cs(51,39): error CS0103: The name 'Newtonsoft' does not exist in the current context [/home/runner/work/MudBlazor/MudBlazor/src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj]
```

caused by https://github.com/microsoft/vstest/pull/15687