### PR TITLE
MudChart: Render an empty Sankey chart when every node is filtered out

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/SankeyChartTests.cs
@@ -313,6 +313,33 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
+        public void HideNodesSmallerThan_FilteringEveryNode_RendersEmptyChart()
+        {
+            var edges = FanEdges(); // weights 10, 20, 30
+            var options = new SankeyChartOptions { HideNodesSmallerThan = 1000 };
+
+            var comp = RenderSankey(edges, options);
+
+            comp.FindAll("svg > rect").Count.Should().Be(0);
+            comp.FindAll("svg > path").Count.Should().Be(0);
+        }
+
+        [Test]
+        public void HideNodesWithNoEdges_RemovingEveryNode_RendersEmptyChart()
+        {
+            var options = new SankeyChartOptions
+            {
+                HideNodesWithNoEdges = true,
+                NodeOverrides = [new SankeyNode("Isolated", 0)],
+            };
+
+            var comp = RenderSankey([], options);
+
+            comp.FindAll("svg > rect").Count.Should().Be(0);
+            comp.FindAll("svg > path").Count.Should().Be(0);
+        }
+
+        [Test]
         [TestCase(AggregationOption.GroupByDataSet)]
         [TestCase(AggregationOption.GroupByLabel)]
         public void Aggregation_BuildsEdgesBetweenSeriesAndLabels(AggregationOption aggregation)

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -139,9 +139,7 @@ namespace MudBlazor.Charts
 
             if (Nodes.Count == 0)
             {
-                NodeRects.Clear();
-                EdgePaths.Clear();
-                NodeValues.Clear();
+                ClearChart();
                 return;
             }
 
@@ -150,8 +148,23 @@ namespace MudBlazor.Charts
             var edges = GetAllEdgesToDraw(nodes);
             if (ChartOptions!.HideNodesWithNoEdges) nodes = RemoveNodesWithNoEdges(nodes, edges);
 
+            // HideNodesSmallerThan and HideNodesWithNoEdges can empty the draw set even when Nodes is not.
+            // The layout below aggregates over it with Max, which throws on an empty sequence.
+            if (nodes.Length == 0)
+            {
+                ClearChart();
+                return;
+            }
+
             GenerateNodeRects(nodes, out var maxColumnValue, out var boundHeightRelativeToNodeHeight);
             GenerateEdgePaths(edges, maxColumnValue, boundHeightRelativeToNodeHeight);
+        }
+
+        private void ClearChart()
+        {
+            NodeRects.Clear();
+            EdgePaths.Clear();
+            NodeValues.Clear();
         }
 
         private SankeyNode[] GetAllNodesToDraw()


### PR DESCRIPTION
`Sankey.RebuildChart` only skipped layout when the node set itself was empty:

```csharp
if (Nodes.Count == 0)
{
    NodeRects.Clear();
    EdgePaths.Clear();
    NodeValues.Clear();
    return;
}

SetBounds();
var nodes = GetAllNodesToDraw();
var edges = GetAllEdgesToDraw(nodes);
if (ChartOptions!.HideNodesWithNoEdges) nodes = RemoveNodesWithNoEdges(nodes, edges);
```

Both of those steps narrow the set further, so the array handed to layout can be empty while `Nodes` is still populated. `GenerateNodeRects` then aggregates over it with `Max`, which throws on an empty sequence:

```
System.InvalidOperationException: Sequence contains no elements
  at System.Linq.Enumerable.MaxFloat[T](IEnumerable`1 source)
  at MudBlazor.Charts.Sankey`1.GenerateNodeRects(...)
  at MudBlazor.Charts.Sankey`1.RebuildChart()
  at MudBlazor.Charts.Sankey`1.OnParametersSet()
```

`SankeyChartOptions.HideNodesSmallerThan` is a public `int` with no upper bound, so any value above every node weight throws straight out of `OnParametersSet`. `HideNodesWithNoEdges` reaches the same state when the only nodes present come from `NodeOverrides` and none of them have edges.

The expected behavior is an empty chart, matching what the empty-node-set path already does. The fix routes the empty draw set through that same clearing path, extracted to `ClearChart` since it now has two callers.