### PR TITLE
MudExpansionPanel: Stop greying icons in body when panel is disabled

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -355,6 +355,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Tests that a disabled panel puts "mud-disabled" on the header only, so the global ".mud-disabled .mud-icon-root" rule cannot grey out icons the user nests in the panel body (#11453).
+        /// </summary>
+        [Test]
+        public async Task MudExpansionPanel_Disabled_AppliesDisabledClassToHeaderOnly()
+        {
+            var comp = Context.Render<MudExpansionPanel>(parameters => parameters
+                .Add(p => p.Text, "Panel"));
+
+            comp.Find(".mud-expand-panel").ClassList.Should().NotContain("mud-disabled");
+            comp.Find(".mud-expand-panel-header").ClassList.Should().NotContain("mud-disabled");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.Disabled, true));
+
+            comp.Find(".mud-expand-panel").ClassList.Should().NotContain("mud-disabled");
+            comp.Find(".mud-expand-panel-header").ClassList.Should().Contain("mud-disabled");
+        }
+
+        /// <summary>
         /// Tests that content is rendered even when collapsed when KeepContentAlive is true.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -25,15 +25,17 @@ namespace MudBlazor
             new CssBuilder("mud-expand-panel")
                 .AddClass("mud-panel-expanded", _expandedState.Value)
                 .AddClass("mud-panel-next-expanded", NextPanelExpanded)
-                .AddClass("mud-disabled", Disabled)
                 .AddClass($"mud-elevation-{Parent?.Elevation.ToString()}")
                 .AddClass($"mud-expand-panel-border", Parent?.Outlined == true)
                 .AddClass(Class)
                 .Build();
 
+        // "mud-disabled" belongs on the header, not on the root: the root also wraps ChildContent,
+        // and the global ".mud-disabled .mud-icon-root" rule would grey out every icon the user nests there.
         protected string HeaderClassname =>
             new CssBuilder("mud-expand-panel-header")
                 .AddClass("mud-expand-panel-header-gutters", Gutters && Parent?.Gutters != false)
+                .AddClass("mud-disabled", Disabled)
                 .AddClass(HeaderClass)
                 .Build();
 

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -30,8 +30,6 @@ namespace MudBlazor
                 .AddClass(Class)
                 .Build();
 
-        // "mud-disabled" belongs on the header, not on the root: the root also wraps ChildContent,
-        // and the global ".mud-disabled .mud-icon-root" rule would grey out every icon the user nests there.
         protected string HeaderClassname =>
             new CssBuilder("mud-expand-panel-header")
                 .AddClass("mud-expand-panel-header-gutters", Gutters && Parent?.Gutters != false)

--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -131,8 +131,8 @@
   }
 }
 
-.mud-disabled {
-  & > .mud-expand-panel-header {
+.mud-expand-panel {
+  & > .mud-expand-panel-header.mud-disabled {
     color: var(--mud-palette-text-disabled);
 
     &:hover {

--- a/src/MudBlazor/Styles/components/_expansionpanel.scss
+++ b/src/MudBlazor/Styles/components/_expansionpanel.scss
@@ -1,4 +1,4 @@
-
+﻿
 .mud-expansion-panels {
   flex: 0 1 auto;
   position: relative;
@@ -114,6 +114,14 @@
     }
   }
 
+  & > .mud-expand-panel-header.mud-disabled {
+    color: var(--mud-palette-text-disabled);
+
+    &:hover {
+      cursor: default;
+    }
+  }
+
   & .mud-expand-panel-content {
     padding-bottom: 16px;
     flex: 1 1 auto;
@@ -127,16 +135,6 @@
     &.mud-expand-panel-dense {
       padding-top: 0px;
       padding-bottom: 0px;
-    }
-  }
-}
-
-.mud-expand-panel {
-  & > .mud-expand-panel-header.mud-disabled {
-    color: var(--mud-palette-text-disabled);
-
-    &:hover {
-      cursor: default;
     }
   }
 }


### PR DESCRIPTION
Fixes #11453 

A disabled `MudExpansionPanel` greys every icon inside it, including icons in the panel body that carry their own `Color`. Measured on the repro, an icon button in the body rendered `rgba(0, 0, 0, 0.376)` instead of its declared `rgb(89, 74, 226)`.

`_icons.scss` styles `.mud-disabled .mud-icon-root` and friends as descendant selectors, and `MudExpansionPanel` put `mud-disabled` on its root `<div>`, which wraps `ChildContent`. So arbitrary user content inherited a state style it never opted into.

Tried narrowing the selector first and backed out: `.mud-disabled` is applied by 15 components, and 7 of them rely on that descendant match to grey their own icons at varying nesting depths (Chip, NavLink, CheckBox, Radio, the DatePicker adornment, Breadcrumbs, Tabs). Any child-combinator or `:not()` narrowing breaks a subset, and `color: inherit`/`currentColor` would beat the icon's own colour class. The selector is load-bearing, so this change leaves it alone.

Instead the class moves to the header, which is the element that actually owns the click and keydown handlers and the tabindex. `MudExpansionPanel` was the only component putting `mud-disabled` on a wrapper that also contains user content. The SCSS selector is updated to match, and its specificity rises from 0,2,0 to 0,3,0 so it still beats the `:hover` cursor rule by specificity rather than source order.

After the change the body icon renders its declared colour while the panel's own expand icon and header text stay disabled-grey. Icons inside `TitleContent` remain greyed, which I take to be correct since the header genuinely is disabled. Body controls were already interactive when disabled (the panel never cascaded `ParentDisabled`) and still are.