### PR TITLE
MudDataGrid: Stop scanning every filtered row for select-all state

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectAllScanTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridSelectAllScanTest.razor
@@ -1,0 +1,47 @@
+﻿<MudDataGrid T="Item" Items="@_items" MultiSelection="true" RowsPerPage="10">
+    <Columns>
+        <SelectColumn T="Item" DisabledFunc="@(x => x.Disabled)" />
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+    <PagerContent>
+        <MudDataGridPager T="Item" />
+    </PagerContent>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Used to verify the select-all checkbox does not scan every filtered row";
+
+    public int DisabledFuncCalls { get; set; }
+
+    private readonly List<Item> _items = new();
+
+    protected override void OnInitialized()
+    {
+        for (var i = 0; i < 500; i++)
+        {
+            _items.Add(new Item(this, i));
+        }
+    }
+
+    public class Item
+    {
+        private readonly DataGridSelectAllScanTest _owner;
+
+        public Item(DataGridSelectAllScanTest owner, int index)
+        {
+            _owner = owner;
+            Name = $"Name{index}";
+        }
+
+        public string Name { get; }
+
+        public bool Disabled
+        {
+            get
+            {
+                _owner.DisabledFuncCalls++;
+                return false;
+            }
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1576,6 +1576,24 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The select-all checkbox covers every filtered row, so its state must be resolved without walking
+        /// the whole data set on each render.
+        /// </summary>
+        [Test]
+        public void DataGridSelectAll_DoesNotScanEveryFilteredRow()
+        {
+            // 500 items, 10 per page, nothing selected.
+            var comp = Context.Render<DataGridSelectAllScanTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSelectAllScanTest.Item>>();
+
+            comp.Instance.DisabledFuncCalls = 0;
+            dataGrid.Render();
+
+            comp.Instance.DisabledFuncCalls.Should().BeLessThan(100,
+                "the select-all state must not be resolved by scanning all 500 filtered rows");
+        }
+
+        /// <summary>
         /// A cell must read its bound property exactly once per render; the value is used by several
         /// render paths and re-reading it invokes the compiled property expression again.
         /// </summary>

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2248,7 +2248,16 @@ namespace MudBlazor
 
         private SelectColumn<T>? GetSelectColumn()
         {
-            return RenderedColumns.OfType<SelectColumn<T>>().FirstOrDefault();
+            // Called once per rendered row, so avoid the LINQ iterator; RenderedColumns is a List and foreach uses its struct enumerator.
+            foreach (var column in RenderedColumns)
+            {
+                if (column is SelectColumn<T> selectColumn)
+                {
+                    return selectColumn;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -2272,15 +2281,40 @@ namespace MudBlazor
         /// <param name="items">The rows the checkbox covers, e.g. all displayed rows for the header checkbox or a group's rows for a group footer checkbox.</param>
         internal bool? GetSelectionState(IEnumerable<T> items)
         {
-            var selectableItems = GetSelectableItems(items).ToList();
-            var selectedCount = selectableItems.Count(Selection.Contains);
-
-            if (selectedCount == 0)
+            // The checkbox covers every filtered row, not just the visible page, so walk the rows once and stop as soon as the answer cannot change.
+            if (Selection.Count == 0)
             {
                 return false;
             }
 
-            return selectedCount == selectableItems.Count ? true : null;
+            var selectColumn = GetSelectColumn();
+            var anySelected = false;
+            var anyUnselected = false;
+
+            foreach (var item in items)
+            {
+                if (IsRowSelectionDisabled(item, selectColumn))
+                {
+                    continue;
+                }
+
+                if (Selection.Contains(item))
+                {
+                    anySelected = true;
+                }
+                else
+                {
+                    anyUnselected = true;
+                }
+
+                if (anySelected && anyUnselected)
+                {
+                    return null;
+                }
+            }
+
+            // No selectable row is selected, or every one of them is.
+            return anySelected;
         }
 
         internal bool? GetRowSelectionState(T item)


### PR DESCRIPTION
`GetSelectionState` covers the whole filtered set, not the visible page, and resolved it in two passes: `ToList()` copied every selectable row into a new list, then `Count()` walked the copy. A 10-row page over 10,000 items did 20,000 operations and allocated a 10,000-element list for one checkbox — again for the footer checkbox when `ShowInFooter` is set — and paid it even with nothing selected, which is how every grid loads.

It now walks the rows once and stops as soon as the answer cannot change, returning early when the selection is empty.

`GetSelectColumn` is on the same path, called once per rendered row via `GetRowSelectionState`, and allocated a LINQ iterator each time. `RenderedColumns` is a `List`, so a `foreach` costs nothing.

Measured with a counter in `SelectColumn.DisabledFunc`, which fires once per item per walk. 500 items, 10 per page, nothing selected, one grid render: **520 → 20 invocations**. The remaining 20 is the per-visible-row cost, which is unavoidable. The win scales with total row count rather than visible row count.

The three outcomes are unchanged — no selectable row selected is `false`, all selected is `true`, anything else is `null`. I checked the rewrite exhaustively against the previous implementation over every combination of selected and disabled rows for 0–6 items: 5,461 cases, 0 mismatches.

`DataGridSelectAll_DoesNotScanEveryFilteredRow` added; it fails on `dev` with 520 against a threshold of 100. Full suite passes (5,693).
