### PR TITLE
MudAutocomplete: Close menu when search returns no items

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -211,14 +211,13 @@ namespace MudBlazor.UnitTests.Components
             // check initial state
             autocomplete.ReadValue.Should().Be("Alabama");
             autocomplete.ReadText.Should().Be("Alabama");
-            // set a value the search won't find
+            // set a value the search won't find; the menu stays closed because the search returns nothing
             await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.Text, "Austria"));
-            // Open must be true to properly simulate a user clicking outside of the component, which is what the next ToggleMenu call below does.
-            await autocompleteComponent.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
-            // now trigger the coercion by closing the menu
-            await comp.InvokeAsync(autocomplete.ToggleMenuAsync);
+            await autocompleteComponent.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
+            // now trigger the coercion by leaving the input, as happens when the user clicks outside of the component
+            await comp.Find("input").BlurAsync(new FocusEventArgs());
+            await autocompleteComponent.WaitForAssertionAsync(() => autocomplete.ReadText.Should().Be("Alabama"));
             autocomplete.ReadValue.Should().Be("Alabama");
-            autocomplete.ReadText.Should().Be("Alabama");
         }
 
         /// <summary>
@@ -1465,7 +1464,8 @@ namespace MudBlazor.UnitTests.Components
             await autocompleteComponent.Find("input").InputAsync("abc");
             await comp.InvokeAsync(async () => await autocomplete.SelectAsync());
             await comp.InvokeAsync(async () => await autocomplete.SelectRangeAsync(0, 1));
-            await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
+            // "abc" matches nothing, so the menu stays closed
+            await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
 
             await autocompleteComponent.Find("input").InputAsync("");
             await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
@@ -2004,31 +2004,100 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// BeforeItemsTemplate should not render when there are no items
+        /// The menu should stay closed when the search returns no items even though BeforeItemsTemplate is set
         /// </summary>
         [Test]
         public async Task Autocomplete_Should_Not_LoadListStartWhenSet()
         {
             var comp = Context.Render<AutocompleteListStartRendersTest>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var returnedItemsCount = -1;
+            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.ReturnedItemsCountChanged, (int count) => returnedItemsCount = count));
 
             await comp.Find("div.mud-input-control").FocusAsync();
-            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            await comp.WaitForAssertionAsync(() => returnedItemsCount.Should().Be(0));
 
-            comp.Find("div.mud-popover").InnerHtml.Should().BeEmpty();
+            autocompleteComponent.Instance.Open.Should().BeFalse();
+            comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
         }
 
         /// <summary>
-        /// AfterItemsTemplate should not render when there are no items
+        /// The menu should stay closed when the search returns no items even though AfterItemsTemplate is set
         /// </summary>
         [Test]
         public async Task Autocomplete_Should_Not_LoadListEndWhenSet()
         {
             var comp = Context.Render<AutocompleteListEndRendersTest>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var returnedItemsCount = -1;
+            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(a => a.ReturnedItemsCountChanged, (int count) => returnedItemsCount = count));
 
             await comp.Find("div.mud-input-control").FocusAsync();
-            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().Contain("mud-popover-open"));
+            await comp.WaitForAssertionAsync(() => returnedItemsCount.Should().Be(0));
 
-            comp.Find("div.mud-popover").InnerHtml.Should().BeEmpty();
+            autocompleteComponent.Instance.Open.Should().BeFalse();
+            comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
+        }
+
+        /// <summary>
+        /// The menu should close instead of staying invisibly open when a search returns no items and no NoItemsTemplate is set (#13360)
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Should_StayClosed_When_SearchReturnsNoItems()
+        {
+            var comp = Context.Render<AutocompleteTest1>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DebounceInterval, 0));
+
+            await comp.Find("input").InputAsync("Calif");
+            await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeTrue());
+
+            await comp.Find("input").InputAsync("Califxyz");
+            await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
+            comp.FindAll(".mud-overlay").Should().BeEmpty();
+            comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
+        }
+
+        /// <summary>
+        /// Clicking the clear button after a search that returned no items should not open the menu (#13360)
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Clear_AfterEmptySearch_Should_NotOpenMenu()
+        {
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
+                .Add(x => x.Clearable, true)
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, (text, _) => Task.FromResult(new[] { "Alabama", "Alaska" }.Where(state => state.Contains(text ?? string.Empty, StringComparison.OrdinalIgnoreCase)))));
+
+            await comp.Find("input").InputAsync("xyz");
+            await comp.WaitForAssertionAsync(() => comp.Instance.Open.Should().BeFalse());
+
+            await comp.Find("button.mud-input-clear-button").MouseDownAsync();
+            await comp.InvokeAsync(() => comp.Instance.HandleClearButtonAsync(new MouseEventArgs()));
+            comp.Instance.Open.Should().BeFalse();
+            comp.Instance.ReadText.Should().BeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// Pressing Enter while the menu is closed after an empty search should still coerce the value when CoerceValue is on (#13360)
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_Enter_AfterEmptySearch_Should_CoerceValue()
+        {
+            var comp = Context.Render<AutocompleteTest1>();
+            var autocompleteComponent = comp.FindComponent<MudAutocomplete<string>>();
+            var autocomplete = autocompleteComponent.Instance;
+            await autocompleteComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.CoerceValue, true)
+                .Add(x => x.Immediate, false));
+
+            await comp.Find("input").InputAsync("Austria");
+            await comp.WaitForAssertionAsync(() => autocomplete.Open.Should().BeFalse());
+
+            await comp.Find("input").KeyUpAsync(new KeyboardEventArgs { Key = "Enter" });
+            await comp.WaitForAssertionAsync(() => autocomplete.ReadValue.Should().Be("Austria"));
         }
 
         [Test]
@@ -2509,7 +2578,8 @@ namespace MudBlazor.UnitTests.Components
                 eventCallbackFactory.Create<MouseEventArgs>(this, (e) => { }) : default;
 
             var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
-                .Add(p => p.OnAdornmentClick, _delegate));
+                .Add(p => p.OnAdornmentClick, _delegate)
+                .Add(p => p.SearchFunc, (_, _) => Task.FromResult<IEnumerable<string>>(["Foo", "Bar"])));
 
             var autocompleteInstance = comp.Instance;
             autocompleteInstance.OnAdornmentClick.HasDelegate.Should().Be(attachDelegate);
@@ -2523,7 +2593,8 @@ namespace MudBlazor.UnitTests.Components
         public async Task Autocomplete_OpenOnFocusShouldWork(bool openOnFocus)
         {
             var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
-                .Add(p => p.OpenOnFocus, openOnFocus));
+                .Add(p => p.OpenOnFocus, openOnFocus)
+                .Add(p => p.SearchFunc, (_, _) => Task.FromResult<IEnumerable<string>>(["Foo", "Bar"])));
             await comp.Find("input").FocusAsync();
 
             await comp.WaitForAssertionAsync(() => comp.Instance.Open.Should().Be(openOnFocus, $"OpenOnFocus should set Open to {openOnFocus} after input Focus"));

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -716,6 +716,9 @@ namespace MudBlazor
         /// <summary>
         /// Opens the drop-down of items, or refreshes the list if it is already open.
         /// </summary>
+        /// <remarks>
+        /// The drop-down stays closed when the search returns no items and no <see cref="NoItemsTemplate"/> is set.
+        /// </remarks>
         public async Task OpenMenuAsync()
         {
             if (MinCharacters > 0 && (string.IsNullOrWhiteSpace(ReadText) || ReadText.Length < MinCharacters))
@@ -830,7 +833,13 @@ namespace MudBlazor
                 _selectedListItemIndex = _enabledItemIndices.Any() ? _enabledItemIndices[0] : -1;
             }
 
-            if (_isFocused || !wasFocused)
+            // An empty result with no NoItemsTemplate would render an invisible zero-height popover, so keep the menu closed instead (#13360).
+            var hasPopoverContent = _items.Length != 0 || NoItemsTemplate is not null;
+            if (!hasPopoverContent)
+            {
+                Open = false;
+            }
+            else if (_isFocused || !wasFocused)
             {
                 // Open after the search has finished if we're still focused (UI), or were never focused in the first place (programmatically).
                 Open = true;
@@ -952,6 +961,12 @@ namespace MudBlazor
                     }
                     else
                     {
+                        // The menu stays closed when a search finds nothing, so Enter must coerce the value here rather than through OnEnterKeyAsync.
+                        // When Immediate is enabled the value was already coerced by TextChanged.
+                        if (!Immediate)
+                        {
+                            await CoerceValueToTextAsync();
+                        }
                         await OpenMenuAsync();
                     }
                     break;
@@ -1179,6 +1194,9 @@ namespace MudBlazor
                 await OnBlur.InvokeAsync(args);
                 return;
             }
+
+            // A genuine leave with the menu closed (such as after a search returned nothing) can't rely on the overlay close to revert the text, so coerce it here.
+            await CoerceTextToValueAsync();
 
             await base.OnBlurredAsync(args);
         }


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/13360

When `SearchFunc` returns zero items and no `NoItemsTemplate` is set, the menu opened anyway: `Open` became true, a zero-height popover rendered, and a click-catching overlay covered the page. The dropdown was visually indistinguishable from closed, so callers couldn't tell whether options were actually showing (#13360), and clicking the clear button made the full list appear out of nowhere because the invisibly-open menu refreshed in place. Older duplicate: https://github.com/MudBlazor/MudBlazor/issues/4315.

The menu now stays closed when a search returns nothing. This matches the WAI-ARIA combobox pattern, native `<datalist>`, and the free-text autocompletes in other libraries, which all hide the panel when there is no content to show. `NoItemsTemplate` is unchanged: when set, the menu still opens and renders it.

Text/value coercion previously relied on the empty menu being open, so two paths were adjusted with it:
- The `CoerceText` revert on click-away ran from the overlay close; a blur with the menu closed now runs it instead.
- `CoerceValue` on Enter routed through the open menu; Enter on a closed menu now coerces (non-`Immediate`) before re-searching.

Note this is a change to default behavior. Tests that asserted the invisible-open state (`.mud-popover-open` with empty content) were reworked, and new tests cover staying closed on empty results, clear-after-empty-search not reopening, and Enter coercion while closed.