### PR TITLE
MudDrawer: Fix CSS classes when using composite breakpoints

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DrawerTest.cs
+++ b/src/MudBlazor.UnitTests/Components/DrawerTest.cs
@@ -400,6 +400,27 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Drawer.Open.Should().BeFalse();
         }
 
+        [TestCase(Breakpoint.SmAndDown, "sm")]
+        [TestCase(Breakpoint.SmAndUp, "sm")]
+        [TestCase(Breakpoint.MdAndDown, "md")]
+        [TestCase(Breakpoint.MdAndUp, "md")]
+        [TestCase(Breakpoint.LgAndDown, "lg")]
+        [TestCase(Breakpoint.LgAndUp, "lg")]
+        [TestCase(Breakpoint.XlAndDown, "xl")]
+        [TestCase(Breakpoint.XlAndUp, "xl")]
+        public async Task CompositeBreakpoint_UsesNormalizedCssClasses(Breakpoint breakpoint, string normalizedBreakpoint)
+        {
+            _ = AddBrowserViewportService(BreakpointBrowserAssociatedSize(Breakpoint.Xs));
+            var comp = Context.Render<DrawerResponsiveTest>(parameters => parameters
+                .Add(x => x.Breakpoint, breakpoint));
+
+            await comp.Find("#toggle-drawer-button").ClickAsync();
+
+            comp.Find("aside.mud-drawer").ClassList.Should().Contain($"mud-drawer-{normalizedBreakpoint}");
+            comp.Find("div.mud-layout").ClassList.Should().Contain($"mud-drawer-open-responsive-{normalizedBreakpoint}-left");
+            comp.Find(".mud-drawer-overlay").ClassList.Should().Contain($"mud-drawer-overlay-{normalizedBreakpoint}");
+        }
+
         [TestCase(Breakpoint.Xs)]
         [TestCase(Breakpoint.Sm)]
         [TestCase(Breakpoint.SmAndDown)]

--- a/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawer.razor.cs
@@ -65,7 +65,7 @@ namespace MudBlazor
                 .AddClass($"mud-drawer--open", _openState.Value)
                 .AddClass($"mud-drawer--closed", !_openState.Value)
                 .AddClass($"mud-drawer--initial", _initial)
-                .AddClass($"mud-drawer-{Breakpoint.ToStringFast(true)}")
+                .AddClass($"mud-drawer-{NormalizedBreakpoint.ToStringFast(true)}")
                 .AddClass($"mud-drawer-clipped-{ClipMode.ToStringFast(true)}")
                 .AddClass($"mud-theme-{Color.ToStringFast(true)}", Color != Color.Default)
                 .AddClass($"mud-elevation-{Elevation}")
@@ -78,7 +78,7 @@ namespace MudBlazor
                 .AddClass($"mud-drawer-pos-{GetPosition()}")
                 .AddClass($"mud-drawer-overlay--open", _openState.Value)
                 .AddClass($"mud-drawer-overlay-{EffectiveVariant.ToStringFast(true)}")
-                .AddClass($"mud-drawer-overlay-{Breakpoint.ToStringFast(true)}")
+                .AddClass($"mud-drawer-overlay-{NormalizedBreakpoint.ToStringFast(true)}")
                 .AddClass($"mud-drawer-overlay--initial", _initial)
                 .AddClass($"mud-skip-overlay-positioning") // popovers try to position the overlay by zindex, this skips that behavior
                 .AddClass($"mud-skip-overlay-section") // drawer overlay remains outside of Section
@@ -417,7 +417,7 @@ namespace MudBlazor
 
         private bool IsBelowCurrentBreakpoint() => IsBelowBreakpoint(_lastUpdatedBreakpoint);
 
-        private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < NormalizeBreakpoint(Breakpoint);
+        private bool IsBelowBreakpoint(Breakpoint breakpoint) => breakpoint < NormalizedBreakpoint;
 
         private bool IsResponsiveOrMini() => Variant is DrawerVariant.Responsive or DrawerVariant.Mini;
 
@@ -436,6 +436,8 @@ namespace MudBlazor
         }
 
         internal bool IsFixed => Fixed && DrawerContainer is MudLayout;
+
+        internal Breakpoint NormalizedBreakpoint => NormalizeBreakpoint(Breakpoint);
 
         private async Task OnPointerEnterAsync()
         {

--- a/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
+++ b/src/MudBlazor/Components/Drawer/MudDrawerContainer.razor.cs
@@ -72,7 +72,7 @@ namespace MudBlazor
             var className = $"mud-drawer-{(drawer.GetState<bool>(nameof(MudDrawer.Open)) ? "open" : "close")}-{variant.ToStringFast(true)}";
             if (variant is DrawerVariant.Responsive or DrawerVariant.Mini)
             {
-                className += $"-{drawer.Breakpoint.ToStringFast(true)}";
+                className += $"-{drawer.NormalizedBreakpoint.ToStringFast(true)}";
             }
             className += $"-{drawer.GetPosition()}";
 


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11151

`MudDrawer` aliases composite breakpoints for its open/close logic (`SmAndDown` and `SmAndUp` both behave as `Sm`, and so on), and the `Breakpoint` parameter documents that aliasing. The CSS class strings used the raw value instead, so `Breakpoint="Breakpoint.SmAndDown"` emitted `mud-drawer-smanddown`, `mud-drawer-open-mini-smanddown-left`, and `mud-drawer-overlay-smanddown`.

The stylesheets only generate rules for the breakpoints in `$breakpoints` (`xs sm md lg xl xxl`), so none of those classes matched anything. Open/close behavior stayed correct, but all breakpoint-dependent styling was silently dropped: the app bar overlapped the drawer instead of being pushed aside, and `mud-main-content` never picked up its margin.

The three class strings now go through a shared `NormalizedBreakpoint` property, which is the approach outlined in the issue thread. `NormalizedBreakpoint` is `internal`, so there is no public API change.

`CompositeBreakpoint_UsesNormalizedCssClasses` asserts the drawer, layout, and overlay classes for all eight composite breakpoints. All eight cases fail without the source change.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
