### PR TITLE
Build: Group test platform dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -85,6 +85,23 @@
             "reviewers": [
                 "meenzen"
             ]
+        },
+        {
+            "description": "Group the Microsoft.Testing.Platform runner stack; these packages move and break together. Majors stay separate so breaking changes arrive alone.",
+            "matchPackageNames": [
+                "Microsoft.NET.Test.Sdk",
+                "Microsoft.Testing**",
+                "nunit",
+                "NUnit3TestAdapter",
+                "coverlet**",
+                "JunitXml.TestLogger"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "groupName": "test platform",
+            "groupSlug": "test-platform"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
Bundles the Microsoft.Testing.Platform runner stack into a single Renovate group.

Test dependencies are roughly a third of Renovate's PR volume. Since March: `Microsoft.Testing.Extensions.HangDump` shipped 5 separate PRs (2.2.2 → 2.3.2), `Microsoft.NET.Test.Sdk` 5, `nunit` 3, plus `coverlet.MTP` and `NUnit3TestAdapter`. Each runs full CI and needs a click.

Grouped:
- `Microsoft.NET.Test.Sdk`, `Microsoft.Testing**`, `nunit`, `NUnit3TestAdapter`, `coverlet**`, `JunitXml.TestLogger`

These are version-coupled under MTP — they move and break as a unit, so one PR is strictly better than five.

Deliberately left ungrouped:
- `bunit`, `AwesomeAssertions`, `Moq`, `RichardSzalay.MockHttp`, `Microsoft.Extensions.TimeProvider.Testing`

These break at compile time in test code, individually and unpredictably. A bunit major touches hundreds of tests. Bundling them means one bad package blocks the rest with no clean revert or bisect.

`matchUpdateTypes` is limited to minor/patch so majors still arrive alone — that is where the breaks live. [#13471](https://github.com/MudBlazor/MudBlazor/pull/13471) (Test.Sdk 18.8 silently dropping transitive Newtonsoft) would still have been its own PR.

Note this overrides the built-in `vstest monorepo` group from `config:recommended` for `Microsoft.NET.Test.Sdk`; an explicit `groupName` wins.

Validated with `renovate-config-validator`.
