### PR TITLE
MudColorPicker: Skip registering the pointermove event when DragEffect is disabled

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1532,15 +1532,16 @@ namespace MudBlazor.UnitTests.Components
             const double y2 = 140.0;
             var expectedColor2 = new MudColor(74, 70, 112, 255);
 
-            await overlay.PointerMoveAsync(new PointerEventArgs { OffsetX = x2, OffsetY = y2, Buttons = 1 });
-
-            // Color shouldn't update if the drag effect is disabled.
             if (disableDragEffect)
             {
+                // The pointer move event is not registered at all while the drag effect is disabled,
+                Func<Task> act = () => overlay.PointerMoveAsync(new PointerEventArgs { OffsetX = x2, OffsetY = y2, Buttons = 1 });
+                await act.Should().ThrowAsync<Bunit.MissingEventHandlerException>();
                 await CheckColorRelatedValues(comp, x1, y1, expectedColor1, ColorPickerMode.RGB);
             }
             else
             {
+                await overlay.PointerMoveAsync(new PointerEventArgs { OffsetX = x2, OffsetY = y2, Buttons = 1 });
                 await CheckColorRelatedValues(comp, x2, y2, expectedColor2, ColorPickerMode.RGB);
             }
 

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor
@@ -62,7 +62,7 @@
                                          id="@_id"
                                          @onpointerdown="OnColorOverlayClick"
                                          @onpointerup="OnColorOverlayClick"
-                                         @onpointermove="OnPointerMoveAsync"
+                                         @onpointermove="@(DragEffect ? EventCallback.Factory.Create<PointerEventArgs>(this, OnPointerMoveAsync) : default)"
                                          @onpointerleave="OnPointerLeaveAsync">
                                         <svg class="mud-picker-color-selector"
                                              height="26"


### PR DESCRIPTION
The colorpicker's spectrum overlay always registers the `onpointermove` event, even when the smooth dragging feature (DragEffect) is disabled, while this is fine when rendering client-side (wasm or js), unfortunately when using blazor interactive server-side rendering, this would trigger an insane number of events over the network just by hovering the mouse over the spectrum which is not ideal, especially when the server is under load, this would tank the site's performance even more.

This PR attempts to address this by only binding the event callback if the dragging feature is enabled `DragEffect="true"`, which will not have any impact on the colorpicker's functionality.

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
