### PR TITLE
MudTr, MudMenu: Fix ARIA token formatting

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -1509,5 +1509,29 @@ namespace MudBlazor.UnitTests.Components
             popoverOpenDuringClick.Should().BeTrue();
             await provider.WaitForAssertionAsync(() => provider.FindAll("div.mud-popover-open").Count.Should().Be(0));
         }
+
+        /// <summary>
+        /// A custom activator spells out aria-expanded as an explicit true or false token.
+        /// </summary>
+        [Test]
+        public async Task ActivatorContent_AriaExpanded_ReflectsOpenState()
+        {
+            Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<MudMenu>(parameters => parameters
+                .Add(p => p.ActivatorContent, _ => builder =>
+                {
+                    builder.OpenElement(0, "span");
+                    builder.AddContent(1, "Activate");
+                    builder.CloseElement();
+                }));
+
+            // A bare attribute renders with an empty value, which assistive technology resolves to the
+            // aria-expanded default, so the token has to be spelled out.
+            comp.Find("div[role=\"button\"]").GetAttribute("aria-expanded").Should().Be("false");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Open, true));
+
+            comp.Find("div[role=\"button\"]").GetAttribute("aria-expanded").Should().Be("true");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3522,5 +3522,36 @@ namespace MudBlazor.UnitTests.Components
             pagers[0].ClassList.Should().Contain("mud-table-pagination-top");
             pagers[1].ClassList.Should().NotContain("mud-table-pagination-top");
         }
+
+        /// <summary>
+        /// Rows spell out aria-disabled as an explicit true or false token.
+        /// </summary>
+        [Test]
+        public void RowAriaDisabled_ReflectsDisabledState()
+        {
+            var comp = Context.Render<MudTable<int>>(parameters => parameters
+                .Add(p => p.Items, new[] { 1, 2 })
+                .Add(p => p.RowTemplate, item => builder =>
+                {
+                    builder.OpenComponent<MudTd>(0);
+                    builder.AddAttribute(1, "ChildContent",
+                        (RenderFragment)(b => b.AddContent(2, item)));
+                    builder.CloseComponent();
+                })
+                .Add(p => p.RowDisabledFunc, item => item == 2)
+            );
+
+            var rows = comp.FindAll("tbody tr.mud-table-row");
+
+            rows.Count.Should().Be(2);
+
+            // A bare attribute renders with an empty value, which assistive technology resolves to the
+            // aria-disabled default of false, so the token has to be spelled out.
+            rows[1].ClassList.Should().Contain("mud-table-row-disabled");
+            rows[1].GetAttribute("aria-disabled").Should().Be("true");
+
+            rows[0].ClassList.Should().NotContain("mud-table-row-disabled");
+            rows[0].GetAttribute("aria-disabled").Should().Be("false");
+        }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -26,7 +26,7 @@
                  tabindex="0"
                  role="button"
                  aria-haspopup="true"
-                 aria-expanded="@_openState.Value">
+                 aria-expanded="@_openState.Value.ToString().ToLowerInvariant()">
                 @ActivatorContent(_menuContext)
             </div>
         }
@@ -39,7 +39,7 @@
                          AutoClose="false"
                          HideSubMenuArrow="true"
                          aria-haspopup="true"
-                         aria-expanded="@_openState.Value"
+                         aria-expanded="@_openState.Value.ToString().ToLowerInvariant()"
                          aria-label="@AriaLabel">
                 @ActivatorContent(_menuContext)
             </MudMenuItem>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -5,7 +5,7 @@
 @inject InternalMudLocalizer Localizer
 
 <tr id="@RowId" class="@Classname" @onclick="@OnRowClickedAsync" @onpointerenter="@RowMouseEnterEventCallback" @onpointerleave="@RowMouseLeaveEventCallback" style="@Style"
-    @attributes="@UserAttributes" @oncontextmenu:preventDefault="PreventContextMenuDefault" aria-disabled="@Disabled">
+    @attributes="@UserAttributes" @oncontextmenu:preventDefault="PreventContextMenuDefault" aria-disabled="@Disabled.ToString().ToLowerInvariant()">
     @if (Context?.Table?.Editable == true && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtStart() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtStart() == true))
     {
         @* Add datalabel as a placeholder to avoid jumps on small viewports *@


### PR DESCRIPTION
`aria-disabled` on `MudTr` and `aria-expanded` on `MudMenu`'s custom activator were bound to a `bool`. Blazor renders a bool-valued attribute on an element as an HTML *boolean attribute* — omitted when false, bare when true:

```razor
aria-disabled="@Disabled"                 <!-- renders aria-disabled="" -->
aria-expanded="@_openState.Value"         <!-- renders aria-expanded="" -->
```

But these are token-typed ARIA attributes, not HTML boolean attributes. An empty value is not a valid token, so it resolves to the attribute's default (`false` / not expanded). The result is that a disabled row is never exposed as disabled, and an open menu is never exposed as expanded — the accessibility half of both features has never worked.

Confirmed by fail-first tests: the disabled row read `""` where `"true"` was expected, and a closed menu had no `aria-expanded` at all.