### PR TITLE
MudSwitch: Stop applying label class to text

### DIFF
--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiMemberTableTests.cs
@@ -55,7 +55,7 @@ public sealed class ApiMemberTableTests : BunitTest
 
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
 
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1\">Show Protected</span>", "There should be a switch for protected properties");
 
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"Classname\">", "The \"Classname\" protected property should be visible");
     }
@@ -75,7 +75,7 @@ public sealed class ApiMemberTableTests : BunitTest
 
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
 
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1\">Show Protected</span>", "There should be a switch for protected properties");
 
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"Classname\">", "The \"Classname\" protected property should NOT be visible");
     }
@@ -95,7 +95,7 @@ public sealed class ApiMemberTableTests : BunitTest
 
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
 
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1\">Show Protected</span>", "There should be a switch for protected properties");
 
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"BeginValidateAsync\">", "The \"BeginValidateAsync\" protected method should be visible");
     }
@@ -115,7 +115,7 @@ public sealed class ApiMemberTableTests : BunitTest
 
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
 
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1\">Show Protected</span>", "There should be a switch for protected properties");
 
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"BeginValidateAsync\">", "The \"BeginValidateAsync\" protected method should NOT be visible");
     }
@@ -135,7 +135,7 @@ public sealed class ApiMemberTableTests : BunitTest
 
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should NOT be a message saying no members are found");
 
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1\">Show Protected</span>", "There should be a switch for protected properties");
 
         comp.Markup.Should().Contain("<td data-label=\"Name\" class=\"mud-table-cell  docs-content-api-cell\" id=\"CurrentView\">", "The \"CurrentView\" protected field should be visible");
     }
@@ -155,7 +155,7 @@ public sealed class ApiMemberTableTests : BunitTest
 
         comp.Markup.Should().Contain("<div class=\"mud-alert-message\">No members match the current filters.</div>", "There should be a message saying no members are found  (since the protected field was the ONLY field)");
 
-        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1 mud-switch mud-input-content-placement-end\">Show Protected</span>", "There should be a switch for protected properties");
+        comp.Markup.Should().Contain("<span class=\"mud-typography mud-typography-body1\">Show Protected</span>", "There should be a switch for protected properties");
 
         comp.Markup.Should().NotContain("<td data-label=\"Name\" class=\"mud-table-cell docs-content-api-cell\" id=\"CurrentView\">", "The \"CurrentView\" protected field should NOT be visible");
     }

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -92,12 +92,17 @@ namespace MudBlazor.UnitTests.Components
             // The label root still carries the mud-switch class.
             comp.Find(".s1 label.mud-switch").Should().NotBeNull();
 
-            // The inner label-text span must NOT reuse mud-switch (consistent with MudCheckBox/MudRadio);
-            // otherwise consumer CSS targeting .mud-switch would unintentionally style the label text too.
-            comp.Find(".s1 label.mud-switch span.mud-typography").ClassList.Should().NotContain("mud-switch");
+            // The inner label-text span must not reuse the control-root label classes.
+            // mud-switch and its content-placement modifier belong on the <label> only, matching MudCheckBox/MudRadio.
+            // Reusing them leaks consumer .mud-switch CSS onto the label text and gives the span an unintended inline-flex layout.
+            var labelSpan = comp.Find(".s1 label.mud-switch span.mud-typography").ClassList;
+            labelSpan.Should().NotContain("mud-switch");
+            labelSpan.Should().NotContain("mud-input-content-placement-end");
 
             // The ChildContent variant behaves the same.
-            comp.Find(".s3 label.mud-switch span.mud-typography").ClassList.Should().NotContain("mud-switch");
+            var childSpan = comp.Find(".s3 label.mud-switch span.mud-typography").ClassList;
+            childSpan.Should().NotContain("mud-switch");
+            childSpan.Should().NotContain("mud-input-content-placement-end");
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -85,27 +85,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public void Switch_LabelText_DoesNotReuseSwitchClass()
-        {
-            var comp = Context.Render<SwitchAriaLabelTest>();
-
-            // The label root still carries the mud-switch class.
-            comp.Find(".s1 label.mud-switch").Should().NotBeNull();
-
-            // The inner label-text span must not reuse the control-root label classes.
-            // mud-switch and its content-placement modifier belong on the <label> only, matching MudCheckBox/MudRadio.
-            // Reusing them leaks consumer .mud-switch CSS onto the label text and gives the span an unintended inline-flex layout.
-            var labelSpan = comp.Find(".s1 label.mud-switch span.mud-typography").ClassList;
-            labelSpan.Should().NotContain("mud-switch");
-            labelSpan.Should().NotContain("mud-input-content-placement-end");
-
-            // The ChildContent variant behaves the same.
-            var childSpan = comp.Find(".s3 label.mud-switch span.mud-typography").ClassList;
-            childSpan.Should().NotContain("mud-switch");
-            childSpan.Should().NotContain("mud-input-content-placement-end");
-        }
-
-        [Test]
         [TestCase(Color.Default, Color.Primary)]
         [TestCase(Color.Primary, Color.Secondary)]
         [TestCase(Color.Secondary, Color.Info)]

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -85,6 +85,22 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Switch_LabelText_DoesNotReuseSwitchClass()
+        {
+            var comp = Context.Render<SwitchAriaLabelTest>();
+
+            // The label root still carries the mud-switch class.
+            comp.Find(".s1 label.mud-switch").Should().NotBeNull();
+
+            // The inner label-text span must NOT reuse mud-switch (consistent with MudCheckBox/MudRadio);
+            // otherwise consumer CSS targeting .mud-switch would unintentionally style the label text too.
+            comp.Find(".s1 label.mud-switch span.mud-typography").ClassList.Should().NotContain("mud-switch");
+
+            // The ChildContent variant behaves the same.
+            comp.Find(".s3 label.mud-switch span.mud-typography").ClassList.Should().NotContain("mud-switch");
+        }
+
+        [Test]
         [TestCase(Color.Default, Color.Primary)]
         [TestCase(Color.Primary, Color.Secondary)]
         [TestCase(Color.Secondary, Color.Info)]

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -21,13 +21,13 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" Class="@LabelClassname" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @Label
                 </MudText>
             }
             @if (ChildContent != null)
             {
-                <MudText HtmlTag="span" Class="@LabelClassname" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }


### PR DESCRIPTION
`MudSwitch` applied its `LabelClassname` (`mud-switch`) to the outer `<label>` **and** to the inner label-text `<MudText>` spans (both `Label` and `ChildContent`). As a result `.mud-switch` matches both the control root and the label text, so consumer CSS targeting `.mud-switch` unintentionally styles the label text as well.

`MudCheckBox` and `MudRadio` derive from the same `MudBooleanInput<T>` base and use the same layout, but apply their label class only to the `<label>`; their inner text spans carry no class. That makes `MudSwitch` inconsistent with its sibling boolean inputs.

This PR removes `Class="@LabelClassname"` from the two inner `<MudText>` spans so `.mud-switch` targets only the control root, matching `MudCheckBox`/`MudRadio`. Disabled/error label-text color continues to flow via CSS `color` inheritance from `label.mud-switch`, and the `.mud-switch` container styles are unaffected.

### Behavior change

`.mud-switch` also supplied `display: inline-flex` to the inner text span, and the label-placement class (`mud-input-content-placement-end`) supplied `flex-direction: row` / `align-items: center` — so the span was an accidental flex row for its own children. Dropping the class reverts it to normal inline flow, matching `MudCheckBox`/`MudRadio`:

- `ChildContent` with multiple block-level elements (e.g. two `<MudText>`) now stacks vertically instead of laying out in a horizontal row.
- Content mixing text with an inline element (e.g. an icon) is baseline-aligned instead of vertically centered.

A single `Label` or single text node — the common case, and every docs example — is unchanged. To restore a centered horizontal row, wrap the content: `<div class="d-flex align-center gap-2">…</div>`.
