### PR TITLE
MudChart: Stop non-finite tooltip coordinates from looping the renderer

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ChartToolTipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartToolTipTests.cs
@@ -31,5 +31,20 @@ namespace MudBlazor.UnitTests.Charts
             comp.Markup.Should().Contain("<text x=\"10.05\" y=\"2.02\" font-size=\"12px\" fill=\"white\" text-anchor=\"middle\" stroke=\"black\" stroke-width=\"0.8\" paint-order=\"stroke\" filter=\"url(#text-shadow)\" blazor:elementReference=\"\">");
             comp.Markup.Should().Contain("<tspan x=\"10.05\" dy=\"-.3em\">Some Title</tspan><tspan x=\"10.05\" dy=\"0\">Some Subtitle</tspan></text>");
         }
+
+        [Test]
+        public void NonFiniteCoordinatesSettleInsteadOfLoopingTheRenderer()
+        {
+            // Recalculating the box ends in StateHasChanged, so the change check has to latch or every render queues another one.
+            // NaN != NaN is always true, so a non-finite coordinate used to recurse until the process died with a stack overflow.
+            var comp = Context.Render<ChartTooltip>(parameters => parameters
+                    .Add(p => p.Title, "Some Title")
+                    .Add(p => p.X, double.NaN)
+                    .Add(p => p.Y, double.NaN)
+                );
+
+            // One initial render plus the one the recalculation asks for, then it settles.
+            comp.RenderCount.Should().BeLessThanOrEqualTo(3);
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -129,15 +129,7 @@ public partial class ChartTooltip : ComponentBase
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        // Equals treats NaN as equal to itself, unlike !=.
-        // A chart handing over a non-finite coordinate would otherwise never latch here.
-        // The recalculation ends in StateHasChanged, so every render would queue another one until the renderer overflows the stack.
-        if (firstRender
-            || FontSize != _previousFontSize
-            || Title != _previousTitle
-            || Subtitle != _previousSubtitle
-            || !_previousX.Equals(X)
-            || !_previousY.Equals(Y))
+        if (firstRender || FontSize != _previousFontSize || Title != _previousTitle || Subtitle != _previousSubtitle || !_previousX.Equals(X) || !_previousY.Equals(Y))
         {
             await RecalculateBoxWidthAsync();
         }

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -129,7 +129,15 @@ public partial class ChartTooltip : ComponentBase
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (firstRender || FontSize != _previousFontSize || Title != _previousTitle || Subtitle != _previousSubtitle || _previousX != X || _previousY != Y)
+        // Equals treats NaN as equal to itself, unlike !=.
+        // A chart handing over a non-finite coordinate would otherwise never latch here.
+        // The recalculation ends in StateHasChanged, so every render would queue another one until the renderer overflows the stack.
+        if (firstRender
+            || FontSize != _previousFontSize
+            || Title != _previousTitle
+            || Subtitle != _previousSubtitle
+            || !_previousX.Equals(X)
+            || !_previousY.Equals(Y))
         {
             await RecalculateBoxWidthAsync();
         }


### PR DESCRIPTION
`ChartTooltip.OnAfterRenderAsync` gated its recalculation on a `!=` comparison of the coordinates:

```csharp
if (firstRender || FontSize != _previousFontSize || Title != _previousTitle || Subtitle != _previousSubtitle || _previousX != X || _previousY != Y)
{
    await RecalculateBoxWidthAsync();
}
```

`RecalculateBoxWidthAsync` stores `_previousX`/`_previousY` and ends in `StateHasChanged()`, so this check has to latch or every render queues another one.

`NaN != NaN` is always true, so a chart that hands over a non-finite coordinate never latches. `Renderer.ProcessRenderQueue` then recurses until the process dies with an uncatchable **stack overflow** — not an exception, so it takes the whole test host down with it (`Zero tests ran`, exit `-1073741571`). `Infinity == Infinity`, so infinite coordinates latched fine, which is why this went unnoticed.

The fix compares with `Equals`, which treats NaN as equal to itself. A non-finite coordinate now renders a tooltip the browser ignores, instead of killing the process. Whether a chart should produce non-finite coordinates in the first place is left to the individual chart types; this is about the failure mode being fatal rather than cosmetic.