### PR TITLE
MudIconButton: Keep padding consistent between variants

### DIFF
--- a/src/MudBlazor/Styles/components/_button.scss
+++ b/src/MudBlazor/Styles/components/_button.scss
@@ -138,7 +138,8 @@
   background-color: var(--mud-palette-action-default-hover);
 
   &.mud-icon-button {
-    padding: 6px;
+    border: 1px solid transparent;
+    padding: 5px;
   }
 
   @media(hover: hover) and (pointer: fine) {
@@ -245,7 +246,7 @@
   font-size: 0.8125rem;
 
   &.mud-icon-button {
-    padding: 5px;
+    padding: 4px;
   }
 }
 
@@ -254,7 +255,7 @@
   font-size: 0.9375rem;
 
   &.mud-icon-button {
-    padding: 5px;
+    padding: 4px;
   }
 }
 


### PR DESCRIPTION
Keeps filled icon buttons aligned with outlined icon buttons by reserving the border space instead of changing the padding. The outer button size stays unchanged.

Fixes #10366

Tested in the UnitTests Viewer at 125% display scaling. The Viewer build passes with 0 warnings and 0 errors.

### 125% display scaling

<img width="128" height="84" alt="Outlined and filled icon buttons at 125% display scaling" src="https://raw.githubusercontent.com/Guflly/MudBlazor/pr-assets/.github/pr-assets/mud-icon-button-125.png" />

**Checklist:**

- [x] I've read the contribution guidelines
- [x] My code follows the style of this project
- [x] This CSS-only change was checked in the test viewer
