### PR TITLE
Docs: Make the Exit Prompt example opt-in

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/ExitPrompt/Examples/ExitPromptExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExitPrompt/Examples/ExitPromptExample.razor
@@ -1,14 +1,15 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudExitPrompt Disabled="_isDisabled" UseNativePrompt="_useNativePrompt"/>
+<MudExitPrompt Disabled="!_enabled" UseNativePrompt="_useNativePrompt"/>
 
 <MudStack Spacing="2">
-    <MudSwitch Label="Disabled" @bind-Value="_isDisabled" Color="Color.Primary"/>
+    <MudSwitch Label="Enabled" @bind-Value="_enabled" Color="Color.Primary"/>
     <MudSwitch Label="Use native prompt" @bind-Value="_useNativePrompt" Color="Color.Primary"/>
     <MudButton Variant="Variant.Outlined" Color="Color.Primary" Href="/components/exitprompt">Test navigation</MudButton>
 </MudStack>
 
 @code {
-    private bool _isDisabled;
+    // Off by default so the docs page doesn't arm navigation prompts until you opt in.
+    private bool _enabled;
     private bool _useNativePrompt;
 }

--- a/src/MudBlazor.Docs/Pages/Components/ExitPrompt/Examples/ExitPromptExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/ExitPrompt/Examples/ExitPromptExample.razor
@@ -9,7 +9,6 @@
 </MudStack>
 
 @code {
-    // Off by default so the docs page doesn't arm navigation prompts until you opt in.
     private bool _enabled;
     private bool _useNativePrompt;
 }


### PR DESCRIPTION
The Exit Prompt example armed `MudExitPrompt` on page load (`_isDisabled` defaulted to `false`). Visiting the page and then navigating to any other docs page triggered a "Leave site?" confirmation, and refreshing or closing the tab fired the native browser prompt, which is hostile for the docs site as a whole.

Fix:
- Flip the demo to opt-in: the switch now toggles `Enabled` (off by default), bound as `Disabled="!_enabled"`.
- With the prompt disarmed on first render the component skips the `beforeunload` listener and `OnLocationChanging` returns early, so browsing away from the page is unaffected until you turn it on.
- Reads clearer than a "Disabled" switch you'd have to turn off, and mirrors realistic usage where `Disabled` is tied to state such as unsaved changes.
