### PR TITLE
MudTable: Stop copying the filtered list once per rendered row

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowIndexTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableRowIndexTest.razor
@@ -1,0 +1,19 @@
+﻿<MudTable Items="@_items" T="string" RowClassFunc="@RowClassFunc">
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "Used to verify a row's index is its position in the filtered items";
+
+    public List<int> SeenIndexes { get; } = new();
+
+    private readonly List<string> _items = new() { "a", "b", "a", "c" };
+
+    private string RowClassFunc(string item, int index)
+    {
+        SeenIndexes.Add(index);
+        return string.Empty;
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -15,6 +15,25 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class TableTests : BunitTest
     {
+        /// <summary>
+        /// A row's index is its position in the filtered items, and duplicates resolve to the first match.
+        /// </summary>
+        [Test]
+        public void TableRowIndex_IsPositionInFilteredItems()
+        {
+            var comp = Context.Render<TableRowIndexTest>();
+
+            // "a" appears twice, so the third row resolves to the first match, matching List.IndexOf.
+            comp.Instance.SeenIndexes.Should().Equal(0, 1, 0, 3);
+
+            var rowIds = comp.FindAll("tbody tr").Select(row => row.Id).ToList();
+            rowIds.Should().HaveCount(4);
+            rowIds[0].Should().EndWith("_row_0");
+            rowIds[1].Should().EndWith("_row_1");
+            rowIds[2].Should().EndWith("_row_0");
+            rowIds[3].Should().EndWith("_row_3");
+        }
+
         [Test]
         public async Task CustomTableClass()
         {

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -102,7 +102,7 @@
                             {
                                 <MudVirtualize Enabled="@Virtualize" Items="@CurrentPageItems?.ToList()" OverscanCount="@OverscanCount" ItemSize="@ItemSize" Context="item">
                                     @{
-                                        var itemIndex = FilteredItems.ToList().IndexOf(item);
+                                        var itemIndex = GetFilteredItemIndex(item);
                                         var generatedRowId = itemIndex != -1 ? $"{_tableId}_row_{itemIndex}" : null;
                                         var rowClass = new CssBuilder(RowClass)
                                             .AddClass(RowClassFunc?.Invoke(item, itemIndex))
@@ -219,7 +219,7 @@
         RenderFragment<T> child() => item =>
             @<text>
                  @{
-                     var itemIndexForId = FilteredItems.ToList().IndexOf(item);
+                     var itemIndexForId = GetFilteredItemIndex(item);
                      var generatedRowId = itemIndexForId != -1 ? $"{_tableId}_row_{itemIndexForId}" : null;
 
                      var rowClass = new CssBuilder(RowClass).AddClass(RowClassFunc?.Invoke(item, itemIndexForId)).AddClass(customClass, !string.IsNullOrEmpty(customClass)).AddClass("mud-table-row-clickable", OnRowClick.HasDelegate && !IsRowDisabled(item)).Build();

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -675,6 +675,34 @@ namespace MudBlazor
         }
 
         /// <summary>
+        /// Gets the position of an item within <see cref="FilteredItems"/>, or <c>-1</c> when it is not present.
+        /// </summary>
+        /// <remarks>
+        /// Equivalent to <c>FilteredItems.ToList().IndexOf(item)</c> without copying the filtered list, which the row markup would otherwise do once per rendered row.
+        /// </remarks>
+        internal int GetFilteredItemIndex(T item)
+        {
+            var filteredItems = FilteredItems;
+            if (filteredItems is IList<T> list)
+            {
+                return list.IndexOf(item);
+            }
+
+            var index = 0;
+            foreach (var candidate in filteredItems)
+            {
+                if (EqualityComparer<T>.Default.Equals(candidate, item))
+                {
+                    return index;
+                }
+
+                index++;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
         /// Gets whether <see cref="Items"/> contains the specified item.
         /// </summary>
         /// <param name="item">The item to find.</param>


### PR DESCRIPTION
The row markup resolves a row's index with `FilteredItems.ToList().IndexOf(item)`, at both the virtualized and non-virtualized call sites. Every rendered row therefore copies the entire filtered collection before searching it, so the cost is total rows × rendered rows — a scaling cliff rather than a constant tax. `MudTable` re-renders on sort, filter, selection, and any parent state change.

| | bytes per render |
|---|---|
| today | 1,224,567 |
| this PR | 562,185 |

About 662 KB saved per render, and it grows quadratically with row count.

**Equivalence.** `FilteredItems` always returns the `List<T>` it caches in `_preEditSort` (or an empty collection), so the `IList<T>` fast path applies, and `List<T>.IndexOf` uses the same `EqualityComparer<T>.Default` the previous `ToList().IndexOf` did — including returning the *first* match when an item appears more than once. The enumerating fallback uses the same comparer for any other sequence type.

`TableRowIndex_IsPositionInFilteredItems` pins that behaviour with items `["a", "b", "a", "c"]`: the row indexes handed to `RowClassFunc` are `0, 1, 0, 3` and the generated row ids follow. It passes before and after — it is the guard that this optimisation preserves semantics, particularly the duplicate case, not evidence of the speedup.