### PR TITLE
MudButtonGroup: Fix Size paddings losing to override-styles rules

### DIFF
--- a/src/MudBlazor/Styles/components/_buttongroup.scss
+++ b/src/MudBlazor/Styles/components/_buttongroup.scss
@@ -39,76 +39,6 @@
     }
   }
 
-  &.mud-button-group-text-size-small .mud-button-root {
-    padding: 4px 5px;
-    font-size: 0.8125rem;
-
-    &.mud-icon-button .mud-icon-root {
-      font-size: 1.422rem;
-    }
-  }
-
-  &.mud-button-group-text-size-large .mud-button-root {
-    padding: 8px 11px;
-    font-size: 0.9375rem;
-
-    &.mud-icon-button .mud-icon-root {
-      font-size: 1.641rem;
-    }
-  }
-
-  &.mud-button-group-outlined-size-small .mud-button-root {
-    padding: 3px 9px;
-    font-size: 0.8125rem;
-
-    &.mud-icon-button {
-      padding: 3px 9px;
-
-      .mud-icon-root {
-        font-size: 1.422rem;
-      }
-    }
-  }
-
-  &.mud-button-group-outlined-size-large .mud-button-root {
-    padding: 7px 21px;
-    font-size: 0.9375rem;
-
-    &.mud-icon-button {
-      padding: 7px 15px;
-
-      .mud-icon-root {
-        font-size: 1.641rem;
-      }
-    }
-  }
-
-  &.mud-button-group-filled-size-small .mud-button-root {
-    padding: 4px 10px;
-    font-size: 0.8125rem;
-
-    &.mud-icon-button {
-      padding: 4px 10px;
-
-      .mud-icon-root {
-        font-size: 1.422rem;
-      }
-    }
-  }
-
-  &.mud-button-group-filled-size-large .mud-button-root {
-    padding: 8px 22px;
-    font-size: 0.9375rem;
-
-    &.mud-icon-button {
-      padding: 8px 16px;
-
-      .mud-icon-root {
-        font-size: 1.641rem;
-      }
-    }
-  }
-
   .mud-button-root.mud-icon-button {
     padding-right: 12px;
     padding-left: 12px;
@@ -357,6 +287,80 @@
             border-top: 1px solid var(--mud-palette-#{$color}-lighten);
           }
         }
+      }
+    }
+  }
+}
+
+// Size-specific paddings must come after the variant blocks above.
+// They share specificity with the override-styles base paddings, so source order decides.
+.mud-button-group-root {
+  &.mud-button-group-text-size-small .mud-button-root {
+    padding: 4px 5px;
+    font-size: 0.8125rem;
+
+    &.mud-icon-button .mud-icon-root {
+      font-size: 1.422rem;
+    }
+  }
+
+  &.mud-button-group-text-size-large .mud-button-root {
+    padding: 8px 11px;
+    font-size: 0.9375rem;
+
+    &.mud-icon-button .mud-icon-root {
+      font-size: 1.641rem;
+    }
+  }
+
+  &.mud-button-group-outlined-size-small .mud-button-root {
+    padding: 3px 9px;
+    font-size: 0.8125rem;
+
+    &.mud-icon-button {
+      padding: 3px 9px;
+
+      .mud-icon-root {
+        font-size: 1.422rem;
+      }
+    }
+  }
+
+  &.mud-button-group-outlined-size-large .mud-button-root {
+    padding: 7px 21px;
+    font-size: 0.9375rem;
+
+    &.mud-icon-button {
+      padding: 7px 15px;
+
+      .mud-icon-root {
+        font-size: 1.641rem;
+      }
+    }
+  }
+
+  &.mud-button-group-filled-size-small .mud-button-root {
+    padding: 4px 10px;
+    font-size: 0.8125rem;
+
+    &.mud-icon-button {
+      padding: 4px 10px;
+
+      .mud-icon-root {
+        font-size: 1.422rem;
+      }
+    }
+  }
+
+  &.mud-button-group-filled-size-large .mud-button-root {
+    padding: 8px 22px;
+    font-size: 0.9375rem;
+
+    &.mud-icon-button {
+      padding: 8px 16px;
+
+      .mud-icon-root {
+        font-size: 1.641rem;
       }
     }
   }


### PR DESCRIPTION
## Description

`MudButtonGroup` ignores its `Size` parameter for button padding. The size-specific rules (e.g. `.mud-button-group-outlined-size-small .mud-button-root { padding: 3px 9px }`) sit near the top of `_buttongroup.scss`, while the variant `override-styles` rules further down (e.g. `.mud-button-group-outlined.mud-button-group-override-styles .mud-button-root { padding: 5px 15px }`) have equal specificity and win by source order. Font-size still applies (the override rules don't set it), so sized groups render with the right text but medium padding.

Measured against a standalone `MudButton` of the same variant and size (default typography, single-line labels):

| Variant / Size | Group before | Group after | MudButton |
| --- | --- | --- | --- |
| Text / Outlined / Filled, Small | 34.75px | 30.75px | 30.75px |
| Text / Outlined / Filled, Medium | 36.5px | 36.5px | 36.5px |
| Text, Large | 38.25px | 42.25px | 42.25px |
| Outlined / Filled, Large | 38.25px | 42.25px | 42.25px |

Fix: move the size-specific blocks after the variant blocks so source order resolves in their favor. The selectors and declarations are unchanged, so behavior with `OverrideStyles="false"` and per-button styling is unaffected; only the size-vs-override conflict is resolved.

Related: https://github.com/MudBlazor/MudBlazor/pull/13480 aligned `MudToggleGroup` to `MudButton` heights the same way (https://github.com/MudBlazor/MudBlazor/issues/13280); this closes the remaining gap so grouped buttons match the standalone control at every size.

## How Has This Been Tested?

Verified in-browser on all nine variant/size combinations (including a `MudIconButton` in each group); group heights match standalone `MudButton` exactly after the change. Verified the compiled CSS emits identical rules in the corrected order.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] The PR is submitted to the correct branch (`dev`).
- [x] My code follows the code style of this project.
- [ ] I've added relevant tests (CSS-only change; layout isn't covered by bUnit).
