### PR TITLE
Build: Rebuild web assets when the toolchain changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Run restore only when restore inputs changed (`*.csproj`, `src/Directory.Build.*
 
 If `.config/dotnet-tools.json` changes, run `dotnet tool restore --tool-manifest .config/dotnet-tools.json`.
 
-If `src/package.json` or `src/bun.lock` changes, run a normal scoped build without `SkipBunCompile` for the affected project so the frontend asset pipeline runs.
+If `src/package.json`, `src/bun.lock`, `src/eslint.config.ts`, `src/Directory.Build.props`, or a project's `build.mjs` changes, run a normal scoped build without `SkipBunCompile` for the affected project so the frontend asset pipeline runs.
 
 ### Default local loop for C# or Razor component changes
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -40,9 +40,7 @@
   <!--
     Shared inputs for every Bun-built asset: the dependency graph and the toolchain version.
     Projects that build web assets add these to their own WebAssetInputs, plus their local build.mjs.
-    Without them the incremental Inputs/Outputs check only watches .js and .scss sources, so changing
-    a dependency or the Bun version leaves the previously built assets in place and the build silently
-    ships stale output.
+    Without them the incremental Inputs/Outputs check only watches .js and .scss sources, so changing a dependency or the Bun version leaves the previously built assets in place and the build silently ships stale output.
     This file is listed because it defines BunVersion, which selects the Bun binary that emits the bundle.
   -->
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -36,4 +36,18 @@
     <BunToolRestore>dotnet tool restore --tool-manifest ../../.config/dotnet-tools.json</BunToolRestore>
     <BunWrapper>dotnet tool run bun -- wrapper --version $(BunVersion) --path ../../tools --silent --</BunWrapper>
   </PropertyGroup>
+
+  <!--
+    Shared inputs for every Bun-built asset: the dependency graph and the toolchain version.
+    Projects that build web assets add these to their own WebAssetInputs, plus their local build.mjs.
+    Without them the incremental Inputs/Outputs check only watches .js and .scss sources, so changing
+    a dependency or the Bun version leaves the previously built assets in place and the build silently
+    ships stale output.
+    This file is listed because it defines BunVersion, which selects the Bun binary that emits the bundle.
+  -->
+  <ItemGroup>
+    <BunToolchainInputs Include="$(MSBuildThisFileDirectory)package.json" />
+    <BunToolchainInputs Include="$(MSBuildThisFileDirectory)bun.lock" />
+    <BunToolchainInputs Include="$(MSBuildThisFileFullPath)" />
+  </ItemGroup>
 </Project>

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -87,7 +87,6 @@
   <!-- Only rebuild web assets if any of the source files have changed -->
   <ItemGroup>
     <ScssAssetInputs Include="Styles/**/*.scss" />
-    <!-- The build script shapes the emitted stylesheet, so it is an input too. -->
     <BuildScriptInputs Include="build.mjs" />
     <WebAssetInputs Include="@(ScssAssetInputs);@(BuildScriptInputs);@(BunToolchainInputs)" />
     <UpToDateCheckInput Include="@(WebAssetInputs)" />

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -87,7 +87,9 @@
   <!-- Only rebuild web assets if any of the source files have changed -->
   <ItemGroup>
     <ScssAssetInputs Include="Styles/**/*.scss" />
-    <WebAssetInputs Include="@(ScssAssetInputs)" />
+    <!-- The build script shapes the emitted stylesheet, so it is an input too. -->
+    <BuildScriptInputs Include="build.mjs" />
+    <WebAssetInputs Include="@(ScssAssetInputs);@(BuildScriptInputs);@(BunToolchainInputs)" />
     <UpToDateCheckInput Include="@(WebAssetInputs)" />
   </ItemGroup>
 

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -105,7 +105,10 @@
   <ItemGroup>
     <JsAssetInputs Include="TScripts/**/*.js" />
     <ScssAssetInputs Include="Styles/**/*.scss" />
-    <WebAssetInputs Include="@(JsAssetInputs);@(ScssAssetInputs)" />
+    <!-- The build script and the lint rules shape the emitted bundle, so they are inputs too. -->
+    <BuildScriptInputs Include="build.mjs" />
+    <BuildScriptInputs Include="../eslint.config.ts" />
+    <WebAssetInputs Include="@(JsAssetInputs);@(ScssAssetInputs);@(BuildScriptInputs);@(BunToolchainInputs)" />
     <UpToDateCheckInput Include="@(WebAssetInputs)" />
     <WebAssetOutputs Include="wwwroot/MudBlazor.min.js;wwwroot/MudBlazor.min.js.map;wwwroot/MudBlazor.min.css" />
   </ItemGroup>

--- a/src/MudBlazor/MudBlazor.csproj
+++ b/src/MudBlazor/MudBlazor.csproj
@@ -105,7 +105,6 @@
   <ItemGroup>
     <JsAssetInputs Include="TScripts/**/*.js" />
     <ScssAssetInputs Include="Styles/**/*.scss" />
-    <!-- The build script and the lint rules shape the emitted bundle, so they are inputs too. -->
     <BuildScriptInputs Include="build.mjs" />
     <BuildScriptInputs Include="../eslint.config.ts" />
     <WebAssetInputs Include="@(JsAssetInputs);@(ScssAssetInputs);@(BuildScriptInputs);@(BunToolchainInputs)" />


### PR DESCRIPTION
The incremental `Inputs`/`Outputs` check on the Bun asset targets only watched `TScripts/**/*.js` and `Styles/**/*.scss`. Everything else that determines the emitted bundle was invisible to it: `src/package.json` and `src/bun.lock` (which pin the `sass` compiler that produces the CSS), `src/eslint.config.ts`, each project's `build.mjs`, and `BunVersion` in `src/Directory.Build.props` (which selects the Bun binary that emits the bundle).

Change any of those and the previously built `MudBlazor.min.js` / `.css` stayed in place, so the build silently shipped stale output:

```console
$ touch src/bun.lock && dotnet build MudBlazor.csproj -f net10.0
Build succeeded.                                    # no asset rebuild

$ touch src/MudBlazor/Styles/MudBlazor.scss && dotnet build …
  Building MudBlazor web assets (inner build …)     # rebuilds
Build succeeded.
```

`AGENTS.md` documented a workaround — "run a normal scoped build without `SkipBunCompile`" — but it could not work, because MSBuild skipped the target before the instruction had any effect. That line is updated here to list the full set of triggering files.

**Change:** add the shared dependency and toolchain files as a `BunToolchainInputs` item in `Directory.Build.props`, next to the existing Bun properties, and have each asset-building project pull them into its own `WebAssetInputs` alongside its local `build.mjs`.