### PR TITLE
MudDateRangePicker: Fix Text not tracking user input

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -799,6 +799,68 @@ namespace MudBlazor.UnitTests.Components
             picker.DateRange.Should().BeNull();
         }
 
+        /// <summary>
+        /// The clear button clears Text along with DateRange and both visible inputs, and tells a bound consumer.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_ClearButton_ShouldClearText()
+        {
+            var textChanges = new List<string>();
+            var comp = Context.Render<MudDateRangePicker>();
+            var picker = comp.Instance;
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.Clearable, true)
+                .Add(p => p.TextChanged, text => textChanges.Add(text))
+                .Add(p => p.DateRange, new DateRange(new DateTime(2020, 10, 26), new DateTime(2020, 10, 29))));
+
+            var rangeText = RangeUtility.Join(new DateTime(2020, 10, 26).ToShortDateString(), new DateTime(2020, 10, 29).ToShortDateString());
+            picker.Text.Should().Be(rangeText);
+            textChanges.Should().Equal(rangeText);
+
+            await comp.Find(".mud-input-clear-button").ClickAsync();
+
+            picker.DateRange.Should().BeNull();
+            comp.FindAll("input").Should().AllSatisfy(input => input.GetAttribute("value").Should().BeNullOrEmpty());
+            picker.Text.Should().BeNull();
+            textChanges.Should().Equal(rangeText, null);
+        }
+
+        /// <summary>
+        /// Calling ClearAsync directly clears Text as well as DateRange, unlike the clear button.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_ClearAsync_ShouldClearTextAndDateRange()
+        {
+            var comp = Context.Render<MudDateRangePicker>();
+            var picker = comp.Instance;
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.DateRange, new DateRange(new DateTime(2020, 10, 26), new DateTime(2020, 10, 29))));
+            picker.Text.Should().NotBeNull();
+
+            await comp.InvokeAsync(() => picker.ClearAsync());
+
+            picker.DateRange.Should().BeNull();
+            picker.Text.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Typing a range into the inputs updates Text as well as DateRange, even though the range input binds its Value rather than its Text.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_TypedRange_ShouldUpdateText()
+        {
+            var start = new DateTime(2020, 10, 26);
+            var end = new DateTime(2020, 10, 29);
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters.Add(p => p.Editable, true));
+            var picker = comp.Instance;
+
+            await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
+            await comp.FindAll("input")[1].ChangeAsync(end.ToShortDateString());
+
+            picker.DateRange.Should().Be(new DateRange(start, end));
+            picker.Text.Should().Be(RangeUtility.Join(start.ToShortDateString(), end.ToShortDateString()));
+        }
+
         [Test]
         public async Task OnPointerOver_ShouldCallJavaScriptFunction()
         {

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -861,6 +861,26 @@ namespace MudBlazor.UnitTests.Components
             picker.Text.Should().Be(RangeUtility.Join(start.ToShortDateString(), end.ToShortDateString()));
         }
 
+        /// <summary>
+        /// Setting DateRange to null clears text that failed to convert, which is the only way out of the conversion error.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_ShouldClearInvalidText_WhenDateRangeSetNull()
+        {
+            const string Invalid = "INVALID_RANGE";
+            var comp = Context.Render<MudDateRangePicker>();
+            var picker = comp.Instance;
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, Invalid));
+            picker.DateRange.Should().BeNull();
+            picker.Text.Should().Be(Invalid);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DateRange, null));
+
+            picker.DateRange.Should().BeNull();
+            picker.Text.Should().BeNull();
+        }
+
         [Test]
         public async Task OnPointerOver_ShouldCallJavaScriptFunction()
         {

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -800,6 +800,87 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Two edits that overlap inside a yielding TextChanged handler still leave Text and DateRange describing the same edit.
+        /// </summary>
+        [Test]
+        [CancelAfter(20000)]
+        public async Task DateRangePicker_OverlappingEdits_ShouldKeepTextAndDateRangeInStep()
+        {
+            var start = new DateTime(2020, 10, 26);
+            var comp = await RenderGatedRangePicker(gateTextChanged: true, out var gate, out var arm);
+            var picker = comp.Instance;
+            await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
+
+            // Hold the first end-date edit inside its callback, then let a second one overtake it.
+            arm();
+            await comp.FindAll("input")[1].ChangeAsync(new DateTime(2020, 10, 29).ToShortDateString());
+            await comp.FindAll("input")[1].ChangeAsync(new DateTime(2020, 10, 30).ToShortDateString());
+            gate.SetResult();
+
+            await comp.WaitForAssertionAsync(() => picker.DateRange.Should().Be(new DateRange(start, new DateTime(2020, 10, 30))));
+            picker.Text.Should().Be(RangeUtility.Join(start.ToShortDateString(), new DateTime(2020, 10, 30).ToShortDateString()));
+        }
+
+        /// <summary>
+        /// An edit superseded while its DateRangeChanged handler yields does not write its stale text over the newer edit.
+        /// </summary>
+        [Test]
+        [CancelAfter(20000)]
+        public async Task DateRangePicker_SupersededEdit_ShouldNotOverwriteNewerText()
+        {
+            var start = new DateTime(2020, 10, 26);
+            var comp = await RenderGatedRangePicker(gateTextChanged: false, out var gate, out var arm);
+            var picker = comp.Instance;
+            await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
+
+            arm();
+            await comp.FindAll("input")[1].ChangeAsync(new DateTime(2020, 10, 29).ToShortDateString());
+            await comp.FindAll("input")[1].ChangeAsync(new DateTime(2020, 10, 30).ToShortDateString());
+            gate.SetResult();
+
+            await comp.WaitForAssertionAsync(() => picker.DateRange.Should().Be(new DateRange(start, new DateTime(2020, 10, 30))));
+            picker.Text.Should().Be(RangeUtility.Join(start.ToShortDateString(), new DateTime(2020, 10, 30).ToShortDateString()));
+        }
+
+        /// <summary>
+        /// Renders an editable range picker whose TextChanged or DateRangeChanged handler blocks on a gate the first time it is armed.
+        /// </summary>
+        /// <param name="gateTextChanged">When <c>true</c> the gate sits on TextChanged; otherwise it sits on DateRangeChanged.</param>
+        /// <param name="gate">Receives the gate to release once both edits have been dispatched.</param>
+        /// <param name="arm">Receives the action that arms the gate for the next callback only.</param>
+        private Task<IRenderedComponent<MudDateRangePicker>> RenderGatedRangePicker(bool gateTextChanged, out TaskCompletionSource gate, out Action arm)
+        {
+            var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var armed = false;
+            gate = source;
+            arm = () => armed = true;
+
+            async Task WaitIfArmedAsync()
+            {
+                if (armed)
+                {
+                    armed = false;
+                    await source.Task;
+                }
+            }
+
+            var comp = Context.Render<MudDateRangePicker>(parameters =>
+            {
+                parameters.Add(p => p.Editable, true);
+                if (gateTextChanged)
+                {
+                    parameters.Add(p => p.TextChanged, async (string _) => await WaitIfArmedAsync());
+                }
+                else
+                {
+                    parameters.Add(p => p.DateRangeChanged, async (DateRange _) => await WaitIfArmedAsync());
+                }
+            });
+
+            return Task.FromResult(comp);
+        }
+
+        /// <summary>
         /// The clear button clears Text along with DateRange and both visible inputs, and tells a bound consumer.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -126,7 +126,9 @@ namespace MudBlazor
             // Normalize the DateRange before exception is thrown
             range = NormalizeDateRange(range);
 
-            if (_dateRange != range)
+            // Text that fails to convert leaves the range null, so a null assignment looks like a no-op and the bad text would stick.
+            // Run it anyway while text remains, as MudDatePicker does.
+            if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text)))
             {
                 var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
                     .Range(0, int.MaxValue)

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -17,6 +17,7 @@ namespace MudBlazor
         private DateTime? _firstDate, _secondDate, _minValidDate, _maxValidDate;
         private DateRange? _dateRange;
         private Range<string>? _rangeText;
+        private int _rangeTextEdit;
 
         /// <summary>
         /// Creates a new instance.
@@ -193,12 +194,21 @@ namespace MudBlazor
                 _rangeText = value;
                 // The range input binds its Value rather than its Text, so nothing else writes MudPicker.Text on the user-input path.
                 // Without this, Text only tracked programmatic DateRange assignments and went stale on typing and on the clear button.
-                ApplyRangeTextAsync(value).CatchAndLog();
+                ApplyRangeTextAsync(value, ++_rangeTextEdit).CatchAndLog();
 
-                async Task ApplyRangeTextAsync(Range<string>? rangeText)
+                async Task ApplyRangeTextAsync(Range<string>? rangeText, int edit)
                 {
-                    await SetTextAsync(rangeText is null ? null : RangeUtility.Join(rangeText.Start, rangeText.End), callback: false);
+                    // The range goes first so it lands before any consumer callback can yield, as it did before Text was written here at all.
                     await SetDateRangeAsync(rangeText is null ? null : ParseDateRangeValue(rangeText.Start, rangeText.End), false);
+
+                    // A handler on that callback can yield long enough for a newer edit to overtake this one.
+                    // Writing Text now would leave it describing an edit the range no longer reflects.
+                    if (edit != _rangeTextEdit)
+                    {
+                        return;
+                    }
+
+                    await SetTextAsync(rangeText is null ? null : RangeUtility.Join(rangeText.Start, rangeText.End), callback: false);
                 }
             }
         }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -189,7 +189,15 @@ namespace MudBlazor
 
                 Touched = true;
                 _rangeText = value;
-                SetDateRangeAsync(value is null ? null : ParseDateRangeValue(value.Start, value.End), false).CatchAndLog();
+                // The range input binds its Value rather than its Text, so nothing else writes MudPicker.Text on the user-input path.
+                // Without this, Text only tracked programmatic DateRange assignments and went stale on typing and on the clear button.
+                ApplyRangeTextAsync(value).CatchAndLog();
+
+                async Task ApplyRangeTextAsync(Range<string>? rangeText)
+                {
+                    await SetTextAsync(rangeText is null ? null : RangeUtility.Join(rangeText.Start, rangeText.End), callback: false);
+                    await SetDateRangeAsync(rangeText is null ? null : ParseDateRangeValue(rangeText.Start, rangeText.End), false);
+                }
             }
         }
 


### PR DESCRIPTION
Two related fixes to the range picker's text handling, one per commit.

**Text not tracking user input.** The range picker binds `MudRangeInput`'s `Value` rather than its `Text`, so unlike the base picker nothing wrote `MudPicker.Text` on the user-input path. `Text` only ever tracked programmatic `DateRange` assignments: typing a range left it `null`, and the clear button left it holding the range that had just been cleared, with `TextChanged` never firing so a bound consumer was never told. The `RangeText` setter now writes `Text` before applying the range.

Worth noting for review: wiring `OnClearButtonClick` on the range input would not have fixed this on its own. By the time `ClearAsync` runs the range is already `null`, so its `SetDateRangeAsync` is skipped by the equality guard and `Text` is never rewritten.

**Text that failed to convert could not be cleared.** `SetDateRangeAsync` gated its whole body on the range changing, so assigning `null` while the range was already `null` did nothing — and text that fails to convert leaves the range `null`, making that exact case unreachable. Neither `DateRange = null` nor `ClearAsync` could remove the bad text.

The second commit mirrors the guard `MudDatePicker` has carried since #7866, using the `IsNullOrEmpty` spelling settled in #13665. It is the same decision as https://github.com/MudBlazor/MudBlazor/pull/13668 for `MudTimePicker` — if the pattern is wrong in one, it should come out of both.
