### PR TITLE
MudDialog: Restore the parameterless DialogService constructor

### DIFF
--- a/src/MudBlazor.UnitTests/Services/DialogServiceTests.cs
+++ b/src/MudBlazor.UnitTests/Services/DialogServiceTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -12,6 +13,35 @@ namespace MudBlazor.UnitTests.Services;
 [TestFixture]
 public class DialogServiceTests
 {
+    [Test]
+    public void ParameterlessConstructor_IsEmittedInMetadata()
+    {
+        // Asserted through reflection rather than `new DialogService()`, which compiles either way:
+        // an optional parameter on the logger constructor satisfies the call site at compile time but
+        // emits no `.ctor()`, so only assemblies compiled against an earlier version notice it missing.
+        var constructor = typeof(DialogService).GetConstructor(Type.EmptyTypes);
+
+        constructor.Should().NotBeNull();
+        constructor.Invoke(null).Should().BeOfType<DialogService>();
+    }
+
+    [Test]
+    public void ServiceProvider_InjectsTheRegisteredLogger()
+    {
+        // The parameterless constructor must not shadow the logger one during activation,
+        // or the missing-provider guidance would silently stop being logged.
+        var loggerMock = new Mock<ILogger<DialogService>>();
+        var services = new ServiceCollection();
+        services.AddSingleton(loggerMock.Object);
+        services.AddScoped<IDialogService, DialogService>();
+        using var provider = services.BuildServiceProvider();
+        var service = provider.GetRequiredService<IDialogService>();
+
+        _ = service.ShowAsync<MudButton>();
+
+        loggerMock.VerifyLogging(DialogService.MissingProviderMessage, LogLevel.Error, Times.Once());
+    }
+
     [Test]
     public void ShowAsync_WithoutProvider_LogsGuidanceOnce()
     {

--- a/src/MudBlazor/Services/Dialog/DialogService.cs
+++ b/src/MudBlazor/Services/Dialog/DialogService.cs
@@ -69,8 +69,21 @@ namespace MudBlazor
         /// <summary>
         /// Initializes a new instance of the <see cref="DialogService"/> class.
         /// </summary>
+        /// <remarks>
+        /// Declared explicitly rather than as an optional parameter on the logger constructor.
+        /// An optional parameter keeps source compatibility but emits no parameterless constructor,
+        /// so assemblies compiled against an earlier version fail with <see cref="MissingMethodException"/>.
+        /// </remarks>
+        public DialogService()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogService"/> class.
+        /// </summary>
         /// <param name="logger">The logger used to surface configuration problems such as a missing provider.</param>
-        public DialogService(ILogger<DialogService>? logger = null)
+        public DialogService(ILogger<DialogService>? logger)
         {
             _logger = logger ?? NullLogger<DialogService>.Instance;
         }

--- a/src/MudBlazor/Services/Dialog/DialogService.cs
+++ b/src/MudBlazor/Services/Dialog/DialogService.cs
@@ -70,12 +70,9 @@ namespace MudBlazor
         /// Initializes a new instance of the <see cref="DialogService"/> class.
         /// </summary>
         /// <remarks>
-        /// Declared explicitly rather than as an optional parameter on the logger constructor.
-        /// An optional parameter keeps source compatibility but emits no parameterless constructor,
-        /// so assemblies compiled against an earlier version fail with <see cref="MissingMethodException"/>.
+        /// Declared explicitly rather than as an optional parameter on the logger constructor to preserve source compatibility.
         /// </remarks>
-        public DialogService()
-            : this(null)
+        public DialogService() : this(null)
         {
         }
 


### PR DESCRIPTION
https://github.com/MudBlazor/MudBlazor/pull/13485 added a logger to `DialogService` as an optional parameter:

```csharp
public DialogService(ILogger<DialogService>? logger = null)
```

`DialogService` previously had no explicit constructor, so the compiler emitted a public `.ctor()`. An optional parameter is a compile-time construct — the emitted signature is `.ctor(ILogger<DialogService>)` and no `.ctor()` remains in metadata.

Source compatibility is preserved, so nothing in this repo notices. But any assembly already compiled against 9.7.0 emits `newobj instance void DialogService::.ctor()` and fails at runtime:

```
MissingMethodException: Method not found: 'Void MudBlazor.DialogService..ctor()'
```

This is a binary break in a minor release. It affects precompiled consumer libraries and test assemblies that construct the service directly rather than through DI.