### PR TITLE
MudDataGrid: Fix select-all checkbox never reaching checked state with disabled rows

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6342,6 +6342,17 @@ namespace MudBlazor.UnitTests.Components
             builder.CloseComponent();
         };
 
+        private static RenderFragment SelectColumnWithFuncInHeaderAndFooter => builder =>
+        {
+            builder.OpenComponent<SelectColumn<TestDataItem>>(0);
+            builder.AddAttribute(1, nameof(SelectColumn<TestDataItem>.DisabledFunc), (Func<TestDataItem, bool>)(item => item.ShouldBeDisabled));
+            builder.AddAttribute(2, nameof(SelectColumn<TestDataItem>.ShowInFooter), true);
+            builder.CloseComponent();
+            builder.OpenComponent<PropertyColumn<TestDataItem, int>>(3);
+            builder.AddAttribute(4, nameof(PropertyColumn<TestDataItem, int>.Property), (Expression<Func<TestDataItem, int>>)(x => x.Id));
+            builder.CloseComponent();
+        };
+
         private static RenderFragment SelectColumnNoFunc => builder =>
         {
             builder.OpenComponent<SelectColumn<TestDataItem>>(0);
@@ -6540,6 +6551,92 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetState(x => x.SelectedItems).Should().Contain(items[0]);
             comp.Instance.GetState(x => x.SelectedItems).Should().Contain(items[1]);
             comp.Instance.GetState(x => x.SelectedItems).Count.Should().Be(2);
+        }
+
+        [Test]
+        public async Task SelectAll_WithDisabledRows_HeaderCheckboxReachesCheckedState()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Enabled Item 1", ShouldBeDisabled = false },
+                new() { Id = 2, Name = "Enabled Item 2", ShouldBeDisabled = false },
+                new() { Id = 3, Name = "Disabled Item", ShouldBeDisabled = true }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFunc)
+            );
+
+            var headerCheckbox = comp.FindComponent<MudCheckBox<bool?>>();
+            headerCheckbox.Instance.ReadValue.Should().BeFalse();
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = true });
+            headerCheckbox.Instance.ReadValue.Should().BeTrue();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[0], items[1] });
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = false });
+            headerCheckbox.Instance.ReadValue.Should().BeFalse();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+
+            await comp.FindAll("td.mud-table-cell .mud-checkbox input")[0].ChangeAsync(new ChangeEventArgs { Value = true });
+            headerCheckbox.Instance.ReadValue.Should().BeNull();
+        }
+
+        [Test]
+        public async Task SelectAll_WithDisabledRows_FooterCheckboxReachesCheckedState()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Enabled Item 1", ShouldBeDisabled = false },
+                new() { Id = 2, Name = "Enabled Item 2", ShouldBeDisabled = false },
+                new() { Id = 3, Name = "Disabled Item", ShouldBeDisabled = true }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFuncInHeaderAndFooter)
+            );
+
+            var footerCheckbox = comp.FindComponents<MudCheckBox<bool?>>()[1];
+            footerCheckbox.Instance.ReadValue.Should().BeFalse();
+
+            await comp.Find("tfoot .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = true });
+            footerCheckbox.Instance.ReadValue.Should().BeTrue();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[0], items[1] });
+
+            await comp.Find("tfoot .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = false });
+            footerCheckbox.Instance.ReadValue.Should().BeFalse();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+
+            await comp.FindAll("td.mud-table-cell .mud-checkbox input")[0].ChangeAsync(new ChangeEventArgs { Value = true });
+            footerCheckbox.Instance.ReadValue.Should().BeNull();
+        }
+
+        [Test]
+        public async Task SelectAll_WithEveryRowDisabled_HeaderCheckboxStaysUnchecked()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Disabled Item 1", ShouldBeDisabled = true },
+                new() { Id = 2, Name = "Disabled Item 2", ShouldBeDisabled = true }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFunc)
+            );
+
+            var headerCheckbox = comp.FindComponent<MudCheckBox<bool?>>();
+            headerCheckbox.Instance.ReadValue.Should().BeFalse();
+
+            await comp.Instance.SetSelectAllAsync(true);
+
+            headerCheckbox.Instance.ReadValue.Should().BeFalse();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -51,17 +51,12 @@ namespace MudBlazor
             {
                 if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
                 {
-                    if (_dataGrid.Selection.Count == Items.Count())
-                    {
-                        return true;
-                    }
-
                     if (_dataGrid.Selection.Count == 0)
                     {
                         return false;
                     }
 
-                    return null;
+                    return _dataGrid.Selection.Count == _dataGrid.GetSelectableItems().Count() ? true : null;
                 }
 
                 return false;

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -47,17 +47,12 @@ namespace MudBlazor
             {
                 if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
                 {
-                    if (_dataGrid.Selection.Count == Items.Count())
-                    {
-                        return true;
-                    }
-
                     if (_dataGrid.Selection.Count == 0)
                     {
                         return false;
                     }
 
-                    return null;
+                    return _dataGrid.Selection.Count == _dataGrid.GetSelectableItems().Count() ? true : null;
                 }
 
                 return false;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2139,11 +2139,7 @@ namespace MudBlazor
 
             if (value) // Logic for selecting all
             {
-                var itemsToSelect = HasServerData ? ServerItems : FilteredItems;
-                var selectColumn = GetSelectColumn();
-                itemsToSelect = itemsToSelect.Where(item => !IsRowSelectionDisabled(item, selectColumn));
-
-                Selection.UnionWith(itemsToSelect);
+                Selection.UnionWith(GetSelectableItems());
             }
 
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
@@ -2157,6 +2153,17 @@ namespace MudBlazor
         private SelectColumn<T>? GetSelectColumn()
         {
             return RenderedColumns.OfType<SelectColumn<T>>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// The items which select-all would select, i.e. every displayed row whose selection is not disabled.
+        /// </summary>
+        internal IEnumerable<T> GetSelectableItems()
+        {
+            var selectColumn = GetSelectColumn();
+            var items = HasServerData ? ServerItems : FilteredItems;
+
+            return items.Where(item => !IsRowSelectionDisabled(item, selectColumn));
         }
 
         internal bool? GetRowSelectionState(T item)


### PR DESCRIPTION
Fixes #13224.

On a grid where any row is disabled through `DisabledFunc`, the `SelectColumn` header checkbox can never show as checked. Selecting all still selects every enabled row, but the header stays indeterminate, so there is no visual signal that select-all completed and no obvious way to read the state.

`HeaderContext.IsAllSelected` compared `Selection.Count` against the grid's full row count, while `SetSelectAllAsync` deliberately excludes disabled rows from what it selects. With one disabled row out of four, `Selection.Count` is permanently 3 against 4, so the comparison can only ever yield false or null. `FooterContext` carried a byte-identical copy.

This extracts the set select-all actually selects into `GetSelectableItems()` and has both contexts compare against it, so the header cannot drift from the behaviour again. What select-all selects is unchanged and disabled rows still stay unselected. No new conditional was introduced: checking the empty case first lets the all-rows-disabled case fall out without one.