### PR TITLE
MudDateRangePicker: Enforce MinDays for same-day selection

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1160,7 +1160,7 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("div.mud-picker-year").First(x => x.TrimmedText().Equals("2025")).ToMarkup().Should().Contain("mud-picker-year-selected");
         }
 
-        [Test]
+        [Test(Description = "https://github.com/MudBlazor/MudBlazor/issues/13611")]
         public async Task DateRangePicker_MinMaxDays()
         {
             //no restrictions - minimum of 3 days
@@ -1168,10 +1168,21 @@ namespace MudBlazor.UnitTests.Components
             var comp = Context.Render<DateRangePickerMinMaxDaysTest>(p => p.Add(x => x.DateRange, startingRange));
 
             await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ClickAsync(new MouseEventArgs());
+            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ToMarkup().Should().Contain("disabled"); //1 day not allowed
             comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("17")).ToMarkup().Should().Contain("disabled");
             await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("18")).ClickAsync(new MouseEventArgs());
 
             comp.Instance.DateRange.Should().Be(new DateRange(new DateTime(2025, 1, 16).Date, new DateTime(2025, 1, 18).Date));
+
+            //minimum of 1 day allows selecting only the start date
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.MinDays, 1));
+            await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ClickAsync(new MouseEventArgs());
+            comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ToMarkup().Should().NotContain("disabled");
+            await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ClickAsync(new MouseEventArgs());
+
+            comp.Instance.DateRange.Should().Be(new DateRange(new DateTime(2025, 1, 16).Date, new DateTime(2025, 1, 16).Date));
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.MinDays, 3));
 
             //no restrictions - maximum of 7 days
             await comp.FindAll("button.mud-picker-calendar-day").First(x => x.TrimmedText().Equals("16")).ClickAsync(new MouseEventArgs());

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -264,7 +264,7 @@ namespace MudBlazor
             var selectedDate = _firstDate.Value;
             var validDateRange = GetValidDateRange(selectedDate);
 
-            return base.IsDayDisabled(date) || IsDateOutOfRange(date, selectedDate, validDateRange);
+            return base.IsDayDisabled(date) || IsDateOutOfRange(date, validDateRange);
         }
 
         private DateRange GetValidDateRange(DateTime selectedDate)
@@ -286,12 +286,11 @@ namespace MudBlazor
             return new DateRange(start, end);
         }
 
-        private static bool IsDateOutOfRange(DateTime date, DateTime selectedDate, DateRange validRange)
+        private static bool IsDateOutOfRange(DateTime date, DateRange validRange)
         {
-            var isNotSelectedDate = date < selectedDate || date > selectedDate;
             var isOutsideValidRange = date < validRange.Start || date > validRange.End;
 
-            return isNotSelectedDate && isOutsideValidRange;
+            return isOutsideValidRange;
         }
 
         private DateTime GetMaxSelectableDate(DateTime startDate, int maxDays)


### PR DESCRIPTION
Fixes #13611.

`MudDateRangePicker` previously exempted the selected start date from its valid-range check. Clicking that date again therefore created a one-day range even when `MinDays` required two or more days.

This removes the exemption so the start date is disabled whenever it falls outside the computed valid end-date range. The regression coverage verifies both sides of the boundary: `MinDays = 3` rejects same-day selection, while `MinDays = 1` still allows it.

Verification:

- `DateRangePicker_MinMaxDays` passed after failing before the production fix.
- All 83 `DateRangePickerTests` passed on .NET 10.
- Changed files pass `dotnet format whitespace` and `git diff --check`.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
