### PR TITLE
Build: Raise AutoTriage backlog sweep items

### DIFF
--- a/.github/workflows/autotriage-backlog.yml
+++ b/.github/workflows/autotriage-backlog.yml
@@ -18,7 +18,7 @@ on:
         description: "Max number of runs"
         type: number
         required: false
-        default: 20
+        default: 30
       extended:
         description: "Enable extended analysis"
         type: boolean
@@ -71,7 +71,7 @@ jobs:
           issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt
           dry-run: ${{ github.event_name != 'schedule' && inputs['dry-run'] }}
-          max-fast-runs: ${{ github.event_name == 'workflow_dispatch' && inputs['max-fast-runs'] || 20 }}
+          max-fast-runs: ${{ github.event_name == 'workflow_dispatch' && inputs['max-fast-runs'] || 30 }}
           extended: ${{ github.event_name == 'workflow_dispatch' && inputs['extended'] || true }}
           model-fast: ${{ github.event_name == 'workflow_dispatch' && inputs['model-fast'] || 'gemini-3.5-flash-lite' }}
           model-pro: ${{ github.event_name == 'workflow_dispatch' && inputs['model-pro'] || 'gemini-3.6-flash' }}


### PR DESCRIPTION
Raises the daily backlog sweep from 20 to 30 items per run (workflow_dispatch default updated to match).

**Why:** the backlog auto-discovery currently finds ~900 open items, so at 20/day a full cycle takes ~45 days. 30/day brings that to ~30 days for very little money:

| | items/run | est. cost/yr¹ | full backlog cycle |
|---|---|---|---|
| today | 20 | ~$26 | ~45 days |
| this PR | 30 | ~$38 | ~30 days |

¹ Measured from `run-summary.json` telemetry across the 32 most recent backlog runs (avg per item: fast ≈ 2.4k fresh + 7.0k cached input, ~1.4k billed output; 9.2% escalate to the pro model at ~4.0k fresh + 8.9k cached input, ~2.2k billed output), priced at current Gemini flex-tier rates for the models the workflow now uses.

Headroom checks:
- Escalations rise from ~1.9 to ~2.8 per run — nowhere near the `max-pro-runs: 20` cap.
- Model time per run goes from ~4 to ~6 minutes; the job stays well inside runner limits.
- The fast-pass screen-out rate has been stable at ~91% over 74 runs, so the extra items are overwhelmingly cheap fast-pass calls.
