### PR TITLE
Docs: Rewrite weak class-level XML summaries

### DIFF
--- a/src/MudBlazor/Attributes/CategoryAttribute.cs
+++ b/src/MudBlazor/Attributes/CategoryAttribute.cs
@@ -10,7 +10,6 @@ namespace MudBlazor
     /// This attribute is similar to <see cref="System.ComponentModel.CategoryAttribute"/>. <br/>
     /// The name of the category can be specified by using a constant defined in the <see cref="CategoryTypes"/> class.
     /// </remarks>
-    /// <seealso cref="CategoryTypes" />
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class CategoryAttribute : Attribute
     {

--- a/src/MudBlazor/Attributes/CategoryAttribute.cs
+++ b/src/MudBlazor/Attributes/CategoryAttribute.cs
@@ -3,13 +3,14 @@ namespace MudBlazor
 {
 
     /// <summary>
-    /// Specifies the name of the category in which to group the property of a MudBlazor component when displayed in the API documentation.
+    /// Groups a MudBlazor component parameter under a named category on its API documentation page.
     /// </summary>
     /// <remarks>
     /// Use this attribute together with the <see cref="Microsoft.AspNetCore.Components.ParameterAttribute"/>. <br/>
     /// This attribute is similar to <see cref="System.ComponentModel.CategoryAttribute"/>. <br/>
     /// The name of the category can be specified by using a constant defined in the <see cref="CategoryTypes"/> class.
     /// </remarks>
+    /// <seealso cref="CategoryTypes" />
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class CategoryAttribute : Attribute
     {

--- a/src/MudBlazor/Base/ComponentBaseWithState.cs
+++ b/src/MudBlazor/Base/ComponentBaseWithState.cs
@@ -11,7 +11,6 @@ namespace MudBlazor;
 /// <summary>
 /// Base class for Blazor components that track parameter changes and manage state through MudBlazor's parameter framework, such as <see cref="MudComponentBase"/>.
 /// </summary>
-/// <seealso cref="MudComponentBase" />
 public class ComponentBaseWithState : ComponentBase
 {
     internal readonly ParameterContainer ParameterContainer = new() { AutoVerify = false };

--- a/src/MudBlazor/Base/ComponentBaseWithState.cs
+++ b/src/MudBlazor/Base/ComponentBaseWithState.cs
@@ -9,8 +9,9 @@ using MudBlazor.State.Builder;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a base class for designing components which maintain state.
+/// Base class for Blazor components that track parameter changes and manage state through MudBlazor's parameter framework, such as <see cref="MudComponentBase"/>.
 /// </summary>
+/// <seealso cref="MudComponentBase" />
 public class ComponentBaseWithState : ComponentBase
 {
     internal readonly ParameterContainer ParameterContainer = new() { AutoVerify = false };

--- a/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
@@ -5,10 +5,12 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing components with bindable items.
+    /// Base class for item container components that bind to a data source and render each item through a template, such as <see cref="MudCarousel{T}"/>.
     /// </summary>
-    /// <typeparam name="TChildComponent">The <see cref="MudComponentBase"/> managed within this component..</typeparam>
+    /// <typeparam name="TChildComponent">The <see cref="MudComponentBase"/> managed within this component.</typeparam>
     /// <typeparam name="TData">The type of item managed by this component.</typeparam>
+    /// <seealso cref="MudBaseItemsControl{T}" />
+    /// <seealso cref="MudCarousel{T}" />
     public abstract class MudBaseBindableItemsControl<TChildComponent, TData> : MudBaseItemsControl<TChildComponent>
         where TChildComponent : MudComponentBase
     {

--- a/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseBindableItemsControl.cs
@@ -9,8 +9,6 @@ namespace MudBlazor
     /// </summary>
     /// <typeparam name="TChildComponent">The <see cref="MudComponentBase"/> managed within this component.</typeparam>
     /// <typeparam name="TData">The type of item managed by this component.</typeparam>
-    /// <seealso cref="MudBaseItemsControl{T}" />
-    /// <seealso cref="MudCarousel{T}" />
     public abstract class MudBaseBindableItemsControl<TChildComponent, TData> : MudBaseItemsControl<TChildComponent>
         where TChildComponent : MudComponentBase
     {

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -6,8 +6,11 @@ using static System.String;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing button components.
+    /// Base class for clickable button components such as <see cref="MudButton"/>, <see cref="MudFab"/>, and <see cref="MudIconButton"/>.
     /// </summary>
+    /// <seealso cref="MudButton" />
+    /// <seealso cref="MudFab" />
+    /// <seealso cref="MudIconButton" />
     public abstract class MudBaseButton : MudComponentBase
     {
         /// <summary>

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -8,9 +8,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for clickable button components such as <see cref="MudButton"/>, <see cref="MudFab"/>, and <see cref="MudIconButton"/>.
     /// </summary>
-    /// <seealso cref="MudButton" />
-    /// <seealso cref="MudFab" />
-    /// <seealso cref="MudIconButton" />
     public abstract class MudBaseButton : MudComponentBase
     {
         /// <summary>

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -9,10 +9,6 @@ namespace MudBlazor
     /// Base class for MudBlazor form input components such as <see cref="MudTextField{T}"/>, <see cref="MudNumericField{T}"/>, and <see cref="MudSelect{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of item being input.</typeparam>
-    /// <seealso cref="MudFormComponent{T, U}" />
-    /// <seealso cref="MudNumericField{T}" />
-    /// <seealso cref="MudSelect{T}" />
-    /// <seealso cref="MudTextField{T}" />
     public abstract class MudBaseInput<T> : MudFormComponent<T, string>
     {
         private bool _isDirty;

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -6,9 +6,13 @@ using MudBlazor.State;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing form input components.
+    /// Base class for MudBlazor form input components such as <see cref="MudTextField{T}"/>, <see cref="MudNumericField{T}"/>, and <see cref="MudSelect{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of item being input.</typeparam>
+    /// <seealso cref="MudFormComponent{T, U}" />
+    /// <seealso cref="MudNumericField{T}" />
+    /// <seealso cref="MudSelect{T}" />
+    /// <seealso cref="MudTextField{T}" />
     public abstract class MudBaseInput<T> : MudFormComponent<T, string>
     {
         private bool _isDirty;

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -8,9 +8,6 @@ namespace MudBlazor
     /// Base class for components that manage a collection of child items with a selected index, such as <see cref="MudCarousel{T}"/> and <see cref="MudTimeline"/>.
     /// </summary>
     /// <typeparam name="TChildComponent">The type of <see cref="MudComponentBase"/> managed by this component.</typeparam>
-    /// <seealso cref="MudBaseBindableItemsControl{TChildComponent, TData}" />
-    /// <seealso cref="MudCarousel{T}" />
-    /// <seealso cref="MudTimeline" />
     public abstract class MudBaseItemsControl<TChildComponent> : MudComponentBase
             where TChildComponent : MudComponentBase
     {

--- a/src/MudBlazor/Base/MudBaseItemsControl.cs
+++ b/src/MudBlazor/Base/MudBaseItemsControl.cs
@@ -5,9 +5,12 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing components which contain items.
+    /// Base class for components that manage a collection of child items with a selected index, such as <see cref="MudCarousel{T}"/> and <see cref="MudTimeline"/>.
     /// </summary>
     /// <typeparam name="TChildComponent">The type of <see cref="MudComponentBase"/> managed by this component.</typeparam>
+    /// <seealso cref="MudBaseBindableItemsControl{TChildComponent, TData}" />
+    /// <seealso cref="MudCarousel{T}" />
+    /// <seealso cref="MudTimeline" />
     public abstract class MudBaseItemsControl<TChildComponent> : MudComponentBase
             where TChildComponent : MudComponentBase
     {

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -8,9 +8,12 @@ using MudBlazor.State;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a form input component which stores a boolean value.
+    /// Base class for form inputs backed by a boolean value, such as <see cref="MudCheckBox{T}"/>, <see cref="MudSwitch{T}"/>, and <see cref="MudRadio{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of item managed by this component.</typeparam>
+    /// <seealso cref="MudCheckBox{T}" />
+    /// <seealso cref="MudRadio{T}" />
+    /// <seealso cref="MudSwitch{T}" />
     public class MudBooleanInput<T> : MudFormComponent<T?, bool?>
     {
         private readonly ParameterState<T?> _valueState;

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -11,9 +11,6 @@ namespace MudBlazor
     /// Base class for form inputs backed by a boolean value, such as <see cref="MudCheckBox{T}"/>, <see cref="MudSwitch{T}"/>, and <see cref="MudRadio{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of item managed by this component.</typeparam>
-    /// <seealso cref="MudCheckBox{T}" />
-    /// <seealso cref="MudRadio{T}" />
-    /// <seealso cref="MudSwitch{T}" />
     public class MudBooleanInput<T> : MudFormComponent<T?, bool?>
     {
         private readonly ParameterState<T?> _valueState;

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -12,7 +12,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for every MudBlazor component, supplying the shared <c>Class</c>, <c>Style</c>, <c>Tag</c>, and <c>UserAttributes</c> parameters.
     /// </summary>
-    /// <seealso cref="ComponentBaseWithState" />
     public abstract class MudComponentBase : ComponentBaseWithState, IMudStateHasChanged
     {
         private ILogger? _logger;

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -10,8 +10,9 @@ using MudBlazor.Interfaces;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing MudBlazor components.
+    /// Base class for every MudBlazor component, supplying the shared <c>Class</c>, <c>Style</c>, <c>Tag</c>, and <c>UserAttributes</c> parameters.
     /// </summary>
+    /// <seealso cref="ComponentBaseWithState" />
     public abstract class MudComponentBase : ComponentBaseWithState, IMudStateHasChanged
     {
         private ILogger? _logger;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -23,9 +23,6 @@ namespace MudBlazor
     /// </summary>
     /// <typeparam name="T">The complex type managed by this input.</typeparam>
     /// <typeparam name="U">The value type managed by this input.</typeparam>
-    /// <seealso cref="MudBaseInput{T}" />
-    /// <seealso cref="MudBooleanInput{T}" />
-    /// <seealso cref="MudComponentBase" />
     public abstract class MudFormComponent<T, U> : MudComponentBase, IFormComponent, IAsyncDisposable
     {
         private IConverter<T?, U?>? _defaultConverter;

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -19,10 +19,13 @@ using static System.String;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing form input components.
+    /// Base class for form components that support validation, error messages, and value conversion, such as <see cref="MudBaseInput{T}"/> and <see cref="MudBooleanInput{T}"/>.
     /// </summary>
     /// <typeparam name="T">The complex type managed by this input.</typeparam>
     /// <typeparam name="U">The value type managed by this input.</typeparam>
+    /// <seealso cref="MudBaseInput{T}" />
+    /// <seealso cref="MudBooleanInput{T}" />
+    /// <seealso cref="MudComponentBase" />
     public abstract class MudFormComponent<T, U> : MudComponentBase, IFormComponent, IAsyncDisposable
     {
         private IConverter<T?, U?>? _defaultConverter;

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbItem.cs
@@ -2,11 +2,11 @@
 
 
 /// <summary>
-/// Represents a portion of a list of breadcrumbs.
+/// A single entry in a <see cref="MudBreadcrumbs"/> trail, carrying its display text, link URL, optional icon, and disabled state.
 /// </summary>
-/// <seealso cref="MudBreadcrumbs" />
 /// <seealso cref="BreadcrumbLink" />
 /// <seealso cref="BreadcrumbSeparator" />
+/// <seealso cref="MudBreadcrumbs" />
 public record BreadcrumbItem
 {
     /// <summary>

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
@@ -9,11 +9,11 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents a segment in a list of breadcrumbs.
+/// The clickable link rendered for each <see cref="BreadcrumbItem"/> in a <see cref="MudBreadcrumbs"/> trail.
 /// </summary>
-/// <seealso cref="MudBreadcrumbs" />
 /// <seealso cref="BreadcrumbItem" />
 /// <seealso cref="BreadcrumbSeparator" />
+/// <seealso cref="MudBreadcrumbs" />
 public partial class BreadcrumbLink
 {
     /// <summary>

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbSeparator.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbSeparator.razor.cs
@@ -8,11 +8,11 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents a divider between breadcrumb items.
+/// The divider rendered between items in a <see cref="MudBreadcrumbs"/> trail, showing the separator character or a custom template.
 /// </summary>
-/// <seealso cref="MudBreadcrumbs" />
 /// <seealso cref="BreadcrumbItem" />
 /// <seealso cref="BreadcrumbLink" />
+/// <seealso cref="MudBreadcrumbs" />
 public partial class BreadcrumbSeparator
 {
     /// <summary>

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
@@ -5,7 +5,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a series of links used to show the user's current location.
+    /// Breadcrumbs show a navigation trail of links marking the user's current location within a page hierarchy.
     /// </summary>
     /// <seealso cref="BreadcrumbItem" />
     /// <seealso cref="BreadcrumbLink" />

--- a/src/MudBlazor/Components/Button/MudButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudButton.razor.cs
@@ -4,7 +4,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a button for actions, links, and commands.
+    /// Buttons trigger actions, submit forms, or navigate to a link.
     /// </summary>
     /// <remarks>
     /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,

--- a/src/MudBlazor/Components/Button/MudFab.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFab.razor.cs
@@ -4,7 +4,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a floating action button.
+    /// Floating action buttons (FABs) trigger the primary action on a page and float above content in a circular or extended shape.
     /// </summary>
     /// <remarks>
     /// Creates a <see href="https://developer.mozilla.org/docs/Web/HTML/Element/Button">button</see> element,
@@ -12,6 +12,7 @@ namespace MudBlazor
     /// You can directly add attributes like <c>title</c> or <c>aria-label</c>.
     /// </remarks>
     /// <seealso cref="MudButton" />
+    /// <seealso cref="MudFabMenu" />
     /// <seealso cref="MudIconButton" />
     /// <seealso cref="MudToggleIconButton" />
     public partial class MudFab : MudBaseButton

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -4,8 +4,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents an item for the <see cref="MudFabMenu"/>.
+/// A floating action button shown as one of the selectable options within a <see cref="MudFabMenu"/>.
 /// </summary>
+/// <seealso cref="MudFab" />
+/// <seealso cref="MudFabMenu" />
 public partial class MudFabMenuItem : MudFab
 {
     private new string Classname => new CssBuilder(base.Classname)

--- a/src/MudBlazor/Components/Card/MudCardActions.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardActions.razor.cs
@@ -4,7 +4,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a set of buttons displayed as part of a <see cref="MudCard"/>.
+    /// The action bar of a <see cref="MudCard"/>, typically holding buttons that trigger the card's related actions.
     /// </summary>
     /// <seealso cref="MudCard" />
     /// <seealso cref="MudCardContent" />

--- a/src/MudBlazor/Components/Card/MudCardContent.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardContent.razor.cs
@@ -4,7 +4,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the primary content displayed within a <see cref="MudCard"/>.
+    /// The primary content area of a <see cref="MudCard"/>, holding its text and body elements.
     /// </summary>
     /// <seealso cref="MudCard" />
     /// <seealso cref="MudCardActions" />

--- a/src/MudBlazor/Components/Card/MudCardHeader.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardHeader.razor.cs
@@ -4,7 +4,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the top portion of a <see cref="MudCard"/>.
+    /// The header area of a <see cref="MudCard"/>, typically holding an avatar, title, and action buttons.
     /// </summary>
     /// <seealso cref="MudCard" />
     /// <seealso cref="MudCardActions" />

--- a/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor.cs
@@ -4,7 +4,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents an image displayed as part of a <see cref="MudCard"/>.
+    /// The media area of a <see cref="MudCard"/>, displaying an image or graphic sized to a set height.
     /// </summary>
     /// <seealso cref="MudCard" />
     /// <seealso cref="MudCardActions" />

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -5,7 +5,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a set of slides which transition after a delay.
+    /// Carousels cycle through a set of slides or images, transitioning automatically or when the user swipes, clicks arrows, or selects a bullet.
     /// </summary>
     /// <typeparam name="TData">The kind of item to display.</typeparam>
     /// <seealso cref="MudCarouselItem" />

--- a/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarouselItem.razor.cs
@@ -6,7 +6,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a slide displayed within a <see cref="MudCarousel{TData}"/>.
+    /// A single slide within a <see cref="MudCarousel{TData}"/>, holding the content shown while it is the selected item.
     /// </summary>
     /// <seealso cref="MudCarousel{TData}" />
     public partial class MudCarouselItem : MudComponentBase, IDisposable

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
@@ -15,9 +15,6 @@ namespace MudBlazor.Charts;
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TChartOptions">The type of chart options.</typeparam>
-/// <seealso cref="BaseRadialChart{T, TChartOptions}" />
-/// <seealso cref="IAxisChartOptions" />
-/// <seealso cref="MudChart{T}" />
 public partial class BaseAxisChart<T, TChartOptions> : MudComponentBase
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TChartOptions : IAxisChartOptions, new()

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
@@ -11,10 +11,13 @@ using MudBlazor.Utilities;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a base component for charts with axes.
+/// Renders the SVG axes, grid lines, series paths, and tooltips shared by axis-based chart types.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TChartOptions">The type of chart options.</typeparam>
+/// <seealso cref="BaseRadialChart{T, TChartOptions}" />
+/// <seealso cref="IAxisChartOptions" />
+/// <seealso cref="MudChart{T}" />
 public partial class BaseAxisChart<T, TChartOptions> : MudComponentBase
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TChartOptions : IAxisChartOptions, new()

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
@@ -15,9 +15,6 @@ namespace MudBlazor.Charts;
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TChartOptions">The type of chart options.</typeparam>
-/// <seealso cref="BaseAxisChart{T, TChartOptions}" />
-/// <seealso cref="IRadialChartOptions" />
-/// <seealso cref="MudRadialChartBase{T, TOptions}" />
 public partial class BaseRadialChart<T, TChartOptions> : MudComponentBase
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TChartOptions : IRadialChartOptions, new()

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
@@ -11,10 +11,13 @@ using MudBlazor.Utilities;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a base component for radial charts.
+/// Renders the SVG segments, labels, and tooltips shared by radial chart types such as pie, donut, radar, and rose.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TChartOptions">The type of chart options.</typeparam>
+/// <seealso cref="BaseAxisChart{T, TChartOptions}" />
+/// <seealso cref="IRadialChartOptions" />
+/// <seealso cref="MudRadialChartBase{T, TOptions}" />
 public partial class BaseRadialChart<T, TChartOptions> : MudComponentBase
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TChartOptions : IRadialChartOptions, new()

--- a/src/MudBlazor/Components/Chart/Base/DefaultAxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultAxisChartOptions.cs
@@ -5,8 +5,12 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the default options for a chart with axes.
+/// Default option values for axis-based charts, including Y-axis ticks, number formats, grid lines, and axis titles.
 /// </summary>
+/// <seealso cref="DefaultAxisLineChartOptions" />
+/// <seealso cref="DefaultBarChartOptions" />
+/// <seealso cref="DefaultChartOptions" />
+/// <seealso cref="IAxisChartOptions" />
 public abstract class DefaultAxisChartOptions : DefaultChartOptions, IAxisChartOptions
 {
     private int _yAxisTicks = 20;

--- a/src/MudBlazor/Components/Chart/Base/DefaultAxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultAxisChartOptions.cs
@@ -7,10 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Default option values for axis-based charts, including Y-axis ticks, number formats, grid lines, and axis titles.
 /// </summary>
-/// <seealso cref="DefaultAxisLineChartOptions" />
-/// <seealso cref="DefaultBarChartOptions" />
-/// <seealso cref="DefaultChartOptions" />
-/// <seealso cref="IAxisChartOptions" />
 public abstract class DefaultAxisChartOptions : DefaultChartOptions, IAxisChartOptions
 {
     private int _yAxisTicks = 20;

--- a/src/MudBlazor/Components/Chart/Base/DefaultAxisLineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultAxisLineChartOptions.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the default options for a line chart.
+/// Default line and area chart options such as stroke width, data markers, interpolation, and per-series display overrides.
 /// </summary>
+/// <seealso cref="DefaultAxisChartOptions" />
+/// <seealso cref="IAxisLineChartOptions" />
+/// <seealso cref="LineChartOptions" />
 public abstract class DefaultAxisLineChartOptions : DefaultAxisChartOptions, IAxisLineChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/DefaultAxisLineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultAxisLineChartOptions.cs
@@ -7,9 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Default line and area chart options such as stroke width, data markers, interpolation, and per-series display overrides.
 /// </summary>
-/// <seealso cref="DefaultAxisChartOptions" />
-/// <seealso cref="IAxisLineChartOptions" />
-/// <seealso cref="LineChartOptions" />
 public abstract class DefaultAxisLineChartOptions : DefaultAxisChartOptions, IAxisLineChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/DefaultBarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultBarChartOptions.cs
@@ -7,9 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Default bar chart options such as justification, group spacing, bar width, and tooltip format.
 /// </summary>
-/// <seealso cref="BarChartOptions" />
-/// <seealso cref="DefaultAxisChartOptions" />
-/// <seealso cref="StackedBarChartOptions" />
 public abstract class DefaultBarChartOptions : DefaultAxisChartOptions
 {
     private double _seriesSpacingRatio = 1;

--- a/src/MudBlazor/Components/Chart/Base/DefaultBarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultBarChartOptions.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the default options for a bar chart.
+/// Default bar chart options such as justification, group spacing, bar width, and tooltip format.
 /// </summary>
+/// <seealso cref="BarChartOptions" />
+/// <seealso cref="DefaultAxisChartOptions" />
+/// <seealso cref="StackedBarChartOptions" />
 public abstract class DefaultBarChartOptions : DefaultAxisChartOptions
 {
     private double _seriesSpacingRatio = 1;

--- a/src/MudBlazor/Components/Chart/Base/DefaultChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultChartOptions.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the default options for a chart.
+/// Default option values shared by all chart types, including legend visibility, tooltips, and the color palette.
 /// </summary>
+/// <seealso cref="DefaultAxisChartOptions" />
+/// <seealso cref="DefaultRadialChartOptions" />
+/// <seealso cref="IChartOptions" />
 public abstract class DefaultChartOptions : IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/DefaultChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultChartOptions.cs
@@ -7,9 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Default option values shared by all chart types, including legend visibility, tooltips, and the color palette.
 /// </summary>
-/// <seealso cref="DefaultAxisChartOptions" />
-/// <seealso cref="DefaultRadialChartOptions" />
-/// <seealso cref="IChartOptions" />
 public abstract class DefaultChartOptions : IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/DefaultRadialChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultRadialChartOptions.cs
@@ -7,10 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Default radial chart options such as data aggregation, fill opacity, and percentage display.
 /// </summary>
-/// <seealso cref="DefaultChartOptions" />
-/// <seealso cref="DonutChartOptions" />
-/// <seealso cref="IRadialChartOptions" />
-/// <seealso cref="PieChartOptions" />
 public abstract class DefaultRadialChartOptions : DefaultChartOptions, IRadialChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/DefaultRadialChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultRadialChartOptions.cs
@@ -5,8 +5,12 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the default options for a radial chart.
+/// Default radial chart options such as data aggregation, fill opacity, and percentage display.
 /// </summary>
+/// <seealso cref="DefaultChartOptions" />
+/// <seealso cref="DonutChartOptions" />
+/// <seealso cref="IRadialChartOptions" />
+/// <seealso cref="PieChartOptions" />
 public abstract class DefaultRadialChartOptions : DefaultChartOptions, IRadialChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IAxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IAxisChartOptions.cs
@@ -5,8 +5,12 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the options for a chart that has axes.
+/// Axis chart options such as Y-axis ticks, number formats, grid lines, and axis titles for charts with X and Y axes.
 /// </summary>
+/// <seealso cref="DefaultAxisChartOptions" />
+/// <seealso cref="IAxisLineChartOptions" />
+/// <seealso cref="IChartOptions" />
+/// <seealso cref="IRadialChartOptions" />
 public interface IAxisChartOptions : IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IAxisChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IAxisChartOptions.cs
@@ -7,10 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Axis chart options such as Y-axis ticks, number formats, grid lines, and axis titles for charts with X and Y axes.
 /// </summary>
-/// <seealso cref="DefaultAxisChartOptions" />
-/// <seealso cref="IAxisLineChartOptions" />
-/// <seealso cref="IChartOptions" />
-/// <seealso cref="IRadialChartOptions" />
 public interface IAxisChartOptions : IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IAxisLineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IAxisLineChartOptions.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the options for a line chart that has axes.
+/// Line and area chart options such as stroke width, data markers, interpolation, and per-series display overrides.
 /// </summary>
+/// <seealso cref="DefaultAxisLineChartOptions" />
+/// <seealso cref="IAxisChartOptions" />
+/// <seealso cref="LineChartOptions" />
 public interface IAxisLineChartOptions : IAxisChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IAxisLineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IAxisLineChartOptions.cs
@@ -7,9 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Line and area chart options such as stroke width, data markers, interpolation, and per-series display overrides.
 /// </summary>
-/// <seealso cref="DefaultAxisLineChartOptions" />
-/// <seealso cref="IAxisChartOptions" />
-/// <seealso cref="LineChartOptions" />
 public interface IAxisLineChartOptions : IAxisChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IChartOptions.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the options for a chart.
+/// Common chart options shared by every chart type, including legend visibility, tooltips, and the color palette.
 /// </summary>
+/// <seealso cref="DefaultChartOptions" />
+/// <seealso cref="IAxisChartOptions" />
+/// <seealso cref="IRadialChartOptions" />
 public interface IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IChartOptions.cs
@@ -7,9 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Common chart options shared by every chart type, including legend visibility, tooltips, and the color palette.
 /// </summary>
-/// <seealso cref="DefaultChartOptions" />
-/// <seealso cref="IAxisChartOptions" />
-/// <seealso cref="IRadialChartOptions" />
 public interface IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IMudAxisChart.cs
+++ b/src/MudBlazor/Components/Chart/Base/IMudAxisChart.cs
@@ -20,9 +20,12 @@ public record struct AxisGridData<T>(int LowestHorizontalLine, int HorizontalLin
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable;
 
 /// <summary>
-/// Represents a chart that has axes.
+/// Axis chart abstraction extending <see cref="IMudChart{T}"/> with shared grid data and support for overlaying one chart on another.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
+/// <seealso cref="BaseAxisChart{T, TChartOptions}" />
+/// <seealso cref="IMudChart{T}" />
+/// <seealso cref="MudAxisChartBase{T, TOptions}" />
 public interface IMudAxisChart<T> : IMudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IMudAxisChart.cs
+++ b/src/MudBlazor/Components/Chart/Base/IMudAxisChart.cs
@@ -23,9 +23,6 @@ public record struct AxisGridData<T>(int LowestHorizontalLine, int HorizontalLin
 /// Axis chart abstraction extending <see cref="IMudChart{T}"/> with shared grid data and support for overlaying one chart on another.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
-/// <seealso cref="BaseAxisChart{T, TChartOptions}" />
-/// <seealso cref="IMudChart{T}" />
-/// <seealso cref="MudAxisChartBase{T, TOptions}" />
 public interface IMudAxisChart<T> : IMudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IMudChart.cs
+++ b/src/MudBlazor/Components/Chart/Base/IMudChart.cs
@@ -10,9 +10,6 @@ namespace MudBlazor.Charts;
 /// Core chart abstraction exposing the data series, legend palette, and chart type, with a method to rebuild the chart on demand.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
-/// <seealso cref="IMudAxisChart{T}" />
-/// <seealso cref="MudChart{T}" />
-/// <seealso cref="MudChartBase{T, TOptions}" />
 public interface IMudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IMudChart.cs
+++ b/src/MudBlazor/Components/Chart/Base/IMudChart.cs
@@ -7,9 +7,12 @@ using System.Numerics;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a chart component.
+/// Core chart abstraction exposing the data series, legend palette, and chart type, with a method to rebuild the chart on demand.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
+/// <seealso cref="IMudAxisChart{T}" />
+/// <seealso cref="MudChart{T}" />
+/// <seealso cref="MudChartBase{T, TOptions}" />
 public interface IMudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IRadialChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IRadialChartOptions.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents the options for a radial chart.
+/// Radial chart options such as data aggregation and fill opacity for pie, donut, radar, and rose charts.
 /// </summary>
+/// <seealso cref="DefaultRadialChartOptions" />
+/// <seealso cref="IAxisChartOptions" />
+/// <seealso cref="IChartOptions" />
 public interface IRadialChartOptions : IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/IRadialChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IRadialChartOptions.cs
@@ -7,9 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Radial chart options such as data aggregation and fill opacity for pie, donut, radar, and rose charts.
 /// </summary>
-/// <seealso cref="DefaultRadialChartOptions" />
-/// <seealso cref="IAxisChartOptions" />
-/// <seealso cref="IChartOptions" />
 public interface IRadialChartOptions : IChartOptions
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
@@ -17,9 +17,6 @@ namespace MudBlazor.Charts;
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
-/// <seealso cref="IAxisLineChartOptions" />
-/// <seealso cref="MudAxisChartBase{T, TOptions}" />
-/// <seealso cref="MudRadialChartBase{T, TOptions}" />
 public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TOptions>
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IAxisLineChartOptions

--- a/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
@@ -12,10 +12,14 @@ using MudBlazor.Interpolation;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a base class for axis-based line charts.
+/// Base class for line-based charts such as <see cref="Line{T}"/>, <see cref="ScatterPlot{T}"/>, and <see cref="TimeSeries{T}"/>.
+/// Generates the SVG line paths, area fills, and data-point markers, with optional interpolation.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
+/// <seealso cref="IAxisLineChartOptions" />
+/// <seealso cref="MudAxisChartBase{T, TOptions}" />
+/// <seealso cref="MudRadialChartBase{T, TOptions}" />
 public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TOptions>
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IAxisLineChartOptions

--- a/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
@@ -15,10 +15,6 @@ namespace MudBlazor;
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
-/// <seealso cref="IMudChart{T}" />
-/// <seealso cref="MudAxisChartBase{T, TOptions}" />
-/// <seealso cref="MudChart{T}" />
-/// <seealso cref="MudRadialChartBase{T, TOptions}" />
 public abstract class MudChartBase<T, TOptions> : MudComponentBase, IMudChart<T>
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IChartOptions

--- a/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
@@ -11,10 +11,14 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a base class for chart components.
+/// Base class for MudBlazor chart components, providing the data series, options, legend, and selection shared by every chart type.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
+/// <seealso cref="IMudChart{T}" />
+/// <seealso cref="MudAxisChartBase{T, TOptions}" />
+/// <seealso cref="MudChart{T}" />
+/// <seealso cref="MudRadialChartBase{T, TOptions}" />
 public abstract class MudChartBase<T, TOptions> : MudComponentBase, IMudChart<T>
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IChartOptions

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -19,9 +19,6 @@ namespace MudBlazor.Charts;
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
-/// <seealso cref="IRadialChartOptions" />
-/// <seealso cref="MudAxisLineChartBase{T, TOptions}" />
-/// <seealso cref="MudChartBase{T, TOptions}" />
 public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions>, IDisposable
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IRadialChartOptions

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -14,10 +14,14 @@ using MudBlazor.Utilities.Debounce;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a base class for radial charts.
+/// Base class for radial charts such as <see cref="Pie{T}"/>, <see cref="Donut{T}"/>, <see cref="Radar{T}"/>, and <see cref="Rose{T}"/>.
+/// Aggregates and normalizes series data into circular segments and legends.
 /// </summary>
 /// <typeparam name="T">The data type of the chart.</typeparam>
 /// <typeparam name="TOptions">The type of options for the chart.</typeparam>
+/// <seealso cref="IRadialChartOptions" />
+/// <seealso cref="MudAxisLineChartBase{T, TOptions}" />
+/// <seealso cref="MudChartBase{T, TOptions}" />
 public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions>, IDisposable
     where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     where TOptions : IRadialChartOptions

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -9,12 +9,12 @@ namespace MudBlazor.Charts
     /// Donut chart that renders each value as a proportional segment of a ring with a hollow center.
     /// </summary>
     /// <typeparam name="T">The numeric type of the values being charted.</typeparam>
-    /// <seealso cref="Bar{T}" />
-    /// <seealso cref="Line{T}" />
-    /// <seealso cref="MudChart{T}" />
-    /// <seealso cref="Pie{T}" />
-    /// <seealso cref="StackedBar{T}" />
-    /// <seealso cref="TimeSeries{T}" />
+    /// <seealso cref="Bar{T}"/>
+    /// <seealso cref="Donut{T}"/>
+    /// <seealso cref="Pie{T}"/>
+    /// <seealso cref="Line{T}"/>
+    /// <seealso cref="StackedBar{T}"/>
+    /// <seealso cref="TimeSeries{T}"/>
     public partial class Donut<T> : MudRadialChartBase<T, DonutChartOptions> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor.cs
@@ -6,14 +6,15 @@ using MudBlazor.Extensions;
 namespace MudBlazor.Charts
 {
     /// <summary>
-    /// Represents a chart which displays values as a percentage of a circle.
+    /// Donut chart that renders each value as a proportional segment of a ring with a hollow center.
     /// </summary>
-    /// <seealso cref="Bar{T}"/>
-    /// <seealso cref="Donut{T}"/>
-    /// <seealso cref="Pie{T}"/>
-    /// <seealso cref="Line{T}"/>
-    /// <seealso cref="StackedBar{T}"/>
-    /// <seealso cref="TimeSeries{T}"/>
+    /// <typeparam name="T">The numeric type of the values being charted.</typeparam>
+    /// <seealso cref="Bar{T}" />
+    /// <seealso cref="Line{T}" />
+    /// <seealso cref="MudChart{T}" />
+    /// <seealso cref="Pie{T}" />
+    /// <seealso cref="StackedBar{T}" />
+    /// <seealso cref="TimeSeries{T}" />
     public partial class Donut<T> : MudRadialChartBase<T, DonutChartOptions> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -390,6 +390,8 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
 }
 
 /// <summary>
-/// Represents a data point in a time series chart, containing a DateTime and a value.
+/// A single data point in a <see cref="TimeSeries{T}" /> chart, pairing a <see cref="DateTime" /> timestamp with a numeric value.
 /// </summary>
+/// <typeparam name="TNumber">The numeric type of the value at each timestamp.</typeparam>
+/// <seealso cref="TimeSeries{T}" />
 public readonly record struct TimeValue<TNumber>(DateTime DateTime, TNumber Value) where TNumber : INumber<TNumber>, IFormattable;

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor.cs
@@ -393,5 +393,4 @@ partial class TimeSeries<T> : MudAxisLineChartBase<T, TimeSeriesChartOptions> wh
 /// A single data point in a <see cref="TimeSeries{T}" /> chart, pairing a <see cref="DateTime" /> timestamp with a numeric value.
 /// </summary>
 /// <typeparam name="TNumber">The numeric type of the value at each timestamp.</typeparam>
-/// <seealso cref="TimeSeries{T}" />
 public readonly record struct TimeValue<TNumber>(DateTime DateTime, TNumber Value) where TNumber : INumber<TNumber>, IFormattable;

--- a/src/MudBlazor/Components/Chart/Models/ChartPoint.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartPoint.cs
@@ -11,7 +11,6 @@ namespace MudBlazor;
 /// A data point in a chart series, holding an optional X value and a required Y value.
 /// </summary>
 /// <typeparam name="T">The numeric type of the Y value.</typeparam>
-/// <seealso cref="ChartSeries{T}" />
 public class ChartPoint<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/ChartPoint.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartPoint.cs
@@ -8,9 +8,10 @@ using MudBlazor.Charts;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the data point in a chart series, with optional X value and required Y value.
+/// A data point in a chart series, holding an optional X value and a required Y value.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The numeric type of the Y value.</typeparam>
+/// <seealso cref="ChartSeries{T}" />
 public class ChartPoint<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
@@ -16,8 +16,6 @@ public interface IChartSeries
 /// A named data set plotted on a <see cref="MudChart{T}" />, carrying the values, legend label, and visibility for one line, bar, or pie series.
 /// </summary>
 /// <typeparam name="T">The numeric type of the series values.</typeparam>
-/// <seealso cref="ChartPoint{T}" />
-/// <seealso cref="MudChart{T}" />
 public sealed class ChartSeries<T> : IChartSeries, IEquatable<ChartSeries<T>> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     public ChartSeries() { }

--- a/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartSeries.cs
@@ -13,9 +13,11 @@ public interface IChartSeries
 }
 
 /// <summary>
-/// Represents a series of data to be plotted on a chart.
+/// A named data set plotted on a <see cref="MudChart{T}" />, carrying the values, legend label, and visibility for one line, bar, or pie series.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The numeric type of the series values.</typeparam>
+/// <seealso cref="ChartPoint{T}" />
+/// <seealso cref="MudChart{T}" />
 public sealed class ChartSeries<T> : IChartSeries, IEquatable<ChartSeries<T>> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     public ChartSeries() { }

--- a/src/MudBlazor/Components/Chart/Models/Enums/AggregationOption.cs
+++ b/src/MudBlazor/Components/Chart/Models/Enums/AggregationOption.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Specifies the options for aggregating data in a dataset.
+/// Specifies how chart data is aggregated before plotting, either not at all, grouped by data set, or grouped by label.
 /// </summary>
+/// <seealso cref="MudChart{T}" />
 public enum AggregationOption
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/Enums/AggregationOption.cs
+++ b/src/MudBlazor/Components/Chart/Models/Enums/AggregationOption.cs
@@ -7,7 +7,6 @@ namespace MudBlazor.Charts;
 /// <summary>
 /// Specifies how chart data is aggregated before plotting, either not at all, grouped by data set, or grouped by label.
 /// </summary>
-/// <seealso cref="MudChart{T}" />
 public enum AggregationOption
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/Enums/LineDisplayType.cs
+++ b/src/MudBlazor/Components/Chart/Models/Enums/LineDisplayType.cs
@@ -1,8 +1,10 @@
 ﻿namespace MudBlazor;
 
 /// <summary>
-/// Specifies the type of graphical representation for a line or area.
+/// Specifies whether a series is drawn as a plain line or as a line with the area beneath it filled.
 /// </summary>
+/// <seealso cref="MudBlazor.Charts.Line{T}" />
+/// <seealso cref="MudChart{T}" />
 public enum LineDisplayType
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/Enums/LineDisplayType.cs
+++ b/src/MudBlazor/Components/Chart/Models/Enums/LineDisplayType.cs
@@ -3,8 +3,6 @@
 /// <summary>
 /// Specifies whether a series is drawn as a plain line or as a line with the area beneath it filled.
 /// </summary>
-/// <seealso cref="MudBlazor.Charts.Line{T}" />
-/// <seealso cref="MudChart{T}" />
 public enum LineDisplayType
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/HeatMapCell.cs
+++ b/src/MudBlazor/Components/Chart/Models/HeatMapCell.cs
@@ -9,9 +9,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor.Charts
 {
     /// <summary>
-    /// Represents a single cell in a heat map chart.
+    /// A single cell in a <see cref="HeatMap{T}" /> chart, carrying its row, column, value, and optional color or custom content.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The numeric type of the cell value.</typeparam>
+    /// <seealso cref="HeatMap{T}" />
+    /// <seealso cref="MudHeatMapCell{T}" />
     public class HeatMapCell<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/HeatMapCell.cs
+++ b/src/MudBlazor/Components/Chart/Models/HeatMapCell.cs
@@ -12,8 +12,6 @@ namespace MudBlazor.Charts
     /// A single cell in a <see cref="HeatMap{T}" /> chart, carrying its row, column, value, and optional color or custom content.
     /// </summary>
     /// <typeparam name="T">The numeric type of the cell value.</typeparam>
-    /// <seealso cref="HeatMap{T}" />
-    /// <seealso cref="MudHeatMapCell{T}" />
     public class HeatMapCell<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         /// <summary>

--- a/src/MudBlazor/Components/Chart/Models/MudHeatMapCell.razor.cs
+++ b/src/MudBlazor/Components/Chart/Models/MudHeatMapCell.razor.cs
@@ -10,10 +10,14 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a single cell in a <see cref="HeatMap{T}"/>. You can override the value from the <see cref="ChartSeries{T}"/> 
-    /// or provide a custom graphic to be shown inside the cell. You should provide a width and height for the custom graphic you are including
-    /// so the Heat Map can resize it dynamically. 
+    /// Overrides a single cell in a <see cref="HeatMap{T}" /> chart, replacing the value from the <see cref="ChartSeries{T}" /> or rendering custom SVG content inside the cell.
     /// </summary>
+    /// <remarks>
+    /// Provide a width and height for custom content so the heat map can resize it dynamically.
+    /// </remarks>
+    /// <typeparam name="T">The numeric type of the cell value.</typeparam>
+    /// <seealso cref="HeatMap{T}" />
+    /// <seealso cref="HeatMapCell{T}" />
     public partial class MudHeatMapCell<T> : MudComponentBase where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         [CascadingParameter]

--- a/src/MudBlazor/Components/Chart/Models/MudHeatMapCell.razor.cs
+++ b/src/MudBlazor/Components/Chart/Models/MudHeatMapCell.razor.cs
@@ -16,8 +16,6 @@ namespace MudBlazor
     /// Provide a width and height for custom content so the heat map can resize it dynamically.
     /// </remarks>
     /// <typeparam name="T">The numeric type of the cell value.</typeparam>
-    /// <seealso cref="HeatMap{T}" />
-    /// <seealso cref="HeatMapCell{T}" />
     public partial class MudHeatMapCell<T> : MudComponentBase where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         [CascadingParameter]

--- a/src/MudBlazor/Components/Chart/Models/SankeyEdge.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyEdge.cs
@@ -18,7 +18,4 @@ namespace MudBlazor.Charts;
 /// <param name="Source">The name of the source <see cref="SankeyNode"/>.</param>
 /// <param name="Target">The name of the target <see cref="SankeyNode"/>.</param>
 /// <param name="Weight">The weight (size) of this edge</param>
-/// <seealso cref="Sankey{T}" />
-/// <seealso cref="SankeyLink" />
-/// <seealso cref="SankeyNode" />
 public record SankeyEdge<T>(string Source, string Target, T Weight) where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable;

--- a/src/MudBlazor/Components/Chart/Models/SankeyEdge.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyEdge.cs
@@ -8,8 +8,7 @@ using System.Numerics;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a directed edge in a Sankey diagram, connecting a source node to a target node with an associated
-/// weight.
+/// A directed edge in a <see cref="Sankey{T}" /> diagram, connecting a source node to a target node with a weight that sets the flow size.
 /// </summary>
 /// <remarks>
 /// The edge is defined by its source node, target node, and a weight value that determines the size of the edge.
@@ -19,4 +18,7 @@ namespace MudBlazor.Charts;
 /// <param name="Source">The name of the source <see cref="SankeyNode"/>.</param>
 /// <param name="Target">The name of the target <see cref="SankeyNode"/>.</param>
 /// <param name="Weight">The weight (size) of this edge</param>
+/// <seealso cref="Sankey{T}" />
+/// <seealso cref="SankeyLink" />
+/// <seealso cref="SankeyNode" />
 public record SankeyEdge<T>(string Source, string Target, T Weight) where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable;

--- a/src/MudBlazor/Components/Chart/Models/SankeyLink.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyLink.cs
@@ -9,7 +9,4 @@ namespace MudBlazor.Charts;
 /// </summary>
 /// <param name="Source">The source <see cref="SankeyNode"/>.</param>
 /// <param name="Target">The target <see cref="SankeyNode"/>.</param>
-/// <seealso cref="Sankey{T}" />
-/// <seealso cref="SankeyEdge{T}" />
-/// <seealso cref="SankeyNode" />
 public record struct SankeyLink(string Source, string Target);

--- a/src/MudBlazor/Components/Chart/Models/SankeyLink.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyLink.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a link in a Sankey diagram, defining the source and target edges.
+/// A link in a <see cref="Sankey{T}" /> diagram, naming the source and target <see cref="SankeyNode" /> it connects.
 /// </summary>
 /// <param name="Source">The source <see cref="SankeyNode"/>.</param>
 /// <param name="Target">The target <see cref="SankeyNode"/>.</param>
+/// <seealso cref="Sankey{T}" />
+/// <seealso cref="SankeyEdge{T}" />
+/// <seealso cref="SankeyNode" />
 public record struct SankeyLink(string Source, string Target);

--- a/src/MudBlazor/Components/Chart/Models/SankeyNode.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyNode.cs
@@ -18,9 +18,6 @@ namespace MudBlazor.Charts;
 /// <param name="Name">The name of this node.</param>
 /// <param name="Column">The column in which to display this node.</param>
 /// <param name="Color">The color of this node. Picks colors from <see cref="IChartOptions.ChartPalette"/> if set to <c>null</c>.</param>
-/// <seealso cref="Sankey{T}" />
-/// <seealso cref="SankeyEdge{T}" />
-/// <seealso cref="SankeyLink" />
 public record SankeyNode(string Name, int Column, MudColor? Color = null)
 {
     public MudColor? Color { get; set; } = Color;

--- a/src/MudBlazor/Components/Chart/Models/SankeyNode.cs
+++ b/src/MudBlazor/Components/Chart/Models/SankeyNode.cs
@@ -8,7 +8,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor.Charts;
 
 /// <summary>
-/// Represents a node in a Sankey diagram, including its name, column position, and optional color.
+/// A node in a <see cref="Sankey{T}" /> diagram, defined by its name, column position, and optional color.
 /// </summary>
 /// <remarks>
 /// A Sankey diagram node is a visual element that represents a specific entity or category in
@@ -18,6 +18,9 @@ namespace MudBlazor.Charts;
 /// <param name="Name">The name of this node.</param>
 /// <param name="Column">The column in which to display this node.</param>
 /// <param name="Color">The color of this node. Picks colors from <see cref="IChartOptions.ChartPalette"/> if set to <c>null</c>.</param>
+/// <seealso cref="Sankey{T}" />
+/// <seealso cref="SankeyEdge{T}" />
+/// <seealso cref="SankeyLink" />
 public record SankeyNode(string Name, int Column, MudColor? Color = null)
 {
     public MudColor? Color { get; set; } = Color;

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -10,8 +10,13 @@ using MudBlazor.Charts;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a graphic display of data values in a line, bar, stacked bar, pie, heat map, or donut shape.
+/// Charts plot numeric data as line, bar, stacked bar, pie, donut, radar, rose, heat map, time series, scatter, or Sankey graphics.
+/// Choose the graphic with the <see cref="ChartType"/> parameter.
 /// </summary>
+/// <typeparam name="T">The numeric type of the data values, such as <c>double</c> or <c>int</c>.</typeparam>
+/// <seealso cref="ChartOptions" />
+/// <seealso cref="ChartSeries{T}" />
+/// <seealso cref="ChartType" />
 public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
     [Inject]

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor.cs
@@ -7,8 +7,6 @@ namespace MudBlazor.Charts
     /// Legend that lists text labels identifying each data series shown in a <see cref="MudChart{T}" />.
     /// </summary>
     /// <typeparam name="T">The numeric type of the charted values.</typeparam>
-    /// <seealso cref="MudChart{T}" />
-    /// <seealso cref="SvgLegend" />
     public partial class Legend<T> : MudChartBase<T, IChartOptions> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         /// <summary>

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor.cs
@@ -4,8 +4,11 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor.Charts
 {
     /// <summary>
-    /// Represents a set of text labels which describe data values in a <see cref="MudChart{T}"/>.
+    /// Legend that lists text labels identifying each data series shown in a <see cref="MudChart{T}" />.
     /// </summary>
+    /// <typeparam name="T">The numeric type of the charted values.</typeparam>
+    /// <seealso cref="MudChart{T}" />
+    /// <seealso cref="SvgLegend" />
     public partial class Legend<T> : MudChartBase<T, IChartOptions> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
     {
         /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/EdgePath.cs
+++ b/src/MudBlazor/Components/Chart/Svg/EdgePath.cs
@@ -5,7 +5,7 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the path of a link (edge) between two nodes in a Sankey chart.
+/// The SVG path connecting a source node to a target node in a Sankey chart.
 /// </summary>
 /// <remarks>
 /// An <see cref="EdgePath"/> defines the SVG path data and associated metadata
@@ -14,6 +14,9 @@ namespace MudBlazor;
 /// or straight path defined by <see cref="SvgPath.Data"/>, and geometric properties
 /// such as the center point of the edge for positioning labels or tooltips.
 /// </remarks>
+/// <seealso cref="NodeRect" />
+/// <seealso cref="MudBlazor.Charts.Sankey{T}" />
+/// <seealso cref="SvgPath" />
 public sealed class EdgePath : SvgPath
 {
     /// <summary>
@@ -42,8 +45,7 @@ public sealed class EdgePath : SvgPath
 }
 
 /// <summary>
-/// Represents a rectangular node in a Sankey chart, including its position,
-/// dimensions, color.
+/// The bounding rectangle of a node in a Sankey chart, holding its position, size, color, and label.
 /// </summary>
 /// <remarks>
 /// A <see cref="NodeRect"/> defines the bounding box of a node (or block)
@@ -72,6 +74,8 @@ public sealed class EdgePath : SvgPath
 /// <param name="Color">
 /// The fill color used to visually represent the node in the chart.
 /// </param>
+/// <seealso cref="EdgePath" />
+/// <seealso cref="MudBlazor.Charts.Sankey{T}" />
 public sealed record NodeRect(int Hash, string Name, double X, double Y, double Width, double Height, string Color)
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/EdgePath.cs
+++ b/src/MudBlazor/Components/Chart/Svg/EdgePath.cs
@@ -14,9 +14,6 @@ namespace MudBlazor;
 /// or straight path defined by <see cref="SvgPath.Data"/>, and geometric properties
 /// such as the center point of the edge for positioning labels or tooltips.
 /// </remarks>
-/// <seealso cref="NodeRect" />
-/// <seealso cref="MudBlazor.Charts.Sankey{T}" />
-/// <seealso cref="SvgPath" />
 public sealed class EdgePath : SvgPath
 {
     /// <summary>
@@ -74,8 +71,6 @@ public sealed class EdgePath : SvgPath
 /// <param name="Color">
 /// The fill color used to visually represent the node in the chart.
 /// </param>
-/// <seealso cref="EdgePath" />
-/// <seealso cref="MudBlazor.Charts.Sankey{T}" />
 public sealed record NodeRect(int Hash, string Name, double X, double Y, double Width, double Height, string Color)
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
@@ -5,7 +5,6 @@ namespace MudBlazor
     /// <summary>
     /// Circle shape rendered as SVG, used to draw points and markers in a chart.
     /// </summary>
-    /// <seealso cref="SvgPath" />
     [DebuggerDisplay("{Index} = {CX},{CY}, R={Radius}")]
     public sealed class SvgCircle : SvgPath
     {

--- a/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgCircle.cs
@@ -3,8 +3,9 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a circular shape drawn as an SVG path.
+    /// Circle shape rendered as SVG, used to draw points and markers in a chart.
     /// </summary>
+    /// <seealso cref="SvgPath" />
     [DebuggerDisplay("{Index} = {CX},{CY}, R={Radius}")]
     public sealed class SvgCircle : SvgPath
     {

--- a/src/MudBlazor/Components/Chart/Svg/SvgLegend.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgLegend.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a series of series labels as an SVG path.
+    /// A single legend entry describing one chart series, with its label, value, and visibility toggle.
     /// </summary>
+    /// <seealso cref="MudBlazor.Charts.Legend{T}" />
+    /// <seealso cref="MudChart{T}" />
     [DebuggerDisplay("{Index} = {Labels}")]
     public class SvgLegend
     {

--- a/src/MudBlazor/Components/Chart/Svg/SvgLegend.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgLegend.cs
@@ -6,8 +6,6 @@ namespace MudBlazor
     /// <summary>
     /// A single legend entry describing one chart series, with its label, value, and visibility toggle.
     /// </summary>
-    /// <seealso cref="MudBlazor.Charts.Legend{T}" />
-    /// <seealso cref="MudChart{T}" />
     [DebuggerDisplay("{Index} = {Labels}")]
     public class SvgLegend
     {

--- a/src/MudBlazor/Components/Chart/Svg/SvgPath.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPath.cs
@@ -3,8 +3,9 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents an arbitrary SVG path.
+    /// Base class for chart shapes rendered as SVG paths, such as <see cref="SvgCircle" />, <see cref="SvgPetal" />, and <see cref="SvgPathPoint" />.
     /// </summary>
+    /// <seealso cref="SvgText" />
     public class SvgPath : IEquatable<SvgPath>
     {
         /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgPath.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPath.cs
@@ -5,7 +5,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for chart shapes rendered as SVG paths, such as <see cref="SvgCircle" />, <see cref="SvgPetal" />, and <see cref="SvgPathPoint" />.
     /// </summary>
-    /// <seealso cref="SvgText" />
     public class SvgPath : IEquatable<SvgPath>
     {
         /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgPathPoint.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPathPoint.cs
@@ -5,8 +5,10 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a specific point along an <see cref="SvgPath"/>.
+/// A point along an <see cref="SvgPath" />, tracking its position within the path.
 /// </summary>
+/// <seealso cref="SvgCircle" />
+/// <seealso cref="SvgPetal" />
 public sealed class SvgPathPoint : SvgPath
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgPathPoint.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPathPoint.cs
@@ -7,8 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// A point along an <see cref="SvgPath" />, tracking its position within the path.
 /// </summary>
-/// <seealso cref="SvgCircle" />
-/// <seealso cref="SvgPetal" />
 public sealed class SvgPathPoint : SvgPath
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgPetal.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPetal.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a petal shape along an <see cref="SvgPath"/>.
+/// A petal shape along an <see cref="SvgPath" />, used to render segments of a Rose chart.
 /// </summary>
+/// <seealso cref="MudBlazor.Charts.Rose{T}" />
 public sealed class SvgPetal : SvgPath
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgPetal.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgPetal.cs
@@ -7,7 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// A petal shape along an <see cref="SvgPath" />, used to render segments of a Rose chart.
 /// </summary>
-/// <seealso cref="MudBlazor.Charts.Rose{T}" />
 public sealed class SvgPetal : SvgPath
 {
     /// <summary>

--- a/src/MudBlazor/Components/Chart/Svg/SvgText.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgText.cs
@@ -5,8 +5,6 @@ namespace MudBlazor
     /// <summary>
     /// A text label rendered as an SVG element in a chart, positioned by X and Y coordinates.
     /// </summary>
-    /// <seealso cref="SvgCircle" />
-    /// <seealso cref="SvgPath" />
     [DebuggerDisplay("X={X}, Y={Y}, Value={Value}")]
     public sealed class SvgText
     {

--- a/src/MudBlazor/Components/Chart/Svg/SvgText.cs
+++ b/src/MudBlazor/Components/Chart/Svg/SvgText.cs
@@ -3,8 +3,10 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a piece of text as an SVG path.
+    /// A text label rendered as an SVG element in a chart, positioned by X and Y coordinates.
     /// </summary>
+    /// <seealso cref="SvgCircle" />
+    /// <seealso cref="SvgPath" />
     [DebuggerDisplay("X={X}, Y={Y}, Value={Value}")]
     public sealed class SvgText
     {

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -13,8 +13,12 @@ using MudBlazor.Utilities.Throttle;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a sophisticated and customizable pop-up for choosing a color.
+    /// Picks a color from a spectrum, palette, or predefined grid, with RGB, HSL, and hexadecimal inputs and optional alpha transparency.
     /// </summary>
+    /// <seealso cref="MudColor" />
+    /// <seealso cref="MudDatePicker" />
+    /// <seealso cref="MudPicker{T}" />
+    /// <seealso cref="MudTimePicker" />
     public partial class MudColorPicker : MudPicker<MudColor>
     {
         private const double MaxY = 250;

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -16,8 +16,7 @@ namespace MudBlazor
     /// Aggregate calculation such as count, sum, average, minimum, or maximum applied to a <see cref="MudDataGrid{T}"/> column footer or group summary.
     /// </summary>
     /// <typeparam name="T">The type of object to aggregate.</typeparam>
-    /// <seealso cref="Column{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudDataGrid{T}"/>
     public class AggregateDefinition<T>
     {
         private readonly AggregateDefinitionExpressionCache _expressionCache = new();

--- a/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/AggregateDefinition.cs
@@ -13,10 +13,11 @@ using MudBlazor.Utilities.Expressions;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a function which calculates aggregate values such as counts, sums, averages, and custom functions.
+    /// Aggregate calculation such as count, sum, average, minimum, or maximum applied to a <see cref="MudDataGrid{T}"/> column footer or group summary.
     /// </summary>
     /// <typeparam name="T">The type of object to aggregate.</typeparam>
-    /// <seealso cref="MudDataGrid{T}"/>
+    /// <seealso cref="Column{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class AggregateDefinition<T>
     {
         private readonly AggregateDefinitionExpressionCache _expressionCache = new();

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -7,9 +7,11 @@ using System.Diagnostics.CodeAnalysis;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the current state of a cell in a <see cref="MudDataGrid{T}"/>.
+    /// Cell state and actions passed to a <see cref="MudDataGrid{T}"/> cell template, exposing the row item, selection state, and editing commands.
     /// </summary>
     /// <typeparam name="T">The type of item displayed in the cell.</typeparam>
+    /// <seealso cref="Column{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class CellContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly HashSet<T> _selection;

--- a/src/MudBlazor/Components/DataGrid/CellContext.cs
+++ b/src/MudBlazor/Components/DataGrid/CellContext.cs
@@ -10,8 +10,6 @@ namespace MudBlazor
     /// Cell state and actions passed to a <see cref="MudDataGrid{T}"/> cell template, exposing the row item, selection state, and editing commands.
     /// </summary>
     /// <typeparam name="T">The type of item displayed in the cell.</typeparam>
-    /// <seealso cref="Column{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class CellContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly HashSet<T> _selection;

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -14,10 +14,14 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a vertical set of values.
+    /// Base class for columns in a <see cref="MudDataGrid{T}"/> such as <see cref="PropertyColumn{T, TProperty}"/>, <see cref="TemplateColumn{T}"/>, and <see cref="SelectColumn{T}"/>.
     /// </summary>
     /// <typeparam name="T">The kind of item for this column.</typeparam>
-    /// <seealso cref="MudDataGrid{T}"/>
+    /// <seealso cref="HierarchyColumn{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="PropertyColumn{T, TProperty}" />
+    /// <seealso cref="SelectColumn{T}" />
+    /// <seealso cref="TemplateColumn{T}" />
     public abstract partial class Column<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {
         private static readonly RenderFragment<CellContext<T>> EmptyChildContent = _ => builder => { };

--- a/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
@@ -8,8 +8,6 @@ namespace MudBlazor.Utilities
     /// Event data for the <see cref="MudDataGrid{T}.HierarchyVisibilityToggled"/> event, carrying the toggled row item and whether it was expanded or collapsed.
     /// </summary>
     /// <typeparam name="T">The item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
-    /// <seealso cref="HierarchyColumn{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class DataGridHierarchyVisibilityToggledEventArgs<T>
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridHierarchyVisibilityToggledEventArgs.cs
@@ -5,9 +5,11 @@
 namespace MudBlazor.Utilities
 {
     /// <summary>
-    /// Represents the information related to a <see cref="MudDataGrid{T}.HierarchyVisibilityToggled"/> event.
+    /// Event data for the <see cref="MudDataGrid{T}.HierarchyVisibilityToggled"/> event, carrying the toggled row item and whether it was expanded or collapsed.
     /// </summary>
     /// <typeparam name="T">The item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
+    /// <seealso cref="HierarchyColumn{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class DataGridHierarchyVisibilityToggledEventArgs<T>
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridRowClickEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowClickEventArgs.cs
@@ -9,9 +9,10 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents the information related to a <see cref="MudDataGrid{T}.RowClick"/> event.
+/// Event data for the <see cref="MudDataGrid{T}.RowClick"/> event, carrying the clicked row item, its index, and the pointer coordinates.
 /// </summary>
 /// <typeparam name="T">The item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
+/// <seealso cref="MudDataGrid{T}" />
 public class DataGridRowClickEventArgs<T> : EventArgs
 {
     /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridRowClickEventArgs.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowClickEventArgs.cs
@@ -12,7 +12,6 @@ namespace MudBlazor;
 /// Event data for the <see cref="MudDataGrid{T}.RowClick"/> event, carrying the clicked row item, its index, and the pointer coordinates.
 /// </summary>
 /// <typeparam name="T">The item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
-/// <seealso cref="MudDataGrid{T}" />
 public class DataGridRowClickEventArgs<T> : EventArgs
 {
     /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -12,8 +12,6 @@ namespace MudBlazor
     /// <summary>
     /// Validates the input fields of a <see cref="MudDataGrid{T}"/> row during inline or form editing.
     /// </summary>
-    /// <seealso cref="MudDataGrid{T}" />
-    /// <seealso cref="MudForm" />
     public class DataGridRowValidator : IForm
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridRowValidator.cs
@@ -10,8 +10,10 @@ using MudBlazor.Interfaces;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the validation logic for a <see cref="MudDataGrid{T}"/> row.
+    /// Validates the input fields of a <see cref="MudDataGrid{T}"/> row during inline or form editing.
     /// </summary>
+    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudForm" />
     public class DataGridRowValidator : IForm
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/Definition/FilterDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/Definition/FilterDefinition.cs
@@ -11,9 +11,6 @@ namespace MudBlazor
     /// A single column filter for a <see cref="MudDataGrid{T}"/>, pairing a column, operator, and value to generate the predicate that filters rows.
     /// </summary>
     /// <typeparam name="T">The type of object being filtered.</typeparam>
-    /// <seealso cref="FilterContext{T}" />
-    /// <seealso cref="IFilterDefinition{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class FilterDefinition<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : IFilterDefinition<T>
     {
         private int _cachedExpressionHashCode;

--- a/src/MudBlazor/Components/DataGrid/Definition/FilterDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/Definition/FilterDefinition.cs
@@ -8,9 +8,12 @@ using System.Diagnostics.CodeAnalysis;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the logic of a filter applied to <see cref="MudGrid"/> data.
+    /// A single column filter for a <see cref="MudDataGrid{T}"/>, pairing a column, operator, and value to generate the predicate that filters rows.
     /// </summary>
     /// <typeparam name="T">The type of object being filtered.</typeparam>
+    /// <seealso cref="FilterContext{T}" />
+    /// <seealso cref="IFilterDefinition{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class FilterDefinition<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : IFilterDefinition<T>
     {
         private int _cachedExpressionHashCode;

--- a/src/MudBlazor/Components/DataGrid/FieldType.cs
+++ b/src/MudBlazor/Components/DataGrid/FieldType.cs
@@ -9,8 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Classifies the data type of a <see cref="MudDataGrid{T}"/> column — string, number, enum, date, boolean, or GUID — used to choose the filter operators available for that column.
     /// </summary>
-    /// <seealso cref="FilterDefinition{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class FieldType
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FieldType.cs
+++ b/src/MudBlazor/Components/DataGrid/FieldType.cs
@@ -7,8 +7,10 @@ using System;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a description of a <see cref="MudGrid"/> field.
+    /// Classifies the data type of a <see cref="MudDataGrid{T}"/> column — string, number, enum, date, boolean, or GUID — used to choose the filter operators available for that column.
     /// </summary>
+    /// <seealso cref="FilterDefinition{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class FieldType
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -10,10 +10,11 @@ using System.Threading.Tasks;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the current state of a filter in a <see cref="MudDataGrid{T}"/>.
+    /// Filter state and actions passed to a <see cref="MudDataGrid{T}"/> column filter template, exposing the filter definition and apply, clear, and close commands.
     /// </summary>
     /// <typeparam name="T">The type of item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
-    /// <seealso cref="MudDataGrid{T}"/>
+    /// <seealso cref="FilterDefinition{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class FilterContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly MudDataGrid<T> _dataGrid;
@@ -82,8 +83,10 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Represents the apply and clear behaviors for a filter of a<see cref="MudDataGrid{T}"/>.
+        /// Apply, clear, and close delegates for a <see cref="MudDataGrid{T}"/> column filter, exposed through <see cref="FilterContext{T}"/>.
         /// </summary>
+        /// <seealso cref="FilterContext{T}" />
+        /// <seealso cref="MudDataGrid{T}" />
         public class FilterActions
         {
             /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FilterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterContext.cs
@@ -13,8 +13,7 @@ namespace MudBlazor
     /// Filter state and actions passed to a <see cref="MudDataGrid{T}"/> column filter template, exposing the filter definition and apply, clear, and close commands.
     /// </summary>
     /// <typeparam name="T">The type of item managed by the <see cref="MudDataGrid{T}"/>.</typeparam>
-    /// <seealso cref="FilterDefinition{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudDataGrid{T}"/>
     public class FilterContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly MudDataGrid<T> _dataGrid;
@@ -85,8 +84,6 @@ namespace MudBlazor
         /// <summary>
         /// Apply, clear, and close delegates for a <see cref="MudDataGrid{T}"/> column filter, exposed through <see cref="FilterContext{T}"/>.
         /// </summary>
-        /// <seealso cref="FilterContext{T}" />
-        /// <seealso cref="MudDataGrid{T}" />
         public class FilterActions
         {
             /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FilterExpressionGenerator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterExpressionGenerator.cs
@@ -9,8 +9,10 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents a service which generates C# functions from text-based filter operations.
+/// Builds LINQ filter expressions from <see cref="MudDataGrid{T}"/> filter definitions and operators for in-memory or <see cref="IQueryable{T}"/> querying.
 /// </summary>
+/// <seealso cref="FilterDefinition{T}" />
+/// <seealso cref="MudDataGrid{T}" />
 public static class FilterExpressionGenerator
 {
     /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FilterExpressionGenerator.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterExpressionGenerator.cs
@@ -11,8 +11,6 @@ namespace MudBlazor;
 /// <summary>
 /// Builds LINQ filter expressions from <see cref="MudDataGrid{T}"/> filter definitions and operators for in-memory or <see cref="IQueryable{T}"/> querying.
 /// </summary>
-/// <seealso cref="FilterDefinition{T}" />
-/// <seealso cref="MudDataGrid{T}" />
 public static class FilterExpressionGenerator
 {
     /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -18,9 +18,7 @@ namespace MudBlazor
     /// The filter row cell shown for a <see cref="MudDataGrid{T}"/> column when <see cref="MudDataGrid{T}.FilterMode"/> is <see cref="DataGridFilterMode.ColumnFilterRow"/>.
     /// </summary>
     /// <typeparam name="T">The type of value managed by the <see cref="MudDataGrid{T}"/></typeparam>
-    /// <seealso cref="Column{T}" />
-    /// <seealso cref="HeaderCell{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudDataGrid{T}"/>
     public partial class FilterHeaderCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor.cs
@@ -15,10 +15,12 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a column filter shown when <see cref="MudDataGrid{T}.FilterMode"/> is <see cref="DataGridFilterMode.ColumnFilterRow"/>.
+    /// The filter row cell shown for a <see cref="MudDataGrid{T}"/> column when <see cref="MudDataGrid{T}.FilterMode"/> is <see cref="DataGridFilterMode.ColumnFilterRow"/>.
     /// </summary>
     /// <typeparam name="T">The type of value managed by the <see cref="MudDataGrid{T}"/></typeparam>
-    /// <seealso cref="MudDataGrid{T}"/>
+    /// <seealso cref="Column{T}" />
+    /// <seealso cref="HeaderCell{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public partial class FilterHeaderCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -10,9 +10,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a cell displayed at the bottom of a column.
+    /// The footer cell displayed at the bottom of a <see cref="MudDataGrid{T}"/> column, typically showing totals or aggregate values.
     /// </summary>
     /// <typeparam name="T">The kind of data managed by this footer.</typeparam>
+    /// <seealso cref="HeaderCell{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public partial class FooterCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -13,8 +13,6 @@ namespace MudBlazor
     /// The footer cell displayed at the bottom of a <see cref="MudDataGrid{T}"/> column, typically showing totals or aggregate values.
     /// </summary>
     /// <typeparam name="T">The kind of data managed by this footer.</typeparam>
-    /// <seealso cref="HeaderCell{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public partial class FooterCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -12,9 +12,11 @@ namespace MudBlazor
 {
 
     /// <summary>
-    /// Represents the current state of a footer in a <see cref="MudDataGrid{T}"/>.
+    /// Footer state and actions passed to a <see cref="MudDataGrid{T}"/> footer template, exposing the displayed items and select-all command.
     /// </summary>
     /// <typeparam name="T">The kind of item being managed.</typeparam>
+    /// <seealso cref="HeaderContext{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class FooterContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly MudDataGrid<T> _dataGrid;
@@ -82,8 +84,10 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Represents the actions which can be performed on the footer of <see cref="MudDataGrid{T}"/> columns.
+        /// Select-all delegate for a <see cref="MudDataGrid{T}"/> footer, exposed through <see cref="FooterContext{T}"/>.
         /// </summary>
+        /// <seealso cref="FooterContext{T}" />
+        /// <seealso cref="MudDataGrid{T}" />
         public class FooterActions
         {
             /// <summary>

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -15,8 +15,6 @@ namespace MudBlazor
     /// Footer state and actions passed to a <see cref="MudDataGrid{T}"/> footer template, exposing the displayed items and select-all command.
     /// </summary>
     /// <typeparam name="T">The kind of item being managed.</typeparam>
-    /// <seealso cref="HeaderContext{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class FooterContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly MudDataGrid<T> _dataGrid;
@@ -86,8 +84,6 @@ namespace MudBlazor
         /// <summary>
         /// Select-all delegate for a <see cref="MudDataGrid{T}"/> footer, exposed through <see cref="FooterContext{T}"/>.
         /// </summary>
-        /// <seealso cref="FooterContext{T}" />
-        /// <seealso cref="MudDataGrid{T}" />
         public class FooterActions
         {
             /// <summary>

--- a/src/MudBlazor/Components/DataGrid/GridState.cs
+++ b/src/MudBlazor/Components/DataGrid/GridState.cs
@@ -10,9 +10,12 @@ using System.Threading;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the current paging, sorting, and filtering for a <see cref="MudDataGrid{T}"/>.
+    /// Paging, sorting, and filtering state that a <see cref="MudDataGrid{T}"/> passes to its <c>ServerData</c> callback for server-side data loading.
     /// </summary>
     /// <typeparam name="T">The kind of item managed by the grid.</typeparam>
+    /// <seealso cref="GridData{T}" />
+    /// <seealso cref="GridStateVirtualize{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class GridState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/GridState.cs
+++ b/src/MudBlazor/Components/DataGrid/GridState.cs
@@ -13,9 +13,6 @@ namespace MudBlazor
     /// Paging, sorting, and filtering state that a <see cref="MudDataGrid{T}"/> passes to its <c>ServerData</c> callback for server-side data loading.
     /// </summary>
     /// <typeparam name="T">The kind of item managed by the grid.</typeparam>
-    /// <seealso cref="GridData{T}" />
-    /// <seealso cref="GridStateVirtualize{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class GridState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
@@ -11,8 +11,6 @@ namespace MudBlazor;
 /// One level of row grouping in a <see cref="MudDataGrid{T}"/>, holding the grouped items, key path, expansion state, and any nested subgroup.
 /// </summary>
 /// <typeparam name="T">The type of item being grouped.</typeparam>
-/// <seealso cref="GroupKeyPath" />
-/// <seealso cref="MudDataGrid{T}" />
 public class GroupDefinition<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
 {
     private GroupDefinition<T>? _innerGroup;

--- a/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
+++ b/src/MudBlazor/Components/DataGrid/GroupDefinition.cs
@@ -8,9 +8,11 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the grouping information for columns in a <see cref="MudDataGrid{T}"/>.
+/// One level of row grouping in a <see cref="MudDataGrid{T}"/>, holding the grouped items, key path, expansion state, and any nested subgroup.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The type of item being grouped.</typeparam>
+/// <seealso cref="GroupKeyPath" />
+/// <seealso cref="MudDataGrid{T}" />
 public class GroupDefinition<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
 {
     private GroupDefinition<T>? _innerGroup;

--- a/src/MudBlazor/Components/DataGrid/GroupKeyPath.cs
+++ b/src/MudBlazor/Components/DataGrid/GroupKeyPath.cs
@@ -4,12 +4,13 @@
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a read-only, ordered collection of group key values forming a unique path through nested group levels.
-    /// Used to identify the exact group or subgroup location in multi-level group scenarios.
+    /// Ordered set of group key values that uniquely identifies a group or subgroup across the nested grouping levels of a <see cref="MudDataGrid{T}"/>.
     /// </summary>
     /// <remarks>
     /// Two <see cref="GroupKeyPath"/> instances are equal if they contain the same elements in the same order.
     /// </remarks>
+    /// <seealso cref="GroupDefinition{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class GroupKeyPath(IList<object?> list) : ReadOnlyCollection<object?>(list)
     {
         public override bool Equals(object? obj)

--- a/src/MudBlazor/Components/DataGrid/GroupKeyPath.cs
+++ b/src/MudBlazor/Components/DataGrid/GroupKeyPath.cs
@@ -9,8 +9,6 @@ namespace MudBlazor
     /// <remarks>
     /// Two <see cref="GroupKeyPath"/> instances are equal if they contain the same elements in the same order.
     /// </remarks>
-    /// <seealso cref="GroupDefinition{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class GroupKeyPath(IList<object?> list) : ReadOnlyCollection<object?>(list)
     {
         public override bool Equals(object? obj)

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -12,10 +12,12 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a cell displayed at the top of a <see cref="MudDataGrid{T}"/> column.
+    /// The header cell displayed at the top of a <see cref="MudDataGrid{T}"/> column, showing the title along with sorting, filtering, and resizing controls.
     /// </summary>
     /// <typeparam name="T">The kind of item managed by the grid.</typeparam>
-    /// <seealso cref="MudDataGrid{T}"/>
+    /// <seealso cref="FilterHeaderCell{T}" />
+    /// <seealso cref="FooterCell{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public partial class HeaderCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {
         private bool _selected;

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -15,9 +15,7 @@ namespace MudBlazor
     /// The header cell displayed at the top of a <see cref="MudDataGrid{T}"/> column, showing the title along with sorting, filtering, and resizing controls.
     /// </summary>
     /// <typeparam name="T">The kind of item managed by the grid.</typeparam>
-    /// <seealso cref="FilterHeaderCell{T}" />
-    /// <seealso cref="FooterCell{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudDataGrid{T}"/>
     public partial class HeaderCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {
         private bool _selected;

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -11,8 +11,6 @@ namespace MudBlazor
     /// Header state and actions passed to a <see cref="MudDataGrid{T}"/> header template, exposing the displayed items and select-all command.
     /// </summary>
     /// <typeparam name="T">The kind of item being managed.</typeparam>
-    /// <seealso cref="FooterContext{T}" />
-    /// <seealso cref="MudDataGrid{T}" />
     public class HeaderContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly MudDataGrid<T> _dataGrid;
@@ -83,8 +81,6 @@ namespace MudBlazor
         /// <summary>
         /// Select-all delegate for a <see cref="MudDataGrid{T}"/> header, exposed through <see cref="HeaderContext{T}"/>.
         /// </summary>
-        /// <seealso cref="HeaderContext{T}" />
-        /// <seealso cref="MudDataGrid{T}" />
         public class HeaderActions
         {
             /// <summary>

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -8,9 +8,11 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents the current state of a header in a <see cref="MudDataGrid{T}"/>.
+    /// Header state and actions passed to a <see cref="MudDataGrid{T}"/> header template, exposing the displayed items and select-all command.
     /// </summary>
     /// <typeparam name="T">The kind of item being managed.</typeparam>
+    /// <seealso cref="FooterContext{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
     public class HeaderContext<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private readonly MudDataGrid<T> _dataGrid;
@@ -79,8 +81,10 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Represents the behaviors allowed for a <see cref="MudDataGrid{T}"/> header.
+        /// Select-all delegate for a <see cref="MudDataGrid{T}"/> header, exposed through <see cref="HeaderContext{T}"/>.
         /// </summary>
+        /// <seealso cref="HeaderContext{T}" />
+        /// <seealso cref="MudDataGrid{T}" />
         public class HeaderActions
         {
             /// <summary>

--- a/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HierarchyColumn.razor.cs
@@ -9,11 +9,14 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a column in a <see cref="MudDataGrid{T}"/> which can be expanded to show additional information.
+/// Adds an expand or collapse button to each <see cref="MudDataGrid{T}"/> row, revealing nested detail content when expanded.
 /// </summary>
 /// <typeparam name="T">The kind of item managed by the column.</typeparam>
-/// <seealso cref="Column{T}"/>
-/// <seealso cref="MudDataGrid{T}"/>
+/// <seealso cref="Column{T}" />
+/// <seealso cref="MudDataGrid{T}" />
+/// <seealso cref="PropertyColumn{T, TProperty}" />
+/// <seealso cref="SelectColumn{T}" />
+/// <seealso cref="TemplateColumn{T}" />
 public partial class HierarchyColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase
 {
     /// <summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -18,9 +18,15 @@ using MudBlazor.Utilities.Clone;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a sortable, filterable data grid with multiselection, pagination, editing, grouping, aggregation, and server-side <see cref="IQueryable{T}"/> support.
+    /// Displays rows of data in a sortable, filterable grid with multiselection, pagination, inline editing, grouping, and aggregation.
     /// </summary>
+    /// <remarks>
+    /// Supports server-side sorting, filtering, and paging of large datasets, including through an <see cref="IQueryable{T}"/> source.
+    /// </remarks>
     /// <typeparam name="T">The type of data represented by each row in this grid.</typeparam>
+    /// <seealso cref="Column{T}" />
+    /// <seealso cref="MudDataGridPager{T}" />
+    /// <seealso cref="MudTable{T}" />
     [CascadingTypeParameter(nameof(T))]
     public partial class MudDataGrid<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor.cs
@@ -15,10 +15,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a pager for navigating pages of a <see cref="MudDataGrid{T}"/>.
+    /// Pagination controls for navigating pages of a <see cref="MudDataGrid{T}"/>, with page-size selection and next and previous buttons.
     /// </summary>
     /// <typeparam name="T">The kind of data displayed in the grid.</typeparam>
-    /// <seealso cref="MudDataGrid{T}"/>
+    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudTablePager" />
     public partial class MudDataGridPager<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -12,10 +12,13 @@ using MudBlazor.Utilities.Expressions;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a column in a <see cref="MudDataGrid{T}"/> associated with an object's property.
+    /// Binds a <see cref="MudDataGrid{T}"/> column to an object property, with automatic sorting, filtering, and formatting of its values.
     /// </summary>
     /// <typeparam name="T">The type of object represented by each row in the data grid.</typeparam>
     /// <typeparam name="TProperty">The type of the property whose values are displayed in the column's cells.</typeparam>
+    /// <seealso cref="Column{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="TemplateColumn{T}" />
     public partial class PropertyColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T, TProperty> : Column<T>
     {
         private readonly Guid _id = Guid.NewGuid();

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
@@ -9,10 +9,12 @@ using MudBlazor.Resources;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a checkbox column used to select rows in a <see cref="MudDataGrid{T}"/>.
+/// Checkboxes for selecting rows in a <see cref="MudDataGrid{T}"/>, with an optional header checkbox to select or clear all rows.
 /// </summary>
 /// <typeparam name="T">The type of item to select.</typeparam>
-/// <seealso cref="MudDataGrid{T}"/>
+/// <seealso cref="Column{T}" />
+/// <seealso cref="MudDataGrid{T}" />
+/// <seealso cref="TemplateColumn{T}" />
 public partial class SelectColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : TemplateColumn<T>
 {
     [Inject]

--- a/src/MudBlazor/Components/DataGrid/TemplateColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/TemplateColumn.cs
@@ -9,9 +9,13 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents an additional column for a <see cref="MudDataGrid{T}"/> which isn't tied to data.
+    /// Renders custom template content in a <see cref="MudDataGrid{T}"/> column instead of binding to a data property, useful for action buttons or computed cells.
     /// </summary>
     /// <typeparam name="T">The type of data represented by this column.</typeparam>
+    /// <seealso cref="Column{T}" />
+    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="PropertyColumn{T, TProperty}" />
+    /// <seealso cref="SelectColumn{T}" />
     public partial class TemplateColumn<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : Column<T>
     {
         protected internal override object? CellContent(T item)

--- a/src/MudBlazor/Components/DatePicker/DateRange.cs
+++ b/src/MudBlazor/Components/DatePicker/DateRange.cs
@@ -5,8 +5,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a date range used by a <see cref="MudDatePicker"/>.
+/// A start and end date pair selected in a <see cref="MudDateRangePicker"/>.
 /// </summary>
+/// <seealso cref="MudDatePicker" />
+/// <seealso cref="MudDateRangePicker" />
 public class DateRange : Range<DateTime?>, IEquatable<DateRange?>
 {
     /// <summary>

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -9,9 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for MudBlazor date pickers such as <see cref="MudDatePicker"/> and <see cref="MudDateRangePicker"/>.
     /// </summary>
-    /// <seealso cref="MudDatePicker" />
-    /// <seealso cref="MudDateRangePicker" />
-    /// <seealso cref="MudPicker{T}" />
     public abstract partial class MudBaseDatePicker : MudPicker<DateTime?>
     {
         private readonly string _mudPickerCalendarContentElementId;

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -7,8 +7,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a base class for designing date picker components.
+    /// Base class for MudBlazor date pickers such as <see cref="MudDatePicker"/> and <see cref="MudDateRangePicker"/>.
     /// </summary>
+    /// <seealso cref="MudDatePicker" />
+    /// <seealso cref="MudDateRangePicker" />
+    /// <seealso cref="MudPicker{T}" />
     public abstract partial class MudBaseDatePicker : MudPicker<DateTime?>
     {
         private readonly string _mudPickerCalendarContentElementId;

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -6,9 +6,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a picker for dates.
+    /// Selects a single date from a calendar shown in a drop-down, dialog, or inline.
     /// </summary>
-    /// <seealso cref="MudDateRangePicker"/>
+    /// <seealso cref="MudDateRangePicker" />
+    /// <seealso cref="MudTimePicker" />
     public class MudDatePicker : MudBaseDatePicker
     {
         private DateTime? _selectedDate;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -6,9 +6,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a picker for a range of dates.
+    /// Selects a start and end date range from a calendar shown in a drop-down, dialog, or inline.
     /// </summary>
-    /// <seealso cref="MudDatePicker"/>
+    /// <seealso cref="DateRange" />
+    /// <seealso cref="MudDatePicker" />
+    /// <seealso cref="MudTimePicker" />
     public partial class MudDateRangePicker : MudBaseDatePicker
     {
         private readonly ParameterState<bool> _allowDisabledDatesInCountState;

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -7,10 +7,14 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a navigation panel docked to the side of the page.
+    /// Navigation drawers, or sidebars, dock to the side of the page to hold navigation links, menus, or other content.
     /// </summary>
-    /// <seealso cref="MudDrawerContainer"/>
-    /// <seealso cref="MudDrawerHeader"/>
+    /// <remarks>
+    /// Supports temporary, persistent, mini, and responsive variants that adapt to the screen size.
+    /// </remarks>
+    /// <seealso cref="MudAppBar" />
+    /// <seealso cref="MudDrawerContainer" />
+    /// <seealso cref="MudDrawerHeader" />
     public partial class MudDrawer : MudComponentBase, INavigationEventReceiver, IBrowserViewportObserver, IAsyncDisposable
     {
         private double _height;

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -7,13 +7,13 @@ namespace MudBlazor
 {
 
     /// <summary>
-    /// A component which can be expanded to show more content or collapsed to show only its header.
+    /// Accordion-style collapsible panel within a <see cref="MudExpansionPanels"/> group that expands to reveal content or collapses to show only its header.
     /// </summary>
     /// <remarks>
     /// This component is always inside a <see cref="MudExpansionPanels"/> component.
     /// </remarks>
-    /// <seealso cref="MudExpansionPanels"/>
-    /// <seealso cref="MudCollapse"/>
+    /// <seealso cref="MudCollapse" />
+    /// <seealso cref="MudExpansionPanels" />
     public partial class MudExpansionPanel : MudComponentBase, IDisposable
     {
         internal readonly ParameterState<bool> _expandedState;

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -6,9 +6,9 @@ namespace MudBlazor
 {
     // TODO: Maybe can inherit from MudBaseInput?
     /// <summary>
-    /// A component similar to <see cref="MudTextField{T}"/> which supports custom content.
+    /// Displays custom content inside a form field with the same label, adornment, and border styling as a <see cref="MudTextField{T}"/>.
     /// </summary>
-    /// <seealso cref="MudTextField{T}"/>
+    /// <seealso cref="MudTextField{T}" />
     public partial class MudField : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/Grid/MudFlexBreak.razor.cs
+++ b/src/MudBlazor/Components/Grid/MudFlexBreak.razor.cs
@@ -8,8 +8,10 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// A component for breaking a flex display using CSS styles.
+/// Forces a line break in a flexbox layout so the items that follow wrap onto a new line.
 /// </summary>
+/// <seealso cref="MudGrid" />
+/// <seealso cref="MudStack" />
 public partial class MudFlexBreak : MudComponentBase
 {
     /// <summary>

--- a/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
+++ b/src/MudBlazor/Components/Hidden/MudHidden.razor.cs
@@ -5,7 +5,7 @@ namespace MudBlazor
 {
 
     /// <summary>
-    /// A component which conditionally renders content depending on the screen size.
+    /// Conditionally renders its content based on the current screen-size breakpoint, showing or hiding it as the viewport changes.
     /// </summary>
     /// <remarks>
     /// This component uses JavaScript to listen for browser window size changes.  If you want a solution using only CSS, you can use the <see href="https://mudblazor.com/features/display#class-reference">responsive display classes</see>.

--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// A component which highlights words or phrases within text.
+/// Highlights occurrences of one or more search terms within a block of text, wrapping each match in a <c>mark</c> element.
 /// </summary>
 public partial class MudHighlighter : MudComponentBase
 {

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -5,9 +5,12 @@ using MudBlazor.Utilities.Debounce;
 namespace MudBlazor
 {
     /// <summary>
-    /// A base class for designing input components which update after a delay.
+    /// Base class for MudBlazor inputs that wait for typing to pause before updating their value, such as <see cref="MudTextField{T}"/> and <see cref="MudNumericField{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of object managed by this input.</typeparam>
+    /// <seealso cref="MudBaseInput{T}" />
+    /// <seealso cref="MudNumericField{T}" />
+    /// <seealso cref="MudTextField{T}" />
     public abstract class MudDebouncedInput<T> : MudBaseInput<T>
     {
         private DebounceDispatcher? _debouncer;

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -8,9 +8,6 @@ namespace MudBlazor
     /// Base class for MudBlazor inputs that wait for typing to pause before updating their value, such as <see cref="MudTextField{T}"/> and <see cref="MudNumericField{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of object managed by this input.</typeparam>
-    /// <seealso cref="MudBaseInput{T}" />
-    /// <seealso cref="MudNumericField{T}" />
-    /// <seealso cref="MudTextField{T}" />
     public abstract class MudDebouncedInput<T> : MudBaseInput<T>
     {
         private DebounceDispatcher? _debouncer;

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -7,9 +7,13 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A component for collecting an input value.
+    /// Renders the underlying HTML input element used by text-based components such as <see cref="MudTextField{T}"/> and <see cref="MudNumericField{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of object managed by this input.</typeparam>
+    /// <seealso cref="MudBaseInput{T}" />
+    /// <seealso cref="MudInputControl" />
+    /// <seealso cref="MudRangeInput{T}" />
+    /// <seealso cref="MudTextField{T}" />
     public partial class MudInput<T> : MudBaseInput<T>
     {
         private string? _internalText;

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor.cs
@@ -5,9 +5,12 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A component for collecting start and end values which define a range.
+    /// Collects start and end values that define a range using two input fields, as used by the <see cref="MudDateRangePicker"/>.
     /// </summary>
     /// <typeparam name="T">The type of object managed by this input.</typeparam>
+    /// <seealso cref="MudBaseInput{T}" />
+    /// <seealso cref="MudDateRangePicker" />
+    /// <seealso cref="MudInput{T}" />
     public partial class MudRangeInput<T> : MudBaseInput<Range<T>>
     {
         private string? _textStart;

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -5,8 +5,11 @@ namespace MudBlazor
 {
 
     /// <summary>
-    /// A base class for designing input components.
+    /// Wraps a form input with its label, helper text, and validation message.
     /// </summary>
+    /// <seealso cref="MudField" />
+    /// <seealso cref="MudInput{T}" />
+    /// <seealso cref="MudTextField{T}" />
     public partial class MudInputControl : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -7,9 +7,6 @@ namespace MudBlazor
     /// <summary>
     /// Wraps a form input with its label, helper text, and validation message.
     /// </summary>
-    /// <seealso cref="MudField" />
-    /// <seealso cref="MudInput{T}" />
-    /// <seealso cref="MudTextField{T}" />
     public partial class MudInputControl : MudComponentBase
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/Layout/MudLayout.razor.cs
+++ b/src/MudBlazor/Components/Layout/MudLayout.razor.cs
@@ -4,13 +4,15 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// A component which defines a common structure for multiple pages.
+/// Arranges the top-level page structure of an app with an app bar, navigation drawer, and main content area.
 /// </summary>
 /// <remarks>
-/// Layouts often contain <see cref="MudAppBar"/> and <see cref="MudDrawer"/> components.  The <see cref="MudMainContent"/> component is used to contain page content.  
+/// Layouts often contain <see cref="MudAppBar"/> and <see cref="MudDrawer"/> components.  The <see cref="MudMainContent"/> component is used to contain page content.
 /// In your layout component, but above this component, add <see cref="MudThemeProvider"/>, <see cref="MudPopoverProvider"/>, <see cref="MudDialogProvider"/>, and <see cref="MudSnackbarProvider"/> components to enable all MudBlazor features.
 /// </remarks>
-/// <seealso cref="MudMainContent"/>
+/// <seealso cref="MudAppBar" />
+/// <seealso cref="MudDrawer" />
+/// <seealso cref="MudMainContent" />
 public partial class MudLayout : MudDrawerContainer
 {
     protected override string Classname =>

--- a/src/MudBlazor/Components/Main/MudMainContent.razor.cs
+++ b/src/MudBlazor/Components/Main/MudMainContent.razor.cs
@@ -8,8 +8,9 @@ using MudBlazor.Utilities;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the main content area of the <see cref="MudLayout"/>.
+/// The main content region of a <see cref="MudLayout"/> where each page's content is rendered.
 /// </summary>
+/// <seealso cref="MudLayout" />
 public partial class MudMainContent : MudComponentBase
 {
     /// <summary>

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -10,7 +10,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// A component for selecting date, time, and color values.
+    /// Base class for MudBlazor pickers such as <see cref="MudDatePicker"/>, <see cref="MudTimePicker"/>, and <see cref="MudColorPicker"/>.
     /// </summary>
     /// <typeparam name="T">The type of value being chosen.</typeparam>
     /// <seealso cref="MudPickerContent" />

--- a/src/MudBlazor/Components/Popover/IPopover.cs
+++ b/src/MudBlazor/Components/Popover/IPopover.cs
@@ -9,10 +9,6 @@ namespace MudBlazor;
 /// <summary>
 /// A popover surface that displays floating content anchored over the page, implemented by <see cref="MudPopoverBase"/> and managed by the <see cref="IPopoverService"/>.
 /// </summary>
-/// <seealso cref="IPopoverService" />
-/// <seealso cref="MudPopover" />
-/// <seealso cref="MudPopoverBase" />
-/// <seealso cref="MudPopoverProvider" />
 public interface IPopover
 {
     /// <summary>

--- a/src/MudBlazor/Components/Popover/IPopover.cs
+++ b/src/MudBlazor/Components/Popover/IPopover.cs
@@ -7,8 +7,12 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a popover component.
+/// A popover surface that displays floating content anchored over the page, implemented by <see cref="MudPopoverBase"/> and managed by the <see cref="IPopoverService"/>.
 /// </summary>
+/// <seealso cref="IPopoverService" />
+/// <seealso cref="MudPopover" />
+/// <seealso cref="MudPopoverBase" />
+/// <seealso cref="MudPopoverProvider" />
 public interface IPopover
 {
     /// <summary>

--- a/src/MudBlazor/Components/Popover/MudPopoverBase.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverBase.cs
@@ -10,12 +10,16 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// A base class for implementing Popover components.
+/// Base class for popover components such as <see cref="MudPopover"/>, handling creation and lifecycle through the <see cref="IPopoverService"/>.
 /// </summary>
 /// <remarks>
 /// This class provides a base implementation for a Popover component. It implements the <see cref="IPopover"/> interface
 /// and utilizes the <see cref="IPopoverService"/> to handle the creation, updating, and destruction of the popover.
 /// </remarks>
+/// <seealso cref="IPopover" />
+/// <seealso cref="IPopoverService" />
+/// <seealso cref="MudPopover" />
+/// <seealso cref="MudPopoverProvider" />
 public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposable
 {
     private bool _afterFirstRender;

--- a/src/MudBlazor/Components/Popover/MudPopoverBase.cs
+++ b/src/MudBlazor/Components/Popover/MudPopoverBase.cs
@@ -16,10 +16,6 @@ namespace MudBlazor;
 /// This class provides a base implementation for a Popover component. It implements the <see cref="IPopover"/> interface
 /// and utilizes the <see cref="IPopoverService"/> to handle the creation, updating, and destruction of the popover.
 /// </remarks>
-/// <seealso cref="IPopover" />
-/// <seealso cref="IPopoverService" />
-/// <seealso cref="MudPopover" />
-/// <seealso cref="MudPopoverProvider" />
 public abstract class MudPopoverBase : MudComponentBase, IPopover, IAsyncDisposable
 {
     private bool _afterFirstRender;

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -7,8 +7,11 @@ using MudBlazor.Components.Snackbar;
 namespace MudBlazor
 {
     /// <summary>
-    /// The service used to display snackbar messages.
+    /// A single snackbar notification shown to the user, holding its message text, <see cref="Severity"/>, and show/hide transition lifecycle.
     /// </summary>
+    /// <seealso cref="ISnackbar" />
+    /// <seealso cref="MudSnackbarProvider" />
+    /// <seealso cref="SnackbarService" />
     public class Snackbar : IDisposable
     {
         private bool _paused = false;

--- a/src/MudBlazor/Components/Snackbar/Snackbar.cs
+++ b/src/MudBlazor/Components/Snackbar/Snackbar.cs
@@ -9,9 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// A single snackbar notification shown to the user, holding its message text, <see cref="Severity"/>, and show/hide transition lifecycle.
     /// </summary>
-    /// <seealso cref="ISnackbar" />
-    /// <seealso cref="MudSnackbarProvider" />
-    /// <seealso cref="SnackbarService" />
     public class Snackbar : IDisposable
     {
         private bool _paused = false;

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -12,8 +12,11 @@ using MudBlazor.Components.Snackbar.InternalComponents;
 namespace MudBlazor
 {
     /// <summary>
-    /// A service for managing snackbars.
+    /// Queues and displays <see cref="Snackbar"/> toast notifications, serving as the default <see cref="ISnackbar"/> implementation rendered by the <see cref="MudSnackbarProvider"/>.
     /// </summary>
+    /// <seealso cref="ISnackbar" />
+    /// <seealso cref="MudSnackbarProvider" />
+    /// <seealso cref="Snackbar" />
     public class SnackbarService : ISnackbar
     {
         private readonly List<Snackbar> _snackBarList;

--- a/src/MudBlazor/Components/Snackbar/SnackbarService.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarService.cs
@@ -14,9 +14,6 @@ namespace MudBlazor
     /// <summary>
     /// Queues and displays <see cref="Snackbar"/> toast notifications, serving as the default <see cref="ISnackbar"/> implementation rendered by the <see cref="MudSnackbarProvider"/>.
     /// </summary>
-    /// <seealso cref="ISnackbar" />
-    /// <seealso cref="MudSnackbarProvider" />
-    /// <seealso cref="Snackbar" />
     public class SnackbarService : ISnackbar
     {
         private readonly List<Snackbar> _snackBarList;

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -7,8 +7,11 @@ namespace MudBlazor
     // note: the MudTable code is split. Everything that has nothing to do with the type parameter of MudTable<T> is here in MudTableBase
 
     /// <summary>
-    /// A base class for designing table components.
+    /// Base class for <see cref="MudTable{T}"/> holding the type-independent table members such as paging, layout, and editing options.
     /// </summary>
+    /// <seealso cref="MudDataGrid{T}" />
+    /// <seealso cref="MudTable{T}" />
+    /// <seealso cref="MudTablePager" />
     public abstract class MudTableBase : MudComponentBase
     {
         private int _currentPage = 0;

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -9,9 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for <see cref="MudTable{T}"/> holding the type-independent table members such as paging, layout, and editing options.
     /// </summary>
-    /// <seealso cref="MudDataGrid{T}" />
-    /// <seealso cref="MudTable{T}" />
-    /// <seealso cref="MudTablePager" />
     public abstract class MudTableBase : MudComponentBase
     {
         private int _currentPage = 0;

--- a/src/MudBlazor/Components/Table/MudTablePager.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor.cs
@@ -9,8 +9,11 @@ namespace MudBlazor
 {
 
     /// <summary>
-    /// A component which changes pages and page size for a <see cref="MudTable{T}"/>.
+    /// Pagination controls for a <see cref="MudTable{T}"/> that navigate between pages and change the number of rows shown per page.
     /// </summary>
+    /// <seealso cref="MudDataGridPager{T}" />
+    /// <seealso cref="MudTable{T}" />
+    /// <seealso cref="MudTableBase" />
     public partial class MudTablePager : MudComponentBase, IDisposable
     {
         protected string Classname =>

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -14,10 +14,10 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Provides a simple way to select time values.
+    /// Selects a time of day from a clock shown in a drop-down, dialog, or inline.
     /// </summary>
-    /// <seealso cref="MudDatePicker"/>
-    /// <seealso cref="MudDateRangePicker"/>
+    /// <seealso cref="MudDatePicker" />
+    /// <seealso cref="MudDateRangePicker" />
     public partial class MudTimePicker : MudPicker<TimeSpan?>
     {
         private OpenTo _currentView;

--- a/src/MudBlazor/Enums/Adornment.cs
+++ b/src/MudBlazor/Enums/Adornment.cs
@@ -9,7 +9,6 @@ namespace MudBlazor;
 /// <remarks>
 /// Adornments can be placed at the start or end of a field, or not displayed at all.
 /// </remarks>
-/// <seealso cref="MudTextField{T}" />
 [EnumExtensions]
 public enum Adornment
 {

--- a/src/MudBlazor/Enums/Adornment.cs
+++ b/src/MudBlazor/Enums/Adornment.cs
@@ -4,11 +4,12 @@ using NetEscapades.EnumGenerators;
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies the position of an adornment in a field.
+/// Specifies where an adornment such as an icon, text, or button appears within a form field.
 /// </summary>
 /// <remarks>
 /// Adornments can be placed at the start or end of a field, or not displayed at all.
 /// </remarks>
+/// <seealso cref="MudTextField{T}" />
 [EnumExtensions]
 public enum Adornment
 {

--- a/src/MudBlazor/Enums/TimelineAlign.cs
+++ b/src/MudBlazor/Enums/TimelineAlign.cs
@@ -4,8 +4,11 @@ using NetEscapades.EnumGenerators;
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies the alignment of each item's dot relative to its text in a <see cref="MudTimeline"/>.
+/// Specifies whether each item's dot aligns to the start, center, or end of its text in a <see cref="MudTimeline"/>.
 /// </summary>
+/// <seealso cref="MudTimeline" />
+/// <seealso cref="MudTimelineItem" />
+/// <seealso cref="TimelineOrientation" />
 [EnumExtensions]
 public enum TimelineAlign
 {

--- a/src/MudBlazor/Enums/TimelineAlign.cs
+++ b/src/MudBlazor/Enums/TimelineAlign.cs
@@ -6,9 +6,6 @@ namespace MudBlazor;
 /// <summary>
 /// Specifies whether each item's dot aligns to the start, center, or end of its text in a <see cref="MudTimeline"/>.
 /// </summary>
-/// <seealso cref="MudTimeline" />
-/// <seealso cref="MudTimelineItem" />
-/// <seealso cref="TimelineOrientation" />
 [EnumExtensions]
 public enum TimelineAlign
 {

--- a/src/MudBlazor/Enums/TimelineOrientation.cs
+++ b/src/MudBlazor/Enums/TimelineOrientation.cs
@@ -4,8 +4,11 @@ using NetEscapades.EnumGenerators;
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies the orientation of items in a <see cref="MudTimeline"/>
+/// Specifies whether items in a <see cref="MudTimeline"/> are arranged vertically or horizontally.
 /// </summary>
+/// <seealso cref="MudTimeline" />
+/// <seealso cref="MudTimelineItem" />
+/// <seealso cref="TimelineAlign" />
 [EnumExtensions]
 public enum TimelineOrientation
 {

--- a/src/MudBlazor/Enums/TimelineOrientation.cs
+++ b/src/MudBlazor/Enums/TimelineOrientation.cs
@@ -6,9 +6,6 @@ namespace MudBlazor;
 /// <summary>
 /// Specifies whether items in a <see cref="MudTimeline"/> are arranged vertically or horizontally.
 /// </summary>
-/// <seealso cref="MudTimeline" />
-/// <seealso cref="MudTimelineItem" />
-/// <seealso cref="TimelineAlign" />
 [EnumExtensions]
 public enum TimelineOrientation
 {

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// Position and size of an HTML element relative to the viewport, mirroring the browser's <c>getBoundingClientRect()</c> along with scroll offsets and out-of-viewport checks.
 /// </summary>
-/// <seealso cref="ElementSize" />
 public class BoundingClientRect
 {
     /// <summary>

--- a/src/MudBlazor/Interop/BoundingClientRect.cs
+++ b/src/MudBlazor/Interop/BoundingClientRect.cs
@@ -1,8 +1,9 @@
 ﻿namespace MudBlazor.Interop;
 
 /// <summary>
-/// Represents the bounding rectangle of an element.
+/// Position and size of an HTML element relative to the viewport, mirroring the browser's <c>getBoundingClientRect()</c> along with scroll offsets and out-of-viewport checks.
 /// </summary>
+/// <seealso cref="ElementSize" />
 public class BoundingClientRect
 {
     /// <summary>

--- a/src/MudBlazor/Interop/ElementSize.cs
+++ b/src/MudBlazor/Interop/ElementSize.cs
@@ -1,8 +1,9 @@
 ﻿namespace MudBlazor.Interop;
 
 /// <summary>
-/// Represents the size of an element.
+/// Width and height of an HTML element, with a timestamp used to discard out-of-order resize events in Blazor Server.
 /// </summary>
+/// <seealso cref="BoundingClientRect" />
 public class ElementSize
 {
     /// <summary>

--- a/src/MudBlazor/Interop/ElementSize.cs
+++ b/src/MudBlazor/Interop/ElementSize.cs
@@ -3,7 +3,6 @@
 /// <summary>
 /// Width and height of an HTML element, with a timestamp used to discard out-of-order resize events in Blazor Server.
 /// </summary>
-/// <seealso cref="BoundingClientRect" />
 public class ElementSize
 {
     /// <summary>

--- a/src/MudBlazor/Services/Browser/IBrowserViewportObserver.cs
+++ b/src/MudBlazor/Services/Browser/IBrowserViewportObserver.cs
@@ -7,8 +7,9 @@ using MudBlazor.Services;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents an observer for browser viewport updates.
+/// Receives notifications when the browser window size or <see cref="Breakpoint"/> changes after subscribing to the <see cref="IBrowserViewportService"/>.
 /// </summary>
+/// <seealso cref="IBrowserViewportService" />
 public interface IBrowserViewportObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/Browser/IBrowserViewportObserver.cs
+++ b/src/MudBlazor/Services/Browser/IBrowserViewportObserver.cs
@@ -9,7 +9,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives notifications when the browser window size or <see cref="Breakpoint"/> changes after subscribing to the <see cref="IBrowserViewportService"/>.
 /// </summary>
-/// <seealso cref="IBrowserViewportService" />
 public interface IBrowserViewportObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/Browser/IBrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/IBrowserViewportService.cs
@@ -7,8 +7,9 @@ using MudBlazor.Services;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a service that serves to listen to browser window size changes and breakpoints.
+/// Reports browser window resize events and responsive <see cref="Breakpoint"/> changes to subscribed observers, and answers media-query and breakpoint checks.
 /// </summary>
+/// <seealso cref="IBrowserViewportObserver" />
 public interface IBrowserViewportService : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Browser/IBrowserViewportService.cs
+++ b/src/MudBlazor/Services/Browser/IBrowserViewportService.cs
@@ -9,7 +9,6 @@ namespace MudBlazor;
 /// <summary>
 /// Reports browser window resize events and responsive <see cref="Breakpoint"/> changes to subscribed observers, and answers media-query and breakpoint checks.
 /// </summary>
-/// <seealso cref="IBrowserViewportObserver" />
 public interface IBrowserViewportService : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Dialog/IDialogService.cs
+++ b/src/MudBlazor/Services/Dialog/IDialogService.cs
@@ -10,11 +10,13 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor
 {
     /// <summary>
-    /// A service for managing <see cref="MudDialog"/> components.
+    /// Shows and closes <see cref="MudDialog"/> dialogs and message boxes from C# code.
     /// </summary>
     /// <remarks>
     /// This service requires a <see cref="MudDialogProvider"/> in your layout page.
     /// </remarks>
+    /// <seealso cref="MudDialog" />
+    /// <seealso cref="MudDialogProvider" />
     public interface IDialogService
     {
 

--- a/src/MudBlazor/Services/Dialog/IDialogService.cs
+++ b/src/MudBlazor/Services/Dialog/IDialogService.cs
@@ -15,8 +15,6 @@ namespace MudBlazor
     /// <remarks>
     /// This service requires a <see cref="MudDialogProvider"/> in your layout page.
     /// </remarks>
-    /// <seealso cref="MudDialog" />
-    /// <seealso cref="MudDialogProvider" />
     public interface IDialogService
     {
 

--- a/src/MudBlazor/Services/JsEvent/IJsEventFactory.cs
+++ b/src/MudBlazor/Services/JsEvent/IJsEventFactory.cs
@@ -7,7 +7,6 @@ namespace MudBlazor.Services;
 /// <summary>
 /// Creates <see cref="IJsEvent"/> instances that subscribe to an element's DOM events such as paste, text selection, and caret position changes.
 /// </summary>
-/// <seealso cref="IJsEvent" />
 public interface IJsEventFactory
 {
     /// <summary>

--- a/src/MudBlazor/Services/JsEvent/IJsEventFactory.cs
+++ b/src/MudBlazor/Services/JsEvent/IJsEventFactory.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor.Services;
 
 /// <summary>
-/// Provides a factory for creating instances of <see cref="IJsEvent"/>.
+/// Creates <see cref="IJsEvent"/> instances that subscribe to an element's DOM events such as paste, text selection, and caret position changes.
 /// </summary>
+/// <seealso cref="IJsEvent" />
 public interface IJsEventFactory
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyDownObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyDownObserver.cs
@@ -7,8 +7,11 @@ using Microsoft.AspNetCore.Components.Web;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents an observer that observes and responds to key down events.
+/// Receives key-down events dispatched by the <see cref="IKeyInterceptorService"/>.
 /// </summary>
+/// <seealso cref="IKeyInterceptorObserver" />
+/// <seealso cref="IKeyInterceptorService" />
+/// <seealso cref="IKeyUpObserver" />
 public interface IKeyDownObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyDownObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyDownObserver.cs
@@ -9,9 +9,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives key-down events dispatched by the <see cref="IKeyInterceptorService"/>.
 /// </summary>
-/// <seealso cref="IKeyInterceptorObserver" />
-/// <seealso cref="IKeyInterceptorService" />
-/// <seealso cref="IKeyUpObserver" />
 public interface IKeyDownObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorObserver.cs
@@ -7,9 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives both key-down and key-up events from the <see cref="IKeyInterceptorService"/> for a specific HTML element.
 /// </summary>
-/// <seealso cref="IKeyDownObserver" />
-/// <seealso cref="IKeyInterceptorService" />
-/// <seealso cref="IKeyUpObserver" />
 public interface IKeyInterceptorObserver : IKeyDownObserver, IKeyUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorObserver.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents an observer that observes and responds to key up and down events.
+/// Receives both key-down and key-up events from the <see cref="IKeyInterceptorService"/> for a specific HTML element.
 /// </summary>
+/// <seealso cref="IKeyDownObserver" />
+/// <seealso cref="IKeyInterceptorService" />
+/// <seealso cref="IKeyUpObserver" />
 public interface IKeyInterceptorObserver : IKeyDownObserver, IKeyUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorService.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorService.cs
@@ -10,7 +10,6 @@ namespace MudBlazor;
 /// <summary>
 /// Intercepts keyboard events for specified HTML elements and dispatches them to subscribed observers, with per-key options to prevent the browser's default behavior.
 /// </summary>
-/// <seealso cref="IKeyInterceptorObserver" />
 public interface IKeyInterceptorService : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorService.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyInterceptorService.cs
@@ -8,8 +8,9 @@ using MudBlazor.Services;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a service that intercepts key events for specified HTML elements.
+/// Intercepts keyboard events for specified HTML elements and dispatches them to subscribed observers, with per-key options to prevent the browser's default behavior.
 /// </summary>
+/// <seealso cref="IKeyInterceptorObserver" />
 public interface IKeyInterceptorService : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyUpObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyUpObserver.cs
@@ -9,9 +9,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives key-up events dispatched by the <see cref="IKeyInterceptorService"/>.
 /// </summary>
-/// <seealso cref="IKeyDownObserver" />
-/// <seealso cref="IKeyInterceptorObserver" />
-/// <seealso cref="IKeyInterceptorService" />
 public interface IKeyUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/IKeyUpObserver.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/IKeyUpObserver.cs
@@ -7,8 +7,11 @@ using Microsoft.AspNetCore.Components.Web;
 namespace MudBlazor;
 
 /// <summary>
-/// Represents an observer that observes and responds to key up events.
+/// Receives key-up events dispatched by the <see cref="IKeyInterceptorService"/>.
 /// </summary>
+/// <seealso cref="IKeyDownObserver" />
+/// <seealso cref="IKeyInterceptorObserver" />
+/// <seealso cref="IKeyInterceptorService" />
 public interface IKeyUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/KeyEventKind.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyEventKind.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor.Services;
 
 /// <summary>
-/// Specifies the type of keyboard event.
+/// Specifies whether a keyboard event is a key-down or key-up event.
 /// </summary>
+/// <seealso cref="IKeyInterceptorService" />
 public enum KeyEventKind
 {
     /// <summary>

--- a/src/MudBlazor/Services/KeyInterceptor/KeyEventKind.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyEventKind.cs
@@ -7,7 +7,6 @@ namespace MudBlazor.Services;
 /// <summary>
 /// Specifies whether a keyboard event is a key-down or key-up event.
 /// </summary>
-/// <seealso cref="IKeyInterceptorService" />
 public enum KeyEventKind
 {
     /// <summary>

--- a/src/MudBlazor/Services/PointerEvents/IPointerDownObserver.cs
+++ b/src/MudBlazor/Services/PointerEvents/IPointerDownObserver.cs
@@ -8,8 +8,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives pointer-down events for an element tracked by the <see cref="IPointerEventsNoneService"/>.
 /// </summary>
-/// <seealso cref="IPointerEventsNoneObserver" />
-/// <seealso cref="IPointerUpObserver" />
 public interface IPointerDownObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/PointerEvents/IPointerDownObserver.cs
+++ b/src/MudBlazor/Services/PointerEvents/IPointerDownObserver.cs
@@ -6,8 +6,10 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents an observer that observes and responds to pointer down events.
+/// Receives pointer-down events for an element tracked by the <see cref="IPointerEventsNoneService"/>.
 /// </summary>
+/// <seealso cref="IPointerEventsNoneObserver" />
+/// <seealso cref="IPointerUpObserver" />
 public interface IPointerDownObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/PointerEvents/IPointerEventsNoneObserver.cs
+++ b/src/MudBlazor/Services/PointerEvents/IPointerEventsNoneObserver.cs
@@ -12,8 +12,6 @@ namespace MudBlazor;
 /// This observer is associated with a unique HTML element ID and is used by the
 /// <see cref="IPointerEventsNoneService"/> to relay pointer interactions from JavaScript to .NET, even though the element itself does not natively receive pointer events.
 /// </remarks>
-/// <seealso cref="IPointerDownObserver" />
-/// <seealso cref="IPointerUpObserver" />
 public interface IPointerEventsNoneObserver : IPointerDownObserver, IPointerUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/PointerEvents/IPointerEventsNoneObserver.cs
+++ b/src/MudBlazor/Services/PointerEvents/IPointerEventsNoneObserver.cs
@@ -6,12 +6,14 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents an observer that listens for pointer down and pointer up events on a specific HTML element with <c>pointer-events: none</c>.
+/// Receives pointer-down and pointer-up events for an HTML element styled <c>pointer-events: none</c>, relayed from JavaScript by the <see cref="IPointerEventsNoneService"/>.
 /// </summary>
 /// <remarks>
 /// This observer is associated with a unique HTML element ID and is used by the
 /// <see cref="IPointerEventsNoneService"/> to relay pointer interactions from JavaScript to .NET, even though the element itself does not natively receive pointer events.
 /// </remarks>
+/// <seealso cref="IPointerDownObserver" />
+/// <seealso cref="IPointerUpObserver" />
 public interface IPointerEventsNoneObserver : IPointerDownObserver, IPointerUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/PointerEvents/IPointerUpObserver.cs
+++ b/src/MudBlazor/Services/PointerEvents/IPointerUpObserver.cs
@@ -6,8 +6,10 @@ namespace MudBlazor;
 
 
 /// <summary>
-/// Represents an observer that observes and responds to pointer up events.
+/// Receives pointer-up events for an element tracked by the <see cref="IPointerEventsNoneService"/>.
 /// </summary>
+/// <seealso cref="IPointerDownObserver" />
+/// <seealso cref="IPointerEventsNoneObserver" />
 public interface IPointerUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/PointerEvents/IPointerUpObserver.cs
+++ b/src/MudBlazor/Services/PointerEvents/IPointerUpObserver.cs
@@ -8,8 +8,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives pointer-up events for an element tracked by the <see cref="IPointerEventsNoneService"/>.
 /// </summary>
-/// <seealso cref="IPointerDownObserver" />
-/// <seealso cref="IPointerEventsNoneObserver" />
 public interface IPointerUpObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/Popover/IPopoverObserver.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverObserver.cs
@@ -7,7 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Receives notifications when popovers are created, updated, or destroyed in the <see cref="IPopoverService"/>.
 /// </summary>
-/// <seealso cref="IPopoverService" />
 public interface IPopoverObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/Popover/IPopoverObserver.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverObserver.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents an observer for popover updates.
+/// Receives notifications when popovers are created, updated, or destroyed in the <see cref="IPopoverService"/>.
 /// </summary>
+/// <seealso cref="IPopoverService" />
 public interface IPopoverObserver
 {
     /// <summary>

--- a/src/MudBlazor/Services/Popover/IPopoverService.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverService.cs
@@ -7,8 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Creates, updates, and destroys popovers rendered by the <see cref="MudPopoverProvider"/> and notifies subscribed <see cref="IPopoverObserver"/> instances of changes.
 /// </summary>
-/// <seealso cref="IPopoverObserver" />
-/// <seealso cref="MudPopover" />
 public interface IPopoverService : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Popover/IPopoverService.cs
+++ b/src/MudBlazor/Services/Popover/IPopoverService.cs
@@ -5,8 +5,10 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a service for managing popovers.
+/// Creates, updates, and destroys popovers rendered by the <see cref="MudPopoverProvider"/> and notifies subscribed <see cref="IPopoverObserver"/> instances of changes.
 /// </summary>
+/// <seealso cref="IPopoverObserver" />
+/// <seealso cref="MudPopover" />
 public interface IPopoverService : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Popover/PopoverHolderOperation.cs
+++ b/src/MudBlazor/Services/Popover/PopoverHolderOperation.cs
@@ -7,9 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Indicates whether a popover holder is being created, removed, or updated in the <see cref="IPopoverService"/>.
 /// </summary>
-/// <seealso cref="IMudPopoverHolder" />
-/// <seealso cref="IPopoverObserver" />
-/// <seealso cref="IPopoverService" />
 public enum PopoverHolderOperation
 {
     /// <summary>

--- a/src/MudBlazor/Services/Popover/PopoverHolderOperation.cs
+++ b/src/MudBlazor/Services/Popover/PopoverHolderOperation.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents the operation types for <see cref="IMudPopoverHolder"/>.
+/// Indicates whether a popover holder is being created, removed, or updated in the <see cref="IPopoverService"/>.
 /// </summary>
+/// <seealso cref="IMudPopoverHolder" />
+/// <seealso cref="IPopoverObserver" />
+/// <seealso cref="IPopoverService" />
 public enum PopoverHolderOperation
 {
     /// <summary>

--- a/src/MudBlazor/Services/ResizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/IResizeObserver.cs
@@ -6,7 +6,6 @@ namespace MudBlazor.Services
     /// <summary>
     /// Watches HTML elements for size changes with the browser's ResizeObserver and reports their bounding rectangles to subscribers.
     /// </summary>
-    /// <seealso cref="IBrowserViewportService" />
     public interface IResizeObserver : IAsyncDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Services/ResizeObserver/IResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/IResizeObserver.cs
@@ -4,8 +4,9 @@ using MudBlazor.Interop;
 namespace MudBlazor.Services
 {
     /// <summary>
-    /// Interface for observing resize events on elements.
+    /// Watches HTML elements for size changes with the browser's ResizeObserver and reports their bounding rectangles to subscribers.
     /// </summary>
+    /// <seealso cref="IBrowserViewportService" />
     public interface IResizeObserver : IAsyncDisposable
     {
         /// <summary>

--- a/src/MudBlazor/Services/Scroll/IScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/IScrollListener.cs
@@ -7,7 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Reports scroll-position changes for a target element at a throttled interval.
 /// </summary>
-/// <seealso cref="IScrollSpy" />
 public interface IScrollListener : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Scroll/IScrollListener.cs
+++ b/src/MudBlazor/Services/Scroll/IScrollListener.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Interface for a scroll listener that listens to scroll events on a specified element.
+/// Reports scroll-position changes for a target element at a throttled interval.
 /// </summary>
+/// <seealso cref="IScrollSpy" />
 public interface IScrollListener : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Scroll/IScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/IScrollSpy.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Interface for spying on scroll events and managing scroll behavior for specified elements.
+/// Tracks which page section is centered in the viewport while scrolling, powering navigation highlighting such as a table of contents.
 /// </summary>
+/// <seealso cref="IScrollListener" />
 public interface IScrollSpy : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Scroll/IScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/IScrollSpy.cs
@@ -7,7 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Tracks which page section is centered in the viewport while scrolling, powering navigation highlighting such as a table of contents.
 /// </summary>
-/// <seealso cref="IScrollListener" />
 public interface IScrollSpy : IAsyncDisposable
 {
     /// <summary>

--- a/src/MudBlazor/Services/Scroll/ScrollBehavior.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollBehavior.cs
@@ -8,8 +8,9 @@ using NetEscapades.EnumGenerators;
 namespace MudBlazor;
 
 /// <summary>
-/// Specifies the scroll behavior for scrolling operations.
+/// Specifies whether a scroll animates smoothly or jumps immediately, matching the CSS <c>scroll-behavior</c> property.
 /// </summary>
+/// <seealso cref="IScrollManager" />
 [EnumExtensions]
 public enum ScrollBehavior
 {

--- a/src/MudBlazor/Services/Scroll/ScrollBehavior.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollBehavior.cs
@@ -10,7 +10,6 @@ namespace MudBlazor;
 /// <summary>
 /// Specifies whether a scroll animates smoothly or jumps immediately, matching the CSS <c>scroll-behavior</c> property.
 /// </summary>
-/// <seealso cref="IScrollManager" />
 [EnumExtensions]
 public enum ScrollBehavior
 {

--- a/src/MudBlazor/State/Builder/IParameterRegistrationBuilderScope.cs
+++ b/src/MudBlazor/State/Builder/IParameterRegistrationBuilderScope.cs
@@ -7,7 +7,6 @@ namespace MudBlazor.State.Builder;
 /// <summary>
 /// Disposable scope for registering MudBlazor component parameters through a <see cref="RegisterParameterBuilder{T}"/>.
 /// </summary>
-/// <seealso cref="RegisterParameterBuilder{T}" />
 public interface IParameterRegistrationBuilderScope : IDisposable
 {
     /// <summary>

--- a/src/MudBlazor/State/Builder/IParameterRegistrationBuilderScope.cs
+++ b/src/MudBlazor/State/Builder/IParameterRegistrationBuilderScope.cs
@@ -5,8 +5,9 @@
 namespace MudBlazor.State.Builder;
 
 /// <summary>
-/// Represents a scope for registering parameters.
+/// Disposable scope for registering MudBlazor component parameters through a <see cref="RegisterParameterBuilder{T}"/>.
 /// </summary>
+/// <seealso cref="RegisterParameterBuilder{T}" />
 public interface IParameterRegistrationBuilderScope : IDisposable
 {
     /// <summary>

--- a/src/MudBlazor/State/EffectiveParameterResult.cs
+++ b/src/MudBlazor/State/EffectiveParameterResult.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace MudBlazor.State;
 
 /// <summary>
-/// Represents the result of resolving which parameter is effective when coordinating between two related parameters.
+/// Outcome of resolving which of two related parameters takes precedence, carrying the selected parameter's name and value.
 /// </summary>
 /// <typeparam name="T1">The type of the first parameter.</typeparam>
 /// <typeparam name="T2">The type of the second parameter.</typeparam>
@@ -16,6 +16,7 @@ namespace MudBlazor.State;
 /// This type is used to determine which of two parameters should take precedence when both are available,
 /// such as when a component has both a typed parameter and a string parameter that represent the same value.
 /// </remarks>
+/// <seealso cref="ParameterState{T}" />
 [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
 public readonly record struct EffectiveParameterResult<T1, T2>
 {

--- a/src/MudBlazor/State/EffectiveParameterResult.cs
+++ b/src/MudBlazor/State/EffectiveParameterResult.cs
@@ -16,7 +16,6 @@ namespace MudBlazor.State;
 /// This type is used to determine which of two parameters should take precedence when both are available,
 /// such as when a component has both a typed parameter and a string parameter that represent the same value.
 /// </remarks>
-/// <seealso cref="ParameterState{T}" />
 [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
 public readonly record struct EffectiveParameterResult<T1, T2>
 {

--- a/src/MudBlazor/State/Handler/IParameterChangedHandler.cs
+++ b/src/MudBlazor/State/Handler/IParameterChangedHandler.cs
@@ -5,9 +5,10 @@
 namespace MudBlazor.State;
 
 /// <summary>
-/// Represents an interface for handling parameter change.
+/// Handles a MudBlazor parameter's value change, receiving the old and new values through <see cref="ParameterChangedEventArgs{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the component's property value.</typeparam>
+/// <seealso cref="ParameterChangedEventArgs{T}" />
 public interface IParameterChangedHandler<T>
 {
     /// <summary>

--- a/src/MudBlazor/State/Handler/IParameterChangedHandler.cs
+++ b/src/MudBlazor/State/Handler/IParameterChangedHandler.cs
@@ -8,7 +8,6 @@ namespace MudBlazor.State;
 /// Handles a MudBlazor parameter's value change, receiving the old and new values through <see cref="ParameterChangedEventArgs{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the component's property value.</typeparam>
-/// <seealso cref="ParameterChangedEventArgs{T}" />
 public interface IParameterChangedHandler<T>
 {
     /// <summary>

--- a/src/MudBlazor/State/Handler/ParameterStateValue.cs
+++ b/src/MudBlazor/State/Handler/ParameterStateValue.cs
@@ -8,12 +8,13 @@ using System.Diagnostics.CodeAnalysis;
 namespace MudBlazor.State;
 
 /// <summary>
-/// Represents a non-generic snapshot of a parameter's name, current value, and last value.
+/// Non-generic snapshot of a parameter's name together with its current and previous values.
 /// </summary>
 /// <remarks>
 /// This struct is used to pass parameter state information to shared change handlers
 /// that need to coordinate changes across multiple parameters.
 /// </remarks>
+/// <seealso cref="ParameterState{T}" />
 [DebuggerDisplay("{ToString(),nq}")]
 public readonly struct ParameterStateValue
 {

--- a/src/MudBlazor/State/Handler/ParameterStateValue.cs
+++ b/src/MudBlazor/State/Handler/ParameterStateValue.cs
@@ -14,7 +14,6 @@ namespace MudBlazor.State;
 /// This struct is used to pass parameter state information to shared change handlers
 /// that need to coordinate changes across multiple parameters.
 /// </remarks>
-/// <seealso cref="ParameterState{T}" />
 [DebuggerDisplay("{ToString(),nq}")]
 public readonly struct ParameterStateValue
 {

--- a/src/MudBlazor/Themes/Models/Breakpoints.cs
+++ b/src/MudBlazor/Themes/Models/Breakpoints.cs
@@ -6,8 +6,6 @@ namespace MudBlazor
     /// <summary>
     /// Pixel width thresholds for the responsive breakpoints (xs, sm, md, lg, xl, and xxl) used to adapt layouts to screen size.
     /// </summary>
-    /// <seealso cref="Breakpoint" />
-    /// <seealso cref="MudHidden" />
     [ExcludeFromCodeCoverage]
     public class Breakpoints
     {

--- a/src/MudBlazor/Themes/Models/Breakpoints.cs
+++ b/src/MudBlazor/Themes/Models/Breakpoints.cs
@@ -4,8 +4,10 @@ namespace MudBlazor
 {
 #pragma warning disable IDE1006 // must being with upper case
     /// <summary>
-    /// Represents the breakpoints for responsive design.
+    /// Pixel width thresholds for the responsive breakpoints (xs, sm, md, lg, xl, and xxl) used to adapt layouts to screen size.
     /// </summary>
+    /// <seealso cref="Breakpoint" />
+    /// <seealso cref="MudHidden" />
     [ExcludeFromCodeCoverage]
     public class Breakpoints
     {

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -1,8 +1,9 @@
 ﻿namespace MudBlazor
 {
     /// <summary>
-    /// Represents the layout properties for a user interface.
+    /// Layout dimensions for MudBlazor components, including the default border radius, drawer widths, and app bar height.
     /// </summary>
+    /// <seealso cref="MudTheme" />
     public class LayoutProperties
     {
         /// <summary>

--- a/src/MudBlazor/Themes/Models/LayoutProperties.cs
+++ b/src/MudBlazor/Themes/Models/LayoutProperties.cs
@@ -3,7 +3,6 @@
     /// <summary>
     /// Layout dimensions for MudBlazor components, including the default border radius, drawer widths, and app bar height.
     /// </summary>
-    /// <seealso cref="MudTheme" />
     public class LayoutProperties
     {
         /// <summary>

--- a/src/MudBlazor/Themes/Models/Palette.cs
+++ b/src/MudBlazor/Themes/Models/Palette.cs
@@ -8,8 +8,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a palette of colors used throughout the application.
+    /// Base class for a MudBlazor color palette, defining the primary, secondary, surface, text, and status colors shared by <see cref="PaletteLight"/> and <see cref="PaletteDark"/>.
     /// </summary>
+    /// <seealso cref="MudTheme" />
+    /// <seealso cref="PaletteDark" />
+    /// <seealso cref="PaletteLight" />
     [JsonDerivedType(typeof(PaletteLight), typeDiscriminator: nameof(PaletteLight))]
     [JsonDerivedType(typeof(PaletteDark), typeDiscriminator: nameof(PaletteDark))]
     public abstract class Palette

--- a/src/MudBlazor/Themes/Models/Palette.cs
+++ b/src/MudBlazor/Themes/Models/Palette.cs
@@ -10,9 +10,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for a MudBlazor color palette, defining the primary, secondary, surface, text, and status colors shared by <see cref="PaletteLight"/> and <see cref="PaletteDark"/>.
     /// </summary>
-    /// <seealso cref="MudTheme" />
-    /// <seealso cref="PaletteDark" />
-    /// <seealso cref="PaletteLight" />
     [JsonDerivedType(typeof(PaletteLight), typeDiscriminator: nameof(PaletteLight))]
     [JsonDerivedType(typeof(PaletteDark), typeDiscriminator: nameof(PaletteDark))]
     public abstract class Palette

--- a/src/MudBlazor/Themes/Models/PaletteDark.cs
+++ b/src/MudBlazor/Themes/Models/PaletteDark.cs
@@ -9,9 +9,6 @@ namespace MudBlazor
     /// <summary>
     /// Dark-mode color palette that overrides <see cref="Palette"/> defaults for MudBlazor's dark theme.
     /// </summary>
-    /// <seealso cref="MudTheme" />
-    /// <seealso cref="Palette" />
-    /// <seealso cref="PaletteLight" />
     public class PaletteDark : Palette
     {
         /// <inheritdoc />

--- a/src/MudBlazor/Themes/Models/PaletteDark.cs
+++ b/src/MudBlazor/Themes/Models/PaletteDark.cs
@@ -7,8 +7,11 @@ using MudBlazor.Utilities;
 namespace MudBlazor
 {
     /// <summary>
-    /// Represents a dark color palette.
+    /// Dark-mode color palette that overrides <see cref="Palette"/> defaults for MudBlazor's dark theme.
     /// </summary>
+    /// <seealso cref="MudTheme" />
+    /// <seealso cref="Palette" />
+    /// <seealso cref="PaletteLight" />
     public class PaletteDark : Palette
     {
         /// <inheritdoc />

--- a/src/MudBlazor/Themes/Models/PaletteLight.cs
+++ b/src/MudBlazor/Themes/Models/PaletteLight.cs
@@ -7,9 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Light-mode color palette that keeps MudBlazor's default theme colors from <see cref="Palette"/>.
 /// </summary>
-/// <seealso cref="MudTheme" />
-/// <seealso cref="Palette" />
-/// <seealso cref="PaletteDark" />
 public class PaletteLight : Palette
 {
     // everything is inherited from Palette so people will know about it.

--- a/src/MudBlazor/Themes/Models/PaletteLight.cs
+++ b/src/MudBlazor/Themes/Models/PaletteLight.cs
@@ -5,8 +5,11 @@
 namespace MudBlazor;
 
 /// <summary>
-/// Represents a light color palette.
+/// Light-mode color palette that keeps MudBlazor's default theme colors from <see cref="Palette"/>.
 /// </summary>
+/// <seealso cref="MudTheme" />
+/// <seealso cref="Palette" />
+/// <seealso cref="PaletteDark" />
 public class PaletteLight : Palette
 {
     // everything is inherited from Palette so people will know about it.

--- a/src/MudBlazor/Themes/Models/Shadow.cs
+++ b/src/MudBlazor/Themes/Models/Shadow.cs
@@ -1,8 +1,9 @@
 ﻿namespace MudBlazor
 {
     /// <summary>
-    /// Represents the typography settings for Shadow.
+    /// Box-shadow values for each elevation level, controlling the depth appearance of MudBlazor surfaces.
     /// </summary>
+    /// <seealso cref="MudTheme" />
     public class Shadow
     {
         /// <summary>

--- a/src/MudBlazor/Themes/Models/Shadow.cs
+++ b/src/MudBlazor/Themes/Models/Shadow.cs
@@ -3,7 +3,6 @@
     /// <summary>
     /// Box-shadow values for each elevation level, controlling the depth appearance of MudBlazor surfaces.
     /// </summary>
-    /// <seealso cref="MudTheme" />
     public class Shadow
     {
         /// <summary>

--- a/src/MudBlazor/Themes/Models/Typography.cs
+++ b/src/MudBlazor/Themes/Models/Typography.cs
@@ -121,8 +121,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the default typography settings.
+    /// Default font settings applied to text without a specific <see cref="Typo"/> style.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class DefaultTypography : BaseTypography
     {
         /// <summary>
@@ -139,8 +141,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the H1 typography settings.
+    /// Default font settings for <see cref="Typo.h1"/> headings.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class H1Typography : BaseTypography
     {
         /// <summary>
@@ -156,8 +160,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the H2 typography settings.
+    /// Default font settings for <see cref="Typo.h2"/> headings.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class H2Typography : BaseTypography
     {
         /// <summary>
@@ -173,8 +179,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the H3 typography settings.
+    /// Default font settings for <see cref="Typo.h3"/> headings.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class H3Typography : BaseTypography
     {
         /// <summary>
@@ -190,8 +198,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the H4 typography settings.
+    /// Default font settings for <see cref="Typo.h4"/> headings.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class H4Typography : BaseTypography
     {
         /// <summary>
@@ -207,8 +217,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the H5 typography settings.
+    /// Default font settings for <see cref="Typo.h5"/> headings.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class H5Typography : BaseTypography
     {
         /// <summary>
@@ -224,8 +236,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the H6 typography settings.
+    /// Default font settings for <see cref="Typo.h6"/> headings.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class H6Typography : BaseTypography
     {
         /// <summary>
@@ -241,8 +255,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Subtitle1 typography settings.
+    /// Default font settings for <see cref="Typo.subtitle1"/> text.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class Subtitle1Typography : BaseTypography
     {
         /// <summary>
@@ -258,8 +274,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Subtitle2 typography settings.
+    /// Default font settings for <see cref="Typo.subtitle2"/> text.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class Subtitle2Typography : BaseTypography
     {
         /// <summary>
@@ -275,8 +293,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Body1 typography settings.
+    /// Default font settings for <see cref="Typo.body1"/> body text.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class Body1Typography : BaseTypography
     {
         /// <summary>
@@ -292,8 +312,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Body2 typography settings.
+    /// Default font settings for <see cref="Typo.body2"/> body text.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class Body2Typography : BaseTypography
     {
         /// <summary>
@@ -309,8 +331,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Button typography settings.
+    /// Default font settings for <see cref="Typo.button"/> text, rendered in uppercase.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class ButtonTypography : BaseTypography
     {
         /// <summary>
@@ -327,8 +351,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Caption typography settings.
+    /// Default font settings for <see cref="Typo.caption"/> text.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class CaptionTypography : BaseTypography
     {
         /// <summary>
@@ -344,8 +370,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the Overline typography settings.
+    /// Default font settings for <see cref="Typo.overline"/> text.
     /// </summary>
+    /// <seealso cref="BaseTypography" />
+    /// <seealso cref="Typography" />
     public class OverlineTypography : BaseTypography
     {
         /// <summary>
@@ -361,8 +389,10 @@ namespace MudBlazor
     }
 
     /// <summary>
-    /// Represents the base typography settings.
+    /// Base class for MudBlazor typography presets, defining the font family, weight, size, line height, letter spacing, and text transform for a <see cref="Typo"/> style.
     /// </summary>
+    /// <seealso cref="DefaultTypography" />
+    /// <seealso cref="Typography" />
     [JsonDerivedType(typeof(DefaultTypography), nameof(DefaultTypography))]
     [JsonDerivedType(typeof(H1Typography), nameof(H1Typography))]
     [JsonDerivedType(typeof(H2Typography), nameof(H2Typography))]

--- a/src/MudBlazor/Themes/Models/Typography.cs
+++ b/src/MudBlazor/Themes/Models/Typography.cs
@@ -123,8 +123,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings applied to text without a specific <see cref="Typo"/> style.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class DefaultTypography : BaseTypography
     {
         /// <summary>
@@ -143,8 +141,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.h1"/> headings.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class H1Typography : BaseTypography
     {
         /// <summary>
@@ -162,8 +158,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.h2"/> headings.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class H2Typography : BaseTypography
     {
         /// <summary>
@@ -181,8 +175,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.h3"/> headings.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class H3Typography : BaseTypography
     {
         /// <summary>
@@ -200,8 +192,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.h4"/> headings.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class H4Typography : BaseTypography
     {
         /// <summary>
@@ -219,8 +209,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.h5"/> headings.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class H5Typography : BaseTypography
     {
         /// <summary>
@@ -238,8 +226,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.h6"/> headings.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class H6Typography : BaseTypography
     {
         /// <summary>
@@ -257,8 +243,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.subtitle1"/> text.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class Subtitle1Typography : BaseTypography
     {
         /// <summary>
@@ -276,8 +260,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.subtitle2"/> text.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class Subtitle2Typography : BaseTypography
     {
         /// <summary>
@@ -295,8 +277,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.body1"/> body text.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class Body1Typography : BaseTypography
     {
         /// <summary>
@@ -314,8 +294,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.body2"/> body text.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class Body2Typography : BaseTypography
     {
         /// <summary>
@@ -333,8 +311,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.button"/> text, rendered in uppercase.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class ButtonTypography : BaseTypography
     {
         /// <summary>
@@ -353,8 +329,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.caption"/> text.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class CaptionTypography : BaseTypography
     {
         /// <summary>
@@ -372,8 +346,6 @@ namespace MudBlazor
     /// <summary>
     /// Default font settings for <see cref="Typo.overline"/> text.
     /// </summary>
-    /// <seealso cref="BaseTypography" />
-    /// <seealso cref="Typography" />
     public class OverlineTypography : BaseTypography
     {
         /// <summary>
@@ -391,8 +363,6 @@ namespace MudBlazor
     /// <summary>
     /// Base class for MudBlazor typography presets, defining the font family, weight, size, line height, letter spacing, and text transform for a <see cref="Typo"/> style.
     /// </summary>
-    /// <seealso cref="DefaultTypography" />
-    /// <seealso cref="Typography" />
     [JsonDerivedType(typeof(DefaultTypography), nameof(DefaultTypography))]
     [JsonDerivedType(typeof(H1Typography), nameof(H1Typography))]
     [JsonDerivedType(typeof(H2Typography), nameof(H2Typography))]

--- a/src/MudBlazor/Themes/Models/Z-Index.cs
+++ b/src/MudBlazor/Themes/Models/Z-Index.cs
@@ -3,7 +3,6 @@
     /// <summary>
     /// Z-index stacking values that control the layering order of overlay components such as the drawer, popover, app bar, dialog, snackbar, and tooltip.
     /// </summary>
-    /// <seealso cref="MudTheme" />
     public class ZIndex
     {
         /// <summary>

--- a/src/MudBlazor/Themes/Models/Z-Index.cs
+++ b/src/MudBlazor/Themes/Models/Z-Index.cs
@@ -1,8 +1,9 @@
 ﻿namespace MudBlazor
 {
     /// <summary>
-    /// Represents the Z-index values for different components.
+    /// Z-index stacking values that control the layering order of overlay components such as the drawer, popover, app bar, dialog, snackbar, and tooltip.
     /// </summary>
+    /// <seealso cref="MudTheme" />
     public class ZIndex
     {
         /// <summary>

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -6,11 +6,6 @@
     /// <remarks>
     /// Applied to a page through a <see cref="MudThemeProvider"/>.
     /// </remarks>
-    /// <seealso cref="LayoutProperties" />
-    /// <seealso cref="Palette" />
-    /// <seealso cref="Shadow" />
-    /// <seealso cref="Typography" />
-    /// <seealso cref="ZIndex" />
     public class MudTheme
     {
         /// <summary>

--- a/src/MudBlazor/Themes/MudTheme.cs
+++ b/src/MudBlazor/Themes/MudTheme.cs
@@ -1,8 +1,16 @@
 ﻿namespace MudBlazor
 {
     /// <summary>
-    /// Represents the theme settings for the MudBlazor user interface.
+    /// Theme settings that define the light and dark color palettes, typography, shadows, layout dimensions, and z-index values for MudBlazor components.
     /// </summary>
+    /// <remarks>
+    /// Applied to a page through a <see cref="MudThemeProvider"/>.
+    /// </remarks>
+    /// <seealso cref="LayoutProperties" />
+    /// <seealso cref="Palette" />
+    /// <seealso cref="Shadow" />
+    /// <seealso cref="Typography" />
+    /// <seealso cref="ZIndex" />
     public class MudTheme
     {
         /// <summary>

--- a/src/MudBlazor/Utilities/Clone/CloneableCloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/CloneableCloneStrategy.cs
@@ -10,8 +10,6 @@ namespace MudBlazor.Utilities.Clone;
 /// Deep-copies objects that implement <see cref="ICloneable"/> by delegating to their own <c>Clone</c> method.
 /// </summary>
 /// <typeparam name="T">The type of the object to be deep-copied, which must implement the <see cref="ICloneable"/> interface.</typeparam>
-/// <seealso cref="ICloneStrategy{T}" />
-/// <seealso cref="SystemTextJsonDeepCloneStrategy{T}" />
 public sealed class CloneableCloneStrategy<T> : ICloneStrategy<T> where T : ICloneable
 {
     /// <inheritdoc />

--- a/src/MudBlazor/Utilities/Clone/CloneableCloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/CloneableCloneStrategy.cs
@@ -7,9 +7,11 @@ using System;
 namespace MudBlazor.Utilities.Clone;
 
 /// <summary>
-/// Provides a deep copy implementation for objects of type <typeparamref name="T"/> that implement the <see cref="ICloneable"/> interface.
+/// Deep-copies objects that implement <see cref="ICloneable"/> by delegating to their own <c>Clone</c> method.
 /// </summary>
 /// <typeparam name="T">The type of the object to be deep-copied, which must implement the <see cref="ICloneable"/> interface.</typeparam>
+/// <seealso cref="ICloneStrategy{T}" />
+/// <seealso cref="SystemTextJsonDeepCloneStrategy{T}" />
 public sealed class CloneableCloneStrategy<T> : ICloneStrategy<T> where T : ICloneable
 {
     /// <inheritdoc />

--- a/src/MudBlazor/Utilities/Clone/ICloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/ICloneStrategy.cs
@@ -5,12 +5,14 @@
 namespace MudBlazor.Utilities.Clone;
 
 /// <summary>
-/// Represents an interface for resolving deep copy operations for objects of type <typeparamref name="T"/>.
+/// Deep-copies objects of type <typeparamref name="T"/> using a pluggable clone strategy.
 /// </summary>
 /// <remarks>
 /// Please ensure that it implements deep copy logic for all nested objects, not just shallow copies.
 /// </remarks>
 /// <typeparam name="T">The type of the object to be deep-copied.</typeparam>
+/// <seealso cref="CloneableCloneStrategy{T}" />
+/// <seealso cref="SystemTextJsonDeepCloneStrategy{T}" />
 public interface ICloneStrategy<T>
 {
     /// <summary>

--- a/src/MudBlazor/Utilities/Clone/ICloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/ICloneStrategy.cs
@@ -11,8 +11,6 @@ namespace MudBlazor.Utilities.Clone;
 /// Please ensure that it implements deep copy logic for all nested objects, not just shallow copies.
 /// </remarks>
 /// <typeparam name="T">The type of the object to be deep-copied.</typeparam>
-/// <seealso cref="CloneableCloneStrategy{T}" />
-/// <seealso cref="SystemTextJsonDeepCloneStrategy{T}" />
 public interface ICloneStrategy<T>
 {
     /// <summary>

--- a/src/MudBlazor/Utilities/Clone/SystemTextJsonCloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/SystemTextJsonCloneStrategy.cs
@@ -9,13 +9,15 @@ using System.Text.Json.Serialization;
 namespace MudBlazor.Utilities.Clone;
 
 /// <summary>
-/// Provides a deep copy implementation using System.Text.Json.
+/// Deep-copies objects by serializing and deserializing them with <c>System.Text.Json</c>.
 /// </summary>
 /// <remarks>
 /// This implementation is <b>not</b> trim safe.
 /// Use different strategy or use System Text Json with <see href="https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation?pivots=dotnet-7-0">source generator</see> and pass <see cref="JsonSerializerContext"/> of your object.
 /// </remarks>
 /// <typeparam name="T">The type of the object to be deep-copied.</typeparam>
+/// <seealso cref="CloneableCloneStrategy{T}" />
+/// <seealso cref="ICloneStrategy{T}" />
 public sealed class SystemTextJsonDeepCloneStrategy<T> : ICloneStrategy<T>
 {
     /// <inheritdoc />

--- a/src/MudBlazor/Utilities/Clone/SystemTextJsonCloneStrategy.cs
+++ b/src/MudBlazor/Utilities/Clone/SystemTextJsonCloneStrategy.cs
@@ -16,8 +16,6 @@ namespace MudBlazor.Utilities.Clone;
 /// Use different strategy or use System Text Json with <see href="https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation?pivots=dotnet-7-0">source generator</see> and pass <see cref="JsonSerializerContext"/> of your object.
 /// </remarks>
 /// <typeparam name="T">The type of the object to be deep-copied.</typeparam>
-/// <seealso cref="CloneableCloneStrategy{T}" />
-/// <seealso cref="ICloneStrategy{T}" />
 public sealed class SystemTextJsonDeepCloneStrategy<T> : ICloneStrategy<T>
 {
     /// <inheritdoc />

--- a/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
@@ -12,7 +12,6 @@
 /// </list>
 /// </summary>
 /// <typeparam name="T">The type of the elements in the collection.</typeparam>
-/// <seealso cref="DoubleEpsilonEqualityComparer" />
 public class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollection<T>?>
 {
     private readonly IEqualityComparer<T> _comparer;

--- a/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/CollectionComparer.cs
@@ -1,10 +1,9 @@
 ﻿namespace MudBlazor;
 
 /// <summary>
-/// Provides a comparer for <see cref="IReadOnlyCollection{T}"/> values using a <see cref="IEqualityComparer{T}"/>.
-/// Equality is set-based: two collections are equal if they contain the same distinct elements,
-/// regardless of order or the number of duplicates. Null is only equal to null.
-/// 
+/// Set-based equality comparer for <see cref="IReadOnlyCollection{T}"/> values that ignores element order and duplicates.
+/// Two collections are equal when they contain the same distinct elements.
+/// Null is only equal to null.
 /// <para>Note:</para>
 /// <list type="bullet">
 ///   <item>The order of elements does not affect equality or hash code.</item>
@@ -12,6 +11,8 @@
 ///   <item>Null and empty collections are treated as distinct values.</item>
 /// </list>
 /// </summary>
+/// <typeparam name="T">The type of the elements in the collection.</typeparam>
+/// <seealso cref="DoubleEpsilonEqualityComparer" />
 public class CollectionComparer<T> : IEqualityComparer<IReadOnlyCollection<T>?>
 {
     private readonly IEqualityComparer<T> _comparer;

--- a/src/MudBlazor/Utilities/Comparer/DoubleEpsilonEqualityComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/DoubleEpsilonEqualityComparer.cs
@@ -5,8 +5,9 @@ using System.Diagnostics;
 namespace MudBlazor;
 
 /// <summary>
-/// Provides a comparer for <see cref="double"/> values with an epsilon tolerance.
+/// Equality comparer for <see cref="double"/> values that treats numbers within an epsilon tolerance as equal.
 /// </summary>
+/// <seealso cref="CollectionComparer{T}" />
 [DebuggerDisplay("Epsilon = {_epsilon}")]
 public class DoubleEpsilonEqualityComparer : IEqualityComparer<double>
 {

--- a/src/MudBlazor/Utilities/Comparer/DoubleEpsilonEqualityComparer.cs
+++ b/src/MudBlazor/Utilities/Comparer/DoubleEpsilonEqualityComparer.cs
@@ -7,7 +7,6 @@ namespace MudBlazor;
 /// <summary>
 /// Equality comparer for <see cref="double"/> values that treats numbers within an epsilon tolerance as equal.
 /// </summary>
-/// <seealso cref="CollectionComparer{T}" />
 [DebuggerDisplay("Epsilon = {_epsilon}")]
 public class DoubleEpsilonEqualityComparer : IEqualityComparer<double>
 {

--- a/src/MudBlazor/Utilities/Converter/ConversionResult.cs
+++ b/src/MudBlazor/Utilities/Converter/ConversionResult.cs
@@ -3,7 +3,7 @@
 namespace MudBlazor.Utilities.Converter.Base;
 
 /// <summary>
-/// Represents the result of a conversion attempt performed by a converter.
+/// Outcome of a converter's attempt to convert a value, carrying either the converted result or the error that occurred.
 /// </summary>
 /// <typeparam name="T">The target type produced by the conversion.</typeparam>
 /// <remarks>

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -9,7 +9,6 @@ namespace MudBlazor.Utilities
     /// <summary>
     /// Builds a space-separated CSS class string with conditionally added classes for a component's markup.
     /// </summary>
-    /// <seealso cref="StyleBuilder" />
     public readonly struct CssBuilder
     {
         private readonly StringBuilder _stringBuilder;

--- a/src/MudBlazor/Utilities/CssBuilder.cs
+++ b/src/MudBlazor/Utilities/CssBuilder.cs
@@ -7,8 +7,9 @@ using System.Text;
 namespace MudBlazor.Utilities
 {
     /// <summary>
-    /// Represents a builder for creating CSS classes used in a component.
+    /// Builds a space-separated CSS class string with conditionally added classes for a component's markup.
     /// </summary>
+    /// <seealso cref="StyleBuilder" />
     public readonly struct CssBuilder
     {
         private readonly StringBuilder _stringBuilder;

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BaseMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BaseMask.cs
@@ -8,11 +8,6 @@ namespace MudBlazor;
 /// Base class for input masks applied by the <see cref="MudMask"/>, <see cref="MudTextField{T}"/>, and <see cref="MudPicker{T}"/> components.
 /// Concrete masks include <see cref="PatternMask"/>, <see cref="RegexMask"/>, <see cref="BlockMask"/>, <see cref="DateMask"/>, and <see cref="MultiMask"/>.
 /// </summary>
-/// <seealso cref="BlockMask" />
-/// <seealso cref="DateMask" />
-/// <seealso cref="MultiMask" />
-/// <seealso cref="PatternMask" />
-/// <seealso cref="RegexMask" />
 public abstract class BaseMask : IMask
 {
     private bool _initialized;

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BaseMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BaseMask.cs
@@ -5,8 +5,14 @@
 namespace MudBlazor;
 
 /// <summary>
-/// A base class for designing input masks for the <see cref="MudMask"/>, <see cref="MudTextField{T}"/>, and <see cref="MudPicker{T}"/> components.
+/// Base class for input masks applied by the <see cref="MudMask"/>, <see cref="MudTextField{T}"/>, and <see cref="MudPicker{T}"/> components.
+/// Concrete masks include <see cref="PatternMask"/>, <see cref="RegexMask"/>, <see cref="BlockMask"/>, <see cref="DateMask"/>, and <see cref="MultiMask"/>.
 /// </summary>
+/// <seealso cref="BlockMask" />
+/// <seealso cref="DateMask" />
+/// <seealso cref="MultiMask" />
+/// <seealso cref="PatternMask" />
+/// <seealso cref="RegexMask" />
 public abstract class BaseMask : IMask
 {
     private bool _initialized;

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -47,7 +47,6 @@ namespace MudBlazor.Utilities
     /// <summary>
     /// Color value with RGB, HSL, hex, and alpha components, plus methods to convert, adjust, parse, and compare colors.
     /// </summary>
-    /// <seealso cref="MudColorPicker" />
     [Serializable]
     public partial class MudColor : ISerializable, IEquatable<MudColor>, IParsable<MudColor>, IFormattable
     {

--- a/src/MudBlazor/Utilities/MudColor.cs
+++ b/src/MudBlazor/Utilities/MudColor.cs
@@ -45,8 +45,9 @@ namespace MudBlazor.Utilities
     }
 
     /// <summary>
-    /// Represents a color with methods to manipulate color values.
+    /// Color value with RGB, HSL, hex, and alpha components, plus methods to convert, adjust, parse, and compare colors.
     /// </summary>
+    /// <seealso cref="MudColorPicker" />
     [Serializable]
     public partial class MudColor : ISerializable, IEquatable<MudColor>, IParsable<MudColor>, IFormattable
     {

--- a/src/MudBlazor/Utilities/NullableObject.cs
+++ b/src/MudBlazor/Utilities/NullableObject.cs
@@ -3,7 +3,7 @@
 namespace MudBlazor.Utilities;
 
 /// <summary>
-/// Represents a wrapper for an object that can be null.
+/// Wraps a value so that null can be stored and compared, including for value types that are not otherwise nullable.
 /// </summary>
 /// <typeparam name="T">The type of the object.</typeparam>
 public readonly struct NullableObject<T> : IEquatable<NullableObject<T>>, IEquatable<T>

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -7,8 +7,9 @@ using System.Text;
 namespace MudBlazor.Utilities
 {
     /// <summary>
-    /// Represents a builder for creating in-line styles used in a component.
+    /// Builds an inline CSS style string with conditionally added declarations for a component's markup.
     /// </summary>
+    /// <seealso cref="CssBuilder" />
     public readonly struct StyleBuilder
     {
         private readonly StringBuilder _stringBuilder;

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -9,7 +9,6 @@ namespace MudBlazor.Utilities
     /// <summary>
     /// Builds an inline CSS style string with conditionally added declarations for a component's markup.
     /// </summary>
-    /// <seealso cref="CssBuilder" />
     public readonly struct StyleBuilder
     {
         private readonly StringBuilder _stringBuilder;


### PR DESCRIPTION
Continues #12423 and rewrites 173 class-level XML `<summary>` tags that opened with generic filler into direct, action-oriented descriptions.

`DocsPageHeader` prerenders each type's `<summary>` as the page subtitle **and** as the `<meta name="description">`, `og:description`, and `twitter:description` for both `/components/*` and `/api/*`. The class summary is the single source of truth for those snippets, so weak or repetitive summaries directly weaken search results and social cards.

Changes
- Rewrote 170 summaries with banned openers ("Represents a…", "A component that…", filler) plus 3 redundant "Interface for…" ones, spanning components, base classes, interfaces, enums, models, Chart, DataGrid, themes, and utilities.
- Voice: plural-noun or verb first for components, "Base class for…" for base types, verb-first for interfaces; kept the first sentence ≤ 170 chars (the meta-description length).
- Added `<seealso>` cross-links between related types.
- Fixed incorrect crefs — several DataGrid types referenced `MudGrid` instead of `MudDataGrid<T>`.
- Preserved existing `<typeparam>` and `<remarks>`.

| Type | Before | After |
|---|---|---|
| `MudButton` | Represents a button for actions, links, and commands. | Buttons trigger actions, submit forms, or navigate to a link. |
| `MudDataGrid` | Represents a sortable, filterable data grid with multiselection, pagination… | Displays rows of data in a sortable, filterable grid with multiselection, pagination, inline editing, grouping, and aggregation. |
| `MudColorPicker` | Represents a sophisticated and customizable pop-up for choosing a color. | Picks a color from a spectrum, palette, or predefined grid, with RGB, HSL, and hexadecimal inputs and optional alpha transparency. |
| `Palette` | Represents a palette of colors used throughout the application. | Base class for a MudBlazor color palette, defining the primary, secondary, surface, text, and status colors shared by PaletteLight and PaletteDark. |
| `IKeyDownObserver` | Represents an observer that observes and responds to key down events. | Receives key-down events dispatched by the IKeyInterceptorService. |
