### PR TITLE
MudFabMenu: Raise open menu above other triggers' z-index (#13604)

### DIFF
--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -175,6 +175,7 @@
 
     &.mud-fab-menu-open {
       pointer-events: auto;
+      z-index: var(--mud-zindex-popover);
 
       .mud-fab-menu-item {
         opacity: 1;


### PR DESCRIPTION
Fixes #13604.

## Root cause

`.mud-fab-menu-button` (trigger) sits at `z-index: popover - 1` unconditionally. `.mud-fab-menu` (items) sits at `popover - 2`, even when open (`.mud-fab-menu-open`). So a trigger always outranks any other menu's open items, regardless of open/closed state — not just a visual glitch: clicks in the overlap zone hit the wrong trigger rather than the item drawn on top (verified with `elementFromPoint` on the issue's own repro).

## Fix

One line: `.mud-fab-menu-open` now gets `z-index: var(--mud-zindex-popover)`, which beats any trigger's `popover - 1`.

## Before/After

Before: the first menu's open items visually sit under/behind the second menu's trigger, and hit-testing confirms clicks there resolve to the trigger, not the item.

After: same repro, `elementFromPoint` at the overlap now resolves to the open item as expected.

(Screenshots/repro: https://try.mudblazor.com/snippet/QawqasEsRtHcOxhk — apply the CSS change and compare.)

## Checklist

- [x] I've read the contribution guidelines
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests — not applicable: this is a pure CSS z-index fix, and bUnit doesn't run a real CSS cascade/layout engine, so no unit test can assert stacking order. Verified instead via live hit-testing (`document.elementFromPoint`) on the issue's repro, before and after the change, plus the full existing suite (5617/5619 passed, 2 pre-existing unrelated skips, no regressions).

## AI assistance disclosure

Investigation, fix, and verification were done with AI assistance (Claude). I reviewed the root-cause analysis against the actual source, wrote/reviewed the one-line diff, and personally ran the build, full test suite, and the before/after hit-testing verification described above before opening this PR.
