### PR TITLE
MudDataGrid: Fix group header alignment on small viewports

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -638,6 +638,16 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
       padding-inline-start: unset;
     }
 
+    // Group header cells carry no data-label.
+    // Without this their empty :before still counts as a flex item, so space-between pushes the group content to the far edge.
+    .mud-table-cell.mud-datagrid-group {
+      justify-content: flex-start;
+
+      &:before {
+        content: none;
+      }
+    }
+
     &.mud-table-small-alignright .mud-table-cell:before {
       margin-right: auto;
     }


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11947

Below the grid's `Breakpoint`, DataGrid group header rows are pushed hard against the right edge of the row.

The small-device layout gives every `.mud-table-cell` `display: flex` with `justify-content: space-between` and a `:before` carrying the column's `data-label`. Group cells have no `data-label`, so their empty `:before` is still generated as a flex item and `space-between` splits it from the group content.

This excludes group cells from the `justify-content` and `:before` rules. It sits inside the existing `table-display-smalldevices` mixin, so it applies to every breakpoint variant. `display: flex` is kept, since the small-device layout depends on the cells being flex boxes.

At 390px the group expander's offset from its cell edge goes from 160px back to 4px, matching both its own desktop value and a `Breakpoint.None` control grid. Desktop is unchanged and ordinary data cells keep their responsive labels.

No unit test: the markup is byte-identical and bUnit renders no stylesheet, so there is nothing for it to assert.

Worth knowing: plain `MudTable` grouping has the same exposure, but its header cells carry no `.mud-datagrid-group` class to target, so they are not covered here.
