### PR TITLE
MudTablePager: Fix navigation icons displaying outside container when minimized

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -486,6 +486,7 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   padding-inline-end: 2px;
   padding-inline-start: unset;
   flex-wrap: nowrap;
+  overflow: auto hidden;
 
   & .mud-tablepager-left {
     flex-direction: row !important;


### PR DESCRIPTION
The goal is to fix the [MudTablePager: Navigation icons display outside container](https://github.com/MudBlazor/MudBlazor/issues/13559) issue. No test is required.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests

Fixes #13559