### PR TITLE
MudMask: Refresh the displayed text when the value is cleared from code

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -1206,6 +1206,26 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Mask.Should().BeSameAs(mask);
         }
 
+        /// <summary>
+        /// Setting the bound date to null from code must clear the masked input, not just the Date and Text properties: https://github.com/MudBlazor/MudBlazor/issues/12822.
+        /// </summary>
+        [Test]
+        public async Task Mask_ClearingDateFromCode_ClearsTheInput()
+        {
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(p => p.Editable, true)
+                .Add(p => p.Mask, new DateMask("dd/MM/yyyy"))
+                .Add(p => p.Date, new DateTime(2026, 6, 15)));
+
+            comp.Find("input").GetAttribute("value").Should().NotBeNullOrEmpty();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Date, (DateTime?)null));
+
+            comp.Instance.Date.Should().BeNull();
+            comp.Instance.Text.Should().BeNullOrEmpty();
+            comp.Find("input").GetAttribute("value").Should().BeNullOrEmpty();
+        }
+
         [Test]
         public async Task FocusSelectAndSelectRange_AreNoOps_WhenNoInputIsRendered()
         {

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -1223,5 +1223,29 @@ namespace MudBlazor.UnitTests.Components
             // But not to the adornment that holds the icon.
             comp.Find("div.mud-input-adornment-end").ClassList.Should().NotContain(customClass);
         }
+
+        /// <summary>
+        /// A value cleared from code must clear the rendered input, even though MudTextField has already emptied the shared mask by the time MudMask sees the change: https://github.com/MudBlazor/MudBlazor/issues/12822.
+        /// </summary>
+        [Test]
+        public async Task TextFieldWithMask_ClearingValueFromCode_ClearsTheInput()
+        {
+            const string initialValue = "01/01/2024";
+
+            var comp = Context.Render<MudTextField<string>>(parameters =>
+            {
+                parameters.Add(m => m.Mask, new DateMask("MM/dd/yyyy"));
+                parameters.Add(m => m.Value, initialValue);
+            });
+            var maskField = comp.FindComponent<MudMask>().Instance;
+
+            comp.Find("input").GetAttribute("value").Should().Be(initialValue);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(m => m.Value, (string)null));
+
+            comp.Instance.ReadText.Should().BeNullOrEmpty();
+            maskField.ReadText.Should().BeNullOrEmpty();
+            comp.Find("input").GetAttribute("value").Should().BeNullOrEmpty();
+        }
     }
 }

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -307,19 +307,16 @@ namespace MudBlazor
                 return;
             var text = ConvertSet(ReadValue);
             var cleanText = Mask.GetCleanText();
-            if (string.IsNullOrEmpty(cleanText) && string.IsNullOrEmpty(text))
-                return;
-
-            if (cleanText != text)
-            {
-                var maskText = Mask.Text;
+            if (!IsSameText(cleanText, text))
                 Mask.SetText(text);
-                if (maskText == Mask.Text)
-                    return;
-            }
 
-            if (ReadText != Mask.Text)
+            // Refresh whenever the displayed text disagrees with the mask, not only when the mask itself just changed.
+            // MudTextField shares this mask instance and applies the incoming value to it first, so a value cleared from code left the mask empty while our own text, and with it the rendered input, stayed on the old value (#12822).
+            if (!IsSameText(ReadText, Mask.Text))
                 await UpdateAsync();
+
+            static bool IsSameText(string? first, string? second)
+                => first == second || (string.IsNullOrEmpty(first) && string.IsNullOrEmpty(second));
         }
 
         protected override async Task UpdateValuePropertyAsync(bool updateText)


### PR DESCRIPTION
Fixes #12822.

Setting a masked picker's `Date` to `null` from code clears the bound value but leaves the old text in the input. It never recovers: still stale after three seconds, after focus, and after blur. The clear button and a manual delete both work, so only one of three paths was broken.

`MudMask` adopts a caller's mask by reference whenever its runtime type is not `PatternMask`, and `MudTextField` holds that same instance and applies the incoming value to it before `MudMask` is told anything. So on the code-set path the shared mask was already empty by the time `UpdateTextPropertyAsync` ran, its "both already empty, nothing to do" early return fired, and `MudMask.Text` — the thing bound to the input's `value` — was never updated. Correct for the mask state, wrong for the DOM. The two working paths go through `UpdateAsync()`, which writes `Text` directly.

This routes the code-set path into that same `UpdateAsync()`, comparing the displayed text against the mask rather than only reacting when the mask itself just changed. It removes two conditionals and adds none; a small null-vs-empty helper keeps an already-empty input from re-rendering on every parameter set, and typing is still short-circuited by the existing `_updating` guard.

The trigger is precisely a mask whose runtime type is not `PatternMask` (`DateMask`, `RegexMask`, `BlockMask`, `MultiMask`), which is why this reads as DatePicker-specific: `DateMask` is the natural choice there. Checked in the browser, a `MudTimePicker` with a `RegexMask` had the same bug and is fixed too, while `PatternMask` pickers, `MudDateRangePicker` and unmasked pickers were never affected and are unchanged. Typing after a code-clear was re-checked keystroke by keystroke and is byte-identical to typing after the clear button.

Two notes for review. The resync is slightly broader than "clearing": any masked input whose displayed text has drifted from the mask now resyncs on an external parameter update. And the underlying oddity is untouched — `MudTextField` and `MudMask` deliberately share one mutable `IMask` instance, with a source comment conceding it "might look strange, but it is absolutely necessary". Un-sharing it would be a much larger change and is worth its own issue; #7583 is the same aliasing seen from another angle.
