### PR TITLE
MudTablePager, MudDataGridPager: Keep pagination updates stable during translation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -929,7 +929,7 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<DataGridPaginationTest>();
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
 
-            dataGrid.FindAll(".mud-table-pagination-caption span[translate='no']")[^1]
+            dataGrid.FindAll(".mud-table-pagination-caption[translate='no']")[^1]
                 .TextContent.Trim().Should().Be("1-10 of 20");
         }
 

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -924,6 +924,16 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void DataGridPagerInfoTextIsExcludedFromBrowserTranslation()
+        {
+            var comp = Context.Render<DataGridPaginationTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridPaginationTest.Item>>();
+
+            dataGrid.FindAll(".mud-table-pagination-caption span[translate='no']")[^1]
+                .TextContent.Trim().Should().Be("1-10 of 20");
+        }
+
+        [Test]
         public async Task DataGridHideNavigation()
         {
             var comp = Context.Render<DataGridPaginationTest>();

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2609,6 +2609,17 @@ namespace MudBlazor.UnitTests.Components
             tableComponent.Find("div.mud-table-page-number-information").Text().Should().Be(expectedInfoText);
         }
 
+        [Test]
+        public void TablePagerInfoTextIsExcludedFromBrowserTranslation()
+        {
+            var tableComponent = Context.Render<TablePagerInfoTextTest1>();
+
+            tableComponent.Find("div.mud-table-page-number-information")
+                .GetAttribute("translate")
+                .Should()
+                .Be("no");
+        }
+
         /// <summary>
         /// Tests the aria-labels for the pager control buttons
         /// </summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -29,7 +29,7 @@
     @if (ShowPageNumber)
     {
         <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
-            @Info
+            <span translate="no">@Info</span>
         </MudText>
     }
     
@@ -44,4 +44,3 @@
     }
 
 </MudToolBar>
-

--- a/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGridPager.razor
@@ -28,8 +28,8 @@
 
     @if (ShowPageNumber)
     {
-        <MudText Typo="Typo.body2" Class="mud-table-pagination-caption">
-            <span translate="no">@Info</span>
+        <MudText Typo="Typo.body2" Class="mud-table-pagination-caption" translate="no">
+            @Info
         </MudText>
     }
     

--- a/src/MudBlazor/Components/Table/MudTablePager.razor
+++ b/src/MudBlazor/Components/Table/MudTablePager.razor
@@ -37,7 +37,7 @@
     @if (!HidePageNumber)
     {
         <div class="mud-table-pagination-caption">
-            <div class="mud-table-page-number-information">@Info</div>
+            <div class="mud-table-page-number-information" translate="no">@Info</div>
         </div>
     }
     @if (!HidePagination)
@@ -57,4 +57,3 @@
         <div class="mud-table-pagination-spacer"></div>
     }
 </MudToolBar>
-


### PR DESCRIPTION
Google Chrome translation mutates the pager info text node outside Blazor. Subsequent renders then update the renderer-owned node rather than the translated replacement, leaving the visible range frozen or at 0-0 of 0.

This marks the dynamic page-range node as non-translatable so Chrome leaves Blazor-owned DOM intact while pagination continues to update. Other table content remains available to browser translation.

Regression coverage verifies the dynamic pager information carries the standard translate=no opt-out.

Validation:
- Focused regression: 1 passed
- Adjacent MudTablePager tests: 10 passed
- dotnet format whitespace on both changed files
- git diff --check

Fixes #13572

**Checklist:**
- [x] I have read the contribution guidelines
- [x] My code follows the style of this project
- [x] I have added or updated relevant unit tests