### PR TITLE
MudBaseInput: Prevent debounced input reformatting text mid-typing

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -635,8 +635,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task NumericField_Debounced_ValueEcho_DoesNotRewriteTextWhileTyping()
         {
-            // The debounce commit echoes back through the parent binding, and that echo used to reformat
-            // mid-typing because the suppression read Immediate, which a debounced field leaves false.
+            // The debounce commit echoes back through the parent binding, and that echo used to reformat mid-typing because the suppression read Immediate, which a debounced field leaves false.
             // "1." became "1", so continuing with "50" produced 150 instead of 1.50.
             var timeProvider = Context.AddFakeTimeProvider();
             var comp = Context.Render<MudNumericField<double?>>(parameters => parameters

--- a/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NumericFieldTests.cs
@@ -629,6 +629,42 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => comp.Instance.ReadText.Should().Be("1234.000"));
         }
 
+        /// <summary>
+        /// A debounced field commits from oninput just like an Immediate one, so its own value echo must not rewrite the text the user is still typing.
+        /// </summary>
+        [Test]
+        public async Task NumericField_Debounced_ValueEcho_DoesNotRewriteTextWhileTyping()
+        {
+            // The debounce commit echoes back through the parent binding, and that echo used to reformat
+            // mid-typing because the suppression read Immediate, which a debounced field leaves false.
+            // "1." became "1", so continuing with "50" produced 150 instead of 1.50.
+            var timeProvider = Context.AddFakeTimeProvider();
+            var comp = Context.Render<MudNumericField<double?>>(parameters => parameters
+                .Add(x => x.DebounceInterval, 200d)
+                .Add(x => x.Culture, CultureInfo.GetCultureInfo("en-US")));
+
+            comp.Instance.Immediate.Should().BeFalse();
+            comp.Instance.EffectiveImmediate.Should().BeTrue("a debounced field still commits from oninput");
+
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "1" });
+            await comp.Find("input").InputAsync("1");
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "." });
+            await comp.Find("input").InputAsync("1.");
+
+            timeProvider.Advance(TimeSpan.FromMilliseconds(300));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1d));
+
+            // The parent's two-way binding hands the committed value straight back.
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, 1d));
+
+            comp.Instance.ReadText.Should().Be("1.", "the trailing separator the user typed must survive the echo");
+
+            await comp.Find("input").KeyDownAsync(new KeyboardEventArgs { Key = "5" });
+            await comp.Find("input").InputAsync("1.5");
+            timeProvider.Advance(TimeSpan.FromMilliseconds(300));
+            await comp.WaitForAssertionAsync(() => comp.Instance.ReadValue.Should().Be(1.5d));
+        }
+
         [Test]
         public async Task NumericField_Immediate_WithCulture_CanTypeZeroAfterDecimalPoint()
         {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -570,12 +570,9 @@ namespace MudBlazor
             {
                 var forceTextUpdate = _forceTextUpdate;
                 _forceTextUpdate = false;
-                // Do not reformat the displayed text from Value on this input's own live ValueChanged
-                // echo (the @bind round-trip mid-typing). On Blazor Server the echo can land between
-                // keystrokes and would reformat while the user is typing, corrupting input (#13002; also
-                // completes #13266/#13250 on Server, which #13311 only fixed for the synchronous case).
-                // A debounced input commits from oninput too, so it needs the same suppression even
-                // though its own Immediate parameter is false.
+                // Do not reformat the displayed text from Value on this input's own live ValueChanged echo, the @bind round-trip mid-typing.
+                // On Blazor Server the echo can land between keystrokes and would reformat while the user is typing, corrupting input (#13002; also completes #13266/#13250 on Server, which #13311 only fixed for the synchronous case).
+                // A debounced input commits from oninput too, so it needs the same suppression even though its own Immediate parameter is false.
                 // External value changes, committed non-live changes, and explicit forced updates still refresh.
                 if (forceTextUpdate || !(EffectiveImmediate && arg.IsChildOriginatedChange))
                 {

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -570,12 +570,14 @@ namespace MudBlazor
             {
                 var forceTextUpdate = _forceTextUpdate;
                 _forceTextUpdate = false;
-                // Do not reformat the displayed text from Value on this input's own Immediate ValueChanged
+                // Do not reformat the displayed text from Value on this input's own live ValueChanged
                 // echo (the @bind round-trip mid-typing). On Blazor Server the echo can land between
                 // keystrokes and would reformat while the user is typing, corrupting input (#13002; also
                 // completes #13266/#13250 on Server, which #13311 only fixed for the synchronous case).
-                // External value changes, non-Immediate commits, and explicit forced updates still refresh.
-                if (forceTextUpdate || !(Immediate && arg.IsChildOriginatedChange))
+                // A debounced input commits from oninput too, so it needs the same suppression even
+                // though its own Immediate parameter is false.
+                // External value changes, committed non-live changes, and explicit forced updates still refresh.
+                if (forceTextUpdate || !(EffectiveImmediate && arg.IsChildOriginatedChange))
                 {
                     await SuppressInteractionEffectsWhileAsync(() => UpdateTextPropertyAsync(false));
                 }


### PR DESCRIPTION
On Blazor Server, `<MudNumericField DebounceInterval="300" @bind-Value="..." />` corrupts what the user types: entering `1.`, pausing past the interval, then `50` leaves `150` in the field and `150` in the bound value.

`OnValueParameterChangedAsync` suppresses the value-to-text resync when the change is the input's own echo, so a `@bind-Value` round-trip cannot rewrite text the user is still typing. It gated that on `Immediate`, which was correct while `MudDebouncedInput` forced `Immediate = true` whenever `DebounceInterval` was set. #13610 replaced that parameter write with `EffectiveImmediate` but left this gate reading the raw parameter, so a debounced input stopped suppressing its own echo.

- The gate now reads `EffectiveImmediate`, because a debounced input commits from `oninput` exactly like an immediate one.

🤖 Verified against a real circuit: before the change the debounced field diverges from the `Immediate="true"` field beside it, after it the two agree. The added test drives the echo the way the parameter round-trip does, and fails without the fix.