### PR TITLE
MudDataGrid: Fix cells registering unused click handlers

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1543,6 +1543,39 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// With no CellClick or CellContextMenuClick delegate the cells must carry no event handlers at all,
+        /// otherwise every td registers a DOM listener that does nothing.
+        /// </summary>
+        [Test]
+        public void DataGridCell_WithoutDelegates_RegistersNoCellEventHandlers()
+        {
+            // DataGridCellClickBubbleTest wires the row events but neither cell event.
+            var comp = Context.Render<DataGridCellClickBubbleTest>();
+
+            var cellHandlers = comp.FindAll(".mud-table-body tr td")
+                .SelectMany(td => td.Attributes.Select(attribute => attribute.Name))
+                .Where(name => name.Contains("onclick") || name.Contains("oncontextmenu"))
+                .ToList();
+
+            cellHandlers.Should().BeEmpty("EventCallback<T>.Empty has a live no-op delegate, so the callbacks must fall back to default instead");
+        }
+
+        /// <summary>
+        /// When both cell delegates are supplied the cells must carry the click and context-menu handlers.
+        /// </summary>
+        [Test]
+        public void DataGridCell_WithDelegates_RegistersCellEventHandlers()
+        {
+            var comp = Context.Render<DataGridEventCallbacksTest>();
+
+            var firstCell = comp.FindAll(".mud-table-body tr td")[0];
+            var cellHandlers = firstCell.Attributes.Select(attribute => attribute.Name).ToList();
+
+            cellHandlers.Should().Contain(name => name.Contains("onclick"));
+            cellHandlers.Should().Contain(name => name.Contains("oncontextmenu"));
+        }
+
+        /// <summary>
         /// When CellContextMenuClick has a delegate, right-clicking a td fires CellContextMenuClick and
         /// stopPropagation prevents RowContextMenuClick from also firing.
         /// </summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2524,15 +2524,18 @@ namespace MudBlazor
             return CellContextMenuClick.InvokeAsync(new DataGridCellClickEventArgs<T>(args, item, rowIndex, columnIndex, column));
         }
 
+        // Returns default, not EventCallback<T>.Empty: Empty carries a live no-op delegate, so HasDelegate is true.
+        // The renderer would then emit an attribute frame and register an event handler for every cell, attaching a DOM listener that does nothing.
+        // default has no delegate, so the renderer elides the attribute entirely.
         private EventCallback<MouseEventArgs> GetCellClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
             => CellClick.HasDelegate
                 ? EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellClickedAsync(args, item, rowIndex, colIndex, column))
-                : EventCallback<MouseEventArgs>.Empty;
+                : default;
 
         private EventCallback<MouseEventArgs> GetCellContextMenuClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
             => CellContextMenuClick.HasDelegate
                 ? EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellContextMenuClickedAsync(args, item, rowIndex, colIndex, column))
-                : EventCallback<MouseEventArgs>.Empty;
+                : default;
 
         /// <summary>
         /// Gets the total count of filtered items in the data grid.

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2524,9 +2524,6 @@ namespace MudBlazor
             return CellContextMenuClick.InvokeAsync(new DataGridCellClickEventArgs<T>(args, item, rowIndex, columnIndex, column));
         }
 
-        // Returns default, not EventCallback<T>.Empty: Empty carries a live no-op delegate, so HasDelegate is true.
-        // The renderer would then emit an attribute frame and register an event handler for every cell, attaching a DOM listener that does nothing.
-        // default has no delegate, so the renderer elides the attribute entirely.
         private EventCallback<MouseEventArgs> GetCellClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
             => CellClick.HasDelegate
                 ? EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellClickedAsync(args, item, rowIndex, colIndex, column))


### PR DESCRIPTION
`GetCellClickCallback` / `GetCellContextMenuClickCallback` returned `EventCallback<MouseEventArgs>.Empty` when the consumer supplied no delegate. `.Empty` is not `default` — it is constructed with a live no-op `Action`, so `HasDelegate` is `true`:

```
EventCallback<T>.Empty.HasDelegate   = True    Delegate = System.Action
default(EventCallback<T>).HasDelegate = False   Delegate = null
```

`RenderTreeBuilder.AddAttribute(seq, name, EventCallback<T>)` appends the frame whenever `HasDelegate`, so the guard never guarded — it swapped one live delegate for another. `RenderTreeDiffBuilder` then assigns an event handler id, serializing `blazor:onclick` / `blazor:oncontextmenu` to the client and attaching real DOM listeners.

A 200x8 grid with neither callback wired registered 3,200 handler ids. On Blazor Server every cell click and right-click in the grid body became a no-op SignalR round-trip for consumers who wired up nothing.

Returning `default` takes the builder's elision path. Frames per `<td>`, replayed against a real `RenderTreeBuilder`:

| | frames |
|---|---|
| before #13489 | 4 |
| dev, no delegate (`.Empty`) | 6 |
| this PR, no delegate (`default`) | 4 |
| both delegates wired | 9 |

The three `:stopPropagation` / `:preventDefault` directives already emit no frames when false, so they are left alone.

Regression introduced by #13489 and not present in any release.

Behaviour is unchanged: nothing reads `HasDelegate` on the returned value, and Razor only passes it to `EventCallback.Factory.Create(this, cb)`, which returns its argument unchanged.
