### PR TITLE
MudElement: Capture element references without an extra render

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -608,5 +608,36 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(comp.Instance.Recover);
             alertTextFunc.Should().Throw<ComponentNotFoundException>();
         }
+
+        /// <summary>
+        /// Buttons still receive their element reference, so <c>FocusAsync</c> has an element to focus.
+        /// </summary>
+        [Test]
+        public async Task ButtonsCaptureTheirElementReference()
+        {
+            var button = Context.Render<MudButton>();
+            var fab = Context.Render<MudFab>();
+            var iconButton = Context.Render<MudIconButton>();
+
+            var focus = async () =>
+            {
+                await button.InvokeAsync(async () => await button.Instance.FocusAsync());
+                await fab.InvokeAsync(async () => await fab.Instance.FocusAsync());
+                await iconButton.InvokeAsync(async () => await iconButton.Instance.FocusAsync());
+            };
+
+            await focus.Should().NotThrowAsync();
+        }
+
+        /// <summary>
+        /// Capturing the element reference must not cost a button a second render (#13519).
+        /// </summary>
+        [Test]
+        public void ButtonsRenderOnceWhenElementReferenceIsCaptured()
+        {
+            Context.Render<MudButton>().RenderCount.Should().Be(1);
+            Context.Render<MudFab>().RenderCount.Should().Be(1);
+            Context.Render<MudIconButton>().RenderCount.Should().Be(1);
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ListTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ListTests.cs
@@ -953,6 +953,36 @@ namespace MudBlazor.UnitTests.Components
             list.GetAttribute("aria-multiselectable").Should().Be("false");
         }
 
+        /// <summary>
+        /// Capturing an item's element reference must not cost that item a second render (#13519).
+        /// </summary>
+        [Test]
+        public void ListItems_RenderOnce_WhenElementReferenceIsCaptured()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Espresso"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Cortado")));
+
+            comp.FindComponents<MudListItem<string>>().Select(x => x.RenderCount).Should().AllBeEquivalentTo(1);
+        }
+
+        /// <summary>
+        /// An item still receives its element reference, so keyboard navigation can move focus onto it.
+        /// </summary>
+        [Test]
+        public async Task ListItem_FocusesCapturedElement()
+        {
+            var comp = Context.Render<MudList<string>>(builder => builder
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Espresso"))
+                .AddChildContent<MudListItem<string>>(item => item.Add(x => x.Text, "Cortado")));
+            var cortado = comp.FindComponents<MudListItem<string>>()
+                .Single(x => x.Instance.Text == "Cortado").Instance;
+
+            var focus = async () => await comp.InvokeAsync(() => cortado.FocusAsync());
+
+            await focus.Should().NotThrowAsync();
+        }
+
         private static bool? CheckBoxValue(IRenderedComponent<ListMultiSelectionTest> comp, string text) =>
             comp.FindComponents<MudListItem<string>>()
                 .Single(x => x.Instance.Text == text)

--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -88,6 +88,21 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-popover-open").Count.Should().Be(1));
         }
 
+        /// <summary>
+        /// Menu items still receive their element reference, which submenu positioning and focus rely on.
+        /// </summary>
+        [Test]
+        public async Task OpenMenu_ItemsCaptureElementReference()
+        {
+            var comp = Context.Render<MenuTest1>();
+
+            await comp.FindAll("button.mud-button-root")[0].ClickAsync();
+
+            var items = comp.FindComponents<MudMenuItem>();
+            items.Should().NotBeEmpty();
+            items.Select(x => x.Instance.ElementReference.Id).Should().OnlyContain(x => !string.IsNullOrEmpty(x));
+        }
+
         [Test]
         public async Task OpenMenu_ClickSecondItem_CheckClosed()
         {

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -11,6 +11,16 @@ namespace MudBlazor
     public abstract class MudBaseButton : MudComponentBase
     {
         /// <summary>
+        /// Stores the rendered element reference without re-rendering this button.
+        /// </summary>
+        protected readonly EventCallback<ElementReference> _captureElementReference;
+
+        protected MudBaseButton()
+        {
+            _captureElementReference = MudElement.CaptureRef(reference => _elementReference = reference);
+        }
+
+        /// <summary>
         /// The custom activation behavior.
         /// </summary>
         /// <remarks>

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -13,7 +13,10 @@ namespace MudBlazor
         /// <summary>
         /// Stores the rendered element reference without re-rendering this button.
         /// </summary>
-        protected readonly EventCallback<ElementReference> _captureElementReference;
+        /// <remarks>
+        /// Only the button markup in this assembly binds it, so it stays off the public API surface.
+        /// </remarks>
+        private protected readonly EventCallback<ElementReference> _captureElementReference;
 
         protected MudBaseButton()
         {

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -2,7 +2,8 @@
 @inherits MudBaseButton
 @implements IDisposable
 
-<MudElement @bind-Ref="@_elementReference"
+<MudElement Ref="@_elementReference"
+            RefChanged="@_captureElementReference"
             HtmlTag="@HtmlTag"
             Class="@Classname"
             Style="@Style"

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudBaseButton
 
-<MudElement @bind-Ref="@_elementReference"
+<MudElement Ref="@_elementReference"
+            RefChanged="@_captureElementReference"
             HtmlTag="@HtmlTag"
             Class="@Classname"
             Style="@Style"

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -1,7 +1,8 @@
 ﻿@namespace MudBlazor
 @inherits MudBaseButton
 
-<MudElement @bind-Ref="@_elementReference"
+<MudElement Ref="@_elementReference"
+            RefChanged="@_captureElementReference"
             HtmlTag="@HtmlTag"
             Class="@Classname" 
             Style="@Style"

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -66,10 +66,8 @@ namespace MudBlazor
         /// Creates a <see cref="RefChanged"/> callback that stores the captured reference without re-rendering the caller.
         /// </summary>
         /// <remarks>
-        /// The callback <c>@bind-Ref</c> emits is bound to the consuming component, so invoking it runs through
-        /// <c>ComponentBase.HandleEventAsync</c> and calls <c>StateHasChanged</c> there.
-        /// Capturing an element reference is not a state change, and that extra render is a large share of the cost of
-        /// building many items at once, such as opening a select with hundreds of options (#13519).
+        /// The callback <c>@bind-Ref</c> emits is bound to the consuming component, so invoking it runs through <c>ComponentBase.HandleEventAsync</c> and calls <c>StateHasChanged</c> there.
+        /// Capturing an element reference is not a state change, and that extra render is a large share of the cost of building many items at once, such as opening a select with hundreds of options (#13519).
         /// </remarks>
         /// <param name="setter">Stores the captured reference.</param>
         internal static EventCallback<ElementReference> CaptureRef(Action<ElementReference> setter) => new(null, setter);

--- a/src/MudBlazor/Components/Element/MudElement.cs
+++ b/src/MudBlazor/Components/Element/MudElement.cs
@@ -62,6 +62,18 @@ namespace MudBlazor
         [Category(CategoryTypes.Button.Behavior)]
         public bool PreventDefault { get; set; }
 
+        /// <summary>
+        /// Creates a <see cref="RefChanged"/> callback that stores the captured reference without re-rendering the caller.
+        /// </summary>
+        /// <remarks>
+        /// The callback <c>@bind-Ref</c> emits is bound to the consuming component, so invoking it runs through
+        /// <c>ComponentBase.HandleEventAsync</c> and calls <c>StateHasChanged</c> there.
+        /// Capturing an element reference is not a state change, and that extra render is a large share of the cost of
+        /// building many items at once, such as opening a select with hundreds of options (#13519).
+        /// </remarks>
+        /// <param name="setter">Stores the captured reference.</param>
+        internal static EventCallback<ElementReference> CaptureRef(Action<ElementReference> setter) => new(null, setter);
+
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);

--- a/src/MudBlazor/Components/List/MudListItem.razor
+++ b/src/MudBlazor/Components/List/MudListItem.razor
@@ -18,7 +18,8 @@
             target="@Target"
             PreventDefault="@GetPreventDefault()"
             ClickPropagation="@GetClickPropagation()"
-            @bind-Ref="_elementReference">
+            Ref="_elementReference"
+            RefChanged="_captureElementReference">
 
     @if (AvatarContent is not null)
     {

--- a/src/MudBlazor/Components/List/MudListItem.razor.cs
+++ b/src/MudBlazor/Components/List/MudListItem.razor.cs
@@ -22,9 +22,11 @@ namespace MudBlazor
         internal string ElementId { get; } = Identifier.Create("list-item");
 
         private readonly ParameterState<bool> _expandedState;
+        private readonly EventCallback<ElementReference> _captureElementReference;
 
         public MudListItem()
         {
+            _captureElementReference = MudElement.CaptureRef(reference => _elementReference = reference);
             using var registerScope = CreateRegisterScope();
             _expandedState = registerScope.RegisterParameter<bool>(nameof(Expanded))
                 .WithParameter(() => Expanded)

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -10,7 +10,8 @@
             ClickPropagation="false"
             @attributes="UserAttributes"
             @onclick="OnClickHandlerAsync"
-            @bind-Ref="ElementReference"
+            Ref="ElementReference"
+            RefChanged="_captureElementReference"
             tabindex="@(!GetDisabled() ? "0" : "-1")"
             aria-disabled="@(GetDisabled() ? "true" : "false")">
 

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor.cs
@@ -10,6 +10,13 @@ namespace MudBlazor
     /// <seealso cref="MudMenu" />
     public partial class MudMenuItem : MudComponentBase
     {
+        private readonly EventCallback<ElementReference> _captureElementReference;
+
+        public MudMenuItem()
+        {
+            _captureElementReference = MudElement.CaptureRef(reference => ElementReference = reference);
+        }
+
         [Inject]
         protected NavigationManager UriHelper { get; set; } = null!;
 


### PR DESCRIPTION
`@bind-Ref` compiles to a `RefChanged` `EventCallback` bound to the consuming component, so delivering the captured `ElementReference` runs through `ComponentBase.HandleEventAsync`, which calls `StateHasChanged`.

Capturing a reference is not a state change, but every `MudListItem`, `MudMenuItem`, `MudButton`, `MudFab` and `MudIconButton` paid a second full render for it. For a list of options that is ~40% of the render cost, which is a large part of why a 1000-option `MudSelect` takes seconds to open (#13519).

This adds `MudElement.CaptureRef(setter)`, which builds the callback with a null receiver so the delegate is invoked directly, and switched the five in-library consumers to it. No public API change, no markup change.

Measured with a bare `Renderer` whose `UpdateDisplayAsync` does nothing, so the figures are render-tree work only (bUnit's HTML materialization dilutes the delta). Median of 7 runs, 1000 items:

| | before | after |
| --- | --- | --- |
| `MudListItem` x1000 | 30.3 MB / 55 ms | 18.3 MB / 28 ms |
| `MudSelect` open, 1000 options | 41.7 MB / 95 ms | 29.5 MB / 67 ms |

In the Viewer (Debug WASM), first open of a 1000-option select goes from ~4.8 s to ~4.4 s; combined with #13707 it reaches ~4.1 s.