### PR TITLE
Tests: Guard null picker reference in DateRangePickerMinMaxDaysTest

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerMinMaxDaysTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DatePicker/DateRangePickerMinMaxDaysTest.razor
@@ -9,7 +9,7 @@
     AdditionalDateClassesFunc="@((DateTime dt)=>((int)dt.DayOfWeek == 0 ? "red-text text-accent-4" : ""))" />
 
     <MudStack Row>
-        <MudSwitch @bind-Value="AllowWeekends" @bind-Value:after="@(() => _picker.RecalculateValidDays())" Color="Color.Primary">Allow Weekends</MudSwitch>
+        <MudSwitch @bind-Value="AllowWeekends" @bind-Value:after="@(() => _picker?.RecalculateValidDays())" Color="Color.Primary">Allow Weekends</MudSwitch>
         <MudSwitch @bind-Value="CountDisabledDays" Color="Color.Primary">Include Disabled</MudSwitch>
     </MudStack>
 


### PR DESCRIPTION
`DateRangePickerMinMaxDaysTest.razor` dereferences `_picker`, which is declared nullable, without a
null check:

```razor
private MudDateRangePicker? _picker;
...
@bind-Value:after="@(() => _picker.RecalculateValidDays())"
```

That is `CS8602`, and because `MudBlazor.UnitTests.Viewer` is a `ProjectReference` of
`MudBlazor.UnitTests`, it fails the `build-test (src/MudBlazor.UnitTests, …)` job before any test runs.

**It is currently failing on every open PR**, not just one — e.g. #13610, #13612, #13613 all fail with
the identical error in the identical file.

### Why it started now, with no code change

`global.json` pins `10.0.100` with `rollForward: latestFeature`, so the CI runners roll forward to
whatever 10.0.4xx SDK the image carries — currently **10.0.400**, whose analysis reports this. A local
10.0.3xx SDK does not, which is why it reproduces on CI but not on a contributor's machine, and why
`dev`'s last run (2026-08-11) was green while everything since is red.

### Fix

```diff
-@bind-Value:after="@(() => _picker.RecalculateValidDays())"
+@bind-Value:after="@(() => _picker?.RecalculateValidDays())"
```

`RecalculateValidDays()` returns `void`, so the conditional access is valid in the `Action` lambda and
behaves identically whenever `_picker` is set — which, given `@ref`, is any time the handler can fire.

Verified locally: `dotnet build src/MudBlazor.UnitTests -c Release` clean (0 warnings, 0 errors) and the
86 `DateRangePicker` tests pass. I could not reproduce the original error locally (SDK 10.0.302), so the
fix is verified as correct-and-harmless rather than as red→green; CI on this PR is the real check.

No visual changes.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests <!-- existing DateRangePicker tests cover the component; the change is a null-guard in a test viewer component -->
