### PR TITLE
MudNavLink: Keep disabled links inert when attributes assigned directly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -40,6 +40,39 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("a").GetAttribute("rel").Should().Be("nofollow");
         }
 
+        [TestCase("href")]
+        [TestCase("HREF")]
+        [TestCase("target")]
+        public void NavLink_Disabled_DropsNavigationAttributesAssignedDirectly(string attributeName)
+        {
+            // UserAttributes is a parameter, so assigning the dictionary directly skips the per-key
+            // matching that routes href/target to Href/Target. A disabled link must stay inert anyway.
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.Disabled, true)
+                .Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    [attributeName] = "/dashboard",
+                    ["data-testid"] = "nav-disabled"
+                }));
+
+            var anchor = comp.Find("a");
+            anchor.HasAttribute(attributeName).Should().BeFalse();
+            anchor.HasAttribute("href").Should().BeFalse();
+            anchor.GetAttribute("data-testid").Should().Be("nav-disabled", because: "only navigation attributes are dropped");
+        }
+
+        [Test]
+        public void NavLink_Enabled_KeepsNavigationAttributesAssignedDirectly()
+        {
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.Href, "/dashboard")
+                .Add(x => x.UserAttributes, new Dictionary<string, object> { ["data-testid"] = "nav-enabled" }));
+
+            var anchor = comp.Find("a");
+            anchor.GetAttribute("href").Should().Be("/dashboard");
+            anchor.GetAttribute("data-testid").Should().Be("nav-enabled");
+        }
+
         [Test]
         public void NavLink_Rel_IsOmittedWhenDisabled()
         {

--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -45,8 +45,8 @@ namespace MudBlazor.UnitTests.Components
         [TestCase("target")]
         public void NavLink_Disabled_DropsNavigationAttributesAssignedDirectly(string attributeName)
         {
-            // UserAttributes is a parameter, so assigning the dictionary directly skips the per-key
-            // matching that routes href/target to Href/Target. A disabled link must stay inert anyway.
+            // UserAttributes is a parameter, so assigning the dictionary directly skips the per-key matching that routes href/target to Href/Target.
+            // A disabled link must stay inert anyway.
             var comp = Context.Render<MudNavLink>(parameters => parameters
                 .Add(x => x.Disabled, true)
                 .Add(x => x.UserAttributes, new Dictionary<string, object>
@@ -64,12 +64,17 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void NavLink_Enabled_KeepsNavigationAttributesAssignedDirectly()
         {
+            // The href here is supplied through UserAttributes rather than the Href parameter, so this exercises the same path as the disabled cases and shows the guard is scoped to Disabled.
             var comp = Context.Render<MudNavLink>(parameters => parameters
                 .Add(x => x.Href, "/dashboard")
-                .Add(x => x.UserAttributes, new Dictionary<string, object> { ["data-testid"] = "nav-enabled" }));
+                .Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    ["href"] = "/override",
+                    ["data-testid"] = "nav-enabled"
+                }));
 
             var anchor = comp.Find("a");
-            anchor.GetAttribute("href").Should().Be("/dashboard");
+            anchor.GetAttribute("href").Should().Be("/override", because: "a caller assigning href directly still overrides Href when the link is enabled");
             anchor.GetAttribute("data-testid").Should().Be("nav-enabled");
         }
 

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -38,17 +38,30 @@ namespace MudBlazor
         {
             get
             {
-                var rel = Rel ?? (!string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty);
-                var attributes = Disabled ? new Dictionary<string, object?>() : new Dictionary<string, object?>
+                // Compared without case so a caller cannot slip navigation attributes past the
+                // disabled check by varying their casing, since HTML attribute names are case-insensitive.
+                var attributes = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+                if (!Disabled)
                 {
-                    { "href", Href },
-                    { "target", Target },
-                    { "rel", rel }
-                };
+                    attributes["href"] = Href;
+                    attributes["target"] = Target;
+                    attributes["rel"] = Rel ?? (!string.IsNullOrWhiteSpace(Target) ? "noopener noreferrer" : string.Empty);
+                }
+
                 foreach (var attribute in UserAttributes)
                 {
                     attributes[attribute.Key] = attribute.Value;
                 }
+
+                if (Disabled)
+                {
+                    // UserAttributes is a parameter in its own right, so assigning it directly bypasses
+                    // the per-key matching that would otherwise route these to Href and Target.
+                    // Without this a caller-supplied href leaves a disabled link fully navigable.
+                    attributes.Remove("href");
+                    attributes.Remove("target");
+                }
+
                 return attributes;
             }
         }

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -38,8 +38,7 @@ namespace MudBlazor
         {
             get
             {
-                // Compared without case so a caller cannot slip navigation attributes past the
-                // disabled check by varying their casing, since HTML attribute names are case-insensitive.
+                // Compared without case so a caller cannot slip navigation attributes past the disabled check by varying their casing, since HTML attribute names are case-insensitive.
                 var attributes = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
                 if (!Disabled)
                 {
@@ -55,8 +54,7 @@ namespace MudBlazor
 
                 if (Disabled)
                 {
-                    // UserAttributes is a parameter in its own right, so assigning it directly bypasses
-                    // the per-key matching that would otherwise route these to Href and Target.
+                    // UserAttributes is a parameter in its own right, so assigning it directly bypasses the per-key matching that would otherwise route these to Href and Target.
                     // Without this a caller-supplied href leaves a disabled link fully navigable.
                     attributes.Remove("href");
                     attributes.Remove("target");


### PR DESCRIPTION
https://github.com/MudBlazor/MudBlazor/pull/13524 forwards `UserAttributes` to the anchor. `UserAttributes` is itself a `[Parameter(CaptureUnmatchedValues = true)]`, so assigning the dictionary **directly** bypasses the per-key matching that would otherwise route `href` and `target` to the `Href` and `Target` parameters:

```razor
<MudNavLink Disabled="true" UserAttributes="@dict" />
@* dict = { ["href"] = "/landed", ["target"] = "_blank" } *@
```

On `dev` that renders a fully navigable anchor that merely *looks* disabled, and clicking it navigates:

```html
<a class="mud-nav-link mud-nav-link-disabled" href="/landed" target="_blank" tabindex="-1">
```

Supplying the same keys as literal attributes or through an `@attributes` splat was never affected — both go through parameter matching, so `href` binds `Href` and never reaches `UserAttributes`. Only the direct-assignment path is exposed, which is why the existing `Disabled` tests and the tests added in #13524 all pass against the bug.

This does not change the DOM placement introduced by #13524. Attributes stay on the anchor.

It drops `href` and `target` from the merged attributes when the link is disabled, and build the dictionary with `StringComparer.OrdinalIgnoreCase` so the guard cannot be sidestepped by spelling them differently — HTML attribute names are case-insensitive, so `HREF` would otherwise survive an ordinal `Remove`.

Everything else a caller supplies is still forwarded, disabled or not.