### PR TITLE
MudSwitch: Fix cursor briefly changing to `pointer` when hovering over disabled switch

### DIFF
--- a/src/MudBlazor/Styles/components/_switch.scss
+++ b/src/MudBlazor/Styles/components/_switch.scss
@@ -71,6 +71,7 @@
 
   &.mud-switch-disabled {
     color: var(--mud-palette-gray-default) !important;
+    cursor: default;
 
     & + .mud-switch-track {
       opacity: 0.12 !important;


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

Noticed a minimal split second switch to the `pointer` mouse style when hovering into a disabled `MudSwitch`. Explicitly setting `cursor: default` on the relevant CSS class fixes this.

#### Before/After

<img width="1238" height="467" alt="recording-20260805-131316" src="https://github.com/user-attachments/assets/88c0c4b6-b8ed-4f70-a7a0-c93332ce909c" />  

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
