### PR TITLE
Build: Document a screen-reader-free accessibility diagnosis workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,7 @@ Use `@attribute [ViewerHidden]` for helper or sub-components that are not meanin
 
 ### Diagnosing accessibility issues
 
-Screen readers render the browser's accessibility tree, so diagnose and verify against the tree, not against NVDA/JAWS narration. A screen reader is never required. The spec to verify against is the matching W3C ARIA Authoring Practices Guide pattern (https://www.w3.org/WAI/ARIA/apg/patterns/) — its role, name, state, and keyboard-interaction tables are the acceptance checklist.
+Screen readers render the browser's accessibility tree, so diagnose and verify against the tree. A screen reader is not required. The spec to verify against is the matching W3C ARIA Authoring Practices Guide pattern (https://www.w3.org/WAI/ARIA/apg/patterns/) — its role, name, state, and keyboard-interaction tables are the acceptance checklist.
 
 Diagnosis loop:
 1. Host the component in the Viewer using the reproduction loop above (`chrome=none`).
@@ -336,11 +336,6 @@ Diagnosis loop:
 3. Interact as a keyboard user would (open the popup, arrow through options, select, close) and re-snapshot after each step. Dynamic states are where most bugs live: `aria-expanded` must flip, `aria-activedescendant` must track the visual highlight, `aria-selected` must follow selection. A highlight implemented only as a CSS class is invisible to assistive tech.
 4. Optionally inject axe-core into the Viewer page for a WCAG rule scan (missing names, role conflicts, contrast). It supplements but does not replace the APG checklist.
 5. Diff the snapshots against the APG pattern; each mismatch is a concrete defect.
-
-Fixing:
-- Reference implementation for popup-input patterns: `MudSelect` (`src/MudBlazor/Components/Select/MudSelect.razor.cs`, combobox/listbox wiring from #13077).
-- Prefer `aria-activedescendant` on the input over moving DOM focus into popovers; reuse the component's existing stable element ids and highlight-index state.
-- Generated-attribute override behavior follows the Accessibility and behavior rules under Component Authoring Rules.
 
 Verify with bUnit assertions on roles and `aria-*` attributes before and after interaction (reference: `SelectTests.cs`), then re-snapshot the accessibility tree in the Viewer to confirm the pattern checklist passes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ private Task ToggleAsync()
 - When generating HTML or ARIA attributes in component code, prefer fallback values so caller-provided attributes can override them whenever feasible; do not hard-force generated attributes unless the behavior truly requires it.
 - Ensure keyboard navigation works for interactive components.
 - Provide accessible names for interactive controls through a label, `aria-label`, or `aria-labelledby`.
+- To diagnose or verify screen-reader behavior, follow Diagnosing accessibility issues under Testing Rules; a screen reader is not required.
 - Components with logic require bUnit tests and a docs page at `src/MudBlazor.Docs/Pages/Components/<ComponentName>.razor`.
 
 ## Docs Pages and Examples
@@ -324,6 +325,24 @@ Reproduction loop:
 7. Delete the component (and rebuild) when done; a scratch component is removed with a single file delete.
 
 Use `@attribute [ViewerHidden]` for helper or sub-components that are not meaningful to open on their own; they stay routable but are kept out of the sidebar listing.
+
+### Diagnosing accessibility issues
+
+Screen readers render the browser's accessibility tree, so diagnose and verify against the tree, not against NVDA/JAWS narration. A screen reader is never required. The spec to verify against is the matching W3C ARIA Authoring Practices Guide pattern (https://www.w3.org/WAI/ARIA/apg/patterns/) — its role, name, state, and keyboard-interaction tables are the acceptance checklist.
+
+Diagnosis loop:
+1. Host the component in the Viewer using the reproduction loop above (`chrome=none`).
+2. Snapshot the accessibility tree (browser tooling accessibility snapshot, or CDP `Accessibility.getFullAXTree`) and check static structure: roles, accessible names, and `aria-*` states present.
+3. Interact as a keyboard user would (open the popup, arrow through options, select, close) and re-snapshot after each step. Dynamic states are where most bugs live: `aria-expanded` must flip, `aria-activedescendant` must track the visual highlight, `aria-selected` must follow selection. A highlight implemented only as a CSS class is invisible to assistive tech.
+4. Optionally inject axe-core into the Viewer page for a WCAG rule scan (missing names, role conflicts, contrast). It supplements but does not replace the APG checklist.
+5. Diff the snapshots against the APG pattern; each mismatch is a concrete defect.
+
+Fixing:
+- Reference implementation for popup-input patterns: `MudSelect` (`src/MudBlazor/Components/Select/MudSelect.razor.cs`, combobox/listbox wiring from #13077).
+- Prefer `aria-activedescendant` on the input over moving DOM focus into popovers; reuse the component's existing stable element ids and highlight-index state.
+- Generated-attribute override behavior follows the Accessibility and behavior rules under Component Authoring Rules.
+
+Verify with bUnit assertions on roles and `aria-*` attributes before and after interaction (reference: `SelectTests.cs`), then re-snapshot the accessibility tree in the Viewer to confirm the pattern checklist passes.
 
 ## Code Style and Analyzer Rules
 


### PR DESCRIPTION
Documents a screen-reader-free workflow for diagnosing accessibility issues, so reports like #13214 stop stalling on "requires NVDA and a11y expertise". Screen readers render the browser's accessibility tree, which agents and contributors can inspect directly with the component hosted in the test Viewer, judged against the matching [W3C ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/) pattern.

Adds a `### Diagnosing accessibility issues` subsection under Testing Rules, plus a one-line cross-reference from the Accessibility and behavior authoring rules:

- Diagnose against the accessibility tree (accessibility snapshot or CDP `Accessibility.getFullAXTree`), not screen-reader narration; the APG pattern tables are the acceptance checklist.
- Diagnosis loop building on the existing Viewer reproduction workflow: snapshot, interact via keyboard, re-snapshot after each step (dynamic states like `aria-expanded`/`aria-activedescendant` are where most bugs live), optional ad-hoc axe-core scan, diff against the pattern.
- Fix pointers: MudSelect's combobox/listbox wiring (#13077) as the reference implementation; prefer `aria-activedescendant` over moving focus into popovers; existing attribute-override rules apply.
- Verify with bUnit aria/role assertions (reference: `SelectTests.cs`) plus a final tree re-snapshot.

Docs-only; no tooling, dependencies, or CI added.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests (N/A — documentation-only change)
