### PR TITLE
Docs: Update CodeBeam extension link

### DIFF
--- a/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
+++ b/src/MudBlazor.Docs/wwwroot/CommunityExtensions.json
@@ -28,7 +28,7 @@
     "Category": "Components",
     "Name": "CodeBeam MudBlazor Extensions",
     "Description": "MudExtensions has 30+ components and utilities from the core library contributors. There are both unique and extended components that add additional features on current Mud components.",
-    "Link": "https://codebeam-mudextensions.pages.dev/",
+    "Link": "https://mudextensions.codebeam.org/",
     "GitHubUserPath": "CodeBeamOrg",
     "GitHubRepoPath": "CodeBeam.MudBlazor.Extensions"
   },


### PR DESCRIPTION
Updates the CodeBeam MudBlazor Extensions entry to its current site so the Community Extensions page no longer sends users to the retired Pages URL.

Fixes #13621

**Verification**
- `jq empty src/MudBlazor.Docs/wwwroot/CommunityExtensions.json`
- `dotnet build src/MudBlazor.Docs/MudBlazor.Docs.csproj --no-restore --nologo` (0 warnings, 0 errors)
- `curl -I https://mudextensions.codebeam.org/` (HTTP 200)

**Checklist:**
- [x] I've read the contribution guidelines
- [x] My change follows the style of this project
- [ ] I've added or updated relevant unit tests (link-only documentation metadata; no executable logic changed)