### PR TITLE
Build: Tighten AutoTriage rules the fast pass misapplies

### DIFF
--- a/.github/AutoTriage.prompt
+++ b/.github/AutoTriage.prompt
@@ -46,18 +46,18 @@ Reproductions:
 
 ### Basic Labeling
 - Apply or remove labels from this section based on the label's description. All other repository labels require specific policy rule authorization (not from the label description alone).
-- Do not add or remove labels previously set by you or a maintainer unless both conditions are true: (a) new context has been added (e.g., new reproduction, logs, confirmations), and (b) a specific rule in this policy authorizes the change.
+- Do not add or remove labels previously set by you or a maintainer unless both conditions are true: (a) new context has been added (e.g., new reproduction, logs, confirmations), and (b) a specific rule in this policy authorizes the change. Never remove a label solely because its criteria no longer appear to be met on re-reading; removal must cite a specific timeline event, dated after the label was applied, that resolves it.
 
 Primary labels (always assign the single best fit to any open thread that lacks one, regardless of author):
 `bug`, `enhancement`, `docs`, `build`, `tests`, `refactor`, `new component`, `question`, `invalid`
-- When changing an existing primary label, always post a comment citing the trigger
+- When changing an existing primary label, post a comment citing the new information that triggered the change. Never post a comment whose only content announces or explains your own labeling actions.
 
 Secondary labels (apply as many as needed; only when core focus):
 `accessibility`, `dependency`, `localization`, `security`, `performance`
 
 Environment Labels (apply at most one per category):
 `blazor: wasm`, `blazor: server`, `blazor: hybrid`, `browser: chromium`, `browser: safari`, `browser: firefox`, `device: mobile`
-- Only add an environment label when the impact is exclusive to that environment. Required evidence — one of: (a) explicit "only in X, not in Y" statement; (b) repro shows failure in X and pass in Y; or (c) cited, known env-specific code path. Never add based on template selections, title/body mentions, or author setup alone. If multiple environments are mentioned without contrast, add none. Remove conflicting or unjustified env labels silently.
+- Only add an environment label when the impact is exclusive to that environment. Required evidence — one of: (a) explicit "only in X, not in Y" statement; (b) repro shows failure in X and pass in Y; or (c) cited, known env-specific code path. Never add based on template selections, title/body mentions, author setup alone, or because the described symptom is commonly associated with one environment. If multiple environments are mentioned without contrast, add none. Remove conflicting or unjustified env labels silently.
 
 Misc labels:
 `API change`, `regression`, `breaking change`, `has workaround`
@@ -205,7 +205,7 @@ General Inactivity Rules:
 Mark issues as `stale` when ONE of these inactivity thresholds are met. For the time-based thresholds, only a comment by a human (non-bot) account counts as activity: bot comments, bot actions, and labeled/unlabeled/renamed/assigned/unassigned events never reset the clock. Measure elapsed time from the last human comment, or from the issue's creation date if there are none.
 - Bug: >=18 months since the last human activity
 - Feature: >=36 months since the last human activity
-- Has `question`, `answered`, `not a bug`, `not planned`, `duplicate`, `invalid`, `fixed`, or any `needs:` label for >=28 consecutive days.
+- Has `question`, `answered`, `not a bug`, `not planned`, `duplicate`, `invalid`, `fixed`, or any `needs:` label for >=28 consecutive days. This label list is exhaustive; no other label (e.g. `has workaround`) makes an issue eligible for `stale`.
 
 Post this comment verbatim (exclude default footer) when marking an issue stale:
 ```


### PR DESCRIPTION
Four one-line tightenings of `.github/AutoTriage.prompt`, each targeting a failure mode observed in the backlog sweep's fast pass. Same approach as #13369, which measurably worked (spurious `help wanted` proposals dropped from 1.5% to 0.4% of screened items after it landed).

Evidence base: all 74 retained backlog runs (2026-05-12 → 2026-07-21), 1,732 fast-pass decisions, 150 fast-vs-pro comparisons. The pro pass vetoed 20% of fast escalations; these edits close the recurring gaps behind those vetoes.

**1. Label removal must cite a resolving event** (Basic Labeling)
Fast re-derives a label's criteria on re-sweep and removes it when they "no longer appear met" — e.g. #1897 (`good first issue`), #7455 (`stale`); 9 of 30 vetoed escalations were removals. Removal now requires citing a timeline event dated after the label was applied.

**2. No self-announcing comments** (primary labels)
"always post a comment citing the trigger" produced comments whose entire content narrates the bot's own labeling (#12034, #12488) — the fast model was *obeying* the rule. Reworded to require citing the new information, and to prohibit comments that only announce a labeling action.

**3. Environment labels: symptom association is not evidence**
#13426 got `blazor: server` proposed because the *described symptom* (circuit termination) is associated with Server. Added to the existing never-add list.

**4. The stale-qualifying label list is exhaustive**
On #11650 the fast pass drafted the auto-close warning citing "`has workaround` label for >28 days" — a trigger that doesn't exist in the policy (the pro pass caught it). The list now says no other label qualifies, naming `has workaround` explicitly.

No rule semantics change for cases that were being handled correctly; each edit only forbids a specific unauthorized inference.
