### PR TITLE
MudPagination: allow BoundaryCount of 0

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -231,7 +231,6 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(9, 3, 2)]
         [TestCase(5, 1, 1)]
         [TestCase(5, -1, 1)]
-        [TestCase(5, 1, -1)]
         [Test]
         public async Task PaginationCountWithoutEllipsis(int count, int middleCount, int boundaryCount)
         {
@@ -243,7 +242,7 @@ namespace MudBlazor.UnitTests.Components
 
             //Expected values
             pagination.GetState(x => x.MiddleCount).Should().Be(Math.Max(1, middleCount));
-            pagination.GetState(x => x.BoundaryCount).Should().Be(Math.Max(1, boundaryCount));
+            pagination.GetState(x => x.BoundaryCount).Should().Be(Math.Max(0, boundaryCount));
 
             for (var i = 1; i <= count; i++)
             {
@@ -276,6 +275,10 @@ namespace MudBlazor.UnitTests.Components
         [TestCase(7, 22, 5, 3, new[] { "1", "2", "3", "4", "5", "6", "7", "8", "9", "…", "20", "21", "22" })]
         [TestCase(16, 22, 5, 3, new[] { "1", "2", "3", "…", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
         [TestCase(22, 22, 5, 3, new[] { "1", "2", "3", "…", "14", "15", "16", "17", "18", "19", "20", "21", "22" })]
+        // BoundaryCount == 0 hides the edge page numbers, showing only ellipsis at the boundaries. See #13181.
+        [TestCase(1, 11, 3, 0, new[] { "1", "2", "3", "4", "…" })]
+        [TestCase(6, 11, 3, 0, new[] { "…", "5", "6", "7", "…" })]
+        [TestCase(11, 11, 3, 0, new[] { "…", "8", "9", "10", "11" })]
         [Test]
         public async Task PaginationCountWithEllipsis(int selectedPage, int count, int middleCount,
             int boundaryCount, string[] expectedValues)

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor.cs
@@ -76,8 +76,9 @@ namespace MudBlazor
         /// </summary>
         /// <remarks>
         /// Defaults to <c>1</c>. <br />
+        /// A value of <c>0</c> shows no edge page numbers: <c>&lt; ... 4 5 6 ... &gt;</c> (useful together with <see cref="ShowFirstButton"/> and <see cref="ShowLastButton"/>) <br />
         /// A value of <c>1</c> would show one-page number at the edge: <c>&lt; 1 ... 4 5 6 ... 9 &gt;</c> <br />
-        /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c> 
+        /// A value of <c>2</c> would show two-page numbers at the edge: <c>&lt; 1 2 ... 4 5 6 ... 8 9 &gt;</c>
         /// </remarks>
         [Parameter, ParameterState]
         [Category(CategoryTypes.Pagination.Appearance)]
@@ -378,7 +379,9 @@ namespace MudBlazor
 
         private Task SetBoundaryCount(int count)
         {
-            var newCount = Math.Max(1, count);
+            // A BoundaryCount of 0 is valid: it hides the edge page numbers, which is useful
+            // when the First/Last navigation buttons are shown instead. Negative values clamp to 0.
+            var newCount = Math.Max(0, count);
 
             return _boundaryCountState.SetValueAsync(newCount);
         }


### PR DESCRIPTION
## Description

Fixes part of #13181. `MudPagination.BoundaryCount` could not be set to `0`: `SetBoundaryCount` clamped the value with `Math.Max(1, count)`, silently forcing at least one boundary page. Setting `BoundaryCount="0"` (for example when using `ShowFirstButton`/`ShowLastButton` instead of edge page numbers) was therefore ignored.

This changes the clamp to `Math.Max(0, count)` so `0` is respected. The existing `GeneratePagination` logic already renders correctly with a boundary count of 0 — it shows ellipsis at the edges instead of the first/last page numbers.

## Changes

- `SetBoundaryCount` now clamps to a minimum of `0` instead of `1`.
- Update the `BoundaryCount` XML docs to describe the `0` case.
- Update `PaginationCountWithoutEllipsis` (a negative boundary now clamps to `0`) and add three `PaginationCountWithEllipsis` cases asserting the rendered output for `BoundaryCount=0` (near start, middle, near end).

## Out of scope

The issue also raises a concern about `MiddleCount` being "overruled" when the gap between shown pages collapses to a single page. That behaviour (replacing a one-page ellipsis with the actual page number) appears intentional and matches the reference MUI component, so I've left it as-is here — happy to discuss it separately.

## Testing

`dotnet test` for the Pagination unit tests — all passing (52/52).
