### PR TITLE
MudPicker: Commit the pending value when tabbing out

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -587,6 +587,70 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task Tab_CommitsPendingTime()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<SimpleTimePickerTest>(parameters => parameters.Add(x => x.Time, new TimeSpan(2, 0, 0)));
+            var picker = comp.FindComponent<MudTimePicker>().Instance;
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = " ", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = "ArrowUp", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => picker.TimeIntermediate.Should().Be(new TimeSpan(3, 0, 0)));
+            picker.Time.Should().Be(new TimeSpan(2, 0, 0));
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = "Tab", Type = "keydown", }));
+
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            await comp.WaitForAssertionAsync(() => picker.Time.Should().Be(new TimeSpan(3, 0, 0)));
+            comp.Find("input").GetAttribute("value").Should().Be("03:00");
+        }
+
+        [Test]
+        public async Task Tab_AfterEscape_DoesNotCommitDiscardedTime()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<SimpleTimePickerTest>(parameters => parameters.Add(x => x.Time, new TimeSpan(2, 0, 0)));
+            var picker = comp.FindComponent<MudTimePicker>().Instance;
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = " ", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(1));
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = "ArrowUp", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => picker.TimeIntermediate.Should().Be(new TimeSpan(3, 0, 0)));
+
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = "Escape", Type = "keydown", }));
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            picker.Time.Should().Be(new TimeSpan(2, 0, 0));
+
+            // Tabbing on through the closed picker must not resurrect the selection Escape threw away.
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = "Tab", Type = "keydown", }));
+
+            await comp.WaitForAssertionAsync(() => picker.Time.Should().Be(new TimeSpan(2, 0, 0)));
+            comp.Find("input").GetAttribute("value").Should().Be("02:00");
+        }
+
+        [Test]
+        public async Task Tab_WithPickerActions_DoesNotCommitPendingTime()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<AutoCompleteTimePickerTest>();
+            var picker = comp.Instance.Picker;
+            await comp.InvokeAsync(() => picker.OpenAsync());
+
+            await comp.InvokeAsync(() => picker.SelectTimeFromStick(5, false));
+            await comp.WaitForAssertionAsync(() => picker.TimeIntermediate.Should().Be(new TimeSpan(5, 45, 0)));
+
+            // PickerActions means the user commits explicitly with OK, so Tab must leave the value alone.
+            await comp.InvokeAsync(() => keyInterceptorService.OnKeyDown(picker.ElementId, new KeyboardEventArgs { Key = "Tab", Type = "keydown", }));
+
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-picker-open").Count.Should().Be(0));
+            picker.Time.Should().Be(new TimeSpan(0, 45, 0));
+            comp.Find("input").GetAttribute("value").Should().Be("00:45");
+        }
+
+        [Test]
         public async Task OnClick_Callback_FiresWhenInputClicked()
         {
             var clicked = false;

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -665,11 +665,14 @@ namespace MudBlazor
                     new("/./", subscribeDown: true, subscribeUp: true)
                 ]);
 
+            // Escape cancels, so it always discards the pending selection. Tab is a plain "move on" and must
+            // leave the same value behind as clicking away does, so it mirrors CloseOverlayAsync's decision.
             await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
                 .HookKeyDown(OnHandleKeyDownAsync)
                 .When(CanHandleKeys, builder => builder
                     .OnKeyDown("Backspace", HandleBackspaceAsync)
-                    .OnKeyDownAny(["Escape", "Tab"], () => CloseAsync(false))));
+                    .OnKeyDown("Escape", () => CloseAsync(false))
+                    .OnKeyDown("Tab", () => CloseAsync(Open && PickerActions == null))));
         }
 
         private bool CanHandleKeys() => !GetDisabledState() && !GetReadOnlyState();

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -665,8 +665,6 @@ namespace MudBlazor
                     new("/./", subscribeDown: true, subscribeUp: true)
                 ]);
 
-            // Escape cancels, so it always discards the pending selection. Tab is a plain "move on" and must
-            // leave the same value behind as clicking away does, so it mirrors CloseOverlayAsync's decision.
             await KeyInterceptorService.SubscribeAsync(ElementId, options, keys => keys
                 .HookKeyDown(OnHandleKeyDownAsync)
                 .When(CanHandleKeys, builder => builder


### PR DESCRIPTION
Fixes #13098 and Fixes #13127.

Tabbing out of an open `MudTimePicker` discards the selection, while clicking away commits it. `EnsureKeyInterceptorAsync` wired Escape and Tab together as `CloseAsync(false)`, hardcoding "do not submit", whereas `CloseOverlayAsync`, used by both the inline and dialog overlays, calls `CloseAsync(PickerActions == null)`. So the two ways of leaving a picker disagree with each other.

This splits them. Escape keeps `submit: false`, which is the conventional cancel. Tab mirrors the click-away decision instead. The `Open &&` guard is load-bearing and not cosmetic: the key interceptor fires on Tab whether or not the picker is open, and `MudTimePicker` never resets `TimeIntermediate` on close, so without it an Escape followed by a Tab would commit the value the user just cancelled. That path is pinned by a test.

Per subtype, only `MudTimePicker` without `PickerActions` actually changes behaviour, because it is the only one where a selection can still be pending at close. `MudDatePicker` already submits on day, month and year click when `PickerActions` is null, so a Tab merely re-submits the same date. `MudDateRangePicker` early-returns unless both ends are set, so a half-picked range is still not committed. `MudColorPicker` does not override `SubmitAsync`, making both paths identical. Any picker with explicit `PickerActions` still discards, so OK and Cancel remain the only commit.