### PR TITLE
MudDataGrid: Reduce per-cell allocations on every render

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellValueReadsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridCellValueReadsTest.razor
@@ -1,0 +1,52 @@
+﻿<MudDataGrid T="Item" Items="@_items">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" />
+        <PropertyColumn Property="x => x.Number" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Used to verify a cell reads its bound property only once per render";
+
+    public int Reads { get; set; }
+
+    private readonly List<Item> _items = new();
+
+    protected override void OnInitialized()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            _items.Add(new Item(this, i));
+        }
+    }
+
+    public class Item
+    {
+        private readonly DataGridCellValueReadsTest _owner;
+        private readonly int _index;
+
+        public Item(DataGridCellValueReadsTest owner, int index)
+        {
+            _owner = owner;
+            _index = index;
+        }
+
+        public string Name
+        {
+            get
+            {
+                _owner.Reads++;
+                return $"Name{_index}";
+            }
+        }
+
+        public int Number
+        {
+            get
+            {
+                _owner.Reads++;
+                return _index;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1543,6 +1543,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A cell must read its bound property exactly once per render; the value is used by several
+        /// render paths and re-reading it invokes the compiled property expression again.
+        /// </summary>
+        [Test]
+        public void DataGridCell_ReadsBoundPropertyOncePerRender()
+        {
+            var comp = Context.Render<DataGridCellValueReadsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellValueReadsTest.Item>>();
+
+            // 3 rows x 2 property columns.
+            const int CellCount = 6;
+
+            comp.Instance.Reads = 0;
+            dataGrid.Render();
+
+            comp.Instance.Reads.Should().Be(CellCount, "each cell should read its property once per render");
+        }
+
+        /// <summary>
         /// When CellContextMenuClick has a delegate, right-clicking a td fires CellContextMenuClick and
         /// stopPropagation prevents RowContextMenuClick from also firing.
         /// </summary>
@@ -5213,16 +5232,16 @@ namespace MudBlazor.UnitTests.Components
             var column = dataGrid.Instance.RenderedColumns.First();
             var cell = new Cell<DataGridCellContextTest.Model>(dataGrid.Instance, column, item, item);
 
-            cell._cellContext.Selected.Should().Be(false);
-            await cell._cellContext.Actions.SetSelectedItemAsync(true);
-            cell._cellContext.Selected.Should().Be(true);
+            cell.Context.Selected.Should().Be(false);
+            await cell.Context.Actions.SetSelectedItemAsync(true);
+            cell.Context.Selected.Should().Be(true);
 
-            await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
-            cell._cellContext.OpenHierarchies.Should().Contain(item);
-            cell._cellContext.Open.Should().Be(true);
-            await cell._cellContext.Actions.ToggleHierarchyVisibilityForItemAsync();
-            cell._cellContext.OpenHierarchies.Should().NotContain(item);
-            cell._cellContext.Open.Should().Be(false);
+            await cell.Context.Actions.ToggleHierarchyVisibilityForItemAsync();
+            cell.Context.OpenHierarchies.Should().Contain(item);
+            cell.Context.Open.Should().Be(true);
+            await cell.Context.Actions.ToggleHierarchyVisibilityForItemAsync();
+            cell.Context.OpenHierarchies.Should().NotContain(item);
+            cell.Context.Open.Should().Be(false);
         }
 
         [Test]

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -27,8 +27,7 @@ namespace MudBlazor
         /// The cell's value.
         /// </summary>
         /// <remarks>
-        /// <see cref="Column{T}.CellContent"/> invokes a compiled property expression and boxes value types, so the result is
-        /// cached for the lifetime of this cell, which is a single render.
+        /// <see cref="Column{T}.CellContent"/> invokes a compiled property expression and boxes value types, so the result is cached for the lifetime of this cell, which is a single render.
         /// </remarks>
         internal object? ComputedValue
         {
@@ -67,6 +66,7 @@ namespace MudBlazor
             get
             {
                 var cellStyle = _column.CellStyleFunc?.Invoke(_item);
+
                 // Most cells style nothing, and StyleBuilder would return an empty string anyway.
                 if (cellStyle is null && _column.CellStyle is null)
                 {

--- a/src/MudBlazor/Components/DataGrid/Cell.cs
+++ b/src/MudBlazor/Components/DataGrid/Cell.cs
@@ -12,21 +12,45 @@ namespace MudBlazor
     {
         private readonly MudDataGrid<T> _dataGrid;
         private readonly Column<T> _column;
+        private readonly T _sourceItem;
+        private CellContext<T>? _cellContext;
+        private object? _computedValue;
+        private bool _hasComputedValue;
         internal T _item;
         internal string? _valueString;
         internal double? _valueNumber;
         internal bool _editing;
-        internal CellContext<T> _cellContext;
 
         #region Computed Properties
 
+        /// <summary>
+        /// The cell's value.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Column{T}.CellContent"/> invokes a compiled property expression and boxes value types, so the result is
+        /// cached for the lifetime of this cell, which is a single render.
+        /// </remarks>
         internal object? ComputedValue
         {
             get
             {
-                return _column.CellContent(_item);
+                if (!_hasComputedValue)
+                {
+                    _computedValue = _column.CellContent(_item);
+                    _hasComputedValue = true;
+                }
+
+                return _computedValue;
             }
         }
+
+        /// <summary>
+        /// The state and actions passed to this cell's template.
+        /// </summary>
+        /// <remarks>
+        /// Only templates read this, so it is built on demand rather than for every cell of every render.
+        /// </remarks>
+        internal CellContext<T> Context => _cellContext ??= new CellContext<T>(_dataGrid, _item, _sourceItem);
 
         internal string ComputedClass =>
             new CssBuilder("mud-table-cell")
@@ -38,11 +62,23 @@ namespace MudBlazor
                 .AddClass(_column.CellClass)
                 .Build();
 
-        internal string ComputedStyle =>
-            new StyleBuilder()
-                .AddStyle(_column.CellStyleFunc?.Invoke(_item))
-                .AddStyle(_column.CellStyle)
-                .Build();
+        internal string ComputedStyle
+        {
+            get
+            {
+                var cellStyle = _column.CellStyleFunc?.Invoke(_item);
+                // Most cells style nothing, and StyleBuilder would return an empty string anyway.
+                if (cellStyle is null && _column.CellStyle is null)
+                {
+                    return string.Empty;
+                }
+
+                return new StyleBuilder()
+                    .AddStyle(cellStyle)
+                    .AddStyle(_column.CellStyle)
+                    .Build();
+            }
+        }
 
         #endregion
 
@@ -51,11 +87,9 @@ namespace MudBlazor
             _dataGrid = dataGrid;
             _column = column;
             _item = item;
+            _sourceItem = sourceItem;
 
             OnStartedEditingItem();
-
-            // Create the CellContext with both the effective item and source item
-            _cellContext = new CellContext<T>(_dataGrid, _item, sourceItem);
         }
 
         public async Task StringValueChangedAsync(string? value)
@@ -65,6 +99,7 @@ namespace MudBlazor
                 await _dataGrid.BeginCellEditAsync(_item);
 
             _column.SetProperty(_item, value);
+            _hasComputedValue = false;
 
             if (_dataGrid.EditMode == DataGridEditMode.Cell)
                 await _dataGrid.CommitItemChangesAsync(_item);
@@ -77,6 +112,7 @@ namespace MudBlazor
                 await _dataGrid.BeginCellEditAsync(_item);
 
             _column.SetProperty(_item, value);
+            _hasComputedValue = false;
 
             if (_dataGrid.EditMode == DataGridEditMode.Cell)
                 await _dataGrid.CommitItemChangesAsync(_item);
@@ -84,12 +120,13 @@ namespace MudBlazor
 
         private void OnStartedEditingItem()
         {
-            if (ComputedValue is null)
+            var computedValue = ComputedValue;
+            if (computedValue is null)
             {
                 return;
             }
 
-            if (ComputedValue is JsonElement element)
+            if (computedValue is JsonElement element)
             {
                 if (_column.dataType == typeof(string))
                 {
@@ -104,11 +141,11 @@ namespace MudBlazor
             {
                 if (_column.dataType == typeof(string))
                 {
-                    _valueString = (string)ComputedValue;
+                    _valueString = (string)computedValue;
                 }
                 else if (_column.isNumber)
                 {
-                    _valueNumber = Convert.ToDouble(ComputedValue);
+                    _valueNumber = Convert.ToDouble(computedValue);
                 }
             }
         }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -319,7 +319,7 @@
 
                         if (column.EditTemplate != null)
                         {
-                            @column.EditTemplate(cell._cellContext)
+                            @column.EditTemplate(cell.Context)
                         }
                         else
                         {
@@ -426,7 +426,7 @@
                      <CascadingValue TValue="Interfaces.IForm" Value="@(isInlineEditing ? _inlineEditValidator : Validator)" IsFixed="true">
                          @if (column.EditTemplate is not null)
                          {
-                             @column.EditTemplate(cell._cellContext)
+                             @column.EditTemplate(cell.Context)
                          }
                          else
                          {
@@ -456,7 +456,7 @@
                  {
                      if (cellTemplate is not null)
                      {
-                         @cellTemplate(cell._cellContext)
+                         @cellTemplate(cell.Context)
                      }
                      else if (column.Culture is not null && column.isNumber)
                      {


### PR DESCRIPTION
`Cell<T>` is constructed for every cell of every render, and its constructor did work most cells never needed.

**The bound property was read up to four times per cell per render.** `Column<T>.CellContent` invokes a compiled property expression and boxes value types. `OnStartedEditingItem` read the `ComputedValue` property two or three separate times (null check, `JsonElement` check, then the cast or `Convert.ToDouble`), and the render path read it once more. Cached for the lifetime of the cell, which is a single render; a write through `StringValueChangedAsync` / `NumberValueChangedAsync` invalidates it.

**`CellContext<T>` was built eagerly, but only templates read it.** It allocates a `CellActions` with six lambdas, five of them capturing, so a cell with no `CellTemplate` or `EditTemplate` paid roughly eleven allocations for an object nothing touched. It is now built on demand. The field `_cellContext` becomes the `Context` property.

**`ComputedStyle` allocated a `StyleBuilder`** even when the column had neither `CellStyleFunc` nor `CellStyle` — the case where `Build()` returns an empty string anyway.

Measured on a 50-row grid, 20 re-renders, counting invocations of the bound property getter:

| | property reads per cell per render |
|---|---|
| dev | 4 (plain property column), 3 (with `Culture`) |
| this PR | 1 |

Rendered markup is unchanged: captured before and after on a grid covering plain, `Culture`, `Format` and template columns, normalised for the non-deterministic element ids, and compared byte for byte (42,200 chars, identical).