### PR TITLE
MudTable: Keep empty table page index non-negative

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -541,6 +541,19 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Issue #13619: Navigating an empty table keeps the current page at zero.
+        /// </summary>
+        [Test]
+        public async Task TableNavigateToEmptyTableKeepsCurrentPageAtZero()
+        {
+            var table = Context.Render<MudTable<string>>();
+
+            await table.InvokeAsync(() => table.Instance.NavigateTo(0));
+
+            table.Instance.CurrentPage.Should().Be(0);
+        }
+
+        /// <summary>
         /// page size option initial value test. Initial value should not be 10 since PageSizeOption is set to be new int[]{8, 16, 32}
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -704,6 +704,7 @@ namespace MudBlazor
         // Applies an internal page change (pager/NavigateTo/clamp/reset); must not update _currentPageParameterValue or it would be mistaken for a parameter change (#13462).
         internal void SetCurrentPage(int page)
         {
+            page = Math.Max(0, page);
             if (_currentPage == page)
             {
                 return;


### PR DESCRIPTION
## Summary

- Keep MudTable page indexes non-negative when navigating an empty table.
- Add regression coverage for NavigateTo(0) with no items.

## Tests

- TableNavigateTo tests: 6 passed.
- TableTests fixture: 144 passed.
- MudBlazor.UnitTests: 5604 passed, 2 skipped.

Fixes #13619, Closes #13620