### PR TITLE
Build: Add downstream-check workflow

### DIFF
--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -19,7 +19,9 @@ concurrency:
 
 env:
   # Synthetic version, high enough that it never collides with a real release.
-  MUDBLAZOR_VERSION: 9.999.0-dev.${{ github.run_id }}
+  # Deliberately stable, not prerelease: satellites that pack on build reject a
+  # prerelease dependency (NU5104), and floating ranges skip prereleases.
+  MUDBLAZOR_VERSION: 9.999.0
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
 jobs:

--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -67,6 +67,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: ${{ matrix.repository }}
+          # These repos version with Nerdbank.GitVersioning, which needs full history.
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/downstream-check.yml
+++ b/.github/workflows/downstream-check.yml
@@ -1,0 +1,97 @@
+name: downstream-check
+
+on:
+  push:
+    branches:
+      - dev
+  # So changes to this workflow can be validated on their own PR.
+  pull_request:
+    paths:
+      - .github/workflows/downstream-check.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Synthetic version, high enough that it never collides with a real release.
+  MUDBLAZOR_VERSION: 9.999.0-dev.${{ github.run_id }}
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+jobs:
+  pack:
+    name: pack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+
+      - name: Restore
+        working-directory: src/MudBlazor
+        run: dotnet restore
+
+      - name: Pack
+        working-directory: src/MudBlazor
+        run: dotnet pack -c Release --no-restore --output "${{ github.workspace }}/packages" -p:Version=${{ env.MUDBLAZOR_VERSION }}
+
+      - name: Upload package
+        uses: actions/upload-artifact@v7
+        with:
+          name: mudblazor-dev-package
+          path: packages/*.nupkg
+          if-no-files-found: error
+
+  build:
+    name: ${{ matrix.name }}
+    needs: pack
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ThemeManager
+            repository: MudBlazor/ThemeManager
+            project: src/MudBlazor.ThemeManager/MudBlazor.ThemeManager.csproj
+          - name: Translations
+            repository: MudBlazor/Translations
+            project: src/MudBlazor.Translations/MudBlazor.Translations.csproj
+
+    steps:
+      - name: Checkout ${{ matrix.repository }}
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ matrix.repository }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Download MudBlazor package
+        uses: actions/download-artifact@v7
+        with:
+          name: mudblazor-dev-package
+          path: ${{ runner.temp }}/packages
+
+      - name: Point MudBlazor at this commit's build
+        run: |
+          dotnet nuget add source "${{ runner.temp }}/packages" --name mudblazor-dev
+          dotnet add ${{ matrix.project }} package MudBlazor --version "$MUDBLAZOR_VERSION"
+
+      # These projects reference MudBlazor by minimum version, and NuGet resolves the
+      # lowest version satisfying that. Without this assertion the build below would
+      # quietly succeed against the released MudBlazor and prove nothing.
+      - name: Verify the pin resolved
+        run: dotnet list ${{ matrix.project }} package | grep -F "$MUDBLAZOR_VERSION"
+
+      - name: Build
+        run: dotnet build ${{ matrix.project }} -c Release


### PR DESCRIPTION
Proof of concept. Packs MudBlazor from the current commit and builds the satellite repos against it, so downstream breakage is attributed to the commit that caused it rather than surfacing weeks later as a user report.

## How it works

`pack` builds a `9.999.0-dev.<run_id>` package and uploads it. `build` then, per satellite: checks out the repo, adds the package folder as a NuGet source, pins MudBlazor to that version, **asserts the pin resolved**, and builds.

That assertion is the part that matters. ThemeManager and Translations both reference `MudBlazor 9.0.0` as a *minimum*, and NuGet resolves the lowest version satisfying it — so without the check the build would quietly succeed against the released MudBlazor and prove nothing.

## Scope

Covers **ThemeManager** and **Translations**: both consume MudBlazor through an ordinary library project.

Deliberately excluded:
- **Icons** — doesn't reference MudBlazor at all, only `Microsoft.AspNetCore.Components.Web`.
- **Templates** — its solution contains only the packaging project (`<Compile Remove="**\*" />`); every MudBlazor reference lives in template content outside the solution. Testing it needs the `dotnet new` instantiation path, which is a bigger job.
- **TryMudBlazor** — `MudBlazor *` plus a pinned-prerelease Roslyn/Razor toolchain. Likely to fail for its own reasons and drown the signal.

## Notes

- **Not a required check**, and this repo has no branch protection, so a failure can't block anything. If a legitimate breaking change turns it red, that's information, not a gate.
- ~3.3 commits/day land on `dev`, so this is ~7 extra jobs/day.
- It runs on its own PRs (`paths:` filter on the workflow file) so it can be validated here rather than merged on faith.

If it proves noisy or low-value, close it — nothing else depends on it.
