### PR TITLE
MudDataGrid: Stop recompiling column property expressions on each render

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPropertyExpressionSwapTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridPropertyExpressionSwapTest.razor
@@ -1,0 +1,27 @@
+﻿@using System.Linq.Expressions
+
+<MudDataGrid T="Item" Items="@_items">
+    <Columns>
+        <PropertyColumn Property="@Selector" />
+        <PropertyColumn Property="@(x => x.Values[Key])" Title="Dynamic" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Used to verify a column follows a property expression that really changed";
+
+    public Expression<Func<Item, string>> Selector { get; set; } = x => x.First;
+
+    public string Key { get; set; } = "a";
+
+    private readonly List<Item> _items = new() { new Item() };
+
+    public class Item
+    {
+        public string First { get; set; } = "first";
+
+        public string Second { get; set; } = "second";
+
+        public Dictionary<string, string> Values { get; } = new() { ["a"] = "alpha", ["b"] = "beta" };
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1613,6 +1613,46 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Re-rendering must not rebuild a column's compiled property accessors; Roslyn hands the column a new
+        /// expression-tree instance on every render, so identity alone cannot decide whether it really changed.
+        /// </summary>
+        [Test]
+        public void DataGridPropertyColumn_KeepsUnchangedPropertyExpression()
+        {
+            var comp = Context.Render<DataGridSortableTest>();
+            var column = comp.FindComponents<PropertyColumn<DataGridSortableTest.Item, string>>().First().Instance;
+
+            var before = column.PropertyExpression;
+
+            comp.Render();
+
+            column.PropertyExpression.Should().BeSameAs(before,
+                "an unchanged property expression must not be reprocessed");
+        }
+
+        /// <summary>
+        /// A column must still follow a property expression that genuinely changed, and must keep reading values
+        /// captured by the expression at evaluation time rather than freezing them when it was compiled.
+        /// </summary>
+        [Test]
+        public void DataGridPropertyColumn_FollowsChangedPropertyExpression()
+        {
+            var comp = Context.Render<DataGridPropertyExpressionSwapTest>();
+            var column = comp.FindComponents<PropertyColumn<DataGridPropertyExpressionSwapTest.Item, string>>().First().Instance;
+
+            comp.Markup.Should().Contain("first").And.Contain("alpha");
+            column.PropertyName.Should().Be("First");
+
+            comp.Instance.Selector = x => x.Second;
+            comp.Instance.Key = "b";
+            comp.Render();
+
+            comp.Markup.Should().Contain("second", "a genuinely different expression must be picked up");
+            comp.Markup.Should().Contain("beta", "a captured value must still be read when the expression is evaluated");
+            column.PropertyName.Should().Be("Second");
+        }
+
+        /// <summary>
         /// A cell must read its bound property exactly once per render; the value is used by several
         /// render paths and re-reading it invokes the compiled property expression again.
         /// </summary>

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -50,10 +50,10 @@ namespace MudBlazor
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
+
             // We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
-            // Razor rebuilds the expression tree on every render, so the instance always differs and identity alone
-            // would mean recompiling every time. Compare the shape instead, and keep the first instance of a given
-            // shape as the canonical one so callers that cache against PropertyExpression keep hitting their cache.
+            // Razor rebuilds the expression tree on every render, so the instance always differs and identity alone would mean recompiling every time.
+            // Compare the shape instead, and keep the first instance of a given shape as the canonical one so callers that cache against PropertyExpression keep hitting their cache.
             // A lambda that captures hashes its closure by reference, so those still recompile, which is the safe answer.
             if (!ReferenceEquals(_lastAssignedProperty, Property))
             {

--- a/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
+++ b/src/MudBlazor/Components/DataGrid/PropertyColumn.cs
@@ -24,10 +24,11 @@ namespace MudBlazor
         private readonly Guid _id = Guid.NewGuid();
 
         private string? _propertyName;
+        private string? _lastMemberName;
         private Func<T, object?>? _cellContentFunc;
         private Func<T, TProperty>? _compiledPropertyFunc;
         private Expression<Func<T, TProperty>>? _lastAssignedProperty;
-        private Expression<Func<T, TProperty>>? _compiledPropertyFuncFor;
+        private int _lastAssignedPropertyHash;
 
         /// <summary>
         /// The property whose values are displayed in the column.
@@ -50,32 +51,46 @@ namespace MudBlazor
         {
             base.OnParametersSet();
             // We have to do a bit of pre-processing on the lambda expression. Only do that if it's new or changed.
-            if (_lastAssignedProperty != Property)
+            // Razor rebuilds the expression tree on every render, so the instance always differs and identity alone
+            // would mean recompiling every time. Compare the shape instead, and keep the first instance of a given
+            // shape as the canonical one so callers that cache against PropertyExpression keep hitting their cache.
+            // A lambda that captures hashes its closure by reference, so those still recompile, which is the safe answer.
+            if (!ReferenceEquals(_lastAssignedProperty, Property))
             {
-                _lastAssignedProperty = Property;
-                var safePropertyExpression = ExpressionNull.AddNullChecks(Property);
-                var compiledPropertyExpression = safePropertyExpression.Compile();
-                _cellContentFunc = item => compiledPropertyExpression(item);
+                var propertyHash = ExpressionHasher.GetHashCode(Property);
+                if (_lastAssignedProperty is null || propertyHash != _lastAssignedPropertyHash)
+                {
+                    _lastAssignedProperty = Property;
+                    _lastAssignedPropertyHash = propertyHash;
+
+                    var safePropertyExpression = ExpressionNull.AddNullChecks(Property);
+                    var compiledPropertyExpression = safePropertyExpression.Compile();
+                    _cellContentFunc = item => compiledPropertyExpression(item);
+                    _compiledPropertyFunc = null;
+
+                    var property = PropertyPath.Visit(Property);
+                    if (property.IsBodyMemberExpression)
+                    {
+                        _propertyName = property.GetPath();
+                    }
+                    else
+                    {
+                        // Most likely this is a dynamic expression that people use as workaround https://try.mudblazor.com/snippet/cYGxuTmhyqAQeCVM
+                        // We can't assign any meaningful name at all, therefore we should assign an unique ID like we do for TemplateColumn
+                        _propertyName = _id.ToString();
+                    }
+
+                    _lastMemberName = property.GetLastMemberName();
+                }
             }
 
-            var property = PropertyPath.Visit(Property);
-            if (property.IsBodyMemberExpression)
-            {
-                _propertyName = property.GetPath();
-            }
-            else
-            {
-                // Most likely this is a dynamic expression that people use as workaround https://try.mudblazor.com/snippet/cYGxuTmhyqAQeCVM
-                // We can't assign any meaningful name at all, therefore we should assign an unique ID like we do for TemplateColumn
-                _propertyName = _id.ToString();
-            }
-            Title ??= property.GetLastMemberName();
+            Title ??= _lastMemberName;
 
             CompileGroupBy();
         }
 
         protected internal override LambdaExpression? PropertyExpression
-            => Property;
+            => _lastAssignedProperty ?? Property;
 
         /// <summary>
         /// The name of the property.
@@ -91,11 +106,8 @@ namespace MudBlazor
 
         protected internal override object? PropertyFunc(T item)
         {
-            if (_compiledPropertyFunc == null || _compiledPropertyFuncFor != Property)
-            {
-                _compiledPropertyFunc = Property.Compile();
-                _compiledPropertyFuncFor = Property;
-            }
+            // Invalidated in OnParametersSet when the expression actually changes.
+            _compiledPropertyFunc ??= (_lastAssignedProperty ?? Property).Compile();
 
             return _compiledPropertyFunc(item);
         }


### PR DESCRIPTION
`PropertyColumn.OnParametersSet` only meant to reprocess `Property` when it changed:

```csharp
if (_lastAssignedProperty != Property)
```

That is a reference comparison, and Razor rebuilds the expression tree on every `BuildRenderTree`, so the reference always differs and the guard never holds. Every column recompiled its property expression on every render — measured with a counter in the compile branch: **60 compiles over 20 renders of a three-column grid**, exactly one per column per render, a 100% miss rate.

`PropertyFunc` had the same defect in its own guard (`_compiledPropertyFuncFor != Property`) and so recompiled on *every call* — and `CompileGroupBy` sets `groupBy = PropertyFunc`, so a grouped grid compiled once per item.

The fix compares the expression's *shape* with the existing `ExpressionHasher` and keeps the first instance of a given shape as the canonical one, returned from `PropertyExpression`. That fixes the filter-predicate recompilation for free, because `FilterDefinition` keys its predicate cache on `Column.PropertyExpression`'s reference. `AggregateDefinition` already caches compiled expressions against the same hasher, so the approach and its collision trade-off are established here.

`Expression.Compile()` for a trivial `x => x.Name` measures 29.8 µs and 4,152 B in Release; MudBlazor wraps the expression in null checks first, so the real per-column figure is higher. An 8-column grid was paying at least that eight times over on every sort click, page change, filter keystroke and cell edit — independent of row count.

This is CPU rather than allocation, which is why it survived the earlier allocation-focused passes.

**Staleness.** A lambda that captures a *local* hashes its closure by reference, so a new closure instance each render yields a new hash and those columns still recompile — the safe answer, and it means dynamic-column grids do not benefit. A lambda that reads an *instance field* keeps working because the compiled delegate re-reads that field when it is evaluated, not when it was compiled. The only genuine residue is a 32-bit hash collision between two structurally different expressions, reachable only when someone swaps a column's lambda at runtime — the same trade-off `AggregateDefinitionExpressionCache` already accepts.

Two tests, and the pair matters:
- `DataGridPropertyColumn_KeepsUnchangedPropertyExpression` fails on `dev` ("Expected `x.Name` … but found `x.Name`" — structurally identical, different instances) and passes here.
- `DataGridPropertyColumn_FollowsChangedPropertyExpression` is the guard against the cache. It swaps the lambda at runtime and asserts the cell text and `PropertyName` follow, and changes a value captured by a dynamic lambda and asserts the cell follows that too. It passes on `dev` as well, by design — it protects existing semantics rather than the fix.

Full suite passes (5,708).
