### PR TITLE
MudDataGrid: Stop allocating handlers for events nobody wired

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1561,6 +1561,26 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// With no RowContextMenuClick delegate the rows must carry no context-menu handler, otherwise every row
+        /// registers a DOM listener that does nothing.
+        /// </summary>
+        [Test]
+        public void DataGridRow_WithoutContextMenuDelegate_RegistersNoContextMenuHandler()
+        {
+            // DataGridCellClickBubbleTest wires RowClick and RowContextMenuClick.
+            var withDelegate = Context.Render<DataGridCellClickBubbleTest>();
+            withDelegate.FindAll(".mud-table-body tr")
+                .SelectMany(row => row.Attributes.Select(attribute => attribute.Name))
+                .Should().Contain(name => name.Contains("oncontextmenu"));
+
+            // DataGridCellValueReadsTest wires neither.
+            var withoutDelegate = Context.Render<DataGridCellValueReadsTest>();
+            withoutDelegate.FindAll(".mud-table-body tr")
+                .SelectMany(row => row.Attributes.Select(attribute => attribute.Name))
+                .Should().NotContain(name => name.Contains("oncontextmenu"));
+        }
+
+        /// <summary>
         /// When both cell delegates are supplied the cells must carry the click and context-menu handlers.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1561,8 +1561,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// With no RowContextMenuClick delegate the rows must carry no context-menu handler, otherwise every row
-        /// registers a DOM listener that does nothing.
+        /// With no RowContextMenuClick delegate the rows must carry no context-menu handler, otherwise every row registers a DOM listener that does nothing.
         /// </summary>
         [Test]
         public void DataGridRow_WithoutContextMenuDelegate_RegistersNoContextMenuHandler()

--- a/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
@@ -100,9 +100,7 @@
         return _resolvedItems;
     }
 
-    // ContextRowClick only ever reaches DataGrid.RowContextMenuClick, so without that delegate the handler would be a
-    // no-op that still costs a DOM listener on every row. The lambda lives in its own method so its closure is not
-    // allocated when the branch is not taken.
+    // ContextRowClick only ever reaches DataGrid.RowContextMenuClick, so without that delegate the handler would be a no-op that still costs a DOM listener on every row. The lambda lives in its own method so its closure is not allocated when the branch is not taken.
     private EventCallback<MouseEventArgs> GetContextMenuCallback(IndexBag<T> itemBag)
         => DataGrid.RowContextMenuClick.HasDelegate
             ? CreateContextMenuCallback(itemBag)

--- a/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
@@ -44,7 +44,7 @@
         <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="itemBag.Item"
             @attributes="GetRowAttributes(itemBag.Item)"
             @onclick="@((args) => RowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)))"
-            @oncontextmenu="@((args) => ContextRowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)))"
+            @oncontextmenu="@GetContextMenuCallback(itemBag)"
             @oncontextmenu:preventDefault="@DataGrid.RowContextMenuClick.HasDelegate">
             <CascadingValue Value="@DataGrid.Validator" IsFixed="true">
                 @{
@@ -99,6 +99,17 @@
         }
         return _resolvedItems;
     }
+
+    // ContextRowClick only ever reaches DataGrid.RowContextMenuClick, so without that delegate the handler would be a
+    // no-op that still costs a DOM listener on every row. The lambda lives in its own method so its closure is not
+    // allocated when the branch is not taken.
+    private EventCallback<MouseEventArgs> GetContextMenuCallback(IndexBag<T> itemBag)
+        => DataGrid.RowContextMenuClick.HasDelegate
+            ? CreateContextMenuCallback(itemBag)
+            : default;
+
+    private EventCallback<MouseEventArgs> CreateContextMenuCallback(IndexBag<T> itemBag)
+        => EventCallback.Factory.Create<MouseEventArgs>(this, args => ContextRowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)));
 
     private Dictionary<string, object?>? GetRowAttributes(T item)
     {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2509,15 +2509,23 @@ namespace MudBlazor
             return CellContextMenuClick.InvokeAsync(new DataGridCellClickEventArgs<T>(args, item, rowIndex, columnIndex, column));
         }
 
+        // The lambdas live in their own methods because the compiler allocates a closure on entry to whichever method
+        // declares one, even when the branch that needs it is never taken.
         private EventCallback<MouseEventArgs> GetCellClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
             => CellClick.HasDelegate
-                ? EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellClickedAsync(args, item, rowIndex, colIndex, column))
+                ? CreateCellClickCallback(item, rowIndex, colIndex, column)
                 : default;
+
+        private EventCallback<MouseEventArgs> CreateCellClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
+            => EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellClickedAsync(args, item, rowIndex, colIndex, column));
 
         private EventCallback<MouseEventArgs> GetCellContextMenuClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
             => CellContextMenuClick.HasDelegate
-                ? EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellContextMenuClickedAsync(args, item, rowIndex, colIndex, column))
+                ? CreateCellContextMenuClickCallback(item, rowIndex, colIndex, column)
                 : default;
+
+        private EventCallback<MouseEventArgs> CreateCellContextMenuClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
+            => EventCallback.Factory.Create<MouseEventArgs>(this, args => OnCellContextMenuClickedAsync(args, item, rowIndex, colIndex, column));
 
         /// <summary>
         /// Gets the total count of filtered items in the data grid.


### PR DESCRIPTION
Two places still paid for cell and row events that have no consumer. Follow-up to #13662, which fixed the frames but not these.

**Cell callbacks.** `GetCellClickCallback` / `GetCellContextMenuClickCallback` correctly return `default` when there is no delegate, but the lambda they would otherwise create captures the method's parameters, and the compiler allocates that closure on entry to the declaring method whether or not the branch is taken. Moving the lambda into its own method confines the allocation to the case that needs it.

Measured in isolation with `GC.GetTotalAllocatedBytes(precise: true)`, 100k calls, Release, `HasDelegate = false`:

| shape | bytes/call |
|---|---|
| ternary with inline lambda (current) | 40.0 |
| early return, lambda still in the method | 40.0 |
| lambda moved to its own method | 0.0 |

Worth noting the middle row: an early return does **not** help. Only moving the lambda does. With `HasDelegate = true` both shapes cost the same 104 B, so users of the feature are unaffected. Two calls per cell per render, so 80 B per cell per render on every grid that does not use these events.

**Row context menu.** The `<tr>` registered an `oncontextmenu` handler unconditionally, even though `ContextRowClick` only ever reaches `RowContextMenuClick`. A grid whose consumer wired nothing still got a live DOM listener on every row — the same defect #13662 fixed for cells. Now gated on the same `DataGrid.RowContextMenuClick.HasDelegate` that the neighbouring `:preventDefault` already reads.

Cell markup is unchanged. Rows correctly lose the dead attribute.

`DataGridRow_WithoutContextMenuDelegate_RegistersNoContextMenuHandler` added; it fails on `dev` with `blazor:oncontextmenu` present on every row, and also asserts the handler is still there when the delegate is supplied. Full suite passes (5,693).
