### PR TITLE
MudText: Render its element directly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TextTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextTests.cs
@@ -29,6 +29,18 @@ public class TextTests : BunitTest
         comp.MarkupMatches("""<p class="mud-typography mud-typography-body1"></p>""");
     }
 
+    /// <summary>
+    /// The typography element is rendered directly, without a nested component between the caller and the DOM.
+    /// </summary>
+    [Test]
+    public void Text_ShouldRenderItsElementWithoutAWrapperComponent()
+    {
+        var comp = Context.Render<MudText>(parameters => parameters.AddChildContent("Flat white"));
+
+        comp.FindComponents<MudElement>().Should().BeEmpty();
+        comp.Find("p.mud-typography").TextContent.Should().Be("Flat white");
+    }
+
     [Test]
     public void UserAttributes_ShouldBeSplattedOnTheRootElement()
     {

--- a/src/MudBlazor/Components/Typography/MudText.razor
+++ b/src/MudBlazor/Components/Typography/MudText.razor
@@ -1,6 +1,0 @@
-@namespace MudBlazor
-@inherits MudComponentBase
-
-<MudElement HtmlTag="@GetActualTag()" Class="@Classname" Style="@Style" UserAttributes="@UserAttributes">
-    @ChildContent
-</MudElement>

--- a/src/MudBlazor/Components/Typography/MudText.razor.cs
+++ b/src/MudBlazor/Components/Typography/MudText.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using MudBlazor.Utilities;
 
 namespace MudBlazor;
@@ -95,6 +96,17 @@ public partial class MudText : MudComponentBase
     [Parameter]
     [Category(CategoryTypes.Text.Behavior)]
     public string? HtmlTag { get; set; }
+
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, GetActualTag());
+        builder.AddMultipleAttributes(1, UserAttributes!);
+        builder.AddAttribute(2, "class", Classname);
+        builder.AddAttribute(3, "style", Style);
+        builder.AddContent(4, ChildContent);
+        builder.CloseElement();
+    }
 
     private string GetActualTag() => string.IsNullOrEmpty(HtmlTag) ? GetTagName(Typo) : HtmlTag;
 


### PR DESCRIPTION
`MudText` delegated to `MudElement` for a plain open-tag / splat / class / style / content sequence. That puts a second component between every piece of text in the library and the DOM, and `MudText` is used nearly everywhere.

Now `MudText` builds that render tree itself. The rendered markup is unchanged, including attribute order (splat first, then `class`, then `style`), so caller-supplied attributes behave exactly as before.

Measured with a bare `Renderer` whose `UpdateDisplayAsync` does nothing, so the figures are render-tree work only. Median of 7 runs, 1000 items:

| | before | after |
| --- | --- | --- |
| `MudText` x1000 | 5.7 MB / 6 ms | 2.5 MB / 2 ms |
| `MudListItem` x1000 | 30.3 MB / 55 ms | 25.5 MB / 48 ms |
| `MudSelect` open, 1000 options | 41.7 MB / 95 ms | 36.8 MB / 79 ms |