### PR TITLE
MudToggleItem: Remove unused `mud-typography-input` class

### DIFF
--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor.cs
@@ -25,7 +25,6 @@ namespace MudBlazor
             .AddClass("mud-toggle-item-fixed", AssertedParent.CheckMark && AssertedParent.FixedContent)
             .AddClass($"mud-toggle-item-size-{AssertedParent.Size.ToStringFast(true)}")
             .AddClass("mud-ripple", AssertedParent.Ripple)
-            .AddClass("mud-typography-input")
             .AddClass(Class)
             .Build();
 


### PR DESCRIPTION
`MudToggleItem` adds a `mud-typography-input` class that is defined nowhere: it has no rule in any stylesheet and no `input` typography variant exists in the theme (the `MudThemeProvider` generates variables for default/h1-h6/subtitle/body/button/caption/overline only). The item actually renders with `MudButton`'s button typography.

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [x] Existing tests cover the change.
