### PR TITLE
MudNavLink: Add a Rel parameter

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -28,6 +28,30 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("a").GetAttribute("rel").Should().Be(expectedRel);
         }
 
+        [TestCase(null)]
+        [TestCase("_blank")]
+        public void NavLink_Rel_ReplacesTheDefault(string target)
+        {
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.Href, "/dashboard")
+                .Add(x => x.Target, target)
+                .Add(x => x.Rel, "nofollow"));
+
+            comp.Find("a").GetAttribute("rel").Should().Be("nofollow");
+        }
+
+        [Test]
+        public void NavLink_Rel_IsOmittedWhenDisabled()
+        {
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.Href, "/dashboard")
+                .Add(x => x.Target, "_blank")
+                .Add(x => x.Rel, "nofollow")
+                .Add(x => x.Disabled, true));
+
+            comp.Find("a").HasAttribute("rel").Should().BeFalse();
+        }
+
         [Test]
         public async Task NavLink_CheckOnClickEvent()
         {

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -38,7 +38,7 @@ namespace MudBlazor
         {
             get
             {
-                var rel = !string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty;
+                var rel = Rel ?? (!string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty);
                 var attributes = Disabled ? new Dictionary<string, object?>() : new Dictionary<string, object?>
                 {
                     { "href", Href },
@@ -104,6 +104,17 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.NavMenu.ClickAction)]
         public string? Target { get; set; }
+
+        /// <summary>
+        /// The relationship between the current document and the linked document when <see cref="Href"/> is set.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which applies <c>noopener noreferrer</c> whenever <see cref="Target"/> is set.
+        /// Setting this replaces that default. Common values can be found here: <see href="https://www.w3schools.com/tags/att_a_rel.asp" />
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.NavMenu.ClickAction)]
+        public string? Rel { get; set; }
 
         /// <summary>
         /// The CSS applied when this link is active.


### PR DESCRIPTION
Follow-up to https://github.com/MudBlazor/MudBlazor/pull/13524, which forwards unmatched attributes to the anchor.

`MudNavLink` generates `rel="noopener noreferrer"` whenever `Target` is set, but has no `Rel` parameter. So a caller-supplied `rel` reaches the anchor through `UserAttributes`, which are merged last, and replaces the generated pair:

```razor
<MudNavLink Href="https://example.com" Target="_blank" rel="nofollow" />
@* renders rel="nofollow" — noopener and noreferrer are gone *@
```

That override is reasonable behaviour, but right now it is an artifact of attribute splatting rather than a documented part of the component's API, and it isn't discoverable from the parameter list or API docs.

`MudBaseButton` and `MudChip` already model the intended shape — an explicit `Rel` parameter that falls back to a generated value only when null:

```csharp
// MudBaseButton.GetRel()
if (Rel is null && Target == "_blank")
    return "noopener";
return Rel;
```

This adds the same parameter to `MudNavLink`.

Deliberately did **not** union the caller's tokens with `noopener noreferrer`. That would hard-force the generated attribute, which contradicts both these two components and the guidance in `AGENTS.md` ("prefer fallback values so caller-provided attributes can override them whenever feasible"), and it would produce contradictory output such as `opener noopener noreferrer` for a caller who genuinely wants `rel="opener"`.

`MudNavLink` still differs from its siblings in emitting `noopener noreferrer` for any `Target` rather than `noopener` for `_blank` only. I left that alone — dropping `noreferrer` changes referrer headers and is a separate decision.