### PR TITLE
MudFormComponent: Stop compiling the For expression on every parameter set

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldValidationNestedForTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TextField/TextFieldValidationNestedForTest.razor
@@ -1,0 +1,29 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+<EditForm Model="_model">
+    <DataAnnotationsValidator />
+    <MudTextField For="@(() => _model.Address.Street)" @bind-Value="_model.Address.Street" />
+</EditForm>
+
+@code {
+    public static string __description__ = "Validation through a nested `For` path, including replacing the nested model instance.";
+
+    private readonly TestModel _model = new();
+
+    public void ReplaceNestedModel() => _model.Address = new AddressModel();
+
+    public object NestedModel => _model.Address;
+
+    public void ForceRender() => StateHasChanged();
+
+    public class TestModel
+    {
+        public AddressModel Address { get; set; } = new();
+    }
+
+    public class AddressModel
+    {
+        [StringLength(3, ErrorMessage = "Should not be longer than 3")]
+        public string? Street { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/NestedForExpressionTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NestedForExpressionTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Bunit;
+using MudBlazor.UnitTests.TestComponents.TextField;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class NestedForExpressionTests : BunitTest
+    {
+        /// <summary>
+        /// A data annotation on a nested For path is found and reported.
+        /// </summary>
+        [Test]
+        public async Task NestedFor_ReportsDataAnnotationError()
+        {
+            var comp = Context.Render<TextFieldValidationNestedForTest>();
+            var textFieldComp = comp.FindComponent<MudTextField<string>>();
+            await textFieldComp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
+
+            await comp.Find("input").ChangeAsync("Quux");
+            await comp.InvokeAsync(() => textFieldComp.Instance.ValidateAsync());
+
+            textFieldComp.Instance.ValidationErrors.Should().ContainSingle().Which.Should().Be("Should not be longer than 3");
+        }
+
+        /// <summary>
+        /// Replacing the nested model instance rebinds the field so validation keeps working against the new object.
+        /// </summary>
+        [Test]
+        public async Task NestedFor_RebindsAfterNestedModelIsReplaced()
+        {
+            var comp = Context.Render<TextFieldValidationNestedForTest>();
+            var textFieldComp = comp.FindComponent<MudTextField<string>>();
+            await textFieldComp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
+
+            await comp.InvokeAsync(comp.Instance.ReplaceNestedModel);
+            await comp.InvokeAsync(comp.Instance.ForceRender);
+
+            await comp.Find("input").ChangeAsync("Quux");
+            await comp.InvokeAsync(() => textFieldComp.Instance.ValidateAsync());
+
+            textFieldComp.Instance.ValidationErrors.Should().ContainSingle().Which.Should().Be("Should not be longer than 3");
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/NestedForExpressionTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NestedForExpressionTests.cs
@@ -2,9 +2,11 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Reflection;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components.Forms;
 using MudBlazor.UnitTests.TestComponents.TextField;
 using NUnit.Framework;
 
@@ -42,10 +44,18 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(comp.Instance.ReplaceNestedModel);
             await comp.InvokeAsync(comp.Instance.ForceRender);
 
+            // The validation error alone would not prove this, because StringLength only inspects the value and reports the same error against either instance.
+            GetFieldIdentifier(textFieldComp.Instance).Model.Should().BeSameAs(comp.Instance.NestedModel);
+
             await comp.Find("input").ChangeAsync("Quux");
             await comp.InvokeAsync(() => textFieldComp.Instance.ValidateAsync());
 
             textFieldComp.Instance.ValidationErrors.Should().ContainSingle().Which.Should().Be("Should not be longer than 3");
         }
+
+        private static FieldIdentifier GetFieldIdentifier(MudTextField<string> textField) =>
+            (FieldIdentifier)typeof(MudFormComponent<string, string>)
+                .GetField("_fieldIdentifier", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(textField)!;
     }
 }

--- a/src/MudBlazor.UnitTests/Utilities/FieldIdentifierResolverTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/FieldIdentifierResolverTests.cs
@@ -35,12 +35,46 @@ namespace MudBlazor.UnitTests.Utilities
 
             public Address Home { get; set; } = new();
 
+            public Person? Partner { get; set; }
+
             public List<Address> Addresses { get; } = [new()];
+        }
+
+        private class Counting
+        {
+            private readonly Queue<Person?> _results;
+
+            public Counting(params Person?[] results) => _results = new Queue<Person?>(results);
+
+            public int Reads { get; private set; }
+
+            public Person? Tracked
+            {
+                get
+                {
+                    Reads++;
+                    return _results.Count > 1 ? _results.Dequeue() : _results.Peek();
+                }
+            }
+
+            public Person Boom => throw new InvalidOperationException("boom");
         }
 
         private static Person? s_static = new();
 
         private Person _person = new();
+
+        /// <summary>
+        /// Runs the same accessor through the resolver and the framework and asserts both fail with the same exception type and message.
+        /// </summary>
+        private static void AssertThrowsLikeFramework<T>(Expression<Func<T>> accessor)
+        {
+            var framework = ((Action)(() => FieldIdentifier.Create(accessor))).Should().Throw<Exception>().Which;
+            var resolver = ((Action)(() => FieldIdentifierResolver.TryCreate(accessor, out _))).Should().Throw<Exception>().Which;
+
+            resolver.Should().BeOfType(framework.GetType());
+            resolver.Message.Should().Be(framework.Message);
+        }
 
         /// <summary>
         /// A chain through a nullable struct resolves to the same field the framework resolves.
@@ -140,6 +174,78 @@ namespace MudBlazor.UnitTests.Utilities
             Expression<Func<string?>> accessor = () => GetPerson().Name!.ToUpperInvariant();
 
             FieldIdentifierResolver.TryCreate(accessor, out _).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A recognized chain whose model is null must throw what the framework throws, and each side reads the getter exactly once — no fallback re-evaluation.
+        /// </summary>
+        [Test]
+        public void NullModelInNestedChain_ThrowsLikeFramework_WithoutFallingBack()
+        {
+            var counting = new Counting([null]);
+
+            AssertThrowsLikeFramework(() => counting.Tracked!.Name);
+
+            counting.Reads.Should().Be(2);
+        }
+
+        /// <summary>
+        /// A getter that returns null once and a value afterwards must fail like the framework's single evaluation would, not bind the second read.
+        /// </summary>
+        [Test]
+        public void GetterReturningNullThenValue_DoesNotBindTheSecondRead()
+        {
+            var counting = new Counting(null, new Person());
+            Expression<Func<string?>> accessor = () => counting.Tracked!.Name;
+
+            Action act = () => FieldIdentifierResolver.TryCreate(accessor, out _);
+
+            act.Should().Throw<ArgumentException>();
+            counting.Reads.Should().Be(1);
+        }
+
+        /// <summary>
+        /// A null owner in the middle of a recognized chain must throw the framework's NullReferenceException instead of reporting unresolved.
+        /// </summary>
+        [Test]
+        public void NullIntermediateOwner_ThrowsLikeFramework()
+        {
+            _person.Partner = null;
+
+            AssertThrowsLikeFramework(() => _person.Partner!.Home.Street);
+        }
+
+        /// <summary>
+        /// An empty nullable struct in the chain must throw the framework's InvalidOperationException without invoking Nullable&lt;T&gt;.Value reflectively.
+        /// </summary>
+        [Test]
+        public void EmptyNullableInChain_ThrowsLikeFramework()
+        {
+            _person.Maybe = null;
+
+            AssertThrowsLikeFramework(() => _person.Maybe!.Value.Inner.Street);
+        }
+
+        /// <summary>
+        /// An exception thrown by a getter must surface as itself, not wrapped in the reflection envelope.
+        /// </summary>
+        [Test]
+        public void ThrowingGetter_SurfacesTheOriginalException()
+        {
+            var counting = new Counting();
+
+            AssertThrowsLikeFramework(() => counting.Boom.Name);
+        }
+
+        /// <summary>
+        /// A null model read straight off a closure field takes the framework's non-compiled path, which fails with a different exception than a nested chain; both must match.
+        /// </summary>
+        [Test]
+        public void NullFlatRoot_ThrowsLikeFramework()
+        {
+            _person = null!;
+
+            AssertThrowsLikeFramework(() => _person.Name);
         }
 
         private Person GetPerson() => _person;

--- a/src/MudBlazor.UnitTests/Utilities/FieldIdentifierResolverTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/FieldIdentifierResolverTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components.Forms;
+using MudBlazor.Utilities.Expressions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities
+{
+    [TestFixture]
+    public class FieldIdentifierResolverTests
+    {
+        private class Address
+        {
+            public string? Street { get; set; }
+        }
+
+        private class Person
+        {
+            public string? Name { get; set; }
+
+            public Address Home { get; set; } = new();
+
+            public List<Address> Addresses { get; } = [new()];
+        }
+
+        private static Person? s_static = new();
+
+        private Person _person = new();
+
+        /// <summary>
+        /// A member read straight off the model resolves to the same field the framework resolves.
+        /// </summary>
+        [Test]
+        public void FlatPath_MatchesFieldIdentifierCreate()
+        {
+            Expression<Func<string?>> accessor = () => _person.Name;
+
+            FieldIdentifierResolver.TryCreate(accessor, out var resolved).Should().BeTrue();
+            resolved.Should().Be(FieldIdentifier.Create(accessor));
+            resolved.Model.Should().BeSameAs(_person);
+        }
+
+        /// <summary>
+        /// A nested member path resolves to the same field the framework resolves, without compiling the expression.
+        /// </summary>
+        [Test]
+        public void NestedPath_MatchesFieldIdentifierCreate()
+        {
+            Expression<Func<string?>> accessor = () => _person.Home.Street;
+
+            FieldIdentifierResolver.TryCreate(accessor, out var resolved).Should().BeTrue();
+            resolved.Should().Be(FieldIdentifier.Create(accessor));
+            resolved.Model.Should().BeSameAs(_person.Home);
+        }
+
+        /// <summary>
+        /// Replacing the model instance must produce a new field identifier, otherwise validation would stay bound to the discarded object.
+        /// </summary>
+        [Test]
+        public void ModelSwap_ResolvesTheCurrentInstance()
+        {
+            Expression<Func<string?>> accessor = () => _person.Home.Street;
+            FieldIdentifierResolver.TryCreate(accessor, out var before);
+
+            _person = new Person();
+
+            FieldIdentifierResolver.TryCreate(accessor, out var after).Should().BeTrue();
+            after.Should().NotBe(before);
+            after.Model.Should().BeSameAs(_person.Home);
+        }
+
+        /// <summary>
+        /// A static root is not handled and must be reported as unresolved so the caller falls back.
+        /// </summary>
+        [Test]
+        public void StaticRoot_ReportsUnresolved()
+        {
+            Expression<Func<string?>> accessor = () => s_static!.Name;
+
+            FieldIdentifierResolver.TryCreate(accessor, out _).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// An indexer in the path is not handled and must be reported as unresolved so the caller falls back.
+        /// </summary>
+        [Test]
+        public void IndexerPath_ReportsUnresolved()
+        {
+            Expression<Func<string?>> accessor = () => _person.Addresses[0].Street;
+
+            FieldIdentifierResolver.TryCreate(accessor, out _).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A method call in the path is not handled and must be reported as unresolved so the caller falls back.
+        /// </summary>
+        [Test]
+        public void MethodCallPath_ReportsUnresolved()
+        {
+            Expression<Func<string?>> accessor = () => GetPerson().Name;
+
+            FieldIdentifierResolver.TryCreate(accessor, out _).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// An expression that is not a member access at all is reported as unresolved so the caller falls back and the framework raises its own error.
+        /// </summary>
+        [Test]
+        public void NonMemberBody_ReportsUnresolved()
+        {
+            Expression<Func<string?>> accessor = () => GetPerson().Name!.ToUpperInvariant();
+
+            FieldIdentifierResolver.TryCreate(accessor, out _).Should().BeFalse();
+        }
+
+        private Person GetPerson() => _person;
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/FieldIdentifierResolverTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/FieldIdentifierResolverTests.cs
@@ -22,8 +22,15 @@ namespace MudBlazor.UnitTests.Utilities
             public string? Street { get; set; }
         }
 
+        private struct Wrapper
+        {
+            public Address Inner { get; set; }
+        }
+
         private class Person
         {
+            public Wrapper? Maybe { get; set; } = new Wrapper { Inner = new Address() };
+
             public string? Name { get; set; }
 
             public Address Home { get; set; } = new();
@@ -34,6 +41,20 @@ namespace MudBlazor.UnitTests.Utilities
         private static Person? s_static = new();
 
         private Person _person = new();
+
+        /// <summary>
+        /// A chain through a nullable struct resolves to the same field the framework resolves.
+        /// </summary>
+        [Test]
+        public void NullableStructInChain_MatchesFieldIdentifierCreate()
+        {
+            // The tree carries a real Nullable<T>.Value member access, and reflection accepts the boxed T as its owner.
+            Expression<Func<string?>> accessor = () => _person.Maybe!.Value.Inner.Street;
+
+            FieldIdentifierResolver.TryCreate(accessor, out var resolved).Should().BeTrue();
+            resolved.Should().Be(FieldIdentifier.Create(accessor));
+            resolved.Model.Should().BeSameAs(_person.Maybe!.Value.Inner);
+        }
 
         /// <summary>
         /// A member read straight off the model resolves to the same field the framework resolves.

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -909,6 +909,7 @@ namespace MudBlazor
             {
                 // For is a fresh expression instance on every render for an inline lambda, so the reference check above never holds and this runs on every parameter set.
                 // FieldIdentifier.Create compiles the expression for anything deeper than model.Property, so resolve the member chain directly and only fall back for exotic shapes.
+                // The resolver reports false without having evaluated anything, so the fallback never runs a user getter a second time.
                 if (!FieldIdentifierResolver.TryCreate(For, out var fieldIdentifier))
                 {
                     fieldIdentifier = FieldIdentifier.Create(For);

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -14,6 +14,7 @@ using MudBlazor.Interfaces;
 using MudBlazor.State;
 using MudBlazor.Utilities.Comparer;
 using MudBlazor.Utilities.Converter.Base;
+using MudBlazor.Utilities.Expressions;
 using static System.String;
 
 namespace MudBlazor
@@ -906,8 +907,14 @@ namespace MudBlazor
             InjectCultureAndFormatToConverter(GetCulture, GetFormat);
             if (For is not null && For != _currentFor)
             {
-                // For is a fresh expression instance on every render for an inline lambda, so only do the reflection and rebinding work when the field it points at actually changed.
-                var fieldIdentifier = FieldIdentifier.Create(For);
+                // For is a fresh expression instance on every render for an inline lambda, so the reference check above never holds and this runs on every parameter set.
+                // FieldIdentifier.Create compiles the expression for anything deeper than model.Property, so resolve the member chain directly and only fall back for exotic shapes.
+                if (!FieldIdentifierResolver.TryCreate(For, out var fieldIdentifier))
+                {
+                    fieldIdentifier = FieldIdentifier.Create(For);
+                }
+
+                // Only do the reflection and rebinding work when the field it points at actually changed.
                 if (!_fieldIdentifier.Equals(fieldIdentifier))
                 {
                     // Extract validation attributes

--- a/src/MudBlazor/Utilities/Expressions/FieldIdentifierResolver.cs
+++ b/src/MudBlazor/Utilities/Expressions/FieldIdentifierResolver.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Microsoft.AspNetCore.Components.Forms;
 
 namespace MudBlazor.Utilities.Expressions;
@@ -22,7 +23,10 @@ internal static class FieldIdentifierResolver
     /// <summary>
     /// Resolves the field the expression points at.
     /// </summary>
-    /// <returns><c>false</c> when the expression is not a plain member chain rooted in a constant, in which case the caller must fall back to <see cref="FieldIdentifier.Create{TField}"/>.</returns>
+    /// <returns><c>false</c> when the expression is not a plain member chain rooted in a constant, in which case the caller must fall back to <see cref="FieldIdentifier.Create{TField}"/>; no part of the chain has been evaluated then.</returns>
+    /// <remarks>
+    /// A recognized chain is evaluated exactly once and any failure throws what <see cref="FieldIdentifier.Create{TField}"/> would have thrown, so the caller never re-runs user getters through the fallback.
+    /// </remarks>
     public static bool TryCreate<TField>(Expression<Func<TField>> accessor, out FieldIdentifier fieldIdentifier)
     {
         var body = accessor.Body;
@@ -31,16 +35,26 @@ internal static class FieldIdentifierResolver
             body = unary.Operand;
         }
 
-        if (body is MemberExpression member && TryEvaluate(member.Expression, out var model) && model is not null)
+        if (body is not MemberExpression member || !TryEvaluate(member.Expression, out var model))
         {
-            fieldIdentifier = new FieldIdentifier(model, member.Member.Name);
-            return true;
+            fieldIdentifier = default;
+            return false;
         }
 
-        fieldIdentifier = default;
-        return false;
+        // FieldIdentifier.Create reads a member straight off a constant without compiling and lets the constructor reject the null model with ArgumentNullException; a deeper chain goes through its compiled path, which throws ArgumentException instead.
+        if (model is null && member.Expression is not MemberExpression { Expression: ConstantExpression })
+        {
+            throw new ArgumentException("The provided expression must evaluate to a non-null value.");
+        }
+
+        fieldIdentifier = new FieldIdentifier(model!, member.Member.Name);
+        return true;
     }
 
+    /// <summary>
+    /// Evaluates a supported owner chain, surfacing the same exceptions the compiled expression would raise.
+    /// </summary>
+    /// <returns><c>false</c> when the chain contains unsupported syntax; nothing has been evaluated in that case, because every shape is checked before the first member is read.</returns>
     private static bool TryEvaluate(Expression? expression, out object? value)
     {
         switch (expression)
@@ -49,15 +63,41 @@ internal static class FieldIdentifierResolver
                 value = constant.Value;
                 return true;
             // A static member has a null Expression, so it fails the recursive call and reports unresolved rather than reading off a null owner.
-            case MemberExpression { Member: FieldInfo field } member when TryEvaluate(member.Expression, out var fieldOwner) && fieldOwner is not null:
-                value = field.GetValue(fieldOwner);
+            case MemberExpression { Member: FieldInfo field } member when TryEvaluate(member.Expression, out var fieldOwner):
+                // A compiled dereference of a null owner throws NullReferenceException, where reflection would throw TargetException.
+                value = field.GetValue(fieldOwner ?? throw new NullReferenceException());
                 return true;
-            case MemberExpression { Member: PropertyInfo property } member when property.GetIndexParameters().Length == 0 && TryEvaluate(member.Expression, out var propertyOwner) && propertyOwner is not null:
-                value = property.GetValue(propertyOwner);
+            case MemberExpression { Member: PropertyInfo property } member when property.GetIndexParameters().Length == 0 && TryEvaluate(member.Expression, out var propertyOwner):
+                value = ReadProperty(property, propertyOwner);
                 return true;
             default:
                 value = null;
                 return false;
+        }
+    }
+
+    private static object? ReadProperty(PropertyInfo property, object? owner)
+    {
+        // A Nullable<T> holding a value boxes as plain T, so the boxed owner already is .Value; NativeAOT also generates no code for reflective invocation of Nullable<T> members, and an empty one must fail like the compiled getter.
+        if (property.DeclaringType is { } declaring && Nullable.GetUnderlyingType(declaring) is not null && property.Name == nameof(Nullable<int>.Value))
+        {
+            return owner ?? throw new InvalidOperationException("Nullable object must have a value.");
+        }
+
+        if (owner is null)
+        {
+            throw new NullReferenceException();
+        }
+
+        try
+        {
+            return property.GetValue(owner);
+        }
+        catch (TargetInvocationException e) when (e.InnerException is not null)
+        {
+            // The compiled expression surfaces the getter's own exception, so unwrap the reflection envelope without losing the original stack.
+            ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+            throw;
         }
     }
 }

--- a/src/MudBlazor/Utilities/Expressions/FieldIdentifierResolver.cs
+++ b/src/MudBlazor/Utilities/Expressions/FieldIdentifierResolver.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace MudBlazor.Utilities.Expressions;
+
+/// <summary>
+/// Builds a <see cref="FieldIdentifier"/> from a <c>For</c> expression without compiling it.
+/// </summary>
+/// <remarks>
+/// <see cref="FieldIdentifier.Create{TField}"/> only has a fast path when the member is read straight off a constant.
+/// A nested path such as <c>() =&gt; _model.Address.Street</c> falls back to <see cref="Expression.Lambda(Expression, ParameterExpression[])"/> plus <see cref="LambdaExpression.Compile()"/>, which costs about 100 us and 4 KB every call.
+/// Walking the member chain with reflection reads the same object graph and stays correct when the model instance is swapped.
+/// </remarks>
+internal static class FieldIdentifierResolver
+{
+    /// <summary>
+    /// Resolves the field the expression points at.
+    /// </summary>
+    /// <returns><c>false</c> when the expression is not a plain member chain rooted in a constant, in which case the caller must fall back to <see cref="FieldIdentifier.Create{TField}"/>.</returns>
+    public static bool TryCreate<TField>(Expression<Func<TField>> accessor, out FieldIdentifier fieldIdentifier)
+    {
+        var body = accessor.Body;
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } unary && unary.Type == typeof(object))
+        {
+            body = unary.Operand;
+        }
+
+        if (body is MemberExpression member && TryEvaluate(member.Expression, out var model) && model is not null)
+        {
+            fieldIdentifier = new FieldIdentifier(model, member.Member.Name);
+            return true;
+        }
+
+        fieldIdentifier = default;
+        return false;
+    }
+
+    private static bool TryEvaluate(Expression? expression, out object? value)
+    {
+        switch (expression)
+        {
+            case ConstantExpression constant:
+                value = constant.Value;
+                return true;
+            case MemberExpression { Member: FieldInfo field } member when TryEvaluate(member.Expression, out var fieldOwner) && (fieldOwner is not null || field.IsStatic):
+                value = field.GetValue(fieldOwner);
+                return true;
+            case MemberExpression { Member: PropertyInfo property } member when property.GetIndexParameters().Length == 0 && TryEvaluate(member.Expression, out var propertyOwner) && (propertyOwner is not null || property.GetMethod?.IsStatic == true):
+                value = property.GetValue(propertyOwner);
+                return true;
+            default:
+                value = null;
+                return false;
+        }
+    }
+}

--- a/src/MudBlazor/Utilities/Expressions/FieldIdentifierResolver.cs
+++ b/src/MudBlazor/Utilities/Expressions/FieldIdentifierResolver.cs
@@ -48,10 +48,11 @@ internal static class FieldIdentifierResolver
             case ConstantExpression constant:
                 value = constant.Value;
                 return true;
-            case MemberExpression { Member: FieldInfo field } member when TryEvaluate(member.Expression, out var fieldOwner) && (fieldOwner is not null || field.IsStatic):
+            // A static member has a null Expression, so it fails the recursive call and reports unresolved rather than reading off a null owner.
+            case MemberExpression { Member: FieldInfo field } member when TryEvaluate(member.Expression, out var fieldOwner) && fieldOwner is not null:
                 value = field.GetValue(fieldOwner);
                 return true;
-            case MemberExpression { Member: PropertyInfo property } member when property.GetIndexParameters().Length == 0 && TryEvaluate(member.Expression, out var propertyOwner) && (propertyOwner is not null || property.GetMethod?.IsStatic == true):
+            case MemberExpression { Member: PropertyInfo property } member when property.GetIndexParameters().Length == 0 && TryEvaluate(member.Expression, out var propertyOwner) && propertyOwner is not null:
                 value = property.GetValue(propertyOwner);
                 return true;
             default:


### PR DESCRIPTION
Razor rebuilds the `For` expression tree on every render, so the `For != _currentFor` guard never holds and `FieldIdentifier.Create` runs on every parameter set. For anything deeper than `model.Property` the framework compiles the expression — a `DynamicMethod` emitted and JITed per call — at the base of every input in the library.

`FieldIdentifierResolver` walks the member chain using the `MemberInfo` already in the tree, so nothing is compiled. Unsupported syntax (static roots, indexers, method calls) is reported unresolved before anything is evaluated and falls back to `FieldIdentifier.Create`. A recognized chain evaluates exactly once, and any failure throws exactly what `Create` would (verified against net8.0 and net10.0): `ArgumentException` for a null model, `NullReferenceException` for a null intermediate, `InvalidOperationException` for an empty nullable, getter exceptions unwrapped from `TargetInvocationException`. `Nullable<T>.Value` is read from the box instead of invoked reflectively, which also keeps NativeAOT working.

Measured in Release, 2,000 iterations after warmup:

| `For` shape | today | with this |
|---|---|---|
| `() => _person.Home.Street` | 107.26 µs / 4,226 B | 0.12 µs / 0 B |
| `() => _person.Name` | 0.12 µs / 0 B | 0.07 µs / 0 B |

Only nested paths change; a flat `For` already hits the framework's fast path.

No caching by expression shape: `FieldIdentifier` compares its model by reference — that is how an input notices `_model = new()` and rebinds. A shape hash would silently keep validation bound to the discarded object.