### PR TITLE
MudForm: Revert aggregating child form errors into Errors

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -2733,44 +2733,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Regression test for: https://github.com/MudBlazor/MudBlazor/issues/11193.
-        /// The Errors property should aggregate the errors of child forms, the same way
-        /// that IsValid reflects the validity of child forms.
-        /// </summary>
-        [Test]
-        public async Task ChildForm_ErrorsPropagateToParent()
-        {
-            var comp = Context.Render<FormWithChildFormTest>();
-            var childFormSwitch = comp.Find(".mud-switch-input");
-            var parentForm = comp.FindComponent<MudForm>().Instance;
-            var parentTextFieldCmp = comp.FindComponent<MudTextField<string>>();
-
-            // Satisfy the parent's own required field, so that any error on the
-            // parent form can only have come from the child form.
-            await parentTextFieldCmp.Find("input").ChangeAsync("Marilyn Manson");
-            parentForm.IsValid.Should().BeTrue();
-            parentForm.Errors.Should().BeEmpty();
-
-            // Display the child form, which holds a second required field.
-            await childFormSwitch.ChangeAsync(true);
-            var forms = comp.FindComponents<MudForm>();
-            forms.Count.Should().Be(2);
-            var childForm = forms[1];
-            var childTextFieldCmp = childForm.FindComponent<MudTextField<string>>();
-
-            // Touch the child's required field and clear it, producing an error.
-            await childTextFieldCmp.Find("input").ChangeAsync("Trent Reznor");
-            await childTextFieldCmp.Find("input").ChangeAsync("");
-
-            childForm.Instance.IsValid.Should().BeFalse();
-            childForm.Instance.Errors.Should().BeEquivalentTo(["Required"]);
-
-            // The parent form has no errors of its own, but must surface the child's.
-            parentForm.IsValid.Should().BeFalse();
-            parentForm.Errors.Should().BeEquivalentTo(["Required"]);
-        }
-
-        /// <summary>
         /// Regression test for: https://github.com/MudBlazor/MudBlazor/issues/12012.
         /// When a form has a validation error and the bound property is updated through code,
         /// the validation error should be cleared if the new value is valid, or updated if still invalid.

--- a/src/MudBlazor/Components/Form/MudForm.razor.cs
+++ b/src/MudBlazor/Components/Form/MudForm.razor.cs
@@ -196,7 +196,7 @@ namespace MudBlazor
         public bool? OverrideFieldValidation { get; set; }
 
         /// <summary>
-        /// The validation errors for inputs within this form and any child forms.
+        /// The validation errors for inputs within this form.
         /// </summary>
         /// <remarks>
         /// When this property changes, <see cref="ErrorsChanged"/> occurs.
@@ -205,7 +205,7 @@ namespace MudBlazor
         [Category(CategoryTypes.Form.ValidationResult)]
         public string[] Errors
         {
-            get => _errors.Concat(ChildForms.SelectMany(childForm => childForm.Errors)).ToArray();
+            get => _errors.ToArray();
             set { /* readonly */ }
         }
 


### PR DESCRIPTION
## Description

Reverts https://github.com/MudBlazor/MudBlazor/pull/13453 for v9.8.0.

That PR changed `Errors` from the form's own error snapshot into a recursively computed value:

```csharp
get => _errors.Concat(ChildForms.SelectMany(childForm => childForm.Errors)).ToArray();
```

`ErrorsChanged` still fires only from the owning form's `OnEvaluateForm`. A child can therefore change the parent's observable `Errors` **without the parent raising its paired change event**, so `@bind-Errors` and anything caching from `ErrorsChanged` go stale while a direct read of `.Errors` is fresh.

This was known at review time and judged acceptable because `IsValid` has aggregated child state with exactly the same gap for a long time. On reflection that reasoning is backwards for a stability release: the inconsistency is not new to the library, but it *is* new for `Errors`, and it is being introduced here. Shipping a public property whose value changes without its event is a contract defect regardless of precedent elsewhere.

Aggregation also left duplicate semantics unsettled. Each form deduplicates internally (`_errors` is a `HashSet<string>`), but the concat across forms is not deduplicated, so a parent and child that both report "Required" surface `["Required", "Required"]`.

## Why revert rather than fix forward

Making this coherent needs a real recursive notification contract — child registration, disposal, and arbitrary nesting all have to propagate, and the same treatment is arguably owed to `IsValid`/`IsValidChanged`. That is a design change, not another getter change, and it is not work to land during a release freeze.

Reverting restores the 9.7.0 semantics so `Errors` and `ErrorsChanged` stay coherent in v9.8.0.

## Follow-up

Reopens #11193, which is a legitimate request — `Errors` genuinely does not reflect child forms, and that is inconsistent with `IsValid`.

The shape I would suggest for v10 is an explicit, additive pair such as `AllErrors` / `AllErrorsChanged`, leaving `Errors` with its existing meaning. That resolves the original issue without redefining a property consumers already depend on, and it can carry a proper notification contract from the start. Redefining `Errors` itself, if we want that, belongs in a major with migration notes.

## Verification

```
MudBlazor.UnitTests: FormTests + RowValidator — 109/109 passed
```

The revert removes `ChildForm_ErrorsPropagateToParent`, which asserted the behaviour being reverted. `FormWithChildFormTest` is untouched — it predates #13453 and is still used by the child-touched tests.

The only `src` consumer of `IForm.Errors` is the row-commit guard in `MudTr.razor.cs`, whose default validator is `TableRowValidator`, a separate `IForm` implementation that this does not affect. `RowValidator` tests are included in the run above.
