### PR TITLE
MudDataGrid: Stop re-rendering grid while typing in column filter menu

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4721,6 +4721,54 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
+        /// <summary>
+        /// Typing into the column filter menu's value box does not re-render the grid, because the filter is not applied until the Filter button is pressed.
+        /// </summary>
+        /// <remarks>
+        /// Re-rendering every row and header cell per keystroke made typing lag badly on a large grid (#13639).
+        /// </remarks>
+        [Test]
+        public async Task DataGridColumnFilterMenu_TypingValue_DoesNotRerenderGrid()
+        {
+            var comp = Context.Render<DataGridColumnFilterMenuTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterMenuTest.Model>>();
+
+            await comp.Find(".filter-button").ClickAsync();
+            var filterInput = comp.FindComponent<MudTextField<string>>();
+
+            var rendersBeforeTyping = dataGrid.RenderCount;
+            await comp.InvokeAsync(() => filterInput.Instance.ValueChanged.InvokeAsync("Ira"));
+
+            dataGrid.RenderCount.Should().Be(rendersBeforeTyping);
+            dataGrid.FindAll("tbody tr").Count.Should().Be(4);
+
+            // The typed value is still captured, so applying it filters as usual.
+            await comp.Find(".apply-filter-button").ClickAsync();
+            dataGrid.Instance.FilterDefinitions.Should().ContainSingle().Which.Value.Should().Be("Ira");
+            dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Editing a filter which is already applied still updates the rows as the value changes.
+        /// </summary>
+        [Test]
+        public async Task DataGridColumnFilterMenu_EditingAppliedFilter_UpdatesRows()
+        {
+            var comp = Context.Render<DataGridColumnFilterMenuTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterMenuTest.Model>>();
+
+            await comp.Find(".filter-button").ClickAsync();
+            await comp.InvokeAsync(() => comp.FindComponent<MudTextField<string>>().Instance.ValueChanged.InvokeAsync("Ira"));
+            await comp.Find(".apply-filter-button").ClickAsync();
+            dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+
+            // Re-open the applied filter and retype: the grid follows the new value without pressing Filter again.
+            await comp.Find(".filter-button").ClickAsync();
+            await comp.InvokeAsync(() => comp.FindComponent<MudTextField<string>>().Instance.ValueChanged.InvokeAsync("Sam"));
+
+            dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+            dataGrid.FindAll("tbody tr td")[0].TextContent.Trim().Should().Be("Sam");
+        }
 
         [Test]
         public async Task DataGridCustomPropertyFilterTemplate()

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -4734,10 +4734,17 @@ namespace MudBlazor.UnitTests.Components
             var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterMenuTest.Model>>();
 
             await comp.Find(".filter-button").ClickAsync();
-            var filterInput = comp.FindComponent<MudTextField<string>>();
 
             var rendersBeforeTyping = dataGrid.RenderCount;
-            await comp.InvokeAsync(() => filterInput.Instance.ValueChanged.InvokeAsync("Ira"));
+
+            // Type through the rendered input: a real keystroke fires keydown as well as input, and both used to re-render the whole grid.
+            var typed = "";
+            foreach (var character in "Ira")
+            {
+                typed += character;
+                await comp.Find(".filter-input input").KeyDownAsync(new KeyboardEventArgs { Key = character.ToString() });
+                await comp.Find(".filter-input input").InputAsync(new ChangeEventArgs { Value = typed });
+            }
 
             dataGrid.RenderCount.Should().Be(rendersBeforeTyping);
             dataGrid.FindAll("tbody tr").Count.Should().Be(4);
@@ -4746,6 +4753,34 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find(".apply-filter-button").ClickAsync();
             dataGrid.Instance.FilterDefinitions.Should().ContainSingle().Which.Value.Should().Be("Ira");
             dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Enter in the column filter menu's value box applies the filter, and Escape clears it.
+        /// </summary>
+        /// <remarks>
+        /// These shortcuts share the value box's keydown handler, which deliberately does not re-render the grid (#13639).
+        /// </remarks>
+        [Test]
+        public async Task DataGridColumnFilterMenu_EnterApplies_EscapeClears()
+        {
+            var comp = Context.Render<DataGridColumnFilterMenuTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridColumnFilterMenuTest.Model>>();
+
+            await comp.Find(".filter-button").ClickAsync();
+            await comp.Find(".filter-input input").InputAsync(new ChangeEventArgs { Value = "Ira" });
+            await comp.Find(".filter-input input").KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            dataGrid.Instance.FilterDefinitions.Should().ContainSingle().Which.Value.Should().Be("Ira");
+            dataGrid.FindAll("tbody tr").Count.Should().Be(1);
+            comp.FindAll(".mud-popover.column-filter-popup.mud-popover-open").Should().BeEmpty();
+
+            await comp.Find(".filter-button").ClickAsync();
+            await comp.Find(".filter-input input").KeyDownAsync(new KeyboardEventArgs { Key = "Escape" });
+
+            dataGrid.Instance.FilterDefinitions.Should().BeEmpty();
+            dataGrid.FindAll("tbody tr").Count.Should().Be(4);
+            comp.FindAll(".mud-popover.column-filter-popup.mud-popover-open").Should().BeEmpty();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -191,11 +191,8 @@ namespace MudBlazor
         // Simple mode applies filters live, so it notifies here; the row and menu modes notify from their own apply paths instead.
         private Task ApplyChangesAsync()
         {
-            // The column filter menu edits a definition the grid has not applied yet, and only FilterDefinitions
-            // feeds the rows and the header's filtered icon, so its value cannot change anything on screen.
-            // Regrouping and re-rendering every cell per keystroke there is pure waste, and it is what makes
-            // typing in the menu's value box lag on a large grid (#13639). The menu's Filter button applies the
-            // definition and refreshes the grid then.
+            // The column filter menu edits a definition the grid has not applied yet, and only FilterDefinitions feeds the rows and the header's filtered icon, so its value cannot change anything on screen.
+            // Regrouping and re-rendering every cell per keystroke there is pure waste, and it is what makes typing in the menu's value box lag on a large grid (#13639). The menu's Filter button applies the definition and refreshes the grid then.
             if (_dataGrid.FilterDefinitions.All(x => x.Id != _filterDefinition.Id))
             {
                 return Task.CompletedTask;

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -28,29 +28,17 @@ namespace MudBlazor
         internal Column<T>? FilterColumn =>
             _column ?? (_dataGrid.RenderedColumns?.FirstOrDefault(c => c.PropertyName == _filterDefinition.Column?.PropertyName));
 
-        // The filter editors live in a render fragment owned by MudDataGrid, so binding their ValueChanged
-        // straight to a handler makes the grid the callback's receiver, and Blazor then re-renders the whole
-        // grid - every header cell, every popover, every visible row - after each keystroke (#13639).
-        // Routing them through this non-component receiver opts out of that automatic render; ApplyChangesAsync
-        // re-renders deliberately, and only when the edited filter is actually applied to the data.
+        // The filter editors live in a render fragment owned by MudDataGrid, so binding their ValueChanged straight to a handler makes the grid the callback's receiver, and Blazor then re-renders the whole grid - every header cell, every popover, every visible row - after each keystroke (#13639).
+        // Routing them through this non-component receiver opts out of that automatic render; ApplyChangesAsync re-renders deliberately, and only when the edited filter is actually applied to the data.
         internal EventCallback<Column<T>> FieldChanged => EventCallback.Factory.Create<Column<T>>(this, FieldChangedAsync);
-
         internal EventCallback<string> OperatorChanged => EventCallback.Factory.Create<string>(this, OperatorChangedAsync);
-
         internal EventCallback<string> StringValueChanged => EventCallback.Factory.Create<string>(this, StringValueChangedAsync);
-
         internal EventCallback<double?> NumberValueChanged => EventCallback.Factory.Create<double?>(this, NumberValueChangedAsync);
-
         internal EventCallback<Enum> EnumValueChanged => EventCallback.Factory.Create<Enum>(this, EnumValueChangedAsync);
-
         internal EventCallback<bool?> BoolValueChanged => EventCallback.Factory.Create<bool?>(this, BoolValueChangedAsync);
-
         internal EventCallback<DateTime?> DateValueChanged => EventCallback.Factory.Create<DateTime?>(this, DateValueChangedAsync);
-
         internal EventCallback<TimeSpan?> TimeValueChanged => EventCallback.Factory.Create<TimeSpan?>(this, TimeValueChangedAsync);
-
         internal EventCallback<DateTime?> DateOnlyValueChanged => EventCallback.Factory.Create<DateTime?>(this, DateOnlyValueChangedAsync);
-
         internal EventCallback<Guid?> GuidValueChanged => EventCallback.Factory.Create<Guid?>(this, GuidValueChangedAsync);
 
         public Filter(MudDataGrid<T> dataGrid, IFilterDefinition<T> filterDefinition, Column<T>? column)

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 
 namespace MudBlazor
 {
@@ -26,6 +27,31 @@ namespace MudBlazor
 
         internal Column<T>? FilterColumn =>
             _column ?? (_dataGrid.RenderedColumns?.FirstOrDefault(c => c.PropertyName == _filterDefinition.Column?.PropertyName));
+
+        // The filter editors live in a render fragment owned by MudDataGrid, so binding their ValueChanged
+        // straight to a handler makes the grid the callback's receiver, and Blazor then re-renders the whole
+        // grid - every header cell, every popover, every visible row - after each keystroke (#13639).
+        // Routing them through this non-component receiver opts out of that automatic render; ApplyChangesAsync
+        // re-renders deliberately, and only when the edited filter is actually applied to the data.
+        internal EventCallback<Column<T>> FieldChanged => EventCallback.Factory.Create<Column<T>>(this, FieldChangedAsync);
+
+        internal EventCallback<string> OperatorChanged => EventCallback.Factory.Create<string>(this, OperatorChangedAsync);
+
+        internal EventCallback<string> StringValueChanged => EventCallback.Factory.Create<string>(this, StringValueChangedAsync);
+
+        internal EventCallback<double?> NumberValueChanged => EventCallback.Factory.Create<double?>(this, NumberValueChangedAsync);
+
+        internal EventCallback<Enum> EnumValueChanged => EventCallback.Factory.Create<Enum>(this, EnumValueChangedAsync);
+
+        internal EventCallback<bool?> BoolValueChanged => EventCallback.Factory.Create<bool?>(this, BoolValueChangedAsync);
+
+        internal EventCallback<DateTime?> DateValueChanged => EventCallback.Factory.Create<DateTime?>(this, DateValueChangedAsync);
+
+        internal EventCallback<TimeSpan?> TimeValueChanged => EventCallback.Factory.Create<TimeSpan?>(this, TimeValueChangedAsync);
+
+        internal EventCallback<DateTime?> DateOnlyValueChanged => EventCallback.Factory.Create<DateTime?>(this, DateOnlyValueChangedAsync);
+
+        internal EventCallback<Guid?> GuidValueChanged => EventCallback.Factory.Create<Guid?>(this, GuidValueChangedAsync);
 
         public Filter(MudDataGrid<T> dataGrid, IFilterDefinition<T> filterDefinition, Column<T>? column)
         {
@@ -177,6 +203,16 @@ namespace MudBlazor
         // Simple mode applies filters live, so it notifies here; the row and menu modes notify from their own apply paths instead.
         private Task ApplyChangesAsync()
         {
+            // The column filter menu edits a definition the grid has not applied yet, and only FilterDefinitions
+            // feeds the rows and the header's filtered icon, so its value cannot change anything on screen.
+            // Regrouping and re-rendering every cell per keystroke there is pure waste, and it is what makes
+            // typing in the menu's value box lag on a large grid (#13639). The menu's Filter button applies the
+            // definition and refreshes the grid then.
+            if (_dataGrid.FilterDefinitions.All(x => x.Id != _filterDefinition.Id))
+            {
+                return Task.CompletedTask;
+            }
+
             _dataGrid.GroupItems();
             return _dataGrid.FilterMode == DataGridFilterMode.Simple
                 ? _dataGrid.NotifyFilterChangedAsync()

--- a/src/MudBlazor/Components/DataGrid/Filter.cs
+++ b/src/MudBlazor/Components/DataGrid/Filter.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace MudBlazor
 {
@@ -40,6 +41,9 @@ namespace MudBlazor
         internal EventCallback<TimeSpan?> TimeValueChanged => EventCallback.Factory.Create<TimeSpan?>(this, TimeValueChangedAsync);
         internal EventCallback<DateTime?> DateOnlyValueChanged => EventCallback.Factory.Create<DateTime?>(this, DateOnlyValueChangedAsync);
         internal EventCallback<Guid?> GuidValueChanged => EventCallback.Factory.Create<Guid?>(this, GuidValueChangedAsync);
+
+        // Keydown fires for every character typed, so it needs the same non-component receiver for the same reason, even though the handler only acts on Enter and Escape.
+        internal EventCallback<KeyboardEventArgs> KeyDown => EventCallback.Factory.Create<KeyboardEventArgs>(this, KeyDownAsync);
 
         public Filter(MudDataGrid<T> dataGrid, IFilterDefinition<T> filterDefinition, Column<T>? column)
         {
@@ -187,12 +191,30 @@ namespace MudBlazor
             return ApplyChangesAsync();
         }
 
+        // The column filter menu's keyboard shortcuts: Enter applies the filter and Escape clears it.
+        // Both paths refresh the grid themselves, so nothing here relies on an automatic render.
+        private Task KeyDownAsync(KeyboardEventArgs args)
+        {
+            if (_column is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return args.Key switch
+            {
+                "Enter" => _column.FilterContext.HeaderCell?.ApplyFilterAsync() ?? Task.CompletedTask,
+                "Escape" => _column.FilterContext.HeaderCell?.ClearFilterAsync() ?? Task.CompletedTask,
+                _ => Task.CompletedTask
+            };
+        }
+
         // Regroups the data after a filter edit and, in Simple mode, raises FilterChanged.
         // Simple mode applies filters live, so it notifies here; the row and menu modes notify from their own apply paths instead.
         private Task ApplyChangesAsync()
         {
             // The column filter menu edits a definition the grid has not applied yet, and only FilterDefinitions feeds the rows and the header's filtered icon, so its value cannot change anything on screen.
-            // Regrouping and re-rendering every cell per keystroke there is pure waste, and it is what makes typing in the menu's value box lag on a large grid (#13639). The menu's Filter button applies the definition and refreshes the grid then.
+            // Regrouping and re-rendering every cell per keystroke there is pure waste, and it is what makes typing in the menu's value box lag on a large grid (#13639).
+            // The menu's Filter button applies the definition and refreshes the grid then.
             if (_dataGrid.FilterDefinitions.All(x => x.Id != _filterDefinition.Id))
             {
                 return Task.CompletedTask;

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -499,7 +499,7 @@
                     <MudItem xs="4">
                         <MudSelect T="Column<T>" 
                                    Value="@filterDefinition.Column"
-                                   ValueChanged="@filter.FieldChangedAsync"
+                                   ValueChanged="@filter.FieldChanged"
                                    FullWidth="true" 
                                    Label="@Localizer[LanguageResource.MudDataGrid_Column]" 
                                    Dense="true" 
@@ -522,7 +522,7 @@
                     else
                     {
                         <MudItem xs="3">
-                            <MudSelect T="string" Value="@filterDefinition.Operator" ValueChanged="@filter.OperatorChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Operator]" Dense="true" Margin="@Margin.Dense"
+                            <MudSelect T="string" Value="@filterDefinition.Operator" ValueChanged="@filter.OperatorChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Operator]" Dense="true" Margin="@Margin.Dense"
                                        Class="filter-operator">
                                 @foreach (var fieldOperator in filterDefinition.Column!.GetFilterOperators(fieldType))
                                 {
@@ -533,17 +533,17 @@
                         <MudItem xs="4">
                             @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
-                                <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                                <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                               Immediate="true" Class="filter-input" />
                             }
                             else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
-                                <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                                <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                                  Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture"/>
                             }
                             else if (fieldType.IsEnum)
                             {
-                                <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                                <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                            Class="filter-input">
                                     <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
                                     @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
@@ -554,7 +554,7 @@
                             }
                             else if (fieldType.IsBoolean)
                             {
-                                <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                                <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                            Class="filter-input">
                                     <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
                                     <MudSelectItem T="bool?" Value="@(true)">@Localizer[LanguageResource.MudDataGrid_True]</MudSelectItem>
@@ -563,22 +563,22 @@
                             }
                             else if (fieldType.IsDateOnly && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
-                                <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChangedAsync" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChanged" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                             }
                             else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                             {
                                 <MudGrid Spacing="0">
                                     <MudItem xs="7">
-                                        <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChangedAsync" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                        <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChanged" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                                     </MudItem>
                                     <MudItem xs="5">
-                                        <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChangedAsync" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time" />
+                                        <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time" />
                                     </MudItem>
                                 </MudGrid>
                             }
                             else if (fieldType.IsGuid)
                             {
-                                <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChangedAsync" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                                <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Label="@Localizer[LanguageResource.MudDataGrid_Value]" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                               Immediate="true" Class="filter-input"/>
                             }
                         </MudItem>
@@ -600,17 +600,17 @@
                     <MudItem xs="12">
                         @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
-                            <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                            <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                           Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
                         }
                         else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
-                            <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                            <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                              Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
                         }
                         else if (fieldType.IsEnum)
                         {
-                            <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                            <MudSelect T="Enum" Value="@filter._valueEnum" ValueChanged="@filter.EnumValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                        Class="filter-input">
                                 <MudSelectItem T="Enum" Value="@(null)"></MudSelectItem>
                                 @foreach (var item in EnumExtensions.GetSafeEnumValues(fieldType.InnerType))
@@ -621,7 +621,7 @@
                         }
                         else if (fieldType.IsBoolean)
                         {
-                            <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
+                            <MudSelect T="bool?" Value="@filter._valueBool" ValueChanged="@filter.BoolValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Dense="true" Margin="@Margin.Dense"
                                        Class="filter-input">
                                 <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
                                 <MudSelectItem T="bool?" Value="@(true)">@Localizer[LanguageResource.MudDataGrid_True]</MudSelectItem>
@@ -630,22 +630,22 @@
                         }
                         else if (fieldType.IsDateOnly && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
-                            <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChangedAsync" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                            <MudDatePicker Date="@filter._valueDateOnlyForPicker" DateChanged="@filter.DateOnlyValueChanged" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                         }
                         else if (fieldType.IsDateTime && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
                             <MudGrid Spacing="0">
                                 <MudItem xs="7">
-                                    <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChangedAsync" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
+                                    <MudDatePicker Date="@filter._valueDateTimeForPicker" DateChanged="@filter.DateValueChanged" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-date"/>
                                 </MudItem>
                                 <MudItem xs="5">
-                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChangedAsync" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time"/>
+                                    <MudTimePicker Time="@filter._valueTime" TimeChanged="@filter.TimeValueChanged" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense" Class="filter-input-time"/>
                                 </MudItem>
                             </MudGrid>
                         }
                         else if (fieldType.IsGuid)
                         {
-                            <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChangedAsync" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
+                            <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
                                           Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
                         }
                     </MudItem>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -601,12 +601,12 @@
                         @if (fieldType.IsString && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
                             <MudTextField T="string" Value="@filter._valueString" ValueChanged="@filter.StringValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
-                                          Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
+                                          Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@filter.KeyDown"/>
                         }
                         else if (fieldType.IsNumber && !(filterDefinition.Operator ?? "").EndsWith("empty"))
                         {
                             <MudNumericField T="double?" Value="@filter._valueNumber" ValueChanged="@filter.NumberValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
-                                             Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
+                                             Immediate="true" Class="filter-input" Culture="@filter.FilterColumn?.Culture" AutoFocus="true" OnKeyDown="@filter.KeyDown"/>
                         }
                         else if (fieldType.IsEnum)
                         {
@@ -646,7 +646,7 @@
                         else if (fieldType.IsGuid)
                         {
                             <MudTextField T="Guid?" Value="@filter._valueGuid" ValueChanged="@filter.GuidValueChanged" FullWidth="true" Placeholder="@Localizer[LanguageResource.MudDataGrid_FilterValue]" Margin="@Margin.Dense"
-                                          Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@(args => OnColumnFilterInputKeyDownAsync(args, column))"/>
+                                          Immediate="true" Class="filter-input" AutoFocus="true" OnKeyDown="@filter.KeyDown"/>
                         }
                     </MudItem>
                 </MudGrid>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1977,21 +1977,6 @@ namespace MudBlazor
                        FilterOperator.DateTime.Empty or FilterOperator.DateTime.NotEmpty;
         }
 
-        private Task OnColumnFilterInputKeyDownAsync(KeyboardEventArgs args, Column<T>? column)
-        {
-            if (column is null)
-            {
-                return Task.CompletedTask;
-            }
-
-            return args.Key switch
-            {
-                "Enter" => column.FilterContext.HeaderCell?.ApplyFilterAsync() ?? Task.CompletedTask,
-                "Escape" => column.FilterContext.HeaderCell?.ClearFilterAsync() ?? Task.CompletedTask,
-                _ => Task.CompletedTask
-            };
-        }
-
         private async Task ApplyFilterFromSimpleModeAsync(IFilterDefinition<T> filterDefinition)
         {
             if (FilterDefinitions.All(x => x.Id != filterDefinition.Id))


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/13639.

Typing one character into a `ColumnFilterMenu` value box re-rendered the entire grid — every row, every header cell, every popover — even though that mode does not apply the filter until its **Filter** button is pressed. On a wide or long grid that is the reported "very laggy, like there's no debounce" typing.

`Filter(...)` is a render fragment owned by `MudDataGrid`, so its event bindings compiled with the grid as the callback receiver, and `ComponentBase`'s `IHandleEvent` implementation called `StateHasChanged()` on the grid for each one. A real keystroke hit that twice — once via `ValueChanged`, once via `OnKeyDown`. Both now build their callbacks with the `Filter<T>` as receiver, which is not `IHandleEvent`, so the automatic render is skipped:

- The Enter/Escape shortcut handler moves onto `Filter<T>`. Those two keys are unaffected — `ApplyFilterAsync` and `ClearFilterAsync` (via `RemoveFilterAsync` → `GroupItems`) refresh the grid themselves — and every other key now costs nothing.
- `ApplyChangesAsync` also stops calling `GroupItems()` for a definition the grid has not applied. Only `FilterDefinitions` feeds the rows and `HasFilter`, so an unapplied value cannot change anything on screen.

Cost of one keystroke (keydown + input), measured with a bUnit bench over repeated re-renders on desktop .NET; WASM is far slower:

| rows × cols | before | after |
| --- | --- | --- |
| 250 × 6 | 45 ms / 70 MB | ~0 / 0.4 KB |
| 250 × 25 | 485 ms / 880 MB | ~0 / 0.4 KB |
| 1000 × 25 | 2369 ms / 3.4 GB | ~0 / 0.4 KB |

Behaviour is unchanged, checked in a real browser against builds with and without this change: typing leaves the rows alone, Filter applies, reopening an applied filter and retyping updates rows live, Clear restores, and real Enter/Escape key events apply and clear then close the menu. Tests cover the typing, Enter/Escape, and applied-filter-editing paths; the typing one drives keydown and input through the rendered input and fails without the change. 327 DataGrid tests pass.

Worth noting for the issue itself: this is **not** a 9.5.0 → 9.8.0 regression. Per-render cost measured 19827 / 19828 / 19827 / 20006 KB at v9.5.0 / v9.6.0 / v9.7.0 / v9.8.0 — flat. The cost was always there; this removes it.
