### PR TITLE
MudCheckBox, MudSwitch, MudRadio: Fix aria-hidden on overridden labels

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -560,12 +560,12 @@ namespace MudBlazor.UnitTests.Components
             // verify checkbox one maintains it's original structure, no aria class used, label with a span element
             checkboxes[0].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".cb1 label.mud-checkbox span.mud-typography");
-            element0.HasAttribute("aria-hidden").Should().BeFalse();
+            element0.GetAttribute("aria-hidden").Should().Be("false");
 
             // checkbox two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             checkboxes[1].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element1 = comp.Find(".cb2 label.mud-checkbox span.mud-typography");
-            element1.HasAttribute("aria-hidden").Should().BeTrue();
+            element1.GetAttribute("aria-hidden").Should().Be("true");
             var input1 = comp.Find(".cb2 label.mud-checkbox input");
             var input1ForId = input1.GetAttribute("aria-labelledby");
             comp.Find($".cb2 label.mud-checkbox #{input1ForId}").Should().NotBeNull();
@@ -573,12 +573,12 @@ namespace MudBlazor.UnitTests.Components
             // checkbox three should have original structure intact, no aria class used, label with a span element for child content
             checkboxes[2].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".cb3 label.mud-checkbox span.mud-typography");
-            element2.HasAttribute("aria-hidden").Should().BeFalse();
+            element2.GetAttribute("aria-hidden").Should().Be("false");
 
             // checkbox four should look identical to two except this time it's with ChildContent
             checkboxes[3].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element3 = comp.Find(".cb4 label.mud-checkbox span.mud-typography");
-            element3.HasAttribute("aria-hidden").Should().BeTrue();
+            element3.GetAttribute("aria-hidden").Should().Be("true");
             var input3 = comp.Find(".cb4 label.mud-checkbox input");
             var input3ForId = input3.GetAttribute("aria-labelledby");
             comp.Find($".cb4 label.mud-checkbox #{input3ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -560,7 +560,7 @@ namespace MudBlazor.UnitTests.Components
             // verify checkbox one maintains it's original structure, no aria class used, label with a span element
             checkboxes[0].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".cb1 label.mud-checkbox span.mud-typography");
-            element0.GetAttribute("aria-hidden").Should().Be("false");
+            element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             checkboxes[1].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
@@ -573,7 +573,7 @@ namespace MudBlazor.UnitTests.Components
             // checkbox three should have original structure intact, no aria class used, label with a span element for child content
             checkboxes[2].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".cb3 label.mud-checkbox span.mud-typography");
-            element2.GetAttribute("aria-hidden").Should().Be("false");
+            element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // checkbox four should look identical to two except this time it's with ChildContent
             checkboxes[3].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -38,7 +38,7 @@ namespace MudBlazor.UnitTests.Components
             var r1 = comp.Find(".r1");
             r1.GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".r1 label.mud-radio span.mud-typography");
-            element0.GetAttribute("aria-hidden").Should().Be("false");
+            element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // radio two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             var r2 = comp.Find(".r2");
@@ -53,7 +53,7 @@ namespace MudBlazor.UnitTests.Components
             var r3 = comp.Find(".r3");
             r3.GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".r3 label.mud-radio span.mud-typography");
-            element2.GetAttribute("aria-hidden").Should().Be("false");
+            element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // radio four should look identical to two except this time it's with ChildContent
             var r4 = comp.Find(".r4");

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -38,13 +38,13 @@ namespace MudBlazor.UnitTests.Components
             var r1 = comp.Find(".r1");
             r1.GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".r1 label.mud-radio span.mud-typography");
-            element0.HasAttribute("aria-hidden").Should().BeFalse();
+            element0.GetAttribute("aria-hidden").Should().Be("false");
 
             // radio two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             var r2 = comp.Find(".r2");
             r2.GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element1 = comp.Find(".r2 label.mud-radio span.mud-typography");
-            element1.HasAttribute("aria-hidden").Should().BeTrue();
+            element1.GetAttribute("aria-hidden").Should().Be("true");
             var input1 = comp.Find(".r2 label.mud-radio input");
             var input1ForId = input1.GetAttribute("aria-labelledby");
             comp.Find($".r2 label.mud-radio #{input1ForId}").Should().NotBeNull();
@@ -53,13 +53,13 @@ namespace MudBlazor.UnitTests.Components
             var r3 = comp.Find(".r3");
             r3.GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".r3 label.mud-radio span.mud-typography");
-            element2.HasAttribute("aria-hidden").Should().BeFalse();
+            element2.GetAttribute("aria-hidden").Should().Be("false");
 
             // radio four should look identical to two except this time it's with ChildContent
             var r4 = comp.Find(".r4");
             r4.GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element3 = comp.Find(".r4 label.mud-radio span.mud-typography");
-            element3.HasAttribute("aria-hidden").Should().BeTrue();
+            element3.GetAttribute("aria-hidden").Should().Be("true");
             var input3 = comp.Find(".r4 label.mud-radio input");
             var input3ForId = input3.GetAttribute("aria-labelledby");
             comp.Find($".r4 label.mud-radio #{input3ForId}").Should().NotBeNull();

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -53,7 +53,7 @@ namespace MudBlazor.UnitTests.Components
             // verify switch one maintains it's original structure, no aria class used, label with a span element
             switches[0].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".s1 label.mud-switch span.mud-typography");
-            element0.GetAttribute("aria-hidden").Should().Be("false");
+            element0.HasAttribute("aria-hidden").Should().BeFalse();
 
             // switch two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             switches[1].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
@@ -66,7 +66,7 @@ namespace MudBlazor.UnitTests.Components
             // switch three should have original structure intact, no aria class used, label with a span element for child content
             switches[2].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".s3 label.mud-switch span.mud-typography");
-            element2.GetAttribute("aria-hidden").Should().Be("false");
+            element2.HasAttribute("aria-hidden").Should().BeFalse();
 
             // switch four should look identical to two except this time it's with ChildContent
             switches[3].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -53,12 +53,12 @@ namespace MudBlazor.UnitTests.Components
             // verify switch one maintains it's original structure, no aria class used, label with a span element
             switches[0].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element0 = comp.Find(".s1 label.mud-switch span.mud-typography");
-            element0.HasAttribute("aria-hidden").Should().BeFalse();
+            element0.GetAttribute("aria-hidden").Should().Be("false");
 
             // switch two should have both a valid label with aria-hidden, an input with arialabelledby and the labelledby element
             switches[1].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element1 = comp.Find(".s2 label.mud-switch span.mud-typography");
-            element1.HasAttribute("aria-hidden").Should().BeTrue();
+            element1.GetAttribute("aria-hidden").Should().Be("true");
             var input1 = comp.Find(".s2 label.mud-switch input");
             var input1ForId = input1.GetAttribute("aria-labelledby");
             comp.Find($".s2 label.mud-switch #{input1ForId}").Should().NotBeNull();
@@ -66,12 +66,12 @@ namespace MudBlazor.UnitTests.Components
             // switch three should have original structure intact, no aria class used, label with a span element for child content
             switches[2].GetElementsByClassName("mud-sr-only").Length.Should().Be(0);
             var element2 = comp.Find(".s3 label.mud-switch span.mud-typography");
-            element2.HasAttribute("aria-hidden").Should().BeFalse();
+            element2.GetAttribute("aria-hidden").Should().Be("false");
 
             // switch four should look identical to two except this time it's with ChildContent
             switches[3].GetElementsByClassName("mud-sr-only").Length.Should().Be(1);
             var element3 = comp.Find(".s4 label.mud-switch span.mud-typography");
-            element3.HasAttribute("aria-hidden").Should().BeTrue();
+            element3.GetAttribute("aria-hidden").Should().Be("true");
             var input3 = comp.Find(".s4 label.mud-switch input");
             var input3ForId = input3.GetAttribute("aria-labelledby");
             comp.Find($".s4 label.mud-switch #{input3ForId}").Should().NotBeNull();

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -12,11 +12,11 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null ? "true" : null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null ? "true" : null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -12,11 +12,11 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -11,11 +11,11 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -11,11 +11,11 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null ? "true" : null)" Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
             }
             @if (ChildContent is not null)
             {
-                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null ? "true" : null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -21,13 +21,13 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null ? "true" : null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @Label
                 </MudText>
             }
             @if (ChildContent != null)
             {
-                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null ? "true" : null)" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -21,13 +21,13 @@
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
-                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
                     @Label
                 </MudText>
             }
             @if (ChildContent != null)
             {
-                <MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" Color="HasErrors ? Color.Error : Color.Inherit">
+                <MudText HtmlTag="span" aria-hidden="@((AriaLabel is not null).ToString().ToLowerInvariant())" Color="HasErrors ? Color.Error : Color.Inherit">
                     @ChildContent
                 </MudText>
             }


### PR DESCRIPTION
When `AriaLabel` is set, these components mark the visible label `aria-hidden` so the accessible name is not announced twice. The attribute was bound to a `bool`:

```razor
<MudText HtmlTag="span" aria-hidden="@(AriaLabel is not null)" ...>
```

Blazor renders a bool-valued attribute as an HTML boolean attribute — bare when true, omitted when false. `aria-hidden` is token-valued, so the label rendered `aria-hidden=""`, which resolves to the default and hides nothing. The duplicate announcement the code exists to prevent has been happening the whole time.

Now emits the token only when the label is actually hidden:

```razor
aria-hidden="@(AriaLabel is not null ? "true" : null)"
```

Deliberately not the usual `.ToString().ToLowerInvariant()` form. `aria-hidden` is `true/false/undefined` defaulting to `undefined`, so absent is not the same as `false`: absent leaves the hidden state to the user agent, which is what a plainly visible label wants, while `aria-hidden="false"` asserts something different and is a no-op inside an `aria-hidden="true"` subtree. This is why it differs from `aria-disabled` and `aria-expanded` in #13643, where always emitting the token is correct.

Screen reader output changes: the visible label text is no longer announced alongside `AriaLabel`. That is what the existing code intends.

The tests asserted `HasAttribute("aria-hidden")`, which an empty value satisfies, so they never caught this. The hidden cases now assert the value instead.
