### PR TITLE
MudSelect: Preserve disabled selections with SelectAll

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -879,6 +879,30 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => select.Instance.GetState(x => x.SelectedValues).Should().HaveCount(0));
         }
 
+        /// <summary>
+        /// SelectAll preserves disabled selected items when selecting and deselecting enabled items (#11236).
+        /// </summary>
+        [Test]
+        public async Task MultiSelect_SelectAll_PreservesDisabledSelectedItems()
+        {
+            var comp = Context.Render<MultiSelectTest7>();
+            var select = comp.FindComponent<MudSelect<string>>();
+            await select.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Comparer, StringComparer.OrdinalIgnoreCase)
+                .Add(x => x.SelectedValues, ["FOURTHA"]));
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+
+            await comp.WaitForAssertionAsync(() => select.Instance.GetState(x => x.SelectedValues)
+                .Should().BeEquivalentTo(["FirstA", "SecondA", "ThirdA", "FOURTHA"]));
+
+            await comp.FindAll("div.mud-list-item")[0].ClickAsync();
+
+            await comp.WaitForAssertionAsync(() => select.Instance.GetState(x => x.SelectedValues)
+                .Should().BeEquivalentTo(["FOURTHA"]));
+        }
+
         [Test]
         public async Task SingleSelect_Should_CallValidationFunc()
         {

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -949,11 +949,16 @@ namespace MudBlazor
         {
             if (MultiSelection && SelectAll)
             {
-                if (_selectedValues.Count == 0)
+                var enabledValues = new HashSet<T?>(Items
+                    .Where(x => !x.Disabled && x.Value != null)
+                    .Select(x => x.Value), Comparer);
+                var selectedEnabledValuesCount = _selectedValues.Count(enabledValues.Contains);
+
+                if (selectedEnabledValuesCount == 0)
                 {
                     _selectAllChecked = false;
                 }
-                else if (Items.Count(x => !x.Disabled) == _selectedValues.Count)
+                else if (selectedEnabledValuesCount == enabledValues.Count)
                 {
                     _selectAllChecked = true;
                 }
@@ -980,25 +985,33 @@ namespace MudBlazor
                 _selectAllChecked = true;
             }
 
-            // Define the items selection
-            if (_selectAllChecked.Value)
-            {
-                await SelectAllItems();
-            }
-            else
-            {
-                await ClearAsync();
-            }
+            await UpdateSelectAllSelectionAsync(_selectAllChecked.Value);
         }
 
-        private async Task SelectAllItems()
+        private async Task UpdateSelectAllSelectionAsync(bool selectAll)
         {
             if (!MultiSelection)
             {
                 return;
             }
 
-            var selectedValues = new HashSet<T?>(Items.Where(x => !x.Disabled && x.Value != null).Select(x => x.Value), Comparer);
+            var disabledValues = new HashSet<T?>(Items
+                .Where(x => x.Disabled)
+                .Select(x => x.Value), Comparer);
+            var selectedValues = new HashSet<T?>(_selectedValues.Where(disabledValues.Contains), Comparer);
+
+            if (selectAll)
+            {
+                selectedValues.UnionWith(Items
+                    .Where(x => !x.Disabled && x.Value != null)
+                    .Select(x => x.Value));
+            }
+            else if (selectedValues.Count == 0)
+            {
+                await ClearAsync();
+                return;
+            }
+
             _selectedValues = new HashSet<T?>(selectedValues, Comparer);
 
             if (MultiSelectionTextFunc != null)

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -950,7 +950,7 @@ namespace MudBlazor
             if (MultiSelection && SelectAll)
             {
                 var enabledValues = new HashSet<T?>(Items
-                    .Where(x => !x.Disabled && x.Value != null)
+                    .Where(x => !x.Disabled && HasNonNullValue(x.Value))
                     .Select(x => x.Value), Comparer);
                 var selectedEnabledValuesCount = _selectedValues.Count(enabledValues.Contains);
 
@@ -1003,7 +1003,7 @@ namespace MudBlazor
             if (selectAll)
             {
                 selectedValues.UnionWith(Items
-                    .Where(x => !x.Disabled && x.Value != null)
+                    .Where(x => !x.Disabled && HasNonNullValue(x.Value))
                     .Select(x => x.Value));
             }
             else if (selectedValues.Count == 0)
@@ -1036,6 +1036,8 @@ namespace MudBlazor
                 SetValueAndUpdateTextAsync((T?)(object?)ReadText, updateText: false).CatchAndLog();
             }
         }
+
+        private static bool HasNonNullValue(T? value) => !ReferenceEquals(value, null);
 
         private async Task OnFocusOutAsync(FocusEventArgs args)
         {


### PR DESCRIPTION
## Description

SelectAll previously replaced the selection with enabled values on the first click and called the full clear path on the second click. Both operations removed disabled values that had already been selected through binding or code.

This change preserves already-selected disabled values while selecting or deselecting enabled options. The SelectAll checkbox state is calculated from enabled values only, so retained disabled values do not leave it indeterminate.

The retained values come from the existing selection rather than the rendered items, preserving the caller's original values when a custom comparer is used.

## Testing

- Added coverage for selecting and deselecting all with a pre-selected disabled value and a case-insensitive comparer
- Ran the SelectTests fixture: 104 passed
- Ran dotnet format whitespace on both changed files

Fixes #11236