### PR TITLE
Inputs: Trigger OnBlur for readonly inputs

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -87,7 +87,7 @@ namespace MudBlazor.UnitTests.Components
             IElement Switch() => comp.Find("#switch");
             await Switch().ChangeAsync(true);
             await comp.WaitForAssertionAsync(() => Switch().HasAttribute("checked").Should().BeTrue());
-            await comp.InvokeAsync(() => select.Instance.OnBlurAsync(new FocusEventArgs()));
+            await comp.Find($"#{select.Instance.ElementId}").TriggerEventAsync("onfocusout", new FocusEventArgs());
             await comp.WaitForAssertionAsync(() => Switch().HasAttribute("checked").Should().BeFalse());
         }
 
@@ -714,6 +714,20 @@ namespace MudBlazor.UnitTests.Components
                 await comp.Find($"#{select.Instance.ElementId}").TriggerEventAsync("onfocusout", new FocusEventArgs());
             });
             eventCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task Select_OnBlurShouldFireOnceOnFocusLoss()
+        {
+            // A focus loss raises both inner blur and outer focusout; expose one callback.
+            var calls = 0;
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
+                .Add(p => p.OnBlur, _ => calls++));
+
+            await comp.Find("input").BlurAsync();
+            await comp.Find($"#{comp.Instance.ElementId}").TriggerEventAsync("onfocusout", new FocusEventArgs());
+
+            calls.Should().Be(1);
         }
 
         [Test]

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -472,34 +472,26 @@ namespace MudBlazor
 
             if (ReadOnly)
             {
+                // Readonly inputs never validate, but they can still be focused and blurred.
+                await OnBlur.InvokeAsync(obj);
+
                 return;
             }
-
-            // all the OnBlur parents (TextField, MudMask, NumericField, DateRange, etc) currently point to this method
-            // which causes this method to be fired repeatedly, we can use the obj.Type of FocusedEventArgs to track it
 
             if (!OnlyValidateIfDirty || _isDirty)
             {
                 Touched = true;
                 if (_validated)
                 {
-                    if (OnBlur.HasDelegate)
-                    {
-                        obj.Type += ".additional";
-                        await OnBlur.InvokeAsync(obj);
-                    }
+                    await OnBlur.InvokeAsync(obj);
+                }
+                else if (OnBlur.HasDelegate)
+                {
+                    await BeginValidationAfterAsync(OnBlur.InvokeAsync(obj));
                 }
                 else
                 {
-                    if (OnBlur.HasDelegate)
-                    {
-                        obj.Type += ".additional";
-                        await BeginValidationAfterAsync(OnBlur.InvokeAsync(obj));
-                    }
-                    else
-                    {
-                        await ValidateValue();
-                    }
+                    await ValidateValue();
                 }
             }
         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -48,7 +48,6 @@
                           ClearIcon="@ClearIcon"
                           OnClearButtonClick="@(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="GetInputUserAttributes()"
-                          OnBlur="@OnBlurAsync"
                           ShrinkLabel="@(ShrinkLabel || CanRenderValue)"
                           InputId="@InputElementId"
                           Required="@Required">

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1392,11 +1392,6 @@ namespace MudBlazor
             await FocusAsync();
         }
 
-        internal Task OnBlurAsync(FocusEventArgs obj)
-        {
-            return OnBlurredAsync(obj);
-        }
-
         protected override void OnInitialized()
         {
             base.OnInitialized();


### PR DESCRIPTION
Fixes #7687.

Read-only inputs can still receive and lose focus, but `MudBaseInput.OnBlurredAsync` returned before invoking the public `OnBlur` callback. This change invokes `OnBlur` while continuing to skip validation for read-only inputs.

Because `MudSelect` uses an always-read-only inner input, enabling that callback would duplicate its existing outer `focusout` callback. The redundant inner wiring is removed, and a regression test verifies that one focus loss produces exactly one callback. The obsolete `.additional` mutation is also removed so consumers receive the original focus event type.

This carries forward the maintainer-reviewed approach from #12959, which was closed to leave the implementation available for a community contribution.

Validation:
- `git diff --check` passes.
- Targeted test command could not run because the required .NET 10 SDK is not installed in this environment.
- `dotnet format` was not run for the same reason.

No visual changes.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests