### PR TITLE
MudChart: Make the legend label part of the checkbox

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/BarChartTests.cs
@@ -347,7 +347,7 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
-        public void BarChart_LegendLabel_HasCursorPointerClass_WhenCanHideSeries()
+        public void BarChart_Legend_HasOneFocusableControlPerSeries()
         {
             var chartSeries = new List<ChartSeries<double>>()
             {
@@ -360,12 +360,13 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.CanHideSeries, true));
 
-            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
-            legendLabels.Count.Should().Be(chartSeries.Count, "each legend item should have a clickable label span");
+            var focusable = comp.FindAll(".mud-chart-legend input, .mud-chart-legend [tabindex]:not([tabindex='-1'])");
+            focusable.Count.Should().Be(chartSeries.Count, "each series should be a single tab stop");
+            comp.FindAll(".mud-chart-legend [role='button']").Should().BeEmpty("the checkbox already carries the toggle semantics");
         }
 
         [Test]
-        public async Task BarChart_LegendLabel_Click_TogglesCheckbox()
+        public void BarChart_Legend_CheckboxIsLabelledBySeriesName()
         {
             var chartSeries = new List<ChartSeries<double>>()
             {
@@ -378,93 +379,25 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, chartSeries)
                 .Add(p => p.CanHideSeries, true));
 
-            // Verify initial state – both series visible
-            var checkboxes = comp.FindAll(".mud-checkbox-input");
-            checkboxes[0].IsChecked().Should().BeTrue("Series 1 should be visible initially");
-            checkboxes[1].IsChecked().Should().BeTrue("Series 2 should be visible initially");
+            // The name has to live inside the checkbox's own label. That is what gives the input an
+            // accessible name and what makes clicking the text toggle the series in a browser.
+            var labels = comp.FindAll(".mud-chart-legend-checkbox label.mud-checkbox");
+            labels.Count.Should().Be(chartSeries.Count);
 
-            // Click the label of the first series
-            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
-            await legendLabels[0].ClickAsync();
-
-            checkboxes = comp.FindAll(".mud-checkbox-input");
-            checkboxes[0].IsChecked().Should().BeFalse("clicking the label should uncheck Series 1");
-            checkboxes[1].IsChecked().Should().BeTrue("Series 2 should remain checked");
-            chartSeries[0].Visible.Should().BeFalse("Series 1 Visible should be false after label click");
-
-            // Click the same label again to re-enable the series
-            legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
-            await legendLabels[0].ClickAsync();
-
-            checkboxes = comp.FindAll(".mud-checkbox-input");
-            checkboxes[0].IsChecked().Should().BeTrue("clicking the label again should re-check Series 1");
-            chartSeries[0].Visible.Should().BeTrue("Series 1 Visible should be true after second label click");
-        }
-
-        [Test]
-        public async Task BarChart_LegendLabel_Click_HidesAndShowsBars()
-        {
-            var chartSeries = new List<ChartSeries<double>>()
+            for (var i = 0; i < chartSeries.Count; i++)
             {
-                new () { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
-                new () { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
-            };
-            string[] xAxisLabels = { "A", "B", "C" };
-
-            var comp = Context.Render<MudChart<double>>(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Bar)
-                .Add(p => p.ChartSeries, chartSeries)
-                .Add(p => p.ChartLabels, xAxisLabels)
-                .Add(p => p.CanHideSeries, true)
-                .Add(p => p.ChartOptions, new BarChartOptions { ChartPalette = _baseChartPalette }));
-
-            var series1Selector = $"[fill='{_baseChartPalette[0]}']";
-            comp.FindAll($"path.mud-chart-bar{series1Selector}").Count.Should().Be(3, "Series 1 should show 3 bars initially");
-
-            // Click the label of Series 1 to hide it
-            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
-            await legendLabels[0].ClickAsync();
-
-            comp.FindAll($"path.mud-chart-bar{series1Selector}").Count.Should().Be(0, "Series 1 bars should be hidden after clicking its label");
-
-            // Click the label again to restore Series 1
-            legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
-            await legendLabels[0].ClickAsync();
-
-            comp.FindAll($"path.mud-chart-bar{series1Selector}").Count.Should().Be(3, "Series 1 bars should reappear after clicking its label again");
-        }
-
-        [Test]
-        public void BarChart_LegendLabel_HasTabIndexAndRoleButton_WhenCanHideSeries()
-        {
-            var chartSeries = new List<ChartSeries<double>>()
-            {
-                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
-                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
-            };
-
-            var comp = Context.Render<MudChart<double>>(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Bar)
-                .Add(p => p.ChartSeries, chartSeries)
-                .Add(p => p.CanHideSeries, true));
-
-            var legendLabels = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer");
-            legendLabels.Count.Should().Be(chartSeries.Count);
-
-            foreach (var label in legendLabels)
-            {
-                label.GetAttribute("tabindex").Should().Be("0", "label must be keyboard-focusable");
-                label.GetAttribute("role").Should().Be("button", "label must be announced as a button to assistive technologies");
+                labels[i].TextContent.Trim().Should().Be(chartSeries[i].Name);
+                labels[i].QuerySelector("input.mud-checkbox-input").Should().NotBeNull();
             }
         }
 
         [Test]
-        public async Task BarChart_LegendLabel_EnterKey_TogglesVisibility()
+        public async Task BarChart_Legend_SpaceKey_TogglesVisibility()
         {
             var chartSeries = new List<ChartSeries<double>>()
             {
-                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
-                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+                new () { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new () { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
             };
 
             var comp = Context.Render<MudChart<double>>(parameters => parameters
@@ -474,51 +407,20 @@ namespace MudBlazor.UnitTests.Charts
 
             chartSeries[0].Visible.Should().BeTrue("Series 1 should be visible initially");
 
-            var label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
-            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Enter" });
+            comp.Find(".mud-checkbox-input").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = " ", Type = "keydown" });
+            await comp.WaitForAssertionAsync(() => chartSeries[0].Visible.Should().BeFalse("Space should hide Series 1"));
 
-            chartSeries[0].Visible.Should().BeFalse("pressing Enter on the label should hide Series 1");
-
-            label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
-            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = "Enter" });
-
-            chartSeries[0].Visible.Should().BeTrue("pressing Enter again should restore Series 1");
+            comp.Find(".mud-checkbox-input").KeyDown(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = " ", Type = "keydown" });
+            await comp.WaitForAssertionAsync(() => chartSeries[0].Visible.Should().BeTrue("Space again should restore Series 1"));
         }
 
         [Test]
-        public async Task BarChart_LegendLabel_SpaceKey_TogglesVisibility()
+        public async Task BarChart_Legend_ToggleCheckbox_DoesNotTriggerOnLegendSelected()
         {
             var chartSeries = new List<ChartSeries<double>>()
             {
-                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
-                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
-            };
-
-            var comp = Context.Render<MudChart<double>>(parameters => parameters
-                .Add(p => p.ChartType, ChartType.Bar)
-                .Add(p => p.ChartSeries, chartSeries)
-                .Add(p => p.CanHideSeries, true));
-
-            chartSeries[0].Visible.Should().BeTrue("Series 1 should be visible initially");
-
-            var label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
-            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = " " });
-
-            chartSeries[0].Visible.Should().BeFalse("pressing Space on the label should hide Series 1");
-
-            label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
-            await label.KeyDownAsync(new Microsoft.AspNetCore.Components.Web.KeyboardEventArgs { Key = " " });
-
-            chartSeries[0].Visible.Should().BeTrue("pressing Space again should restore Series 1");
-        }
-
-        [Test]
-        public async Task BarChart_LegendLabel_Click_DoesNotTriggerOnLegendSelected()
-        {
-            var chartSeries = new List<ChartSeries<double>>()
-            {
-                new() { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
-                new() { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
+                new () { Name = "Series 1", Data = new double[] { 10, 20, 30 } },
+                new () { Name = "Series 2", Data = new double[] { 40, 50, 60 } },
             };
 
             var comp = Context.Render<MudChart<double>>(parameters => parameters
@@ -528,11 +430,11 @@ namespace MudBlazor.UnitTests.Charts
 
             var initialSelectedIndex = comp.Instance.GetState(x => x.SelectedIndex);
 
-            var label = comp.FindAll(".mud-chart-legend-checkbox span.cursor-pointer")[0];
-            await label.ClickAsync();
+            await comp.Find(".mud-checkbox-input").ChangeAsync(new ChangeEventArgs { Value = false });
 
+            chartSeries[0].Visible.Should().BeFalse("the checkbox drives series visibility");
             comp.Instance.GetState(x => x.SelectedIndex).Should().Be(initialSelectedIndex,
-                "clicking the label should only toggle series visibility, not change the selected chart index");
+                "toggling a series should not change the selected chart index");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -20,8 +20,6 @@
                 else
                 {
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">
-                        @* The series name is the checkbox's own label, so clicking it toggles the series
-                           natively and the checkbox gains an accessible name, without a second tab stop. *@
                         <MudCheckBox Value="@item.Visible"
                                      ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())"
                                      Label="@item.Labels"

--- a/src/MudBlazor/Components/Chart/Parts/Legend.razor
+++ b/src/MudBlazor/Components/Chart/Parts/Legend.razor
@@ -20,13 +20,13 @@
                 else
                 {
                     <div class="mud-chart-legend-checkbox" style="@GetCheckBoxStyle(item.Index)">
-                        <MudCheckBox Value="@item.Visible" ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())" Size="Size.Small" Dense />
-                        <span class="mud-typography mud-typography-body2 ml-n2 align-self-center cursor-pointer"
-                              tabindex="0"
-                              role="button"
-                              @onclick="@(_ => item.HandleCheckboxChangeAsync())"
-                              @onclick:stopPropagation="true"
-                              @onkeydown="@(async (KeyboardEventArgs e) => { if (e.Key is "Enter" or " ") await item.HandleCheckboxChangeAsync(); })">@item.Labels</span>
+                        @* The series name is the checkbox's own label, so clicking it toggles the series
+                           natively and the checkbox gains an accessible name, without a second tab stop. *@
+                        <MudCheckBox Value="@item.Visible"
+                                     ValueChanged="@((bool _) => item.HandleCheckboxChangeAsync())"
+                                     Label="@item.Labels"
+                                     Size="Size.Small"
+                                     Dense />
                     </div>
                 }
             </div>

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -84,7 +84,9 @@
       }
 
       & .mud-input-control {
-        width: 35px !important;
+        // Sized to content because the series name is rendered inside the checkbox's label.
+        // A fixed width here would clip it out of the legend item's box.
+        width: auto !important;
       }
     }
   }

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -84,8 +84,6 @@
       }
 
       & .mud-input-control {
-        // Sized to content because the series name is rendered inside the checkbox's label.
-        // A fixed width here would clip it out of the legend item's box.
         width: auto !important;
       }
     }


### PR DESCRIPTION
## Description

Follow-up to https://github.com/MudBlazor/MudBlazor/pull/13522, which made the legend label clickable by adding a focusable `role="button"` span next to the checkbox. The feature is good; the extra control is the problem.

Measured on a line chart with 3 hideable series:

- 6 focusable elements, two per series. The checkbox and the span are separate tab stops for the same action.
- The span has no `aria-pressed` and no `aria-label`, so it announces as a button with no state.
- Its `keydown` handler does not `preventDefault`, so Space toggles the series *and* scrolls the page.
- The checkbox has no accessible name. Its `<label>` has no `for` and no text, so it announces as a bare "checkbox". That predates #13522, but adding a second control for the same series made it more confusing rather than less.

## Fix

Pass the series name to `MudCheckBox` as `Label` and drop the span. `MudCheckBox` renders `Label` inside the `<label>` that wraps the native input, so:

- clicking the text still toggles the series, now through native label activation
- the input gains an accessible name
- one tab stop per series
- no `aria-pressed` is needed, since a checkbox reports state through `checked`
- Space is handled by `MudCheckBox`, whose key interceptor already registers `preventDown` for `" "`, so it no longer scrolls the page

`StopClickPropagation` defaults to `true` on `MudBooleanInput`, so toggling still does not bubble to the legend item and `OnLegendSelected` is unaffected.

## Stylesheet change

`_charts.scss` pinned the control to the width of the checkbox glyph:

```scss
& .mud-input-control {
  width: 35px !important;
}
```

That was added in #7869, when the label was rendered outside the control, purely to stop `MudInputControl` from taking more room than the glyph. With the label inside, it clipped the name out of the legend item's box: items collapsed to 35px while the label text rendered at 42px, 33px and 57px, hanging outside its own item. `overflow` is visible so the text still painted, but the flex layout reserved no space for it, so labels overlapped adjacent legend items once series names got longer.

Sizing the control to its content restores correct measurements. The rule only applies when `CanHideSeries` is on, since `.mud-input-control` exists in the legend only when a checkbox is rendered.

## Verification

Browser, Blazor Server host, 3 series including a deliberately long name:

| | Before | After |
| --- | --- | --- |
| Focusable elements | 6 | 3 |
| `[role="button"]` | 3 | 0 |
| Checkbox accessible name | none | series name |
| Legend item widths | 35 / 35 / 35, all labels overflowing | 70 / 61 / 222, none overflowing |

Clicking the label text still toggles: checkboxes go `[true,true,true]` → `[false,true,true]` and the rendered series paths go 3 → 2 → 3. Per-series checkbox colours still resolve from `--checkbox-color` (`#2979FF`, `#1DE9B6`, `#FFC400`).

```
MudBlazor.UnitTests: Charts — 411/411 passed
```

Built without `SkipBunCompile` so the stylesheet change is compiled.

## Tests

The seven `BarChart_LegendLabel_*` tests from #13522 asserted on the span that this removes, so they are replaced by four that target the new structure:

- `BarChart_Legend_HasOneFocusableControlPerSeries`
- `BarChart_Legend_CheckboxIsLabelledBySeriesName` — the name must be inside the checkbox's `<label>`, which is what produces both the accessible name and the native click
- `BarChart_Legend_SpaceKey_TogglesVisibility`
- `BarChart_Legend_ToggleCheckbox_DoesNotTriggerOnLegendSelected`

Toggling and bar visibility remain covered by the pre-existing `BarChart_CanHideSeries`.

Label clicking is now native browser behaviour rather than a Blazor handler, so bUnit cannot dispatch it — that path is covered by the structural test above plus the browser check.

## Behaviour change

Enter previously toggled the series. `MudCheckBox` maps Enter to "set true", so Enter now shows the series instead of toggling it. Space toggles. This matches every other checkbox in the library, and Enter is not a checkbox activation key in the ARIA pattern, but it is a change from what #13522 shipped.
