### PR TITLE
MudDatePicker: Fix Text becoming null instead of empty after clearing

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -187,17 +187,14 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// The clear button leaves Text as an empty string even when the SetDateAsync debounce window has already
-        /// elapsed between the input clearing its text and the picker running ClearAsync.
+        /// The clear button leaves Text as an empty string even when the SetDateAsync debounce window has already elapsed between the input clearing its text and the picker running ClearAsync.
         /// </summary>
         [Test]
         public async Task DatePicker_Should_Clear_WhenDebounceWindowElapsed()
         {
             var timeProvider = Context.AddFakeTimeProvider();
-            // A single clear-button click reaches SetDateAsync twice: once from the input emptying its text, and
-            // once from ClearAsync.
-            // On a loaded machine the second call can land after the 100ms debounce window, which used to overwrite
-            // the already-empty Text with null.
+            // A single clear-button click reaches SetDateAsync twice: once from the input emptying its text, and once from ClearAsync.
+            // On a loaded machine the second call can land after the 100ms debounce window, which used to overwrite the already-empty Text with null.
             // Auto-advancing the clock on every read reproduces that slow machine deterministically.
             timeProvider.AutoAdvanceAmount = TimeSpan.FromMilliseconds(150);
 

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -186,6 +186,34 @@ namespace MudBlazor.UnitTests.Components
             picker.Date.Should().Be(null);
         }
 
+        /// <summary>
+        /// The clear button leaves Text as an empty string even when the SetDateAsync debounce window has already
+        /// elapsed between the input clearing its text and the picker running ClearAsync.
+        /// </summary>
+        [Test]
+        public async Task DatePicker_Should_Clear_WhenDebounceWindowElapsed()
+        {
+            var timeProvider = Context.AddFakeTimeProvider();
+            // A single clear-button click reaches SetDateAsync twice: once from the input emptying its text, and
+            // once from ClearAsync.
+            // On a loaded machine the second call can land after the 100ms debounce window, which used to overwrite
+            // the already-empty Text with null.
+            // Auto-advancing the clock on every read reproduces that slow machine deterministically.
+            timeProvider.AutoAdvanceAmount = TimeSpan.FromMilliseconds(150);
+
+            var comp = Context.Render<MudDatePicker>();
+            var picker = comp.Instance;
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.Clearable, true)
+                .Add(p => p.Date, new DateTime(2020, 10, 26)));
+            picker.Date.Should().Be(new DateTime(2020, 10, 26));
+
+            await comp.Find(".mud-input-clear-button").ClickAsync();
+
+            picker.Text.Should().Be("");
+            picker.Date.Should().Be(null);
+        }
+
         [Test]
         public async Task DataPicker_ShouldClearText_WhenDateSetNull()
         {

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -63,11 +63,10 @@ namespace MudBlazor
 
             // When the _value is null and an invalid date is entered into the UI, the data value passed to this method
             // will be null. We need to check if the text has been set my the user and if so handle tha validation
-            // without this the UI doesn't display a validation error correctly.
+            // without this the UI doesn't display a validation error correctly
             // Empty text is not user input that failed to convert, so it must not re-enter this branch.
-            // A clear-button click empties the text before ClearAsync runs, so re-entering here would overwrite
-            // Text with null whenever the debounce window above had already closed, leaving the observable result
-            // dependent on the wall clock.
+            // A clear-button click empties the text before ClearAsync runs, so re-entering would overwrite Text with null once the debounce window above had closed.
+            // That would leave the observable result dependent on the wall clock.
             if (_value != date || (date is null && !string.IsNullOrEmpty(Text)))
             {
                 if (!suppressInteraction)

--- a/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDatePicker.cs
@@ -63,8 +63,12 @@ namespace MudBlazor
 
             // When the _value is null and an invalid date is entered into the UI, the data value passed to this method
             // will be null. We need to check if the text has been set my the user and if so handle tha validation
-            // without this the UI doesn't display a validation error correctly
-            if (_value != date || (date is null && Text != null))
+            // without this the UI doesn't display a validation error correctly.
+            // Empty text is not user input that failed to convert, so it must not re-enter this branch.
+            // A clear-button click empties the text before ClearAsync runs, so re-entering here would overwrite
+            // Text with null whenever the debounce window above had already closed, leaving the observable result
+            // dependent on the wall clock.
+            if (_value != date || (date is null && !string.IsNullOrEmpty(Text)))
             {
                 if (!suppressInteraction)
                 {


### PR DESCRIPTION
A single clear-button click reaches `SetDateAsync` twice: once from the input emptying its own text, once from `ClearAsync`. By the second call the value is already `null`, so the 100ms `DebounceTimeoutMs` wall clock decided the outcome — inside the window it returned early and `Text` stayed `""`; outside it, `(date is null && Text != null)` matched the empty string and overwrote `Text` with `null`.

Empty text can never be user input that failed to convert: the converter returns a successful null for it, and only non-empty text can throw. Narrowing the guard to `!string.IsNullOrEmpty(Text)` makes the second call a no-op either way. Not `IsNullOrWhiteSpace` — `ConvertBack(" ")` throws, so a lone space must stay clearable.

Reviewer notes:

- Not test-only. `await ElementReference.FocusAsync()` sits between the two calls, so on Blazor Server the round-trip can exceed the window and yield `null` where WASM yields `""`. This converges them on `""`, asserted since #4854.
- When value and text are already empty, the redundant `DateChanged(null)`/`FieldChanged(null)` no longer re-fire. Validation still runs.
- The "erase invalid text down to empty" flow now reaches #12695's `else if (forceUpdate)` branch, which runs `ResetConverterErrors()`.
- No sibling picker is affected; `DebounceTimeoutMs` appears nowhere else.

The new test pins the previously untested timing branch with `FakeTimeProvider.AutoAdvanceAmount = 150ms`. It fails on `dev` with the reported message and passes with the fix.