### PR TITLE
MudTimePicker: Clear text that failed to convert

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TimePickerTests.cs
@@ -62,6 +62,62 @@ namespace MudBlazor.UnitTests.Components
             picker.ReadValue.Should().Be(null);
         }
 
+        /// <summary>
+        /// A programmatic clear leaves Text as an empty string, because TimeSpanConverter converts null to string.Empty where the date converter yields null.
+        /// </summary>
+        [Test]
+        public async Task TimePicker_ClearAsync_ShouldLeaveEmptyText()
+        {
+            var comp = Context.Render<MudTimePicker>(parameters => parameters.Add(p => p.Time, new TimeSpan(10, 30, 0)));
+            var picker = comp.Instance;
+            picker.Text.Should().Be("10:30");
+
+            await comp.InvokeAsync(() => picker.ClearAsync());
+
+            picker.ReadValue.Should().BeNull();
+            picker.Text.Should().Be("");
+        }
+
+        /// <summary>
+        /// Setting Time to null clears text that failed to convert, which is the only way out of the conversion error.
+        /// </summary>
+        [Test]
+        public async Task TimePicker_ShouldClearInvalidText_WhenTimeSetNull()
+        {
+            var comp = Context.Render<MudTimePicker>();
+            var picker = comp.Instance;
+            picker.Text.Should().Be(null);
+            picker.ReadValue.Should().Be(null);
+
+            const string Invalid = "INVALID_TIME";
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Text, Invalid));
+            picker.ReadValue.Should().Be(null);
+            picker.Text.Should().Be(Invalid);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Time, null));
+
+            // TimeSpanConverter converts null to string.Empty, where the date converter would yield null.
+            picker.ReadValue.Should().Be(null);
+            picker.Text.Should().Be("");
+        }
+
+        /// <summary>
+        /// ClearAsync also clears text that failed to convert, even though the value was already null.
+        /// </summary>
+        [Test]
+        public async Task TimePicker_ClearAsync_ShouldClearInvalidText()
+        {
+            const string Invalid = "INVALID_TIME";
+            var comp = Context.Render<MudTimePicker>(parameters => parameters.Add(p => p.Text, Invalid));
+            var picker = comp.Instance;
+            picker.Text.Should().Be(Invalid);
+            picker.ReadValue.Should().Be(null);
+
+            await comp.InvokeAsync(() => picker.ClearAsync());
+
+            picker.Text.Should().Be("");
+        }
+
         [Test]
         public async Task Open_ClickOutside_CheckClosed()
         {

--- a/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
+++ b/src/MudBlazor/Components/TimePicker/MudTimePicker.razor.cs
@@ -159,7 +159,9 @@ namespace MudBlazor
         /// <param name="suppressInteraction">When <c>true</c>, the change is treated as programmatic and does not mark the picker touched or fire <c>FieldChanged</c>.</param>
         protected async Task SetTimeAsync(TimeSpan? time, bool updateValue, bool suppressInteraction = false)
         {
-            if (_value != time)
+            // Text that fails to convert leaves the value null, so a null assignment looks like a no-op and the bad text would stick.
+            // Run it anyway while text remains, as MudDatePicker does.
+            if (_value != time || (time is null && !string.IsNullOrEmpty(Text)))
             {
                 if (!suppressInteraction)
                 {
@@ -169,6 +171,7 @@ namespace MudBlazor
                 _value = time;
                 if (updateValue)
                 {
+                    ResetConverterErrors();
                     await SetTextAsync(ConvertSet(_value), false);
                 }
 


### PR DESCRIPTION
`SetTimeAsync` gated its whole body on the time changing, so assigning `null` while the time was already `null` did nothing. Text that failed to convert leaves the time `null`, which made that exact case unreachable: the bad text stayed on screen and neither `Time = null` nor `ClearAsync` could remove it.

This mirrors the guard `MudDatePicker` has carried since #7866, using the `IsNullOrEmpty` spelling settled in #13665. `ResetConverterErrors` is called on the same path — `MudTimePicker` never called it anywhere — so a stale conversion error no longer outlives the text that caused it.

For review: `TimeSpanConverter` converts `null` to `string.Empty` where the date converter yields `null`, so a cleared time picker reports `Text` as `""`. A test copied from the `MudDatePicker` equivalent would fail on that difference; the assertion here carries a comment saying why.

Same decision as https://github.com/MudBlazor/MudBlazor/pull/13667 for `MudDateRangePicker` — if the pattern is wrong in one, it should come out of both.
