### PR TITLE
Various components: Stop erasing caller-supplied attributes

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CardTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CardTests.cs
@@ -23,5 +23,17 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => button.Instance.OnClick.InvokeAsync());
             await comp.WaitForAssertionAsync(() => numeric.Instance.Value.Should().Be(1));
         }
+
+        /// <summary>
+        /// A caller-supplied title used to be erased by the trailing null literal.
+        /// </summary>
+        [Test]
+        public void CardMedia_Should_KeepUserSuppliedTitle()
+        {
+            var comp = Context.Render<MudCardMedia>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "title", "Cover art" } }));
+
+            comp.Find("div").GetAttribute("title").Should().Be("Cover art");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ImageTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ImageTests.cs
@@ -129,6 +129,30 @@ namespace MudBlazor.UnitTests.Components
 
             img.GetAttribute("src").Should().Be(initialSrc);
         }
+
+        /// <summary>
+        /// A caller-supplied alt used to be erased by the trailing null literal, leaving the image with no alt at all.
+        /// </summary>
+        [Test]
+        public void Image_Should_KeepUserSuppliedAlt()
+        {
+            var comp = Context.Render<MudImage>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "alt", "A red bicycle" } }));
+
+            comp.Find("img").GetAttribute("alt").Should().Be("A red bicycle");
+        }
+
+        /// <summary>
+        /// The Alt parameter still supplies the value when the caller does not.
+        /// </summary>
+        [Test]
+        public void Image_Should_UseAltParameterWhenUserAttributesAreAbsent()
+        {
+            var comp = Context.Render<MudImage>(parameters => parameters
+                .Add(p => p.Alt, "A red bicycle"));
+
+            comp.Find("img").GetAttribute("alt").Should().Be("A red bicycle");
+        }
     }
 }
 

--- a/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavGroupTests.cs
@@ -58,6 +58,31 @@ namespace MudBlazor.UnitTests.Components
 
             bool GetExpandedState() => comp.FindComponent<MudCollapse>().Instance.Expanded;
         }
+
+        /// <summary>
+        /// The nav landmark takes its accessible name from Title, which a caller must be able to override.
+        /// </summary>
+        [Test]
+        public void NavGroup_Should_LetUserAttributesOverrideAriaLabel()
+        {
+            var comp = Context.Render<MudNavGroup>(parameters => parameters
+                .Add(p => p.Title, "Reports")
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-label", "Quarterly reports" } }));
+
+            comp.Find("nav").GetAttribute("aria-label").Should().Be("Quarterly reports");
+        }
+
+        /// <summary>
+        /// Title still names the landmark when the caller does not supply an aria-label.
+        /// </summary>
+        [Test]
+        public void NavGroup_Should_UseTitleAsAriaLabel()
+        {
+            var comp = Context.Render<MudNavGroup>(parameters => parameters
+                .Add(p => p.Title, "Reports"));
+
+            comp.Find("nav").GetAttribute("aria-label").Should().Be("Reports");
+        }
     }
 }
 

--- a/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavMenuTests.cs
@@ -154,5 +154,31 @@ namespace MudBlazor.UnitTests.Components
             comp.Markup.Should().Contain("mud-expanded");
             comp.Markup.Should().Contain("aria-hidden=\"false\"");
         }
+
+        /// <summary>
+        /// A caller-supplied id used to be erased by the trailing null literal, leaving the nav landmark with no id at all.
+        /// </summary>
+        [Test]
+        public void NavMenu_Should_KeepUserSuppliedId()
+        {
+            var comp = Context.Render<MudNavMenu>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "id", "main-nav" } }));
+
+            comp.Find("nav").GetAttribute("id").Should().Be("main-nav");
+        }
+
+        /// <summary>
+        /// Inside a nav group the generated menu id must still win so the toggle button's aria-controls stays wired.
+        /// </summary>
+        [Test]
+        public void NavMenu_Should_KeepGeneratedMenuIdInsideNavGroup()
+        {
+            var comp = Context.Render<MudNavGroup>(parameters => parameters
+                .Add(p => p.Expanded, true));
+
+            var controls = comp.Find("button").GetAttribute("aria-controls");
+            controls.Should().NotBeNullOrEmpty();
+            comp.FindAll("nav").Should().Contain(nav => nav.GetAttribute("id") == controls);
+        }
     }
 }

--- a/src/MudBlazor/Components/Card/MudCardMedia.razor
+++ b/src/MudBlazor/Components/Card/MudCardMedia.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<div @attributes="UserAttributes" title="@Title" class="@Classname" style="@StyleString"></div>
+<div title="@Title" @attributes="UserAttributes" class="@Classname" style="@StyleString"></div>

--- a/src/MudBlazor/Components/Image/MudImage.razor
+++ b/src/MudBlazor/Components/Image/MudImage.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<img @attributes="UserAttributes" src="@_srcState.Value" alt="@Alt" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnErrorAsync">
+<img alt="@Alt" @attributes="UserAttributes" src="@_srcState.Value" class="@Classname" style="@Style" width="@Width" height="@Height" @onerror="OnErrorAsync">

--- a/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavGroup.razor
@@ -4,11 +4,11 @@
 
 @inject InternalMudLocalizer Localizer
 
-<nav @attributes="UserAttributes"
+<nav aria-label="@Title"
+     @attributes="UserAttributes"
      class="@Classname"
      disabled="@_navigationContext.Disabled"
-     style="@Style"
-     aria-label="@Title">
+     style="@Style">
     <button @onclick="ExpandedToggleAsync"
             tabindex="@ButtonTabIndex"
             class="@ButtonClassname"

--- a/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavMenu.razor
@@ -1,8 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase
 
-<nav @attributes="UserAttributes"
-     id="@NavigationContext?.MenuId"
+<nav id="@NavigationContext?.MenuId"
+     @attributes="UserAttributes"
      class="@Classname"
      style="@Style">
     <CascadingValue Value="@this" IsFixed="true">


### PR DESCRIPTION
Four components write an attribute **after** the `@attributes="UserAttributes"` splat while binding it to an expression that is `null` in ordinary use:

```razor
<img @attributes="UserAttributes" src="@_srcState.Value" alt="@Alt" ...>
```

Blazor resolves duplicate attributes last-write-wins, and a `null` value does not *yield* to the earlier write — it removes the attribute from the frame entirely. So a caller-supplied value is not merely ignored, it is **deleted**.

| Component | Attribute | What happens today |
|---|---|---|
| `MudNavMenu` | `id` | `NavigationContext` is `null` for any caller-authored `<MudNavMenu>` (only `MudNavGroup` supplies one), so the `<nav>` renders with **no id at all** — breaking skip links, `#id` styling, and external `aria-controls`. There is no `Id` parameter, so plain markup reaches the splat. |
| `MudNavGroup` | `aria-label` | With `TitleContent` and no `Title`, the `<nav>` landmark is left with **no accessible name**. |
| `MudImage` | `alt` | The `<img>` renders with **no alt**, so screen readers announce the src filename — a WCAG 1.1.1 failure. |
| `MudCardMedia` | `title` | Tooltip silently lost. |

Rendered output before the fix, with the caller passing `alt="caller-alt"` and `id="caller-nav"`:

```html
<img class="mud-image object-fill object-center">
<nav class="mud-navmenu mud-navmenu-default mud-navmenu-margin-none"></nav>
```

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
