### PR TITLE
MudMenu, MudBadge: Do not register handlers that can never fire

### DIFF
--- a/src/MudBlazor.UnitTests/Components/BadgeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BadgeTests.cs
@@ -1,5 +1,6 @@
 ﻿using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Badge;
 using NUnit.Framework;
@@ -9,6 +10,36 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class BadgeTests : BunitTest
     {
+        /// <summary>
+        /// A badge without an OnClick subscriber must not register a DOM click listener, so it cannot cost a round-trip.
+        /// </summary>
+        [Test]
+        public async Task Badge_WithoutOnClick_RegistersNoClickListener()
+        {
+            var comp = Context.Render<MudBadge>(parameters => parameters.Add(x => x.Visible, true));
+            var badge = comp.Find("span.mud-badge");
+
+            var click = async () => await badge.ClickAsync(new MouseEventArgs());
+
+            await click.Should().ThrowAsync<MissingEventHandlerException>();
+        }
+
+        /// <summary>
+        /// A badge with an OnClick subscriber still registers the DOM click listener.
+        /// </summary>
+        [Test]
+        public async Task Badge_WithOnClick_RegistersClickListener()
+        {
+            var clicked = false;
+            var comp = Context.Render<MudBadge>(parameters => parameters
+                .Add(x => x.Visible, true)
+                .Add(x => x.OnClick, EventCallback.Factory.Create<MouseEventArgs>(this, () => clicked = true)));
+
+            await comp.Find("span.mud-badge").ClickAsync(new MouseEventArgs());
+
+            clicked.Should().BeTrue();
+        }
+
         [Test]
         public async Task Badge_Renders_Using_Default_Values()
         {

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -19,6 +19,35 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class MenuTests : BunitTest
     {
+        /// <summary>
+        /// A left-click menu must not register a contextmenu DOM listener, so a right-click cannot cost a round-trip.
+        /// </summary>
+        [Test]
+        public async Task Menu_LeftClickActivation_RegistersNoContextMenuListener()
+        {
+            var comp = Context.Render<MudMenu>(parameters => parameters.Add(p => p.Label, "Menu"));
+            var root = comp.Find("div.mud-menu");
+
+            var contextMenu = async () => await root.ContextMenuAsync(new MouseEventArgs { Button = 2 });
+
+            await contextMenu.Should().ThrowAsync<MissingEventHandlerException>();
+        }
+
+        /// <summary>
+        /// A right-click menu keeps its contextmenu DOM listener.
+        /// </summary>
+        [Test]
+        public async Task Menu_RightClickActivation_RegistersContextMenuListener()
+        {
+            var comp = Context.Render<MudMenu>(parameters => parameters
+                .Add(p => p.Label, "Menu")
+                .Add(p => p.ActivationEvent, MouseEvent.RightClick));
+
+            var contextMenu = async () => await comp.Find("div.mud-menu").ContextMenuAsync(new MouseEventArgs { Button = 2 });
+
+            await contextMenu.Should().NotThrowAsync();
+        }
+
         [Test]
         public async Task OpenMenu_ClickFirstItem_CheckClosed()
         {

--- a/src/MudBlazor/Components/Badge/MudBadge.razor
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor
@@ -6,7 +6,7 @@
     @if (Visible)
     {
         <span class="@WrapperClass">
-            <span role="status" aria-live="polite" aria-label="@BadgeAriaLabel" class="@BadgeClassname" @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(HandleBadgeClick)">
+            <span role="status" aria-live="polite" aria-label="@BadgeAriaLabel" class="@BadgeClassname" @onclick="@BadgeClickCallback">
                 @if (!Dot)
                 {
                     @if (!string.IsNullOrEmpty(Icon))

--- a/src/MudBlazor/Components/Badge/MudBadge.razor.cs
+++ b/src/MudBlazor/Components/Badge/MudBadge.razor.cs
@@ -161,6 +161,14 @@ namespace MudBlazor
 
         private string? _content;
 
+        // Without this gate the badge always registers a DOM click listener, even when nobody subscribed to OnClick.
+        // A null delegate is not enough, because Razor still hands Blazor an EventCallback carrying this component as the receiver, which the render tree treats as a live handler.
+        // Only a default EventCallback keeps the listener off the element.
+        private EventCallback<MouseEventArgs> BadgeClickCallback =>
+            OnClick.HasDelegate
+                ? EventCallback.Factory.Create<MouseEventArgs>(this, this.AsNonRenderingEventHandler<MouseEventArgs>(HandleBadgeClick))
+                : default;
+
         internal Task HandleBadgeClick(MouseEventArgs e)
         {
             if (OnClick.HasDelegate)

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -7,7 +7,7 @@
      style="@Style"
      @onpointerenter="@PointerEnterAsync"
      @onpointerleave="@PointerLeaveAsync"
-     @oncontextmenu="@(ActivationEvent == MouseEvent.RightClick && ActivatorContent is null ? ToggleMenuAsync : (args => Task.CompletedTask))"
+     @oncontextmenu="@ContextMenuCallback"
      @oncontextmenu:preventDefault="@(ActivationEvent == MouseEvent.RightClick)"
      @oncontextmenu:stopPropagation="@(ActivationEvent == MouseEvent.RightClick)"
      @onkeydown="TrackKeyboardInteraction">

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -621,6 +621,13 @@ namespace MudBlazor
             await OpenMenuAsync(args, true);
         }
 
+        // Only wire oncontextmenu when right-click actually activates this menu.
+        // The no-op lambda this replaces was still a live delegate, so every menu registered a real DOM listener that did nothing, which on Blazor Server turns every right-click inside a menu into a wasted network round-trip.
+        private EventCallback<MouseEventArgs> ContextMenuCallback =>
+            ActivationEvent == MouseEvent.RightClick && ActivatorContent is null
+                ? EventCallback.Factory.Create<MouseEventArgs>(this, ToggleMenuAsync)
+                : default;
+
         /// <summary>
         /// Toggles the menu's open or closed state.
         /// </summary>


### PR DESCRIPTION
Both components bind an element event unconditionally and decide afterwards that there is nothing to do.

`MudMenu` bound `oncontextmenu` to `args => Task.CompletedTask` whenever right-click was not its activation event. A lambda is a live delegate, so the renderer assigned it a handler id and every menu registered a real DOM listener that resolves to nothing.

`MudBadge` always bound `onclick` and only checked `OnClick.HasDelegate` once the event had already arrived, so a purely decorative badge carried a listener as well.

Both now return `default` when the feature is off. That is the only value that keeps the attribute off the element — `EventCallback<T>.Empty` would not, because it carries a live no-op `Action`, and a `null` delegate would not either, since Razor still hands Blazor an `EventCallback` with this component as the receiver.

Measured on the sweep harness: 100 default-activation menus drop from 500 to 400 DOM listeners, and 100 badges with no `OnClick` drop from 100 to 0. Every `MudDataGrid` column header hosts a `MudMenu`, so a five-column grid ships five dead contextmenu listeners today.

This is worth more than its byte count: on Blazor Server each dead listener turns a user interaction — every right-click inside any left-click menu, every click on a decorative badge — into a network round-trip that does nothing.

Four tests, paired so the gate cannot silently disable a working feature: `Badge_WithoutOnClick_RegistersNoClickListener` and `Menu_LeftClickActivation_RegistersNoContextMenuListener` assert `MissingEventHandlerException`, and both fail on `dev` today; `Badge_WithOnClick_RegistersClickListener` and `Menu_RightClickActivation_RegistersContextMenuListener` assert the listener survives when the feature is on.

`MudTooltip` has the same shape and was deliberately left out. Gating its five handlers needs a `ShowToolTip()` condition as well as the per-event flags, and that would change when `VisibleChanged` fires for a tooltip with no content — a behaviour change rather than a dead-listener removal, so it wants its own PR and its own argument.