### PR TITLE
Docs: Document palette color strings

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
@@ -64,7 +64,7 @@
             <SectionHeader Title="Custom Themes">
                 <Description>To customize the theme, you need to give the ThemeProvider a new <CodeInline>MudTheme</CodeInline> class with the settings you want to change.
                     <CodeInline>PaletteLight</CodeInline> defines the color of the Light Palette. <CodeInline>PaletteDark</CodeInline> on the other hand defines the colors of
-                    the Dark Palette.</Description>
+                    the Dark Palette. Palette colors are <CodeInline>MudColor</CodeInline> values and can be assigned from strings in hexadecimal, RGB, or RGBA format.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesCustomExample)" />
         </DocsPageSection>


### PR DESCRIPTION
Documents that palette `MudColor` values accept hexadecimal, RGB, and RGBA strings while keeping the existing custom theme example on the recommended `Colors.*` statics.

Closes #13530

## Screenshots

**Before**

![Custom Themes documentation before](https://gist.githubusercontent.com/roian6/c80294159fa551a411bec61189319c73/raw/ec6c024043889d58ec2d177395920cc4ce8d84a0/before-custom-themes.png)

**After**

![Custom Themes documentation after](https://gist.githubusercontent.com/roian6/c80294159fa551a411bec61189319c73/raw/75d53e8e63e53c4a0e11a434406dec8dd7eda243/after-custom-themes.png)

The only visible change is the added sentence describing the accepted string formats; the example and rendered theme remain unchanged.

## Testing

- `dotnet build src/MudBlazor.Docs/MudBlazor.Docs.csproj --no-restore /p:SkipBunCompile=true --nologo` — succeeded with 0 warnings and 0 errors
- Generated docs test for `OverviewThemesCustomExample` — 1 discovered, 1 passed
- `dotnet build src/MudBlazor.Docs.Server/MudBlazor.Docs.Server.csproj --no-restore --nologo` — succeeded with 0 warnings and 0 errors
- Locally previewed `/customization/overview` before and after

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
