### PR TITLE
MudTable: Fix loading bar offset when the header row is missing or empty

### DIFF
--- a/src/MudBlazor/Styles/components/_table.scss
+++ b/src/MudBlazor/Styles/components/_table.scss
@@ -331,6 +331,13 @@ $header-height-with-filter-dense: 89px; // 39px + 50px (filter row height)
         top: $header-height-with-filter-dense;
       }
 
+      // Row 1 (loading row with no header row above it, or one that renders no cells and so has no height).
+      // The offsets above assume a header row is there to sit under; without one they push the loader into empty space.
+      .mud-table-loading-row:first-child > .mud-table-loading,
+      tr:not(:has(> *)) + .mud-table-loading-row > .mud-table-loading {
+        top: 0;
+      }
+
       & * .mud-table-cell.sticky-left,
       & * .mud-table-cell.sticky-right {
         z-index: 3;


### PR DESCRIPTION
Fixes #12182

`.mud-table-sticky-header .mud-table-head .mud-table-loading` pins the built-in progress row with a hard-coded `top: $header-height-dense`, independent of the header row's *actual* rendered height. With `CustomHeader="true"` and an empty `HeaderContent` the header has no height, so the loading bar is pushed 39px down into empty space instead of sitting flush against the top of the table.

This adds a `top: 0` for the two shapes where there is no header row to sit under: the loading row is the first row, or the row above it renders no cells.

```scss
.mud-table-loading-row:first-child > .mud-table-loading,
tr:not(:has(> *)) + .mud-table-loading-row > .mud-table-loading {
  top: 0;
}
```

Measured in Chrome as the loading bar's top minus the scroll container's top, at rest and at `scrollTop = 120`:

| table | shape | before | after |
|---|---|---|---|
| A | `FixedHeader`, `CustomHeader`, empty `HeaderContent` (the issue) | 39px | **0px** |
| B | same but `FixedHeader="false"` (the thread's workaround) | 0px | 0px |
| D | `FixedHeader` with a real `<MudTh>` header (regression control) | 39px | **39px** |

D stays pinned at 39px both at rest and while scrolling, so normal sticky-header behaviour is unchanged.

## Before/After

Before

<img width="2304" height="576" alt="image" src="https://github.com/user-attachments/assets/446d45ea-30bb-447c-a99c-c45f02688be6" />

After

<img width="2304" height="576" alt="image" src="https://github.com/user-attachments/assets/e1c0edd3-eac6-4f2e-9039-a5a74062e4f2" />
