### PR TITLE
MudHotkey: Make modifier matching side-agnostic

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Hotkey/Examples/HotkeyExampleChildContent.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hotkey/Examples/HotkeyExampleChildContent.razor
@@ -33,5 +33,5 @@
     private bool _disabled;
     private JsKey _selectedKey = JsKey.KeyA;
     private bool _hideChildContentOnRepress = true;
-    private IReadOnlyCollection<JsKeyModifier> _selectedKeyModifiers = [JsKeyModifier.ControlLeft];
+    private IReadOnlyCollection<JsKeyModifier> _selectedKeyModifiers = [JsKeyModifier.Control];
 }

--- a/src/MudBlazor.Docs/Pages/Components/Hotkey/Examples/HotkeyExampleEventCallback.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hotkey/Examples/HotkeyExampleEventCallback.razor
@@ -25,7 +25,7 @@
 
 @code {
     private JsKey _selectedKey = JsKey.KeyB;
-    private IReadOnlyCollection<JsKeyModifier> _selectedKeyModifiers = [JsKeyModifier.ControlLeft];
+    private IReadOnlyCollection<JsKeyModifier> _selectedKeyModifiers = [JsKeyModifier.Control];
 
     private void OnHotKey(HotkeyEventArgs args)
     {

--- a/src/MudBlazor.Docs/Shared/Appbar.razor
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor
@@ -1,7 +1,6 @@
 ﻿@using MudBlazor.Utilities
 
-<MudHotkey Key="JsKey.KeyK" KeyModifiers="CtrlLeftKeyModifiers" OnHotkeyPressed="HandleSearchHotkeyAsync" />
-<MudHotkey Key="JsKey.KeyK" KeyModifiers="CtrlRightKeyModifiers" OnHotkeyPressed="HandleSearchHotkeyAsync" />
+<MudHotkey Key="JsKey.KeyK" KeyModifiers="CtrlKeyModifiers" OnHotkeyPressed="HandleSearchHotkeyAsync" />
 
 <div class="d-flex align-center flex-grow-1 d-md-none">
     <MudIconButton OnClick="DrawerToggleCallback" Icon="@Icons.Material.Rounded.Notes" Color="Color.Inherit" Edge="Edge.Start" aria-label="Toggle drawer" />

--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -21,8 +21,7 @@ public partial class Appbar : IDisposable
     private MudAutocomplete<ApiLinkServiceEntry>? _searchBarAutocomplete;
     private MudAutocomplete<ApiLinkServiceEntry>? _searchDialogAutocomplete;
     private DialogOptions _dialogOptions = new() { Position = DialogPosition.TopCenter, NoHeader = true, CloseOnEscapeKey = true };
-    private static readonly JsKeyModifier[] CtrlLeftKeyModifiers = [JsKeyModifier.ControlLeft];
-    private static readonly JsKeyModifier[] CtrlRightKeyModifiers = [JsKeyModifier.ControlRight];
+    private static readonly JsKeyModifier[] CtrlKeyModifiers = [JsKeyModifier.Control];
 
     public bool IsSearchDialogOpen
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyEventArgsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyEventArgsTest.razor
@@ -3,8 +3,8 @@
 @* Several hotkeys wired to a single handler that tells them apart via HotkeyEventArgs.
    Includes two hotkeys on the SAME Key distinguished only by modifiers (issue #13125's motivation). *@
 <MudHotkey Key="JsKey.KeyA" OnHotkeyPressed="OnHotKey" />
-<MudHotkey Key="JsKey.KeyB" KeyModifiers="@(new[] { JsKeyModifier.ShiftLeft })" OnHotkeyPressed="OnHotKey" />
-<MudHotkey Key="JsKey.KeyB" KeyModifiers="@(new[] { JsKeyModifier.ControlLeft, JsKeyModifier.ShiftLeft })" OnHotkeyPressed="OnHotKey" />
+<MudHotkey Key="JsKey.KeyB" KeyModifiers="@(new[] { JsKeyModifier.Shift })" OnHotkeyPressed="OnHotKey" />
+<MudHotkey Key="JsKey.KeyB" KeyModifiers="@(new[] { JsKeyModifier.Control, JsKeyModifier.Shift })" OnHotkeyPressed="OnHotKey" />
 
 @code {
     public HotkeyEventArgs? LastArgs { get; private set; }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hotkey/MudHotkeyTest.razor
@@ -27,7 +27,7 @@
     public JsKey Key { get; set; } = JsKey.KeyA;
 
     [Parameter]
-    public IEnumerable<JsKeyModifier> KeyModifiers { get; set; } = [JsKeyModifier.ControlLeft];
+    public IEnumerable<JsKeyModifier> KeyModifiers { get; set; } = [JsKeyModifier.Control];
     
     [Parameter]
     public bool PreventEventPropagation { get; set; } = true;

--- a/src/MudBlazor.UnitTests/Components/MudHotkeyTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MudHotkeyTests.cs
@@ -19,6 +19,12 @@ namespace MudBlazor.UnitTests.Components;
 public class MudHotkeyTests : BunitTest
 {
     [Test]
+    public void Hotkey_ModifiersShouldBeSideAgnostic()
+    {
+        Enum.GetNames<JsKeyModifier>().Should().Equal("Shift", "Control", "Alt", "Meta");
+    }
+
+    [Test]
     public async Task Hotkey_ShouldShowChildContent()
     {
         // Arrange
@@ -63,16 +69,16 @@ public class MudHotkeyTests : BunitTest
         comp.Instance.LastArgs!.KeyModifiers.Should().BeEmpty();
         comp.Instance.LastArgs!.Sender.Should().BeSameAs(hotkeys[0].Instance);
 
-        // The second hotkey: KeyB + ShiftLeft.
+        // The second hotkey: KeyB + Shift.
         await comp.InvokeAsync(hotkeys[1].Instance.MudHotkeyProviderJsCallback);
         comp.Instance.LastArgs!.Key.Should().Be(JsKey.KeyB);
-        comp.Instance.LastArgs!.KeyModifiers.Should().ContainSingle().Which.Should().Be(JsKeyModifier.ShiftLeft);
+        comp.Instance.LastArgs!.KeyModifiers.Should().ContainSingle().Which.Should().Be(JsKeyModifier.Shift);
         comp.Instance.LastArgs!.Sender.Should().BeSameAs(hotkeys[1].Instance);
 
         // The third hotkey: SAME Key as the second, distinguished only by its (multiple) modifiers.
         await comp.InvokeAsync(hotkeys[2].Instance.MudHotkeyProviderJsCallback);
         comp.Instance.LastArgs!.Key.Should().Be(JsKey.KeyB);
-        comp.Instance.LastArgs!.KeyModifiers.Should().BeEquivalentTo([JsKeyModifier.ControlLeft, JsKeyModifier.ShiftLeft]);
+        comp.Instance.LastArgs!.KeyModifiers.Should().BeEquivalentTo([JsKeyModifier.Control, JsKeyModifier.Shift]);
         comp.Instance.LastArgs!.Sender.Should().BeSameAs(hotkeys[2].Instance);
 
         comp.Instance.PressedCount.Should().Be(3);
@@ -111,7 +117,7 @@ public class MudHotkeyTests : BunitTest
 
         await comp.SetParametersAndRenderAsync(p => p
             .Add(x => x.Key, JsKey.KeyB)
-            .Add(x => x.KeyModifiers, [JsKeyModifier.ShiftLeft])
+            .Add(x => x.KeyModifiers, [JsKeyModifier.Shift])
             .Add(x => x.PreventEventPropagation, false));
 
         // Shared handler, so only one update called

--- a/src/MudBlazor/TScripts/mudHotkeyListener.js
+++ b/src/MudBlazor/TScripts/mudHotkeyListener.js
@@ -92,35 +92,19 @@ class MudHotkeyListener {
         const pressedModifiers = new Set();
 
         if (e.ctrlKey) {
-            if (e.code === "ControlRight" || e.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
-                pressedModifiers.add("ControlRight");
-            } else {
-                pressedModifiers.add("ControlLeft");
-            }
+            pressedModifiers.add("Control");
         }
 
         if (e.shiftKey) {
-            if (e.code === "ShiftRight" || e.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
-                pressedModifiers.add("ShiftRight");
-            } else {
-                pressedModifiers.add("ShiftLeft");
-            }
+            pressedModifiers.add("Shift");
         }
 
         if (e.altKey) {
-            if (e.code === "AltRight" || e.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
-                pressedModifiers.add("AltRight");
-            } else {
-                pressedModifiers.add("AltLeft");
-            }
+            pressedModifiers.add("Alt");
         }
 
         if (e.metaKey) {
-            if (e.code === "MetaRight" || e.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
-                pressedModifiers.add("MetaRight");
-            } else {
-                pressedModifiers.add("MetaLeft");
-            }
+            pressedModifiers.add("Meta");
         }
 
         return pressedModifiers;

--- a/src/MudBlazor/Utilities/JsKeyModifier.cs
+++ b/src/MudBlazor/Utilities/JsKeyModifier.cs
@@ -1,16 +1,12 @@
 ﻿namespace MudBlazor.Utilities;
 
 /// <summary>
-/// Contains all Javascript modifier key code strings (using e.code standard).
+/// Contains the JavaScript modifier key names used by <see cref="MudHotkey"/>.
 /// </summary>
 public enum JsKeyModifier
 {
-    ShiftLeft,
-    ShiftRight,
-    ControlLeft,
-    ControlRight,
-    AltLeft,
-    AltRight,
-    MetaLeft,
-    MetaRight
+    Shift,
+    Control,
+    Alt,
+    Meta
 }


### PR DESCRIPTION
This makes `MudHotkey` modifiers side-agnostic so hotkeys work with either the left or right modifier key. As discussed in #13390, this is a breaking change intended for the next major version.

- collapse `JsKeyModifier` from left/right variants into `Shift`, `Control`, `Alt`, and `Meta`
- derive pressed modifiers from the `KeyboardEvent` modifier flags
- consolidate the duplicate Ctrl+K appbar hotkey registration
- update the Hotkey examples, viewer components, and unit tests

Fixes #13390

**Validation:**
- `MudHotkeyTests`: 6 passed
- normal `net10.0` asset build: 0 warnings, 0 errors, including JS lint and bundle generation
- generated Hotkey docs tests: 4 passed
- browser-verified left/right Ctrl+A, right Ctrl+B, and left/right Ctrl+K behavior

No visual changes.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
