### PR TITLE
MudTable: Clamp CurrentPage to 0 when navigating an empty table

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableNavigateToEmptyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableNavigateToEmptyTest.razor
@@ -1,0 +1,13 @@
+<MudTable @ref="Table" Items="Items">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "Table - NavigateTo(int) on an empty table must clamp CurrentPage to 0, not set it to -1 (#13619)";
+
+    public MudTable<string> Table { get; set; } = null!;
+
+    public IEnumerable<string> Items { get; set; } = [];
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -541,6 +541,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Navigating an empty table to a page index must clamp CurrentPage to 0, not set it to -1 (#13619).
+        /// </summary>
+        [Test]
+        public async Task TableNavigateToEmptyTableClampsCurrentPageToZero()
+        {
+            var comp = Context.Render<TableNavigateToEmptyTest>();
+            var table = comp.FindComponent<MudTable<string>>();
+
+            table.Instance.CurrentPage.Should().Be(0);
+            comp.FindAll("tr.mud-table-row").Count.Should().Be(0);
+
+            await table.InvokeAsync(() => table.Instance.NavigateTo(0));
+            table.Instance.CurrentPage.Should().Be(0);
+
+            await table.InvokeAsync(() => table.Instance.NavigateTo(5));
+            table.Instance.CurrentPage.Should().Be(0);
+        }
+
+        /// <summary>
         /// page size option initial value test. Initial value should not be 10 since PageSizeOption is set to be new int[]{8, 16, 32}
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -698,7 +698,7 @@ namespace MudBlazor
         /// <param name="pageIndex">The index of the page to navigate to.</param>
         public void NavigateTo(int pageIndex)
         {
-            SetCurrentPage(Math.Min(Math.Max(0, pageIndex), NumPages - 1));
+            SetCurrentPage(Math.Max(0, Math.Min(pageIndex, NumPages - 1)));
         }
 
         // Applies an internal page change (pager/NavigateTo/clamp/reset); must not update _currentPageParameterValue or it would be mistaken for a parameter change (#13462).


### PR DESCRIPTION
NavigateTo(int) clamped the page index with
Math.Min(Math.Max(0, pageIndex), NumPages - 1). With an empty table NumPages
is 0, so every call resolved to -1, making the pager show "-9-0 of N" after
clearing a search or filter on a server-side table. The upper bound is now
clamped with Math.Max(0, ...), matching NavigateTo(Page.Last).

Changed files:
- src/MudBlazor/Components/Table/MudTableBase.cs (one-line clamp)
- src/MudBlazor.UnitTests/Components/TableTests.cs (regression test)
- src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableNavigateToEmptyTest.razor (test component)

Closes #13619

## Verification

- New test TableNavigateToEmptyTableClampsCurrentPageToZero: fails on the
  pre-fix code, passes with the fix
- Full TableTests suite: 144/144 pass

**Checklist:**
- [x] I've read the contribution guidelines
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
