### PR TITLE
MudTable: Fix NavigateTo(int) clamping to page 0 when the table is empty

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -541,6 +541,53 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Navigating to a page on an empty table must keep CurrentPage at 0 and render "0-0 of 0" instead of a negative page (#13619).
+        /// </summary>
+        [Test]
+        public async Task TableNavigateToPage_EmptyTable_CurrentPageClampedToZero()
+        {
+            var comp = Context.Render<MudTable<int>>(parameters => parameters
+                .Add(p => p.Items, Array.Empty<int>())
+                .Add(p => p.RowTemplate, (context) => builder =>
+                {
+                    builder.OpenComponent<MudTd>(0);
+                    builder.AddAttribute(1, "ChildContent", (RenderFragment)(b => b.AddContent(2, context)));
+                    builder.CloseComponent();
+                })
+                .Add(p => p.PagerContent, (RenderFragment)(builder =>
+                {
+                    builder.OpenComponent<MudTablePager>(0);
+                    builder.CloseComponent();
+                })));
+
+            await comp.InvokeAsync(() => comp.Instance.NavigateTo(0));
+
+            comp.Instance.CurrentPage.Should().Be(0);
+            comp.FindAll("div.mud-table-pagination-caption")[^1].TextContent.Trim().Should().Be("0-0 of 0");
+        }
+
+        /// <summary>
+        /// Out-of-range page indexes on an empty table must clamp to page 0 instead of a negative page (#13619).
+        /// </summary>
+        [Test]
+        public async Task TableNavigateToPage_EmptyTable_OutOfRangeIndexClampedToZero()
+        {
+            var comp = Context.Render<MudTable<int>>(parameters => parameters
+                .Add(p => p.Items, Array.Empty<int>())
+                .Add(p => p.RowTemplate, (context) => builder =>
+                {
+                    builder.OpenComponent<MudTd>(0);
+                    builder.AddAttribute(1, "ChildContent", (RenderFragment)(b => b.AddContent(2, context)));
+                    builder.CloseComponent();
+                }));
+
+            await comp.InvokeAsync(() => comp.Instance.NavigateTo(-1));
+            comp.Instance.CurrentPage.Should().Be(0);
+            await comp.InvokeAsync(() => comp.Instance.NavigateTo(5));
+            comp.Instance.CurrentPage.Should().Be(0);
+        }
+
+        /// <summary>
         /// page size option initial value test. Initial value should not be 10 since PageSizeOption is set to be new int[]{8, 16, 32}
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTableBase.cs
+++ b/src/MudBlazor/Components/Table/MudTableBase.cs
@@ -698,7 +698,7 @@ namespace MudBlazor
         /// <param name="pageIndex">The index of the page to navigate to.</param>
         public void NavigateTo(int pageIndex)
         {
-            SetCurrentPage(Math.Min(Math.Max(0, pageIndex), NumPages - 1));
+            SetCurrentPage(Math.Clamp(pageIndex, 0, Math.Max(0, NumPages - 1)));
         }
 
         // Applies an internal page change (pager/NavigateTo/clamp/reset); must not update _currentPageParameterValue or it would be mistaken for a parameter change (#13462).


### PR DESCRIPTION
## Description

NavigateTo(int) can set CurrentPage to -1 when a table is empty. This can happen when a reload returns zero rows, leaving the pager with an invalid page index.

This change keeps the current page at 0 when the table has no pages.

## What changed

- Fixed page navigation for empty tables.
- Added regression tests covering empty-table navigation and out-of-range page indexes.

## Testing

Ran the test suite: 5605 passed, 2 skipped, 0 failed.

Fixes #13619