### PR TITLE
MudFabMenu: Honour ClickPropagation on menu items

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/FabMenuClickPropagationTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/FabMenuClickPropagationTest.razor
@@ -1,0 +1,15 @@
+<div class="outer-element" @onclick="@(() => OuterClickCount++)">
+    <MudFabMenu StartIcon="@Icons.Material.Outlined.Settings" OpenOnMouseHover="false">
+        <MudFabMenuItem EndIcon="@Icons.Material.Outlined.LooksOne"
+                        ClickPropagation="@ClickPropagation"
+                        OnClick="@(() => ItemClickCount++)" />
+    </MudFabMenu>
+</div>
+
+@code {
+    [Parameter] public bool ClickPropagation { get; set; }
+
+    public int OuterClickCount { get; private set; }
+
+    public int ItemClickCount { get; private set; }
+}

--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -178,4 +178,43 @@ public class FabMenuTests : BunitTest
         var expectedRel = rel ?? (target == "_blank" ? "noopener" : null);
         item.GetAttribute("rel").Should().Be(expectedRel);
     }
+
+    /// <summary>
+    /// Test case for <seealso cref="https://github.com/MudBlazor/MudBlazor/issues/13605"/>
+    /// </summary>
+    [Test]
+    public async Task ItemClick_ShouldNotReachAncestor_WhenClickPropagationIsFalse()
+    {
+        var comp = Context.Render<FabMenuClickPropagationTest>();
+
+        await comp.Find(".mud-fab-menu-button").ClickAsync();
+        await comp.WaitForAssertionAsync(() => comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Should().ContainSingle());
+
+        await comp.FindAll(".mud-fab-menu-item")[0].ClickAsync();
+
+        await comp.WaitForAssertionAsync(() =>
+        {
+            comp.Instance.ItemClickCount.Should().Be(1);
+            comp.Instance.OuterClickCount.Should().Be(0);
+            // the menu must still close, even though the click no longer bubbles to the menu container
+            comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Should().BeEmpty();
+        });
+    }
+
+    [Test]
+    public async Task ItemClick_ShouldReachAncestor_WhenClickPropagationIsTrue()
+    {
+        var comp = Context.Render<FabMenuClickPropagationTest>(parameters => parameters.Add(p => p.ClickPropagation, true));
+
+        await comp.Find(".mud-fab-menu-button").ClickAsync();
+        await comp.WaitForAssertionAsync(() => comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Should().ContainSingle());
+
+        await comp.FindAll(".mud-fab-menu-item")[0].ClickAsync();
+
+        await comp.WaitForAssertionAsync(() =>
+        {
+            comp.Instance.ItemClickCount.Should().Be(1);
+            comp.Instance.OuterClickCount.Should().Be(1);
+        });
+    }
 }

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -231,12 +231,22 @@ public partial class MudFabMenu : MudFab
         _lastInteractionWasTouch = false;
     }
 
-    private async Task OnMenuClickAsync()
+    private Task OnMenuClickAsync() => CloseOnItemClickedAsync();
+
+    /// <summary>
+    /// Closes the menu after a menu item was clicked, when <see cref="CloseOnMenuItemClicked"/> is set.
+    /// </summary>
+    internal async Task CloseOnItemClickedAsync()
     {
-        if (CloseOnMenuItemClicked)
+        if (!CloseOnMenuItemClicked)
         {
-            await ToggleMenuAsync(false);
+            return;
         }
+
+        await ToggleMenuAsync(false);
+
+        // A menu item's click handler does not render, so the closed state needs a render of its own.
+        StateHasChanged();
     }
 
     private void OnTouchStart()

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor
@@ -17,7 +17,7 @@
         HtmlTag="@HtmlTag"
         Rel="@Rel"
         Disabled="@Disabled"
-        ClickPropagation="true"
+        ClickPropagation="@ClickPropagation"
         DropShadow="@DropShadow"
         Ripple="@Ripple"
         @attributes="@UserAttributes"

--- a/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenuItem.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
@@ -10,6 +11,9 @@ namespace MudBlazor;
 /// <seealso cref="MudFabMenu" />
 public partial class MudFabMenuItem : MudFab
 {
+    [CascadingParameter]
+    protected MudFabMenu? ParentMenu { get; set; }
+
     private new string Classname => new CssBuilder(base.Classname)
         .AddClass("mud-fab-menu-item")
         .AddClass(Class)
@@ -23,4 +27,21 @@ public partial class MudFabMenuItem : MudFab
     /// </remarks>
     [Parameter, Category(CategoryTypes.Button.Appearance)]
     public override Size Size { get; set; } = Size.Medium;
+
+    protected override async Task OnClickHandler(MouseEventArgs ev)
+    {
+        if (GetDisabledState())
+        {
+            return;
+        }
+
+        await base.OnClickHandler(ev);
+
+        // The menu used to close because the click bubbled up to the menu container. It now closes from
+        // here, so that stopping propagation does not also stop the menu from closing.
+        if (ParentMenu is not null)
+        {
+            await ParentMenu.CloseOnItemClickedAsync();
+        }
+    }
 }


### PR DESCRIPTION
Fixes #13605

`MudFabMenuItem` renders a `MudFab` with `ClickPropagation="true"` hardcoded, so the `ClickPropagation` parameter it inherits from `MudBaseButton` never had any effect. Clicking a menu item always reached the ancestors of the menu, which is what the issue reports: an `@onclick` handler on the surrounding element fires alongside the item's own handler.

The hardcoded value was load-bearing, though. The menu closes through the click handler on the menu container, and it only got there because the item let the click bubble out of itself. Simply passing the parameter through stops the menu from closing at all — the three existing close tests (`RendersCorrectlyOnClick`, `RendersCorrectlyOnTouch`, `RendersCorrectlyOnHover`) catch exactly that.

So the item now closes the menu itself through the cascaded `MudFabMenu` instead of relying on the event escaping. One extra detail: an item's click handler is wired with `AsNonRenderingEventHandler`, so closing from there changes the state without producing a render — `CloseOnItemClickedAsync` requests one explicitly.

**Behavior note:** `ClickPropagation` defaults to `false` on `MudBaseButton`, so a `MudFabMenuItem` no longer propagates its click by default. That matches `MudFab` and `MudButton`, and `ClickPropagation="true"` restores the old behavior for anyone relying on it. No public API was added or changed.

**Before/After:**
Nothing rendered changes, so there is no meaningful screenshot: the menu opens, the item's `OnClick` fires and the menu closes exactly as before. The only difference is whether the DOM click event continues past the item, which the two new tests assert in both directions.

**Verification:**
`dotnet test src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj` — full run, 5619 passed / 0 failed / 2 skipped, against a clean baseline of 5617 passed on `dev` before the change (the two added tests account for the difference).

**AI disclosure:**
AI assistance was used to write this change. The diagnosis was verified against the repository rather than assumed: the phantom behavior was reproduced with a failing test first, the two mechanisms involved were distinguished by instrumenting the rendered class list, and the non-rendering click handler was confirmed by probing the handler at runtime. Both the fix and the tests were run locally in full as described above, and the diff was reviewed before submitting.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
