### PR TITLE
MudDataGrid: Remove dead field that renders every header cell twice

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHeaderRenderOnSelectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHeaderRenderOnSelectionTest.razor
@@ -1,0 +1,35 @@
+﻿<MudDataGrid T="Item" Items="@_items" MultiSelection="true" SelectOnRowClick="true">
+    <Columns>
+        <SelectColumn T="Item" />
+        <PropertyColumn Property="x => x.Name">
+            <HeaderTemplate>
+                @{ HeaderRenders++; }
+                <span>Name</span>
+            </HeaderTemplate>
+        </PropertyColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Used to verify header cells render once per selection change";
+
+    public int HeaderRenders { get; set; }
+
+    private readonly List<Item> _items = new()
+    {
+        new Item("A"),
+        new Item("B"),
+        new Item("C"),
+        new Item("D")
+    };
+
+    public class Item
+    {
+        public Item(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1613,6 +1613,33 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A selection change must render each header cell once; the grid's own StateHasChanged already covers them.
+        /// </summary>
+        [Test]
+        public async Task DataGridHeaderCell_RendersOncePerSelectionChange()
+        {
+            var comp = Context.Render<DataGridHeaderRenderOnSelectionTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHeaderRenderOnSelectionTest.Item>>();
+            var item = dataGrid.Instance.Items.First();
+
+            comp.Instance.HeaderRenders = 0;
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectedItemAsync(true, item));
+            comp.Instance.HeaderRenders.Should().Be(1, "selecting a row should render the header once");
+
+            comp.Instance.HeaderRenders = 0;
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectAllAsync(true));
+            comp.Instance.HeaderRenders.Should().Be(1, "select-all should render the header once");
+
+            // The header must still reflect the new state, so the test cannot pass by rendering zero times.
+            comp.FindAll("thead input[type=checkbox]")[0].IsChecked().Should().BeTrue();
+
+            comp.Instance.HeaderRenders = 0;
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSelectAllAsync(false));
+            comp.Instance.HeaderRenders.Should().Be(1, "deselect-all should render the header once");
+            comp.FindAll("thead input[type=checkbox]")[0].IsChecked().Should().BeFalse();
+        }
+
+        /// <summary>
         /// A cell must read its bound property exactly once per render; the value is used by several
         /// render paths and re-reading it invokes the compiled property expression again.
         /// </summary>

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -18,7 +18,6 @@ namespace MudBlazor
     /// <seealso cref="MudDataGrid{T}"/>
     public partial class HeaderCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T> : MudComponentBase, IDisposable
     {
-        private bool _selected;
         private bool _isResizing;
         private double? _resizerHeight;
         private bool _filtersMenuVisible;
@@ -260,8 +259,6 @@ namespace MudBlazor
             if (DataGrid != null)
             {
                 DataGrid.SortChangedEvent += OnGridSortChanged;
-                DataGrid.SelectedAllItemsChangedEvent += OnSelectedAllItemsChanged;
-                DataGrid.SelectedItemsChangedEvent += OnSelectedItemsChanged;
             }
         }
 
@@ -308,19 +305,6 @@ namespace MudBlazor
             {
                 Column.SortIndex = sortDefinition.Index;
             }
-        }
-
-        private void OnSelectedAllItemsChanged(bool value)
-        {
-            _selected = value;
-            StateHasChanged();
-        }
-
-        private void OnSelectedItemsChanged(HashSet<T> items)
-        {
-            Debug.Assert(DataGrid is not null);
-            _selected = items.Count == DataGrid.GetFilteredItemsCount();
-            StateHasChanged();
         }
 
         private async Task OnResizerPointerDown(PointerEventArgs args)
@@ -769,8 +753,6 @@ namespace MudBlazor
             if (DataGrid is not null)
             {
                 DataGrid.SortChangedEvent -= OnGridSortChanged;
-                DataGrid.SelectedAllItemsChangedEvent -= OnSelectedAllItemsChanged;
-                DataGrid.SelectedItemsChangedEvent -= OnSelectedItemsChanged;
             }
         }
     }

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -334,8 +334,6 @@ namespace MudBlazor
         #region Notify Children Delegates
 
         internal Action<Dictionary<string, SortDefinition<T>>, HashSet<string>?>? SortChangedEvent { get; set; }
-        internal Action<HashSet<T>>? SelectedItemsChangedEvent { get; set; }
-        internal Action<bool>? SelectedAllItemsChangedEvent { get; set; }
         internal Action? StartedEditingItemEvent { get; set; }
         internal Action? EditingCanceledEvent { get; set; }
 
@@ -1076,13 +1074,12 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Fires SelectedItemsChanged event and invokes SelectedItemsChangedEvent.
+        /// Publishes the current selection so bound parameters and their change callbacks see it.
         /// </summary>
         private async Task FireSelectionChangedEventsAsync()
         {
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
             await _selectedItemsState.SetValueAsync(new HashSet<T>(Selection, Comparer));
-            SelectedItemsChangedEvent?.Invoke(Selection);
         }
 
         private void ApplyInitialExpansionForNewItems(NotifyCollectionChangedEventArgs e)
@@ -2168,7 +2165,6 @@ namespace MudBlazor
 
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
             await _selectedItemsState.SetValueAsync(new HashSet<T>(Selection, Comparer));
-            await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
 
             await InvokeAsync(StateHasChanged);
         }
@@ -2211,8 +2207,6 @@ namespace MudBlazor
 
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
             await InvokeAsync(() => _selectedItemsState.SetValueAsync(new HashSet<T>(Selection, Comparer)));
-            await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
-            await InvokeAsync(() => SelectedAllItemsChangedEvent?.Invoke(value));
 
             await InvokeAsync(StateHasChanged);
         }
@@ -2241,7 +2235,6 @@ namespace MudBlazor
 
             // Create new HashSet instance to ensure ParameterState's comparer detects changes
             await InvokeAsync(() => _selectedItemsState.SetValueAsync(new HashSet<T>(Selection, Comparer)));
-            await InvokeAsync(() => SelectedItemsChangedEvent?.Invoke(Selection));
 
             await InvokeAsync(StateHasChanged);
         }


### PR DESCRIPTION
`HeaderCell._selected` has been written-only since #8886 renamed it from `_isSelected` in 2023 without restoring a reader. The two selection handlers that maintain it therefore do nothing but call `StateHasChanged()` on every header cell, plus a `GetFilteredItemsCount()` per cell.

The grid already follows every selection mutation with its own `StateHasChanged`, and `HeaderCell` has no `ShouldRender` override, so that render alone rebuilds all header cells. The handlers just added a second pass — each header cell built its render tree twice per row click and three times per select-all.

Removing the field and both handlers leaves `SelectedItemsChangedEvent` and `SelectedAllItemsChangedEvent` with no subscribers anywhere in the assembly, so both `internal` events and their four `InvokeAsync` dispatches go too.

Measured with a bare `Microsoft.AspNetCore.Components.RenderTree.Renderer` and a `HeaderTemplate` invocation counter, 8 `PropertyColumn`s plus a `SelectColumn`, 25 rows paged:

| action | bytes | |
|---|---|---|
| row-click selection | 502,435 → 433,927 | −13.6% |
| select-all | 602,104 → 464,749 | −22.8% |

Header cells go from 2 render-tree builds per selection change (3 for select-all) to 1, and `GetFilteredItemsCount` calls per selection change drop from 23 to 8. The saving is a fixed ~7.6 KB per column, so it is proportionally small on a tall grid.

Checked the field is unread four ways before deleting: grep across `src/MudBlazor`, the `.razor` file, `private` accessibility (so invisible to derived types), and the test suite's reflection — the only `BindingFlags.NonPublic` field lookups on `HeaderCell` target `_gridElement` and `_headerElement`.

The select-all header checkbox stays correct because it reads `HeaderContext.IsAllSelected` at render time and the grid still renders. The footer's identical checkbox never subscribed to these events and has always relied on exactly that.

`DataGridHeaderCell_RendersOncePerSelectionChange` added. It asserts one header render after select-row, select-all and deselect-all, and *also* asserts the header checkbox actually reflects the new state, so it cannot be satisfied by rendering zero times. Fails on `dev` with "found 2". Full suite passes (5,707).
