### PR TITLE
MudChart: Renormalise Sankey node column indices

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -99,6 +100,13 @@ namespace MudBlazor.UnitTests.Charts
             var sankey = RenderSankey(edges);
 
             sankey.FindAll("svg > rect").Count.Should().Be(2);
+
+            // Both nodes settle in the same column, leaving no horizontal span to divide across.
+            // A non-finite x from that division never settles in ChartTooltip's change check
+            // (NaN != NaN) and spins the renderer until it overflows the stack.
+            sankey.FindAll("svg > rect")
+                .Select(rect => rect.GetAttribute("x"))
+                .Should().AllBe("10");
         }
 
         [Test]
@@ -123,6 +131,39 @@ namespace MudBlazor.UnitTests.Charts
             // A=0, B=1, C/D=2, E=3 : longest path is 3, so 4 distinct columns.
             sankey.Nodes.Select(n => n.Column).Distinct().Count().Should().Be(4);
             sankey.Nodes.Select(n => n.Name).Should().BeEquivalentTo(["A", "B", "C", "D", "E"]);
+        }
+
+        [Test]
+        public void NonContiguousNodeColumns_CollapseToContiguousPositions()
+        {
+            // Overrides may leave gaps between column indices.
+            // Horizontal placement divides the raw index by the number of distinct columns, so the
+            // indices have to be renormalised to 0..n-1 or the later nodes land far past the viewBox.
+            var edges = new List<SankeyEdge<double>>
+            {
+                new("A", "B", 10),
+                new("B", "C", 10),
+            };
+            var options = new SankeyChartOptions
+            {
+                NodeOverrides =
+                [
+                    new SankeyNode("A", 0),
+                    new SankeyNode("B", 2),
+                    new SankeyNode("C", 5),
+                ],
+            };
+
+            var comp = RenderSankey(edges, options);
+
+            // Columns 0/2/5 collapse to 0/1/2, spreading evenly over the default 650-wide viewBox:
+            // 10px horizontal padding on each side and 10px node width leave 610px of travel.
+            var positions = comp.FindAll("svg > rect")
+                .Select(rect => double.Parse(rect.GetAttribute("x"), CultureInfo.InvariantCulture))
+                .OrderBy(x => x)
+                .ToArray();
+
+            positions.Should().Equal(10, 315, 620);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -102,8 +102,7 @@ namespace MudBlazor.UnitTests.Charts
             sankey.FindAll("svg > rect").Count.Should().Be(2);
 
             // Both nodes settle in the same column, leaving no horizontal span to divide across.
-            // A non-finite x from that division never settles in ChartTooltip's change check
-            // (NaN != NaN) and spins the renderer until it overflows the stack.
+            // A non-finite x from that division never settles in ChartTooltip's change check (NaN != NaN) and spins the renderer until it overflows the stack.
             sankey.FindAll("svg > rect")
                 .Select(rect => rect.GetAttribute("x"))
                 .Should().AllBe("10");
@@ -137,8 +136,7 @@ namespace MudBlazor.UnitTests.Charts
         public void NonContiguousNodeColumns_CollapseToContiguousPositions()
         {
             // Overrides may leave gaps between column indices.
-            // Horizontal placement divides the raw index by the number of distinct columns, so the
-            // indices have to be renormalised to 0..n-1 or the later nodes land far past the viewBox.
+            // Horizontal placement divides the raw index by the number of distinct columns, so the indices have to be renormalised to 0..n-1 or the later nodes land far past the viewBox.
             var edges = new List<SankeyEdge<double>>
             {
                 new("A", "B", 10),
@@ -156,7 +154,7 @@ namespace MudBlazor.UnitTests.Charts
 
             var comp = RenderSankey(edges, options);
 
-            // Columns 0/2/5 collapse to 0/1/2, spreading evenly over the default 650-wide viewBox:
+            // Columns 0/2/5 collapse to 0/1/2, spreading evenly over the default 650-wide viewBox.
             // 10px horizontal padding on each side and 10px node width leave 610px of travel.
             var positions = comp.FindAll("svg > rect")
                 .Select(rect => double.Parse(rect.GetAttribute("x"), CultureInfo.InvariantCulture))

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -425,7 +425,11 @@ namespace MudBlazor.Charts
         {
             NodeRects.Clear();
 
-            var nodesPerColumn = NormaliseNodeColumnIndices(nodes)
+            // Mutates in place: the value mapping below is keyed by node, and record equality
+            // covers Column, so every read of nodes has to see the same normalised records.
+            NormaliseNodeColumnIndices(nodes);
+
+            var nodesPerColumn = nodes
                 .GroupBy(x => x.Column)
                 .OrderBy(grp => grp.Key)
                 .ToArray();
@@ -445,7 +449,12 @@ namespace MudBlazor.Charts
             // Draw all nodes column per column
             foreach (var column in nodesPerColumn)
             {
-                var x = (column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth) + HorizontalPadding;
+                // A single-column chart has no horizontal span to spread across, and the sole column
+                // is always column 0 after normalisation. Dividing by zero here yields NaN, which
+                // never settles in ChartTooltip's change check and spins the renderer forever.
+                var x = maxColumns == 0
+                    ? HorizontalPadding
+                    : (column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth) + HorizontalPadding;
                 var totalRelativeColumnValue = column.Sum(n => relativeNodesValuesMapping[n]);
                 var totalVerticalSpace = _boundHeight - (double.CreateSaturating(totalRelativeColumnValue) * boundHeightRelativeToNodeHeight);
                 var verticalSpacing = Math.Max(totalVerticalSpace / (column.Count() + 1), ChartOptions!.MinVerticalSpacing);
@@ -474,18 +483,28 @@ namespace MudBlazor.Charts
             }
         }
 
-        private static SankeyNode[] NormaliseNodeColumnIndices(SankeyNode[] nodes)
+        /// <summary>
+        /// Rewrites the column indices of <paramref name="nodes"/> in place so they run 0..n-1 with no gaps.
+        /// </summary>
+        /// <remarks>
+        /// Column overrides and node filtering can leave gaps between indices.
+        /// Horizontal placement divides the index by the number of distinct columns, so an
+        /// un-normalised index puts the node past the right edge of the chart bounds.
+        /// </remarks>
+        private static void NormaliseNodeColumnIndices(SankeyNode[] nodes)
         {
-            // Normalise column indices
             var columnMap = nodes
                 .Select(n => n.Column)
                 .Distinct()
                 .OrderBy(c => c)
                 .Select((c, index) => new { Old = c, New = index })
                 .ToDictionary(x => x.Old, x => x.New);
-            Array.ForEach(nodes, node => node = node with { Column = columnMap[node.Column] });
 
-            return nodes;
+            // SankeyNode is a record class, so the with-copy has to be written back into the array.
+            for (var i = 0; i < nodes.Length; i++)
+            {
+                nodes[i] = nodes[i] with { Column = columnMap[nodes[i].Column] };
+            }
         }
 
         private Dictionary<SankeyNode, double> GetNormalisedNodeValuesMapping(SankeyNode[] nodes, double maxColumnValue)

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -425,8 +425,7 @@ namespace MudBlazor.Charts
         {
             NodeRects.Clear();
 
-            // Mutates in place: the value mapping below is keyed by node, and record equality
-            // covers Column, so every read of nodes has to see the same normalised records.
+            // Mutates in place: the value mapping below is keyed by node, and record equality covers Column, so every read of nodes has to see the same normalised records.
             NormaliseNodeColumnIndices(nodes);
 
             var nodesPerColumn = nodes
@@ -449,9 +448,8 @@ namespace MudBlazor.Charts
             // Draw all nodes column per column
             foreach (var column in nodesPerColumn)
             {
-                // A single-column chart has no horizontal span to spread across, and the sole column
-                // is always column 0 after normalisation. Dividing by zero here yields NaN, which
-                // never settles in ChartTooltip's change check and spins the renderer forever.
+                // A single-column chart has no horizontal span to spread across, and after normalisation its sole column is always 0.
+                // Dividing by zero here yields NaN, which never settles in ChartTooltip's change check and spins the renderer forever.
                 var x = maxColumns == 0
                     ? HorizontalPadding
                     : (column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth) + HorizontalPadding;
@@ -488,8 +486,7 @@ namespace MudBlazor.Charts
         /// </summary>
         /// <remarks>
         /// Column overrides and node filtering can leave gaps between indices.
-        /// Horizontal placement divides the index by the number of distinct columns, so an
-        /// un-normalised index puts the node past the right edge of the chart bounds.
+        /// Horizontal placement divides the index by the number of distinct columns, so an un-normalised index puts the node past the right edge of the chart bounds.
         /// </remarks>
         private static void NormaliseNodeColumnIndices(SankeyNode[] nodes)
         {


### PR DESCRIPTION
## Description

`Sankey.NormaliseNodeColumnIndices` never did anything:

```csharp
Array.ForEach(nodes, node => node = node with { Column = columnMap[node.Column] });
```

`SankeyNode` is a record *class*, and the lambda assigns to its own parameter, so each `with`-copy was discarded and nothing was written back to the array.

This matters because horizontal placement divides the raw column index by the number of distinct columns:

```csharp
var x = (column.First().Column / (double)maxColumns * boundWidthRelativeToNodeWidth) + HorizontalPadding;
```

With a gap in the indices the divisor no longer matches the values being divided, so nodes land past the right edge of the chart. Columns `0/2/5` put the last node at `x=1535` in a 650-wide viewBox. Both `SankeyChartOptions.NodeOverrides` (arbitrary user-supplied columns) and node filtering (`HideNodesSmallerThan`, `HideNodesWithNoEdges` emptying a middle column) can produce such gaps.

The fix writes the copy back with an indexed loop. It has to mutate in place rather than return a new array: `GenerateNodeRects` also reads `nodes` for `maxColumnValue` and for `GetNormalisedNodeValuesMapping`, whose dictionary is keyed by the record. Record equality covers `Column`, so a non-mutating variant would throw `KeyNotFoundException` on lookup. The call site is now a statement to make that explicit.

### Single-column guard

Renormalisation makes the sole column of a single-column chart always `0`, which turns the pre-existing `maxColumns == 0` division from `Infinity` into `NaN`.

That distinction is load-bearing. `ChartTooltip.OnAfterRenderAsync` gates its `StateHasChanged()` on `_previousX != X`; `NaN != NaN` is always true, so the guard never latches and the renderer recurses until the process dies with an uncatchable stack overflow. `Infinity == Infinity`, which is why it latched before and the divide-by-zero went unnoticed. Without this guard the existing `CircularEdgesDoNotHang` test kills the test host outright.

Anchoring the single column at `HorizontalPadding` matches what the general formula already produces for column 0.