### PR TITLE
MudDataGrid: Scope group footer select-all to its own group

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6797,6 +6797,33 @@ namespace MudBlazor.UnitTests.Components
             groupB.Instance.ReadValue.Should().BeFalse();
         }
 
+        /// <summary>
+        /// A group footer must not select anything while the grid is in single selection mode, matching the grid-wide select-all.
+        /// </summary>
+        [Test]
+        public async Task SelectAll_GroupFooterCheckbox_DoesNothingWithoutMultiSelection()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "A" },
+                new() { Id = 2, Name = "A" },
+                new() { Id = 3, Name = "B" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, false)
+                .Add(p => p.Groupable, true)
+                .Add(p => p.GroupExpanded, true)
+                .Add(p => p.Columns, GroupedSelectColumnWithFuncInFooter)
+            );
+
+            // SelectColumn hides its own checkbox here, but a custom footer template can still reach the action.
+            await comp.Instance.SetGroupSelectAllAsync(true, items.Take(2));
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+        }
+
         [Test]
         public void DataGridRowDetailInitiallyExpandedMultiple()
         {

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6403,6 +6403,21 @@ namespace MudBlazor.UnitTests.Components
             builder.CloseComponent();
         };
 
+        private static RenderFragment GroupedSelectColumnWithFuncInFooter => builder =>
+        {
+            builder.OpenComponent<SelectColumn<TestDataItem>>(0);
+            builder.AddAttribute(1, nameof(SelectColumn<TestDataItem>.DisabledFunc), (Func<TestDataItem, bool>)(item => item.ShouldBeDisabled));
+            builder.AddAttribute(2, nameof(SelectColumn<TestDataItem>.ShowInFooter), true);
+            builder.CloseComponent();
+            builder.OpenComponent<PropertyColumn<TestDataItem, int>>(3);
+            builder.AddAttribute(4, nameof(PropertyColumn<TestDataItem, int>.Property), (Expression<Func<TestDataItem, int>>)(x => x.Id));
+            builder.CloseComponent();
+            builder.OpenComponent<PropertyColumn<TestDataItem, string>>(5);
+            builder.AddAttribute(6, nameof(PropertyColumn<TestDataItem, string>.Property), (Expression<Func<TestDataItem, string>>)(x => x.Name));
+            builder.AddAttribute(7, nameof(PropertyColumn<TestDataItem, string>.Grouping), true);
+            builder.CloseComponent();
+        };
+
         private static RenderFragment SelectColumnNoFunc => builder =>
         {
             builder.OpenComponent<SelectColumn<TestDataItem>>(0);
@@ -6687,6 +6702,99 @@ namespace MudBlazor.UnitTests.Components
 
             headerCheckbox.Instance.ReadValue.Should().BeFalse();
             comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task SelectAll_GroupFooterCheckbox_AppliesToItsOwnGroupOnly()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "A" },
+                new() { Id = 2, Name = "A" },
+                new() { Id = 3, Name = "B" },
+                new() { Id = 4, Name = "B" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Groupable, true)
+                .Add(p => p.GroupExpanded, true)
+                .Add(p => p.Columns, GroupedSelectColumnWithFuncInFooter)
+            );
+
+            // In render order: header, group "A" footer, group "B" footer, grid footer.
+            var checkboxes = comp.FindComponents<MudCheckBox<bool?>>();
+            var header = checkboxes[0];
+            var groupA = checkboxes[1];
+            var groupB = checkboxes[2];
+            var gridFooter = checkboxes[3];
+
+            await groupA.Find("input").ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[0], items[1] });
+            groupA.Instance.ReadValue.Should().BeTrue();
+            groupB.Instance.ReadValue.Should().BeFalse();
+            header.Instance.ReadValue.Should().BeNull();
+            gridFooter.Instance.ReadValue.Should().BeNull();
+
+            await groupB.Find("input").ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(items);
+            header.Instance.ReadValue.Should().BeTrue();
+            gridFooter.Instance.ReadValue.Should().BeTrue();
+
+            await groupA.Find("input").ChangeAsync(new ChangeEventArgs { Value = false });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[2], items[3] });
+            groupA.Instance.ReadValue.Should().BeFalse();
+            groupB.Instance.ReadValue.Should().BeTrue();
+
+            await gridFooter.Find("input").ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(items);
+
+            await gridFooter.Find("input").ChangeAsync(new ChangeEventArgs { Value = false });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+            groupA.Instance.ReadValue.Should().BeFalse();
+            groupB.Instance.ReadValue.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task SelectAll_GroupFooterCheckbox_SkipsDisabledRowsAndReportsPartialSelection()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "A" },
+                new() { Id = 2, Name = "A" },
+                new() { Id = 3, Name = "A", ShouldBeDisabled = true },
+                new() { Id = 4, Name = "B" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Groupable, true)
+                .Add(p => p.GroupExpanded, true)
+                .Add(p => p.Columns, GroupedSelectColumnWithFuncInFooter)
+            );
+
+            var checkboxes = comp.FindComponents<MudCheckBox<bool?>>();
+            var groupA = checkboxes[1];
+            var groupB = checkboxes[2];
+
+            await comp.FindAll("tbody td.mud-table-cell .mud-checkbox input")[0].ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[0] });
+            groupA.Instance.ReadValue.Should().BeNull();
+            groupB.Instance.ReadValue.Should().BeFalse();
+
+            await groupA.Find("input").ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[0], items[1] });
+            groupA.Instance.ReadValue.Should().BeTrue();
+            groupB.Instance.ReadValue.Should().BeFalse();
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/Column.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/Column.razor.cs
@@ -595,7 +595,6 @@ namespace MudBlazor
         // These are set in OnInitialized() so they can't be null
         internal HeaderContext<T> headerContext = null!;
         private FilterContext<T> filterContext = null!;
-        internal FooterContext<T> footerContext = null!;
 
         // Cached filter definition to avoid repeated lookups during rendering
         private IFilterDefinition<T>? _cachedFilterDefinition;
@@ -693,9 +692,6 @@ namespace MudBlazor
 
             // Add the FilterContext
             filterContext = new FilterContext<T>(DataGrid);
-
-            // Add the FooterContext
-            footerContext = new FooterContext<T>(DataGrid);
         }
 
         internal IReadOnlyCollection<string> GetFilterOperators(FieldType fieldType)

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
@@ -56,7 +56,7 @@
                                     ContextRowClick="@((args) => ContextRowClick.InvokeAsync((args.args, args.item, args.index)))"/>
             <!-- Group Footer -->
             <tr class="mud-table-row">
-                @DataGrid.FooterCells(Items)
+                @DataGrid.FooterCells(Items, Items)
             </tr>
         }
     }

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor
@@ -15,7 +15,7 @@
         }
         else if (footerTemplate != null)
         {
-            @footerTemplate(Column.footerContext)
+            @footerTemplate(_footerContext)
         }
     </td>
 }

--- a/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterCell.razor.cs
@@ -39,6 +39,24 @@ namespace MudBlazor
         [Parameter]
         public IEnumerable<T>? CurrentItems { get; set; }
 
+        /// <summary>
+        /// The rows of the group this footer cell belongs to.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which scopes the footer to the whole grid.  It is set for the footer rendered underneath a single group of rows.
+        /// </remarks>
+        [Parameter]
+        public IEnumerable<T>? GroupItems { get; set; }
+
+        // Set in OnInitialized() so it can't be null.
+        private FooterContext<T> _footerContext = null!;
+
+        protected override void OnInitialized()
+        {
+            Debug.Assert(DataGrid is not null);
+            _footerContext = new FooterContext<T>(DataGrid) { GroupItemsFunc = () => GroupItems };
+        }
+
         private string Classname =>
             new CssBuilder(Column?.FooterClassname)
                 .AddClass(Column?.FooterClassFunc?.Invoke(items ?? Enumerable.Empty<T>()))

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -20,6 +20,11 @@ namespace MudBlazor
         private readonly MudDataGrid<T> _dataGrid;
 
         /// <summary>
+        /// Supplies the rows of the group this footer belongs to, or <c>null</c> when the footer applies to the whole grid.
+        /// </summary>
+        internal Func<IEnumerable<T>?> GroupItemsFunc { private get; init; } = static () => null;
+
+        /// <summary>
         /// The items which apply to the footer.
         /// </summary>
         public IEnumerable<T> Items
@@ -49,6 +54,11 @@ namespace MudBlazor
         {
             get
             {
+                if (GroupItemsFunc() is { } groupItems)
+                {
+                    return _dataGrid.GetGroupSelectionState(groupItems);
+                }
+
                 if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
                 {
                     if (_dataGrid.Selection.Count == 0)
@@ -72,7 +82,9 @@ namespace MudBlazor
             _dataGrid = dataGrid;
             Actions = new FooterActions
             {
-                SetSelectAllAsync = x => _dataGrid.SetSelectAllAsync(x ?? false),
+                SetSelectAllAsync = x => GroupItemsFunc() is { } groupItems
+                    ? _dataGrid.SetGroupSelectAllAsync(x ?? false, groupItems)
+                    : _dataGrid.SetSelectAllAsync(x ?? false),
             };
         }
 

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -345,7 +345,7 @@
 
 
 
-    internal RenderFragment FooterCells(IEnumerable<T> currentItems) =>
+    internal RenderFragment FooterCells(IEnumerable<T> currentItems, IEnumerable<T>? groupItems = null) =>
         @<text>
              @if (currentItems is not null)
              {
@@ -355,7 +355,7 @@
                      {
                          if (column.AggregateDefinition is not null || column.GetFooterTemplate() is not null || HasFooter)
                          {
-                             <FooterCell T="T" Column="@column" CurrentItems="@currentItems"></FooterCell>
+                             <FooterCell T="T" Column="@column" CurrentItems="@currentItems" GroupItems="@groupItems"></FooterCell>
                          }
                      }
                  }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2165,6 +2165,31 @@ namespace MudBlazor
             await InvokeAsync(StateHasChanged);
         }
 
+        /// <summary>
+        /// Selects or clears every selectable row of a single group, leaving rows outside of the group untouched.
+        /// </summary>
+        /// <param name="value">When <c>true</c>, the group's rows are added to the selection; otherwise they are removed from it.</param>
+        /// <param name="groupItems">The rows belonging to the group.</param>
+        internal async Task SetGroupSelectAllAsync(bool value, IEnumerable<T> groupItems)
+        {
+            var selectableItems = GetSelectableItems(groupItems);
+
+            if (value)
+            {
+                Selection.UnionWith(selectableItems);
+            }
+            else
+            {
+                Selection.ExceptWith(selectableItems);
+            }
+
+            // Create new HashSet instance to ensure ParameterState's comparer detects changes
+            await InvokeAsync(() => _selectedItemsState.SetValueAsync(new HashSet<T>(Selection, Comparer)));
+            await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
+
+            await InvokeAsync(StateHasChanged);
+        }
+
         private SelectColumn<T>? GetSelectColumn()
         {
             return RenderedColumns.OfType<SelectColumn<T>>().FirstOrDefault();
@@ -2173,12 +2198,33 @@ namespace MudBlazor
         /// <summary>
         /// The items which select-all would select, i.e. every displayed row whose selection is not disabled.
         /// </summary>
-        internal IEnumerable<T> GetSelectableItems()
+        internal IEnumerable<T> GetSelectableItems() => GetSelectableItems(HasServerData ? ServerItems : FilteredItems);
+
+        /// <summary>
+        /// The items of <paramref name="items"/> whose selection is not disabled.
+        /// </summary>
+        internal IEnumerable<T> GetSelectableItems(IEnumerable<T> items)
         {
             var selectColumn = GetSelectColumn();
-            var items = HasServerData ? ServerItems : FilteredItems;
 
             return items.Where(item => !IsRowSelectionDisabled(item, selectColumn));
+        }
+
+        /// <summary>
+        /// The state of a group's select-all checkbox: <c>true</c> when every selectable row of the group is selected, <c>false</c> when none of them is, otherwise <c>null</c>.
+        /// </summary>
+        /// <param name="groupItems">The rows belonging to the group.</param>
+        internal bool? GetGroupSelectionState(IEnumerable<T> groupItems)
+        {
+            var selectableItems = GetSelectableItems(groupItems).ToList();
+            var selectedCount = selectableItems.Count(Selection.Contains);
+
+            if (selectedCount == 0)
+            {
+                return false;
+            }
+
+            return selectedCount == selectableItems.Count ? true : null;
         }
 
         internal bool? GetRowSelectionState(T item)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2172,6 +2172,10 @@ namespace MudBlazor
         /// <param name="groupItems">The rows belonging to the group.</param>
         internal async Task SetGroupSelectAllAsync(bool value, IEnumerable<T> groupItems)
         {
+            // nothing should happen if multiselection is false
+            if (!MultiSelection)
+                return;
+
             var selectableItems = GetSelectableItems(groupItems);
 
             if (value)


### PR DESCRIPTION
Fixes #8524.

A group footer's select-all checkbox selects every row in the grid rather than the rows in its group. Driven in the browser on a two-group, six-row grid: clicking group A's footer selected all six and moved the header, both group checkboxes and the `<tfoot>` in lockstep, and a follow-up "off" click toggled itself straight back on. After this change group A selects exactly rows 1-3, group B exactly 4-6, deselect is likewise group-scoped, and grid-level select-all is unchanged.

The obstacle was not reaching the group's rows: `DataGridGroupRow` already passes them into `FooterCells`. It was that `FooterContext<T>` was a single instance per `Column<T>`, shared by the grid `<tfoot>` and every per-group footer, so it structurally could not know its own scope. Ownership moves to `FooterCell`, which is already per-footer-row, and the context is built with a closure so it cannot go stale across re-renders. `Column.footerContext` became dead and is removed; it had no other references.

`GetSelectableItems()` from #13596 is preserved: its body moved into an overload taking a set, and the no-arg version delegates to it, so the disabled-row exclusion behaves identically. The new group path unions or excepts only its own selectable rows and never calls `Selection.Clear()`. The group tri-state is computed against the group's rows, so "all selected" and "select all" now agree about which set they mean, which is the mistake that made the earlier header tri-state wrong.