### PR TITLE
MudInput, MudOverlay: Degrade gracefully when script is not loaded

### DIFF
--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -1,5 +1,11 @@
-﻿using AwesomeAssertions;
+﻿using System.Linq;
+using AwesomeAssertions;
 using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using MudBlazor.Interop;
+using MudBlazor.UnitTests.Mocks;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components;
@@ -71,5 +77,36 @@ public class InputTests : BunitTest
         {
             comp.Find("div.mud-input").ClassList.Should().NotContain("mud-input-full-width");
         }
+    }
+
+    [Test]
+    [NonParallelizable] // ScriptDiagnostics.MissingScriptLogged is process-wide; keep other fixtures from racing the reset.
+    public void MissingMudBlazorScript_LogsGuidanceOnceAndDoesNotCrash()
+    {
+        // https://github.com/MudBlazor/MudBlazor/issues/13477
+        // When the MudBlazor script isn't referenced, window.mudElementRef is undefined and the
+        // first-render blur-attach interop throws. That must not tear down the circuit; instead
+        // we log actionable guidance once, no matter how many inputs are on the page.
+        Context.JSInterop
+            .SetupVoid("mudElementRef.addOnBlurEvent", _ => true)
+            .SetException(new JSException("Could not find 'mudElementRef.addOnBlurEvent' ('mudElementRef' was undefined)."));
+
+        var provider = new MockLoggerProvider();
+        var logger = (MockLogger)provider.CreateLogger(GetType().FullName!);
+        Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider));
+
+        ScriptDiagnostics.MissingScriptLogged = false;
+
+        var render = () =>
+        {
+            Context.Render<MudInput<string>>();
+            Context.Render<MudInput<int>>();
+        };
+
+        render.Should().NotThrow();
+
+        var errors = logger.GetEntries().Where(e => e.Level == LogLevel.Error).ToList();
+        errors.Should().ContainSingle();
+        errors[0].Message.Should().Be(ScriptDiagnostics.MissingScriptMessage);
     }
 }

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -109,4 +109,29 @@ public class InputTests : BunitTest
         errors.Should().ContainSingle();
         errors[0].Message.Should().Be(ScriptDiagnostics.MissingScriptMessage);
     }
+
+    private static readonly Exception[] BenignBlurInteropExceptions =
+    [
+        new JSDisconnectedException("disconnected"),
+        new TaskCanceledException(),
+        new ObjectDisposedException("circuit"),
+    ];
+
+    [TestCaseSource(nameof(BenignBlurInteropExceptions))]
+    public void BlurInterop_BenignErrors_DoNotCrashOrLog(Exception exception)
+    {
+        // Disconnects and teardown races during the first-render blur attach are expected noise; they must neither crash nor log guidance.
+        Context.JSInterop
+            .SetupVoid("mudElementRef.addOnBlurEvent", _ => true)
+            .SetException(exception);
+
+        var provider = new MockLoggerProvider();
+        var logger = (MockLogger)provider.CreateLogger(GetType().FullName!);
+        Context.Services.AddLogging(x => x.ClearProviders().AddProvider(provider));
+
+        var render = () => Context.Render<MudInput<string>>();
+
+        render.Should().NotThrow();
+        logger.GetEntries().Where(e => e.Level == LogLevel.Error).Should().BeEmpty();
+    }
 }

--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -253,6 +253,7 @@ public class ServiceCollectionExtensionsTests
     {
         // Arrange
         var services = new ServiceCollection()
+            .AddLogging()
             .AddSingleton<IJSRuntime, MockJsRuntime>();
 
         // Act

--- a/src/MudBlazor.UnitTests/Services/ScrollManagerTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ScrollManagerTests.cs
@@ -1,7 +1,9 @@
 ﻿using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
+using MudBlazor.Interop;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Services;
@@ -10,13 +12,15 @@ namespace MudBlazor.UnitTests.Services;
 public class ScrollManagerTests
 {
     private Mock<IJSRuntime> _runtimeMock;
+    private Mock<ILogger<ScrollManager>> _loggerMock;
     private ScrollManager _service;
 
     [SetUp]
     public void SetUp()
     {
         _runtimeMock = new Mock<IJSRuntime>(MockBehavior.Strict);
-        _service = new ScrollManager(_runtimeMock.Object);
+        _loggerMock = new Mock<ILogger<ScrollManager>>();
+        _service = new ScrollManager(_runtimeMock.Object, _loggerMock.Object);
     }
 
     [Test]
@@ -118,14 +122,34 @@ public class ScrollManagerTests
     }
 
     [Test]
-    public async Task LockScrollAsync_PropagatesJsRuntimeError()
+    public async Task LockScrollAsync_SwallowsDisconnect()
     {
-        // lockScroll must surface failures; only the unlock/dispose paths swallow them.
+        // MudOverlay awaits this from its lifecycle methods, so a disconnect mid-render must not surface as an unhandled exception.
         SetupThrowingInvocation("mudScrollManager.lockScroll", new JSDisconnectedException("disconnected"));
 
         var act = async () => await _service.LockScrollAsync("#dialog", "locked");
 
-        await act.Should().ThrowAsync<JSDisconnectedException>();
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    [NonParallelizable] // ScriptDiagnostics.MissingScriptLogged is process-wide; keep other fixtures from racing the reset.
+    public async Task LockScrollAsync_MissingScript_LogsGuidanceOnceAndDoesNotThrow()
+    {
+        // https://github.com/MudBlazor/MudBlazor/issues/13477
+        // Every dialog and overlay locks scroll from a lifecycle method; when the MudBlazor script
+        // isn't referenced this must log actionable guidance once instead of killing the circuit.
+        SetupThrowingInvocation("mudScrollManager.lockScroll", new JSException("Could not find 'mudScrollManager.lockScroll' ('mudScrollManager' was undefined)."));
+        ScriptDiagnostics.MissingScriptLogged = false;
+
+        var act = async () =>
+        {
+            await _service.LockScrollAsync("#dialog", "locked");
+            await _service.LockScrollAsync("#dialog", "locked");
+        };
+
+        await act.Should().NotThrowAsync();
+        _loggerMock.VerifyLogging(ScriptDiagnostics.MissingScriptMessage, LogLevel.Error, Times.Once());
     }
 
     [Test]

--- a/src/MudBlazor.UnitTests/Services/ScrollManagerTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ScrollManagerTests.cs
@@ -121,11 +121,18 @@ public class ScrollManagerTests
         _runtimeMock.VerifyAll();
     }
 
-    [Test]
-    public async Task LockScrollAsync_SwallowsDisconnect()
+    private static readonly Exception[] BenignInteropExceptions =
+    [
+        new JSDisconnectedException("disconnected"),
+        new TaskCanceledException(),
+        new ObjectDisposedException("circuit"),
+    ];
+
+    [TestCaseSource(nameof(BenignInteropExceptions))]
+    public async Task LockScrollAsync_SwallowsBenignInteropError(Exception exception)
     {
-        // MudOverlay awaits this from its lifecycle methods, so a disconnect mid-render must not surface as an unhandled exception.
-        SetupThrowingInvocation("mudScrollManager.lockScroll", new JSDisconnectedException("disconnected"));
+        // MudOverlay awaits this from its lifecycle methods, so a disconnect or teardown mid-render must not surface as an unhandled exception.
+        SetupThrowingInvocation("mudScrollManager.lockScroll", exception);
 
         var act = async () => await _service.LockScrollAsync("#dialog", "locked");
 

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
+using MudBlazor.Interop;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -413,7 +414,25 @@ namespace MudBlazor
             if (firstRender && !_disposed)
             {
                 // Attach a JS blur fallback for cases where focus is dismissed without Blazor observing the native blur event.
-                await ElementReference.MudAttachBlurEventWithJS(_dotNetReferenceLazy.Value);
+                // Tolerate a missing or late-loading MudBlazor script: log actionable guidance once instead of tearing down the circuit (#13477).
+                try
+                {
+                    await ElementReference.MudAttachBlurEventWithJS(_dotNetReferenceLazy.Value);
+                }
+                catch (JSException)
+                {
+                    // mudElementRef is undefined, so the MudBlazor script isn't loaded on the page.
+                    ScriptDiagnostics.LogMissingScriptOnce(Logger);
+                }
+                catch (JSDisconnectedException)
+                {
+                }
+                catch (TaskCanceledException)
+                {
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Interop/ScriptDiagnostics.cs
+++ b/src/MudBlazor/Interop/ScriptDiagnostics.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+
+namespace MudBlazor.Interop;
+
+/// <summary>
+/// One-time diagnostics for interop failures caused by the MudBlazor script bundle not being loaded.
+/// </summary>
+internal static class ScriptDiagnostics
+{
+    // Logged at most once per process; a missing MudBlazor script affects every component identically, so repeating it per call site is just noise.
+    internal static bool MissingScriptLogged;
+
+    internal const string MissingScriptMessage =
+        "MudBlazor's JavaScript could not be found, so components that rely on it won't work. " +
+        "Reference the MudBlazor script in your host page (App.razor or index.html) after the Blazor script: " +
+        "<script src=\"_content/MudBlazor/MudBlazor.min.js\"></script>. " +
+        "See https://mudblazor.com/getting-started/installation";
+
+    internal static void LogMissingScriptOnce(ILogger logger)
+    {
+        if (MissingScriptLogged)
+        {
+            return;
+        }
+
+        MissingScriptLogged = true;
+        logger.LogError(MissingScriptMessage);
+    }
+}

--- a/src/MudBlazor/Interop/ScriptDiagnostics.cs
+++ b/src/MudBlazor/Interop/ScriptDiagnostics.cs
@@ -18,6 +18,7 @@ internal static class ScriptDiagnostics
         "MudBlazor's JavaScript could not be found, so components that rely on it won't work. " +
         "Reference the MudBlazor script in your host page (App.razor or index.html) after the Blazor script: " +
         "<script src=\"_content/MudBlazor/MudBlazor.min.js\"></script>. " +
+        "If it is already referenced, confirm the script returns 200 in the browser's Network tab and hard-refresh to clear a stale cached page. " +
         "See https://mudblazor.com/getting-started/installation";
 
     internal static void LogMissingScriptOnce(ILogger logger)

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -2,7 +2,9 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using MudBlazor.Interop;
 
 namespace MudBlazor;
 
@@ -15,23 +17,26 @@ namespace MudBlazor;
 internal sealed class ScrollManager : IScrollManager
 {
     private readonly IJSRuntime _jSRuntime;
+    private readonly ILogger<ScrollManager> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ScrollManager"/> class with the specified JavaScript runtime.
     /// </summary>
     /// <param name="jSRuntime">The JavaScript runtime.</param>
-    public ScrollManager(IJSRuntime jSRuntime)
+    /// <param name="logger">The logger.</param>
+    public ScrollManager(IJSRuntime jSRuntime, ILogger<ScrollManager> logger)
     {
         _jSRuntime = jSRuntime;
+        _logger = logger;
     }
 
     /// <inheritdoc />
     public ValueTask ScrollToAsync(string? id, int left, int top, ScrollBehavior scrollBehavior) =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollTo", id, left, top, scrollBehavior.ToStringFast(true));
+        InvokeVoidSafelyAsync("mudScrollManager.scrollTo", id, left, top, scrollBehavior.ToStringFast(true));
 
     /// <inheritdoc />
     public ValueTask ScrollIntoViewAsync(string? selector, ScrollBehavior behavior) =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollIntoView", selector, behavior.ToStringFast(true));
+        InvokeVoidSafelyAsync("mudScrollManager.scrollIntoView", selector, behavior.ToStringFast(true));
 
     /// <inheritdoc />
     public ValueTask ScrollToTopAsync(string? id, ScrollBehavior scrollBehavior = ScrollBehavior.Auto) =>
@@ -39,21 +44,21 @@ internal sealed class ScrollManager : IScrollManager
 
     /// <inheritdoc />
     public ValueTask ScrollToBottomAsync(string elementId, ScrollBehavior scrollBehavior = ScrollBehavior.Auto) =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToBottom", elementId, scrollBehavior.ToStringFast(true));
+        InvokeVoidSafelyAsync("mudScrollManager.scrollToBottom", elementId, scrollBehavior.ToStringFast(true));
 
     /// <inheritdoc />
     public ValueTask ScrollToYearAsync(string elementId) =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToYear", elementId);
+        InvokeVoidSafelyAsync("mudScrollManager.scrollToYear", elementId);
 
     /// <inheritdoc />
     public ValueTask ScrollToListItemAsync(string elementId) =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.scrollToListItem", elementId);
+        InvokeVoidSafelyAsync("mudScrollManager.scrollToListItem", elementId);
 
     // lockScroll and unlockScroll use a counter system in javascript so we can lock/unlock without limit
     // and maintain the proper lock. IF YOU CHANGE THIS, CHANGE THE JAVASCRIPT AS WELL
     /// <inheritdoc />
     public ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);
+        InvokeVoidSafelyAsync("mudScrollManager.lockScroll", selector, cssClass);
 
     /// <inheritdoc />
     public ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
@@ -62,4 +67,28 @@ internal sealed class ScrollManager : IScrollManager
     /// <inheritdoc />
     public ValueTask ScrollToVirtualizedItemAsync(string containerId, int itemIndex, double itemHeight, string targetItemId, ScrollBehavior scrollBehavior = ScrollBehavior.Auto) =>
         _jSRuntime.InvokeVoidAsyncIgnoreErrors("mudScrollManager.scrollToVirtualizedItem", containerId, itemIndex, itemHeight, targetItemId, scrollBehavior.ToStringFast(true));
+
+    // Several callers await these from component lifecycle methods (e.g. MudOverlay locks scroll for every dialog), where an unhandled JSException tears down a Blazor Server circuit.
+    // Tolerate a missing MudBlazor script: log actionable guidance once instead of crashing (#13477).
+    private async ValueTask InvokeVoidSafelyAsync(string identifier, params object?[] args)
+    {
+        try
+        {
+            await _jSRuntime.InvokeVoidAsync(identifier, args);
+        }
+        catch (JSException)
+        {
+            // mudScrollManager is undefined, so the MudBlazor script isn't loaded on the page.
+            ScriptDiagnostics.LogMissingScriptOnce(_logger);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (TaskCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
 }


### PR DESCRIPTION
Fixes #13477. In a Blazor Server app where `_content/MudBlazor/MudBlazor.min.js` isn't referenced (missing `<script>`, wrong path, or a stale/cached host page pointing at a dead bundle), `window.mudElementRef` / `window.mudScrollManager` are `undefined`. The first eager interop call then throws a `JSException` that tears the **whole circuit** down — the user sees "An unhandled error has occurred", not a hint about what's wrong.

Two entry points do eager interop with no error handling:

- **MudInput** attaches a blur fallback on first render, so a bare `<MudTextField>` crashes immediately (the reported stack: `MudInput.OnAfterRenderAsync`).
- **ScrollManager.LockScrollAsync** is awaited from `MudOverlay`'s lifecycle, so **every dialog/overlay/drawer open** crashes the circuit. (Its sibling `UnlockScrollAsync` was already error-handled — this was an asymmetry.)

Every other interop call in these paths already tolerates a missing script; these two didn't.

## Changes

- Add internal `ScriptDiagnostics` holding the canonical message + a process-wide once-gate, so the guidance is logged **once** no matter how many components hit it.
- `MudInput`: wrap the first-render blur attach in a `JSException` guard → log once, keep the circuit alive. Benign disconnect/cancel/dispose are swallowed silently.
- `ScrollManager`: route all interop through one guarded helper (same catch set); `lockScroll` no longer crashes on overlay open.

The message names the exact fix:

> MudBlazor's JavaScript could not be found, so components that rely on it won't work. Reference the MudBlazor script in your host page (App.razor or index.html) after the Blazor script: `<script src="_content/MudBlazor/MudBlazor.min.js"></script>`. See https://mudblazor.com/getting-started/installation


## Prior art

Same pattern — tolerate the failure and surface actionable guidance instead of crashing:

- https://github.com/MudBlazor/MudBlazor/pull/13371 — log once instead of throwing when no `MudPopoverProvider` is in the render scope (https://github.com/MudBlazor/MudBlazor/issues/11887)
- https://github.com/MudBlazor/MudBlazor/pull/13317 — swallow the WebView focus `JSException` thrown from `OnAfterRenderAsync` (https://github.com/MudBlazor/MudBlazor/issues/12184)
- https://github.com/MudBlazor/MudBlazor/pull/11039 and https://github.com/MudBlazor/MudBlazor/pull/11436 — added error handling to the dispose side of this same blur bridge; this PR closes the asymmetry on the attach side
- https://github.com/MudBlazor/MudBlazor/pull/13431 — dispose-before-first-render guard on this same attach path
- Past reports of this symptom class: https://github.com/MudBlazor/MudBlazor/issues/5020, https://github.com/MudBlazor/MudBlazor/issues/1353
