### PR TITLE
Core: Give every regex a match timeout

### DIFF
--- a/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
+++ b/src/MudBlazor/Components/Highlighter/MudHighlighter.razor.cs
@@ -5,6 +5,7 @@
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Components.Highlighter; // Added for FragmentInfo
+using MudBlazor.Utilities;
 // Removed: using static MudBlazor.Components.Highlighter.Splitter; 
 // We will call Splitter methods statically: Splitter.GetFragments, Splitter.GetHtmlAwareFragments
 
@@ -96,5 +97,5 @@ public partial class MudHighlighter : MudComponentBase
 
     bool IsMatch(string fragment) => !string.IsNullOrWhiteSpace(fragment) &&
                                      !string.IsNullOrWhiteSpace(_regex) &&
-                                     Regex.IsMatch(fragment, _regex, CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
+                                     Regex.IsMatch(fragment, _regex, CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase, RegexDefaults.MatchTimeout);
 }

--- a/src/MudBlazor/Components/Highlighter/Splitter.cs
+++ b/src/MudBlazor/Components/Highlighter/Splitter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor.Components.Highlighter;
 
@@ -18,8 +19,6 @@ public record FragmentInfo(string Content, FragmentType Type);
 /// </summary>
 public static partial class Splitter
 {
-    private static readonly TimeSpan _regexTimeout = TimeSpan.FromSeconds(5);
-
     private static readonly Regex _htmlTagRegex = HtmlTagMatcher();
 
     private static readonly Regex _tagParser = HtmlTagParser();
@@ -51,7 +50,7 @@ public static partial class Splitter
         }
 
         regex = BuildRegexPattern(highlightTerms, untilNextBoundary);
-        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive) | RegexOptions.NonBacktracking, _regexTimeout);
+        var splits = Regex.Split(text, regex, GetRegexOptions(caseSensitive) | RegexOptions.NonBacktracking, RegexDefaults.MatchTimeout);
         var nonEmpty = splits.Where(s => !string.IsNullOrEmpty(s)).ToArray();
 
         return new Memory<string>(nonEmpty);
@@ -134,11 +133,11 @@ public static partial class Splitter
     {
         regex = string.Empty;
 
-        if (terms.Count == 0) return new Regex("^$", RegexOptions.NonBacktracking, _regexTimeout);
+        if (terms.Count == 0) return new Regex("^$", RegexOptions.NonBacktracking, RegexDefaults.MatchTimeout);
 
         regex = BuildRegexPattern(terms, untilNextBoundary);
 
-        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline | RegexOptions.NonBacktracking, _regexTimeout);
+        return new Regex(regex, GetRegexOptions(caseSensitive) | RegexOptions.Singleline | RegexOptions.NonBacktracking, RegexDefaults.MatchTimeout);
     }
 
     private static List<FragmentInfo> ProcessRawFragments(
@@ -360,9 +359,9 @@ public static partial class Splitter
 
     private readonly record struct TagInfo(string Name, bool IsClosing, bool IsSelfClosing);
 
-    [GeneratedRegex(@"(<\s*/?\s*\w+[^>]*?/?>)", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline, "en-US")]
+    [GeneratedRegex(@"(<\s*/?\s*\w+[^>]*?/?>)", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline, RegexDefaults.MatchTimeoutMilliseconds, "en-US")]
     private static partial Regex HtmlTagMatcher();
 
-    [GeneratedRegex(@"^<\s*(/)?\s*(\w+)[^>]*?(\/)?\s*>$", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
+    [GeneratedRegex(@"^<\s*(/)?\s*(\w+)[^>]*?(\/)?\s*>$", RegexOptions.IgnoreCase | RegexOptions.Compiled, RegexDefaults.MatchTimeoutMilliseconds, "en-US")]
     private static partial Regex HtmlTagParser();
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -523,7 +523,7 @@ namespace MudBlazor
             await JsApiService.CopyToClipboardAsync(text ?? string.Empty);
         }
 
-        [GeneratedRegex(@"^.$")]
+        [GeneratedRegex(@"^.$", RegexOptions.None, RegexDefaults.MatchTimeoutMilliseconds)]
         private static partial Regex ValidCharacterRegularExpression();
     }
 }

--- a/src/MudBlazor/Converters/TimeSpanConverter.cs
+++ b/src/MudBlazor/Converters/TimeSpanConverter.cs
@@ -5,6 +5,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using MudBlazor.Resources;
+using MudBlazor.Utilities;
 using MudBlazor.Utilities.Exceptions;
 
 namespace MudBlazor;
@@ -73,6 +74,6 @@ internal sealed partial class TimeSpanConverter : IReversibleConverter<TimeSpan?
         throw new ConversionException(LanguageResource.Converter_InvalidTimeSpan);
     }
 
-    [GeneratedRegex("AM|PM", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    [GeneratedRegex("AM|PM", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, RegexDefaults.MatchTimeoutMilliseconds)]
     private static partial Regex AmPmRegularExpression();
 }

--- a/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Utilities;
 
 namespace MudBlazor.Services;
 
@@ -28,7 +29,7 @@ public sealed class KeyMapBuilder
         {
             try
             {
-                return new Regex(key.Substring(1, key.Length - 2), RegexOptions.None, TimeSpan.FromMilliseconds(250));
+                return new Regex(key.Substring(1, key.Length - 2), RegexOptions.None, RegexDefaults.MatchTimeout);
             }
             catch
             {

--- a/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/BlockMask.cs
@@ -4,6 +4,7 @@
 
 using System.Text;
 using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
@@ -58,7 +59,7 @@ public class BlockMask : RegexMask
         base.InitInternals();
         Blocks ??= [];
         Mask = BuildRegex(Blocks);
-        _regex = new Regex(Mask);
+        _regex = new Regex(Mask, RegexOptions.None, RegexDefaults.MatchTimeout);
     }
 
     /// <inheritdoc />

--- a/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/DateMask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
@@ -259,6 +260,6 @@ public partial class DateMask : PatternMask
         }
     }
 
-    [GeneratedRegex(@"^\d+$")]
+    [GeneratedRegex(@"^\d+$", RegexOptions.None, RegexDefaults.MatchTimeoutMilliseconds)]
     private static partial Regex ValidDigitRegularExpression();
 }

--- a/src/MudBlazor/Utilities/MaskAlgorithms/MultiMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/MultiMask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor
 {
@@ -111,7 +112,7 @@ namespace MudBlazor
 
             foreach (var option in _options)
             {
-                if (option.Regex != null && Regex.IsMatch(text, option.Regex))
+                if (option.Regex != null && Regex.IsMatch(text, option.Regex, RegexOptions.None, RegexDefaults.MatchTimeout))
                 {
                     return option;
                 }

--- a/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/PatternMask.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
@@ -222,7 +223,7 @@ public class PatternMask : BaseMask
     protected virtual bool IsMatch(char maskChar, char textChar)
     {
         var maskDef = MaskDictionary[maskChar];
-        return Regex.IsMatch(textChar.ToString(), maskDef.Regex);
+        return Regex.IsMatch(textChar.ToString(), maskDef.Regex, RegexOptions.None, RegexDefaults.MatchTimeout);
     }
 
     /// <summary>

--- a/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
+using MudBlazor.Utilities;
 
 namespace MudBlazor;
 
@@ -69,7 +70,7 @@ public class RegexMask : BaseMask
     /// </summary>
     protected virtual void InitRegex()
     {
-        _regex = new Regex(_regexPattern);
+        _regex = new Regex(_regexPattern, RegexOptions.None, RegexDefaults.MatchTimeout);
     }
 
     /// <inheritdoc />

--- a/src/MudBlazor/Utilities/RegexDefaults.cs
+++ b/src/MudBlazor/Utilities/RegexDefaults.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Utilities;
+
+/// <summary>
+/// Shared defaults applied to every regular expression in MudBlazor.
+/// </summary>
+internal static class RegexDefaults
+{
+    /// <summary>
+    /// The match timeout, in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// Guards against catastrophic backtracking in user-supplied patterns such as masks.
+    /// Deliberately generous so a legitimate pattern never hits it, even on a loaded server.
+    /// This is a constant because <see cref="System.Text.RegularExpressions.GeneratedRegexAttribute"/> requires a compile-time value.
+    /// </remarks>
+    public const int MatchTimeoutMilliseconds = 1000;
+
+    /// <summary>
+    /// <see cref="MatchTimeoutMilliseconds"/> for APIs which take a <see cref="TimeSpan"/>.
+    /// </summary>
+    public static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(MatchTimeoutMilliseconds);
+}


### PR DESCRIPTION
Regular expressions built from user-supplied patterns (masks) or run over arbitrary user text had no match timeout, so a pathological pattern could hang the render loop via catastrophic backtracking. This also clears the Sonar "Regular expressions should be executed with a timeout" warnings for the library.

Adds an internal `RegexDefaults` (`src/MudBlazor/Utilities/RegexDefaults.cs`) holding a single 1s value in two forms:

- `MatchTimeoutMilliseconds` — `const int`, because `[GeneratedRegex]` requires a compile-time value
- `MatchTimeout` — the same value as a `TimeSpan` for `new Regex(...)` and the static `Regex.*` overloads

Applied at every regex site in `MudBlazor`:

| File | Change |
|---|---|
| `RegexMask` | user-supplied pattern, now timed |
| `BlockMask` | generated pattern, now timed |
| `PatternMask` | per-char `IsMatch` against `MaskDef.Regex` |
| `MultiMask` | `MaskOption.Regex` |
| `DateMask`, `MudMask`, `TimeSpanConverter` | `[GeneratedRegex]` gained `matchTimeoutMilliseconds` |
| `MudHighlighter` | last untimed `IsMatch` |
| `Splitter` | dropped the local 5s `_regexTimeout` field; 3 runtime sites + 2 `[GeneratedRegex]` moved onto the shared value |
| `KeyMapBuilder` | 250ms -> shared value |

### Why a constant

A configurable timeout was considered and rejected:

- `[GeneratedRegex]` takes a compile-time constant, so a runtime setting would apply to some regexes and silently not others.
- Cached `Regex` instances capture the timeout at construction, so setting the value after the first mask is built would do nothing — the same set-once ordering trap `MudGlobal` has hit before.
- Lowering it turns slow-server hiccups into `RegexMatchTimeoutException`; raising it defeats the purpose. Neither direction is a setting worth exposing.

`RegexOptions.NonBacktracking` is the stronger guarantee and `Splitter` already uses it, but it throws `NotSupportedException` for lookarounds and backreferences, so it can't be applied to user-supplied mask patterns. A timeout is the right tool there.

### Behavior changes

Two intentional ones: `Splitter` goes 5s -> 1s and `KeyMapBuilder` 250ms -> 1s. Neither should ever fire — `Splitter`'s runtime regexes are `NonBacktracking` (linear by construction) and `KeyMapBuilder` matches a single key name — but 250ms was tight enough to be plausible on a stalled server, so raising it is the safer direction.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests
