### PR TITLE
Core: Normalize JavaScript files to utf-8 without a BOM

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -48,7 +48,12 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # JavaScript / TypeScript files
-[*.{js,mjs,ts}]
+# charset is utf-8 without a BOM: the EditorConfig spec discourages utf-8-bom,
+# and unlike C# nothing in this toolchain expects one here.
+# The glob lists every module extension so a new one cannot silently escape the
+# rules the way .mts would have.
+[*.{js,cjs,mjs,ts,cts,mts}]
+charset = utf-8
 indent_size = 4
 end_of_line = lf
 insert_final_newline = true

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -48,11 +48,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # JavaScript / TypeScript files
-# charset is utf-8 without a BOM: the EditorConfig spec discourages utf-8-bom,
-# and unlike C# nothing in this toolchain expects one here.
-# The glob lists every module extension so a new one cannot silently escape the
-# rules the way .mts would have.
 [*.{js,cjs,mjs,ts,cts,mts}]
+# charset is utf-8 without a BOM: the EditorConfig spec discourages utf-8-bom, and unlike C# nothing in this toolchain expects one here.
 charset = utf-8
 indent_size = 4
 end_of_line = lf

--- a/src/MudBlazor.Docs/wwwroot/JS/docs.js
+++ b/src/MudBlazor.Docs/wwwroot/JS/docs.js
@@ -1,8 +1,8 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-//General functions for Docs page 
+//General functions for Docs page
 class MudBlazorDocs {
 
     // return the inner text of the element referenced by given element id
@@ -135,7 +135,7 @@ window.CookieConsent = {
 
     ApplyPreferences: function (categories, services) {
         const activatableScriptTags = document.querySelectorAll("script[type='text/plain']");
-        
+
         activatableScriptTags.forEach(originalScriptElement => {
             const requiredCategory = originalScriptElement.getAttribute("data-consent-category");
 
@@ -190,13 +190,13 @@ window.CookieConsent = {
                     };
 
                     CookieConsent.Data.LoadedScripts.push(loadedScript);
-                    
+
                     CookieConsent.BroadcastEventAll("JsBroadcastEventScriptLoaded", JSON.stringify({
                         AllLoadedScripts: CookieConsent.Data.LoadedScripts,
                         Script: loadedScript
                     }));
                 });
-                
+
                 // Load the script and place it in the DOM
                 if (sourceUri) {
                     newScriptElement.src = sourceUri;
@@ -206,7 +206,7 @@ window.CookieConsent = {
             }
         });
     },
-    
+
     ReadLoadedScripts: function () {
         return JSON.stringify(CookieConsent.Data.LoadedScripts);
     },
@@ -220,7 +220,7 @@ window.CookieConsent = {
     RegisterBroadcastReceiver: function (context, isWasm) {
         if (typeof window.CookieConsentContext === 'undefined') {
             console.log("CookieConsent: Creating default value for window.CookieConsentContext.Broadcasting")
-            
+
             window.CookieConsentContext = {
                 Broadcasting: {
                     ServerContext: null,
@@ -231,11 +231,11 @@ window.CookieConsent = {
 
         if (isWasm) {
             console.log("CookieConsent: Registered context for WASM");
-            
+
             window.CookieConsentContext.Broadcasting.WasmContext = context;
         } else {
             console.log("CookieConsent: Registered context for Server");
-            
+
             window.CookieConsentContext.Broadcasting.ServerContext = context;
         }
     },

--- a/src/MudBlazor/TScripts/mudAAAlicense.js
+++ b/src/MudBlazor/TScripts/mudAAAlicense.js
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
  * MudBlazor (https://mudblazor.com/)
  * Copyright (c) 2021 MudBlazor
  * Licensed under MIT (https://github.com/MudBlazor/MudBlazor/blob/master/LICENSE)

--- a/src/MudBlazor/TScripts/mudDragAndDrop.js
+++ b/src/MudBlazor/TScripts/mudDragAndDrop.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudInput.js
+++ b/src/MudBlazor/TScripts/mudInput.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudJsEvent.js
+++ b/src/MudBlazor/TScripts/mudJsEvent.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudKeyInterceptor.js
+++ b/src/MudBlazor/TScripts/mudKeyInterceptor.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudPointerEventsNone.js
+++ b/src/MudBlazor/TScripts/mudPointerEventsNone.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudPopover.js
+++ b/src/MudBlazor/TScripts/mudPopover.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudResizeListener.js
+++ b/src/MudBlazor/TScripts/mudResizeListener.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudResizeObserver.js
+++ b/src/MudBlazor/TScripts/mudResizeObserver.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudScrollListener.js
+++ b/src/MudBlazor/TScripts/mudScrollListener.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudScrollManager.js
+++ b/src/MudBlazor/TScripts/mudScrollManager.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudScrollSpy.js
+++ b/src/MudBlazor/TScripts/mudScrollSpy.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudSplitPanel.js
+++ b/src/MudBlazor/TScripts/mudSplitPanel.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudTableCell.js
+++ b/src/MudBlazor/TScripts/mudTableCell.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudThemeProvider.js
+++ b/src/MudBlazor/TScripts/mudThemeProvider.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudTimePicker.js
+++ b/src/MudBlazor/TScripts/mudTimePicker.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor/TScripts/mudWindow.js
+++ b/src/MudBlazor/TScripts/mudWindow.js
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 


### PR DESCRIPTION
Follows #13672, which did the same for SCSS.

19 of the 30 tracked JS files carry a UTF-8 BOM, two lack a final newline, one has trailing whitespace.

`[*.{js,mjs,ts}]` declared no charset at all, so the BOMs were violating nothing. This adds `charset = utf-8` and brings the files in line with it — the spec discourages `utf-8-bom`, and unlike C# nothing here expects one. The glob is also widened to `{js,cjs,mjs,ts,cts,mts}`; `.mts` and `.cts` matched nothing before.

No functional change. `MudBlazor.min.js` is byte-identical either way, since Bun strips a BOM while bundling. `docs.js` is served raw rather than bundled, so it was checked in a browser instead: loads clean, all its globals present.