### PR TITLE
Docs: preconnect to the Google Fonts origins

### DIFF
--- a/src/MudBlazor.Docs.Wasm/wwwroot/index.html
+++ b/src/MudBlazor.Docs.Wasm/wwwroot/index.html
@@ -63,6 +63,8 @@
     <link rel="mask-icon" href="_content/MudBlazor.Docs/safari-pinned-tab.svg" color="#7e6fff">
     <meta name="msapplication-TileColor" content="#110e2d">
     <meta name="theme-color" content="#ffffff">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
     <link href="_content/MudBlazor/MudBlazor.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />

--- a/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
+++ b/src/MudBlazor.Docs.WasmHost/Pages/_Host.cshtml
@@ -72,6 +72,8 @@
     <link rel="mask-icon" href="_content/MudBlazor.Docs/safari-pinned-tab.svg" color="#7e6fff">
     <meta name="msapplication-TileColor" content="#110e2d">
     <meta name="theme-color" content="#ffffff">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
     <link href="_content/MudBlazor/MudBlazor.min.css?v=#{CACHE_TOKEN}#" rel="stylesheet" />


### PR DESCRIPTION
Small, isolated critical-path tweak from the perf review in #13495.

The docs load two stylesheets from `fonts.googleapis.com`, which in turn pull font files from `fonts.gstatic.com`, two separate cross-origin hosts. Today the browser only starts the DNS + TLS handshake to those hosts when it parses the `<link>` tags, so the font connection setup is serialized after the head is parsed.

Adding `rel="preconnect"` starts that handshake in parallel with the WASM boot, shaving roughly one round-trip (~100–300 ms on mobile) off the font path. The fonts already use `display=swap`, so text is never blocked - this only affects connection setup, and the change is applied to both `index.html` (standalone) and `_Host.cshtml` (prerender host) to keep them in sync.