### PR TITLE
Various components: Let UserAttributes override generated ARIA attributes

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -864,5 +864,31 @@ namespace MudBlazor.UnitTests.Components
             fileUpload.GetState(x => x.ErrorText).Should().BeNullOrEmpty(); // ErrorText should be cleared
             fileUpload.ValidationErrors.Should().BeEmpty(); // ValidationErrors related to MaxFileSize should be cleared
         }
+
+        /// <summary>
+        /// A caller-supplied aria-required should win over the computed value, and required should still follow the parameter.
+        /// </summary>
+        [Test]
+        public void FileUpload_Should_LetUserAttributesOverrideAriaRequired()
+        {
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-required", "true" } }));
+
+            var input = comp.Find("input[type=file]");
+            input.GetAttribute("aria-required").Should().Be("true");
+            input.HasAttribute("required").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// The generated per-input id stays component-owned so the file picker interop keeps working.
+        /// </summary>
+        [Test]
+        public void FileUpload_Should_KeepGeneratedInputId()
+        {
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "id", "caller-id" } }));
+
+            comp.Find("input[type=file]").GetAttribute("id").Should().NotBe("caller-id");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -72,4 +72,40 @@ public class InputTests : BunitTest
             comp.Find("div.mud-input").ClassList.Should().NotContain("mud-input-full-width");
         }
     }
+
+    /// <summary>
+    /// A caller-supplied aria-required should reach both halves of the range, while required still follows the parameter.
+    /// </summary>
+    [Test]
+    public void RangeInputLetsUserAttributesOverrideAriaRequired()
+    {
+        var comp = Context.Render<MudRangeInput<string>>(parameters => parameters
+            .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-required", "true" } }));
+
+        var inputs = comp.FindAll("input");
+        inputs.Should().HaveCount(2);
+
+        foreach (var input in inputs)
+        {
+            input.GetAttribute("aria-required").Should().Be("true");
+            input.HasAttribute("required").Should().BeFalse();
+        }
+    }
+
+    /// <summary>
+    /// The per-input aria-label and id stay component-owned so the two halves keep distinct names and identifiers.
+    /// </summary>
+    [Test]
+    public void RangeInputKeepsPerInputAriaLabelAndId()
+    {
+        var comp = Context.Render<MudRangeInput<string>>(parameters => parameters
+            .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-required", "true" } }));
+
+        var inputs = comp.FindAll("input");
+
+        inputs[0].GetAttribute("aria-label").Should().Be("Start");
+        inputs[1].GetAttribute("aria-label").Should().Be("End");
+        inputs[0].GetAttribute("id").Should().EndWith("-start");
+        inputs[1].GetAttribute("id").Should().EndWith("-end");
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/MaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MaskTests.cs
@@ -1247,5 +1247,54 @@ namespace MudBlazor.UnitTests.Components
             maskField.ReadText.Should().BeNullOrEmpty();
             comp.Find("input").GetAttribute("value").Should().BeNullOrEmpty();
         }
+
+        /// <summary>
+        /// Caller-supplied ARIA attributes should win over the computed values, and required should still follow the parameter.
+        /// </summary>
+        [Test]
+        public void Mask_Should_LetUserAttributesOverrideAriaAttributes()
+        {
+            var comp = Context.Render<MudMask>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object>
+                {
+                    { "aria-required", "true" },
+                    { "aria-invalid", "true" },
+                    { "aria-describedby", "my-hint" }
+                }));
+
+            var input = comp.Find("input");
+            input.GetAttribute("aria-required").Should().Be("true");
+            input.GetAttribute("aria-invalid").Should().Be("true");
+            input.GetAttribute("aria-describedby").Should().Be("my-hint");
+            input.HasAttribute("required").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// The multiline mask renders a textarea and should honour caller-supplied ARIA attributes the same way.
+        /// </summary>
+        [Test]
+        public void Mask_Should_LetUserAttributesOverrideAriaAttributesOnTextArea()
+        {
+            var comp = Context.Render<MudMask>(parameters => parameters
+                .Add(p => p.Lines, 3)
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-required", "true" } }));
+
+            comp.Find("textarea").GetAttribute("aria-required").Should().Be("true");
+        }
+
+        /// <summary>
+        /// Without caller-supplied values the computed ARIA attributes are still rendered.
+        /// </summary>
+        [Test]
+        public void Mask_Should_ComputeAriaAttributesWhenUserAttributesAreAbsent()
+        {
+            var comp = Context.Render<MudMask>(parameters => parameters
+                .Add(p => p.Required, true));
+
+            var input = comp.Find("input");
+            input.GetAttribute("aria-required").Should().Be("true");
+            input.GetAttribute("aria-invalid").Should().Be("false");
+            input.HasAttribute("required").Should().BeTrue();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -533,5 +533,29 @@ namespace MudBlazor.UnitTests.Components
             var comp2 = Context.Render<MudRadio<bool>>(x => x.Add(f => f.For, () => value.Boolean).Add(l => l.Label, "Label Parameter"));
             comp2.Instance.Label.Should().Be("Label Parameter"); //existing label should remain
         }
+
+        /// <summary>
+        /// A radiogroup cannot carry the native required attribute, so aria-required is its only required-ness signal and callers must be able to set it.
+        /// </summary>
+        [Test]
+        public void RadioGroup_Should_LetUserAttributesOverrideAriaRequired()
+        {
+            var comp = Context.Render<MudRadioGroup<string>>(parameters => parameters
+                .Add(p => p.UserAttributes!, new Dictionary<string, object> { { "aria-required", "true" } }));
+
+            comp.Find("div[role=radiogroup]").GetAttribute("aria-required").Should().Be("true");
+        }
+
+        /// <summary>
+        /// Without a caller-supplied value the radiogroup still announces required-ness from the parameter.
+        /// </summary>
+        [Test]
+        public void RadioGroup_Should_ComputeAriaRequiredFromParameter()
+        {
+            var comp = Context.Render<MudRadioGroup<string>>(parameters => parameters
+                .Add(p => p.Required, true));
+
+            comp.Find("div[role=radiogroup]").GetAttribute("aria-required").Should().Be("true");
+        }
     }
 }

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
@@ -19,14 +19,14 @@
                        multiple="@(typeof(T) == typeof(IReadOnlyList<IBrowserFile>) ? "" : null)"
                        accept="@Accept"
                        disabled="@(GetDisabledState())"
+                       aria-required="@Required.ToString().ToLowerInvariant()"
                        @attributes="UserAttributes"
                        @ondragenter="OnDragEnterAsync"
                        @ondrop="OnDropAsync"
                        @ondragleave="OnDragLeaveAsync"
                        @ondragend="OnDragEndAsync"
                        id="@GetInputId(localIndex)"
-                       required="@Required"
-                       aria-required="@Required.ToString().ToLowerInvariant()" />
+                       required="@Required" />
         }
         @if (CustomContent == null)
         {

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -26,6 +26,7 @@
     }
 
     <input @ref="_elementReferenceStart"
+           aria-required="@Required.ToString().ToLowerInvariant()"
            @attributes="UserAttributes"
            id="@(string.IsNullOrEmpty(InputElementId) ? null : $"{InputElementId}-start")"
            type="@InputTypeString"
@@ -41,10 +42,10 @@
            inputmode="@InputMode.ToStringFast(true)"
            pattern="@Pattern"
            required="@Required"
-           aria-required="@Required.ToString().ToLowerInvariant()"
            aria-label="@(StartInputAriaLabel ?? Localizer[LanguageResource.MudRangeInput_Start])" />
     <MudIcon Class="mud-range-input-separator mud-flip-x-rtl" Icon="@SeparatorIcon" Color="@Color.Default" />
     <input @ref="_elementReferenceEnd"
+           aria-required="@Required.ToString().ToLowerInvariant()"
            @attributes="UserAttributes"
            id="@(string.IsNullOrEmpty(InputElementId) ? null : $"{InputElementId}-end")"
            type="@InputTypeString"
@@ -60,7 +61,6 @@
            @onkeydown="@InvokeKeyDownAsync"
            @onkeyup="@InvokeKeyUpAsync"
            required="@Required"
-           aria-required="@Required.ToString().ToLowerInvariant()"
            aria-label="@(EndInputAriaLabel ?? Localizer[LanguageResource.MudRangeInput_End])" />
 
     @if (IsClearable() && !GetDisabledState())

--- a/src/MudBlazor/Components/Mask/MudMask.razor
+++ b/src/MudBlazor/Components/Mask/MudMask.razor
@@ -21,6 +21,9 @@
     {
         <textarea class="@InputClassname"
                   @ref="_elementReference"
+                  aria-describedby="@GetAriaDescribedByString()"
+                  aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
+                  aria-required="@Required.ToString().ToLowerInvariant()"
                   @attributes="UserAttributes"
                   id="@InputElementId"
                   type="@InputType.ToStringFast(true)"
@@ -36,10 +39,7 @@
                   @bind:set="@OnInputAsync"
                   @bind:event="oninput"
                   inputmode="@InputMode.ToStringFast(true)"
-                  aria-describedby="@GetAriaDescribedByString()"
-                  aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
-                  required="@Required"
-                  aria-required="@Required.ToString().ToLowerInvariant()">
+                  required="@Required">
             @ReadText
         </textarea>
     }
@@ -47,6 +47,9 @@
     {
         <input class="@InputClassname"
                @ref="_elementReference"
+               aria-describedby="@GetAriaDescribedByString()"
+               aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
+               aria-required="@Required.ToString().ToLowerInvariant()"
                @attributes="UserAttributes"
                id="@InputElementId"
                type="@InputType.ToStringFast(true)"
@@ -62,10 +65,7 @@
                @bind:set="@OnInputAsync"
                @bind:event="oninput"
                inputmode="@InputMode.ToStringFast(true)"
-               aria-describedby="@GetAriaDescribedByString()"
-               aria-invalid="@HasErrors.ToString().ToLowerInvariant()"
-               required="@Required"
-               aria-required="@Required.ToString().ToLowerInvariant()">
+               required="@Required">
     }
 
     @if (GetDisabledState())

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -11,7 +11,7 @@
         <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="false">
             <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                 <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
-                    <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" aria-required="@Required.ToString().ToLowerInvariant()">
+                    <div role="radiogroup" aria-required="@Required.ToString().ToLowerInvariant()" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
                         @ChildContent
                     </div>
                 </CascadingValue>


### PR DESCRIPTION
Follows https://github.com/MudBlazor/MudBlazor/pull/13613, which moved `aria-describedby`, `aria-invalid` and `aria-required` above the `@attributes="UserAttributes"` splat on `MudInput` so a caller can override them. Blazor resolves duplicate attributes last-write-wins, so a literal written after the splat silently discards the caller's value, and one written before it acts as a fallback.

### Deliberately unchanged

- **`required` stays below the splat everywhere.** It is native browser behaviour rather than an ARIA annotation, and it drives `MudFormComponent` validation and the label asterisk, not just the DOM. Keeping the pair separable is the point of the original change.
- **`MudRangeInput`'s `aria-label` and `id` stay below.** Their values differ per input (`"Start"`/`"End"`, `-start`/`-end`), and one dictionary cannot express two values for one key — a caller value would be duplicated onto both halves, breaking the distinct accessible names and producing a duplicate DOM id. `StartInputAriaLabel`/`EndInputAriaLabel` remain the supported override path.
- **`MudFileUpload`'s `id` stays below.** The splat sits inside a `@for`, so a single caller id would land on every active input and break `mudFileUpload.openFilePicker`, which resolves by `getElementById` and no-ops silently on a miss.

### Behaviour

| | before | after |
|---|---|---|
| no caller-supplied value | computed value rendered | **unchanged** — the literal is still emitted, just earlier |
| caller supplies `aria-required` / `aria-invalid` / `aria-describedby` | silently discarded | caller's value wins |
| `required` attribute | from `Required` | **unchanged** |

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
