### PR TITLE
MudInput: Stop the clear button reopening its host component

### DIFF
--- a/src/MudBlazor.UnitTests/Components/InputTests.cs
+++ b/src/MudBlazor.UnitTests/Components/InputTests.cs
@@ -104,6 +104,22 @@ public class InputTests : BunitTest
     }
 
     /// <summary>
+    /// The clear button must stop its own mousedown, because the components that host it, such as MudSelect and the pickers, open on that event.
+    /// </summary>
+    [Test]
+    public void MudInputClearButtonShouldStopMouseDownPropagation()
+    {
+        var comp = Context.Render<MudInput<string>>(parameters => parameters
+            .Add(x => x.Clearable, true)
+            .Add(x => x.Value, "Some value")
+        );
+
+        var button = comp.Find("div.mud-input .mud-input-clear-button");
+
+        button.HasAttribute("blazor:onmousedown:stopPropagation").Should().BeTrue();
+    }
+
+    /// <summary>
     /// IsClearing must reset even when the OnClearButtonClick handler throws, so later interactions are not suppressed.
     /// </summary>
     [Test]

--- a/src/MudBlazor/Components/Input/MudInput.razor
+++ b/src/MudBlazor/Components/Input/MudInput.razor
@@ -107,8 +107,7 @@
                        OnClick="@HandleClearButtonAsync"
                        aria-label="@Localizer[LanguageResource.MudInput_Clear]"
                        tabindex="-1"
-                       @onmousedown="@HandleClearMouseDownAsync"
-                       @onmouseleave="@HandleClearMouseLeaveAsync"/>
+                       @attributes="ClearButtonAttributes" />
     }
 
     @if (Adornment == Adornment.End)

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -323,6 +323,18 @@ namespace MudBlazor
             }
         }
 
+        // The clear button lives inside components that open on mousedown, such as MudSelect and the pickers, so its own mousedown must not reach them.
+        // A `@onmousedown:stopPropagation` directive cannot sit beside `@onmousedown` on a component, so both travel through the splat instead, which is what the directive compiles to anyway.
+        // Built once per input because the callbacks are bound to instance methods and never change.
+        private Dictionary<string, object>? _clearButtonAttributes;
+
+        private Dictionary<string, object> ClearButtonAttributes => _clearButtonAttributes ??= new Dictionary<string, object>(3)
+        {
+            ["onmousedown"] = EventCallback.Factory.Create<MouseEventArgs>(this, HandleClearMouseDownAsync),
+            ["__internal_stopPropagation_onmousedown"] = true,
+            ["onmouseleave"] = EventCallback.Factory.Create<MouseEventArgs>(this, HandleClearMouseLeaveAsync),
+        };
+
         protected virtual async Task HandleClearMouseDownAsync(MouseEventArgs e)
         {
             IsClearing = true;

--- a/src/MudBlazor/Components/Input/MudInput.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInput.razor.cs
@@ -325,7 +325,6 @@ namespace MudBlazor
 
         // The clear button lives inside components that open on mousedown, such as MudSelect and the pickers, so its own mousedown must not reach them.
         // A `@onmousedown:stopPropagation` directive cannot sit beside `@onmousedown` on a component, so both travel through the splat instead, which is what the directive compiles to anyway.
-        // Built once per input because the callbacks are bound to instance methods and never change.
         private Dictionary<string, object>? _clearButtonAttributes;
 
         private Dictionary<string, object> ClearButtonAttributes => _clearButtonAttributes ??= new Dictionary<string, object>(3)


### PR DESCRIPTION
Clearing a `MudSelect` clears the value and then immediately reopens the dropdown.

The clear button used to carry `@onmousedown:stopPropagation`. #13529 replaced that directive with an `@onmousedown` handler so the input can track that a clear is in flight, but a component cannot carry both spellings of the same event, so the propagation guard was dropped. `MudSelect` opens from the mousedown on `.mud-input-control`, which now receives the clear button's mousedown.

- Both the handler and the stop-propagation flag travel through the splat instead, which is what the directive compiles to anyway, so the in-flight tracking and the guard coexist.

bUnit dispatches events straight to the target element and never bubbles, so the reopening is not observable in a unit test; the added test asserts the rendered attribute. Behaviour was checked in a browser against a `MudSelect`, both date pickers, an autocomplete and a plain text field — only the select regressed, and all of them still clear correctly.