### PR TITLE
MudAutocomplete: Fix menu opening when clearing while menu is closed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteHandleClearButtonAsyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteHandleClearButtonAsyncTest.razor
@@ -6,6 +6,7 @@
                  @bind-Value="_value"
                  @bind-Text="_text"
                  Clearable
+                 DebounceInterval="DebounceInterval"
                  SearchFunc="Search"
                  OnClearButtonClick=@ClearClicked
                  OpenChanged=@OpenChanged />
@@ -38,6 +39,8 @@
     }
 
     public MudAutocomplete<string> Autocomplete { get; private set; } = default!;
+
+    [Parameter] public int DebounceInterval { get; set; } = 100;
 
     string StatusMessage { get { return $"State: Clear = {ClearCount} - Open = {OpenedCount} - Close = {ClosedCount} - Text = {_text ?? "null"}"; } }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteHandleClearButtonAsyncTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteHandleClearButtonAsyncTest.razor
@@ -42,15 +42,24 @@
 
     [Parameter] public int DebounceInterval { get; set; } = 100;
 
+    // When set, ClearClicked stays pending until the test releases ClearGate, so keyups can be dispatched mid-transaction.
+    [Parameter] public bool GateClear { get; set; }
+
+    public TaskCompletionSource ClearGate { get; } = new();
+
     string StatusMessage { get { return $"State: Clear = {ClearCount} - Open = {OpenedCount} - Close = {ClosedCount} - Text = {_text ?? "null"}"; } }
 
     public int ClosedCount { get; private set; }
     public int OpenedCount { get; private set; }
     public int ClearCount { get; private set; }
 
-    private void ClearClicked()
+    private async Task ClearClicked()
     {
         ClearCount++;
+        if (GateClear)
+        {
+            await ClearGate.Task;
+        }
     }
 
     private void OpenChanged(bool opened)

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2727,6 +2727,63 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.ClearCount.Should().Be(1);
         }
 
+        /// <summary>
+        /// Clicking the clear button without a preceding mousedown, as with keyboard activation or element.click(), must not open the menu (follow-up to #13529).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Remain_Closed_On_Keyboard_ClearButton_Activation()
+        {
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0));
+
+            await comp.Find("button.mud-input-clear-button").ClickAsync(new());
+
+            comp.Instance.Autocomplete.Open.Should().BeFalse();
+            comp.Instance.OpenedCount.Should().Be(0);
+            comp.Instance.ClosedCount.Should().Be(0);
+            comp.Instance.ClearCount.Should().Be(1);
+        }
+
+        /// <summary>
+        /// A full pointer interaction on the clear button, mousedown followed by click through the input's own handler, must not open a closed menu (follow-up to #13529).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Remain_Closed_On_Pointer_ClearButton_Interaction()
+        {
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0));
+
+            var button = comp.Find("button.mud-input-clear-button");
+            await button.MouseDownAsync(new());
+            await button.ClickAsync(new());
+
+            comp.Instance.Autocomplete.Open.Should().BeFalse();
+            comp.Instance.OpenedCount.Should().Be(0);
+            comp.Instance.ClosedCount.Should().Be(0);
+            comp.Instance.ClearCount.Should().Be(1);
+        }
+
+        /// <summary>
+        /// A full pointer interaction on the clear button while the menu is open must keep it open (#13528).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Remain_Open_On_Pointer_ClearButton_Interaction()
+        {
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0));
+
+            await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.OpenMenuAsync());
+
+            var button = comp.Find("button.mud-input-clear-button");
+            await button.MouseDownAsync(new());
+            await button.ClickAsync(new());
+
+            comp.Instance.Autocomplete.Open.Should().BeTrue();
+            comp.Instance.OpenedCount.Should().Be(1);
+            comp.Instance.ClosedCount.Should().Be(0);
+            comp.Instance.ClearCount.Should().Be(1);
+        }
+
         [Test]
         public void PopoverSettings_SetsDefaultValues()
         {

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2728,10 +2728,10 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Clicking the clear button without a preceding mousedown, as with keyboard activation or element.click(), must not open the menu (follow-up to #13529).
+        /// Clicking the clear button without a preceding mousedown, as with element.click(), must not open the menu (follow-up to #13529).
         /// </summary>
         [Test]
-        public async Task Autocomplete_Should_Remain_Closed_On_Keyboard_ClearButton_Activation()
+        public async Task Autocomplete_Should_Remain_Closed_On_Programmatic_ClearButton_Click()
         {
             var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
                 .Add(x => x.DebounceInterval, 0));
@@ -2760,6 +2760,52 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Autocomplete.Open.Should().BeFalse();
             comp.Instance.OpenedCount.Should().Be(0);
             comp.Instance.ClosedCount.Should().Be(0);
+            comp.Instance.ClearCount.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Enter activates the clear button on keydown and its keyup lands on the input focused by the clear handler; that stray keyup must not reopen the menu, while a subsequent full Enter keystroke still opens it (follow-up to #13529).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Remain_Closed_On_Enter_ClearButton_Activation()
+        {
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0));
+            var input = comp.Find("input");
+
+            // Enter on the focused clear button: the click fires on keydown with no mousedown,
+            // then the keyup lands on the input because the clear handler moved focus there.
+            await comp.Find("button.mud-input-clear-button").ClickAsync(new());
+            await input.KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            comp.Instance.Autocomplete.Open.Should().BeFalse();
+            comp.Instance.OpenedCount.Should().Be(0);
+            comp.Instance.ClearCount.Should().Be(1);
+
+            // A genuine Enter keystroke on the input still opens the menu.
+            await input.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            await input.KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            comp.Instance.Autocomplete.Open.Should().BeTrue();
+            comp.Instance.OpenedCount.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Enter on the clear button while the menu is open must not let the stray keyup select the highlighted item and restore the cleared value (follow-up to #13529).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Not_Select_On_Enter_ClearButton_Activation_While_Open()
+        {
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0));
+
+            await Context.Renderer.Dispatcher.InvokeAsync(() => comp.Instance.Autocomplete.OpenMenuAsync());
+
+            await comp.Find("button.mud-input-clear-button").ClickAsync(new());
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            comp.Instance.Autocomplete.Open.Should().BeTrue();
+            comp.Instance.Autocomplete.Value.Should().BeNull();
             comp.Instance.ClearCount.Should().Be(1);
         }
 

--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2791,6 +2791,30 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// The stray Enter keyup must stay suppressed even when it arrives while an asynchronous clear callback is still pending (follow-up to #13529).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_Remain_Closed_On_Enter_ClearButton_Activation_With_Pending_Callback()
+        {
+            var comp = Context.Render<AutocompleteHandleClearButtonAsyncTest>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.GateClear, true));
+
+            // Enter fires the click on keydown; the gated callback keeps the clear transaction pending.
+            var clickTask = comp.Find("button.mud-input-clear-button").ClickAsync(new());
+            comp.Instance.ClearCount.Should().Be(1, "the click must have reached the gated clear callback");
+
+            // The keyup lands on the input while the clear callback is still awaited.
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+
+            comp.Instance.ClearGate.SetResult();
+            await clickTask;
+
+            comp.Instance.Autocomplete.Open.Should().BeFalse();
+            comp.Instance.OpenedCount.Should().Be(0);
+        }
+
+        /// <summary>
         /// Enter on the clear button while the menu is open must not let the stray keyup select the highlighted item and restore the cleared value (follow-up to #13529).
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -1,5 +1,7 @@
 ﻿using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components;
@@ -98,6 +100,28 @@ public class InputTests : BunitTest
         await button.MouseDownAsync();
         comp.Instance.IsClearing.Should().BeTrue();
         await button.MouseLeaveAsync();
+        comp.Instance.IsClearing.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// IsClearing must reset even when the OnClearButtonClick handler throws, so later interactions are not suppressed.
+    /// </summary>
+    [Test]
+    public async Task MudInputIsClearingShouldResetWhenClearHandlerThrows()
+    {
+        var comp = Context.Render<MudInput<string>>(parameters => parameters
+            .Add(x => x.Clearable, true)
+            .Add(x => x.Value, "Some value")
+            .Add(x => x.OnClearButtonClick, new EventCallback<MouseEventArgs>(null, (Action)(() => throw new InvalidOperationException("boom"))))
+        );
+
+        var button = comp.Find("div.mud-input .mud-input-clear-button");
+        await button.MouseDownAsync();
+        comp.Instance.IsClearing.Should().BeTrue();
+
+        await comp.Invoking(c => button.ClickAsync(new MouseEventArgs()))
+            .Should().ThrowAsync<InvalidOperationException>();
+
         comp.Instance.IsClearing.Should().BeFalse();
     }
 

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -645,6 +645,9 @@ namespace MudBlazor
             else if (Immediate)
                 await CoerceValueToTextAsync();
 
+            if (_elementReference?.IsClearing == true)
+                return;
+
             if (DebounceInterval <= 0)
                 await OpenMenuAsync();
             else

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -953,8 +953,9 @@ namespace MudBlazor
             {
                 case "Enter":
                 case "NumpadEnter":
-                    if (_skipNextEnterKeyUp)
+                    if (_skipNextEnterKeyUp || _elementReference.IsClearing)
                     {
+                        // A stray keyup from clear-button activation; the keystroke began on the button, not the input.
                         _skipNextEnterKeyUp = false;
                         break;
                     }
@@ -1142,6 +1143,10 @@ namespace MudBlazor
         {
             // clear button clicked, let's make sure text is cleared and the menu has focus
 
+            // Enter activates the clear button on keydown, and the matching keyup lands on the input the clear transaction focuses.
+            // Arm the suppression before the first await so the keyup can't slip in while an asynchronous clear callback is still pending.
+            _skipNextEnterKeyUp = true;
+
             // These lines prevent the menu from opening when OpenOnFocus is true, which is the default.
             _debounceTimer?.Dispose();
             if (_items?.Length > 0)
@@ -1156,10 +1161,6 @@ namespace MudBlazor
             {
                 await OpenMenuAsync();
             }
-
-            // Enter activates the clear button on keydown, and the matching keyup lands on the input we just focused.
-            // Swallow that stray keyup so it can't reopen the menu or select the highlighted item.
-            _skipNextEnterKeyUp = true;
         }
         internal async Task AdornmentClickHandlerAsync()
         {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -19,6 +19,7 @@ namespace MudBlazor
 
         private bool _isCleared;
         private bool _isProcessingValue;
+        private bool _skipNextEnterKeyUp;
         private int _selectedListItemIndex;
         private readonly int _elementKey = 0;
         private int _returnedItemsCount;
@@ -903,6 +904,9 @@ namespace MudBlazor
 
         private async Task OnInputKeyDownAsync(KeyboardEventArgs args)
         {
+            // A genuine keystroke on the input starts with keydown, so any pending stray-keyup suppression is over.
+            _skipNextEnterKeyUp = false;
+
             switch (args.Key)
             {
                 // We need to catch Tab here because a tab will move focus to the next element and thus we'd never get the tab key in OnInputKeyUpAsync.
@@ -949,6 +953,12 @@ namespace MudBlazor
             {
                 case "Enter":
                 case "NumpadEnter":
+                    if (_skipNextEnterKeyUp)
+                    {
+                        _skipNextEnterKeyUp = false;
+                        break;
+                    }
+
                     if (Open)
                     {
                         await OnEnterKeyAsync();
@@ -1146,6 +1156,10 @@ namespace MudBlazor
             {
                 await OpenMenuAsync();
             }
+
+            // Enter activates the clear button on keydown, and the matching keyup lands on the input we just focused.
+            // Swallow that stray keyup so it can't reopen the menu or select the highlighted item.
+            _skipNextEnterKeyUp = true;
         }
         internal async Task AdornmentClickHandlerAsync()
         {

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -310,10 +310,17 @@ namespace MudBlazor
 
         protected virtual async Task HandleClearButtonAsync(MouseEventArgs e)
         {
-            await SetTextAndUpdateValueAsync(string.Empty, updateValue: true);
-            await ElementReference.FocusAsync();
-            await OnClearButtonClick.InvokeAsync(e);
-            IsClearing = false;
+            IsClearing = true;
+            try
+            {
+                await SetTextAndUpdateValueAsync(string.Empty, updateValue: true);
+                await ElementReference.FocusAsync();
+                await OnClearButtonClick.InvokeAsync(e);
+            }
+            finally
+            {
+                IsClearing = false;
+            }
         }
 
         protected virtual async Task HandleClearMouseDownAsync(MouseEventArgs e)


### PR DESCRIPTION
Follow-up to https://github.com/MudBlazor/MudBlazor/pull/13529. The `IsClearing` guards added there sit on the click and focus handlers, but the menu opens one step earlier: `MudInput.HandleClearButtonAsync` sets the text to empty, which flows through `TextChanged` into `MudAutocomplete.UpdateValuePropertyAsync`, whose unguarded `OpenMenuAsync()` (or debounce timer) reopens the menu before the guarded handlers ever run. Since the flag was armed only by `mousedown`, keyboard or programmatic activation of the clear button never set it at all, and if `OnClearButtonClick` threw, the flag stayed stuck.

- `MudInput.HandleClearButtonAsync` now arms `IsClearing` for the whole transaction and releases it in `finally`, covering keyboard/programmatic activation and exceptions.
- `MudAutocomplete.UpdateValuePropertyAsync` skips the menu-open dispatch while clearing, closing the boundary the previous guards missed. Value coercion still runs, and the clear handler's own `if (Open) OpenMenuAsync()` still refreshes the list when the menu was open, so the behavior #13528 asked for is preserved.
- `MudAutocomplete` also swallows the stray Enter keyup that follows keyboard activation of the clear button: Enter fires the click on keydown, the handler moves focus to the input, and the keyup would otherwise land there and reopen the menu (or select the highlighted item and restore the cleared value). A genuine Enter keystroke on the input disarms the suppression on keydown, so normal open-on-Enter is unaffected.
