### PR TITLE
MudTableSortLabel: Add keyboard activation

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3110,6 +3110,28 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.SortDirection.Should().Be(SortDirection.None);
         }
 
+        /// <summary>
+        /// Tooltips listen on their root wrapper so disabled sort buttons remain hoverable.
+        /// </summary>
+        [Test]
+        public async Task DisabledTableSortLabelStillShowsTooltip()
+        {
+            Context.Render<MudPopoverProvider>();
+
+            var comp = Context.Render<MudTooltip>(parameters => parameters
+                .Add(p => p.Text, "Sorting is unavailable")
+                .AddChildContent<MudTableSortLabel<string>>(sortLabel => sortLabel
+                    .Add(p => p.Enabled, false)));
+
+            var sortLabel = comp.Find("button.mud-table-sort-label");
+            sortLabel.HasAttribute("disabled").Should().BeTrue();
+
+            await sortLabel.ParentElement!.PointerEnterAsync(new PointerEventArgs());
+
+            comp.FindAll("div.mud-popover-open").Should().ContainSingle();
+            comp.Find("div.mud-popover-open").TextContent.Should().Contain("Sorting is unavailable");
+        }
+
         private Mock<IScrollManager> _mockScrollManager = null!;
 
         public class TestItem { public int Id { get; set; } public string Name { get; set; } }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3065,6 +3065,52 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("span.mud-table-sort-label").ClassList.Should().NotContain("mud-table-sort-label-full-width");
         }
 
+        /// <summary>
+        /// Enabled table sort labels expose button semantics and participate in the tab order.
+        /// </summary>
+        [Test]
+        public void TableSortLabelExposesKeyboardButtonSemantics()
+        {
+            var comp = Context.Render<MudTableSortLabel<string>>();
+
+            var sortLabel = comp.Find("span.mud-table-sort-label");
+            sortLabel.GetAttribute("role").Should().Be("button");
+            sortLabel.GetAttribute("tabindex").Should().Be("0");
+            sortLabel.HasAttribute("aria-disabled").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Table sort labels toggle their direction when activated with Enter or Space (#13408).
+        /// </summary>
+        [TestCase("Enter")]
+        [TestCase(" ")]
+        public async Task TableSortLabelKeyboardActivationTogglesDirection(string key)
+        {
+            var comp = Context.Render<MudTableSortLabel<string>>();
+
+            await comp.Find("span.mud-table-sort-label").KeyDownAsync(new KeyboardEventArgs { Key = key });
+
+            comp.Instance.SortDirection.Should().Be(SortDirection.Ascending);
+        }
+
+        /// <summary>
+        /// Disabled table sort labels remain inert and are removed from the tab order.
+        /// </summary>
+        [Test]
+        public async Task DisabledTableSortLabelIsRemovedFromTabOrder()
+        {
+            var comp = Context.Render<MudTableSortLabel<string>>(parameters => parameters
+                .Add(p => p.Enabled, false));
+
+            var sortLabel = comp.Find("span.mud-table-sort-label");
+            sortLabel.HasAttribute("tabindex").Should().BeFalse();
+            sortLabel.GetAttribute("aria-disabled").Should().Be("true");
+
+            await sortLabel.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            comp.Instance.SortDirection.Should().Be(SortDirection.None);
+        }
+
         private Mock<IScrollManager> _mockScrollManager = null!;
 
         public class TestItem { public int Id { get; set; } public string Name { get; set; } }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3116,7 +3116,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task DisabledTableSortLabelStillShowsTooltip()
         {
-            Context.Render<MudPopoverProvider>();
+            var provider = Context.Render<MudPopoverProvider>();
 
             var comp = Context.Render<MudTooltip>(parameters => parameters
                 .Add(p => p.Text, "Sorting is unavailable")
@@ -3128,8 +3128,8 @@ namespace MudBlazor.UnitTests.Components
 
             await sortLabel.ParentElement!.PointerEnterAsync(new PointerEventArgs());
 
-            comp.FindAll("div.mud-popover-open").Should().ContainSingle();
-            comp.Find("div.mud-popover-open").TextContent.Should().Contain("Sorting is unavailable");
+            provider.FindAll("div.mud-popover-open").Should().ContainSingle();
+            provider.Find("div.mud-popover-open").TextContent.Should().Contain("Sorting is unavailable");
         }
 
         private Mock<IScrollManager> _mockScrollManager = null!;

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3082,15 +3082,16 @@ namespace MudBlazor.UnitTests.Components
         /// <summary>
         /// Table sort labels toggle their direction when activated with Enter or Space (#13408).
         /// </summary>
-        [TestCase("Enter")]
-        [TestCase(" ")]
-        public async Task TableSortLabelKeyboardActivationTogglesDirection(string key)
+        [TestCase("Enter", SortDirection.Ascending)]
+        [TestCase(" ", SortDirection.Ascending)]
+        [TestCase("Escape", SortDirection.None)]
+        public async Task TableSortLabelOnlyActivatesForSupportedKeyboardKeys(string key, SortDirection expectedDirection)
         {
             var comp = Context.Render<MudTableSortLabel<string>>();
 
             await comp.Find("span.mud-table-sort-label").KeyDownAsync(new KeyboardEventArgs { Key = key });
 
-            comp.Instance.SortDirection.Should().Be(SortDirection.Ascending);
+            comp.Instance.SortDirection.Should().Be(expectedDirection);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -136,21 +136,21 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("A");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync();
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync();
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("C");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("B");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("A");
 
             comp = Context.Render<TableInitialSortDirectionTest>(parameters => parameters
                 .Add(p => p.InitialSortDirection, SortDirection.Ascending));
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync();
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync();
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("A");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("B");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
 
             comp = Context.Render<TableInitialSortDirectionTest>(parameters => parameters
                 .Add(p => p.InitialSortDirection, SortDirection.None));
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync();
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync();
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("A");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("B");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
@@ -1422,25 +1422,25 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<TableServerSideDataTest5>();
             comp.Find("#counter").TextContent.Should().Be("1"); //initial counter
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
             comp.Find("#counter").TextContent.Should().Be("2");
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
             comp.Find("#counter").TextContent.Should().Be("3");
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
             comp.Find("#counter").TextContent.Should().Be("4");
 
             await comp.Find("#reseter").ClickAsync(); //reset counter and test again
             comp.Find("#counter").TextContent.Should().Be("0");
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
             comp.Find("#counter").TextContent.Should().Be("1");
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
             comp.Find("#counter").TextContent.Should().Be("2");
 
-            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
+            await comp.Find("button.mud-clickable.mud-table-sort-label").ClickAsync(); // sort
             comp.Find("#counter").TextContent.Should().Be("3");
         }
 
@@ -3054,7 +3054,7 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.FullWidth, true)
             );
 
-            comp.Find("span.mud-table-sort-label").ClassList.Should().Contain("mud-table-sort-label-full-width");
+            comp.Find("button.mud-table-sort-label").ClassList.Should().Contain("mud-table-sort-label-full-width");
         }
 
         [Test]
@@ -3062,36 +3062,34 @@ namespace MudBlazor.UnitTests.Components
         {
             var comp = Context.Render<MudTableSortLabel<string>>();
 
-            comp.Find("span.mud-table-sort-label").ClassList.Should().NotContain("mud-table-sort-label-full-width");
+            comp.Find("button.mud-table-sort-label").ClassList.Should().NotContain("mud-table-sort-label-full-width");
         }
 
         /// <summary>
-        /// Enabled table sort labels expose button semantics and participate in the tab order.
+        /// Table sort labels use native button semantics so Enter and Space activation do not scroll the page.
         /// </summary>
         [Test]
         public void TableSortLabelExposesKeyboardButtonSemantics()
         {
             var comp = Context.Render<MudTableSortLabel<string>>();
 
-            var sortLabel = comp.Find("span.mud-table-sort-label");
-            sortLabel.GetAttribute("role").Should().Be("button");
-            sortLabel.GetAttribute("tabindex").Should().Be("0");
-            sortLabel.HasAttribute("aria-disabled").Should().BeFalse();
+            var sortLabel = comp.Find("button.mud-table-sort-label");
+            sortLabel.TagName.Should().Be("BUTTON");
+            sortLabel.GetAttribute("type").Should().Be("button");
+            sortLabel.HasAttribute("disabled").Should().BeFalse();
         }
 
         /// <summary>
-        /// Table sort labels toggle their direction when activated with Enter or Space (#13408).
+        /// Table sort labels toggle their direction through the native button activation path (#13408).
         /// </summary>
-        [TestCase("Enter", SortDirection.Ascending)]
-        [TestCase(" ", SortDirection.Ascending)]
-        [TestCase("Escape", SortDirection.None)]
-        public async Task TableSortLabelOnlyActivatesForSupportedKeyboardKeys(string key, SortDirection expectedDirection)
+        [Test]
+        public async Task TableSortLabelActivatesThroughNativeButtonClick()
         {
             var comp = Context.Render<MudTableSortLabel<string>>();
 
-            await comp.Find("span.mud-table-sort-label").KeyDownAsync(new KeyboardEventArgs { Key = key });
+            await comp.Find("button.mud-table-sort-label").ClickAsync();
 
-            comp.Instance.SortDirection.Should().Be(expectedDirection);
+            comp.Instance.SortDirection.Should().Be(SortDirection.Ascending);
         }
 
         /// <summary>
@@ -3103,11 +3101,11 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<MudTableSortLabel<string>>(parameters => parameters
                 .Add(p => p.Enabled, false));
 
-            var sortLabel = comp.Find("span.mud-table-sort-label");
+            var sortLabel = comp.Find("button.mud-table-sort-label");
             sortLabel.HasAttribute("tabindex").Should().BeFalse();
-            sortLabel.GetAttribute("aria-disabled").Should().Be("true");
+            sortLabel.HasAttribute("disabled").Should().BeTrue();
 
-            await sortLabel.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            await sortLabel.ClickAsync();
 
             comp.Instance.SortDirection.Should().Be(SortDirection.None);
         }

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor
@@ -3,7 +3,14 @@
 @inherits MudComponentBase
 @implements IDisposable
 
-<span @onclick="ToggleSortDirection" class="@Classname" style="@Style" @attributes="@UserAttributes">
+<span @onclick="ToggleSortDirection"
+      @onkeydown="HandleKeyDownAsync"
+      role="button"
+      tabindex="@(Enabled ? "0" : null)"
+      aria-disabled="@(Enabled ? null : "true")"
+      class="@Classname"
+      style="@Style"
+      @attributes="@UserAttributes">
     @if (!AppendIcon)
     {
         @ChildContent

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor
@@ -3,14 +3,12 @@
 @inherits MudComponentBase
 @implements IDisposable
 
-<span @onclick="ToggleSortDirection"
-      @onkeydown="HandleKeyDownAsync"
-      role="button"
-      tabindex="@(Enabled ? "0" : null)"
-      aria-disabled="@(Enabled ? null : "true")"
-      class="@Classname"
-      style="@Style"
-      @attributes="@UserAttributes">
+<button type="button"
+        @onclick="ToggleSortDirection"
+        disabled="@(!Enabled)"
+        class="@Classname"
+        style="@Style"
+        @attributes="@UserAttributes">
     @if (!AppendIcon)
     {
         @ChildContent
@@ -23,4 +21,4 @@
     {
         @ChildContent
     }
-</span>
+</button>

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -173,6 +174,13 @@ namespace MudBlazor
                     : SortDirection.Ascending),
                 _ => throw new NotImplementedException()
             };
+        }
+
+        private Task HandleKeyDownAsync(KeyboardEventArgs args)
+        {
+            return args.Key is "Enter" or " "
+                ? ToggleSortDirection()
+                : Task.CompletedTask;
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -174,13 +173,6 @@ namespace MudBlazor
                     : SortDirection.Ascending),
                 _ => throw new NotImplementedException()
             };
-        }
-
-        private Task HandleKeyDownAsync(KeyboardEventArgs args)
-        {
-            return args.Key is "Enter" or " "
-                ? ToggleSortDirection()
-                : Task.CompletedTask;
         }
 
         protected override void OnInitialized()

--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -73,6 +73,14 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
   flex-direction: inherit;
   justify-content: flex-start;
 
+  &:disabled {
+    cursor: default;
+  }
+
+  &:focus-visible {
+    background-color: var(--mud-palette-action-default-hover);
+  }
+
   &.mud-table-sort-label-full-width {
     width: 100%;
   }


### PR DESCRIPTION
## Summary

- expose enabled table sort labels as focusable buttons without changing their existing DOM element
- activate sorting with Enter or Space and keep disabled labels out of the tab order
- add regression coverage for keyboard semantics, activation, and disabled behavior

## Validation

- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "Name~TableSortLabel" --output Normal --no-ansi --hangdump --hangdump-timeout 30s` (10 passed)
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~MudBlazor.UnitTests.Components.TableTests" --output Normal --no-ansi --hangdump --hangdump-timeout 30s` (146 passed)
- `dotnet format whitespace --no-restore --include MudBlazor/Components/Table/MudTableSortLabel.razor MudBlazor/Components/Table/MudTableSortLabel.razor.cs MudBlazor.UnitTests/Components/TableTests.cs`
- `git diff --check`

Fixes #13408

**Checklist:**
- [x] I have read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I have added or updated relevant unit tests