### PR TITLE
Code Quality: Remove unnecessary boolean literals

### DIFF
--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -69,8 +69,8 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
 
     private bool IsAnchor => !string.IsNullOrWhiteSpace(Href);
 
-    private bool IsButton => GetDisabled() is false
-                             && GetReadOnly() is false
+    private bool IsButton => !GetDisabled()
+                             && !GetReadOnly()
                              && (ChipSet is not null || OnClick.HasDelegate);
 
     private bool IsClosable => (OnClose.HasDelegate || ChipSet?.AllClosable == true) && !IsAnchor;
@@ -452,7 +452,7 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
 
     protected async Task OnCloseAsync(MouseEventArgs ev)
     {
-        if (GetReadOnly() || IsClosable is false)
+        if (GetReadOnly() || !IsClosable)
         {
             return;
         }

--- a/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
@@ -60,7 +60,7 @@
             @attributes="GetRowAttributes(itemBag.Item)"
             @onclick="@((args) => RowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)))"
             @oncontextmenu="@((args) => ContextRowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)))"
-            @oncontextmenu:preventDefault="@(DataGrid.RowContextMenuClick.HasDelegate ? true : false)">
+            @oncontextmenu:preventDefault="@DataGrid.RowContextMenuClick.HasDelegate">
             <CascadingValue Value="@DataGrid.Validator" IsFixed="true">
                 @foreach (var column in DataGrid.RenderedColumns)
                 {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -403,7 +403,7 @@ namespace MudBlazor
 
                     break;
                 case "ArrowDown":
-                    if (Open == false && Editable == false)
+                    if (!Open && !Editable)
                     {
                         Open = true;
                     }

--- a/src/MudBlazor/Components/Divider/MudDivider.razor.cs
+++ b/src/MudBlazor/Components/Divider/MudDivider.razor.cs
@@ -19,7 +19,7 @@ public partial class MudDivider : MudComponentBase
             .AddClass("mud-divider-flexitem", FlexItem)
             .AddClass("mud-divider-light", Light)
             .AddClass("mud-divider-vertical", Vertical)
-            .AddClass($"mud-divider-{DividerType.ToStringFast(true)}", DividerType != DividerType.FullWidth || (DividerType == DividerType.FullWidth && Vertical == false))
+            .AddClass($"mud-divider-{DividerType.ToStringFast(true)}", DividerType != DividerType.FullWidth || (DividerType == DividerType.FullWidth && !Vertical))
             .AddClass(Class)
             .Build();
 

--- a/src/MudBlazor/Components/ExitPrompt/MudExitPrompt.razor.cs
+++ b/src/MudBlazor/Components/ExitPrompt/MudExitPrompt.razor.cs
@@ -126,7 +126,7 @@ public partial class MudExitPrompt : MudComponentBase, IAsyncDisposable
             TextToDisplay,
             Localizer[LanguageResource.MudExitPrompt_Exit],
             Localizer[LanguageResource.MudExitPrompt_Cancel]
-        ) == true;
+        ) ?? false;
     }
 
     private async Task EnableAsync()

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -32,7 +32,7 @@ namespace MudBlazor
         protected string InnerClassname =>
             new CssBuilder("mud-input-slot")
                 .AddClass("mud-input-root")
-                .AddClass("mud-input-slot-nopadding", () => InnerPadding == false)
+                .AddClass("mud-input-slot-nopadding", () => !InnerPadding)
                 .AddClass($"mud-input-root-{Variant.ToStringFast(true)}")
                 .AddClass($"mud-input-adorned-{Adornment.ToStringFast(true)}", Adornment != Adornment.None)
                 .AddClass($"mud-input-root-margin-{Margin.ToStringFast(true)}", () => Margin != Margin.None)

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -268,7 +268,7 @@ namespace MudBlazor
         {
             // The form is valid when no control has an error and every required control holds a value.
             // A required field is satisfied by having a value, not by being touched.
-            var noErrors = _formControls.All(x => x.HasErrors == false);
+            var noErrors = _formControls.All(x => !x.HasErrors);
             var requiredAllHaveValue = _formControls.Where(x => x.Required).All(x => x.HasValue());
             return noErrors && requiredAllHaveValue;
         }

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -49,9 +49,9 @@ namespace MudBlazor
 
         protected string ClearButtonClassname =>
             new CssBuilder("mud-input-clear-button")
-                .AddClass("me-n1", Adornment == Adornment.End && HideSpinButtons == false)
+                .AddClass("me-n1", Adornment == Adornment.End && !HideSpinButtons)
                 .AddClass("mud-icon-button-edge-end", Adornment == Adornment.End && HideSpinButtons)
-                .AddClass("me-6", Adornment != Adornment.End && HideSpinButtons == false)
+                .AddClass("me-6", Adornment != Adornment.End && !HideSpinButtons)
                 .AddClass("mud-icon-button-edge-margin-end", Adornment != Adornment.End && HideSpinButtons)
                 .AddClass("mud-no-activator")
                 .Build();

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -380,7 +380,7 @@ namespace MudBlazor
             // the only case a manual Navigition is required, is when
             // the target is empty, but a force reload is desired, all other cases are handled
             // by the html anchor
-            if (ForceLoad && string.IsNullOrEmpty(Href) == false && string.IsNullOrEmpty(Target))
+            if (ForceLoad && !string.IsNullOrEmpty(Href) && string.IsNullOrEmpty(Target))
             {
                 UriHelper.NavigateTo(Href, forceLoad: ForceLoad);
             }
@@ -547,7 +547,7 @@ namespace MudBlazor
 
             await OnClick.InvokeAsync(new MouseEventArgs());
 
-            if (activateLink && string.IsNullOrEmpty(Href) == false && string.IsNullOrEmpty(Target))
+            if (activateLink && !string.IsNullOrEmpty(Href) && string.IsNullOrEmpty(Target))
             {
                 UriHelper.NavigateTo(Href, forceLoad: ForceLoad);
             }

--- a/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
+++ b/src/MudBlazor/Components/ScrollToTop/MudScrollToTop.razor.cs
@@ -135,7 +135,7 @@ namespace MudBlazor
                 ? e.FirstChildBoundingClientRect?.Top * -1
                 : e.ScrollTop;
 
-            if (topOffset >= TopOffset && Visible != true)
+            if (topOffset >= TopOffset && !Visible)
             {
                 Visible = true;
                 await InvokeAsync(StateHasChanged);

--- a/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor.cs
@@ -30,7 +30,7 @@ public partial class MudStepper : MudComponentBase
 
     protected string Classname =>
         new CssBuilder("mud-stepper")
-            .AddClass("mud-stepper__horizontal", Vertical == false)
+            .AddClass("mud-stepper__horizontal", !Vertical)
             .AddClass("mud-stepper__vertical", Vertical)
             .AddClass("mud-stepper__center-labels", CenterLabels && !Vertical)
             .AddClass(Class)

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -649,7 +649,7 @@ namespace MudBlazor
 
         internal async Task SetPanelRefAsync(ElementReference reference)
         {
-            if (HasRendered && _resizeObserver!.IsElementObserved(reference) == false)
+            if (HasRendered && !_resizeObserver!.IsElementObserved(reference))
                 await _resizeObserver!.Observe(reference);
 
             _redraw = true;


### PR DESCRIPTION
Fixes 17 SonarCloud S1125 issues ("Remove the unnecessary Boolean literal(s)") across 12 components by replacing `== false`, `is false`, `!= true`, and `? true : false` with plain negation.

All operands are non-nullable `bool`, so the rewrites are exactly equivalent. The one exception is `MudExitPrompt`, where `ShowMessageBoxAsync` returns `bool?` — there `== true` became `?? false`, which preserves the null-collapsing that comparison was doing.

| File | Change |
|---|---|
| MudChip | `GetDisabled() is false && GetReadOnly() is false` → `!GetDisabled() && !GetReadOnly()`; `IsClosable is false` → `!IsClosable` |
| DataGridVirtualizeRow | `HasDelegate ? true : false` → `HasDelegate` |
| MudDatePicker | `Open == false && Editable == false` → `!Open && !Editable` |
| MudDivider | `Vertical == false` → `!Vertical` |
| MudExitPrompt | `ShowMessageBoxAsync(...) == true` → `... ?? false` |
| MudField | `InnerPadding == false` → `!InnerPadding` |
| MudForm | `x.HasErrors == false` → `!x.HasErrors` |
| MudInput | `HideSpinButtons == false` → `!HideSpinButtons` (x2) |
| MudListItem | `string.IsNullOrEmpty(Href) == false` → `!string.IsNullOrEmpty(Href)` (x2) |
| MudScrollToTop | `Visible != true` → `!Visible` |
| MudStepper | `Vertical == false` → `!Vertical` |
| MudTabs | `IsElementObserved(reference) == false` → `!IsElementObserved(reference)` |

No behavior change, so no new tests.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
