### PR TITLE
MudCheckBox: Skip key interop the checkbox can never use

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -346,6 +346,27 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => checkbox.ReadValue.Should().Be(null));
         }
 
+        /// <summary>
+        /// Disabling keyboard handling avoids and removes the checkbox key interceptor.
+        /// </summary>
+        [Test]
+        public async Task KeyboardEnabled_ControlsKeyInterceptorLifetime()
+        {
+            var keyInterceptorService = Context.AddKeyInterceptorService();
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters
+                .Add(x => x.KeyboardEnabled, false));
+
+            keyInterceptorService.ObserversCount.Should().Be(0);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.KeyboardEnabled, true));
+            keyInterceptorService.ObserversCount.Should().Be(1);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.KeyboardEnabled, false));
+            keyInterceptorService.ObserversCount.Should().Be(0);
+        }
+
         [Test]
         [TestCase(Color.Default, Color.Primary)]
         [TestCase(Color.Primary, Color.Secondary)]

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor
@@ -7,7 +7,8 @@
         <label class="@LabelClassname" id="@_elementId" @onkeydown="HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
                 @*note: stopping the click propagation is important here. otherwise checking the checkbox results in click events on its parent (i.e. table row), which is generally not what you would want*@
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                @*note: when keyboard handling is off there is no key interceptor to swallow Space, so suppress the browser's own keyup activation instead. Only keyup is suppressed, so Tab still moves focus.*@
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="checkbox" class="mud-checkbox-input" checked="@BoolValue" @onkeyup:preventDefault="@(!KeyboardEnabled)" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
+++ b/src/MudBlazor/Components/CheckBox/MudCheckBox.razor.cs
@@ -15,6 +15,7 @@ namespace MudBlazor
     {
         private readonly string _elementId = Identifier.Create("checkbox");
         private readonly string _ariaId = Identifier.Create("cbox-aria-");
+        private bool _keyInterceptorSubscribed;
 
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
@@ -160,7 +161,7 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if (firstRender)
+            if (KeyboardEnabled && !_keyInterceptorSubscribed)
             {
                 var options = new KeyInterceptorOptions(
                     "mud-button-root",
@@ -178,7 +179,15 @@ namespace MudBlazor
                         .OnKeyDownAny(["Enter", "NumpadEnter"], () => SetBoolValueAsync(true, true))
                         .OnKeyDown("Backspace", HandleBackspaceAsync)
                         .OnKeyDown(" ", HandleSpaceAsync)));
+
+                _keyInterceptorSubscribed = true;
             }
+            else if (!KeyboardEnabled && _keyInterceptorSubscribed)
+            {
+                await KeyInterceptorService.UnsubscribeAsync(_elementId);
+                _keyInterceptorSubscribed = false;
+            }
+
             await base.OnAfterRenderAsync(firstRender);
         }
 
@@ -224,9 +233,10 @@ namespace MudBlazor
         {
             await base.DisposeAsyncCore();
 
-            if (IsJSRuntimeAvailable)
+            if (IsJSRuntimeAvailable && _keyInterceptorSubscribed)
             {
                 await KeyInterceptorService.UnsubscribeAsync(_elementId);
+                _keyInterceptorSubscribed = false;
             }
         }
     }


### PR DESCRIPTION
`MudCheckBox` subscribed a JavaScript key interceptor on first render and disconnected it on dispose unconditionally, even when `KeyboardEnabled` was `false` and no key could ever be handled. Every multi-selection `MudListItem` renders an internal checkbox with `KeyboardEnabled="false"`, so large multi-select lists paid for one guaranteed-dead interceptor per item.

## Change

- Track whether a subscription exists; subscribe only while `KeyboardEnabled` is `true`, unsubscribe when it turns `false`, and skip the disposal interop when nothing was subscribed.
- Suppress the browser's native Space activation with `@onkeyup:preventDefault` when `KeyboardEnabled` is `false` — see below.

No public API change.

## Please look at this part

The interceptor was doing double duty. Managed key handling runs through the component's own `@onkeydown` → `DispatchAsync` → observer; the JS side mainly exists for `preventDefault`. So simply dropping the subscription restored the browser default: a standalone `<MudCheckBox KeyboardEnabled="false">` started **toggling on Space**, which makes the parameter mean nothing. Measured before/after in a browser, so this is not hypothetical.

The fix is `@onkeyup:preventDefault="@(!KeyboardEnabled)"` on the input. Checkbox activation is a keyup default, so suppressing keyup alone kills Space without touching Tab. `@onkeydown:preventDefault` would *not* work here — Blazor evaluates `:preventDefault` statically per render, so it would also swallow Tab and trap focus (verified: `defaultPrevented` true on the Tab keydown).

This swaps one suppression mechanism for another rather than only changing when we subscribe, and I could only verify keyup activation semantics in Chrome. The spec routes checkbox activation through the synthetic click dispatched at keyup, so I expect it holds elsewhere, but it is worth a second opinion.

## Measured effect

Counted in a browser by wrapping `mudKeyInterceptor.connect`:

| Action | Before | After |
| --- | --- | --- |
| Mount 100 multi-selection `MudListItem`s | 200 connects | 100 |
| Internal checkboxes holding an interceptor | one per item | 0 |

## Verified in a browser (20/20)

Space suppressed on a keyboard-disabled checkbox while a mouse click still toggles it; Tab keydown not `defaultPrevented`; Space/Delete/Enter and TriState Backspace unchanged on enabled checkboxes; ReadOnly and Disabled unchanged; `false` → `true` → `false` at runtime subscribes and unsubscribes correctly; multi-select list items still toggle on Space, and clicking an item's checkbox then pressing Space does not double-toggle.

## Tests

`CheckBoxTests.KeyboardEnabled_ControlsKeyInterceptorLifetime` covers the lifecycle and fails without the fix. Full unit suite: 5759 passed, 0 failed.
