### PR TITLE
MudTabs: Keep badges visible beside truncated labels

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
@@ -24,3 +24,16 @@
 	<MudTabPanel Text="Timing" BadgeDot="true" BadgeColor="Color.Primary" />
 	<MudTabPanel Text="Metrics" BadgeIcon="@Icons.Material.Filled.Check" BadgeColor="Color.Success" />
 </MudTabs>
+
+<MudTabs Elevation="2" MinimumTabWidth="160px" Class="mb-6">
+    <MudTabPanel Text="Deliveries and returns" BadgeData='"99+"' BadgeColor="Color.Error" />
+    <MudTabPanel Text="Outstanding invoices" BadgeData="128" BadgeMax="999" BadgeColor="Color.Error" />
+    <MudTabPanel Text="Notifications and alerts" Icon="@Icons.Material.Filled.Notifications" BadgeData='"NEW"' BadgeColor="Color.Info" />
+</MudTabs>
+
+<MudRTLProvider RightToLeft="true">
+    <MudTabs Elevation="2" MinimumTabWidth="160px" Class="mb-6">
+        <MudTabPanel Text="التسليمات والمرتجعات" BadgeData='"99+"' BadgeColor="Color.Error" />
+        <MudTabPanel Text="الإشعارات والتنبيهات" Icon="@Icons.Material.Filled.Notifications" BadgeData='"NEW"' BadgeColor="Color.Info" />
+    </MudTabs>
+</MudRTLProvider>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
@@ -25,15 +25,15 @@
 	<MudTabPanel Text="Metrics" BadgeIcon="@Icons.Material.Filled.Check" BadgeColor="Color.Success" />
 </MudTabs>
 
-<MudTabs Elevation="2" MinimumTabWidth="160px" Class="mb-6">
-    <MudTabPanel Text="Deliveries and returns" BadgeData='"99+"' BadgeColor="Color.Error" />
-    <MudTabPanel Text="Outstanding invoices" BadgeData="128" BadgeMax="999" BadgeColor="Color.Error" />
-    <MudTabPanel Text="Notifications and alerts" Icon="@Icons.Material.Filled.Notifications" BadgeData='"NEW"' BadgeColor="Color.Info" />
+<MudTabs Elevation="2" MinimumTabWidth="160px" Class="mb-6" Style="width:100%; max-width:480px">
+    <MudTabPanel Text="Deliveries and returns" BadgeData='"99+"' BadgeColor="Color.Error" Style="width:160px" />
+    <MudTabPanel Text="Outstanding invoices" BadgeData="128" BadgeMax="999" BadgeColor="Color.Error" Style="width:160px" />
+    <MudTabPanel Text="Notifications and alerts" Icon="@Icons.Material.Filled.Notifications" BadgeData='"NEW"' BadgeColor="Color.Info" Style="width:160px" />
 </MudTabs>
 
 <MudRTLProvider RightToLeft="true">
-    <MudTabs Elevation="2" MinimumTabWidth="160px" Class="mb-6">
-        <MudTabPanel Text="التسليمات والمرتجعات" BadgeData='"99+"' BadgeColor="Color.Error" />
-        <MudTabPanel Text="الإشعارات والتنبيهات" Icon="@Icons.Material.Filled.Notifications" BadgeData='"NEW"' BadgeColor="Color.Info" />
+    <MudTabs Elevation="2" MinimumTabWidth="160px" Class="mb-6" Style="width:100%; max-width:320px">
+        <MudTabPanel Text="التسليمات والمرتجعات" BadgeData='"99+"' BadgeColor="Color.Error" Style="width:160px" />
+        <MudTabPanel Text="الإشعارات والتنبيهات" Icon="@Icons.Material.Filled.Notifications" BadgeData='"NEW"' BadgeColor="Color.Info" Style="width:160px" />
     </MudTabs>
 </MudRTLProvider>

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/TabsPage.razor
@@ -108,7 +108,10 @@
         <DocsPageSection>
             <SectionHeader Title="Badges">
                 <Description>
-                    Badges can be applied to icons or text within tabs for additional context.
+                    Badges can show notifications, counts, or status information for a tab.
+                    For text tabs, the badge remains visible at the label's trailing edge while long labels truncate.
+                    Material Design 3 recommends limiting badge content to four characters, including a trailing <CodeInline>+</CodeInline>.
+                    Use <CodeInline>BadgeMax</CodeInline> to format large numeric counts.
                 </Description>
             </SectionHeader>
             <SectionContent Code="@nameof(TabsWithBagdesExample)" ShowCode="false">

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -273,6 +273,41 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void TextTabBadgeRendersAfterShrinkableLabel()
+        {
+            var comp = Context.Render<MudTabs>(parameters => parameters
+                .AddChildContent<MudTabPanel>(panel => panel
+                    .Add(x => x.Text, "Deliveries and returns")
+                    .Add(x => x.BadgeData, "99+")));
+
+            var content = comp.Find(".mud-tab-content");
+            var children = content.Children;
+
+            children.Should().HaveCount(2);
+            children[0].ClassList.Should().Contain("mud-tab-label");
+            children[0].TrimmedText().Should().Be("Deliveries and returns");
+            children[1].ClassList.Should().Contain("mud-tab-badge");
+            children[1].QuerySelector(".mud-badge")!.TextContent.Trim().Should().Be("99+");
+        }
+
+        [Test]
+        public void IconAndTextTabBadgeRendersInM3InlineOrder()
+        {
+            var comp = Context.Render<MudTabs>(parameters => parameters
+                .AddChildContent<MudTabPanel>(panel => panel
+                    .Add(x => x.Icon, Icons.Material.Filled.Notifications)
+                    .Add(x => x.Text, "Notifications and alerts")
+                    .Add(x => x.BadgeData, 12)));
+
+            var children = comp.Find(".mud-tab-content").Children;
+
+            children.Should().HaveCount(3);
+            children[0].ClassList.Should().Contain("mud-tab-icon-text");
+            children[1].ClassList.Should().Contain("mud-tab-label");
+            children[2].ClassList.Should().Contain("mud-tab-badge");
+        }
+
+        [Test]
         public async Task ScrollToItem_NoScrollingNeeded()
         {
             var comp = Context.Render<ScrollableTabsTest>();

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -308,6 +308,24 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void TabContentWithTextPreservesTrailingBadge()
+        {
+            var comp = Context.Render<MudTabs>(parameters => parameters
+                .AddChildContent<MudTabPanel>(panel => panel
+                    .Add(x => x.Text, "Sort label")
+                    .Add(x => x.TabContent, builder => builder.AddMarkupContent(0, "<span class=\"custom-tab-content\">Custom</span>"))
+                    .Add(x => x.BadgeData, 3)));
+
+            var children = comp.Find(".mud-tab").Children;
+
+            children.Should().HaveCount(2);
+            children[0].ClassList.Should().Contain("custom-tab-content");
+            children[0].TrimmedText().Should().Be("Custom");
+            children[1].ClassList.Should().Contain("mud-tab-badge");
+            children[1].QuerySelector(".mud-badge")!.TextContent.Trim().Should().Be("3");
+        }
+
+        [Test]
         public async Task ScrollToItem_NoScrollingNeeded()
         {
             var comp = Context.Render<ScrollableTabsTest>();

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -147,7 +147,7 @@
                 <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)" Class="mud-tab-icon-text" />
                 @panel.Text
             }
-            @if (string.IsNullOrEmpty(panel.Text) && HasBadge(panel))
+            @if ((panel.TabContent is not null || string.IsNullOrEmpty(panel.Text)) && HasBadge(panel))
             {
                 <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Max="@panel.BadgeMax" Color="@panel.BadgeColor" Class="mud-tab-badge" />
             }

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor
@@ -81,6 +81,11 @@
 </div>
 
 @code {
+    private static bool HasBadge(MudTabPanel panel)
+    {
+        return panel.BadgeData is not null || panel.BadgeIcon is not null || panel.BadgeDot;
+    }
+
     private RenderFragment RenderTabWrapperSection(MudTabPanel panel) =>
         @<text>
             @if (panel.TabContent is null && panel.TabWrapperContent is null)
@@ -118,6 +123,17 @@
             {
                 @panel.TabContent
             }
+            else if (!string.IsNullOrEmpty(panel.Text) && HasBadge(panel))
+            {
+                <span class="mud-tab-content">
+                    @if (!string.IsNullOrEmpty(panel.Icon))
+                    {
+                        <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)" Class="mud-tab-icon-text" />
+                    }
+                    <span class="mud-tab-label">@panel.Text</span>
+                    <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Max="@panel.BadgeMax" Color="@panel.BadgeColor" Class="mud-tab-badge" />
+                </span>
+            }
             else if (!string.IsNullOrEmpty(panel.Text) && string.IsNullOrEmpty(panel.Icon))
             {
                 @panel.Text
@@ -131,7 +147,7 @@
                 <MudIcon Icon="@panel.Icon" Color="@GetPanelIconColor(panel)" Class="mud-tab-icon-text" />
                 @panel.Text
             }
-            @if (panel.BadgeData is not null || panel.BadgeIcon is not null || panel.BadgeDot)
+            @if (string.IsNullOrEmpty(panel.Text) && HasBadge(panel))
             {
                 <MudBadge Dot="@panel.BadgeDot" Content="@panel.BadgeData" Icon="@panel.BadgeIcon" Max="@panel.BadgeMax" Color="@panel.BadgeColor" Class="mud-tab-badge" />
             }

--- a/src/MudBlazor/Styles/components/_tabs.scss
+++ b/src/MudBlazor/Styles/components/_tabs.scss
@@ -195,6 +195,21 @@
     color: var(--mud-palette-text-disabled);
   }
 
+  & .mud-tab-content {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  & .mud-tab-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   & .mud-tab-icon-text {
     margin-right: 8px;
     margin-inline-end: 8px;
@@ -235,7 +250,27 @@
   }
 }
 
-.mud-tab-badge {
+.mud-tab-content > .mud-tab-badge {
+  &.mud-badge-root {
+    position: static;
+    display: inline-flex;
+    flex: 0 0 auto;
+    margin-inline-start: 4px;
+
+    .mud-badge-wrapper {
+      position: static;
+      width: auto;
+      height: auto;
+      flex: 0 0 auto;
+    }
+
+    .mud-badge {
+      position: static;
+    }
+  }
+}
+
+.mud-tab > .mud-tab-badge {
   margin-left: 8px;
   margin-inline-start: 8px;
   margin-inline-end: unset;


### PR DESCRIPTION
## Summary

`MudTabs` badges could be clipped, overlap text, or force long labels to wrap when space was limited. This change keeps text-tab badges visible at the label's trailing edge while allowing the label to truncate.

The layout follows Material Design 3 guidance with a 4px label-to-badge gap while preserving the existing 8px icon-to-label spacing.

Fixes #1668

## Changes

- Groups the optional icon, shrinkable label, and badge for standard text tabs.
- Keeps badges visible while long labels truncate with an ellipsis.
- Uses logical spacing for consistent LTR and RTL layouts.
- Preserves icon-only tabs, custom `TabContent`, and `TabWrapperContent`.
- Updates the Tabs documentation and constrained badge examples.
- Makes no public API or dependency changes.

## Visual Evidence

### Before — Desktop 1440×1000

![Before desktop](https://files.catbox.moe/mb0n07.png)

Badges are clipped at the tab boundary, labels wrap, and RTL content can collide with the badge.

### After — Desktop 1440×1000

![After desktop](https://files.catbox.moe/9tov6m.png)

Badges remain contained, labels truncate, and spacing remains consistent in LTR and RTL layouts.

### Before — Narrow 390×844

![Before narrow](https://files.catbox.moe/r19pgt.png)

The constrained layout clips badges and retains the RTL text/badge collision.

### After — Narrow 390×844

![After narrow](https://files.catbox.moe/c2p76i.png)

Badges remain visible without overlapping adjacent tabs, and labels yield before the badge.

## Compatibility Notes

- Unlike the top-corner overlay explored in #13411, text badges remain inline with their labels.
- Default 160px tabs and explicitly constrained tabs retain their outer width when badge content changes.
- With a custom minimum width below the content's natural size, the inline badge can contribute to the tab's natural width. This is intentional for the Material Design 3 text-tab layout.
- The reverted multi-row header behavior from #9108 remains untouched.

**Checklist:**

- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

-- Coded by Codebringer / AI  
-- Codebringer for versile2  
-- versile2 approved
