### PR TITLE
MudColorPicker: Clear text that has no value behind it

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorPickerTests.cs
@@ -1939,6 +1939,25 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// ClearAsync clears a picker given Text without a Value, which the original value-only guard skipped.
+        /// </summary>
+        [Test]
+        public async Task ColorPicker_ClearAsync_ShouldClearTextWithoutValue()
+        {
+            var comp = Context.Render<MudColorPicker>(parameters => parameters
+                .Add(p => p.Text, "#180f6fff")
+                .Add(p => p.Clearable, true));
+            var picker = comp.Instance;
+            picker.ReadValue.Should().BeNull();
+            comp.Find("input").GetAttribute("value").Should().Be("#180f6fff");
+
+            await comp.InvokeAsync(() => picker.ClearAsync());
+
+            picker.GetState(x => x.Text).Should().BeNull();
+            comp.Find("input").GetAttribute("value").Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
         /// Calling ClearAsync programmatically clears the color, not just the popover.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
+++ b/src/MudBlazor/Components/ColorPicker/MudColorPicker.razor.cs
@@ -467,7 +467,7 @@ namespace MudBlazor
         /// <inheritdoc />
         public override async Task ClearAsync(bool close = true)
         {
-            if (_valueState.Value is not null)
+            if (_valueState.Value is not null || !string.IsNullOrEmpty(_textState.Value))
             {
                 await SetColorAsync(null);
             }


### PR DESCRIPTION
Follow-up to #13666, from review feedback on that PR.

The guard it added skipped the clear whenever `Value` was null:

```csharp
if (_valueState.Value is not null)
```

`Text` is a parameter in its own right, so `<MudColorPicker Text="#180f6fff" />` with no `Value` is reachable from ordinary markup — the input renders the colour string while `Value` stays null. `ClearAsync` then hit the guard, skipped straight to the base method, and left the text on screen.

Verified before the change:

```
before: ReadValue=null textState=#180f6fff input=#180f6fff
after:  ReadValue=null textState=#180f6fff input=#180f6fff
```

The guard now fires on text as well as value. It still skips the redundant second pass on a clear-button click, because that path nulls both before `ClearAsync` runs.

Worth flagging separately: that state is reachable at all because nothing on `MudColorPicker` parses `Text` into `Value` — `_textState` is registered with no change handler, so a text-only picker shows a colour it does not hold. This PR clears what is displayed; it does not close that gap.
