### PR TITLE
Docs: fix typo in MudPageContentSection param docs

### DIFF
--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentSection.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentSection.cs
@@ -49,8 +49,8 @@ namespace MudBlazor
         /// </summary>
         /// <param name="title">name of the section will be displayed in the navigation</param>
         /// <param name="id">id of the section. It will be appending to the current url, if the section becomes active</param>
-        /// <param name="level">The level within the hierachy</param>
-        /// <param name="parent">The parent of the section. null if there is no parent or no hierachy</param>
+        /// <param name="level">The level within the hierarchy</param>
+        /// <param name="parent">The parent of the section. null if there is no parent or no hierarchy</param>
         public MudPageContentSection(string title, string id, int level, MudPageContentSection? parent)
         {
             Title = title;


### PR DESCRIPTION
Fix a spelling typo ("hierachy" -> "hierarchy") in the XML `<param>` documentation of the public `MudPageContentSection` constructor. The word appears twice (the `level` and `parent` params) and shows up in IntelliSense.

Documentation only, no behavior change.
