### PR TITLE
Code Quality: Replace nested ternaries

### DIFF
--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -56,7 +56,12 @@
             var y = verticalLineValue.Y.ToStr();
             var rotationValue = ChartOptions?.XAxisLabelRotation ?? 0;
             var rotation = (-rotationValue).ToString();
-            var textAnchor = rotationValue > 0 ? "end" : rotationValue < 0 ? "start" : "middle";
+            var textAnchor = Math.Sign(rotationValue) switch
+            {
+                1 => "end",
+                -1 => "start",
+                _ => "middle"
+            };
             @((MarkupString)$"<text x='{x}' y='{y}' font-size='12px' text-anchor='{textAnchor}' dominant-baseline='middle' transform='rotate({rotation} {x} {y})'>{verticalLineValue.Value}</text>")
         }
     </g>

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor
@@ -80,8 +80,10 @@
         {
             foreach (var axisLine in _axisLines)
             {
-                var anchor = Math.Abs(axisLine.LabelX) < 10 ? "middle" : (axisLine.LabelX < 0 ? "end" : "start");
-                var baseline = Math.Abs(axisLine.LabelY) < 10 ? "middle" : (axisLine.LabelY < 0 ? "auto" : "hanging");
+                var offCenterAnchor = axisLine.LabelX < 0 ? "end" : "start";
+                var offCenterBaseline = axisLine.LabelY < 0 ? "auto" : "hanging";
+                var anchor = Math.Abs(axisLine.LabelX) < 10 ? "middle" : offCenterAnchor;
+                var baseline = Math.Abs(axisLine.LabelY) < 10 ? "middle" : offCenterBaseline;
 
                 builder.OpenElement(seq++, "text");
                 builder.AddAttribute(seq++, "class", "mud-chart-axis-label");

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -38,11 +38,12 @@ namespace MudBlazor
         {
             get
             {
+                var rel = !string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty;
                 var attributes = Disabled ? new Dictionary<string, object?>() : new Dictionary<string, object?>
                 {
                     { "href", Href },
                     { "target", Target },
-                    { "rel", !string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty }
+                    { "rel", rel }
                 };
                 foreach (var attribute in UserAttributes)
                 {

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -893,23 +893,24 @@ namespace MudBlazor
                 .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
                 .Build();
 
-        protected string SliderStyle => RightToLeft
-            ? new StyleBuilder()
-                .AddStyle("width", _sliderSizePercentage.ToPercent(), Position is Position.Top or Position.Bottom)
-                .AddStyle("right", _sliderPositionPercentage.ToPercent(), Position is Position.Top or Position.Bottom)
-                .AddStyle("transition", SliderAnimation ? "right .3s cubic-bezier(.64,.09,.08,1);" : "none", Position is Position.Top or Position.Bottom)
-                .AddStyle("transition", SliderAnimation ? "top .3s cubic-bezier(.64,.09,.08,1);" : "none", _isVerticalTabs)
-                .AddStyle("height", _sliderSizePercentage.ToPercent(), _isVerticalTabs)
-                .AddStyle("top", _sliderPositionPercentage.ToPercent(), _isVerticalTabs)
-                .Build()
-            : new StyleBuilder()
-                .AddStyle("width", _sliderSizePercentage.ToPercent(), Position is Position.Top or Position.Bottom)
-                .AddStyle("left", _sliderPositionPercentage.ToPercent(), Position is Position.Top or Position.Bottom)
-                .AddStyle("transition", SliderAnimation ? "left .3s cubic-bezier(.64,.09,.08,1);" : "none", Position is Position.Top or Position.Bottom)
-                .AddStyle("transition", SliderAnimation ? "top .3s cubic-bezier(.64,.09,.08,1);" : "none", _isVerticalTabs)
-                .AddStyle("height", _sliderSizePercentage.ToPercent(), _isVerticalTabs)
-                .AddStyle("top", _sliderPositionPercentage.ToPercent(), _isVerticalTabs)
-                .Build();
+        protected string SliderStyle
+        {
+            get
+            {
+                var horizontalEdge = RightToLeft ? "right" : "left";
+                var horizontalTransition = SliderAnimation ? $"{horizontalEdge} .3s cubic-bezier(.64,.09,.08,1);" : "none";
+                var verticalTransition = SliderAnimation ? "top .3s cubic-bezier(.64,.09,.08,1);" : "none";
+
+                return new StyleBuilder()
+                    .AddStyle("width", _sliderSizePercentage.ToPercent(), Position is Position.Top or Position.Bottom)
+                    .AddStyle(horizontalEdge, _sliderPositionPercentage.ToPercent(), Position is Position.Top or Position.Bottom)
+                    .AddStyle("transition", horizontalTransition, Position is Position.Top or Position.Bottom)
+                    .AddStyle("transition", verticalTransition, _isVerticalTabs)
+                    .AddStyle("height", _sliderSizePercentage.ToPercent(), _isVerticalTabs)
+                    .AddStyle("top", _sliderPositionPercentage.ToPercent(), _isVerticalTabs)
+                    .Build();
+            }
+        }
 
         private Position ConvertPosition(Position position)
         {

--- a/src/MudBlazor/Services/SearchService.cs
+++ b/src/MudBlazor/Services/SearchService.cs
@@ -172,7 +172,13 @@ internal sealed class SearchService : ISearchService
 
         // Typo tolerance: allow a limited number of edits proportional to length.
         var maxLen = Math.Max(qt.Length, tt.Length);
-        var maxDist = maxLen <= 3 ? 0 : maxLen <= 5 ? 1 : maxLen <= 8 ? 2 : 3;
+        var maxDist = maxLen switch
+        {
+            <= 3 => 0,
+            <= 5 => 1,
+            <= 8 => 2,
+            _ => 3
+        };
 
         if (maxDist > 0)
         {
@@ -196,7 +202,12 @@ internal sealed class SearchService : ISearchService
             return PrefixScore(b.Length, a.Length);
 
         var maxLen = Math.Max(a.Length, b.Length);
-        var maxDist = maxLen <= 5 ? 1 : maxLen <= 8 ? 2 : 3;
+        var maxDist = maxLen switch
+        {
+            <= 5 => 1,
+            <= 8 => 2,
+            _ => 3
+        };
         var dist = EditDistance(a, b);
         if (dist <= maxDist)
             return (maxLen - dist) * 100 / maxLen;


### PR DESCRIPTION
Fixes 11 SonarCloud S3358 issues ("Extract this nested ternary operation into an independent statement"). Each nested conditional becomes either a switch expression or a named local, with identical evaluation semantics — nothing that was lazy became eager.

| File | Change |
|---|---|
| BaseAxisChart.razor | `rotationValue > 0 ? "end" : rotationValue < 0 ? "start" : "middle"` → `Math.Sign(rotationValue) switch` |
| Radar.razor | Inner anchor/baseline ternaries hoisted to `offCenterAnchor` / `offCenterBaseline` |
| MudNavLink.razor.cs | `rel` value hoisted out of the dictionary initializer |
| MudTabs.razor.cs | `SliderStyle` reworked — see below |
| SearchService.cs | Two `maxLen <= a ? .. : maxLen <= b ? ..` chains → range-pattern `switch` |

`Math.Sign` is exact here: `XAxisLabelRotation` is an `int`, so it yields exactly -1/0/1 and maps one-to-one onto the original arms with no NaN case to worry about.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
