### PR TITLE
MudSplitPanel: Defer divider operations until initialization

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SplitPanel/SplitPanelDividerPositionOnFirstRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SplitPanel/SplitPanelDividerPositionOnFirstRenderTest.razor
@@ -1,0 +1,26 @@
+<MudSplitPanel @ref="_panel">
+    <FirstPanel>First Panel</FirstPanel>
+    <SecondPanel>Second Panel</SecondPanel>
+</MudSplitPanel>
+
+@code {
+    private MudSplitPanel _panel = null!;
+
+    [Parameter]
+    public int? DividerPosition { get; set; }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            if (DividerPosition is { } offset)
+            {
+                await _panel.SetDividerPositionAsync(offset);
+            }
+            else
+            {
+                await _panel.ResetDividerPositionAsync();
+            }
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/SplitPanel/SplitPanelGetOnFirstRenderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/SplitPanel/SplitPanelGetOnFirstRenderTest.razor
@@ -1,0 +1,16 @@
+<MudSplitPanel @ref="_panel">
+    <FirstPanel>First Panel</FirstPanel>
+    <SecondPanel>Second Panel</SecondPanel>
+</MudSplitPanel>
+
+@code {
+    private MudSplitPanel _panel = null!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await _panel.GetDividerPositionAsync();
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
@@ -79,6 +79,30 @@ public class SplitPanelTests : BunitTest
     }
 
     [Test]
+    public void ResetDividerPositionFromParentFirstRender_RunsAfterBuild()
+    {
+        Context.Render<SplitPanelDividerPositionOnFirstRenderTest>();
+
+        var invocations = Context.JSInterop.Invocations.ToArray();
+        invocations.Should().HaveCount(2);
+        invocations[0].Identifier.Should().Be("mudSplitPanel.build");
+        invocations[1].Identifier.Should().Be("mudSplitPanel_resetDividerPosition");
+    }
+
+    [Test]
+    public void SetDividerPositionFromParentFirstRender_RunsAfterBuild()
+    {
+        Context.Render<SplitPanelDividerPositionOnFirstRenderTest>(parameters => parameters
+            .Add(p => p.DividerPosition, 123));
+
+        var invocations = Context.JSInterop.Invocations.ToArray();
+        invocations.Should().HaveCount(2);
+        invocations[0].Identifier.Should().Be("mudSplitPanel.build");
+        invocations[1].Identifier.Should().Be("mudSplitPanel_setDividerPosition");
+        invocations[1].Arguments[1].Should().Be(123);
+    }
+
+    [Test]
     public async Task ExecutesSetDividerPositionJsCall()
     {
         var comp = Context.Render<SplitPanelTest>();
@@ -96,6 +120,15 @@ public class SplitPanelTests : BunitTest
 
         var invocation = Context.JSInterop.VerifyInvoke("mudSplitPanel_getDividerPosition");
         invocation.Arguments.Count.Should().Be(1);
+    }
+
+    [Test]
+    public void GetDividerPositionFromParentFirstRender_ThrowsClearException()
+    {
+        var action = () => Context.Render<SplitPanelGetOnFirstRenderTest>();
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("The split panel has not been initialized yet.");
     }
 
     [Test]

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor.cs
@@ -185,6 +185,10 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     // teardown unsubscribes the exact id that was built.
     private string? _builtContainerId;
 
+    private bool _isBuilt;
+    private bool _hasPendingDividerRequest;
+    private int? _pendingDividerPosition;
+
     private string ResolvedContainerId => _builtContainerId ?? GetEffectiveElementId(_containerId);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -195,6 +199,22 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
         {
             _builtContainerId = GetEffectiveElementId(_containerId);
             await JsRuntime.InvokeVoidAsync("mudSplitPanel.build", _builtContainerId, Horizontal, ResetOnDoubleClick, MinPanelSize, FirstPanelInitialSize, PanelGap);
+            _isBuilt = true;
+
+            if (_hasPendingDividerRequest)
+            {
+                var pendingDividerPosition = _pendingDividerPosition;
+                _hasPendingDividerRequest = false;
+                _pendingDividerPosition = null;
+                if (pendingDividerPosition is { } offset)
+                {
+                    await SetDividerPositionAsync(offset);
+                }
+                else
+                {
+                    await ResetDividerPositionAsync();
+                }
+            }
         }
     }
 
@@ -211,8 +231,18 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// <summary>
     /// Resets the divider position to its initial value.
     /// </summary>
+    /// <remarks>
+    /// Calls made before the component is initialized are applied after initialization.
+    /// </remarks>
     public async Task ResetDividerPositionAsync()
     {
+        if (!_isBuilt)
+        {
+            _hasPendingDividerRequest = true;
+            _pendingDividerPosition = null;
+            return;
+        }
+
         await JsRuntime.InvokeVoidAsync("mudSplitPanel_resetDividerPosition", ResolvedContainerId);
     }
 
@@ -221,18 +251,32 @@ public partial class MudSplitPanel : MudComponentBase, IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// Note that this function ignores <see cref="MinPanelSize"/>.
+    /// Calls made before the component is initialized are applied after initialization.
     /// </remarks>
     /// <param name="offset">The offset in pixels from the left or top border.</param>
     public async Task SetDividerPositionAsync(int offset)
     {
+        if (!_isBuilt)
+        {
+            _hasPendingDividerRequest = true;
+            _pendingDividerPosition = offset;
+            return;
+        }
+
         await JsRuntime.InvokeVoidAsync("mudSplitPanel_setDividerPosition", ResolvedContainerId, offset);
     }
 
     /// <summary>
     /// Returns the current offset of the divider from the left or top border in pixels.
     /// </summary>
+    /// <exception cref="InvalidOperationException">The component has not been initialized.</exception>
     public async Task<int> GetDividerPositionAsync()
     {
+        if (!_isBuilt)
+        {
+            throw new InvalidOperationException("The split panel has not been initialized yet.");
+        }
+
         return await JsRuntime.InvokeAsync<int>("mudSplitPanel_getDividerPosition", ResolvedContainerId);
     }
 


### PR DESCRIPTION
## Summary

- defer early reset and set requests until the JavaScript split-panel instance is built
- apply the last requested divider position immediately after initialization
- return a clear `InvalidOperationException` when the divider position is queried before initialization
- cover parent `OnAfterRenderAsync` ordering for reset, set, and get

Fixes #13576

## Validation

- fail-first regression: the new parent-first-render test initially observed `mudSplitPanel_resetDividerPosition` before `mudSplitPanel.build`
- `dotnet build src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj -p:SkipBunCompile=true` — passed with 0 warnings and 0 errors
- filtered `SplitPanelTests` — 12 passed, 0 failed
- `dotnet format whitespace --no-restore --include ...` — 0 files changed

**Checklist:**
- [x] I have read the contribution guidelines
- [x] My code follows the style of this project
- [x] I have added or updated relevant unit tests