### PR TITLE
MudDataGrid: Fix select-all showing checked when a disabled selected row offsets an unselected one

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -7005,6 +7005,62 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task SelectAll_WithSelectedDisabledRow_HeaderCheckboxNotFalselyChecked()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Enabled Selected", ShouldBeDisabled = false },
+                new() { Id = 2, Name = "Disabled Selected", ShouldBeDisabled = true },
+                new() { Id = 3, Name = "Enabled Unselected", ShouldBeDisabled = false },
+                new() { Id = 4, Name = "Disabled Unselected", ShouldBeDisabled = true }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFunc)
+            );
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.SelectedItems, new HashSet<TestDataItem> { items[0], items[1] }));
+
+            // The selected count matches the selectable count, but the selected disabled row must not stand in for the unselected enabled row.
+            var headerCheckbox = comp.FindComponent<MudCheckBox<bool?>>();
+            headerCheckbox.Instance.ReadValue.Should().BeNull();
+        }
+
+        [Test]
+        public async Task SelectAll_Toggle_PreservesSelectedDisabledRow()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Enabled Selected", ShouldBeDisabled = false },
+                new() { Id = 2, Name = "Disabled Selected", ShouldBeDisabled = true },
+                new() { Id = 3, Name = "Enabled Unselected", ShouldBeDisabled = false }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnWithFunc)
+            );
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.SelectedItems, new HashSet<TestDataItem> { items[0], items[1] }));
+
+            var headerCheckbox = comp.FindComponent<MudCheckBox<bool?>>();
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = true });
+            headerCheckbox.Instance.ReadValue.Should().BeTrue();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(items);
+
+            // Deselecting all only removes the rows the header checkbox controls; the disabled row's selection survives.
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = false });
+            headerCheckbox.Instance.ReadValue.Should().BeFalse();
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEquivalentTo(new[] { items[1] });
+        }
+
+        [Test]
         public async Task SelectAll_GroupFooterCheckbox_AppliesToItsOwnGroupOnly()
         {
             var items = new List<TestDataItem>

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -7004,6 +7004,9 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
         }
 
+        /// <summary>
+        /// A selected disabled row must not stand in for an unselected enabled row in the select-all state: regression from https://github.com/MudBlazor/MudBlazor/pull/13596.
+        /// </summary>
         [Test]
         public async Task SelectAll_WithSelectedDisabledRow_HeaderCheckboxNotFalselyChecked()
         {
@@ -7029,6 +7032,9 @@ namespace MudBlazor.UnitTests.Components
             headerCheckbox.Instance.ReadValue.Should().BeNull();
         }
 
+        /// <summary>
+        /// Toggling select-all only affects the rows its checkbox controls, so a disabled row selected from code survives: https://github.com/MudBlazor/MudBlazor/pull/13596.
+        /// </summary>
         [Test]
         public async Task SelectAll_Toggle_PreservesSelectedDisabledRow()
         {

--- a/src/MudBlazor/Components/DataGrid/FooterContext.cs
+++ b/src/MudBlazor/Components/DataGrid/FooterContext.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace MudBlazor
@@ -50,28 +49,7 @@ namespace MudBlazor
         /// <summary>
         /// Indicates whether all values are currently selected.
         /// </summary>
-        public bool? IsAllSelected
-        {
-            get
-            {
-                if (GroupItemsFunc() is { } groupItems)
-                {
-                    return _dataGrid.GetGroupSelectionState(groupItems);
-                }
-
-                if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
-                {
-                    if (_dataGrid.Selection.Count == 0)
-                    {
-                        return false;
-                    }
-
-                    return _dataGrid.Selection.Count == _dataGrid.GetSelectableItems().Count() ? true : null;
-                }
-
-                return false;
-            }
-        }
+        public bool? IsAllSelected => _dataGrid.GetSelectionState(GroupItemsFunc() ?? Items);
 
         /// <summary>
         /// Creates a new instance.

--- a/src/MudBlazor/Components/DataGrid/HeaderContext.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderContext.cs
@@ -41,23 +41,7 @@ namespace MudBlazor
         /// <summary>
         /// Indicates whether all items are currently selected.
         /// </summary>
-        public bool? IsAllSelected
-        {
-            get
-            {
-                if (_dataGrid.Selection is not null && (Items?.Any() ?? false))
-                {
-                    if (_dataGrid.Selection.Count == 0)
-                    {
-                        return false;
-                    }
-
-                    return _dataGrid.Selection.Count == _dataGrid.GetSelectableItems().Count() ? true : null;
-                }
-
-                return false;
-            }
-        }
+        public bool? IsAllSelected => _dataGrid.GetSelectionState(Items);
 
         /// <summary>
         /// Creates a new instance.

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2166,11 +2166,16 @@ namespace MudBlazor
             if (!MultiSelection)
                 return;
 
-            Selection.Clear(); // Clear selection first, regardless of selecting or unselecting all.
+            var selectableItems = GetSelectableItems();
 
-            if (value) // Logic for selecting all
+            if (value)
             {
-                Selection.UnionWith(GetSelectableItems());
+                Selection.UnionWith(selectableItems);
+            }
+            else
+            {
+                // Only remove the rows the checkbox controls so selections it cannot restore, such as disabled rows, survive.
+                Selection.ExceptWith(selectableItems);
             }
 
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
@@ -2231,12 +2236,12 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// The state of a group's select-all checkbox: <c>true</c> when every selectable row of the group is selected, <c>false</c> when none of them is, otherwise <c>null</c>.
+        /// The state of a select-all checkbox covering <paramref name="items"/>: <c>true</c> when every selectable row is selected, <c>false</c> when none of them is, otherwise <c>null</c>.
         /// </summary>
-        /// <param name="groupItems">The rows belonging to the group.</param>
-        internal bool? GetGroupSelectionState(IEnumerable<T> groupItems)
+        /// <param name="items">The rows the checkbox covers, e.g. all displayed rows for the header checkbox or a group's rows for a group footer checkbox.</param>
+        internal bool? GetSelectionState(IEnumerable<T> items)
         {
-            var selectableItems = GetSelectableItems(groupItems).ToList();
+            var selectableItems = GetSelectableItems(items).ToList();
             var selectedCount = selectableItems.Count(Selection.Contains);
 
             if (selectedCount == 0)


### PR DESCRIPTION
Fixes a regression from #13596, found while verifying the v9.9.0 candidate.

**Bug:** `HeaderContext`/`FooterContext.IsAllSelected` compared `Selection.Count == GetSelectableItems().Count()` — counts of two different sets. A selected row that isn't selectable (disabled via `SelectColumn.DisabledFunc`, or hidden by a filter) inflates the left side, so with rows Ada (enabled, selected), Grace (disabled, selected), Linus (enabled, unselected), Margaret (disabled, unselected) the header reads fully checked while Linus is unselected. Clicking that falsely checked header then ran `Selection.Clear()`, wiping every selection including Grace, whose own checkbox is disabled so she can't be re-selected.

**Change:**
- The select-all state is now membership-based and shared with the group footer checkbox logic from #13410: `GetGroupSelectionState` is renamed to `GetSelectionState` and both contexts delegate to it. Checked only when every displayed selectable row is selected; unchecked when none of them is.
- `SetSelectAllAsync(false)` mirrors `SetGroupSelectAllAsync`: `ExceptWith(selectable)` instead of `Clear()`, so deselect-all only removes rows the checkbox controls and a disabled row's selection survives the toggle.

**Reviewer note:** the second point also means header deselect-all no longer purges selections hidden by an active filter — the same rule the group checkbox already follows, but it is a deliberate behavior change on top of the state fix.

Two regression tests added; the full `DataGridTests` class passes, and the original repro was re-verified in the browser (header and footer render indeterminate, and toggling select-all preserves the disabled row's selection).
