### PR TITLE
Core: Degrade gracefully when the MudBlazor script isn't loaded

### DIFF
--- a/src/MudBlazor.UnitTests/Services/ScrollManagerTests.cs
+++ b/src/MudBlazor.UnitTests/Services/ScrollManagerTests.cs
@@ -118,14 +118,15 @@ public class ScrollManagerTests
     }
 
     [Test]
-    public async Task LockScrollAsync_PropagatesJsRuntimeError()
+    public async Task LockScrollAsync_SwallowsJsRuntimeError()
     {
-        // lockScroll must surface failures; only the unlock/dispose paths swallow them.
+        // Lock runs eagerly on overlay/dialog open, so a missing or disconnected script must degrade instead of tearing down the circuit.
+        // This mirrors UnlockScrollAsync; the pair are symmetric.
         SetupThrowingInvocation("mudScrollManager.lockScroll", new JSDisconnectedException("disconnected"));
 
         var act = async () => await _service.LockScrollAsync("#dialog", "locked");
 
-        await act.Should().ThrowAsync<JSDisconnectedException>();
+        await act.Should().NotThrowAsync();
     }
 
     [Test]

--- a/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
+++ b/src/MudBlazor/Extensions/ElementReferenceExtensions.cs
@@ -25,16 +25,16 @@ namespace MudBlazor
         }
 
         public static ValueTask MudFocusFirstAsync(this ElementReference elementReference, int skip = 0, int min = 0) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.focusFirst", elementReference, skip, min) ?? ValueTask.CompletedTask;
+            elementReference.GetJSRuntime()?.InvokeVoidAsyncIgnoreErrors("mudElementRef.focusFirst", elementReference, skip, min) ?? ValueTask.CompletedTask;
 
         public static ValueTask MudFocusLastAsync(this ElementReference elementReference, int skip = 0, int min = 0) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.focusLast", elementReference, skip, min) ?? ValueTask.CompletedTask;
+            elementReference.GetJSRuntime()?.InvokeVoidAsyncIgnoreErrors("mudElementRef.focusLast", elementReference, skip, min) ?? ValueTask.CompletedTask;
 
         public static ValueTask MudSaveFocusAsync(this ElementReference elementReference) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.saveFocus", elementReference) ?? ValueTask.CompletedTask;
+            elementReference.GetJSRuntime()?.InvokeVoidAsyncIgnoreErrors("mudElementRef.saveFocus", elementReference) ?? ValueTask.CompletedTask;
 
         public static ValueTask MudRestoreFocusAsync(this ElementReference elementReference) =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.restoreFocus", elementReference) ?? ValueTask.CompletedTask;
+            elementReference.GetJSRuntime()?.InvokeVoidAsyncIgnoreErrors("mudElementRef.restoreFocus", elementReference) ?? ValueTask.CompletedTask;
 
         public static ValueTask MudBlurAsync(this ElementReference elementReference) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.blur", elementReference) ?? ValueTask.CompletedTask;
@@ -48,25 +48,51 @@ namespace MudBlazor
         public static ValueTask MudChangeCssAsync(this ElementReference elementReference, string css) =>
             elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.changeCss", elementReference, css) ?? ValueTask.CompletedTask;
 
-        public static ValueTask<BoundingClientRect> MudGetBoundingClientRectAsync(this ElementReference elementReference) =>
-            elementReference.GetJSRuntime()?.InvokeAsync<BoundingClientRect>("mudElementRef.getBoundingClientRect", elementReference) ?? ValueTask.FromResult(new BoundingClientRect());
+        public static async ValueTask<BoundingClientRect> MudGetBoundingClientRectAsync(this ElementReference elementReference)
+        {
+            var jsRuntime = elementReference.GetJSRuntime();
+            if (jsRuntime is null)
+            {
+                return new BoundingClientRect();
+            }
 
-        public static ValueTask<int[]> AddDefaultPreventingHandlers(this ElementReference elementReference, string[] eventNames) =>
-            elementReference.GetJSRuntime()?.InvokeAsync<int[]>("mudElementRef.addDefaultPreventingHandlers", elementReference, eventNames) ?? new ValueTask<int[]>(Array.Empty<int>());
+            var (_, boundingClientRect) = await jsRuntime.InvokeAsyncWithErrorHandling(new BoundingClientRect(), "mudElementRef.getBoundingClientRect", elementReference);
+
+            return boundingClientRect;
+        }
+
+        public static async ValueTask<int[]> AddDefaultPreventingHandlers(this ElementReference elementReference, string[] eventNames)
+        {
+            var jsRuntime = elementReference.GetJSRuntime();
+            if (jsRuntime is null)
+            {
+                return Array.Empty<int>();
+            }
+
+            var (_, listenerIds) = await jsRuntime.InvokeAsyncWithErrorHandling(Array.Empty<int>(), "mudElementRef.addDefaultPreventingHandlers", elementReference, eventNames);
+
+            return listenerIds;
+        }
 
         public static ValueTask RemoveDefaultPreventingHandlers(this ElementReference elementReference, string[] eventNames, int[] listenerIds)
         {
+            // No handlers were attached (for example, the script was unavailable), so there is nothing to remove.
+            if (listenerIds.Length == 0)
+            {
+                return ValueTask.CompletedTask;
+            }
+
             if (eventNames.Length != listenerIds.Length)
             {
                 throw new ArgumentException($"Number of elements in {nameof(eventNames)} and {nameof(listenerIds)} has to match.");
             }
 
-            return elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.removeDefaultPreventingHandlers", elementReference, eventNames, listenerIds) ?? ValueTask.CompletedTask;
+            return elementReference.GetJSRuntime()?.InvokeVoidAsyncIgnoreErrors("mudElementRef.removeDefaultPreventingHandlers", elementReference, eventNames, listenerIds) ?? ValueTask.CompletedTask;
         }
 
         public static ValueTask MudAttachBlurEventWithJS<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(
             this ElementReference elementReference,
             DotNetObjectReference<T> obj) where T : class =>
-            elementReference.GetJSRuntime()?.InvokeVoidAsync("mudElementRef.addOnBlurEvent", elementReference, obj) ?? ValueTask.CompletedTask;
+            elementReference.GetJSRuntime()?.InvokeVoidAsyncIgnoreErrors("mudElementRef.addOnBlurEvent", elementReference, obj) ?? ValueTask.CompletedTask;
     }
 }

--- a/src/MudBlazor/Services/Scroll/ScrollManager.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollManager.cs
@@ -53,7 +53,7 @@ internal sealed class ScrollManager : IScrollManager
     // and maintain the proper lock. IF YOU CHANGE THIS, CHANGE THE JAVASCRIPT AS WELL
     /// <inheritdoc />
     public ValueTask LockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>
-        _jSRuntime.InvokeVoidAsync("mudScrollManager.lockScroll", selector, cssClass);
+        _jSRuntime.InvokeVoidAsyncIgnoreErrors("mudScrollManager.lockScroll", selector, cssClass);
 
     /// <inheritdoc />
     public ValueTask UnlockScrollAsync(string selector = "body", string cssClass = "scroll-locked") =>


### PR DESCRIPTION
Fixes #13477 and Supersedes #13484.

## Problem

When the host page doesn't load `_content/MudBlazor/MudBlazor.min.js` — a forgotten `<script>` tag, a wrong path, or the bundle failing to load/execute (e.g. an old WebView) — `window.mudElementRef` / `window.mudScrollManager` are `undefined`. The first **eager** interop call then throws a `JSException` out of a lifecycle method and tears down the entire circuit; the user just sees "An unhandled error has occurred."

This isn't only the reported `<MudTextField>`. The same eager, un-guarded interop hits every dialog (`MudFocusTrap.saveFocus`/`focusFirst`), `MudDrawer`/`MudTabs` (`getBoundingClientRect`), and overlay/dialog open (`ScrollManager.lockScroll`). These are the last eager interop calls that didn't already tolerate a missing script.

## Fix

Route the eager, lifecycle-invoked interop through the **existing** error-handling helpers — no new exception handling, no logging, no new types.

- `ElementReferenceExtensions`: `focusFirst`/`focusLast`/`saveFocus`/`restoreFocus`/`addOnBlurEvent` → `InvokeVoidAsyncIgnoreErrors`; `getBoundingClientRect`/`addDefaultPreventingHandlers` → `InvokeAsyncWithErrorHandling` with a fallback. `RemoveDefaultPreventingHandlers` short-circuits when nothing was attached so a skipped add can't throw a length-mismatch on teardown.
- `ScrollManager.LockScrollAsync` → `InvokeVoidAsyncIgnoreErrors`, symmetric with `UnlockScrollAsync`. The `LockScrollAsync_PropagatesJsRuntimeError` test becomes `_SwallowsJsRuntimeError`: the old "lock must surface failures" invariant *was* the asymmetry that crashed dialog/overlay open.
- User-action-only calls (`blur`/`select`/`selectRange`/`changeCss`) stay raw — they never run eagerly.

Degradation is silent, consistent with every other interop call in these files.