### PR TITLE
MudCarousel: Select the first item added after an empty first render

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CarouselTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CarouselTests.cs
@@ -345,5 +345,37 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("button.mud-inherit-text").Count.Should().Be(2);
             comp.FindAll("button.mud-primary-text").Count.Should().Be(0);
         }
+
+        [Test]
+        public void Carousel_SelectsFirstItemAddedAfterFirstRender()
+        {
+            var source = new List<string>();
+            var selectedIndexes = new List<int>();
+            var comp = Context.Render<MudCarousel<string>>(parameters => parameters
+                .Add(p => p.ItemsSource, source)
+                .Add(p => p.AutoCycle, false)
+                .Add(p => p.SelectedIndexChanged, index => selectedIndexes.Add(index)));
+
+            comp.Instance.SelectedIndex.Should().Be(-1);
+            comp.FindAll("div.mud-carousel-item").Count.Should().Be(0);
+
+            // The first item to arrive after an empty first render must become the selected one.
+            source.Add("Item 1");
+            comp.Render();
+
+            comp.Instance.Items.Count.Should().Be(1);
+            comp.Instance.SelectedIndex.Should().Be(0);
+            comp.Instance.SelectedContainer.Should().Be(comp.Instance.Items[0]);
+            comp.FindAll("div.mud-carousel-item").Count.Should().Be(1);
+            selectedIndexes.Should().Equal(0);
+
+            // Later items must not steal the selection.
+            source.Add("Item 2");
+            comp.Render();
+
+            comp.Instance.Items.Count.Should().Be(2);
+            comp.Instance.SelectedIndex.Should().Be(0);
+            selectedIndexes.Should().Equal(0);
+        }
     }
 }

--- a/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
+++ b/src/MudBlazor/Components/Carousel/MudCarousel.razor.cs
@@ -256,6 +256,9 @@ namespace MudBlazor
             if (Items.Count - 1 == SelectedIndex)
                 _currentColor = item.Color;
 
+            if (SelectedIndex < 0)
+                MoveTo(0);
+
             StateHasChanged();
         }
 


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/4094

A carousel whose item source is empty on first render never shows items added later. Bullets appear but no slide does.

`MudBaseItemsControl` only auto-selects index 0 inside `if (firstRender)`, so an initially empty carousel keeps `SelectedIndex` at -1 forever. `AddItem` registers the item and calls `StateHasChanged`, but `MudCarouselItem` renders nothing unless it is the selected one.

This selects index 0 from `AddItem` when nothing is selected yet. Going through `MoveTo` keeps the colour tracking, auto-cycle timer reset and `SelectedIndexChanged` behaviour identical to any other selection change.

The `firstRender` gate is deliberately left alone: `MudTimeline` shares the same base class but registers its children directly rather than through `AddItem`, so it still relies on it.

Carousels that already have items are unaffected, and adding more does not move the selection. The regression test fails without the change.
