### PR TITLE
MudDateRangePicker: Keep other half of range when one input fails to convert

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -950,7 +950,9 @@ namespace MudBlazor.UnitTests.Components
         {
             var start = new DateTime(2020, 10, 26);
             var end = new DateTime(2020, 10, 30);
-            var comp = Context.Render<MudDateRangePicker>();
+            DateRange bound = null;
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
+                .Bind(x => x.DateRange, bound, value => bound = value));
             var picker = comp.Instance;
 
             await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
@@ -968,6 +970,36 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
             picker.DateRange.Should().Be(new DateRange(start, end));
+        }
+
+        /// <summary>
+        /// A deliberate null assignment must still clear text that failed to convert, even after the binding echo preserved it.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_ExplicitNull_ShouldClearInvalidText_AfterTheEchoPreservedIt()
+        {
+            var start = new DateTime(2020, 10, 26);
+            var end = new DateTime(2020, 10, 30);
+            DateRange bound = null;
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
+                .Bind(x => x.DateRange, bound, value => bound = value));
+
+            await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
+            await comp.FindAll("input")[1].ChangeAsync(end.ToShortDateString());
+            await comp.FindAll("input")[0].ChangeAsync("INVALID");
+
+            // The binding hands the resulting null straight back, which must leave the edit alone.
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DateRange, null));
+
+            ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().Be("INVALID");
+            ((IHtmlInputElement)comp.FindAll("input")[1]).Value.Should().Be(end.ToShortDateString());
+
+            // Assigning null again is the consumer deliberately clearing, which is the only way out of a conversion error.
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DateRange, null));
+
+            comp.Instance.Text.Should().BeNull();
+            ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().BeEmpty();
+            ((IHtmlInputElement)comp.FindAll("input")[1]).Value.Should().BeEmpty();
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -943,6 +943,35 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// A start date that fails to convert must not take the end date with it, because the null range echoes back through a two-way binding while the user is still editing.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_ShouldKeepTheOtherHalf_WhenOneInputFailsToConvert()
+        {
+            var start = new DateTime(2020, 10, 26);
+            var end = new DateTime(2020, 10, 30);
+            var comp = Context.Render<MudDateRangePicker>();
+            var picker = comp.Instance;
+
+            await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
+            await comp.FindAll("input")[1].ChangeAsync(end.ToShortDateString());
+            picker.DateRange.Should().Be(new DateRange(start, end));
+
+            await comp.FindAll("input")[0].ChangeAsync("INVALID");
+            picker.DateRange.Should().BeNull("the range no longer converts");
+
+            // The two-way binding hands that null straight back while the user is still in the field.
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DateRange, null));
+
+            ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().Be("INVALID", "the text the user typed must stay put");
+            ((IHtmlInputElement)comp.FindAll("input")[1]).Value.Should().Be(end.ToShortDateString(), "the end date still converts and was not edited");
+
+            // Fixing the start recovers the whole range rather than only half of it.
+            await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
+            picker.DateRange.Should().Be(new DateRange(start, end));
+        }
+
+        /// <summary>
         /// Setting DateRange to null clears text that failed to convert, which is the only way out of the conversion error.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -966,7 +966,6 @@ namespace MudBlazor.UnitTests.Components
             ((IHtmlInputElement)comp.FindAll("input")[0]).Value.Should().Be("INVALID", "the text the user typed must stay put");
             ((IHtmlInputElement)comp.FindAll("input")[1]).Value.Should().Be(end.ToShortDateString(), "the end date still converts and was not edited");
 
-            // Fixing the start recovers the whole range rather than only half of it.
             await comp.FindAll("input")[0].ChangeAsync(start.ToShortDateString());
             picker.DateRange.Should().Be(new DateRange(start, end));
         }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -128,8 +128,10 @@ namespace MudBlazor
             range = NormalizeDateRange(range);
 
             // Text that fails to convert leaves the range null, so a null assignment looks like a no-op and the bad text would stick.
-            // Run it anyway while text remains, as MudDatePicker does.
-            if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text)))
+            // Run it anyway while text remains, as MudDatePicker does, but not while that text is the edit the user is making right now:
+            // a two-way bound DateRange echoes the null straight back, and clearing there would throw away the half of the range that still parses.
+            var textIsLiveUserEdit = _rangeText is not null && string.Equals(Text, RangeUtility.Join(_rangeText.Start, _rangeText.End), StringComparison.Ordinal);
+            if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text) && !textIsLiveUserEdit))
             {
                 var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
                     .Range(0, int.MaxValue)

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -18,6 +18,7 @@ namespace MudBlazor
         private DateRange? _dateRange;
         private Range<string>? _rangeText;
         private int _rangeTextEdit;
+        private int _echoPendingForEdit = -1;
 
         /// <summary>
         /// Creates a new instance.
@@ -128,9 +129,12 @@ namespace MudBlazor
             range = NormalizeDateRange(range);
 
             // Text that fails to convert leaves the range null, so a null assignment looks like a no-op and the bad text would stick.
-            // Run it anyway while text remains, as MudDatePicker does, but not while that text is the edit the user is making right now.
-            var textIsLiveUserEdit = _rangeText is not null && string.Equals(Text, RangeUtility.Join(_rangeText.Start, _rangeText.End), StringComparison.Ordinal);
-            if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text) && !textIsLiveUserEdit))
+            // Run it anyway while text remains, as MudDatePicker does, except for the null a two-way binding hands straight back from the edit that produced it.
+            // Only the assignment right after that edit can be the echo, so consuming the marker leaves a later deliberate null free to clear.
+            var isEditEcho = _echoPendingForEdit == _rangeTextEdit;
+            _echoPendingForEdit = -1;
+
+            if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text) && !isEditEcho))
             {
                 var doesRangeContainDisabledDates = !AllowDisabledDatesInRange && range is { Start: not null, End: not null } && Enumerable
                     .Range(0, int.MaxValue)
@@ -210,6 +214,11 @@ namespace MudBlazor
                     }
 
                     await SetTextAsync(rangeText is null ? null : RangeUtility.Join(rangeText.Start, rangeText.End), callback: false);
+
+                    if (_dateRange is null && DateRangeChanged.HasDelegate)
+                    {
+                        _echoPendingForEdit = edit;
+                    }
                 }
             }
         }

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -128,8 +128,8 @@ namespace MudBlazor
             range = NormalizeDateRange(range);
 
             // Text that fails to convert leaves the range null, so a null assignment looks like a no-op and the bad text would stick.
-            // Run it anyway while text remains, as MudDatePicker does, but not while that text is the edit the user is making right now:
-            // a two-way bound DateRange echoes the null straight back, and clearing there would throw away the half of the range that still parses.
+            // Run it anyway while text remains, as MudDatePicker does, but not while that text is the edit the user is making right now.
+            // A two-way bound DateRange echoes the null straight back, and clearing there would throw away the half of the range that still parses.
             var textIsLiveUserEdit = _rangeText is not null && string.Equals(Text, RangeUtility.Join(_rangeText.Start, _rangeText.End), StringComparison.Ordinal);
             if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text) && !textIsLiveUserEdit))
             {

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor.cs
@@ -129,7 +129,6 @@ namespace MudBlazor
 
             // Text that fails to convert leaves the range null, so a null assignment looks like a no-op and the bad text would stick.
             // Run it anyway while text remains, as MudDatePicker does, but not while that text is the edit the user is making right now.
-            // A two-way bound DateRange echoes the null straight back, and clearing there would throw away the half of the range that still parses.
             var textIsLiveUserEdit = _rangeText is not null && string.Equals(Text, RangeUtility.Join(_rangeText.Start, _rangeText.End), StringComparison.Ordinal);
             if (_dateRange != range || (range is null && !string.IsNullOrEmpty(Text) && !textIsLiveUserEdit))
             {


### PR DESCRIPTION
Typing a typo into the start date of a two-way bound `MudDateRangePicker` blanks both inputs, so an end date that still converts is destroyed and correcting the typo only brings back half the range.

#13667 made `Text` follow what the user types and, so an unconvertible value can still be cleared, made a null `DateRange` assignment run even when the range is already null as long as text remains. Those two halves collide: because the edit now writes `Text`, the null it produces echoes back through the binding with text present, and the re-entry clears `_rangeText`.

- Mark the edit whose null the binding may hand back, and consume that mark on the next assignment. Only the assignment immediately following the edit is treated as the echo, so a later deliberate `DateRange = null` still clears invalid text.

Two tests cover the pair: one that a typo leaves the other half alone, and one walking the full sequence — invalid text typed, echo preserves it, later explicit null clears it. Both fail without the change.

Worth knowing for review: under `@bind-DateRange` the parent's field is already null by the time the echo lands, so Blazor elides a repeat `= null` and it never reaches the component at all. The escape paths that do reach it are a deliberate parameter assignment (the new test) and `ClearAsync()` (checked in a browser). That is unchanged by this PR.
