### PR TITLE
MudNavLink: Forward user attributes to the anchor element

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -64,6 +64,33 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.IsNavigated.Should().BeFalse();
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void NavLink_UserAttributes_AppearOnAnchor(bool disabled)
+        {
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.Href, "/dashboard")
+                .Add(x => x.Disabled, disabled)
+                .AddUnmatched("aria-label", "Dashboard")
+                .AddUnmatched("data-testid", "nav-dashboard"));
+            comp.Find("a.mud-nav-link").GetAttribute("aria-label").Should().Be("Dashboard");
+            comp.Find("a.mud-nav-link").GetAttribute("data-testid").Should().Be("nav-dashboard");
+            comp.Find(".mud-nav-item").HasAttribute("aria-label").Should().BeFalse();
+        }
+
+        [Test]
+        public void NavLink_UserAttributes_AppearOnClickableElement()
+        {
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.OnClick, (MouseEventArgs _) => { })
+                .AddUnmatched("aria-label", "Dashboard")
+                .AddUnmatched("data-testid", "nav-dashboard"));
+            comp.FindAll("a").Should().BeEmpty();
+            comp.Find(".mud-nav-link").GetAttribute("aria-label").Should().Be("Dashboard");
+            comp.Find(".mud-nav-link").GetAttribute("data-testid").Should().Be("nav-dashboard");
+            comp.Find(".mud-nav-item").HasAttribute("aria-label").Should().BeFalse();
+        }
+
         [Test]
         public async Task NavLinkOnClickErrorContentCaughtException()
         {

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor
@@ -2,13 +2,13 @@
 @inherits MudComponentBase
 @using Microsoft.AspNetCore.Components.Routing
 
-<div @attributes="UserAttributes" class="@Classname" disabled="@Disabled" style="@Style">
+<div class="@Classname" disabled="@Disabled" style="@Style">
     @{
         if (!OnClick.HasDelegate)
         {
             <NavLink @onclick="this.AsNonRenderingEventHandler(HandleNavigation)"
-                    class="@LinkClassname"
                     @attributes="@Attributes"
+                    class="@LinkClassname"
                     tabindex="@TabIndex"
                     Match="@Match"
                     ActiveClass="@ActiveClass">
@@ -24,6 +24,7 @@
         else
         {
             <div @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
+                 @attributes="UserAttributes"
                  class="@LinkClassname"
                  tabindex="@TabIndex">
                 @if (!string.IsNullOrEmpty(Icon))

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -36,12 +36,20 @@ namespace MudBlazor
 
         protected Dictionary<string, object?> Attributes
         {
-            get => Disabled ? new Dictionary<string, object?>() : new Dictionary<string, object?>
+            get
             {
-                { "href", Href },
-                { "target", Target },
-                { "rel", !string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty }
-            };
+                var attributes = Disabled ? new Dictionary<string, object?>() : new Dictionary<string, object?>
+                {
+                    { "href", Href },
+                    { "target", Target },
+                    { "rel", !string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty }
+                };
+                foreach (var attribute in UserAttributes)
+                {
+                    attributes[attribute.Key] = attribute.Value;
+                }
+                return attributes;
+            }
         }
 
         protected int TabIndex => Disabled || NavigationContext is { Disabled: true } or { Expanded: false } ? -1 : 0;


### PR DESCRIPTION
## Description

MudNavLink currently splats `UserAttributes` onto the wrapper `div.mud-nav-item` instead of the rendered link. That makes it impossible to set `aria-label` (or any aria/data attribute) on the actual `a.mud-nav-link`, which fails accessibility audits with "Links do not have a discernible name". There is no workaround from Razor. Native Blazor `NavLink` applies its AdditionalAttributes to the anchor, so this also brings MudNavLink in line with that.

Raised in discussion #7283.

Changes:
- `UserAttributes` are merged into the attribute set rendered on the `NavLink` anchor (also when `Disabled`, so a disabled link keeps its accessible name)
- when `OnClick` is set and a clickable `div.mud-nav-link` is rendered instead of an anchor, `UserAttributes` are splatted onto that element
- the wrapper `div.mud-nav-item` no longer receives `UserAttributes`

Note: attributes users previously set via splatting moved from the wrapper div to the link element. Anyone selecting the wrapper by a `data-*` attribute will need to adjust, but the link element is where these attributes belong and matches native `NavLink` behaviour.

No visual changes.

## How Has This Been Tested?

Added bUnit tests covering `aria-label` and a `data-*` attribute appearing on `a.mud-nav-link` (enabled and disabled) and on the clickable element in `OnClick` mode:
- `NavLink_UserAttributes_AppearOnAnchor`
- `NavLink_UserAttributes_AppearOnClickableElement`

All existing NavLink/NavMenu/NavGroup/NavigationAccessibility tests pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`)
- [x] My code follows the code style of this project
- [x] I've added relevant tests
