### PR TITLE
MudDataGrid: One sentence per comment line

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1543,8 +1543,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// With no CellClick or CellContextMenuClick delegate the cells must carry no event handlers at all,
-        /// otherwise every td registers a DOM listener that does nothing.
+        /// With no CellClick or CellContextMenuClick delegate the cells must carry no event handlers at all, otherwise every td registers a DOM listener that does nothing.
         /// </summary>
         [Test]
         public void DataGridCell_WithoutDelegates_RegistersNoCellEventHandlers()
@@ -1595,8 +1594,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// The select-all checkbox covers every filtered row, so its state must be resolved without walking
-        /// the whole data set on each render.
+        /// The select-all checkbox covers every filtered row, so its state must be resolved without walking the whole data set on each render.
         /// </summary>
         [Test]
         public void DataGridSelectAll_DoesNotScanEveryFilteredRow()
@@ -1640,8 +1638,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// A cell must read its bound property exactly once per render; the value is used by several
-        /// render paths and re-reading it invokes the compiled property expression again.
+        /// A cell must read its bound property exactly once per render, because the value is used by several render paths and re-reading it invokes the compiled property expression again.
         /// </summary>
         [Test]
         public void DataGridCell_ReadsBoundPropertyOncePerRender()

--- a/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
@@ -100,7 +100,8 @@
         return _resolvedItems;
     }
 
-    // ContextRowClick only ever reaches DataGrid.RowContextMenuClick, so without that delegate the handler would be a no-op that still costs a DOM listener on every row. The lambda lives in its own method so its closure is not allocated when the branch is not taken.
+    // ContextRowClick only ever reaches DataGrid.RowContextMenuClick, so without that delegate the handler would be a no-op that still costs a DOM listener on every row.
+    // The lambda lives in its own method so its closure is not allocated when the branch is not taken.
     private EventCallback<MouseEventArgs> GetContextMenuCallback(IndexBag<T> itemBag)
         => DataGrid.RowContextMenuClick.HasDelegate
             ? CreateContextMenuCallback(itemBag)

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -2536,8 +2536,7 @@ namespace MudBlazor
             return CellContextMenuClick.InvokeAsync(new DataGridCellClickEventArgs<T>(args, item, rowIndex, columnIndex, column));
         }
 
-        // The lambdas live in their own methods because the compiler allocates a closure on entry to whichever method
-        // declares one, even when the branch that needs it is never taken.
+        // The lambdas live in their own methods because the compiler allocates a closure on entry to whichever method declares one, even when the branch that needs it is never taken.
         private EventCallback<MouseEventArgs> GetCellClickCallback(T item, int rowIndex, int colIndex, Column<T> column)
             => CellClick.HasDelegate
                 ? CreateCellClickCallback(item, rowIndex, colIndex, column)


### PR DESCRIPTION
Comments in the recent DataGrid changes were wrapped to a column width, splitting single sentences across lines. One was the reverse, with two sentences sharing a line.

Five comments, no code change:

- `MudDataGrid.razor.cs` — the cell-callback closure comment was split across two lines.
- `DataGridVirtualizeRow.razor` — the `ContextRowClick` comment had two sentences on one line.
- `DataGridTests.cs` — three test summaries were each split across two lines.
