### PR TITLE
Docs: Update community extension link

### DIFF
--- a/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
+++ b/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
@@ -68,7 +68,7 @@
     "Category": "Style",
     "Name": "MudBlocks",
     "Description": "A collection of MudBlazor blocks. Predefined, reusable UI elements or layouts designed to simplify development by combining multiple components into cohesive sections; such as headers, footers, forms, cards, or dashboards.",
-    "Link": "https://mudblocks.cc/",
+    "Link": "https://github.com/mouse0270/MudBlocks",
     "GitHubUserPath": "mouse0270",
     "GitHubRepoPath": "mudblocks"
   },


### PR DESCRIPTION
## Summary

Updates the MudBlocks community extension entry to link directly to its canonical GitHub repository instead of the external `mudblocks.cc` site.

## Changes

- Replaced the MudBlocks `Link` value with `https://github.com/mouse0270/MudBlocks`.
- Preserved the existing GitHub owner and repository metadata.

## Tested With

- `python3 -m json.tool src/MudBlazor.Docs/wwwroot/CommunityExtensions.json`
- `jq -e '[.[] | select(.Name == "MudBlocks")] | length == 1 and .[0].Link == "https://github.com/mouse0270/MudBlocks"' src/MudBlazor.Docs/wwwroot/CommunityExtensions.json`
- `dotnet restore src/MudBlazor.Docs/MudBlazor.Docs.csproj --nologo`
- `dotnet build src/MudBlazor.Docs/MudBlazor.Docs.csproj --no-restore --nologo`
- `git diff --check HEAD^ HEAD`

## Notes

No visual evidence is included because this PR changes only the destination of an existing link; it does not change rendering or layout.

-- Coded by Codebringer / AI
-- Codebringer for versile2
-- versile2 approved
