### PR TITLE
MudDataGrid: Honor a custom Comparer for hierarchy expansion state

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridComparerSelectionCollapseTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridComparerSelectionCollapseTest.razor
@@ -1,0 +1,66 @@
+﻿@* Test component for selection collapse and SelectedItemsChanged when Comparer is swapped at runtime *@
+
+<MudDataGrid T="Person" Items="@Items" Comparer="@Comparer" MultiSelection="true"
+             SelectedItems="@SelectedItems" SelectedItemsChanged="OnSelectedItemsChanged">
+    <Columns>
+        <SelectColumn T="Person" />
+        <PropertyColumn Property="x => x.GroupId" />
+        <PropertyColumn Property="x => x.SubId" />
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Swapping Comparer to a coarser instance at runtime collapses the live selection and fires SelectedItemsChanged with the collapsed set.";
+
+    public IEqualityComparer<Person> Comparer { get; set; } = new CompositeComparer();
+
+    public List<Person> Items { get; } =
+    [
+        new Person(1, 1, "Alpha"),
+        new Person(1, 2, "Bravo"),
+        new Person(2, 1, "Charlie")
+    ];
+
+    public HashSet<Person> SelectedItems { get; set; } = [];
+
+    public int SelectedItemsChangedCount { get; private set; }
+
+    private void OnSelectedItemsChanged(HashSet<Person> items)
+    {
+        SelectedItemsChangedCount++;
+        SelectedItems = items;
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Swaps in a coarser comparer instance, the way a fresh reference is detected by HasParameterChanged.
+    /// </summary>
+    public void SwapToGroupComparer()
+    {
+        Comparer = new GroupComparer();
+        StateHasChanged();
+    }
+
+    public record Person(int GroupId, int SubId, string Name);
+
+    /// <summary>
+    /// Keys on the composite of GroupId and SubId, so Alpha and Bravo remain distinct despite sharing a GroupId.
+    /// </summary>
+    public class CompositeComparer : IEqualityComparer<Person>
+    {
+        public bool Equals(Person? x, Person? y) => x?.GroupId == y?.GroupId && x?.SubId == y?.SubId;
+
+        public int GetHashCode(Person obj) => HashCode.Combine(obj.GroupId, obj.SubId);
+    }
+
+    /// <summary>
+    /// Keys on GroupId alone, so Alpha and Bravo become equal once this comparer is applied.
+    /// </summary>
+    public class GroupComparer : IEqualityComparer<Person>
+    {
+        public bool Equals(Person? x, Person? y) => x?.GroupId == y?.GroupId;
+
+        public int GetHashCode(Person obj) => obj.GroupId;
+    }
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyComparerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHierarchyComparerTest.razor
@@ -1,0 +1,58 @@
+﻿@* Test component for hierarchy expansion surviving a refetch under a custom Comparer *@
+
+<MudDataGrid T="Model" Items="@Items" Comparer="@ItemComparer">
+    <Columns>
+        <HierarchyColumn T="Model" />
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+    <ChildRowContent>
+        <tr>
+            <td colspan="2" class="hierarchy-detail">Details for @context.Item.Name</td>
+        </tr>
+    </ChildRowContent>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "An expanded hierarchy row must stay expanded when a refetch replaces the items with equal-but-new instances.";
+
+    public IdComparer ItemComparer { get; } = new();
+
+    public List<Model> Items { get; set; } =
+    [
+        new Model(1, "Sam"),
+        new Model(2, "Alicia"),
+        new Model(3, "Ira")
+    ];
+
+    /// <summary>
+    /// Replaces every item with a distinct instance which is equal only under <see cref="ItemComparer"/>, the way a server refetch would.
+    /// </summary>
+    public void Refetch()
+    {
+        Items = Items.Select(x => new Model(x.Id, x.Name)).ToList();
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// A reference type on purpose, so two instances are never equal under the default comparer.
+    /// </summary>
+    public class Model
+    {
+        public Model(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+    }
+
+    public class IdComparer : IEqualityComparer<Model>
+    {
+        public bool Equals(Model? x, Model? y) => x?.Id == y?.Id;
+
+        public int GetHashCode(Model obj) => obj.Id;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -633,6 +633,32 @@ namespace MudBlazor.UnitTests.Components
                 dataGrid.FindAll("td.hierarchy-detail").Select(x => x.TextContent.Trim()).Should().Equal("Details for Sam"));
         }
 
+        /// <summary>
+        /// Swapping Comparer to a coarser instance at runtime collapses the live selection and fires SelectedItemsChanged with the collapsed set.
+        /// </summary>
+        [Test]
+        public async Task DataGridComparerSwapCollapsesSelection()
+        {
+            var comp = Context.Render<DataGridComparerSelectionCollapseTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridComparerSelectionCollapseTest.Person>>();
+
+            // Alpha (GroupId 1, SubId 1) and Bravo (GroupId 1, SubId 2) are distinct under the initial composite comparer.
+            var checkboxes = dataGrid.FindAll("tbody input[type=checkbox]");
+            await checkboxes[0].ChangeAsync(true);
+            checkboxes = dataGrid.FindAll("tbody input[type=checkbox]");
+            await checkboxes[1].ChangeAsync(true);
+
+            comp.Instance.SelectedItems.Count.Should().Be(2);
+            comp.Instance.SelectedItemsChangedCount.Should().Be(2);
+
+            await comp.InvokeAsync(comp.Instance.SwapToGroupComparer);
+
+            // Alpha and Bravo share GroupId 1, so the coarser comparer collapses them into a single selected entry.
+            await comp.WaitForAssertionAsync(() => comp.Instance.SelectedItems.Count.Should().Be(1));
+            comp.Instance.SelectedItems.Single().GroupId.Should().Be(1);
+            comp.Instance.SelectedItemsChangedCount.Should().Be(3);
+        }
+
         [Test]
         public async Task DataGridSingleSelection()
         {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -585,6 +585,9 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Instance.Selection.Comparer.Should().BeOfType<DataGridSelectionComparerTest.RoleComparer>();
         }
 
+        /// <summary>
+        /// Rows bound through SelectedItems render selected when the instances only match under a custom Comparer.
+        /// </summary>
         [Test]
         public async Task DataGridSelectedItemsHonorCustomComparer()
         {
@@ -607,6 +610,27 @@ namespace MudBlazor.UnitTests.Components
             checkboxes[0].IsChecked().Should().BeFalse();
             checkboxes[1].IsChecked().Should().BeTrue();
             checkboxes[2].IsChecked().Should().BeFalse();
+        }
+
+        /// <summary>
+        /// An expanded hierarchy row stays expanded when a refetch replaces the items with equal-but-new instances under a custom Comparer.
+        /// </summary>
+        [Test]
+        public async Task DataGridHierarchyExpansionHonorsCustomComparerAcrossRefetch()
+        {
+            var comp = Context.Render<DataGridHierarchyComparerTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHierarchyComparerTest.Model>>();
+
+            // Expand the first row through its hierarchy toggle button.
+            await dataGrid.FindAll("tbody button.mud-icon-button")[0].ClickAsync();
+
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll("td.hierarchy-detail").Select(x => x.TextContent.Trim()).Should().Equal("Details for Sam"));
+
+            await comp.InvokeAsync(comp.Instance.Refetch);
+
+            await comp.WaitForAssertionAsync(() =>
+                dataGrid.FindAll("td.hierarchy-detail").Select(x => x.TextContent.Trim()).Should().Equal("Details for Sam"));
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -38,8 +38,8 @@ namespace MudBlazor
         private bool _isFirstRendered = false;
         private bool _filtersMenuVisible = false;
         private bool _columnsPanelVisible = false;
-        internal HashSet<T> _openHierarchies = [];
-        private readonly HashSet<T> _initialExpansions = [];
+        internal HashSet<T> _openHierarchies;
+        private HashSet<T> _initialExpansions;
         private Func<T, bool>? _initialExpandedFunc = null;
         private Func<T, bool>? _buttonDisabledFunc = null;
         private EventCallback<DataGridHierarchyVisibilityToggledEventArgs<T>> _hierarchyColumnVisibilityToggled;
@@ -85,7 +85,11 @@ namespace MudBlazor
         {
             _inlineEditValidator = new DataGridInlineEditValidator(() => Validator);
             Selection = new HashSet<T>(Comparer);
+            // Unlike Selection this is never rebuilt when Comparer changes, because it is only observable while still empty; every set later published into it is built from the live Comparer.
             SelectedItems = new HashSet<T>(Comparer);
+            // Hierarchy expansion is keyed by item as well, so these sets must honor Comparer or an expanded row collapses once a refetch supplies equal-but-new instances.
+            _openHierarchies = new HashSet<T>(Comparer);
+            _initialExpansions = new HashSet<T>(Comparer);
             using var registerScope = CreateRegisterScope();
             registerScope.RegisterParameter<IEnumerable<T>?>(nameof(Items))
                 .WithParameter(() => Items)
@@ -1396,7 +1400,9 @@ namespace MudBlazor
         /// The comparer used to determine row selection.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>null</c>. When set, this comparer will be used to determine if a row is selected.
+        /// Defaults to <see cref="EqualityComparer{T}.Default" />.
+        /// This comparer decides whether a row is selected and whether an expanded hierarchy row is still the same row after the data is refreshed.
+        /// Pass a stable instance: a change is detected by reference, so an inline <c>Comparer="@(new MyComparer())"</c> creates a fresh instance on every render and rebuilds the selection set every time.
         /// </remarks>
         [Parameter, ParameterState(ParameterUsage = ParameterUsageOptions.None)]
         public IEqualityComparer<T>? Comparer { get; set; } = EqualityComparer<T>.Default;
@@ -1656,10 +1662,21 @@ namespace MudBlazor
             }
         }
 
-        private void OnComparerChanged(ParameterChangedEventArgs<IEqualityComparer<T>?> args)
+        private async Task OnComparerChanged(ParameterChangedEventArgs<IEqualityComparer<T>?> args)
         {
-            // A HashSet keeps the comparer it was constructed with, so Selection has to be rebuilt to adopt the new one.
+            // A HashSet keeps the comparer it was constructed with, so every item-keyed set has to be rebuilt to adopt the new one.
+            // These are safe to reassign because CellContext captures them by reference but is constructed fresh inside the render fragment on every render.
+            var previousSelectionCount = Selection.Count;
             Selection = new HashSet<T>(Selection, args.Value);
+            _openHierarchies = new HashSet<T>(_openHierarchies, args.Value);
+            _initialExpansions = new HashSet<T>(_initialExpansions, args.Value);
+
+            // A coarser comparer collapses entries that were previously distinct, which silently drops rows from the selection.
+            // Publish that, otherwise the bound SelectedItems keeps contents the grid can no longer hold.
+            if (Selection.Count != previousSelectionCount)
+            {
+                await FireSelectionChangedEventsAsync();
+            }
         }
 
         private async Task OnExpandSingleRowChangedAsync(ParameterChangedEventArgs<bool> args)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -85,9 +85,7 @@ namespace MudBlazor
         {
             _inlineEditValidator = new DataGridInlineEditValidator(() => Validator);
             Selection = new HashSet<T>(Comparer);
-            // Unlike Selection this is never rebuilt when Comparer changes, because it is only observable while still empty; every set later published into it is built from the live Comparer.
             SelectedItems = new HashSet<T>(Comparer);
-            // Hierarchy expansion is keyed by item as well, so these sets must honor Comparer or an expanded row collapses once a refetch supplies equal-but-new instances.
             _openHierarchies = new HashSet<T>(Comparer);
             _initialExpansions = new HashSet<T>(Comparer);
             using var registerScope = CreateRegisterScope();


### PR DESCRIPTION
Follow-up to #13593, which fixed the selection set but left the hierarchy sets with the same defect.

`_openHierarchies` and `_initialExpansions` are field initializers (`= []`), so unlike `Selection` they never see `Comparer` at all. `CellContext.Open` resolves to `OpenHierarchies.Contains(_sourceItem)`, so with a custom comparer the lookup runs under the default one. Refetching data with equal-but-new instances then silently collapses every expanded hierarchy row: `PruneHierarchyExpansionsFromCurrentItems` correctly keeps the old entries, because it tests against a comparer-built set, but the render-time `Contains` against the new instance misses.

This builds both sets from `Comparer` and rebuilds them in the existing `OnComparerChanged` handler, preserving contents, exactly as `Selection` is handled. Reassignment is safe for the same reason it is safe there: `CellContext` is constructed inline in the render fragment, so every render gets a fresh alias rather than holding a stale reference.

The added test asserts the observable defect, that an expanded detail row survives a refetch. Without the source change it fails with the detail row gone entirely rather than on any internal comparer identity. DataGrid tests are 287 passing, 0 failing.

Also in this change: the XML doc on `Comparer` said it defaults to `null` when it actually defaults to `EqualityComparer<T>.Default`, which is precisely what makes the first-render change fire, plus a remark that an inline `new` comparer produces a fresh instance per render and so rebuilds the sets each time, and a comment on why `SelectedItems` is deliberately not rebuilt.