### PR TITLE
Build: Assign AutoTriage primary labels regardless of author

### DIFF
--- a/.github/AutoTriage.prompt
+++ b/.github/AutoTriage.prompt
@@ -48,7 +48,7 @@ Reproductions:
 - Apply or remove labels from this section based on the label's description. All other repository labels require specific policy rule authorization (not from the label description alone).
 - Do not add or remove labels previously set by you or a maintainer unless both conditions are true: (a) new context has been added (e.g., new reproduction, logs, confirmations), and (b) a specific rule in this policy authorizes the change.
 
-Primary labels (apply best fit):
+Primary labels (always assign the single best fit to any open thread that lacks one, regardless of author):
 `bug`, `enhancement`, `docs`, `build`, `tests`, `refactor`, `new component`, `question`, `invalid`
 - When changing an existing primary label, always post a comment citing the trigger
 


### PR DESCRIPTION
## Problem

AutoTriage intermittently leaves maintainer-authored PRs without a primary label (`bug`, `enhancement`, …), so they end up being labeled by hand.

The PR pass runs pro-only, and the model sometimes over-generalizes this policy's many maintainer/bot carve-outs (information-request comments, `help wanted`, `awaiting triage`, inactivity, title edits) into "do nothing on maintainer PRs." Combined with the harness's default-forbidden stance, the ambiguity resolves to an empty action plan.

It's nondeterministic — near-identical maintainer bug-fixes split on it. From the runs' own reasoning traces:

- #13509 → applied `bug` ("it's a bug fix… I'll apply the `bug` label").
- #13510 → applied nothing ("it is a bug fix, so I can apply `bug`, **however, since the author is a maintainer, I should do nothing**").
- #13507 → applied nothing ("since the author is a maintainer, most automation is bypassed per policy").

## Fix

Reword the Primary-labels line from the permissive *"apply best fit"* to an imperative, author-independent directive. Under the default-forbidden harness, permission-flavored wording is too weak to overcome the inaction bias; *"always assign … regardless of author"* gives the explicit authorization the model needs and directly rebuts the maintainer-suppression reasoning. It also sidesteps the misreading of the *"labels previously set by … a maintainer"* clause, which only guards labels already present.

Prompt-only — the AutoTriage harness and workflow config are untouched.
