### PR TITLE
MudColorPicker: Fix ClearAsync not clearing the color

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1937,5 +1937,45 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().Contain(comp.Instance.ClearIcon);
         }
+
+        /// <summary>
+        /// Calling ClearAsync programmatically clears the color, not just the popover.
+        /// </summary>
+        [Test]
+        public async Task ColorPicker_ClearAsync_ShouldClearValue()
+        {
+            var color = new MudColor("#180f6fff");
+            var comp = Context.Render<MudColorPicker>(parameters => parameters
+                .Add(p => p.Value, color)
+                .Add(p => p.Clearable, true));
+            var picker = comp.Instance;
+
+            await comp.InvokeAsync(() => picker.ClearAsync());
+
+            picker.ReadValue.Should().BeNull();
+            picker.GetState(x => x.Text).Should().BeNull();
+            comp.Find("input").GetAttribute("value").Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// The clear button clears the color through the text channel rather than through ClearAsync, and reports null text where the date and time pickers report an empty string.
+        /// </summary>
+        [Test]
+        public async Task ColorPicker_ClearButton_ShouldClearValueAndReportNullText()
+        {
+            var textChanges = new List<string>();
+            var comp = Context.Render<MudColorPicker>(parameters => parameters
+                .Add(p => p.Value, new MudColor("#180f6fff"))
+                .Add(p => p.TextChanged, text => textChanges.Add(text))
+                .Add(p => p.Clearable, true));
+            var picker = comp.Instance;
+
+            await comp.Find(".mud-input-clear-button").ClickAsync();
+
+            picker.ReadValue.Should().BeNull();
+            picker.GetState(x => x.Text).Should().BeNull();
+            textChanges.Should().Equal(["#180f6fff", null]); // the initial color, then the clear
+            comp.Find("input").GetAttribute("value").Should().BeNullOrEmpty();
+        }
     }
 }

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -464,6 +464,19 @@ namespace MudBlazor
             }
         }
 
+        /// <inheritdoc />
+        public override async Task ClearAsync(bool close = true)
+        {
+            // The base implementation only closes the popover, so without this override the public API cleared nothing.
+            // The clear button appeared to work only because it pushes an empty string up the text channel first.
+            if (_valueState.Value is not null)
+            {
+                await SetColorAsync(null);
+            }
+
+            await base.ClearAsync(close);
+        }
+
         protected override async Task SetTextAsync(string? value, bool callback)
         {
             if (callback)

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -467,8 +467,6 @@ namespace MudBlazor
         /// <inheritdoc />
         public override async Task ClearAsync(bool close = true)
         {
-            // The base implementation only closes the popover, so without this override the public API cleared nothing.
-            // The clear button appeared to work only because it pushes an empty string up the text channel first.
             if (_valueState.Value is not null)
             {
                 await SetColorAsync(null);


### PR DESCRIPTION
`MudColorPicker` never overrode `ClearAsync`, so it resolved to `MudPicker.ClearAsync`, whose entire body closes the popover. `Value`, the text state and `Touched` were left untouched, and `ClearAsync(close: false)` was a complete no-op.

The clear button appeared to work only by a side path: `MudInput.HandleClearButtonAsync` pushes an empty string up the text channel first, which reaches `SetInputStringAsync` and clears the color before `ClearAsync` ever runs. `ResetValueAsync` cleared it too, so `Clear` and `Reset` disagreed on this one component.

The override is guarded on the value already being null, so a clear-button click does not run validation a second time.

Two tests added — the component had no clear coverage of any kind.
