### PR TITLE
MudDatePicker: Commit month and year selection with PickerActions

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutocompleteDatePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/AutocompleteDatePickerTest.razor
@@ -1,6 +1,6 @@
 ﻿<MudPopoverProvider />
 
-<MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="_date" AutoClose="AutoClose" ClosingDelay="ClosingDelay">
+<MudDatePicker id="picker" @ref="_picker" Label="With action buttons" @bind-Date="_date" AutoClose="AutoClose" ClosingDelay="ClosingDelay" OpenTo="OpenTo" FixDay="FixDay">
     <PickerActions>
         <MudButton Class="mr-auto align-self-start" OnClick="@(() => _picker.ClearAsync())">Clear</MudButton>
         <MudButton OnClick="@(() => _picker.CloseAsync(false))">Cancel</MudButton>
@@ -20,4 +20,11 @@
     // Mirrors MudBaseDatePicker.ClosingDelay; tests set 0 to remove the post-commit close timer.
     [Parameter]
     public int ClosingDelay { get; set; } = 100;
+
+    // Month/year tests open straight to the month view and fix the day so the month is the last view.
+    [Parameter]
+    public OpenTo OpenTo { get; set; } = OpenTo.Date;
+
+    [Parameter]
+    public int? FixDay { get; set; }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -3,6 +3,7 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.TestComponents.DatePicker;
@@ -990,6 +991,45 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => datePicker.Instance.ClearAsync());
             datePicker.Instance.Date.Should().BeNull();
             comp.FindAll("div.mud-popover-open").Count.Should().Be(1);
+        }
+
+        [Test]
+        public async Task DatePicker_Static_WithPickerActions_MonthClickCommits()
+        {
+            // FixDay makes the month the last view, so clicking a month is the whole selection.
+            RenderFragment<MudPicker<DateTime?>> pickerActions = _ => builder => { };
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(p => p.PickerVariant, PickerVariant.Static)
+                .Add(p => p.PickerActions, pickerActions)
+                .Add(p => p.OpenTo, OpenTo.Month)
+                .Add(p => p.FixDay, 1));
+
+            await comp.FindAll("div.mud-picker-month-container > button.mud-picker-month")[2].ClickAsync();
+
+            // A static picker commits without an action button, the same as a day click does.
+            await comp.WaitForAssertionAsync(() => comp.Instance.Date.Should().Be(new DateTime(DateTime.Now.Year, 3, 1)));
+        }
+
+        [Test]
+        public async Task DatePicker_WithPickerActions_MonthClickDoesNotCommitUntilClose()
+        {
+            var comp = Context.Render<AutocompleteDatePickerTest>(parameters => parameters
+                .Add(p => p.OpenTo, OpenTo.Month)
+                .Add(p => p.FixDay, 1));
+            var datePicker = comp.FindComponent<MudDatePicker>();
+            var initialDate = datePicker.Instance.Date;
+
+            await comp.InvokeAsync(datePicker.Instance.OpenAsync);
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-month-container").Count.Should().Be(1));
+
+            await comp.FindAll("div.mud-picker-month-container > button.mud-picker-month")[2].ClickAsync();
+
+            // An inline picker with action buttons holds the month pending until one of them closes it.
+            datePicker.Instance.Date.Should().Be(initialDate);
+
+            await comp.InvokeAsync(() => datePicker.Instance.CloseAsync(true));
+
+            await comp.WaitForAssertionAsync(() => datePicker.Instance.Date.Should().Be(new DateTime(2025, 3, 1)));
         }
 
         [Test]

--- a/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs
@@ -460,7 +460,7 @@ namespace MudBlazor
 
         protected virtual async Task SubmitAndCloseAsync()
         {
-            if (PickerActions == null)
+            if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
             {
                 await SubmitAsync();
 

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -147,16 +147,7 @@ namespace MudBlazor
                 return;
             await FocusAsync();
             _selectedDate = dateTime;
-            if (PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static)
-            {
-                await SubmitAsync();
-
-                if (PickerVariant != PickerVariant.Static)
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(ClosingDelay), TimeProvider);
-                    await CloseAsync(false);
-                }
-            }
+            await SubmitAndCloseAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/10969

A `PickerVariant.Static` date picker that declares `<PickerActions>` never commits a month or year selection. The bound date stays null, `DateChanged` never fires, and the clicked cell never gains `.mud-picker-month-selected`.

Day clicks commit when `PickerActions == null || AutoClose || PickerVariant == PickerVariant.Static`. Month and year selection go through `SubmitAndCloseAsync`, which only checked `PickerActions == null`. The `AutoClose` and `Static` exemptions had only ever been added to the day path.

This applies the same condition in `SubmitAndCloseAsync` and collapses the day path's duplicated block to call it, so all three selection paths share one condition instead of two restatements. The removed inline condition was already the exact expression now in the base, so day selection is unchanged.

An inline picker with real Ok/Cancel actions still holds the value pending until Ok, which is deliberate. All 379 picker tests pass with no existing assertion changed. Two tests added; the regression one fails without the change.

Out of scope, both worth their own issue:

* `MudDateRangePicker` keeps its own variant of this condition. Wiring it onto `SubmitAndCloseAsync` breaks `DateRangePickerTests.SubmitAsync_WhenReadOnly_DoesNotCommitCompleteRange`, which asserts deliberate behaviour, so it needs its own repro rather than a test rewrite here. It never reaches `SubmitAndCloseAsync` by any other path, so this change does not affect it.
* `MudTimePicker` has a fourth spelling of the same condition in two places and likely the identical bug.
