### PR TITLE
MudDrawer: Keep mini drawer nav link text accessible to screen readers

### DIFF
--- a/src/MudBlazor/Styles/abstracts/_mixins.scss
+++ b/src/MudBlazor/Styles/abstracts/_mixins.scss
@@ -32,6 +32,19 @@
   }
 }
 
+// Hides content visually while leaving it in the accessibility tree.
+@mixin sr-only {
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+}
+
 @mixin slider-track {
   &::-webkit-slider-runnable-track {
     @content

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -249,14 +249,7 @@
   & > .mud-drawer-content > .mud-navmenu {
     // Visually hidden instead of display: none so the link keeps its accessible name.
     & .mud-nav-link .mud-icon-root:first-child + .mud-nav-link-text {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      margin: -1px;
-      padding: 0;
-      overflow: hidden;
-      clip-path: inset(50%);
-      white-space: nowrap;
+      @include sr-only;
     }
   }
 

--- a/src/MudBlazor/Styles/components/_navmenu.scss
+++ b/src/MudBlazor/Styles/components/_navmenu.scss
@@ -247,8 +247,16 @@
 
 .mud-drawer--closed.mud-drawer-mini {
   & > .mud-drawer-content > .mud-navmenu {
+    // Visually hidden instead of display: none so the link keeps its accessible name.
     & .mud-nav-link .mud-icon-root:first-child + .mud-nav-link-text {
-      display: none;
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      overflow: hidden;
+      clip-path: inset(50%);
+      white-space: nowrap;
     }
   }
 

--- a/src/MudBlazor/Styles/utilities/layout/_visibility.scss
+++ b/src/MudBlazor/Styles/utilities/layout/_visibility.scss
@@ -11,13 +11,5 @@
 }
 
 .mud-sr-only {
-  position: absolute;
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  white-space: nowrap;
-  padding: 0;
-  border: 0;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
+  @include sr-only;
 }


### PR DESCRIPTION
## Description

When a mini-variant drawer is collapsed, this rule hides every nav link label with `display: none`:

```css
.mud-drawer--closed.mud-drawer-mini > .mud-drawer-content > .mud-navmenu .mud-nav-link .mud-icon-root:first-child + .mud-nav-link-text { display: none; }
```

`display: none` removes the text from the accessibility tree entirely, not only from view. Each collapsed nav link becomes an icon-only `<a>` with no accessible name, so Lighthouse and axe report "Links do not have a discernible name" on any app using a collapsed mini drawer. Same family of audit findings as discussion #10515.

## Fix

Replace `display: none` with the standard visually-hidden pattern (`position: absolute; width/height: 1px; clip-path: inset(50%); overflow: hidden; white-space: nowrap; margin: -1px; padding: 0`). The text stays invisible and out of layout, but screen readers can still read it as the link's name.

The selector is unchanged, so specificity and everything else stay as they were. The rule only applies under `.mud-drawer--closed`, so the open drawer state (including OpenMiniOnHover expansion) is unaffected. No left/right offsets are involved, so RTL layout is unaffected too.

## Screenshots

No visual changes - the text remains invisible, it is only restored to the accessibility tree.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The PR is submitted to the correct branch (`dev`)
- [x] My code follows the code style of this project
- [x] CSS-only styling change, no tests required per CONTRIBUTING
