### PR TITLE
Code Quality: Make method overloads adjacent

### DIFF
--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -568,35 +568,6 @@ namespace MudBlazor
             }
         }
 
-        protected virtual void ValidateModelWithFullPathOfMember(Func<object, string, IEnumerable<string?>> func, List<string> errors)
-        {
-            try
-            {
-                if (Form?.Model is null)
-                {
-                    return;
-                }
-
-                if (For is null)
-                {
-                    errors.Add($"For is null, please set parameter For on the form input component of type {GetType().Name}");
-                    return;
-                }
-
-                foreach (var error in func(Form.Model, For.GetFullPathOfMember()))
-                {
-                    if (!IsNullOrEmpty(error))
-                    {
-                        errors.Add(error);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                errors.Add("Error in validation func: " + e.Message);
-            }
-        }
-
         protected virtual async Task ValidateWithFunc(Func<T?, Task<bool>> func, T? value, List<string> errors)
         {
             try
@@ -633,6 +604,35 @@ namespace MudBlazor
             try
             {
                 foreach (var error in await func(value))
+                {
+                    if (!IsNullOrEmpty(error))
+                    {
+                        errors.Add(error);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                errors.Add("Error in validation func: " + e.Message);
+            }
+        }
+
+        protected virtual void ValidateModelWithFullPathOfMember(Func<object, string, IEnumerable<string?>> func, List<string> errors)
+        {
+            try
+            {
+                if (Form?.Model is null)
+                {
+                    return;
+                }
+
+                if (For is null)
+                {
+                    errors.Add($"For is null, please set parameter For on the form input component of type {GetType().Name}");
+                    return;
+                }
+
+                foreach (var error in func(Form.Model, For.GetFullPathOfMember()))
                 {
                     if (!IsNullOrEmpty(error))
                     {

--- a/src/MudBlazor/Components/List/MudList.razor.cs
+++ b/src/MudBlazor/Components/List/MudList.razor.cs
@@ -324,6 +324,11 @@ namespace MudBlazor
             }
         }
 
+        internal void Register(MudList<T> child)
+        {
+            _childLists.Add(child);
+        }
+
         internal void Unregister(MudListItem<T> item)
         {
             if (!_items.Remove(item))
@@ -336,11 +341,6 @@ namespace MudBlazor
                 _activeItem = null;
                 EnsureActiveItem();
             }
-        }
-
-        internal void Register(MudList<T> child)
-        {
-            _childLists.Add(child);
         }
 
         internal void Unregister(MudList<T> child)

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -15,6 +15,7 @@ namespace MudBlazor
     public partial class MudPageContentNavigation : IAsyncDisposable, IMudStateHasChanged
     {
         private readonly List<MudPageContentSection> _sections = new();
+        private readonly Dictionary<MudPageContentSection, MudPageContentSection> _parentMapper = new();
         private IScrollSpy? _scrollSpy;
 
         [Inject]
@@ -122,8 +123,6 @@ namespace MudBlazor
         /// <param name="sectionId">id of the section. It will be appending to the current url, if the section becomes active</param>
         /// <param name="forceUpdate">If true, StateHasChanged is called, forcing a re-render of the component</param>
         public void AddSection(string sectionName, string sectionId, bool forceUpdate) => AddSection(new MudPageContentSection(sectionName, sectionId), forceUpdate);
-
-        private readonly Dictionary<MudPageContentSection, MudPageContentSection> _parentMapper = new();
 
         /// <summary>
         /// Add a section to the content navigation

--- a/src/MudBlazor/Extensions/CollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/CollectionExtensions.cs
@@ -33,6 +33,29 @@ internal static class CollectionExtensions
     }
 
     /// <summary>
+    /// Determines whether any element of a list satisfies a condition.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of the list.</typeparam>
+    /// <param name="list">The list to apply the predicate to.</param>
+    /// <param name="predicate">The predicate to apply to each element.</param>
+    /// <returns>true if any elements match the predicate; otherwise, false.</returns>
+    internal static bool Any<T>(this List<T> list, Predicate<T> predicate)
+    {
+        return list.FindIndex(predicate) != -1;
+    }
+
+    /// <summary>
+    /// Determines if a list has any elements.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of the list.</typeparam>
+    /// <param name="list">The list to check.</param>
+    /// <returns>true if the list has any elements; otherwise, false.</returns>
+    internal static bool Any<T>(this List<T> list)
+    {
+        return list.Count > 0;
+    }
+
+    /// <summary>
     /// Determines whether the given element exists in the array.
     /// </summary>
     /// <typeparam name="T">The type of the elements of the array.</typeparam>
@@ -65,29 +88,6 @@ internal static class CollectionExtensions
     internal static T? FirstOrDefault<T>(this T[] array)
     {
         return array.Length > 0 ? array[0] : default;
-    }
-
-    /// <summary>
-    /// Determines whether any element of a list satisfies a condition.
-    /// </summary>
-    /// <typeparam name="T">The type of the elements of the list.</typeparam>
-    /// <param name="list">The list to apply the predicate to.</param>
-    /// <param name="predicate">The predicate to apply to each element.</param>
-    /// <returns>true if any elements match the predicate; otherwise, false.</returns>
-    internal static bool Any<T>(this List<T> list, Predicate<T> predicate)
-    {
-        return list.FindIndex(predicate) != -1;
-    }
-
-    /// <summary>
-    /// Determines if a list has any elements.
-    /// </summary>
-    /// <typeparam name="T">The type of the elements of the list.</typeparam>
-    /// <param name="list">The list to check.</param>
-    /// <returns>true if the list has any elements; otherwise, false.</returns>
-    internal static bool Any<T>(this List<T> list)
-    {
-        return list.Count > 0;
     }
 
     /// <summary>

--- a/src/MudBlazor/Extensions/KeepInRangeExtensions.cs
+++ b/src/MudBlazor/Extensions/KeepInRangeExtensions.cs
@@ -8,8 +8,8 @@ namespace MudBlazor.Extensions
         public static double EnsureRange(this double input, double min, double max) => Math.Max(min, Math.Min(max, input));
         public static byte EnsureRange(this byte input, byte max) => EnsureRange(input, (byte)0, max);
         public static byte EnsureRange(this byte input, byte min, byte max) => Math.Max(min, Math.Min(max, input));
-        public static byte EnsureRangeToByte(this int input) => (byte)EnsureRange(input, 0, 255);
         public static int EnsureRange(this int input, int max) => EnsureRange(input, 0, max);
         public static int EnsureRange(this int input, int min, int max) => Math.Max(min, Math.Min(max, input));
+        public static byte EnsureRangeToByte(this int input) => (byte)EnsureRange(input, 0, 255);
     }
 }

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -263,19 +263,6 @@ namespace MudBlazor.Services
         }
 
         /// <summary>
-        /// Replaces the default <see cref="ILocalizationEnumInterceptor"/> with custom implementation.
-        /// </summary>
-        /// <typeparam name="TInterceptor">Custom <see cref="ILocalizationEnumInterceptor"/> implementation.</typeparam>
-        /// <param name="services">IServiceCollection</param>
-        /// <returns>Continues the IServiceCollection chain.</returns>
-        public static IServiceCollection AddLocalizationEnumInterceptor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor>(this IServiceCollection services) where TInterceptor : class, ILocalizationEnumInterceptor
-        {
-            services.Replace(ServiceDescriptor.Transient<ILocalizationEnumInterceptor, TInterceptor>());
-
-            return services;
-        }
-
-        /// <summary>
         /// Replaces the default <see cref="ILocalizationInterceptor"/> with custom implementation.
         /// </summary>
         /// <typeparam name="TInterceptor">Custom <see cref="ILocalizationInterceptor"/> implementation.</typeparam>
@@ -285,6 +272,19 @@ namespace MudBlazor.Services
         public static IServiceCollection AddLocalizationInterceptor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor>(this IServiceCollection services, Func<IServiceProvider, TInterceptor> implementationFactory) where TInterceptor : class, ILocalizationInterceptor
         {
             services.Replace(ServiceDescriptor.Transient<ILocalizationInterceptor>(implementationFactory));
+
+            return services;
+        }
+
+        /// <summary>
+        /// Replaces the default <see cref="ILocalizationEnumInterceptor"/> with custom implementation.
+        /// </summary>
+        /// <typeparam name="TInterceptor">Custom <see cref="ILocalizationEnumInterceptor"/> implementation.</typeparam>
+        /// <param name="services">IServiceCollection</param>
+        /// <returns>Continues the IServiceCollection chain.</returns>
+        public static IServiceCollection AddLocalizationEnumInterceptor<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TInterceptor>(this IServiceCollection services) where TInterceptor : class, ILocalizationEnumInterceptor
+        {
+            services.Replace(ServiceDescriptor.Transient<ILocalizationEnumInterceptor, TInterceptor>());
 
             return services;
         }

--- a/src/MudBlazor/Extensions/TableButtonPositionExtensions.cs
+++ b/src/MudBlazor/Extensions/TableButtonPositionExtensions.cs
@@ -11,22 +11,24 @@ public static class TableButtonPositionExtensions
 
     public static bool DisplayApplyButtonAtStart(this TableApplyButtonPosition position) =>
         position is TableApplyButtonPosition.Start or TableApplyButtonPosition.StartAndEnd;
-    public static bool DisplayEditButtonAtStart(this TableEditButtonPosition position) =>
-        position is TableEditButtonPosition.Start or TableEditButtonPosition.StartAndEnd;
 
     public static bool DisplayApplyButtonAtStart(this TableContext? context, bool ignoreEditable) =>
         context is not null && context.Table is not null && context.Editable(ignoreEditable) && context.Table.ApplyButtonPosition.DisplayApplyButtonAtStart();
 
     public static bool DisplayApplyButtonAtEnd(this TableApplyButtonPosition position) =>
         position is TableApplyButtonPosition.End or TableApplyButtonPosition.StartAndEnd;
-    public static bool DisplayEditButtonAtEnd(this TableEditButtonPosition position) =>
-        position is TableEditButtonPosition.End or TableEditButtonPosition.StartAndEnd;
 
     public static bool DisplayApplyButtonAtEnd(this TableContext? context, bool ignoreEditable) =>
         context is not null && context.Table is not null && context.Editable(ignoreEditable) && context.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd();
 
+    public static bool DisplayEditButtonAtStart(this TableEditButtonPosition position) =>
+        position is TableEditButtonPosition.Start or TableEditButtonPosition.StartAndEnd;
+
     public static bool DisplayEditButtonAtStart(this TableContext? context, bool ignoreEditable) =>
         context is not null && context.Table is not null && context.Editable(ignoreEditable) && context.Table.EditButtonPosition.DisplayEditButtonAtStart() && context.Table.EditTrigger == TableEditTrigger.EditButton;
+
+    public static bool DisplayEditButtonAtEnd(this TableEditButtonPosition position) =>
+        position is TableEditButtonPosition.End or TableEditButtonPosition.StartAndEnd;
 
     public static bool DisplayEditButtonAtEnd(this TableContext? context, bool ignoreEditable) =>
         context is not null && context.Table is not null && context.Editable(ignoreEditable) && context.Table.EditButtonPosition.DisplayEditButtonAtEnd() && context.Table.EditTrigger == TableEditTrigger.EditButton;

--- a/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
+++ b/src/MudBlazor/Services/KeyInterceptor/KeyMapBuilder.cs
@@ -60,6 +60,16 @@ public sealed class KeyMapBuilder
     }
 
     /// <summary>
+    /// Maps multiple keys to an action on key down with a shared condition.
+    /// More efficient than calling OnKeyDown multiple times with the same condition.
+    /// </summary>
+    public KeyMapBuilder OnKeyDownAny(IEnumerable<string> keys, Func<Task> action, Func<bool> when)
+    {
+        _commands.Add(new ConditionalCommand(new MultiKeyCommand(KeyEventKind.Down, keys, action), when));
+        return this;
+    }
+
+    /// <summary>
     /// Maps multiple keys to a single action on key up.
     /// </summary>
     public KeyMapBuilder OnKeyUpAny(IEnumerable<string> keys, Func<Task> action)
@@ -154,16 +164,6 @@ public sealed class KeyMapBuilder
 
         _commands.Add(command);
 
-        return this;
-    }
-
-    /// <summary>
-    /// Maps multiple keys to an action on key down with a shared condition.
-    /// More efficient than calling OnKeyDown multiple times with the same condition.
-    /// </summary>
-    public KeyMapBuilder OnKeyDownAny(IEnumerable<string> keys, Func<Task> action, Func<bool> when)
-    {
-        _commands.Add(new ConditionalCommand(new MultiKeyCommand(KeyEventKind.Down, keys, action), when));
         return this;
     }
 

--- a/src/MudBlazor/Services/Scroll/ScrollSpy.cs
+++ b/src/MudBlazor/Services/Scroll/ScrollSpy.cs
@@ -48,14 +48,14 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
+        public async Task ScrollToSection(Uri uri) => await ScrollToSection(uri.Fragment);
+
+        /// <inheritdoc />
         public async Task SetSectionAsActive(string id)
         {
             CenteredSection = id;
             await _js.InvokeVoidAsyncWithErrorHandling("mudScrollSpy.activateSection", id.Trim('#'));
         }
-
-        /// <inheritdoc />
-        public async Task ScrollToSection(Uri uri) => await ScrollToSection(uri.Fragment);
 
         /// <summary>
         /// Invoked by JavaScript when a section change occurs.

--- a/src/MudBlazor/Utilities/StyleBuilder.cs
+++ b/src/MudBlazor/Utilities/StyleBuilder.cs
@@ -72,29 +72,6 @@ namespace MudBlazor.Utilities
                 .Append(';');
 
         /// <summary>
-        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
-        /// </summary>
-        /// <param name="style">The style to add.</param>
-        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder AddStyle(string? style) => !string.IsNullOrWhiteSpace(style) ? AddRaw(style).AddRaw(';') : this;
-
-        /// <summary>
-        /// Adds a conditional style to the builder with a space separator and closing semicolon.
-        /// </summary>
-        /// <param name="style">The style to add.</param>
-        /// <param name="when">The condition.</param>
-        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder AddStyle(string? style, bool when) => when ? AddStyle(style) : this;
-
-        /// <summary>
-        /// Adds a conditional style to the builder with a space separator and closing semicolon.
-        /// </summary>
-        /// <param name="style">The style to add.</param>
-        /// <param name="when">The condition as function.</param>
-        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
-        public StyleBuilder AddStyle(string? style, Func<bool>? when) => AddStyle(style, when is not null && when());
-
-        /// <summary>
         /// Adds a raw string to the builder that will be concatenated with the next style or value added to the builder.
         /// </summary>
         /// <param name="style">The raw style to add.</param>
@@ -118,6 +95,29 @@ namespace MudBlazor.Utilities
             _stringBuilder.Append(c);
             return this;
         }
+
+        /// <summary>
+        /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.
+        /// </summary>
+        /// <param name="style">The style to add.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder AddStyle(string? style) => !string.IsNullOrWhiteSpace(style) ? AddRaw(style).AddRaw(';') : this;
+
+        /// <summary>
+        /// Adds a conditional style to the builder with a space separator and closing semicolon.
+        /// </summary>
+        /// <param name="style">The style to add.</param>
+        /// <param name="when">The condition.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder AddStyle(string? style, bool when) => when ? AddStyle(style) : this;
+
+        /// <summary>
+        /// Adds a conditional style to the builder with a space separator and closing semicolon.
+        /// </summary>
+        /// <param name="style">The style to add.</param>
+        /// <param name="when">The condition as function.</param>
+        /// <returns>The <see cref="StyleBuilder"/> instance.</returns>
+        public StyleBuilder AddStyle(string? style, Func<bool>? when) => AddStyle(style, when is not null && when());
 
         /// <summary>
         /// Adds a conditional in-line style to the builder with a space separator and closing semicolon.


### PR DESCRIPTION
Fixes 16 SonarCloud S4136 issues ("All 'X' method overloads should be adjacent") by reordering members so each group of same-named overloads is contiguous.

This is pure code motion. Every changed file is a permutation of its former self — no member, XML doc comment, or attribute was added, removed, or reworded. I verified that mechanically: for each file, the whitespace-stripped character multiset is identical before and after.

| File | Overload group made adjacent |
|---|---|
| MudFormComponent.cs | `ValidateWithFunc`, `ValidateModelWithFullPathOfMember` |
| MudList.razor.cs | `Unregister` |
| MudPageContentNavigation.razor.cs | `AddSection` |
| CollectionExtensions.cs | `Any`, `FirstOrDefault` |
| KeepInRangeExtensions.cs | `EnsureRange` |
| ServiceCollectionExtensions.cs | `AddLocalizationInterceptor`, `AddLocalizationEnumInterceptor` |
| TableButtonPositionExtensions.cs | `DisplayApplyButtonAtStart/AtEnd`, `DisplayEditButtonAtStart/AtEnd` |
| KeyMapBuilder.cs | `OnKeyDownAny` |
| ScrollSpy.cs | `ScrollToSection` |
| StyleBuilder.cs | `AddStyle` |

Two notes for the reviewer:

- In `MudPageContentNavigation`, the thing sitting between the two `AddSection` overloads was a field, not a method, so the fix moves `_parentMapper` up to the other private fields. That field is dead — a grep across `src` (including `.razor` markup) finds only its own declaration. I left the deletion out to keep this diff pure motion; worth a separate cleanup.
- Sonar's list does not include `MudBaseDatePicker.GetMonthName` or `MudDialogProvider.DismissInstance`, which also look like non-adjacent overload groups. They are out of scope here since this PR tracks the flagged issues only.

No behavior change, so no new tests.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
