### PR TITLE
Docs: only refresh the nav menu when the active section changes

### DIFF
--- a/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
@@ -23,8 +23,18 @@ namespace MudBlazor.Docs.Shared
 
         public void Refresh()
         {
-            _section = NavMan.GetSection();
-            _componentLink = NavMan.GetComponentLink();
+            var section = NavMan.GetSection();
+            var componentLink = NavMan.GetComponentLink();
+
+            // Refresh() is called from DocsLayout.OnAfterRender on every render. The menu only depends on the
+            // active section (which group is expanded), so skip re-rendering its ~250 links when nothing changed.
+            if (section == _section && componentLink == _componentLink)
+            {
+                return;
+            }
+
+            _section = section;
+            _componentLink = componentLink;
             StateHasChanged();
         }
     }

--- a/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
+++ b/src/MudBlazor.Docs/Shared/NavMenu.razor.cs
@@ -26,8 +26,7 @@ namespace MudBlazor.Docs.Shared
             var section = NavMan.GetSection();
             var componentLink = NavMan.GetComponentLink();
 
-            // Refresh() is called from DocsLayout.OnAfterRender on every render. The menu only depends on the
-            // active section (which group is expanded), so skip re-rendering its ~250 links when nothing changed.
+            // The menu only depends on the active section (which group is expanded), so skip re-rendering when nothing changed.
             if (section == _section && componentLink == _componentLink)
             {
                 return;


### PR DESCRIPTION
Small, isolated render optimization from the perf review in #13495.

`DocsLayout.OnAfterRender` calls `NavMenu.Refresh()` on **every** render (there is no `firstRender` guard), and `Refresh()` called `StateHasChanged()` unconditionally. So the nav menu — which expands to ~250 `MudNavLink`s once Components and Component API are open — was re-rendered on every layout render, even when nothing relevant had changed (drawer toggle, theme change, any incidental layout re-render).

The menu's output depends only on the stable `MenuService` data plus the active section (which group is `Expanded`). This guards the re-render on the section / component link actually changing.

Most noticeable on low-powered devices, where re-rendering + diffing the full menu on every layout render is wasted work.