### PR TITLE
Build: Remove dotnet-format problem matcher action

### DIFF
--- a/.github/workflows/build-test-mudblazor.yml
+++ b/.github/workflows/build-test-mudblazor.yml
@@ -34,8 +34,6 @@ jobs:
         working-directory: src
         run: dotnet restore
 
-      - uses: xt0rted/dotnet-format-problem-matcher@v1
-
       - name: Determine changed files
         id: changed-files
         uses: tj-actions/changed-files@v47


### PR DESCRIPTION
`xt0rted/dotnet-format-problem-matcher@v1` has produced no annotations since .NET 6. Its regex requires leading whitespace (`^\s+(.*)\((\d+),(\d+)\):...`), which matched the old standalone tool. SDK `dotnet format` output starts at column 0, so nothing matches — verified against real output on SDK 10.0.302: **0 of 10 diagnostic lines**. A broken matcher is invisible, which is why it went unnoticed.

Removing rather than pinning: 12 stars, last release 2020-02-18, `using: node12`, mutable `v1` tag, running in a job with a write-scoped token — and the default branch is 1006 commits ahead of `v1` and still node12, so there is nothing to upgrade to.

No impact on enforcement: `dotnet format --verify-no-changes` still fails the job and logs every `file(line,column)`. Only the inline annotations are lost, and they have not worked since 2021.