### PR TITLE
MudOverlay: Add IOverlayService to dismiss the top-most open overlay

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ApiDocsTests.cs
@@ -42,6 +42,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
             _ctx.Services.AddTransient<IJsEventFactory, MockJsEventFactory>();
             _ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
             _ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
+            _ctx.Services.AddScoped<IOverlayService, OverlayService>();
             _ctx.Services.AddTransient<InternalMudLocalizer>();
             _ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
             _ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();

--- a/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Generated/ExampleDocsTests.cs
@@ -36,6 +36,7 @@ namespace MudBlazor.UnitTests.Docs.Generated
             _ctx.Services.AddSingleton<IPopoverService, MockPopoverService>();
             _ctx.Services.AddScoped<IRenderQueueService, RenderQueueService>();
             _ctx.Services.AddScoped<IPointerEventsNoneService, MockPointerEventsNoneService>();
+            _ctx.Services.AddScoped<IOverlayService, OverlayService>();
             _ctx.Services.AddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
             _ctx.Services.AddTransient<InternalMudLocalizer>();
             _ctx.Services.AddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();

--- a/src/MudBlazor.UnitTests/Services/Overlay/OverlayServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Overlay/OverlayServiceTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Services.Overlay;
+
+#nullable enable
+[TestFixture]
+public class OverlayServiceTests
+{
+    [Test]
+    public void HasVisibleOverlay_ShouldBeFalse_AtInitialization()
+    {
+        var service = new OverlayService();
+
+        service.HasVisibleOverlay.Should().BeFalse();
+    }
+
+    [Test]
+    public void RegisterOverlay_ShouldThrow_WhenCallbackIsNull()
+    {
+        var service = new OverlayService();
+
+        var act = () => service.RegisterOverlay(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void RegisterOverlay_ShouldMarkOverlayVisible_UntilTokenDisposed()
+    {
+        var service = new OverlayService();
+
+        var token = service.RegisterOverlay(() => Task.CompletedTask);
+        service.HasVisibleOverlay.Should().BeTrue();
+
+        token.Dispose();
+        service.HasVisibleOverlay.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CloseLastOverlayAsync_ShouldReturnFalse_WhenNoOverlayVisible()
+    {
+        var service = new OverlayService();
+
+        var result = await service.CloseLastOverlayAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CloseLastOverlayAsync_ShouldCloseMostRecentlyRegistered_First()
+    {
+        var service = new OverlayService();
+        var closed = new List<int>();
+        service.RegisterOverlay(() => { closed.Add(1); return Task.CompletedTask; });
+        service.RegisterOverlay(() => { closed.Add(2); return Task.CompletedTask; });
+
+        (await service.CloseLastOverlayAsync()).Should().BeTrue();
+        closed.Should().Equal(2);
+
+        (await service.CloseLastOverlayAsync()).Should().BeTrue();
+        closed.Should().Equal(2, 1);
+
+        service.HasVisibleOverlay.Should().BeFalse();
+        (await service.CloseLastOverlayAsync()).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CloseLastOverlayAsync_ShouldRemoveOverlay_EvenWhenCallbackDoesNotDisposeToken()
+    {
+        var service = new OverlayService();
+        service.RegisterOverlay(() => Task.CompletedTask);
+
+        await service.CloseLastOverlayAsync();
+
+        service.HasVisibleOverlay.Should().BeFalse();
+    }
+}

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor.cs
@@ -18,6 +18,7 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     private int _lockCount;
     private bool _previousAbsolute;
     private bool _previousLockScroll;
+    private IDisposable? _overlayRegistration;
     private readonly ParameterState<bool> _visibleState;
     private readonly string _elementId = Identifier.Create("overlay");
 
@@ -51,6 +52,12 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     /// </summary>
     [Inject]
     private IPointerEventsNoneService PointerEventsNoneService { get; set; } = null!;
+
+    /// <summary>
+    /// Tracks this overlay while it is dismissible so host code can close it (e.g. a hardware Back button).
+    /// </summary>
+    [Inject]
+    private IOverlayService OverlayService { get; set; } = null!;
 
     /// <summary>
     /// Child content of the component.
@@ -236,6 +243,8 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
 
     protected override async Task OnParametersSetAsync()
     {
+        UpdateOverlayRegistration();
+
         if (IsJSRuntimeAvailable && (_previousLockScroll != LockScroll || _previousAbsolute != Absolute))
         {
             // handle lock scroll change when user changes LockScroll parameter
@@ -276,6 +285,23 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
 
     // change lockscroll value when user toggles visible state
     private Task HandleVisibleChanged(ParameterChangedEventArgs<bool> args) => HandleLockScrollChange();
+
+    // Registers this overlay as dismissible while it is visible with auto-close enabled, so host code
+    // (e.g. an Android hardware Back handler) can close it via IOverlayService. The registration reuses
+    // CloseOverlayAsync, the same path taken by an outside click, so the owning component closes correctly.
+    private void UpdateOverlayRegistration()
+    {
+        var dismissible = _visibleState.Value && AutoClose;
+        if (dismissible && _overlayRegistration is null)
+        {
+            _overlayRegistration = OverlayService.RegisterOverlay(CloseOverlayAsync);
+        }
+        else if (!dismissible && _overlayRegistration is not null)
+        {
+            _overlayRegistration.Dispose();
+            _overlayRegistration = null;
+        }
+    }
 
     protected internal async Task OnClickHandlerAsync(MouseEventArgs ev)
     {
@@ -355,6 +381,9 @@ public partial class MudOverlay : MudComponentBase, IPointerEventsNoneObserver, 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
+        _overlayRegistration?.Dispose();
+        _overlayRegistration = null;
+
         if (!IsJSRuntimeAvailable)
         {
             return;

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -411,6 +411,7 @@ namespace MudBlazor.Services
         private static IServiceCollection AddCommonServices(this IServiceCollection service)
         {
             service.TryAddSingleton(TimeProvider.System);
+            service.TryAddScoped<IOverlayService, OverlayService>();
 
             return service;
         }

--- a/src/MudBlazor/Services/Overlay/IOverlayService.cs
+++ b/src/MudBlazor/Services/Overlay/IOverlayService.cs
@@ -1,0 +1,50 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+/// <summary>
+/// Tracks the dismissible overlays that are currently visible and lets host code close the most recently opened one.
+/// </summary>
+/// <remarks>
+/// A dismissible overlay is any visible <see cref="MudOverlay"/> with <see cref="MudOverlay.AutoClose"/> enabled, which
+/// is the backdrop used by menus, selects, autocompletes, pickers, and dialogs, as well as by user-created overlays.
+/// <para>
+/// This exists for platforms that own a global "back"/dismiss gesture outside the DOM, where a synthetic key event is
+/// not reliable, for example the Android hardware Back button in a Blazor Hybrid (MAUI) app (a WebView does not forward a
+/// hardware Escape to the DOM) or browser Back / <c>popstate</c> in a PWA. Such a handler can dismiss the open overlay
+/// before navigating:
+/// <code>
+/// if (OverlayService.HasVisibleOverlay)
+///     await OverlayService.CloseLastOverlayAsync();
+/// else
+///     Navigate();
+/// </code>
+/// </para>
+/// </remarks>
+public interface IOverlayService
+{
+    /// <summary>
+    /// Gets a value indicating whether any dismissible (auto-close) overlay is currently visible.
+    /// </summary>
+    bool HasVisibleOverlay { get; }
+
+    /// <summary>
+    /// Closes the most recently opened dismissible overlay, running the same close path as clicking outside it.
+    /// </summary>
+    /// <returns><c>true</c> if an overlay was closed; otherwise <c>false</c> when none was visible.</returns>
+    /// <remarks>
+    /// Closing mutates component state, so call this from within <see cref="Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync(System.Func{System.Threading.Tasks.Task})"/>
+    /// (or otherwise on the renderer's synchronization context) when invoking it from outside the Blazor render loop.
+    /// </remarks>
+    Task<bool> CloseLastOverlayAsync();
+
+    /// <summary>
+    /// Registers a dismissible overlay's close callback and returns a token that unregisters it when disposed.
+    /// </summary>
+    /// <param name="closeAsync">The callback that closes the overlay, invoked by <see cref="CloseLastOverlayAsync"/>.</param>
+    /// <returns>A token that unregisters the overlay when disposed (for example when it is hidden or disposed).</returns>
+    /// <remarks>This is called internally by <see cref="MudOverlay"/> while it is visible with auto-close enabled.</remarks>
+    IDisposable RegisterOverlay(Func<Task> closeAsync);
+}

--- a/src/MudBlazor/Services/Overlay/OverlayService.cs
+++ b/src/MudBlazor/Services/Overlay/OverlayService.cs
@@ -1,0 +1,88 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor;
+
+/// <inheritdoc cref="IOverlayService" />
+internal sealed class OverlayService : IOverlayService
+{
+    private readonly object _syncRoot = new();
+
+    // Ordered by registration; the last entry is the most recently opened (top-most) overlay.
+    private readonly List<Registration> _registrations = new();
+
+    /// <inheritdoc />
+    public bool HasVisibleOverlay
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _registrations.Count > 0;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IDisposable RegisterOverlay(Func<Task> closeAsync)
+    {
+        ArgumentNullException.ThrowIfNull(closeAsync);
+
+        var registration = new Registration(this, closeAsync);
+        lock (_syncRoot)
+        {
+            _registrations.Add(registration);
+        }
+
+        return registration;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CloseLastOverlayAsync()
+    {
+        Registration? top;
+        lock (_syncRoot)
+        {
+            if (_registrations.Count == 0)
+            {
+                return false;
+            }
+
+            top = _registrations[^1];
+
+            // Remove eagerly so state is consistent even if the overlay never re-renders to unregister itself.
+            // The overlay also disposes its token as it hides, but Unregister is idempotent, so that is a no-op.
+            _registrations.RemoveAt(_registrations.Count - 1);
+        }
+
+        // Runs the overlay's own close path (Visible = false + OnClosed), the same as an outside click.
+        await top.CloseAsync();
+
+        return true;
+    }
+
+    private void Unregister(Registration registration)
+    {
+        lock (_syncRoot)
+        {
+            _registrations.Remove(registration);
+        }
+    }
+
+    private sealed class Registration : IDisposable
+    {
+        private readonly OverlayService _owner;
+        private readonly Func<Task> _closeAsync;
+
+        public Registration(OverlayService owner, Func<Task> closeAsync)
+        {
+            _owner = owner;
+            _closeAsync = closeAsync;
+        }
+
+        public Task CloseAsync() => _closeAsync();
+
+        public void Dispose() => _owner.Unregister(this);
+    }
+}


### PR DESCRIPTION
Closes #13496.

### What

Adds `IOverlayService`, which tracks the dismissible overlays that are currently visible and lets host code close the most recently opened one:

```csharp
public interface IOverlayService
{
    bool HasVisibleOverlay { get; }
    Task<bool> CloseLastOverlayAsync();
    IDisposable RegisterOverlay(Func<Task> closeAsync); // used internally by MudOverlay
}
```

`MudOverlay` registers itself while it is **visible with `AutoClose` enabled**, using its existing `CloseOverlayAsync` as the close callback. A host back/dismiss handler can then do:

```csharp
if (OverlayService.HasVisibleOverlay)
    await OverlayService.CloseLastOverlayAsync();
else
    Navigate();
```

### Why

Host code sometimes needs to dismiss the top overlay from outside the DOM: the Android hardware Back button in a Blazor Hybrid (MAUI) app, or browser Back / `popstate` in a PWA. A synthetic key event isn't reliable there (a MAUI WebView doesn't forward a hardware Escape to the DOM), so a programmatic entry point is needed.

### Differences from the proposal in #13496

The issue suggested `AnyOpen` / `CloseTopmostAsync` on `IPopoverService`. I moved it to a new **overlay** service instead, because:

- **Overlays, not popovers, are the dismissal primitive.** Menus, selects, autocompletes, pickers, and dialog backdrops all close via `MudOverlay` (`AutoClose` → `CloseOverlayAsync`). Closing at the popover level would set the inner popover's `Open` to false while leaving the owning component's own open state (e.g. `MudMenu._openState`) out of sync. Reusing `MudOverlay.CloseOverlayAsync` runs the exact same path as an outside click, so the owner closes correctly (e.g. `MudMenu` via its `OnClosed="CloseMenuAsync"`).
- **One hook covers everything.** Registering in `MudOverlay` covers menu/select/autocomplete/picker/dialog and any user overlay at once, with no per-component changes.
- **`AutoClose` is the right gate.** "Dismissible by back" == "dismissible by an outside click". Modal overlays that ignore outside clicks are also left alone by back, which is correct. Popovers without an overlay (e.g. tooltips) are intentionally not affected.

Naming maps 1:1: `AnyOpen` → `HasVisibleOverlay`, `CloseTopmostAsync` → `CloseLastOverlayAsync`.

### Notes

- Registered as scoped in `AddCommonServices` (pulled in wherever popovers/overlays are used).
- `CloseLastOverlayAsync` removes the top registration eagerly so state stays consistent even if the overlay never re-renders to unregister itself; the overlay's own token dispose is idempotent.
- Unit tests added in `OverlayServiceTests`.
- Verified end-to-end in a real MAUI Android app: with the overflow `MudMenu` or a bare `MudPopover`+`MudOverlay` open, the hardware Back button now dismisses the overlay and keeps the user in the app, instead of backgrounding it.
