### PR TITLE
Build: Fix docs server launch profile being discarded

### DIFF
--- a/src/MudBlazor.Docs.Server/Properties/launchSettings.json
+++ b/src/MudBlazor.Docs.Server/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7128;http://localhost:5128",
-      "launchUrl": "", // change to "components/list" for testing MudList for example but don't commit this change
+      "launchUrl": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
`src/MudBlazor.Docs.Server/Properties/launchSettings.json` has a `//` comment on the `launchUrl` line. The SDK parses that file as strict JSON, so the comment invalidates the entire file:

```
The launch profile "(Default)" could not be applied.
'/' is an invalid start of a property name. Expected a '"'. LineNumber: 5
```

With no profile applied, `ASPNETCORE_ENVIRONMENT` is never set and `dotnet run` starts the docs site in **Production**. Static web assets from referenced projects are not served there, so every `_content/**` request 404s — `MudBlazor.min.js`, `MudBlazor.min.css`, `docs.js`, sponsor images and third-party assets alike. The result is an unstyled page with no interactivity, and nothing obviously points at the cause.

Verified by running `dotnet run` with no environment override before and after: the log goes from `Hosting environment: Production` to `Development`, and the three probed assets go from 404 to 200.

It is the only one of the five `launchSettings.json` files in the repo that does not parse.
