### PR TITLE
Tests: Normalize button HTML attributes

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/IconButtonTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/IconButtonTest.razor
@@ -1,10 +1,10 @@
 ﻿<MudIconButton Icon="@Icons.Material.Filled.Favorite"
 			   Color="Color.Secondary"
-			   Title="This should appear when hovering over the button, not just the icon" />
+			   title="This should appear when hovering over the button, not just the icon" />
 
 <MudFab Icon="@Icons.Material.Filled.Sailing"
 		Color="Color.Secondary"
-		Title="This should appear when hovering over the button, not just the icon" />
+		title="This should appear when hovering over the button, not just the icon" />
 
 		
 <MudFab Icon="@Icons.Material.Filled.RestoreFromTrash"

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldAutoSizingDialog.razor
@@ -22,14 +22,14 @@
     <DialogActions>
         <MudButton Class="cancel-button"
                    StartIcon="@Icons.Material.Rounded.Close"
-                   AriaLabel="Cancel"
+                   aria-label="Cancel"
                    OnClick="Cancel">
             Cancel
         </MudButton>
 
         <MudButton Class="submit-button"
                    StartIcon="@Icons.Material.Rounded.Check"
-                   AriaLabel="Submit"
+                   aria-label="Submit"
                    OnClick="Submit"
                    Variant="Variant.Filled"
                    Color="Color.Primary">

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFixedSizingDialog.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldFixedSizingDialog.razor
@@ -21,14 +21,14 @@
     <DialogActions>
         <MudButton Class="cancel-button"
                    StartIcon="@Icons.Material.Rounded.Close"
-                   AriaLabel="Cancel"
+                   aria-label="Cancel"
                    OnClick="Cancel">
             Cancel
         </MudButton>
 
         <MudButton Class="submit-button"
                    StartIcon="@Icons.Material.Rounded.Check"
-                   AriaLabel="Submit"
+                   aria-label="Submit"
                    OnClick="Submit"
                    Variant="Variant.Filled"
                    Color="Color.Primary">

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -25,24 +25,6 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class TextFieldTests : BunitTest
     {
-        [TestCase(typeof(TextFieldAutoSizingDialog))]
-        [TestCase(typeof(TextFieldFixedSizingDialog))]
-        public async Task DialogButtons_ShouldRenderValidAriaLabels(Type dialogType)
-        {
-            var provider = Context.Render<MudDialogProvider>();
-            var dialogService = Context.Services.GetRequiredService<IDialogService>();
-
-            await provider.InvokeAsync(() => dialogService.ShowAsync(dialogType));
-
-            var cancelButton = provider.Find(".cancel-button");
-            cancelButton.GetAttribute("aria-label").Should().Be("Cancel");
-            cancelButton.GetAttribute("arialabel").Should().BeNull();
-
-            var submitButton = provider.Find(".submit-button");
-            submitButton.GetAttribute("aria-label").Should().Be("Submit");
-            submitButton.GetAttribute("arialabel").Should().BeNull();
-        }
-
         /// <summary>
         /// Text Field id should propagate to label for attribute
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -25,6 +25,24 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class TextFieldTests : BunitTest
     {
+        [TestCase(typeof(TextFieldAutoSizingDialog))]
+        [TestCase(typeof(TextFieldFixedSizingDialog))]
+        public async Task DialogButtons_ShouldRenderValidAriaLabels(Type dialogType)
+        {
+            var provider = Context.Render<MudDialogProvider>();
+            var dialogService = Context.Services.GetRequiredService<IDialogService>();
+
+            await provider.InvokeAsync(() => dialogService.ShowAsync(dialogType));
+
+            var cancelButton = provider.Find(".cancel-button");
+            cancelButton.GetAttribute("aria-label").Should().Be("Cancel");
+            cancelButton.GetAttribute("arialabel").Should().BeNull();
+
+            var submitButton = provider.Find(".submit-button");
+            submitButton.GetAttribute("aria-label").Should().Be("Submit");
+            submitButton.GetAttribute("arialabel").Should().BeNull();
+        }
+
         /// <summary>
         /// Text Field id should propagate to label for attribute
         /// </summary>


### PR DESCRIPTION
## Summary

Buttons have no `Title` or `AriaLabel` parameter (removed in #9098), so those attributes were captured by `MudComponentBase.UserAttributes` and emitted verbatim. `AriaLabel` rendered as the invalid `arialabel`, which screen readers ignore.

Related to #9098

## Changes

- Use `aria-label` on the Cancel and Submit buttons in both TextField sizing dialog test components.
- Use lowercase `title` on the `MudIconButton` and `MudFab` viewer examples to match the HTML attribute.
- Add the missing trailing newline to `IconButtonTest.razor`.

Test components only — no library or public API changes.
