### PR TITLE
MudTablePager: Fix navigation icons displaying outside container when minimized

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -486,8 +486,6 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   padding-right: 2px;
   padding-inline-end: 2px;
   padding-inline-start: unset;
-  // Wrap onto another row when the controls no longer fit.
-  // A fixed height with overflow hides the navigation buttons behind a scrollbar and still clips them.
   flex-wrap: wrap;
 
   & .mud-tablepager-left {
@@ -505,8 +503,6 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 }
 
 .mud-table-pagination-spacer {
-  // A 100% basis makes the spacer claim a whole flex line once the toolbar can wrap.
-  // That drops the end and center alignment even at widths that never needed to wrap.
   flex: 1 1 auto;
 }
 

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -481,12 +481,12 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 
 .mud-table-pagination-toolbar {
   border-top: 1px solid var(--mud-palette-table-lines);
-  height: 52px;
+  height: auto;
+  min-height: 52px;
   padding-right: 2px;
   padding-inline-end: 2px;
   padding-inline-start: unset;
-  flex-wrap: nowrap;
-  overflow: auto hidden;
+  flex-wrap: wrap;
 
   & .mud-tablepager-left {
     flex-direction: row !important;

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -486,6 +486,8 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   padding-right: 2px;
   padding-inline-end: 2px;
   padding-inline-start: unset;
+  // Wrap onto another row when the controls no longer fit.
+  // A fixed height with overflow hides the navigation buttons behind a scrollbar and still clips them.
   flex-wrap: wrap;
 
   & .mud-tablepager-left {
@@ -503,7 +505,9 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
 }
 
 .mud-table-pagination-spacer {
-  flex: 1 1 100%;
+  // A 100% basis makes the spacer claim a whole flex line once the toolbar can wrap.
+  // That drops the end and center alignment even at widths that never needed to wrap.
+  flex: 1 1 auto;
 }
 
 .mud-table-pagination-caption {
@@ -709,7 +713,6 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   .mud-table {
     .mud-table-pagination {
       .mud-table-pagination-toolbar {
-        flex-wrap: wrap;
         padding-top: 16px;
         padding-right: 16px;
         padding-inline-end: 16px;


### PR DESCRIPTION
The goal is to fix the [MudTablePager: Navigation icons display outside container](https://github.com/MudBlazor/MudBlazor/issues/13559) issue. No test is required. Following the discussion in the [PR](https://github.com/MudBlazor/MudBlazor/pull/13566)

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests

Fixes #13559