### PR TITLE
Build: Cache bun packages in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,6 +26,13 @@ runs:
         key: ${{ github.repository }}-bun-binary-${{ hashFiles('**/Directory.Build.props') }}
         path: ./tools/BunDotNet
 
+    - name: Cache Bun packages
+      uses: actions/cache@v6
+      with:
+        # The build installs from 'src/bun.lock', so the resolved package set changes only when it does
+        key: ${{ github.repository }}-bun-packages-${{ hashFiles('src/bun.lock') }}
+        path: ~/.bun/install/cache
+
     - name: Restore NuGet packages
       shell: bash
       run: dotnet restore ${{ inputs.project-path }}


### PR DESCRIPTION
Every build job now runs `bun install --frozen-lockfile` (#13657), but the workflow caches only the bun binary, so all five jobs re-download the ~90 package dependency graph from npm on every run.

Cache the package store alongside the binary, keyed on `src/bun.lock` since that is exactly what determines the resolved set.

Measured on Linux: a cold install of this graph is ~500 ms against ~22 ms warm, and the store is ~22 MB across 129 entries. `bun pm cache` confirms `~/.bun/install/cache` is the path. The wall-clock saving is small; the larger point is that a build no longer needs npm reachable to produce assets from an unchanged lockfile.
