### PR TITLE
MudTable: Clamp CurrentPage to 0 when table is empty

### DIFF
--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -698,7 +698,7 @@ namespace MudBlazor
         /// <param name="pageIndex">The index of the page to navigate to.</param>
         public void NavigateTo(int pageIndex)
         {
-            SetCurrentPage(Math.Min(Math.Max(0, pageIndex), NumPages - 1));
+            SetCurrentPage(NumPages == 0 ? 0 : Math.Min(Math.Max(0, pageIndex), NumPages - 1));
         }
 
         // Applies an internal page change (pager/NavigateTo/clamp/reset); must not update _currentPageParameterValue or it would be mistaken for a parameter change (#13462).


### PR DESCRIPTION
Fixes #13619

When the table is empty (NumPages == 0), NavigateTo(int) was setting CurrentPage to -1 because Math.Min(0, -1) = -1. Now it checks for empty table first and returns 0.