### PR TITLE
Code Quality: Fix trivial SonarQube violations

### DIFF
--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -36,7 +36,7 @@
                     <g class="mud-chart-labels">
                         @if (!string.IsNullOrEmpty(item.LabelXValue) || !string.IsNullOrEmpty(item.LabelYValue))
                         {
-                            @RenderValueLabel(petal);
+                            @RenderValueLabel(petal)
                         }
                     </g>
                 }

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -362,7 +362,7 @@ namespace MudBlazor.Charts
             var result = new List<ChartSeries<T>>();
             var chartSeries = ChartSeries.Take(aggregated.Length);
 
-            foreach (var (series, index) in chartSeries.Select((s, i) => (s, i)))
+            foreach (var series in chartSeries)
             {
                 var data = new List<(SankeyLink, T)>();
                 var values = series.Data?.Values ?? [];

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -57,7 +57,7 @@ else if (Column != null && !Column.HiddenState.Value)
                 <span class="@SortHeaderClass" @onclick="SortChangedAsync">
                     @if (headerTemplate != null)
                     {
-                        @headerTemplate(Column.headerContext);
+                        @headerTemplate(Column.headerContext)
                     }
                     else if (IncludeHierarchyToggle)
                     {
@@ -73,7 +73,7 @@ else if (Column != null && !Column.HiddenState.Value)
             { 
                 @if (headerTemplate != null)
                 {
-                    @headerTemplate(Column.headerContext);
+                    @headerTemplate(Column.headerContext)
                 }
                 else if (IncludeHierarchyToggle)
                 {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -203,7 +203,7 @@
                                 }
                             </thead>
                             <tbody class="@BodyClassname">
-                                @if (Virtualize || CurrentPageItems.Count() > 0)
+                                @if (Virtualize || CurrentPageItems.Any())
                                 {
                                     if (IsGrouped)
                                     {

--- a/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogProvider.razor.cs
@@ -227,7 +227,7 @@ namespace MudBlazor
 
         private IDialogReference? GetDialogReference(Guid id)
         {
-            return _dialogs.ToArray().FirstOrDefault(d => d.Id == id);
+            return _dialogs.FirstOrDefault(d => d.Id == id);
         }
 
         private void LocationChanged(object? sender, LocationChangedEventArgs args)

--- a/src/MudBlazor/Components/ExitPrompt/MudExitPrompt.razor.cs
+++ b/src/MudBlazor/Components/ExitPrompt/MudExitPrompt.razor.cs
@@ -108,7 +108,6 @@ public partial class MudExitPrompt : MudComponentBase, IAsyncDisposable
         if (!await IsNavigationAllowedAsync())
         {
             context.PreventNavigation();
-            return;
         }
     }
 

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor.cs
@@ -571,7 +571,7 @@ namespace MudBlazor
         {
             if (!(typeof(T) == typeof(IReadOnlyList<IBrowserFile>) || typeof(T) == typeof(IBrowserFile)))
             {
-                Logger.LogWarning("T must be of type {type1} or {type2}", typeof(IReadOnlyList<IBrowserFile>), typeof(IBrowserFile));
+                Logger.LogWarning("T must be of type {Type1} or {Type2}", typeof(IReadOnlyList<IBrowserFile>), typeof(IBrowserFile));
             }
 
             base.OnInitialized();

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -1233,7 +1233,7 @@ namespace MudBlazor
                 return;
             if (activeIndex + 1 == _panels.Count)
             {
-                var lastPanel = _panels.Last();
+                var lastPanel = _panels[^1];
                 ScrollToItem(lastPanel, true);
                 return;
             }

--- a/src/MudBlazor/Interop/ResizeListenerInterop.cs
+++ b/src/MudBlazor/Interop/ResizeListenerInterop.cs
@@ -19,7 +19,7 @@ internal class ResizeListenerInterop
 
     public async ValueTask<bool> MatchMedia(string mediaQuery, CancellationToken cancellationToken = default)
     {
-        var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(false, "mudResizeListener.matchMedia", cancellationToken, mediaQuery);
+        var (_, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(false, "mudResizeListener.matchMedia", cancellationToken, mediaQuery);
 
         return value;
     }
@@ -47,7 +47,7 @@ internal class ResizeListenerInterop
 
     public async ValueTask<BrowserWindowSize> GetBrowserWindowSize(CancellationToken cancellationToken = default)
     {
-        var (success, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(new BrowserWindowSize(), "mudResizeListener.getBrowserWindowSize", cancellationToken);
+        var (_, value) = await _jsRuntime.InvokeAsyncWithErrorHandling(new BrowserWindowSize(), "mudResizeListener.getBrowserWindowSize", cancellationToken);
 
         return value;
     }

--- a/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
+++ b/src/MudBlazor/Services/ResizeObserver/ResizeObserver.cs
@@ -67,7 +67,7 @@ internal sealed class ResizeObserver : IResizeObserver
         var counter = 0;
         foreach (var item in result)
         {
-            _cachedValues.Add(filteredElements.ElementAt(counter), item);
+            _cachedValues.Add(filteredElements[counter], item);
             counter++;
         }
 

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -36,8 +36,7 @@ window.mudDragAndDrop = {
     getDropZoneIdentifierOnPosition: (x, y) => {
         const elems = document.elementsFromPoint(x, y);
         // Use top-to-bottom hit testing so nested layouts still resolve the visually closest zone.
-        const dropZones = elems.filter(e => e.classList.contains('mud-drop-zone'));
-        const dropZone = dropZones[0];
+        const dropZone = elems.find(e => e.classList.contains('mud-drop-zone'));
         if (dropZone) {
             return dropZone.getAttribute('identifier') || "";
         }
@@ -51,8 +50,7 @@ window.mudDragAndDrop = {
 
         const elems = document.elementsFromPoint(x, y);
 
-        const dropItems = elems.filter(e => e.classList.contains('mud-drop-item') && e.id != id);
-        const dropItem = dropItems[0];
+        const dropItem = elems.find(e => e.classList.contains('mud-drop-item') && e.id != id);
         if (dropItem) {
             return dropItem.getAttribute('index') || "";
         }

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -31,7 +31,7 @@ window.getTabbableElements = (element) => {
 // Legacy serializer kept on `window` for JS interop payload normalization in browser-only call paths.
 // Source inspiration: https://github.com/RemiBou/BrowserInterop
 function serializeParameter(data, spec) {
-    if (typeof data == "undefined" ||
+    if (data === undefined ||
         data === null) {
         return null;
     }

--- a/src/MudBlazor/TScripts/mudInputSizing.js
+++ b/src/MudBlazor/TScripts/mudInputSizing.js
@@ -62,7 +62,7 @@ window.mudInputSizing = {
 
         // Update parameters that affect the functionality and visuals of the sizing input.
         elem.updateParameters = function (newMaxLines) {
-            maxLinesValue = newMaxLines > 0 ? newMaxLines : 0;
+            maxLinesValue = Math.max(newMaxLines, 0);
         };
 
         // Capture min and max height in closure to trigger height adjustment on element in the input.

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -100,7 +100,7 @@ class MudKeyInterceptor {
             // Normalize direct lookups to lowercase once so event handlers can stay allocation-light.
             this._keyOptions[keyOption.key.toLowerCase()] = keyOption;
         // remove whitespace and enforce lowercase
-        const whitespace = new RegExp("\\s", "g");
+        const whitespace = /\s/g;
         keyOption.preventDown = (keyOption.preventDown || "none").replace(whitespace, "").toLowerCase();
         keyOption.preventUp = (keyOption.preventUp || "none").replace(whitespace, "").toLowerCase();
         keyOption.stopDown = (keyOption.stopDown || "none").replace(whitespace, "").toLowerCase();

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -94,8 +94,7 @@ class MudScrollManager {
         if (this._lockCount === 0) {
             const element = document.querySelector(selector) || document.body;
             // remove both lock classes to be sure it's unlocked
-            element.classList.remove(lockclass);
-            element.classList.remove(lockclass + "-no-padding");
+            element.classList.remove(lockclass, lockclass + "-no-padding");
         }
     }
 


### PR DESCRIPTION
Clears 18 open SonarCloud issues with mechanical changes that have no behavior change. Picked from the [current issue list](https://sonarcloud.io/summary/overall?id=MudBlazor_MudBlazor) by taking only the ones that are provably equivalent.

## C#

- **S1116** — `HeaderCell.razor`, `BaseRadialChart.razor`: stray `;` after a Razor implicit expression. Verified against the generated code: it compiles to a bare empty statement, not rendered content.
- **S1481** — `ResizeListenerInterop`, `Sankey`: unused deconstruction target and an unused `Select` index.
- **S1155** — `MudDataGrid.razor`: `CurrentPageItems.Count() > 0` → `Any()`. `CurrentPageItems` is an `IEnumerable<T>`, so the old form fully enumerated on every render.
- **S6608** — `MudTabs`, `ResizeObserver`: `Last()`/`ElementAt()` on a `List<>` → indexer.
- **S6678** — `MudFileUpload`: `{type1}`/`{type2}` → PascalCase log placeholders.
- **S3626** — `MudExitPrompt`: redundant trailing `return`.
- **S2971** — `MudDialogProvider.GetDialogReference`: drop `ToArray()`.

## JS

- **S7778** — `mudScrollManager`: two `classList.remove()` calls → one variadic call.
- **S7750** — `mudDragAndDrop`: `filter(...)[0]` → `find(...)`.
- **S6325 + S7780** — `mudKeyInterceptor`: `new RegExp("\s", "g")` → `/\s/g`.
- **S7766** — `mudInputSizing`: `n > 0 ? n : 0` → `Math.max(n, 0)`. `MaxLines` is an `int` over interop, so it is always a number.
- **S7741** — `mudHelpers`: `typeof data == "undefined"` → `data === undefined`.

## Not included

Three other `S2971` hits in `MudDialogProvider` look identical but are not. `_dialogs` is a `List<>` and those loop bodies remove from it, so the `ToArray()` is a required snapshot — dropping it throws `InvalidOperationException`. Only the `FirstOrDefault` call site is a true positive.

Also skipped, and worth a suppression rather than a fix: the 12 `S1854` hits on `seq` in the chart render fragments. Sonar flags the last `seq++` in each block, but Blazor sequence numbers should stay uniform and append-only.