### PR TITLE
MudChart: Allow clicking legend label to toggle series visibility

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -435,6 +435,107 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
+        public void BarChart_LegendLabel_HasTabIndexAndRoleButton_WhenCanHideSeries()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.CanHideSeries, true));
+
+            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
+            legendLabels.Count.Should().Be(chartSeries.Count);
+
+            foreach (var label in legendLabels)
+            {
+                label.GetAttribute("tabindex").Should().Be("0", "label must be keyboard-focusable");
+                label.GetAttribute("role").Should().Be("button", "label must be announced as a button to assistive technologies");
+            }
+        }
+
+        [Test]
+        public async Task BarChart_LegendLabel_EnterKey_TogglesVisibility()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.CanHideSeries, true));
+
+            chartSeries[0].Visible.Should().BeTrue("Series 1 should be visible initially");
+
+            var label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
+            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Enter" });
+
+            chartSeries[0].Visible.Should().BeFalse("pressing Enter on the label should hide Series 1");
+
+            label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
+            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Enter" });
+
+            chartSeries[0].Visible.Should().BeTrue("pressing Enter again should restore Series 1");
+        }
+
+        [Test]
+        public async Task BarChart_LegendLabel_SpaceKey_TogglesVisibility()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.CanHideSeries, true));
+
+            chartSeries[0].Visible.Should().BeTrue("Series 1 should be visible initially");
+
+            var label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
+            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = " " });
+
+            chartSeries[0].Visible.Should().BeFalse("pressing Space on the label should hide Series 1");
+
+            label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
+            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = " " });
+
+            chartSeries[0].Visible.Should().BeTrue("pressing Space again should restore Series 1");
+        }
+
+        [Test]
+        public async Task BarChart_LegendLabel_Click_DoesNotTriggerOnLegendSelected()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.CanHideSeries, true));
+
+            var initialSelectedIndex = comp.Instance.GetState(x => x.SelectedIndex);
+
+            var label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
+            await label.ClickAsync();
+
+            comp.Instance.GetState(x => x.SelectedIndex).Should().Be(initialSelectedIndex,
+                "clicking the label should only toggle series visibility, not change the selected chart index");
+        }
+
+        [Test]
         public void BarChartOverlay_RendersOverlayBars()
         {
             // Outer StackedBar chart with a nested Bar overlay that shares the outer axis chart.

--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -347,6 +347,94 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
+        public void BarChart_LegendLabel_HasCursorPointerClass_WhenCanHideSeries()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new () { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.CanHideSeries, true));
+
+            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
+            legendLabels.Count.Should().Be(chartSeries.Count, "each legend item should have a clickable label span");
+        }
+
+        [Test]
+        public async Task BarChart_LegendLabel_Click_TogglesCheckbox()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new () { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.CanHideSeries, true));
+
+            // Verify initial state – both series visible
+            var checkboxes = comp.FindAll(".mud-checkbox-input");
+            checkboxes[0].IsChecked().Should().BeTrue("Series 1 should be visible initially");
+            checkboxes[1].IsChecked().Should().BeTrue("Series 2 should be visible initially");
+
+            // Click the label of the first series
+            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
+            await legendLabels[0].ClickAsync();
+
+            checkboxes = comp.FindAll(".mud-checkbox-input");
+            checkboxes[0].IsChecked().Should().BeFalse("clicking the label should uncheck Series 1");
+            checkboxes[1].IsChecked().Should().BeTrue("Series 2 should remain checked");
+            chartSeries[0].Visible.Should().BeFalse("Series 1 Visible should be false after label click");
+
+            // Click the same label again to re-enable the series
+            legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
+            await legendLabels[0].ClickAsync();
+
+            checkboxes = comp.FindAll(".mud-checkbox-input");
+            checkboxes[0].IsChecked().Should().BeTrue("clicking the label again should re-check Series 1");
+            chartSeries[0].Visible.Should().BeTrue("Series 1 Visible should be true after second label click");
+        }
+
+        [Test]
+        public async Task BarChart_LegendLabel_Click_HidesAndShowsBars()
+        {
+            var chartSeries = new List<ChartSeries<double>>()
+            {
+                new () { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new () { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+            };
+            string[] xAxisLabels = { "A", "B", "C" };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, chartSeries)
+                .Add(p => p.ChartLabels, xAxisLabels)
+                .Add(p => p.CanHideSeries, true)
+                .Add(p => p.ChartOptions, new BarChartOptions { ChartPalette = _baseChartPalette }));
+
+            var series1Selector = $"[fill='{_baseChartPalette[0]}']";
+            comp.FindAll($"path.mud-chart-bar{series1Selector}").Count.Should().Be(3, "Series 1 should show 3 bars initially");
+
+            // Click the label of Series 1 to hide it
+            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
+            await legendLabels[0].ClickAsync();
+
+            comp.FindAll($"path.mud-chart-bar{series1Selector}").Count.Should().Be(0, "Series 1 bars should be hidden after clicking its label");
+
+            // Click the label again to restore Series 1
+            legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
+            await legendLabels[0].ClickAsync();
+
+            comp.FindAll($"path.mud-chart-bar{series1Selector}").Count.Should().Be(3, "Series 1 bars should reappear after clicking its label again");
+        }
+
+        [Test]
         public void BarChartOverlay_RendersOverlayBars()
         {
             // Outer StackedBar chart with a nested Bar overlay that shares the outer axis chart.

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -21,7 +21,7 @@
                 {   
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
                         <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense/>
-                        <MudText Typo="Typo.body2" Class="ml-n2 align-self-center cursor-pointer" HtmlTag="span" @onclick="@item.HandleCheckboxChangeAsync">@item.Labels</MudText>
+<MudText Typo="Typo.body2" Class="ml-n2 align-self-center cursor-pointer" HtmlTag="span" tabindex="0" @onclick:stopPropagation="true" @onclick="@item.HandleCheckboxChangeAsync" @onkeydown:stopPropagation="true" @onkeydown="@(async (KeyboardEventArgs e) => { if (e.Key == \"Enter\") await item.HandleCheckboxChangeAsync(); })">@item.Labels</MudText>
                     </div> 
                 }                 
             </div>

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -7,23 +7,28 @@
 @if (ShowLegend is not false)
 {
     <div @attributes="UserAttributes" class="mud-chart-legend">
-        @foreach (var item in Data)        
+        @foreach (var item in Data)
         {
             <div class="@($"mud-chart-legend-item {(CanHideSeries ? "" : "pa-1")}")"
-                 @onclick:stopPropagation=@(ChartContainer!=null)
-                 @onclick=@(async () => { if (OnLegendSelected.HasDelegate) { await OnLegendSelected.InvokeAsync(item.Index); }})>
-                @if(!CanHideSeries)
+                 @onclick:stopPropagation=@(ChartContainer != null)
+                 @onclick=@(async () => { if (OnLegendSelected.HasDelegate) { await OnLegendSelected.InvokeAsync(item.Index); } })>
+                @if (!CanHideSeries)
                 {
                     <span class="mud-chart-legend-marker" style="@($"background-color:{ChartPalette!.GetValue(item.Index % ChartPalette.Length)}")"></span>
                     <MudText Typo="Typo.body2" HtmlTag="span">@item.Labels</MudText>
                 }
                 else
-                {   
-                    <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
-                        <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense/>
-<MudText Typo="Typo.body2" Class="ml-n2 align-self-center cursor-pointer" HtmlTag="span" tabindex="0" @onclick:stopPropagation="true" @onclick="@item.HandleCheckboxChangeAsync" @onkeydown:stopPropagation="true" @onkeydown="@(async (KeyboardEventArgs e) => { if (e.Key == \"Enter\") await item.HandleCheckboxChangeAsync(); })">@item.Labels</MudText>
-                    </div> 
-                }                 
+                {
+                    <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">
+                        <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense />
+                        <span class="mud-typography mud-typography-body2 ml-n2 align-self-center cursor-pointer"
+                              tabindex="0"
+                              role="button"
+                              @onclick="@(_ => item.HandleCheckboxChangeAsync())"
+                              @onclick:stopPropagation="true"
+                              @onkeydown="@(async (KeyboardEventArgs e) => { if (e.Key is "Enter" or " ") await item.HandleCheckboxChangeAsync(); })">@item.Labels</span>
+                    </div>
+                }
             </div>
         }
     </div>

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -21,7 +21,7 @@
                 {   
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">    
                         <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense/>
-                        <MudText Typo="Typo.body2" Class="ml-n2 align-self-center" HtmlTag="span">@item.Labels</MudText>
+                        <MudText Typo="Typo.body2" Class="ml-n2 align-self-center cursor-pointer" HtmlTag="span" @onclick="@item.HandleCheckboxChangeAsync">@item.Labels</MudText>
                     </div> 
                 }                 
             </div>


### PR DESCRIPTION
* Allows the label for a chart series to be clickable along with the checkbox. 
* Displays the correct pointer for the label.
* Tests to validate the label is also clickable.


https://github.com/user-attachments/assets/a4ec6832-577f-4176-8355-16c93a74fbf6



Fixes #13517 
