### PR TITLE
MudStepper: Add ActionsClass

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Stepper/StepperPage.razor
@@ -56,7 +56,8 @@
                 <Description>
                     The component can be customized via <CodeInline>@nameof(MudStepper.TitleTemplate)</CodeInline>, <CodeInline>@nameof(MudStepper.LabelTemplate)</CodeInline> and <CodeInline>@nameof(MudStepper.ConnectorTemplate)</CodeInline>.
                     You can also add a success message after the last step thanks to the <CodeInline>@nameof(MudStepper.CompletedContent)</CodeInline> fragment.<br />
-                    You can also replace the step action buttons (previous, skip and next) by providing alternative buttons via the<CodeInline>@nameof(MudStepper.ActionContent)</CodeInline> template.
+                    Use <CodeInline>@nameof(MudStepper.ActionsClass)</CodeInline> to apply custom styles, such as sticky positioning, to the action bar.<br />
+                    You can also replace the step action buttons (previous, skip and next) by providing alternative buttons via the <CodeInline>@nameof(MudStepper.ActionContent)</CodeInline> template.
                 </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(StepperCustomizationExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests/Components/StepperTests.cs
+++ b/src/MudBlazor.UnitTests/Components/StepperTests.cs
@@ -55,6 +55,17 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void ActionsClass_AppliesCustomClass_Issue13478()
+        {
+            var stepper = Context.Render<MudStepper>(self =>
+            {
+                self.Add(x => x.ActionsClass, "sticky-actions");
+            });
+
+            stepper.Find(".mud-stepper-actions").ClassList.Should().Contain("sticky-actions");
+        }
+
+        [Test]
         public async Task StepperStepContext_ShouldBeAvailableInsideChildContent()
         {
             MudStepContext? firstStepContext = null;

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -60,7 +60,7 @@
         @ChildContent
     </CascadingValue>
 
-    <MudCardActions Class="mud-stepper-actions">
+    <MudCardActions Class="@ActionsClassname">
         @if (ActionContent == null)
         {
             @if (ShowResetButton)

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -47,6 +47,11 @@ public partial class MudStepper : MudComponentBase
             .AddClass(NavClass)
             .Build();
 
+    protected string ActionsClassname =>
+        new CssBuilder("mud-stepper-actions")
+            .AddClass(ActionsClass)
+            .Build();
+
     internal string GetStepButtonId(MudStep step) => $"stepper-{_componentId}-tab-{step.FieldId}";
 
     internal string GetStepPanelId(MudStep step) => $"stepper-{_componentId}-tabpanel-{step.FieldId}";
@@ -219,6 +224,16 @@ public partial class MudStepper : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.List.Appearance)]
     public string? NavClass { get; set; }
+
+    /// <summary>
+    /// The CSS classes applied to the action bar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>. Multiple classes must be separated by spaces.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.List.Appearance)]
+    public string? ActionsClass { get; set; }
 
     /// <summary>
     /// Allows users to move between steps arbitrarily.


### PR DESCRIPTION
## Description

Adds an `ActionsClass` parameter to `MudStepper`, allowing consumers to apply custom CSS classes to the action bar that contains the reset, previous, skip, complete, and next controls.

This enables scenarios such as making the action bar sticky without requiring users to replace the entire `ActionContent` template.

Closes #13478.

## Changes

- Added the public `MudStepper.ActionsClass` parameter with XML documentation and the appropriate appearance category.
- Added an `ActionsClassname` CSS builder that preserves the existing `mud-stepper-actions` class and appends consumer-provided classes.
- Applied the composed class to `MudCardActions`.
- Added a bUnit regression test verifying that a custom action class is rendered.
- Updated the Stepper documentation to describe the new customization option.

## Impact

This is an additive, backward-compatible API change. Existing steppers retain the same markup and styling when `ActionsClass` is not set.

## Validation

- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-build --no-restore -- --filter "FullyQualifiedName~StepperTests" --output Normal --no-ansi --hangdump --hangdump-timeout 30s`
  - 37 tests passed.
- `dotnet test --project src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true -- --filter "FullyQualifiedName~Stepper" --output Normal --no-ansi --hangdump --hangdump-timeout 30s`
  - 10 generated documentation tests passed.
- Ran scoped whitespace formatting for all four changed files.
- `git diff --check` passed.

No screenshot is included because the change does not alter the default appearance; it only exposes an opt-in CSS class hook.

