### PR TITLE
Docs: Specify generic types in chart examples

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarCustomGraphicsExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudChart ChartType="ChartType.Bar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
+<MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
 	<CustomGraphics>
 		<style>
 			.heavy { font: bold 30px Helvetica; }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarExample1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Bar" ChartSeries="@_series" @bind-SelectedIndex="_index" ChartLabels="@_xAxisLabels" ChartOptions="_axisChartOptions"
+    <MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@_series" @bind-SelectedIndex="_index" ChartLabels="@_xAxisLabels" ChartOptions="_axisChartOptions"
               Width="100%" Height="@($"{_height}px")" MatchBoundsToSize="@_matchBoundsToSize"></MudChart>
 </MudPaper>
 

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarValueLabelsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarValueLabelsExample.razor
@@ -1,6 +1,6 @@
 @namespace MudBlazor.Docs.Examples
 
-<MudChart ChartType="ChartType.Bar" ChartSeries="@_series" ChartLabels="@_xAxisLabels"
+<MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@_series" ChartLabels="@_xAxisLabels"
           ChartOptions="@_options" Width="100%" Height="350px" />
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudChart ChartType="ChartType.Donut" Width="100%" Height="300px" ChartSeries="@Data.AsChartDataSet()" ChartLabels="@Labels">
+<MudChart T="int" ChartType="ChartType.Donut" Width="100%" Height="300px" ChartSeries="@Data.AsChartDataSet()" ChartLabels="@Labels">
 	<CustomGraphics>
 		<text class="mud-donut-text mud-typography-h3" x="50%" y="50%">@Data.Sum()</text>
 	</CustomGraphics>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DynamicChartExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DynamicChartExample1.razor
@@ -13,7 +13,7 @@
         </MudMenu>
     </MudToolBar>
 
-    <MudChart ChartType="_chartType"
+    <MudChart T="double" ChartType="_chartType"
               ChartSeries="_dataSet"
               ChartLabels="@_labels"
               Width="100%" Height="400px" CanHideSeries MatchBoundsToSize />

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="pa-4">
-    <MudChart ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
+    <MudChart T="double" ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
               ChartLabels="@_xLabels" Width="100%" Height="350px"></MudChart>
 </MudPaper>
 <MudPaper Class="pa-4 mt-2 d-flex justify-center">

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample2.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="pa-4">
-    <MudChart ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
+    <MudChart T="double" ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
               ChartLabels="@_xLabels" Width="100%" Height="350px"></MudChart>
 </MudPaper>
 <MudPaper Class="pa-4 mt-2 d-flex justify-center">

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample3.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample3.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="pa-4">
-    <MudChart ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
+    <MudChart T="double" ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
               ChartLabels="@_xLabels" Width="100%" Height="350px"></MudChart>
 </MudPaper>
 <MudPaper Class="pa-4 mt-2 d-flex justify-center">

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample5.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample5.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="pa-4">
-    <MudChart ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
+    <MudChart T="double" ChartType="ChartType.HeatMap" ChartSeries="@_series" ChartOptions="@_options"
               ChartLabels="@_xLabels" Width="100%" Height="350px"></MudChart>
 </MudPaper>
 <MudPaper Class="pa-4 mt-2 d-flex justify-center">

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample7.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/HeatMapExample7.razor
@@ -2,7 +2,7 @@
 
 <MudTabs Rounded ApplyEffectsToContainer TabPanelsClass="pa-6" Color="Color.Primary" Centered>
     <MudTabPanel Text="Example One">
-        <MudChart ChartType="ChartType.HeatMap"
+        <MudChart T="double" ChartType="ChartType.HeatMap"
                     ChartSeries="@exampleOne"
                     ChartOptions="@chartOptions"
                     ChartLabels="@testLabels"
@@ -11,7 +11,7 @@
         </MudChart>
     </MudTabPanel>
     <MudTabPanel Text="Example Two">
-        <MudChart ChartType="ChartType.HeatMap"
+        <MudChart T="double" ChartType="ChartType.HeatMap"
                     ChartSeries="@exampleTwo"
                     ChartOptions="@chartOptions"
                     ChartLabels="@testLabels"

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExample1.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Line" ChartSeries="@_series" ChartLabels="@_xAxisLabels" ChartOptions="@_options" Width="100%" Height="@($"{_height}px")"
+    <MudChart T="double" ChartType="ChartType.Line" ChartSeries="@_series" ChartLabels="@_xAxisLabels" ChartOptions="@_options" Width="100%" Height="@($"{_height}px")"
               @bind-SelectedIndex="_index" MatchBoundsToSize="_matchBoundsToSize"/>
 </MudPaper>
 

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExampleHideLines.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExampleHideLines.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div>
-    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px" CanHideSeries/>
+    <MudChart T="double" ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px" CanHideSeries/>
     <MudButton Variant="Variant.Filled" @onclick="RandomizeData">Randomize data</MudButton>
 </div>
 

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExampleInterpolation.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExampleInterpolation.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div>
-    <MudChart ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@ChartLabels" Width="100%" Height="350" ChartOptions="_options"></MudChart>
+    <MudChart T="double" ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@ChartLabels" Width="100%" Height="350" ChartOptions="_options"></MudChart>
     <MudButton @onclick="RandomizeData">Randomize Data</MudButton>
     <MudMenu Label="Interpolation Algorithm" FullWidth="true">
         <MudMenuItem OnClick="() => OnClickMenu(InterpolationOption.Straight)">Straight</MudMenuItem>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExampleYAxisTicks.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/LineExampleYAxisTicks.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div>
-    <MudChart ChartType="ChartType.Line" ChartSeries="@_series" ChartLabels="@_xAxisLabels" ChartOptions="@_options" Width="100%" Height="350px"></MudChart>
+    <MudChart T="double" ChartType="ChartType.Line" ChartSeries="@_series" ChartLabels="@_xAxisLabels" ChartOptions="@_options" Width="100%" Height="350px"></MudChart>
     <MudSlider @bind-Value="_options.YAxisTicks" Min="10" Max="400" Step="10" Color="Color.Info">Y-Axis Ticks: @_options.YAxisTicks.ToString()</MudSlider>
 </div>
 

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/MixedChartExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/MixedChartExample1.razor
@@ -3,7 +3,7 @@
 @using MudBlazor.Charts
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.StackedBar" ChartSeries="@StackedDataSet" ChartOptions="@_barChartOptions" MatchBoundsToSize="true" Width="100%" Height="500px">
+    <MudChart T="double" ChartType="ChartType.StackedBar" ChartSeries="@StackedDataSet" ChartOptions="@_barChartOptions" MatchBoundsToSize="true" Width="100%" Height="500px">
         <Line ChartSeries="@LineDataSet" ChartOptions="@_lineChartOptions" />
     </MudChart>
 </MudPaper>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/PieExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/PieExample1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="pa-4">
-    <MudChart ChartType="ChartType.Pie" ChartSeries="@data.AsChartDataSet()" @bind-SelectedIndex="Index" ChartLabels="@labels" Width="100%" Height="300px" />
+    <MudChart T="double" ChartType="ChartType.Pie" ChartSeries="@data.AsChartDataSet()" @bind-SelectedIndex="Index" ChartLabels="@labels" Width="100%" Height="300px" />
 </MudPaper>
 <MudPaper Class="pa-4 mt-2 d-flex justify-center">
     <MudButton OnClick="AddDataSize" Variant="Variant.Filled" Color="Color.Primary">Add</MudButton>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RadarChartExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RadarChartExample1.razor
@@ -2,7 +2,7 @@
 @using MudBlazor.Charts
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart @ref="_chart" ChartType="ChartType.Radar" ChartSeries="@_series" ChartLabels="@_chartLabels" ChartOptions="@_options" Width="100%" Height="400px" MatchBoundsToSize>
+    <MudChart T="double" @ref="_chart" ChartType="ChartType.Radar" ChartSeries="@_series" ChartLabels="@_chartLabels" ChartOptions="@_options" Width="100%" Height="400px" MatchBoundsToSize>
         <CustomGraphics>
             <text class="mud-chart-selected-text"
                   x="90%"

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RadarChartExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RadarChartExample2.razor
@@ -2,7 +2,7 @@
 @using MudBlazor.Charts
 
 <MudPaper Class="doc-section-component-container mx-8">
-    <MudChart ChartType="ChartType.Radar" ChartSeries="@_series" ChartLabels="@_chartLabels" ChartOptions="@_options" Width="100%" Height="500px" MatchBoundsToSize CanHideSeries />
+    <MudChart T="double" ChartType="ChartType.Radar" ChartSeries="@_series" ChartLabels="@_chartLabels" ChartOptions="@_options" Width="100%" Height="500px" MatchBoundsToSize CanHideSeries />
 </MudPaper>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RoseChartExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RoseChartExample1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Rose" ChartSeries="@_series" @bind-SelectedIndex="_selectedIndex" ChartOptions="@_options" Width="100%" Height="300px">
+    <MudChart T="double" ChartType="ChartType.Rose" ChartSeries="@_series" @bind-SelectedIndex="_selectedIndex" ChartOptions="@_options" Width="100%" Height="300px">
         <CustomGraphics>
             <text x="50"
                   y="25"

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RoseChartExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/RoseChartExample2.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container mx-8">
-    <MudChart ChartType="ChartType.Rose" ChartSeries="@_series" ChartOptions="@_options" Width="100%" Height="400px" ChartLabels="@_labels" />
+    <MudChart T="double" ChartType="ChartType.Rose" ChartSeries="@_series" ChartOptions="@_options" Width="100%" Height="400px" ChartLabels="@_labels" />
 </MudPaper>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample1.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Sankey" Width="650px" Height="350px" ChartSeries="@_series"/>
+    <MudChart T="int" ChartType="ChartType.Sankey" Width="650px" Height="350px" ChartSeries="@_series"/>
 </MudPaper>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample2.razor
@@ -13,7 +13,7 @@
 </MudStack>
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Sankey" ChartSeries="@_series" Width="@($"{_width}px")" Height="@($"{_height}px")" ChartOptions="@_options"/>
+    <MudChart T="double" ChartType="ChartType.Sankey" ChartSeries="@_series" Width="@($"{_width}px")" Height="@($"{_height}px")" ChartOptions="@_options"/>
 </MudPaper>
 
 <MudGrid>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample3.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/SankeyExample3.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart @ref="_mudChart" ChartType="ChartType.Sankey" ChartSeries="@Series.AsList()" Width="@_width" Height="@_height" @bind-SelectedIndex="_selectedIndex"/>
+    <MudChart T="int" @ref="_mudChart" ChartType="ChartType.Sankey" ChartSeries="@Series.AsList()" Width="@_width" Height="@_height" @bind-SelectedIndex="_selectedIndex"/>
 </MudPaper>
 
 <MudGrid>
@@ -36,4 +36,3 @@
 
     private ChartSeries<int> Series => new() { Name = "Ball Catalog", Data = _edges };
 }
-

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarCustomGraphicsExample.razor
@@ -1,6 +1,6 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-<MudChart ChartType="ChartType.StackedBar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
+<MudChart T="double" ChartType="ChartType.StackedBar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
 	<CustomGraphics>
 		<style>
 			.heavy { font: bold 30px Helvetica; }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarExample1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.StackedBar" ChartSeries="@_series" LegendPosition="@_legendPosition" ChartLabels="@_xAxisLabels" Width="100%" Height="350px" ChartOptions="_axisChartOptions"
+    <MudChart T="double" ChartType="ChartType.StackedBar" ChartSeries="@_series" LegendPosition="@_legendPosition" ChartLabels="@_xAxisLabels" Width="100%" Height="350px" ChartOptions="_axisChartOptions"
               @bind-SelectedIndex="_index" MatchBoundsToSize="_matchBoundsToSize"/>
 </MudPaper>
 

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarValueLabelsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarValueLabelsExample.razor
@@ -1,6 +1,6 @@
 @namespace MudBlazor.Docs.Examples
 
-<MudChart ChartType="ChartType.StackedBar" ChartSeries="@_series" ChartLabels="@_xAxisLabels"
+<MudChart T="double" ChartType="ChartType.StackedBar" ChartSeries="@_series" ChartLabels="@_xAxisLabels"
           ChartOptions="@_options" Width="100%" Height="350px" />
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/TimeSeriesExample1.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/TimeSeriesExample1.razor
@@ -3,7 +3,7 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudPaper Class="doc-section-component-container">
-    <MudChart ChartType="ChartType.Timeseries"
+    <MudChart T="double" ChartType="ChartType.Timeseries"
               ChartSeries="@_series"
               @bind-SelectedIndex="_index"
               MatchBoundsToSize="@_matchBoundsToSize"


### PR DESCRIPTION
## Summary
- declare the numeric type explicitly on every chart docs example
- keep each `MudChart<T>` aligned with its `ChartSeries<T>` data
- make copied Playground snippets compile without relying on generic inference

Fixes #13551

## Validation
- `git diff --check`
- audited all chart examples to confirm every `MudChart` declares `T`
- .NET build not run locally because the required .NET 10 SDK is unavailable in this environment; CI will provide compile coverage

**Checklist:**
- [x] I've read the contribution guidelines
- [x] My code follows the style of this project
- [x] No logic changed; existing generated docs tests cover these examples