### PR TITLE
MudListItem: Skip key interceptors for popup options

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -21,6 +21,25 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class AutocompleteTests : BunitTest
     {
+        /// <summary>
+        /// Autocomplete owns result keyboard navigation without installing an interceptor for every result.
+        /// </summary>
+        [Test]
+        public async Task AutocompleteResults_DoNotRegisterKeyInterceptors()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var provider = Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
+                .Add(x => x.DebounceInterval, 0)
+                .Add(x => x.SearchFunc, (_, _) => Task.FromResult<IEnumerable<string>>(["one", "two", "three"])));
+
+            await comp.Find("input").InputAsync(new ChangeEventArgs { Value = "o" });
+            await provider.WaitForAssertionAsync(() => provider.FindComponents<MudListItem<string>>().Should().HaveCount(3));
+
+            provider.FindComponents<MudListItem<string>>().Should().OnlyContain(x => !x.Instance.KeyboardEnabled);
+            keyInterceptorService.ObserversCount.Should().Be(0);
+        }
+
         [Test]
         public async Task Autocomplete_Should_Handle_Converter_WithStrict()
         {

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -13,6 +13,42 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class ListTests : BunitTest
     {
+        /// <summary>
+        /// List items install their own key interceptor by default.
+        /// </summary>
+        [Test]
+        public void ListItems_RegisterKeyInterceptorsByDefault()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+
+            Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Espresso"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Cortado")));
+
+            keyInterceptorService.ObserversCount.Should().Be(2);
+        }
+
+        /// <summary>
+        /// Items skip their key interceptor when keyboard handling is delegated to a parent component.
+        /// </summary>
+        [Test]
+        public async Task KeyboardDisabled_SkipsAndRemovesKeyInterceptor()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<MudListItem<string>>(parameters => parameters
+                .Add(x => x.KeyboardEnabled, false));
+
+            keyInterceptorService.ObserversCount.Should().Be(0);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.KeyboardEnabled, true));
+            keyInterceptorService.ObserversCount.Should().Be(1);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.KeyboardEnabled, false));
+            keyInterceptorService.ObserversCount.Should().Be(0);
+        }
+
         [Test]
         public async Task ListItem_RendersText_AndSecondaryText()
         {

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -14,6 +14,23 @@ namespace MudBlazor.UnitTests.Components
     [TestFixture]
     public class SelectTests : BunitTest
     {
+        /// <summary>
+        /// Select owns popup keyboard navigation without installing an interceptor for every option.
+        /// </summary>
+        [Test]
+        public async Task SelectOptions_DoNotRegisterKeyInterceptors()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<SelectTest1>();
+            var observersWhileClosed = keyInterceptorService.ObserversCount;
+
+            await comp.Find("div.mud-input-control").MouseDownAsync();
+            await comp.WaitForAssertionAsync(() => comp.FindComponents<MudListItem<string>>().Should().HaveCount(4));
+
+            comp.FindComponents<MudListItem<string>>().Should().OnlyContain(x => !x.Instance.KeyboardEnabled);
+            keyInterceptorService.ObserversCount.Should().Be(observersWhileClosed);
+        }
+
         [Test]
         public async Task Select_CheckListClass()
         {

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -96,7 +96,7 @@
                                 bool showSelectedTemplate = ItemSelectedTemplate is not null && isSelected;
                                 bool showDisabledTemplate = ItemDisabledTemplate is not null && isDisabled;
                                 var captureIndex = index;
-                                <MudListItem T="T" Value="@item" @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" OnClick="@(async () => await ListItemOnClickAsync(item))" OnClickPreventDefault="true" Class="@GetListItemClassname(isSelected)">
+                                <MudListItem T="T" Value="@item" @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" KeyboardEnabled="false" OnClick="@(async () => await ListItemOnClickAsync(item))" OnClickPreventDefault="true" Class="@GetListItemClassname(isSelected)">
                                     @if (showDisabledTemplate)
                                     {
                                         @ItemDisabledTemplate!(item)

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -139,6 +139,16 @@ namespace MudBlazor
         public bool Ripple { get; set; } = true;
 
         /// <summary>
+        /// Allows this item to handle keyboard input.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.  Set to <c>false</c> when a parent component owns keyboard navigation, which avoids a key interceptor per item.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool KeyboardEnabled { get; set; } = true;
+
+        /// <summary>
         /// The icon to display for this list item.
         /// </summary>
         /// <remarks>
@@ -300,42 +310,50 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            var effectiveElementId = GetEffectiveElementId(ElementId);
+            var effectiveElementId = KeyboardEnabled ? GetEffectiveElementId(ElementId) : null;
 
-            if (firstRender || !string.Equals(_subscribedElementId, effectiveElementId, StringComparison.Ordinal))
+            if (!string.Equals(_subscribedElementId, effectiveElementId, StringComparison.Ordinal))
             {
                 if (!string.IsNullOrEmpty(_subscribedElementId))
                 {
                     await KeyInterceptorService.UnsubscribeAsync(_subscribedElementId);
+                    _subscribedElementId = null;
                 }
 
-                var options = new KeyInterceptorOptions(
-                    [
-                        // prevent scrolling page
-                        new(" ", preventDown: "key+none", preventUp: "key+none"),
-                        // prevent scrolling page and move focus to previous item
-                        new("ArrowUp", preventDown: "key+none"),
-                        // prevent scrolling page and move focus to next item
-                        new("ArrowDown", preventDown: "key+none"),
-                        new("Home", preventDown: "key+none"),
-                        new("End", preventDown: "key+none"),
-                        new("Enter", preventDown: "key+none"),
-                        new("NumpadEnter", preventDown: "key+none")
-                    ]);
-
-                await KeyInterceptorService.SubscribeAsync(effectiveElementId, options, keys => keys
-                    .When(CanHandleKeys, builder => builder
-                        .OnKeyDown("ArrowDown", HandleArrowDownAsync)
-                        .OnKeyDown("ArrowUp", HandleArrowUpAsync)
-                        .OnKeyDown("Home", HandleHomeAsync)
-                        .OnKeyDown("End", HandleEndAsync)
-                        .OnKeyDown(" ", HandleSpaceAsync)
-                        .OnKeyDownAny(["Enter", "NumpadEnter"], HandleEnterAsync)));
-
-                _subscribedElementId = effectiveElementId;
+                if (effectiveElementId is not null)
+                {
+                    await SubscribeToKeyInterceptorAsync(effectiveElementId);
+                    _subscribedElementId = effectiveElementId;
+                }
             }
 
             await base.OnAfterRenderAsync(firstRender);
+        }
+
+        private Task SubscribeToKeyInterceptorAsync(string elementId)
+        {
+            var options = new KeyInterceptorOptions(
+                [
+                    // prevent scrolling page
+                    new(" ", preventDown: "key+none", preventUp: "key+none"),
+                    // prevent scrolling page and move focus to previous item
+                    new("ArrowUp", preventDown: "key+none"),
+                    // prevent scrolling page and move focus to next item
+                    new("ArrowDown", preventDown: "key+none"),
+                    new("Home", preventDown: "key+none"),
+                    new("End", preventDown: "key+none"),
+                    new("Enter", preventDown: "key+none"),
+                    new("NumpadEnter", preventDown: "key+none")
+                ]);
+
+            return KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
+                .When(CanHandleKeys, builder => builder
+                    .OnKeyDown("ArrowDown", HandleArrowDownAsync)
+                    .OnKeyDown("ArrowUp", HandleArrowUpAsync)
+                    .OnKeyDown("Home", HandleHomeAsync)
+                    .OnKeyDown("End", HandleEndAsync)
+                    .OnKeyDown(" ", HandleSpaceAsync)
+                    .OnKeyDownAny(["Enter", "NumpadEnter"], HandleEnterAsync)));
         }
 
         protected async Task OnClickHandlerAsync(MouseEventArgs eventArgs)

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -322,38 +322,34 @@ namespace MudBlazor
 
                 if (effectiveElementId is not null)
                 {
-                    await SubscribeToKeyInterceptorAsync(effectiveElementId);
+                    var options = new KeyInterceptorOptions(
+                        [
+                            // prevent scrolling page
+                            new(" ", preventDown: "key+none", preventUp: "key+none"),
+                            // prevent scrolling page and move focus to previous item
+                            new("ArrowUp", preventDown: "key+none"),
+                            // prevent scrolling page and move focus to next item
+                            new("ArrowDown", preventDown: "key+none"),
+                            new("Home", preventDown: "key+none"),
+                            new("End", preventDown: "key+none"),
+                            new("Enter", preventDown: "key+none"),
+                            new("NumpadEnter", preventDown: "key+none")
+                        ]);
+
+                    await KeyInterceptorService.SubscribeAsync(effectiveElementId, options, keys => keys
+                        .When(CanHandleKeys, builder => builder
+                            .OnKeyDown("ArrowDown", HandleArrowDownAsync)
+                            .OnKeyDown("ArrowUp", HandleArrowUpAsync)
+                            .OnKeyDown("Home", HandleHomeAsync)
+                            .OnKeyDown("End", HandleEndAsync)
+                            .OnKeyDown(" ", HandleSpaceAsync)
+                            .OnKeyDownAny(["Enter", "NumpadEnter"], HandleEnterAsync)));
+
                     _subscribedElementId = effectiveElementId;
                 }
             }
 
             await base.OnAfterRenderAsync(firstRender);
-        }
-
-        private Task SubscribeToKeyInterceptorAsync(string elementId)
-        {
-            var options = new KeyInterceptorOptions(
-                [
-                    // prevent scrolling page
-                    new(" ", preventDown: "key+none", preventUp: "key+none"),
-                    // prevent scrolling page and move focus to previous item
-                    new("ArrowUp", preventDown: "key+none"),
-                    // prevent scrolling page and move focus to next item
-                    new("ArrowDown", preventDown: "key+none"),
-                    new("Home", preventDown: "key+none"),
-                    new("End", preventDown: "key+none"),
-                    new("Enter", preventDown: "key+none"),
-                    new("NumpadEnter", preventDown: "key+none")
-                ]);
-
-            return KeyInterceptorService.SubscribeAsync(elementId, options, keys => keys
-                .When(CanHandleKeys, builder => builder
-                    .OnKeyDown("ArrowDown", HandleArrowDownAsync)
-                    .OnKeyDown("ArrowUp", HandleArrowUpAsync)
-                    .OnKeyDown("Home", HandleHomeAsync)
-                    .OnKeyDown("End", HandleEndAsync)
-                    .OnKeyDown(" ", HandleSpaceAsync)
-                    .OnKeyDownAny(["Enter", "NumpadEnter"], HandleEnterAsync)));
         }
 
         protected async Task OnClickHandlerAsync(MouseEventArgs eventArgs)

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -124,6 +124,7 @@
                                              Text="@SelectAllText"
                                              OnClick="SelectAllClickAsync"
                                              OnClickPreventDefault="true"
+                                             KeyboardEnabled="false"
                                              Dense="@Dense"
                                              Class="mb-2" />
                                 <MudDivider />

--- a/src/MudBlazor/Components/Select/MudSelectItem.razor
+++ b/src/MudBlazor/Components/Select/MudSelectItem.razor
@@ -4,7 +4,7 @@
 
 @if (!HideContent)
 {
-    <MudListItem @attributes="GetUserAttributes()" Value="@ItemId" id="@ItemId" OnClick="this.AsNonRenderingEventHandler(OnClickHandleAsync)" OnClickPreventDefault="true" Icon="@CheckBoxIcon" Disabled="@Disabled" Class="@GetCssClasses()" Style="@Style">
+    <MudListItem @attributes="GetUserAttributes()" Value="@ItemId" id="@ItemId" OnClick="this.AsNonRenderingEventHandler(OnClickHandleAsync)" OnClickPreventDefault="true" Icon="@CheckBoxIcon" Disabled="@Disabled" KeyboardEnabled="false" Class="@GetCssClasses()" Style="@Style">
         @if (ChildContent is not null)
         {
             @ChildContent


### PR DESCRIPTION
Every rendered `MudListItem<T>` subscribes its own JavaScript key interceptor in `OnAfterRenderAsync`. That is correct for a standalone `MudList`, where focus moves between items, but it is dead weight inside `MudSelect` and `MudAutocomplete`: those keep focus on their activator/input and own popup keyboard navigation themselves, so the per-option interceptors can never fire.

Change

- Add `KeyboardEnabled` to `MudListItem<T>` (default `true`), mirroring the existing parameter of the same name on `MudCheckBox<T>`.
- Make the subscription lifecycle follow the parameter, so a runtime `true`/`false` change subscribes and unsubscribes rather than leaking a stale registration.
- Set `KeyboardEnabled="false"` on the option items generated by `MudSelectItem`, the Select's "select all" item, and Autocomplete results.

Standalone list items are untouched and keep today's behavior.

Counted in a browser by wrapping `mudKeyInterceptor.connect`:

| Action | Before | After |
| --- | --- | --- |
| Open a 50-option `MudSelect` | 50 connects | 0 |
| Reopen the same select | 50 connects | 0 |
| Open a 50-option multi-select (with `SelectAll`) | 51 connects | 0 |
| Type into a `MudAutocomplete` with 50 results | 51 interceptors attached | 0 |