### PR TITLE
MudPopover: Always outrank a fixed AppBar's z-index on the click-outside overlay (#13635)

### DIFF
--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -667,7 +667,15 @@ window.mudpopoverHelper = {
             // skip any overlay marked with mud-skip-overlay
             if (overlay && !overlay.classList.contains('mud-skip-overlay-positioning')) {
                 // Only assign z-index if it doesn't already exist or has changed
-                const popoverContentNodeZindex = Number(popoverContentNode.style['z-index'] || 0);
+                let popoverContentNodeZindex = Number(popoverContentNode.style['z-index'] || 0);
+                // The overlay must always be able to catch outside clicks over a fixed AppBar to
+                // close the popover, regardless of where the popover itself happens to render
+                // (matches .mud-overlay-drawer's own "always above the AppBar" rule in _overlay.scss).
+                const appBarElements = document.getElementsByClassName("mud-appbar mud-appbar-fixed-top");
+                if (appBarElements.length > 0) {
+                    const appBarZIndex = Number.parseInt(window.getComputedStyle(appBarElements[0]).zIndex) || 0;
+                    popoverContentNodeZindex = Math.max(popoverContentNodeZindex, appBarZIndex + 1);
+                }
                 const overlayZindex = Number(overlay.style['z-index'] || 0);
                 if (popoverContentNodeZindex > overlayZindex) {
                     overlay.style['z-index'] = popoverContentNodeZindex;


### PR DESCRIPTION
Fixes #13635.

## Root cause

The AppBar-aware z-index bump in `placePopover()` only fires when a popover's own placement happens to overlap the AppBar's height (`top + offsetY < appBarOffset`), and only for flip-capable popovers. `updatePopoverOverlay()` then mirrors whatever z-index the popover ended up with onto the shared click-outside overlay — so the overlay only out-ranks the AppBar (1301 vs 1300) when that placement condition happened to fire. Otherwise the overlay stays at its default (1201), sits below the AppBar (1300), and clicks on the AppBar never reach the outside-click-close handler — the popover stays open.

This is inconsistent with MudBlazor's own existing intent for the Drawer overlay:
```scss
&.mud-overlay-drawer {
  z-index: calc(var(--mud-zindex-appbar) + 1); //<-- Yes this is correct we want to display it on top of the Appbar
}
```
Popover's overlay is the only one not reliably following that same rule.

## Fix

In `updatePopoverOverlay()`, floor the overlay's z-index at `appbar-zindex + 1` whenever a fixed-top AppBar exists (read live via `getComputedStyle`, so custom `ZIndex.AppBar` theme overrides are respected), independent of the popover's own placement. Doesn't touch `placePopover`'s existing flip-gated logic — that logic is now redundant in the case it already covered, but harmless to leave as-is.

Scoped safely: `updatePopoverOverlay()` already only touches an overlay lacking `mud-skip-overlay-positioning` — Dialog's and Drawer's own overlays already opt out of this function entirely, so this change can't affect them. It only raises a floor (`Math.max`), never lowers or retargets which overlay gets touched.

## Before/After

Before: a `MudMenu` opened somewhere on the page that doesn't overlap the AppBar; clicking the AppBar does not close it.

After: same scenario, clicking the AppBar closes the menu, matching a popover that *does* overlap the AppBar (which already worked).

Repro used for both: https://try.mudblazor.com/snippet/QawqasEsRtHcOxhk-style — AppBar + `MudMenu` placed clear of it. Verified locally (before/after, code stashed and restored) via the Viewer, and confirmed no regression on the existing `PopoverAppBarMenuSubMenuTest` nested-menu scenario.

## Checklist

- [x] I've read the contribution guidelines
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests — not applicable: this is real-browser JS/CSS cascade behavior (z-index stacking against a live AppBar element), and bUnit doesn't execute real browser layout/JS, so no unit test can assert it. Verified instead via the Viewer (real browser), before and after the change, plus the full existing suite (5617/5619 passed, 2 pre-existing unrelated skips, no regressions).

## AI assistance disclosure

Investigation, fix, and verification were done with AI assistance (Claude). I reviewed the root-cause analysis against the actual source (including cross-checking the full z-index scale and the Drawer-overlay precedent), wrote/reviewed the diff, and personally ran the build, full test suite, and the before/after Viewer verification described above before opening this PR.
