### PR TITLE
MudDebouncedInput: Fix DebounceInterval ignored when set in a derived component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@
     - [Example of a bad Parameter definition](#example-of-a-bad-parameter-definition)
     - [Example of a good Parameter definition](#example-of-a-good-parameter-definition)
     - [Can I share change handlers between parameters?](#can-i-share-change-handlers-between-parameters)
+    - [Does the change handler run for the parameter's initial value?](#does-the-change-handler-run-for-the-parameters-initial-value)
     - [What about the bad parameters all over the MudBlazor code base?](#what-about-the-bad-parameters-all-over-the-mudblazor-code-base)
   - [Avoid overwriting parameters in Blazor Components](#avoid-overwriting-parameters-in-blazor-components)
     - [Example of a bad code](#example-of-a-bad-code)
@@ -234,6 +235,44 @@ Yes, if you pass them as a method group like in the example below, shared parame
 ```
 
 **NB**: if you pass lambda functions as change handlers they will be called once each for every changed parameter even if they contain the same code!
+
+### Does the change handler run for the parameter's initial value?
+
+No. A change handler only fires for values that arrive through the `ParameterView`, i.e. values written in
+razor markup by the consumer. It does **not** fire for a value that the component already carries, such as:
+
+```c#
+// property initializer
+[Parameter] public double DebounceInterval { get; set; } = 1000;
+```
+
+```razor
+@* a derived component assigning the inherited parameter in its constructor *@
+@inherits MudTextField<T>
+
+@code {
+    public MyTextField()
+    {
+        DebounceInterval = 1000;
+    }
+}
+```
+
+In both cases the parameter is absent from the `ParameterView` (or, if the consumer happens to pass the same
+value, it is present but unchanged), so no change is detected and the handler is skipped.
+
+This only matters when the handler has a side effect that must also apply to the initial value, for example
+creating a timer or a dispatcher. Seed that state from `OnInitialized` in addition to the change handler:
+
+```c#
+protected override void OnInitialized()
+{
+    base.OnInitialized();
+    _debouncer ??= CreateDebouncer(DebounceInterval);
+}
+```
+
+See `MudDebouncedInput<T>` and `MudColorPicker` for the pattern in practice.
 
 ### What about the bad parameters all over the MudBlazor code base?
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/InheritedDebouncedTextField.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/InheritedDebouncedTextField.razor
@@ -1,0 +1,14 @@
+@inherits MudTextField<string>
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+    public InheritedDebouncedTextField()
+    {
+        // Set in the constructor on purpose: this value never travels through the ParameterView,
+        // so it exercises the initial-value path of MudDebouncedInput instead of the change handler.
+        DebounceInterval = 200d;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -219,6 +219,62 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A DebounceInterval assigned in the constructor of a derived component never travels through the
+        /// ParameterView, so the change handler does not run for it. It must still be honored.
+        /// </summary>
+        [Test]
+        public async Task DebounceInterval_SetInDerivedComponentConstructor_ShouldDebounce()
+        {
+            var timeProvider = Context.AddFakeTimeProvider();
+            var comp = Context.Render<InheritedDebouncedTextField>();
+            var textField = comp.Instance;
+            var input = comp.Find("input");
+
+            //Act
+            await input.InputAsync(new ChangeEventArgs() { Value = "Some Value" });
+
+            //Assert
+            textField.DebounceInterval.Should().Be(200d);
+            textField.Immediate.Should().BeTrue();
+
+            //input value has changed, but elapsed time is 0, so Value should not change in TextField
+            textField.ReadValue.Should().BeNull();
+
+            //DebounceInterval is 200 ms, so at 100 ms Value should not change in TextField
+            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+            textField.ReadValue.Should().BeNull();
+
+            //More than 200 ms had elapsed, so Value should be updated
+            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Some Value"));
+        }
+
+        /// <summary>
+        /// When the constructor value and the value passed in markup are equal, the parameter counts as
+        /// unchanged and the change handler is skipped. Debouncing must still work.
+        /// </summary>
+        [Test]
+        public async Task DebounceInterval_MatchingConstructorAndParameterValue_ShouldDebounce()
+        {
+            var timeProvider = Context.AddFakeTimeProvider();
+            var comp = Context.Render<InheritedDebouncedTextField>(parameters => parameters.Add(p => p.DebounceInterval, 200d));
+            var textField = comp.Instance;
+            var input = comp.Find("input");
+
+            //Act
+            await input.InputAsync(new ChangeEventArgs() { Value = "Some Value" });
+
+            //Assert
+            textField.ReadValue.Should().BeNull();
+
+            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+            textField.ReadValue.Should().BeNull();
+
+            timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+            await comp.WaitForAssertionAsync(() => textField.ReadValue.Should().Be("Some Value"));
+        }
+
+        /// <summary>
         /// DebounceInterval updates with epsilon-equivalent values should not break debouncing
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -235,7 +235,7 @@ namespace MudBlazor.UnitTests.Components
 
             //Assert
             textField.DebounceInterval.Should().Be(200d);
-            textField.Immediate.Should().BeTrue();
+            textField.EffectiveImmediate.Should().BeTrue();
 
             //input value has changed, but elapsed time is 0, so Value should not change in TextField
             textField.ReadValue.Should().BeNull();

--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -90,6 +90,16 @@ namespace MudBlazor
             await base.ValidateValue();
         }
 
+        /// <inheritdoc />
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            // The DebounceInterval change handler only runs for values that arrive through the ParameterView.
+            // A value coming from a property initializer or from the constructor of a derived component never
+            // does, so seed the debouncer here from the initial value.
+            _debouncer ??= CreateDebouncer(DebounceInterval);
+        }
+
         private async Task OnDebounceIntervalChangedAsync(ParameterChangedEventArgs<double> args)
         {
             if (args.Value <= 0)
@@ -103,7 +113,7 @@ namespace MudBlazor
             // Create debouncer if we don't have one
             if (_debouncer is null)
             {
-                _debouncer = new DebounceDispatcher(TimeSpan.FromMilliseconds(args.Value), false, TimeProvider);
+                _debouncer = CreateDebouncer(args.Value);
             }
             else
             {
@@ -115,6 +125,10 @@ namespace MudBlazor
                 }
             }
         }
+
+        private DebounceDispatcher? CreateDebouncer(double intervalMilliseconds) => intervalMilliseconds > 0
+            ? new DebounceDispatcher(TimeSpan.FromMilliseconds(intervalMilliseconds), false, TimeProvider)
+            : null;
 
         private async Task<bool> SynchronizePendingValueForValidationAsync()
         {


### PR DESCRIPTION
Fixes: https://github.com/MudBlazor/MudBlazor/issues/13513

The debouncer was only created from the DebounceInterval change handler, which never runs for a value that does not arrive through the ParameterView (a derived component's constructor or a property initializer).

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask! -->
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
