### PR TITLE
Auto-load a version-stamped script via a Blazor JS initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,6 +379,7 @@ FodyWeavers.xsd
 **/MudBlazor.min.js
 **/MudBlazor.min.js.gz
 **/MudBlazor.min.js.map
+src/MudBlazor/wwwroot/MudBlazor.lib.module.js
 **/MudBlazorDocs.min.css
 **/MudBlazorDocs.css
 **/MudBlazorDocs.min.css.map

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -70,12 +70,24 @@
                         new CodeFile("WebAssembly Standalone", nameof(InstallationManualCssFontsExampleWasmStandalone)),
                     ])" />
                     <SectionHeader Class="mt-6">
-                        <Description>Next, add the MudBlazor js file next to the default Blazor script at the end:</Description>
+                        <Description>
+                            MudBlazor loads its script automatically, so the following reference is optional.
+                            Adding it next to the default Blazor script is still recommended on .NET 9 or later so that
+                            <CodeInline>@@Assets[""]</CodeInline> fingerprints the file for cache busting;
+                            auto-loading detects the reference and won't load the script twice.
+                        </Description>
                     </SectionHeader>
                     <SectionContent Codes="@([
                         new CodeFile(".NET 9", nameof(InstallScriptManual)),
                         new CodeFile("WebAssembly Standalone", nameof(InstallScriptManualWasmStandalone)),
                     ])" />
+                    <SectionHeader Class="mt-6">
+                        <Description>
+                            To disable auto-loading entirely, for example under a strict Content Security Policy,
+                            set <CodeInline>window.mudBlazorNoAutoLoad = true</CodeInline> in a script before the Blazor script.
+                            Blazor Hybrid apps on WebView packages older than 8.0.4 don't run JavaScript initializers and still require the manual reference.
+                        </Description>
+                    </SectionHeader>
                     <SectionHeader Class="mt-6">
                         <Description>
                             On .NET 9 or later, ensure that the <CodeInline>app.MapStaticAssets()</CodeInline> middleware

--- a/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
+++ b/src/MudBlazor.Docs/Pages/Getting Started/Installation/Installation.razor
@@ -71,10 +71,11 @@
                     ])" />
                     <SectionHeader Class="mt-6">
                         <Description>
-                            MudBlazor loads its script automatically, so the following reference is optional.
-                            Adding it next to the default Blazor script is still recommended on .NET 9 or later so that
-                            <CodeInline>@@Assets[""]</CodeInline> fingerprints the file for cache busting;
-                            auto-loading detects the reference and won't load the script twice.
+                            MudBlazor's script loads automatically with the package version as a cache-busting query,
+                            so no script reference is needed.
+                            Add one manually only to control script order or satisfy a strict Content Security Policy —
+                            auto-loading detects the reference and won't load the script twice — or on Blazor Hybrid with
+                            WebView packages older than 8.0.4, which don't run JavaScript initializers:
                         </Description>
                     </SectionHeader>
                     <SectionContent Codes="@([
@@ -83,9 +84,8 @@
                     ])" />
                     <SectionHeader Class="mt-6">
                         <Description>
-                            To disable auto-loading entirely, for example under a strict Content Security Policy,
-                            set <CodeInline>window.mudBlazorNoAutoLoad = true</CodeInline> in a script before the Blazor script.
-                            Blazor Hybrid apps on WebView packages older than 8.0.4 don't run JavaScript initializers and still require the manual reference.
+                            To disable auto-loading entirely, set <CodeInline>window.mudBlazorNoAutoLoad = true</CodeInline>
+                            in a script before the Blazor script.
                         </Description>
                     </SectionHeader>
                     <SectionHeader Class="mt-6">

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -67,6 +67,7 @@
       <FilesToClean Include="./TScripts/combined/MudBlazor.js" />
       <FilesToClean Include="./wwwroot/MudBlazor.min.js" />
       <FilesToClean Include="./wwwroot/MudBlazor.min.js.map" />
+      <FilesToClean Include="./wwwroot/MudBlazor.lib.module.js" />
       <FilesToClean Include="./wwwroot/MudBlazor.min.css" />
       <FilesToClean Include="./wwwroot/MudBlazor.css" />
       <FilesToClean Include="./wwwroot/css/MudBlazor.css" />
@@ -107,7 +108,7 @@
     <ScssAssetInputs Include="Styles/**/*.scss" />
     <WebAssetInputs Include="@(JsAssetInputs);@(ScssAssetInputs)" />
     <UpToDateCheckInput Include="@(WebAssetInputs)" />
-    <WebAssetOutputs Include="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.js.map;wwwroot/MudBlazor.min.css" />
+    <WebAssetOutputs Include="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.js.map;wwwroot/MudBlazor.lib.module.js;wwwroot/MudBlazor.min.css" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -129,7 +130,8 @@
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 
     <Exec Command="$(BunWrapper) run build.mjs"
-          WorkingDirectory="$(MSBuildProjectDirectory)" />
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          EnvironmentVariables="MUD_VERSION=$(Version)" />
   </Target>
 
   <Target Name="BuildWebAssetsInner"
@@ -148,7 +150,8 @@
           WorkingDirectory="$(MSBuildProjectDirectory)" />
 
     <Exec Command="$(BunWrapper) run build.mjs"
-          WorkingDirectory="$(MSBuildProjectDirectory)" />
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          EnvironmentVariables="MUD_VERSION=$(Version)" />
   </Target>
 
   <Target Name="RegisterGeneratedAssets"

--- a/src/MudBlazor/TScripts/MudBlazor.lib.module.js
+++ b/src/MudBlazor/TScripts/MudBlazor.lib.module.js
@@ -1,4 +1,8 @@
 // Blazor JS initializer: auto-loads MudBlazor.min.js so consumers don't have to add the <script> tag manually.
+// build.mjs stamps the package version and emits this file to wwwroot; it is not part of the bundle.
+
+// Cache-busts the bundle across MudBlazor updates.
+const MUD_VERSION = "__MUD_VERSION__";
 
 function alreadyLoaded() {
     // Opt-out for consumers who want to control script placement/order themselves.
@@ -20,16 +24,17 @@ function loadMudScript() {
     }
 
     // Resolve the bundle relative to this module so a non-root <base href> still works.
-    const scriptUrl = new URL('MudBlazor.min.js', import.meta.url).href;
+    const scriptUrl = new URL('MudBlazor.min.js', import.meta.url);
+    scriptUrl.searchParams.set('v', MUD_VERSION);
 
     return new Promise((resolve) => {
         const script = document.createElement('script');
-        script.src = scriptUrl;
+        script.src = scriptUrl.href;
         script.dataset.mudblazor = '';
         // Never block Blazor startup: resolve on error too. A failed load is handled by MudBlazor's own graceful-degradation (interop calls no-op instead of crashing).
         script.onload = () => resolve();
         script.onerror = () => {
-            console.error(`MudBlazor: failed to load ${scriptUrl}. Interactive features will not work.`);
+            console.error(`MudBlazor: failed to load ${scriptUrl.href}. Interactive features will not work.`);
             resolve();
         };
         document.head.appendChild(script);

--- a/src/MudBlazor/build.mjs
+++ b/src/MudBlazor/build.mjs
@@ -22,6 +22,8 @@ const scriptDirectory = path.dirname(scriptFilename);
 const jsDirectory = path.join(scriptDirectory, "TScripts");
 const jsEntrypoint = path.join(scriptDirectory, "TScripts/entrypoint.js");
 const jsOutputFile = path.join(scriptDirectory, "wwwroot/MudBlazor.min.js");
+const initializerInput = path.join(scriptDirectory, "TScripts/MudBlazor.lib.module.js");
+const initializerOutput = path.join(scriptDirectory, "wwwroot/MudBlazor.lib.module.js");
 const scssInput = path.join(scriptDirectory, "Styles/MudBlazor.scss");
 const scssInputDir = path.dirname(scssInput);
 const scssOutput = path.join(scriptDirectory, "wwwroot/MudBlazor.min.css");
@@ -69,6 +71,20 @@ async function buildJS() {
         },
         sourcemap: "linked",
     });
+
+    timer.stop();
+}
+
+function buildInitializer() {
+    console.log("Writing JS initializer", initializerOutput);
+    const timer = startTimer("build-initializer");
+
+    // The JS initializer is not bundled; it is emitted verbatim with the package version stamped in
+    // so it can cache-bust MudBlazor.min.js across updates. MSBuild passes MUD_VERSION to build.mjs.
+    const version = process.env.MUD_VERSION || "dev";
+    const content = fs.readFileSync(initializerInput, "utf8").replace("__MUD_VERSION__", version);
+    fs.mkdirSync(path.dirname(initializerOutput), { recursive: true });
+    fs.writeFileSync(initializerOutput, content);
 
     timer.stop();
 }
@@ -126,6 +142,7 @@ function buildSCSS() {
 async function buildAll() {
     await eslint();
     await buildJS();
+    buildInitializer();
     buildSCSS();
     printTimings();
 }
@@ -148,6 +165,7 @@ if (process.argv.includes("watch")) {
             try {
                 await eslint();
                 await buildJS();
+                buildInitializer();
                 printTimings();
             } catch (e) {
                 console.error("JS build failed:", e);

--- a/src/MudBlazor/wwwroot/MudBlazor.lib.module.js
+++ b/src/MudBlazor/wwwroot/MudBlazor.lib.module.js
@@ -1,0 +1,54 @@
+// Blazor JS initializer: auto-loads MudBlazor.min.js so consumers don't have to add the
+// <script> tag manually. Addresses the recurring "mudElementRef undefined" circuit crash
+// (#13477) and the install-step request (#8098).
+//
+// CSS is deliberately NOT auto-injected here — injecting a stylesheet after prerender causes
+// a flash of unstyled content, which is the SSR concern that stalled #8098.
+
+function alreadyLoaded() {
+    // Opt-out for consumers who want to control script placement/order themselves.
+    if (window.mudBlazorNoAutoLoad === true) {
+        return true;
+    }
+
+    // Globals already present (bundle executed), or a manual <script> reference exists.
+    if (window.mudElementRef) {
+        return true;
+    }
+
+    return !!document.querySelector('script[data-mudblazor], script[src*="MudBlazor.min.js"]');
+}
+
+function loadMudScript() {
+    if (alreadyLoaded()) {
+        return Promise.resolve();
+    }
+
+    // Resolve the bundle relative to this module so a non-root <base href> still works.
+    const scriptUrl = new URL('MudBlazor.min.js', import.meta.url).href;
+
+    return new Promise((resolve) => {
+        const script = document.createElement('script');
+        script.src = scriptUrl;
+        script.setAttribute('data-mudblazor', '');
+        // Never block Blazor startup: resolve on error too. A failed load is handled by
+        // MudBlazor's own graceful-degradation (interop calls no-op instead of crashing).
+        script.onload = () => resolve();
+        script.onerror = () => {
+            console.error(`MudBlazor: failed to load ${scriptUrl}. Interactive features will not work.`);
+            resolve();
+        };
+        document.head.appendChild(script);
+    });
+}
+
+// Blazor Web App (blazor.web.js, .NET 8+). Runs before the interactive runtime starts;
+// returning the promise makes Blazor await the script so globals exist before components render.
+export function beforeWebStart() {
+    return loadMudScript();
+}
+
+// Classic Blazor Server (blazor.server.js), standalone WASM (blazor.webassembly.js), and Hybrid (MAUI).
+export function beforeStart() {
+    return loadMudScript();
+}

--- a/src/MudBlazor/wwwroot/MudBlazor.lib.module.js
+++ b/src/MudBlazor/wwwroot/MudBlazor.lib.module.js
@@ -25,7 +25,7 @@ function loadMudScript() {
     return new Promise((resolve) => {
         const script = document.createElement('script');
         script.src = scriptUrl;
-        script.setAttribute('data-mudblazor', '');
+        script.dataset.mudblazor = '';
         // Never block Blazor startup: resolve on error too. A failed load is handled by MudBlazor's own graceful-degradation (interop calls no-op instead of crashing).
         script.onload = () => resolve();
         script.onerror = () => {

--- a/src/MudBlazor/wwwroot/MudBlazor.lib.module.js
+++ b/src/MudBlazor/wwwroot/MudBlazor.lib.module.js
@@ -1,9 +1,4 @@
-// Blazor JS initializer: auto-loads MudBlazor.min.js so consumers don't have to add the
-// <script> tag manually. Addresses the recurring "mudElementRef undefined" circuit crash
-// (#13477) and the install-step request (#8098).
-//
-// CSS is deliberately NOT auto-injected here — injecting a stylesheet after prerender causes
-// a flash of unstyled content, which is the SSR concern that stalled #8098.
+// Blazor JS initializer: auto-loads MudBlazor.min.js so consumers don't have to add the <script> tag manually.
 
 function alreadyLoaded() {
     // Opt-out for consumers who want to control script placement/order themselves.
@@ -31,8 +26,7 @@ function loadMudScript() {
         const script = document.createElement('script');
         script.src = scriptUrl;
         script.setAttribute('data-mudblazor', '');
-        // Never block Blazor startup: resolve on error too. A failed load is handled by
-        // MudBlazor's own graceful-degradation (interop calls no-op instead of crashing).
+        // Never block Blazor startup: resolve on error too. A failed load is handled by MudBlazor's own graceful-degradation (interop calls no-op instead of crashing).
         script.onload = () => resolve();
         script.onerror = () => {
             console.error(`MudBlazor: failed to load ${scriptUrl}. Interactive features will not work.`);
@@ -42,8 +36,7 @@ function loadMudScript() {
     });
 }
 
-// Blazor Web App (blazor.web.js, .NET 8+). Runs before the interactive runtime starts;
-// returning the promise makes Blazor await the script so globals exist before components render.
+// Blazor Web App (blazor.web.js, .NET 8+). Runs before the interactive runtime starts; returning the promise makes Blazor await the script so globals exist before components render.
 export function beforeWebStart() {
     return loadMudScript();
 }


### PR DESCRIPTION
Closes #8098. Related: #13477, #13509.

MudBlazor's script now loads automatically via a Blazor JS initializer (`MudBlazor.lib.module.js`), removing the `<script>` install step — the source of one of our most recurring support patterns (#13477, and four issues from a single docs typo: #11572, #11558, #11555, #11525).

- `build.mjs` stamps `$(Version)` into the initializer, which loads `MudBlazor.min.js?v={version}` — so every MudBlazor update busts the browser cache. This covers .NET 8 and WebAssembly Standalone too, which never had `@Assets` fingerprinting, and avoids reintroducing the stale-cache class (#13486) that fingerprinting solved on .NET 9.
- `beforeWebStart` covers Blazor Web Apps (all render modes; avoids dotnet/aspnetcore#54049 on .NET 8/9); classic `beforeStart` covers Server, WASM Standalone, and Hybrid. The load is awaited, so the globals exist before any component renders.
- Skips loading when the bundle already executed, a manual `<script>` tag is present, or `window.mudBlazorNoAutoLoad = true` (strict CSP / custom ordering). The bundle isn't idempotent, so the guard is load-bearing.
- Hybrid needs Microsoft.AspNetCore.Components.WebView 8.0.4+ for initializers; older setups keep the manual tag and behave exactly as today.
- The initializer source lives in `TScripts` and the `wwwroot` copy is a generated output like `MudBlazor.min.js`. The version is stamped when the assets build, so CI's clean release builds always carry the release version.
- Docs: the script reference step is now optional, kept only for CSP/ordering/older Hybrid.

Ant Design Blazor and Microsoft's FluentUI-Blazor ship the same initializer pattern.

Verified in a Release .NET 10 Blazor Web App (InteractiveServer): no tag → bundle auto-injects as `MudBlazor.min.js?v=9.9.9-test`, globals defined before first render, dialogs/tabs/drawer work; manual tag kept → no double-load, exactly one script.
