### PR TITLE
MudToggleGroup: Match outlined group height to MudButton

### DIFF
--- a/src/MudBlazor/Styles/components/_togglegroup.scss
+++ b/src/MudBlazor/Styles/components/_togglegroup.scss
@@ -56,8 +56,7 @@
     }
   }
 
-  // Absorb the group border into the item padding so the overall height matches
-  // MudButton, which pairs its 1px outlined border with 5px/3px/7px padding.
+  // Absorb the group border into the item padding so the overall height matches MudButton, which pairs its 1px outlined border with 5px/3px/7px padding.
   .mud-toggle-item {
     padding: 5px;
 

--- a/src/MudBlazor/Styles/components/_togglegroup.scss
+++ b/src/MudBlazor/Styles/components/_togglegroup.scss
@@ -55,6 +55,20 @@
       margin-top: -1px;
     }
   }
+
+  // Absorb the group border into the item padding so the overall height matches
+  // MudButton, which pairs its 1px outlined border with 5px/3px/7px padding.
+  .mud-toggle-item {
+    padding: 5px;
+
+    &.mud-toggle-item-size-small {
+      padding: 3px;
+    }
+
+    &.mud-toggle-item-size-large {
+      padding: 7px;
+    }
+  }
 }
 
 .mud-toggle-item {


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/13280: An outlined `MudToggleGroup` renders 2px taller than `MudButtonGroup` and `MudButton`, so they look misaligned side by side.

Cause: `MudButton` absorbs its outlined border into its padding (text/filled `6px` vs outlined `5px` + `1px` border), so every variant lands on the same height. `MudToggleGroup` draws the border on the group wrapper instead, but its items keep the full uncompensated padding, so the wrapper border adds 2px on top.

Fix: apply the same convention to the outlined toggle group by reducing item padding 1px per side (`5px`/`3px`/`7px`, mirroring `MudButton`'s outlined paddings).

Measured on the issue's repro (default typography, single-line labels):

| Size | ToggleGroup before | ToggleGroup after | MudButton |
| --- | --- | --- | --- |
| Small | 32.75px | 30.75px | 30.75px |
| Medium | 38.5px | 36.5px | 36.5px |
| Large | 44.25px | 42.25px | 42.25px |

- No change when `Outlined="false"` (already matched)
- Selected items keep the same padding, so nothing shifts on selection

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] I've added relevant tests.
