### PR TITLE
MudInput: Let UserAttributes override computed ARIA attributes

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -1758,6 +1758,31 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A caller-supplied aria-required should win over the value computed from Required, and required should still follow the parameter.
+        /// </summary>
+        [Test]
+        public void TextField_Should_LetUserAttributesOverrideAriaRequired()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-required", "true" } }));
+
+            comp.Find("input").GetAttribute("aria-required").Should().Be("true");
+            comp.Find("input").HasAttribute("required").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A caller-supplied aria-invalid should win over the value computed from the error state.
+        /// </summary>
+        [Test]
+        public void TextField_Should_LetUserAttributesOverrideAriaInvalid()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-invalid", "true" } }));
+
+            comp.Find("input").GetAttribute("aria-invalid").Should().Be("true");
+        }
+
+        /// <summary>
         /// Bug : https://github.com/MudBlazor/MudBlazor/issues/10606
         /// When the user inputs a single space, the required text field should show an error.
         /// </summary>

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -23,7 +23,7 @@
         <textarea class="@InputClassname"
                   @ref="ElementReference"
                   rows="@Lines"
-                  @attributes="UserAttributes"
+                  @attributes="GetInputUserAttributes()"
                   id="@InputElementId"
                   type="@InputTypeString"
                   placeholder="@Placeholder"
@@ -39,10 +39,7 @@
                   maxlength="@MaxLength"
                   @onkeydown:preventDefault="@KeyDownPreventDefault"
                   @onkeyup:preventDefault="@KeyUpPreventDefault"
-                  aria-describedby="@GetAriaDescribedByString()"
-                  aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
-                  required="@Required"
-                  aria-required="@Required.ToString().ToLowerInvariant()">
+                  required="@Required">
             @ReadText
             </textarea>
         @*note: the value="@_internalText" is absolutely essential here. the inner html @Text is needed by tests checking it*@
@@ -51,7 +48,7 @@
     {
         <input class="@InputClassname"
                @ref="ElementReference"
-               @attributes="UserAttributes"
+               @attributes="GetInputUserAttributes()"
                id="@InputElementId"
                type="@InputTypeString"
                @bind:event="@(Immediate ? "oninput" : "onchange")"
@@ -68,10 +65,7 @@
                maxlength="@MaxLength"
                @onkeydown:preventDefault="KeyDownPreventDefault"
                @onkeyup:preventDefault="@KeyUpPreventDefault"
-               aria-describedby="@GetAriaDescribedByString()"
-               aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
-               required="@Required"
-               aria-required="@Required.ToString().ToLowerInvariant()">
+               required="@Required">
 
         @if (GetDisabledState())
         {

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -18,12 +18,16 @@
                            AriaLabel="@AdornmentAriaLabel" />
     }
 
+    @*note: the aria-* attributes below are written before @attributes on purpose. They are fallbacks, and the last write wins, so the splat lets a consumer override them through UserAttributes. required stays after the splat because it is native behavior rather than an annotation.*@
     @if (ShouldUseTextArea)
     {
         <textarea class="@InputClassname"
                   @ref="ElementReference"
                   rows="@Lines"
-                  @attributes="GetInputUserAttributes()"
+                  aria-describedby="@GetAriaDescribedByString()"
+                  aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
+                  aria-required="@Required.ToString().ToLowerInvariant()"
+                  @attributes="UserAttributes"
                   id="@InputElementId"
                   type="@InputTypeString"
                   placeholder="@Placeholder"
@@ -48,7 +52,10 @@
     {
         <input class="@InputClassname"
                @ref="ElementReference"
-               @attributes="GetInputUserAttributes()"
+               aria-describedby="@GetAriaDescribedByString()"
+               aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
+               aria-required="@Required.ToString().ToLowerInvariant()"
+               @attributes="UserAttributes"
                id="@InputElementId"
                type="@InputTypeString"
                @bind:event="@(Immediate ? "oninput" : "onchange")"

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -18,7 +18,6 @@
                            AriaLabel="@AdornmentAriaLabel" />
     }
 
-    @*note: the aria-* attributes below are written before @attributes on purpose. They are fallbacks, and the last write wins, so the splat lets a consumer override them through UserAttributes. required stays after the splat because it is native behavior rather than an annotation.*@
     @if (ShouldUseTextArea)
     {
         <textarea class="@InputClassname"

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -241,29 +241,6 @@ namespace MudBlazor
         /// The hidden input can no longer fire them, so forwarding them here does not double up.
         /// Caller-provided <c>UserAttributes</c> take precedence over the computed accessibility fallbacks. Returns <c>null</c> for every other render so the always-emitted (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
         /// </remarks>
-        /// <summary>
-        /// Builds the attributes splatted onto the rendered input, applying the computed accessibility values as fallbacks so caller-provided <c>UserAttributes</c> take precedence.
-        /// </summary>
-        /// <remarks>
-        /// These were previously literal attributes written after the <c>UserAttributes</c> splat, so last-write-wins meant a consumer could never override them.
-        /// <c>required</c> stays a literal attribute because it is native behavior rather than an ARIA annotation.
-        /// </remarks>
-        private Dictionary<string, object?> GetInputUserAttributes()
-        {
-            var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase);
-
-            var describedBy = GetAriaDescribedByString();
-            if (describedBy is not null)
-            {
-                attributes.TryAdd("aria-describedby", describedBy);
-            }
-
-            attributes.TryAdd("aria-invalid", HasErrors.ToString().ToLowerInvariant());
-            attributes.TryAdd("aria-required", Required.ToString().ToLowerInvariant());
-
-            return attributes;
-        }
-
         private Dictionary<string, object?>? GetDisplayUserAttributes()
         {
             if (InputType != InputType.Hidden || ChildContent is null)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -241,6 +241,29 @@ namespace MudBlazor
         /// The hidden input can no longer fire them, so forwarding them here does not double up.
         /// Caller-provided <c>UserAttributes</c> take precedence over the computed accessibility fallbacks. Returns <c>null</c> for every other render so the always-emitted (but hidden) presenter <c>div</c> does not get spurious attributes or allocate on the common input path.
         /// </remarks>
+        /// <summary>
+        /// Builds the attributes splatted onto the rendered input, applying the computed accessibility values as fallbacks so caller-provided <c>UserAttributes</c> take precedence.
+        /// </summary>
+        /// <remarks>
+        /// These were previously literal attributes written after the <c>UserAttributes</c> splat, so last-write-wins meant a consumer could never override them.
+        /// <c>required</c> stays a literal attribute because it is native behavior rather than an ARIA annotation.
+        /// </remarks>
+        private Dictionary<string, object?> GetInputUserAttributes()
+        {
+            var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase);
+
+            var describedBy = GetAriaDescribedByString();
+            if (describedBy is not null)
+            {
+                attributes.TryAdd("aria-describedby", describedBy);
+            }
+
+            attributes.TryAdd("aria-invalid", HasErrors.ToString().ToLowerInvariant());
+            attributes.TryAdd("aria-required", Required.ToString().ToLowerInvariant());
+
+            return attributes;
+        }
+
         private Dictionary<string, object?>? GetDisplayUserAttributes()
         {
             if (InputType != InputType.Hidden || ChildContent is null)


### PR DESCRIPTION
`MudInput` splats `UserAttributes` and then writes `aria-describedby`, `aria-invalid` and
`aria-required` as literal attributes **afterwards**:

```razor
<input class="@InputClassname"
       @attributes="UserAttributes"                                   ← the caller's splat …
       …
       aria-describedby="@GetAriaDescribedByString()"
       aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
       required="@Required"
       aria-required="@Required.ToString().ToLowerInvariant()">       ← … overwritten here
```

Because the render tree resolves duplicate attributes last-write-wins, a caller-supplied value for any
of those three is silently discarded.

The fix is to move the three ARIA attributes **above** the splat. The same last-write-wins rule then
makes the caller the winner and the computed value the fallback:

```razor
<input class="@InputClassname"
       @ref="ElementReference"
       aria-describedby="@GetAriaDescribedByString()"
       aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
       aria-required="@Required.ToString().ToLowerInvariant()"        ← fallbacks …
       @attributes="UserAttributes"                                   ← … the caller can override
       …
       required="@Required">                                          ← after the splat, not overridable
```

**`required` deliberately stays below the splat** and bound to the parameter. It is native behaviour
rather than an ARIA annotation, and keeping it there is what makes the pair separable.

`MudInput.razor.cs` is untouched — this is an ordering change only, so it adds no code and allocates
nothing per render.

### Why separating them matters

`Required` currently drives the HTML5 `required` attribute and `aria-required` from a single `bool`, so
a consumer cannot express *"this field is required, announce it to assistive technology, but do not add
the HTML5 attribute"*.

That is exactly what a form validated **server-side** and rendered `novalidate` needs. Concretely, in a
library that renders `novalidate` and validates on the server, a genuinely required field ends up
rendering `aria-required="false"` — not merely silent, but an affirmatively wrong statement to a screen
reader, and a WCAG 2.1 **3.3.2 Labels or Instructions** (Level A) failure. The only workaround today is
to set `Required="true"` and accept the HTML5 attribute, which re-arms native browser validation
wherever `novalidate` does not apply.

With this change such a consumer passes `aria-required="true"` through `UserAttributes` and leaves
`Required` alone.

It also makes the three attributes overridable for anyone with a different accessibility need —
pointing `aria-describedby` at their own help element, for instance — which is not currently possible.

### Behaviour

| | before | after |
|---|---|---|
| no caller-supplied value | computed value rendered | **unchanged** — the literal is still there, just earlier |
| caller supplies `aria-required` / `aria-invalid` / `aria-describedby` | silently discarded | caller's value wins |
| `required` attribute | from `Required` | **unchanged** — still from `Required` |

Default rendering is byte-identical, which is why the existing suites pass untouched.

### Tests

Two new tests in `TextFieldTests`, following the existing
`RequiredTextField_Should_HaveRequiredAndAriaRequiredAttributes` pattern:

- `TextField_Should_LetUserAttributesOverrideAriaRequired` — also asserts `required` stays absent, which
  is the point of the change.
- `TextField_Should_LetUserAttributesOverrideAriaInvalid`

Verified locally:

| Check | Result |
|---|---|
| `dotnet build src/MudBlazor.UnitTests -c Release` | clean, 0 warnings |
| full `MudBlazor.UnitTests` suite | **5611 passed, 0 failed** (2 pre-existing skips) |
| the two new tests with the attribute ordering inverted | **2/2 fail** (they bite) |

The 109 existing assertions across the suite that read `aria-required` / `aria-invalid` are untouched
and pass — the evidence that the fallback preserves current behaviour.

No visual changes, so no screenshots.

<sub>An earlier revision did this with a `GetInputUserAttributes()` helper mirroring
`GetDisplayUserAttributes()`. Per review that allocated a dictionary on every render of every input;
the ordering change gets the same result with no allocation and no new code.</sub>

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
