### PR TITLE
MudDataGrid: Fix Virtualization with sticky columns and column resizer

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeStickyColumnsResizerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridVirtualizeStickyColumnsResizerTest.razor
@@ -1,0 +1,48 @@
+﻿<div style="height: 100%">
+    <MudDataGrid T="Model" Items="@_items" FixedHeader="true" ColumnResizeMode="ResizeMode.Container" Height="600px" HorizontalScrollbar="true" Virtualize="true" OverscanCount="0" Bordered="true">
+        <Columns>
+            <PropertyColumn Property="x => x.Column1" StickyLeft="true" />
+            <PropertyColumn Property="x => x.Column2" />
+            <PropertyColumn Property="x => x.Column3" />
+            <PropertyColumn Property="x => x.Column4" />
+            <PropertyColumn Property="x => x.Column5" Resizable="true" />
+            <PropertyColumn Property="x => x.Column6" />
+            <PropertyColumn Property="x => x.Column7" />
+            <PropertyColumn Property="x => x.Column8" />
+            <PropertyColumn Property="x => x.Column9" />
+            <PropertyColumn Property="x => x.Column10" Resizable="false" />
+            <PropertyColumn Property="x => x.Column11" />
+            <PropertyColumn Property="x => x.Column12" />
+            <PropertyColumn Property="x => x.Column13" />
+            <PropertyColumn Property="x => x.Column14" />
+            <PropertyColumn Property="x => x.Column15" Resizable="true"/>
+            <PropertyColumn Property="x => x.Column16" />
+            <PropertyColumn Property="x => x.Column17" />
+            <PropertyColumn Property="x => x.Column18" />
+            <PropertyColumn Property="x => x.Column19" />
+            <PropertyColumn Property="x => x.Column20" Resizable="false" />
+            <PropertyColumn Property="x => x.Column21" />
+            <PropertyColumn Property="x => x.Column22" />
+            <PropertyColumn Property="x => x.Column23" />
+            <PropertyColumn Property="x => x.Column24" StickyRight="true" />
+        </Columns>
+    </MudDataGrid>
+</div>
+
+@code {
+    public static string __description__ = "Resizable virtualized Datagrid with sticky columns. Validate scrolling works and virtualisation does too";
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        for (int i = 0; i < 1000; i++)
+        {
+            _items.Add(new Model($"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}", $"Value_{i}"));
+        }
+    }
+    private List<Model> _items = new List<Model>();
+
+    public record Model(string Column1, string Column2, string Column3, string Column4, string Column5, string Column6, string Column7, 
+        string Column8, string Column9, string Column10, string Column11, string Column12, string Column13, string Column14, string Column15, 
+        string Column16, string Column17, string Column18, string Column19, string Column20, string Column21, string Column22, string Column23, string Column24);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5195,12 +5195,23 @@ namespace MudBlazor.UnitTests.Components
             footer.GetAttribute("style").Should().Contain("position:sticky");
             footer.GetAttribute("style").Should().Contain("left:0px");
 
-            var body = dataGrid.Find(".mud-table-container");
-            body.GetAttribute("style").Should().Contain("width:max-content");
-            body.GetAttribute("style").Should().Contain("overflow:clip");
+            var root = dataGrid.Find(".mud-table-root");
+            root.GetAttribute("style").Should().Contain("width:max-content");
 
             dataGrid.Find("th").ClassList.Should().Contain("sticky-left");
             dataGrid.FindAll("th").Last().ClassList.Should().Contain("sticky-right");
+        }
+
+        [Test]
+        public async Task DataGridVirtualizeStickyColumnsResizer()
+        {
+            var comp = Context.Render<DataGridVirtualizeStickyColumnsResizerTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridVirtualizeStickyColumnsResizerTest.Model>>();
+            var itemCount = dataGrid.Instance.Items.Count();
+            // Count data rows using the mud-table-row class; avoids counting Virtualize spacer <tr> elements.
+            dataGrid.FindAll("tbody tr.mud-table-row").Count.Should().NotBe(itemCount, because: "With Virtualization, we should not render every rows");
+            dataGrid.FindAll("tbody tr.mud-table-row").Count.Should().Be(100, because: "With Virtualization, we should not render every rows");
+
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5203,18 +5203,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
-        public async Task DataGridVirtualizeStickyColumnsResizer()
-        {
-            var comp = Context.Render<DataGridVirtualizeStickyColumnsResizerTest>();
-            var dataGrid = comp.FindComponent<MudDataGrid<DataGridVirtualizeStickyColumnsResizerTest.Model>>();
-            var itemCount = dataGrid.Instance.Items.Count();
-            // Count data rows using the mud-table-row class; avoids counting Virtualize spacer <tr> elements.
-            dataGrid.FindAll("tbody tr.mud-table-row").Count.Should().NotBe(itemCount, because: "With Virtualization, we should not render every rows");
-            dataGrid.FindAll("tbody tr.mud-table-row").Count.Should().Be(100, because: "With Virtualization, we should not render every rows");
-
-        }
-
-        [Test]
         public async Task DataGridCellContext()
         {
             var comp = Context.Render<DataGridCellContextTest>();

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -39,7 +39,7 @@
             <div @ref=_gridElement class="@TableClass" style="@TableStyle">
                 <MudDropContainer @ref="_dropContainer" T="Column<T>" Items="@RenderedColumns" ItemsSelector="(item, dropzone) => RenderedColumnsItemsSelector(item, dropzone)" ItemDropped="ItemUpdatedAsync" CanDropClass="@DropAllowedClass" NoDropClass="@DropNotAllowedClass" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
                     <ChildContent>
-                        <table @attributes="TableAttributes" class="mud-table-root">
+                        <table @attributes="TableAttributes" class="mud-table-root" style="@TableRootStyle">
                             @if (ColGroup != null)
                             {
                                 <colgroup>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -141,9 +141,12 @@ namespace MudBlazor
         protected string TableStyle =>
             new StyleBuilder()
                 .AddStyle("height", Height, !string.IsNullOrWhiteSpace(Height))
-                .AddStyle("width", "max-content", when: HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container)
-                .AddStyle("overflow", "clip", when: (HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container) && HasStickyColumns)
                 .AddStyle("display", "block", when: HorizontalScrollbar)
+                .Build();
+
+        protected string TableRootStyle =>
+            new StyleBuilder()
+                .AddStyle("width", "max-content", when: HorizontalScrollbar || ColumnResizeMode == ResizeMode.Container)
                 .Build();
 
         protected string TableClass =>


### PR DESCRIPTION
**Description**
Remove the Overflow: clip; logic I introduced in #6991 for a logic that doesn't break the virtualization. 

I removed the overflow:clip from the mud-table-container and moved the width: max-content from mud-table-container to mud-table-root. This PR aim to fix #7709, fix #9083 and fix #13618

**Before/After:**
I pasted my new UnitTest Component in the playground:

https://github.com/user-attachments/assets/bffa4921-a2b0-4226-9a45-0d80ddd11194

If you set the Height at 100% instead of 600px, you break virtualization:

https://github.com/user-attachments/assets/6f36d94e-0ab4-4b83-b1f2-0eaf033077d6

This is the UnitTest with my PR build:

https://github.com/user-attachments/assets/6407504b-3730-4a81-bcb6-cb100b9d35d2

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
