### PR TITLE
MudInputControl: Respect non-full-width sizing in flex layouts

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -39,6 +39,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DatePickerInputUsesFullWidthTextField()
+        {
+            var comp = Context.Render<MudDatePicker>();
+
+            var inputControl = comp.Find(".mud-input-control");
+            inputControl.ClassList.Should().Contain("mud-input-control-full-width");
+            inputControl.ClassList.Should().NotContain("mud-input-control-width-auto");
+        }
+
+        [Test]
         public void DatePickerOpenButtonDefaultAriaLabel()
         {
             var comp = Context.Render<DatePickerValidationTest>();

--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -13,6 +13,14 @@ namespace MudBlazor.UnitTests.Components
     public class FieldTests : BunitTest
     {
         [Test]
+        public void FieldDoesNotUseAutoWidthInputControlClass()
+        {
+            var comp = Context.Render<MudField>();
+
+            comp.Find(".mud-input-control").ClassList.Should().NotContain("mud-input-control-width-auto");
+        }
+
+        [Test]
         public void Field_ShouldRender_Variants()
         {
             var comp = Context.Render<FieldTest>();

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -46,6 +46,18 @@ namespace MudBlazor.UnitTests.Components
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("numericFieldLabelTest");
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void InputControlWidthClassFollowsFullWidth(bool fullWidth)
+        {
+            var comp = Context.Render<MudNumericField<int>>(parameters => parameters
+                .Add(x => x.FullWidth, fullWidth));
+
+            var inputControl = comp.Find(".mud-input-control");
+            inputControl.ClassList.Should().Contain(fullWidth ? "mud-input-control-full-width" : "mud-input-control-width-auto");
+            inputControl.ClassList.Should().NotContain(fullWidth ? "mud-input-control-width-auto" : "mud-input-control-full-width");
+        }
+
         /// <summary>
         /// Initial Text for double should be 0, with F1 format it should be 0.0
         /// </summary>

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -37,6 +37,18 @@ namespace MudBlazor.UnitTests.Components
             label[1].Attributes.GetNamedItem("for")?.Value.Should().StartWith("mudinput");
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void InputControlWidthClassFollowsFullWidth(bool fullWidth)
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(x => x.FullWidth, fullWidth));
+
+            var inputControl = comp.Find(".mud-input-control");
+            inputControl.ClassList.Should().Contain(fullWidth ? "mud-input-control-full-width" : "mud-input-control-width-auto");
+            inputControl.ClassList.Should().NotContain(fullWidth ? "mud-input-control-width-auto" : "mud-input-control-full-width");
+        }
+
         /// <summary>
         /// Initial Text for double should be 0, with F1 format it should be 0.0
         /// </summary>

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -13,7 +13,6 @@ namespace MudBlazor
             new CssBuilder("mud-input-control")
                 .AddClass("mud-input-required", when: () => Required)
                 .AddClass($"mud-input-control-margin-{Margin.ToStringFast(true)}", when: () => Margin != Margin.None)
-                .AddClass("mud-input-control-width-auto", !FullWidth)
                 .AddClass("mud-input-control-full-width", FullWidth)
                 .AddClass("mud-input-error", Error)
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}-with-label", !string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -13,6 +13,7 @@ namespace MudBlazor
             new CssBuilder("mud-input-control")
                 .AddClass("mud-input-required", when: () => Required)
                 .AddClass($"mud-input-control-margin-{Margin.ToStringFast(true)}", when: () => Margin != Margin.None)
+                .AddClass("mud-input-control-width-auto", !FullWidth)
                 .AddClass("mud-input-control-full-width", FullWidth)
                 .AddClass("mud-input-error", Error)
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}-with-label", !string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -130,6 +130,7 @@ namespace MudBlazor
         protected string Classname =>
             new CssBuilder("mud-input-input-control mud-input-number-control")
                 .AddClass(HideSpinButtons ? "mud-input-nospin" : "mud-input-showspin")
+                .AddClass("mud-input-control-width-auto", !FullWidth)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -18,6 +18,7 @@
                        Placeholder="@Placeholder"
                        HelperText="@HelperText"
                        HelperTextOnFocus="@HelperTextOnFocus"
+                       FullWidth="true"
                        Variant="@Variant"
                        ReadOnly="@(!Editable || GetReadOnlyState())"
                        Disabled="@GetDisabledState()"

--- a/src/MudBlazor/Components/TextField/MudTextField.razor.cs
+++ b/src/MudBlazor/Components/TextField/MudTextField.razor.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
         protected string Classname =>
             new CssBuilder("mud-input-input-control")
                 .AddClass($"mud-input-sizing-{Sizing.ToStringFast(true)}")
+                .AddClass("mud-input-control-width-auto", !FullWidth)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -9,6 +9,10 @@
   flex-direction: column;
   vertical-align: top;
 
+  &.mud-input-control-width-auto {
+    flex: 0 1 auto;
+  }
+
   &.mud-input-control-full-width {
     width: 100%;
   }


### PR DESCRIPTION
## Summary

`MudTextField` and `MudNumericField` currently let their outer `MudInputControl` wrapper grow into surplus horizontal flex space even when `FullWidth` is `false`. This change gives the non-full-width wrapper normal, shrinkable flex-item sizing while preserving explicit full-width growth. Because the rule applies to the outer wrapper, width constraints govern the complete field layout box, including labels, helper text, counters, and errors.

This aligns the wrapper behavior with the non-growing `inline-flex` hosts used by Material 2 MDC and Material 3 Material Web. It is reference alignment, not a claim of strict Material specification noncompliance.

## Changes

- Render `mud-input-control-width-auto` from `MudTextField` and `MudNumericField` when `FullWidth` is `false`.
- Apply `flex: 0 1 auto` to that state so constrained fields do not claim surplus space but can still shrink.
- Preserve `mud-input-control-full-width`, `width: 100%`, and growing flex behavior when `FullWidth` is `true`.
- Cover both target fields' wrapper-class states and verify a non-target `MudField` retains the legacy shared-wrapper class contract.
- Mark the text field nested inside `MudPicker` as explicitly full-width so picker columns keep filling their allocated width.

## Visual Evidence

Before - desktop 1280x900: both 150px fields grow to about 406px and consume the spacer's available width.

![before desktop - constrained fields grow](https://camo.githubusercontent.com/04fc9a2228fb62637c7257abd1c1b1c217e67c68ebb7db49d2549110fd939204/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f313532373038373537383430313037393239362f313532373631373634373737393338313234382f6265666f72652d6465736b746f702d31323830783930302e706e673f65783d36613562353034632669733d366135396665636326686d3d6433376263373461383732343430316232353866373661633135643334363162643231636466333863373038653565316233343764663037636230393935663726)

After - desktop 1280x900: both fields remain 150px and the spacer receives about 768px.

![after desktop - constrained fields preserve width](https://camo.githubusercontent.com/dd8fd49e283fc972d07d3d474bf058b3a513745d160aa2574d4da54fdbcc0111/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f313532373038373537383430313037393239362f313532373631373635323537333437303735302f61667465722d6465736b746f702d31323830783930302e706e673f65783d36613562353034652669733d366135396665636526686d3d3263663838373665623136316564353232636365366435313764393839373565343230353164656534306332333662323363656234346535343162366364643326)

Before - compact 500x800:

![before compact layout](https://camo.githubusercontent.com/53a52c0c692e4cca62fdf1dc393a336fbe34f8f07df79c76e6c14074795e868b/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f313532373038373537383430313037393239362f313532373631373635353037333237363031342f6265666f72652d6d6f62696c652d353030783830302e706e673f65783d36613562353034652669733d366135396665636526686d3d6536366231656536633530646561353766336339633633633839386438343535663338626461643464393132626436356565653332656238393433386438623926)

After - compact 500x800: both wrappers retain `flex-shrink: 1`, the spacer collapses to 0px, and the row remains within its 436px content width.

![after compact layout](https://camo.githubusercontent.com/4c72dd8ad936cea522f4f43ff1488faf3757651640623be1671dae1c6f67b1d3/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f313532373038373537383430313037393239362f313532373631373635383034323731323037342f61667465722d6d6f62696c652d353030783830302e706e673f65783d36613562353034662669733d366135396665636626686d3d3034306139313130643265393636616661646639396235383766393931616439663466313063656230666461356564633035303536356633343461353662643726)

`FullWidth=true` remains 600px in the bounded desktop row and fills the available 436px at the compact viewport before and after.

## Tested With

- RED: `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~InputControlWidthClassFollowsFullWidth" --output Normal --no-ansi --hangdump --hangdump-timeout 30s` (2 expected failures for the missing non-full-width class; 2 full-width cases passed)
- GREEN: the same command passed 4/4 cases after the implementation.
- Sentinel correction RED: `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~FieldDoesNotUseAutoWidthInputControlClass" --output Normal --no-ansi --hangdump --hangdump-timeout 30s` (1 expected failure at the original head because `MudField` received the target-only class)
- Corrected GREEN: target false/true states plus the non-target regression passed 5/5.
- Picker preservation RED: `DatePickerInputUsesFullWidthTextField` failed at the target-scoped head because the nested picker field used the auto-width class; it passed after the internal full-width opt-in.
- Final focused target/non-target/picker contracts passed 6/6.
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore -- --filter "FullyQualifiedName~TextFieldTests|FullyQualifiedName~NumericFieldTests|FullyQualifiedName~FieldTests|FullyQualifiedName~DatePickerTests" --output Normal --no-ansi --hangdump --hangdump-timeout 30s` (434/434 passed)
- `dotnet build src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj --no-restore --nologo` (0 warnings, 0 errors; normal SCSS/asset pipeline)
- `dotnet format whitespace --no-restore --include MudBlazor/Components/Picker/MudPicker.razor MudBlazor/Components/TextField/MudTextField.razor.cs MudBlazor/Components/NumericField/MudNumericField.razor.cs MudBlazor.UnitTests/Components/DatePickerTests.cs MudBlazor.UnitTests/Components/FieldTests.cs MudBlazor.UnitTests/Components/TextFieldTests.cs MudBlazor.UnitTests/Components/NumericFieldTests.cs`
- Playwright Viewer route `/viewer/Scratch/InputControlWidthRepro?theme=light&dir=ltr&chrome=none` at 1280x900 and 500x800; the scratch component was removed before commit.
- `git diff --check`

## Notes

This intentionally does not move or duplicate `Style` onto `MudInputControl` and does not add a public fit-content parameter. The private class is emitted only by non-full-width `MudTextField` and `MudNumericField`; other shared-wrapper consumers retain their previous flex behavior, and the picker-owned nested text field explicitly retains fill behavior.

-- Coded by Codebringer / AI

-- Codebringer for versile2

-- versile2 approved
