### PR TITLE
MudNumericField: Preserve terminal Pattern quantifiers

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -1201,6 +1201,24 @@ namespace MudBlazor.UnitTests.Components
             field.GetAttribute("type").Should().Be("text");
         }
 
+        /// <summary>
+        /// Existing quantifiers and end anchors are preserved while single-key patterns remain repeatable (#13646).
+        /// </summary>
+        [TestCase("", "")]
+        [TestCase(@"[0-9,.\-]", @"[0-9,.\-]*")]
+        [TestCase(@"[0-9,.\-]*", @"[0-9,.\-]*")]
+        [TestCase(@"[0-9]+", @"[0-9]+")]
+        [TestCase(@"[0-9]?", @"[0-9]?")]
+        [TestCase(@"[0-9]{1,3}", @"[0-9]{1,3}")]
+        [TestCase(@"^-?[0-9.,]*$", @"^-?[0-9.,]*$")]
+        public void NumericField_Should_RenderEffectivePattern(string pattern, string expectedPattern)
+        {
+            var comp = Context.Render<MudNumericField<decimal>>(parameters => parameters
+                .Add(x => x.Pattern, pattern));
+
+            comp.Find("input").GetAttribute("pattern").Should().Be(expectedPattern);
+        }
+
         [Test]
         public void NumericField_Should_RenderSpinbuttonAriaAttributes()
         {

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor
@@ -53,7 +53,7 @@
                           max="@(_maxHasValue ? FormatParam(_max) : null)"
                           step="@(_stepHasValue ? FormatParam(_step) : "any")"
                           InputMode="@InputMode"
-                          Pattern="@(Pattern == null ? null : Pattern!.TrimEnd('*')+"*")"
+                          Pattern="@EffectivePattern"
                           OnAdornmentClick="@OnAdornmentClick"
                           OnBlur="@OnBlurredAsync"
                           OnKeyDown="@HandleKeyDownAsync"

--- a/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
+++ b/src/MudBlazor/Components/NumericField/MudNumericField.razor.cs
@@ -174,6 +174,27 @@ namespace MudBlazor
 
         private string EffectiveKeyFilterPattern => (Pattern ?? DefaultKeyFilterPattern).TrimEnd('*');
 
+        private string? EffectivePattern
+        {
+            get
+            {
+                if (Pattern is null)
+                {
+                    return null;
+                }
+
+                var trimmed = Pattern.TrimEnd('*');
+                if (trimmed.Length == 0)
+                {
+                    return trimmed;
+                }
+
+                return trimmed[^1] is '+' or '?' or '}' or '$'
+                    ? trimmed
+                    : trimmed + "*";
+            }
+        }
+
         /// <inheritdoc />
         public override ValueTask FocusAsync() => FocusAsync(preventScroll: false);
 


### PR DESCRIPTION
## Summary

- preserve `MudNumericField` patterns that already end in a quantifier or end anchor
- preserve an explicitly empty pattern instead of emitting an invalid lone quantifier
- continue appending `*` to legacy single-character patterns
- add bUnit coverage for empty, `*`, `+`, `?`, `{n,m}`, `$`, and unquantified patterns

Fixes #13646

**Before/After:**

Direct Chromium DevTools recording (Chromium `150.0.7871.128`), comparing base `56f4cc01` with PR head `a0e55152` using the same input and `checkValidity()` call:

[![Before/after Chromium DevTools recording](https://gist.githubusercontent.com/roian6/5426aea3ce51e3c3fe20cb566bc14b8d/raw/ce830c877dc8ecbca0a7f2fc82fd1dcd0e03ee99/mudnumericfield-pattern-before-after-short.gif)](https://gist.githubusercontent.com/roian6/5426aea3ce51e3c3fe20cb566bc14b8d/raw/8ae8391a39281095bd27bca5e37bf5c507d3547c/mudnumericfield-pattern-before-after-short.mp4)

[MP4 recording (12.4 seconds)](https://gist.githubusercontent.com/roian6/5426aea3ce51e3c3fe20cb566bc14b8d/raw/8ae8391a39281095bd27bca5e37bf5c507d3547c/mudnumericfield-pattern-before-after-short.mp4)

Before, `Pattern="^-?[0-9.,]*$"` rendered as the invalid `^-?[0-9.,]*$*`, and Chromium reported `Nothing to repeat`. After, the rendered pattern remains `^-?[0-9.,]*$`; the same `checkValidity()` call returns `true` without a pattern/RegExp console error.

## Verification

- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~NumericField_Should_RenderEffectivePattern" --output Normal --no-ansi --hangdump --hangdump-timeout 30s` — 7 passed
- `dotnet build src/MudBlazor.UnitTests.Viewer/MudBlazor.UnitTests.Viewer.csproj --no-restore /p:SkipBunCompile=true --nologo` — succeeded with 0 warnings and 0 errors
- focused browser probe in Chromium against the real UnitTests Viewer — malformed pattern reproduced before the change; corrected pattern and no RegExp console error after the change

## Scope

This keeps the existing key-filter behavior and does not introduce position-aware filtering or change the public `Pattern` API.

## AI assistance

AI assistance was used for investigation, test drafting, and an independent blocker-only review. I reviewed the final diff, verified the regression failed on current `dev`, ran the focused tests and Viewer build locally, and captured the browser evidence above.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
