### PR TITLE
MudDataGrid: Render grouped rows again after a filter matches nothing

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeGroupingQuickFilterTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeGroupingQuickFilterTest.razor
@@ -1,0 +1,34 @@
+﻿<MudDataGrid T="Item" Items="@_items" QuickFilter="@QuickFilter" Virtualize="true"
+             Groupable="true" GroupExpanded="true" Height="200px">
+    <NoRecordsContent>
+        <span class="no-records">No records</span>
+    </NoRecordsContent>
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Groupable="false" />
+        <PropertyColumn Property="x => x.Category" Grouping="true" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = @"A virtualized, grouped grid must keep rendering its groups after the quick filter passes through a state where nothing matches.";
+
+    private string _search = string.Empty;
+
+    private readonly List<Item> _items =
+    [
+        new("Alpha1", "Alpha"),
+        new("Alpha2", "Alpha"),
+        new("Bravo1", "Bravo")
+    ];
+
+    private Func<Item, bool> QuickFilter => x =>
+        string.IsNullOrEmpty(_search) || x.Name.Contains(_search, StringComparison.OrdinalIgnoreCase);
+
+    public void SetSearch(string search)
+    {
+        _search = search;
+        StateHasChanged();
+    }
+
+    public record Item(string Name, string Category);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -775,5 +775,27 @@ namespace MudBlazor.UnitTests.Components
             Assert.That(groupRowA_X.Instance.GroupDefinition.Expanded, Is.True, "SubGroup X under group A should be expanded");
             Assert.That(groupRowB_X.Instance.GroupDefinition.Expanded, Is.False, "SubGroup X under group B should remain collapsed");
         }
+
+        [Test]
+        public async Task DataGridVirtualizeGroupingRecoversAfterQuickFilterMatchesNothing()
+        {
+            var comp = Context.Render<DataGridVirtualizeGroupingQuickFilterTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridVirtualizeGroupingQuickFilterTest.Item>>();
+
+            dataGrid.FindAll("td.mud-datagrid-group").Count.Should().Be(2);
+
+            await comp.InvokeAsync(() => comp.Instance.SetSearch("zzz"));
+
+            dataGrid.Instance.IsGrouped.Should().BeFalse();
+            dataGrid.FindAll("td.mud-datagrid-group").Should().BeEmpty();
+            dataGrid.FindAll(".no-records").Count.Should().Be(1);
+
+            await comp.InvokeAsync(() => comp.Instance.SetSearch("Alpha"));
+
+            dataGrid.Instance.IsGrouped.Should().BeTrue();
+            dataGrid.FindAll("td.mud-datagrid-group").Count.Should().Be(1);
+            dataGrid.FindAll("tbody tr.mud-table-row td:not(.mud-datagrid-group)").Count.Should().Be(4);
+            dataGrid.FindAll(".no-records").Should().BeEmpty();
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -203,7 +203,12 @@
                                 }
                             </thead>
                             <tbody class="@BodyClassname">
-                                @if (Virtualize || CurrentPageItems.Any())
+                                @{
+                                    // Reading CurrentPageItems refreshes FilteredItems, and with it the grouping state,
+                                    // so it has to happen before IsGrouped picks which body to render.
+                                    var hasCurrentPageItems = CurrentPageItems.Any();
+                                }
+                                @if (Virtualize || hasCurrentPageItems)
                                 {
                                     if (IsGrouped)
                                     {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -204,8 +204,7 @@
                             </thead>
                             <tbody class="@BodyClassname">
                                 @{
-                                    // Reading CurrentPageItems refreshes FilteredItems, and with it the grouping state,
-                                    // so it has to happen before IsGrouped picks which body to render.
+                                    // Reading CurrentPageItems refreshes FilteredItems, and with it the grouping state, so it has to happen before IsGrouped picks which body to render.
                                     var hasCurrentPageItems = CurrentPageItems.Any();
                                 }
                                 @if (Virtualize || hasCurrentPageItems)


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11783
Fixes https://github.com/MudBlazor/MudBlazor/issues/11996

A grid with `Virtualize="true"` and grouping active renders an empty body permanently once the filtered result passes through a zero-match state on its way back to a matching one. `FilteredItems` reports the correct non-zero count but no group headers and no rows render, and it never recovers on its own. Any unrelated re-render fixes it.

That precondition is why the two reports look different. #11996 hits it by swapping `Items` to an empty list and back. #11783 hits it through a Chinese IME, because the composition buffer briefly holds latin pinyin that matches nothing before the commit replaces it.

The sequence:

1. `GroupItems()` returns early when the filtered count is zero, having already set `_groupDefinition` to default, so `IsGrouped` latches false.
2. The body checks `Virtualize || CurrentPageItems.Any()`. The short circuit means `FilteredItems` is never evaluated before the following `@if (IsGrouped)` reads the stale false, so the grid emits the ungrouped `DataGridVirtualizeRow`.
3. Later in the same pass the footer evaluates `CurrentPageItems`, which recomputes and flips `IsGrouped` back to true.
4. `DataGridVirtualizeRow` renders after its parent, now sees `IsGrouped == true`, but its `GroupedItems` parameter is null, so it falls through to `NoRecordsContent` forever.

A non-virtualized grid is immune only because `CurrentPageItems.Any()` forces the recompute before `IsGrouped` is read.

This reads `CurrentPageItems` into a local before the branch so the grouping state is resolved first. It adds no recompute: `FilteredItems` caches per render pass and the footer already read it on every render, so the filter/sort/group pass ran once per render before and still does. Non-virtualized grids emit identical code.

All DataGrid tests pass (284) with nothing changed, and the full suite is green. The regression test asserts on the DOM rather than on `IsGrouped`, because by assertion time the footer has already flipped `IsGrouped` back to true and a test checking that would pass on broken source.

One thing to note: in the empty state of a virtualized grouped grid the row count goes from 1 to 3, because it now correctly takes the ungrouped branch and picks up `Virtualize`'s two zero-height spacer rows. The `NoRecordsContent` markup is character-identical and there is no visual difference. The upside is that the empty state no longer depends on whether the previous render had matches.
