### PR TITLE
MudDialog: Log guidance when no MudDialogProvider is present

### DIFF
--- a/src/MudBlazor.UnitTests/Services/DialogServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/DialogServiceTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services;
+
+[TestFixture]
+public class DialogServiceTests
+{
+    [Test]
+    public void ShowAsync_WithoutProvider_LogsGuidanceOnce()
+    {
+        // With no <MudDialogProvider/> subscribed, a dialog never renders and ShowAsync blocks until its
+        // render timeout. Surface actionable guidance once instead of failing silently.
+        // The guidance is logged synchronously in ShowCoreAsync before the render-complete wait, so the
+        // returned tasks are intentionally not awaited (awaiting would block on that timeout).
+        var loggerMock = new Mock<ILogger<DialogService>>();
+        var service = new DialogService(loggerMock.Object);
+
+        _ = service.ShowAsync<MudButton>();
+        _ = service.ShowAsync<MudButton>();
+
+        loggerMock.VerifyLogging(DialogService.MissingProviderMessage, LogLevel.Error, Times.Once());
+    }
+}

--- a/src/MudBlazor/Services/Dialog/DialogService.cs
+++ b/src/MudBlazor/Services/Dialog/DialogService.cs
@@ -5,6 +5,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace MudBlazor
 {
@@ -54,6 +56,23 @@ namespace MudBlazor
                     builder.AddAttribute(2, ChildContent, renderFragment);
                     builder.CloseComponent();
                 };
+        }
+
+        internal const string MissingProviderMessage =
+            "Missing <MudDialogProvider /> in the active render scope, so dialogs cannot be displayed. " +
+            "Add <MudDialogProvider /> within the same interactive render mode as the components that open dialogs: in your layout for global interactivity, or on each page for per-page interactivity. " +
+            "See https://mudblazor.com/getting-started/installation#manual-install-add-components";
+
+        private readonly ILogger<DialogService> _logger;
+        private bool _missingProviderLogged;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogService"/> class.
+        /// </summary>
+        /// <param name="logger">The logger used to surface configuration problems such as a missing provider.</param>
+        public DialogService(ILogger<DialogService>? logger = null)
+        {
+            _logger = logger ?? NullLogger<DialogService>.Instance;
         }
 
         /// <inheritdoc />
@@ -252,6 +271,13 @@ namespace MudBlazor
             if (dialogInstanceAddedAsync is not null)
             {
                 await dialogInstanceAddedAsync(dialogReference);
+            }
+            else if (!_missingProviderLogged)
+            {
+                // No MudDialogProvider is subscribed, so this dialog will never render (ShowAsync then blocks until its render timeout).
+                // Log once with actionable guidance instead of failing silently.
+                _missingProviderLogged = true;
+                _logger.LogError(MissingProviderMessage);
             }
 
             return dialogReference;


### PR DESCRIPTION
Follow-up to the missing-script diagnostics work, extending the existing missing-`MudPopoverProvider` pattern to dialogs.

Calling `IDialogService.ShowAsync` with no `<MudDialogProvider />` in the active render scope fails **silently**: `DialogInstanceAddedAsync` has no subscriber, so the dialog is never handed to a provider and never renders. Worse, `ShowAsync` then blocks on its 5-second render-complete timeout before returning an invisible dialog — so the symptom is "the button does nothing for 5 seconds", with nothing in the logs.

This is the same class of setup mistake we already surface for popovers, and a very common one (provider omitted, or placed in a different interactive render-mode scope than the code that opens the dialog).

## Changes

- `DialogService`: when `DialogInstanceAddedAsync` is null at show-time, log an actionable message once (gated per service instance, like `PopoverService`). The message names the provider and the render-scope requirement, reusing the existing missing-provider phrasing:

  > Missing `<MudDialogProvider />` in the active render scope, so dialogs cannot be displayed. Add `<MudDialogProvider />` within the same interactive render mode as the components that open dialogs: in your layout for global interactivity, or on each page for per-page interactivity. See https://mudblazor.com/getting-started/installation#manual-install-add-components

- `DialogService` gains an optional `ILogger<DialogService>` constructor parameter (`= null`, falls back to `NullLogger`), so existing `new DialogService()` usage stays source-compatible.

Deliberately scoped to `MudDialogProvider` and left `MudSnackbarProvider` out. `MudSnackbarProvider` renders its queued snackbars on first render, so a snackbar added before the provider subscribes still shows — which makes "no subscriber at Add-time" an unreliable signal that would produce false positives during startup. The dialog path has no such replay: a null subscriber at show-time means the dialog is genuinely lost, so the signal is reliable. A snackbar equivalent would need a non-transient check and can follow separately.


## Prior art

- https://github.com/MudBlazor/MudBlazor/pull/13371 — the direct precedent: `PopoverService` logs once with the same "active render scope" phrasing when no `MudPopoverProvider` is present (https://github.com/MudBlazor/MudBlazor/issues/11887)
- https://github.com/MudBlazor/MudBlazor/pull/7994 — `MudToggleGroup` warns when its bindings don't match `SelectionMode`
- https://github.com/MudBlazor/MudBlazor/pull/13484 — same series: one-time actionable log when the MudBlazor script isn't loaded
