### PR TITLE
Build: Pin .NET SDK to `10.0.4xx` feature band

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,9 +7,6 @@
         ":ignoreModulesAndTests",
         "mergeConfidence:all-badges"
     ],
-    "ignoreDeps": [
-        "dotnet-sdk"
-    ],
     "labels": [
         "dependency",
         "build"
@@ -25,6 +22,49 @@
         ]
     },
     "packageRules": [
+        {
+            "description": ".NET SDK versions are x.y.znn where z is the feature band and nn the in-band patch. Renovate's default versioning classifies BOTH 10.0.400->10.0.401 and 10.0.400->10.0.500 as 'patch'. Remap the band digit into the 'minor' slot so the two are separable.",
+            "matchDatasources": [
+                "dotnet-version"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "versioning": "regex:^(?<major>\\d+)\\.\\d+\\.(?<minor>\\d)(?<patch>\\d{2})$",
+            "separateMinorPatch": true
+        },
+        {
+            "description": "In-band SDK servicing patches are a no-op for CI (setup-dotnet installs the channel head of the band regardless of the patch digits) and raising the pinned floor would only break contributors who have not patched this month. No PRs for them.",
+            "matchDatasources": [
+                "dotnet-version"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "enabled": false
+        },
+        {
+            "description": "A new SDK feature band swaps Roslyn, the Razor source generator, and dotnet format. Surface it as one reviewable PR instead of letting CI roll onto it unannounced. This grouping also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the SDK bump.",
+            "matchDatasources": [
+                "dotnet-version"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "matchUpdateTypes": [
+                "major",
+                "minor"
+            ],
+            "groupName": "dotnet sdk feature band",
+            "groupSlug": "dotnet-sdk-feature-band",
+            "reviewers": [
+                "team:core-team"
+            ],
+            "minimumReleaseAge": "5 days"
+        },
         {
             "matchPackageNames": [
                 "Microsoft.CodeAnalysis**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
     },
     "packageRules": [
         {
-            "description": ".NET SDK feature bands (the z in x.y.znn) swap Roslyn, the Razor source generator, and dotnet format; the last two bands (10.0.300, 10.0.400) each broke CI on release day. Allowing only band-floor versions (patch 00) means in-band servicing patches get no PR (CI installs the band head regardless, and raising the pinned floor would only break contributors who have not patched), while a new band arrives as one reviewable PR after a soak. The group also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the bump. Renovate classifies a band jump as 'patch', so any future patch-wide automerge rule must exclude dotnet-sdk.",
+            "description": "A new SDK feature band means a new compiler, so it arrives as its own reviewable PR pinned to the band floor (x.y.z00). In-band servicing patches reach CI automatically and get no PR.",
             "matchDatasources": [
                 "dotnet-version"
             ],
@@ -32,11 +32,7 @@
             ],
             "allowedVersions": "/^\\d+\\.\\d+\\.\\d00$/",
             "groupName": "dotnet sdk feature band",
-            "groupSlug": "dotnet-sdk-feature-band",
-            "reviewers": [
-                "team:core-team"
-            ],
-            "minimumReleaseAge": "5 days"
+            "groupSlug": "dotnet-sdk-feature-band"
         },
         {
             "matchPackageNames": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,41 +23,14 @@
     },
     "packageRules": [
         {
-            "description": ".NET SDK versions are x.y.znn where z is the feature band and nn the in-band patch. Renovate's default versioning classifies BOTH 10.0.400->10.0.401 and 10.0.400->10.0.500 as 'patch'. Remap the band digit into the 'minor' slot so the two are separable.",
+            "description": ".NET SDK feature bands (the z in x.y.znn) swap Roslyn, the Razor source generator, and dotnet format; the last two bands (10.0.300, 10.0.400) each broke CI on release day. Allowing only band-floor versions (patch 00) means in-band servicing patches get no PR (CI installs the band head regardless, and raising the pinned floor would only break contributors who have not patched), while a new band arrives as one reviewable PR after a soak. The group also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the bump. Renovate classifies a band jump as 'patch', so any future patch-wide automerge rule must exclude dotnet-sdk.",
             "matchDatasources": [
                 "dotnet-version"
             ],
             "matchPackageNames": [
                 "dotnet-sdk"
             ],
-            "versioning": "regex:^(?<major>\\d+)\\.\\d+\\.(?<minor>\\d)(?<patch>\\d{2})$",
-            "separateMinorPatch": true
-        },
-        {
-            "description": "In-band SDK servicing patches are a no-op for CI (setup-dotnet installs the channel head of the band regardless of the patch digits) and raising the pinned floor would only break contributors who have not patched this month. No PRs for them.",
-            "matchDatasources": [
-                "dotnet-version"
-            ],
-            "matchPackageNames": [
-                "dotnet-sdk"
-            ],
-            "matchUpdateTypes": [
-                "patch"
-            ],
-            "enabled": false
-        },
-        {
-            "description": "A new SDK feature band swaps Roslyn, the Razor source generator, and dotnet format. Surface it as one reviewable PR instead of letting CI roll onto it unannounced. This grouping also overrides the 'dotnet monorepo' group from group:monorepos, which would otherwise absorb the SDK bump.",
-            "matchDatasources": [
-                "dotnet-version"
-            ],
-            "matchPackageNames": [
-                "dotnet-sdk"
-            ],
-            "matchUpdateTypes": [
-                "major",
-                "minor"
-            ],
+            "allowedVersions": "/^\\d+\\.\\d+\\.\\d00$/",
             "groupName": "dotnet sdk feature band",
             "groupSlug": "dotnet-sdk-feature-band",
             "reviewers": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Please make sure that you follow our [code of conduct](/CODE_OF_CONDUCT.md)
 
 ## Minimal Prerequisites to Compile from Source
 
--   [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (pinned in `global.json`; it can build the older targets too)
+-   [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0), 10.0.4xx feature band (pinned in `global.json`; any 10.0.4xx patch works — it can build the older targets too)
 
 The `MudBlazor` library multi-targets net8.0, net9.0, and net10.0. `dotnet test` and IDE builds only compile the framework that is needed (the tests build just net10.0), but a direct `dotnet build src/MudBlazor` compiles all three. For a faster single-framework build while developing, pass `-f`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Please make sure that you follow our [code of conduct](/CODE_OF_CONDUCT.md)
 
 ## Minimal Prerequisites to Compile from Source
 
--   [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0), 10.0.4xx feature band (pinned in `global.json`; any 10.0.4xx patch works — it can build the older targets too)
+-   [.NET SDK](https://dotnet.microsoft.com/download/dotnet) (see `global.json` for the pinned feature band; any patch of that band works — it can build the older targets too)
 
 The `MudBlazor` library multi-targets net8.0, net9.0, and net10.0. `dotnet test` and IDE builds only compile the framework that is needed (the tests build just net10.0), but a direct `dotnet build src/MudBlazor` compiles all three. For a faster single-framework build while developing, pass `-f`:
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestFeature"
+    "version": "10.0.400",
+    "rollForward": "latestPatch",
+    "errorMessage": "MudBlazor builds on the .NET SDK 10.0.4xx feature band (pinned in global.json). Install it from https://dotnet.microsoft.com/download/dotnet/10.0 - any 10.0.4xx patch works. Run 'dotnet --list-sdks' to see what you have."
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "10.0.400",
     "rollForward": "latestPatch",
-    "errorMessage": "MudBlazor builds on the .NET SDK 10.0.4xx feature band (pinned in global.json). Install it from https://dotnet.microsoft.com/download/dotnet/10.0 - any 10.0.4xx patch works. Run 'dotnet --list-sdks' to see what you have."
+    "errorMessage": "MudBlazor pins the .NET SDK to the feature band in global.json - any equal or newer patch of that band works. Install it from https://dotnet.microsoft.com/download/dotnet and run 'dotnet --list-sdks' to see what you have."
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
On 2026-08-11 the .NET SDK 10.0.400 feature band shipped and CI adopted it the same day: `global.json` has `"rollForward": "latestFeature"`, which `setup-dotnet` turns into "install the newest 10.0 band the moment one is published". The new Roslyn raised CS8602 on pre-existing code, `TreatWarningsAsErrors` promoted it to an error, and every open PR was red for ~16 hours (https://github.com/MudBlazor/MudBlazor/pull/13610, https://github.com/MudBlazor/MudBlazor/pull/13612, https://github.com/MudBlazor/MudBlazor/pull/13613) until https://github.com/MudBlazor/MudBlazor/pull/13614. The 10.0.300 band crossing did the same to the analyzer tests in May (https://github.com/MudBlazor/MudBlazor/issues/13204).

This PR switches feature-band adoption from a release-day surprise to a reviewed Renovate PR, while keeping in-band servicing patches automatic.

Changes

- **global.json** pins the 10.0.4xx band: `"version": "10.0.400"` + `"rollForward": "latestPatch"`. Zero delta for CI, which already installs 10.0.400 on every job. The new `errorMessage` field (a .NET 10 global.json feature) replaces the default resolver error with an actionable one pointing at the pinned band and the download page.
- **In-band servicing patches stay automatic and PR-free**: `setup-dotnet` translates this pin into `dotnet-install --channel 10.0.4xx` (verified against its v6 source), so CI always installs the head of the band while the pinned floor stays at `.400` and never breaks contributors who have not patched.
- **Renovate owns band upgrades** (`ignoreDeps` removed): a single package rule allows only band-floor versions (`x.y.z00`), so the only SDK PR Renovate can ever open is the next band's floor — one grouped PR, roughly quarterly. The group name also keeps the bump out of the `dotnet monorepo` group, which would otherwise absorb it as routine package churn.
- **CONTRIBUTING.md** points at `global.json` for the required band.

Contributors need any SDK from the pinned band; `winget install Microsoft.DotNet.SDK.10` currently installs it. The band version lives on a single line of `global.json` — the error message and CONTRIBUTING.md are evergreen — so a future Renovate band PR is the entire change.
