### PR TITLE
MudThemeProvider: Log guidance when the MudBlazor script is missing

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -3,6 +3,9 @@ using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.ThemeProvider;
 using MudBlazor.Utilities;
@@ -676,6 +679,31 @@ namespace MudBlazor.UnitTests.Components
 
             // Assert - should be light palette again
             comp.Instance.GetCurrentPalette().Should().BeOfType<PaletteLight>();
+        }
+
+        [Test]
+        public void FirstRender_WithoutScript_LogsGuidance()
+        {
+            // window.mudElementRef missing means MudBlazor.min.js never loaded; interop degrades silently, so surface the one actionable hint.
+            var loggerMock = new Mock<ILogger<MudThemeProvider>>();
+            Context.Services.AddSingleton(loggerMock.Object);
+            Context.JSInterop.Setup<bool>("window.hasOwnProperty", "mudElementRef").SetResult(false);
+
+            Context.Render<MudThemeProvider>();
+
+            loggerMock.VerifyLogging(MudThemeProvider.MissingScriptMessage, LogLevel.Error, Times.Once());
+        }
+
+        [Test]
+        public void FirstRender_WithScript_DoesNotLog()
+        {
+            var loggerMock = new Mock<ILogger<MudThemeProvider>>();
+            Context.Services.AddSingleton(loggerMock.Object);
+            Context.JSInterop.Setup<bool>("window.hasOwnProperty", "mudElementRef").SetResult(true);
+
+            Context.Render<MudThemeProvider>();
+
+            loggerMock.VerifyLogging(MudThemeProvider.MissingScriptMessage, LogLevel.Error, Times.Never());
         }
     }
 }

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -32,8 +33,17 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
 
     private event Func<bool, Task>? DarkModeChanged;
 
+    internal const string MissingScriptMessage =
+        "MudBlazor's JavaScript was not found, so interactive features will not work. " +
+        "Reference the script in your host page (App.razor or index.html) after the Blazor script: <script src=\"_content/MudBlazor/MudBlazor.min.js\"></script>. " +
+        "If it is already referenced, confirm it returns HTTP 200 in the browser's Network tab and hard-refresh to rule out a stale cache. " +
+        "See https://mudblazor.com/getting-started/installation";
+
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = null!;
+
+    [Inject]
+    private ILogger<MudThemeProvider> Logger { get; set; } = null!;
 
     /// <summary>
     /// The theme used by the application.
@@ -153,6 +163,8 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     {
         if (firstRender)
         {
+            await WarnIfScriptMissingAsync();
+
             if (_observeSystemDarkModeChangeState.Value && !_observing)
             {
                 _observing = true;
@@ -161,6 +173,17 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
         }
 
         await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private async Task WarnIfScriptMissingAsync()
+    {
+        // Positive presence probe through a browser built-in, so a genuine error inside the script is never mislabeled as a missing script.
+        // Interop calls degrade silently when the script is absent; this surfaces the one actionable hint.
+        var (ran, present) = await JsRuntime.InvokeAsyncWithErrorHandling(true, "window.hasOwnProperty", "mudElementRef");
+        if (ran && !present)
+        {
+            Logger.LogError(MissingScriptMessage);
+        }
     }
 
     // <inheritdoc />


### PR DESCRIPTION
Follow-up to #13509: interop now degrades silently when `_content/MudBlazor/MudBlazor.min.js` isn't loaded, so a misconfigured app has no error anywhere pointing at the cause. Related: #13477.

`MudThemeProvider` probes for `window.mudElementRef` once on first render and logs one actionable error when it's absent:

> MudBlazor's JavaScript was not found, so interactive features will not work. Reference the script in your host page (App.razor or index.html) after the Blazor script: `<script src="_content/MudBlazor/MudBlazor.min.js"></script>`. If it is already referenced, confirm it returns HTTP 200 in the browser's Network tab and hard-refresh to rule out a stale cache. See https://mudblazor.com/getting-started/installation

- The probe calls `window.hasOwnProperty("mudElementRef")` — a browser built-in that exists regardless of MudBlazor's bundle. A positive presence check is deterministic: a genuine error inside the script can never be mislabeled as a missing script, unlike catching `JSException`.
- Logs only when the probe actually ran and returned false, so prerender and disconnect paths can't false-log.
- Gated on first render — once per circuit, the same cadence as the missing-provider log from #13485, and the same `internal const` message + `VerifyLogging` test pattern.
