### PR TITLE
MudDataGrid: Label the empty boolean filter option

### DIFF
--- a/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/FilterHeaderCell.razor
@@ -37,7 +37,7 @@
                 else if (fieldType.IsBoolean)
                 {
                     <MudSelect T="bool?" Value="@valueBool" ValueChanged="@BoolValueChangedAsync" FullWidth="true" Dense="true" Margin="@Margin.Dense">
-                        <MudSelectItem T="bool?" Value="@(null)"></MudSelectItem>
+                        <MudSelectItem T="bool?" Value="@(null)">@Localizer[LanguageResource.MudDataGrid_All]</MudSelectItem>
                         <MudSelectItem T="bool?" Value="@(true)">@Localizer[LanguageResource.MudDataGrid_True]</MudSelectItem>
                         <MudSelectItem T="bool?" Value="@(false)">@Localizer[LanguageResource.MudDataGrid_False]</MudSelectItem>
                     </MudSelect>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -159,6 +159,9 @@
   <data name="MudDataGrid_False" xml:space="preserve">
     <value>false</value>
   </data>
+  <data name="MudDataGrid_All" xml:space="preserve">
+    <value>all</value>
+  </data>
   <data name="MudDataGrid_Unsort" xml:space="preserve">
     <value>Unsort</value>
   </data>


### PR DESCRIPTION
## Description
The column filter row currently renders its null boolean choice as an empty, undersized menu item. Label that no-filter choice as localizable text so it is understandable and has consistent height alongside the true and false choices.

## Changes
- add the MudDataGrid_All localization resource
- render that resource for the null boolean filter option

## Testing
- git diff --check
- build and formatting could not run because the required .NET 10.0.400 SDK is not installed in the local environment

Fixes #13508