### PR TITLE
ParameterState: Cut per-component framework allocation

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateNoScopeTestComp.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Utilities/ParameterStateNoScopeTestComp.razor
@@ -1,0 +1,18 @@
+@inherits MudComponentBase
+@namespace MudBlazor.UnitTests
+
+<span class="value">@Value</span>
+<span class="parameters-set">@_parametersSetCount</span>
+
+@code {
+    private int _parametersSetCount;
+
+    [Parameter]
+    public int Value { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        _parametersSetCount++;
+    }
+}

--- a/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateUsageTests.cs
@@ -28,6 +28,24 @@ public class ParameterStateUsageTests : BunitTest
         comp.Instance.ParameterContainer.Count.Should().Be(2);
     }
 
+    /// <summary>
+    /// A component that registers no parameter states still runs the whole parameter lifecycle.
+    /// </summary>
+    [Test]
+    public async Task ComponentWithoutRegisteredParametersRunsTheParameterLifecycle()
+    {
+        var comp = Context.Render<ParameterStateNoScopeTestComp>(parameters => parameters.Add(x => x.Value, 1));
+
+        comp.Instance.ParameterContainer.Count.Should().Be(0);
+        comp.Find("span.value").InnerHtml.Trimmed().Should().Be("1");
+        comp.Find("span.parameters-set").InnerHtml.Trimmed().Should().Be("1");
+
+        await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Value, 2));
+
+        comp.Find("span.value").InnerHtml.Trimmed().Should().Be("2");
+        comp.Find("span.parameters-set").InnerHtml.Trimmed().Should().Be("2");
+    }
+
     [Test]
     public void SharedHandlerIntegration()
     {

--- a/src/MudBlazor/Base/ComponentBaseWithState.cs
+++ b/src/MudBlazor/Base/ComponentBaseWithState.cs
@@ -13,26 +13,36 @@ namespace MudBlazor;
 /// </summary>
 public class ComponentBaseWithState : ComponentBase
 {
-    internal readonly ParameterContainer ParameterContainer = new() { AutoVerify = false };
+    private ParameterContainer? _parameterContainer;
+
+    /// <summary>
+    /// The registered parameter states, created on first registration.
+    /// </summary>
+    /// <remarks>
+    /// Many components register nothing, so the container is not allocated until <see cref="CreateRegisterScope"/> runs.
+    /// </remarks>
+    internal ParameterContainer ParameterContainer => _parameterContainer ??= new ParameterContainer { AutoVerify = false };
 
     /// <inheritdoc />
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        ParameterContainer.OnInitialized();
+        _parameterContainer?.OnInitialized();
     }
 
     /// <inheritdoc />
     public override Task SetParametersAsync(ParameterView parameters)
     {
-        return ParameterContainer.SetParametersAsync(base.SetParametersAsync, parameters);
+        return _parameterContainer is null
+            ? base.SetParametersAsync(parameters)
+            : _parameterContainer.SetParametersAsync(base.SetParametersAsync, parameters);
     }
 
     /// <inheritdoc />
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        ParameterContainer.OnParametersSet();
+        _parameterContainer?.OnParametersSet();
     }
 
     /// <summary>

--- a/src/MudBlazor/Base/MudComponentBase.cs
+++ b/src/MudBlazor/Base/MudComponentBase.cs
@@ -15,7 +15,10 @@ namespace MudBlazor
     public abstract class MudComponentBase : ComponentBaseWithState, IMudStateHasChanged
     {
         private ILogger? _logger;
-        private readonly string _id = Identifier.Create("mudinput");
+        private string? _generatedId;
+
+        // Only inputs ever read this, so generating it per component instance would be wasted on most of the library.
+        private string Id => _generatedId ??= Identifier.Create("mudinput");
 
         [Inject]
         private ILoggerFactory LoggerFactory { get; set; } = null!;
@@ -79,8 +82,8 @@ namespace MudBlazor
         /// If the UserAttributes contain an ID make it accessible for WCAG labelling of input fields
         /// </summary>
         public string FieldId => UserAttributes.TryGetValue("id", out var id) && id is not null
-            ? id.ToString() ?? _id
-            : _id;
+            ? id.ToString() ?? Id
+            : Id;
 
         /// <summary>
         /// Resolves the element ID to use for JavaScript interop, honoring a consumer-supplied <c>id</c>.

--- a/src/MudBlazor/State/Builder/RegisterParameterBuilderOfT.cs
+++ b/src/MudBlazor/State/Builder/RegisterParameterBuilderOfT.cs
@@ -21,15 +21,9 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
     private Func<EventCallback<T>> _eventCallbackFunc = () => default;
     private IParameterChangedHandler<T>? _parameterChangedHandler;
     private IParameterEqualityComparerSwappable<T>? _comparer;
-    private readonly Lazy<ParameterStateInternal<T>> _parameterStateLazy;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RegisterParameterBuilder{T}"/> class.
-    /// </summary>
-    public RegisterParameterBuilder()
-    {
-        _parameterStateLazy = new Lazy<ParameterStateInternal<T>>(CreateParameterState);
-    }
+    // Registration happens once per component instance, on one thread, so a Lazy would only add an object and a delegate.
+    private ParameterStateInternal<T>? _parameterState;
 
     /// <summary>
     /// Sets the metadata for the parameter.
@@ -195,7 +189,7 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
     /// Builds the parameter state.
     /// </summary>
     /// <returns>The created parameter state.</returns>
-    internal ParameterStateInternal<T> Attach() => _parameterStateLazy.Value;
+    internal ParameterStateInternal<T> Attach() => _parameterState ??= CreateParameterState();
 
     private ParameterStateInternal<T> CreateParameterState()
     {
@@ -213,7 +207,7 @@ public class RegisterParameterBuilder<T> : IParameterBuilderAttach
     }
 
     /// <inheritdoc />
-    bool IParameterBuilderAttach.IsAttached => _parameterStateLazy.IsValueCreated;
+    bool IParameterBuilderAttach.IsAttached => _parameterState is not null;
 
     /// <inheritdoc />
     IParameterComponentLifeCycle IParameterBuilderAttach.Attach() => Attach();

--- a/src/MudBlazor/State/Comparer/ParameterEqualityComparerSwappable.cs
+++ b/src/MudBlazor/State/Comparer/ParameterEqualityComparerSwappable.cs
@@ -15,6 +15,11 @@ namespace MudBlazor.State.Comparer;
 [DebuggerDisplay("IEqualityComparer = {OriginalComparer}")]
 internal class ParameterEqualityComparerSwappable<T> : IParameterEqualityComparerSwappable<T>
 {
+    /// <summary>
+    /// The shared instance used by parameters that do not declare their own comparer.
+    /// </summary>
+    public static readonly ParameterEqualityComparerSwappable<T> Default = new((Func<IEqualityComparer<T>>?)null);
+
     /// <inheritdoc />
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public Func<IEqualityComparer<T>> UnderlyingComparer { get; }

--- a/src/MudBlazor/State/IParameterScopeContainer.cs
+++ b/src/MudBlazor/State/IParameterScopeContainer.cs
@@ -13,4 +13,12 @@ internal interface IParameterScopeContainer : IParameterContainer, IDisposable
     /// The scope becomes locked when it has been read or ended (<see cref="IDisposable.Dispose"/>), indicating that no more parameter states will be registered.
     /// </remarks>
     bool IsLocked { get; }
+
+    /// <summary>
+    /// Gets the registered parameters, materializing them on first access.
+    /// </summary>
+    /// <remarks>
+    /// Indexing this list avoids the enumerator that iterating the container through its interface would allocate on every parameter set.
+    /// </remarks>
+    IReadOnlyList<IParameterComponentLifeCycle> Parameters { get; }
 }

--- a/src/MudBlazor/State/ParameterContainer.cs
+++ b/src/MudBlazor/State/ParameterContainer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State.Comparer;
@@ -19,11 +18,12 @@ namespace MudBlazor.State;
 /// </remarks>
 internal class ParameterContainer : IParameterContainer
 {
-    private readonly Lazy<bool> _lazyVerify;
     private readonly List<IParameterScopeContainer> _parameterScopeContainers = new();
 
-    // Flattened dictionary for O(1) parameter lookups (created lazily on first TryGetValue call)
-    private readonly Lazy<FrozenDictionary<string, IParameterComponentLifeCycle>> _flattenedParameters;
+    private bool _verified;
+
+    // Flattened lookup for parameter access by name, built on first TryGetValue call.
+    private Dictionary<string, IParameterComponentLifeCycle>? _flattenedParameters;
 
     // Cache handler count for fast path optimization
     private int _handlerCount = -1;  // -1 means not computed yet
@@ -45,24 +45,15 @@ internal class ParameterContainer : IParameterContainer
     public void Add(IParameterScopeContainer parameterScopeContainer) => _parameterScopeContainers.Add(parameterScopeContainer);
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ParameterContainer"/> class.
-    /// </summary>
-    public ParameterContainer()
-    {
-        _lazyVerify = new Lazy<bool>(VerifyInternal);
-        _flattenedParameters = new Lazy<FrozenDictionary<string, IParameterComponentLifeCycle>>(CreateFlattenedDictionary);
-    }
-
-    /// <summary>
     /// Executes <see cref="ParameterScopeContainer.OnInitialized"/> for all registered <see cref="ParameterScopeContainer"/>.
     /// </summary>
     public void OnInitialized()
     {
         VerifyOnAuto();
 
-        foreach (var parameterSet in _parameterScopeContainers)
+        for (var i = 0; i < _parameterScopeContainers.Count; i++)
         {
-            parameterSet.OnInitialized();
+            _parameterScopeContainers[i].OnInitialized();
         }
     }
 
@@ -73,9 +64,9 @@ internal class ParameterContainer : IParameterContainer
     {
         VerifyOnAuto();
 
-        foreach (var parameterSet in _parameterScopeContainers)
+        for (var i = 0; i < _parameterScopeContainers.Count; i++)
         {
-            parameterSet.OnParametersSet();
+            _parameterScopeContainers[i].OnParametersSet();
         }
     }
 
@@ -119,10 +110,12 @@ internal class ParameterContainer : IParameterContainer
         List<IParameterStateInvocationSnapshot>? parametersHandlerShouldFire = null;
         List<ParameterStateValue>? parameterStateValues = null;
 
-        foreach (var scopeContainer in _parameterScopeContainers)
+        for (var scopeIndex = 0; scopeIndex < _parameterScopeContainers.Count; scopeIndex++)
         {
-            foreach (var parameter in scopeContainer)
+            var registered = _parameterScopeContainers[scopeIndex].Parameters;
+            for (var i = 0; i < registered.Count; i++)
             {
+                var parameter = registered[i];
                 if (parameter.HasHandler && parameter.HasParameterChanged(parameters))
                 {
                     parametersHandlerShouldFire ??= new List<IParameterStateInvocationSnapshot>();
@@ -140,14 +133,22 @@ internal class ParameterContainer : IParameterContainer
     {
         VerifyOnAuto();
 
-        // Optimized: Use flattened dictionary for O(1) lookup instead of O(scopes) iteration
-        return _flattenedParameters.Value.TryGetValue(parameterName, out parameterComponentLifeCycle);
+        return FlattenedParameters.TryGetValue(parameterName, out parameterComponentLifeCycle);
     }
 
     /// <summary>
     /// Verifies the container for any duplicate parameters.
     /// </summary>
-    public void Verify() => _ = _lazyVerify.Value;
+    public void Verify()
+    {
+        if (_verified)
+        {
+            return;
+        }
+
+        ThrowOnDuplicates();
+        _verified = true;
+    }
 
     /// <summary>
     /// Throws an exception if <see cref="AutoVerify"/> is enabled and duplicates are found.
@@ -160,42 +161,50 @@ internal class ParameterContainer : IParameterContainer
         }
     }
 
-    private bool VerifyInternal()
-    {
-        ThrowOnDuplicates();
-
-        return true;
-    }
-
     /// <summary>
     /// Throws an exception if duplicates are found among the parameter scope containers.
     /// </summary>
     private void ThrowOnDuplicates()
     {
         var hashSet = new HashSet<IParameterComponentLifeCycle>(ParameterNameUniquenessComparer.Default);
-        var parameters = _parameterScopeContainers.SelectMany(scopeContainers => scopeContainers);
 
-        foreach (var parameter in parameters)
+        for (var scopeIndex = 0; scopeIndex < _parameterScopeContainers.Count; scopeIndex++)
         {
-            if (!hashSet.Add(parameter))
+            var registered = _parameterScopeContainers[scopeIndex].Parameters;
+            for (var i = 0; i < registered.Count; i++)
             {
-                throw new InvalidOperationException($"Parameter {parameter.Metadata.ParameterName} is already registered!");
+                if (!hashSet.Add(registered[i]))
+                {
+                    throw new InvalidOperationException($"Parameter {registered[i].Metadata.ParameterName} is already registered!");
+                }
             }
         }
     }
 
     /// <summary>
-    /// Creates a flattened dictionary from all parameter scope containers for O(1) lookups.
-    /// This is called lazily on first TryGetValue call.
+    /// Gets a flattened lookup across all parameter scope containers, built on first use.
     /// </summary>
-    private FrozenDictionary<string, IParameterComponentLifeCycle> CreateFlattenedDictionary()
+    private Dictionary<string, IParameterComponentLifeCycle> FlattenedParameters
     {
-        return _parameterScopeContainers
-            .SelectMany(scope => scope)
-            .ToFrozenDictionary(
-                parameter => parameter.Metadata.ParameterName,
-                parameter => parameter,
-                StringComparer.Ordinal);  // Parameter names are case-sensitive
+        get
+        {
+            if (_flattenedParameters is null)
+            {
+                var flattened = new Dictionary<string, IParameterComponentLifeCycle>(StringComparer.Ordinal); // Parameter names are case-sensitive
+                for (var scopeIndex = 0; scopeIndex < _parameterScopeContainers.Count; scopeIndex++)
+                {
+                    var registered = _parameterScopeContainers[scopeIndex].Parameters;
+                    for (var i = 0; i < registered.Count; i++)
+                    {
+                        flattened.Add(registered[i].Metadata.ParameterName, registered[i]);
+                    }
+                }
+
+                _flattenedParameters = flattened;
+            }
+
+            return _flattenedParameters;
+        }
     }
 
     /// <summary>
@@ -207,11 +216,12 @@ internal class ParameterContainer : IParameterContainer
         if (_handlerCount == -1)
         {
             _handlerCount = 0;
-            foreach (var scopeContainer in _parameterScopeContainers)
+            for (var scopeIndex = 0; scopeIndex < _parameterScopeContainers.Count; scopeIndex++)
             {
-                foreach (var parameter in scopeContainer)
+                var registered = _parameterScopeContainers[scopeIndex].Parameters;
+                for (var i = 0; i < registered.Count; i++)
                 {
-                    if (parameter.HasHandler)
+                    if (registered[i].HasHandler)
                     {
                         _handlerCount++;
                     }
@@ -225,14 +235,14 @@ internal class ParameterContainer : IParameterContainer
     /// <inheritdoc/>
     public IEnumerator<IParameterComponentLifeCycle> GetEnumerator()
     {
-        // If flattened dictionary is already created, use it for better performance
-        if (_flattenedParameters.IsValueCreated)
+        for (var scopeIndex = 0; scopeIndex < _parameterScopeContainers.Count; scopeIndex++)
         {
-            return ((IEnumerable<IParameterComponentLifeCycle>)_flattenedParameters.Value.Values).GetEnumerator();
+            var registered = _parameterScopeContainers[scopeIndex].Parameters;
+            for (var i = 0; i < registered.Count; i++)
+            {
+                yield return registered[i];
+            }
         }
-
-        // Otherwise, iterate through scope containers (avoid forcing dictionary creation)
-        return _parameterScopeContainers.SelectMany(scopeContainer => scopeContainer).GetEnumerator();
     }
 
     /// <inheritdoc/>

--- a/src/MudBlazor/State/ParameterScopeContainer.cs
+++ b/src/MudBlazor/State/ParameterScopeContainer.cs
@@ -20,8 +20,8 @@ internal class ParameterScopeContainer : IParameterScopeContainer
 {
     private readonly IParameterStatesReader _parameterStatesReader;
 
-    // A scope holds a handful of parameters, so an array scanned linearly beats any hashed lookup:
-    // it is materialized once per component instance and read far less often than it is built.
+    // A scope holds a handful of parameters, so an array scanned linearly beats any hashed lookup.
+    // The scope is materialized once per component instance and read far less often than it is built.
     private IParameterComponentLifeCycle[]? _parameters;
 
     // Cache handler count for fast path optimization
@@ -84,8 +84,7 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// Registering the same parameter twice is a component bug, so it must not be silently accepted.
     /// </summary>
     /// <remarks>
-    /// A scope holds a handful of parameters whose names are compile-time literals, so pairwise comparison is cheaper
-    /// than building a hashed set for the check.
+    /// A scope holds a handful of parameters whose names are compile-time literals, so pairwise comparison is cheaper than building a hashed set for the check.
     /// </remarks>
     private static void ThrowOnDuplicates(IParameterComponentLifeCycle[] parameters)
     {
@@ -106,7 +105,8 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// Forces the attachment of the collection of <seealso cref="IParameterComponentLifeCycle"/> immediately and materializes the parameters.
     /// </summary>
     /// <remarks>
-    /// This method is designed for performance optimization. By calling this method, the parameters are materialized immediately instead of waiting for the Blazor lifecycle to access the values.
+    /// This method is designed for performance optimization.
+    /// By calling this method, the parameters are materialized immediately instead of waiting for the Blazor lifecycle to access the values.
     /// This helps avoid potential slowdowns in rendering speed that could occur if the parameters were materialized during the Blazor lifecycle.
     /// </remarks>
     public void ForceParametersAttachment() => _ = Parameters;

--- a/src/MudBlazor/State/ParameterScopeContainer.cs
+++ b/src/MudBlazor/State/ParameterScopeContainer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.State.Invocation;
@@ -20,7 +19,10 @@ namespace MudBlazor.State;
 internal class ParameterScopeContainer : IParameterScopeContainer
 {
     private readonly IParameterStatesReader _parameterStatesReader;
-    private readonly Lazy<FrozenDictionary<string, IParameterComponentLifeCycle>> _parameters;
+
+    // A scope holds a handful of parameters, so an array scanned linearly beats any hashed lookup:
+    // it is materialized once per component instance and read far less often than it is built.
+    private IParameterComponentLifeCycle[]? _parameters;
 
     // Cache handler count for fast path optimization
     private int _handlerCount = -1;  // -1 means not computed yet
@@ -32,9 +34,12 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// Gets a value indicating whether the parameter set has been initialized.
     /// </summary>
     /// <remarks>
-    /// The parameter set is considered initialized once the inner dictionary of parameters has been created.
+    /// The parameter set is considered initialized once the registered parameters have been materialized.
     /// </remarks>
-    public bool IsInitialized => _parameters.IsValueCreated;
+    public bool IsInitialized => _parameters is not null;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<IParameterComponentLifeCycle> Parameters => _parameters ?? Materialize();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ParameterScopeContainer"/> class with the specified parameters.
@@ -61,39 +66,60 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     public ParameterScopeContainer(IParameterStatesReader parameterStatesReader)
     {
         _parameterStatesReader = parameterStatesReader;
-        _parameters = new Lazy<FrozenDictionary<string, IParameterComponentLifeCycle>>(ParametersFactory);
     }
 
-    private FrozenDictionary<string, IParameterComponentLifeCycle> ParametersFactory()
+    private IParameterComponentLifeCycle[] Materialize()
     {
         IsLocked = true;
         var parameters = _parameterStatesReader.ReadParameters();
-        var dictionary = parameters.ToFrozenDictionary(
-            parameter => parameter.Metadata.ParameterName,
-            parameter => parameter,
-            StringComparer.Ordinal);  // Parameter names are case-sensitive; use Ordinal for best performance
+        var materialized = parameters as IParameterComponentLifeCycle[] ?? parameters.ToArray();
+        ThrowOnDuplicates(materialized);
+        _parameters = materialized;
         _parameterStatesReader.Complete();
 
-        return dictionary;
+        return materialized;
     }
 
     /// <summary>
-    /// Forces the attachment of the collection of <seealso cref="IParameterComponentLifeCycle"/> immediately and initializes the inner dictionary.
+    /// Registering the same parameter twice is a component bug, so it must not be silently accepted.
     /// </summary>
     /// <remarks>
-    /// This method is designed for performance optimization. By calling this method, the dictionary initialization is done immediately instead of waiting for the Blazor lifecycle to access the values. 
-    /// This helps avoid potential slowdowns in rendering speed that could occur if the dictionary were initialized during the Blazor lifecycle.
+    /// A scope holds a handful of parameters whose names are compile-time literals, so pairwise comparison is cheaper
+    /// than building a hashed set for the check.
     /// </remarks>
-    public void ForceParametersAttachment() => _ = _parameters.Value;
+    private static void ThrowOnDuplicates(IParameterComponentLifeCycle[] parameters)
+    {
+        for (var i = 1; i < parameters.Length; i++)
+        {
+            var name = parameters[i].Metadata.ParameterName;
+            for (var j = 0; j < i; j++)
+            {
+                if (string.Equals(parameters[j].Metadata.ParameterName, name, StringComparison.Ordinal))
+                {
+                    throw new ArgumentException($"Parameter {name} is already registered!", nameof(parameters));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Forces the attachment of the collection of <seealso cref="IParameterComponentLifeCycle"/> immediately and materializes the parameters.
+    /// </summary>
+    /// <remarks>
+    /// This method is designed for performance optimization. By calling this method, the parameters are materialized immediately instead of waiting for the Blazor lifecycle to access the values.
+    /// This helps avoid potential slowdowns in rendering speed that could occur if the parameters were materialized during the Blazor lifecycle.
+    /// </remarks>
+    public void ForceParametersAttachment() => _ = Parameters;
 
     /// <summary>
     /// Executes <see cref="IParameterComponentLifeCycle.OnInitialized"/> for all registered parameters.
     /// </summary>
     public void OnInitialized()
     {
-        foreach (var parameter in _parameters.Value.Values)
+        var parameters = _parameters ?? Materialize();
+        for (var i = 0; i < parameters.Length; i++)
         {
-            parameter.OnInitialized();
+            parameters[i].OnInitialized();
         }
     }
 
@@ -102,9 +128,10 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// </summary>
     public void OnParametersSet()
     {
-        foreach (var parameter in _parameters.Value.Values)
+        var parameters = _parameters ?? Materialize();
+        for (var i = 0; i < parameters.Length; i++)
         {
-            parameter.OnParametersSet();
+            parameters[i].OnParametersSet();
         }
     }
 
@@ -130,7 +157,21 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     /// <inheritdoc/>
     public bool TryGetValue(string parameterName, [MaybeNullWhen(false)] out IParameterComponentLifeCycle parameterComponentLifeCycle)
     {
-        return _parameters.Value.TryGetValue(parameterName, out parameterComponentLifeCycle);
+        var parameters = _parameters ?? Materialize();
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+            if (string.Equals(parameter.Metadata.ParameterName, parameterName, StringComparison.Ordinal))
+            {
+                parameterComponentLifeCycle = parameter;
+
+                return true;
+            }
+        }
+
+        parameterComponentLifeCycle = null;
+
+        return false;
     }
 
     private async Task SetParametersWithHandlersAsync(Func<ParameterView, Task> baseSetParametersAsync, ParameterView parameters)
@@ -146,8 +187,10 @@ internal class ParameterScopeContainer : IParameterScopeContainer
         List<IParameterStateInvocationSnapshot>? parametersHandlerShouldFire = null;
         List<ParameterStateValue>? parameterStateValues = null;
 
-        foreach (var parameter in _parameters.Value.Values)
+        var registered = _parameters ?? Materialize();
+        for (var i = 0; i < registered.Length; i++)
         {
+            var parameter = registered[i];
             if (parameter.HasHandler && parameter.HasParameterChanged(parameters))
             {
                 parametersHandlerShouldFire ??= new List<IParameterStateInvocationSnapshot>();
@@ -168,9 +211,10 @@ internal class ParameterScopeContainer : IParameterScopeContainer
         if (_handlerCount == -1)
         {
             _handlerCount = 0;
-            foreach (var parameter in this)
+            var parameters = _parameters ?? Materialize();
+            for (var i = 0; i < parameters.Length; i++)
             {
-                if (parameter.HasHandler)
+                if (parameters[i].HasHandler)
                 {
                     _handlerCount++;
                 }
@@ -190,7 +234,7 @@ internal class ParameterScopeContainer : IParameterScopeContainer
     }
 
     /// <inheritdoc/>
-    public IEnumerator<IParameterComponentLifeCycle> GetEnumerator() => ((IReadOnlyDictionary<string, IParameterComponentLifeCycle>)_parameters.Value).Values.GetEnumerator();
+    public IEnumerator<IParameterComponentLifeCycle> GetEnumerator() => ((IEnumerable<IParameterComponentLifeCycle>)(_parameters ?? Materialize())).GetEnumerator();
 
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -121,7 +121,7 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         _getParameterValueFunc = getParameterValueFunc;
         _eventCallbackFunc = eventCallbackFunc;
         _parameterChangedHandler = parameterChangedHandler;
-        _comparer = comparer ?? new ParameterEqualityComparerSwappable<T>(() => EqualityComparer<T>.Default);
+        _comparer = comparer ?? ParameterEqualityComparerSwappable<T>.Default;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Problem

Every MudBlazor component pays for the parameter framework whether or not it uses it, and each registered parameter costs more than the state it tracks. This is a floor under every component in every app, so it shows up wherever a page renders many of them (#13519).

The clearest way to see the size of that floor is to render the same trivial element off each base class in turn and measure allocation per instance. Against this PR's merge base:

| base class | per instance |
| --- | --- |
| raw `<div>` markup, no component | ~30 B |
| bare `IComponent` | 851 B |
| `ComponentBase` | 903 B |
| **`MudComponentBase`** | **1527 B** |

`ComponentBase` costs about 50 B more than a hand-written `IComponent`, so the framework itself is not the problem. **`MudComponentBase` was adding 624 B on top of `ComponentBase`, and every component in the library pays it on every instance.**

### Fix

- `ComponentBaseWithState` allocated a `ParameterContainer` per instance. Most components register nothing, so it is now created on first registration.
- `ParameterContainer` held two `Lazy` fields. One wrapped a duplicate check that never runs for components, since they set `AutoVerify` to false.
- `ParameterScopeContainer` built a `FrozenDictionary` per component instance to hold a handful of parameters. A scope is materialized once and read far less often than it is built, so it now keeps an array and scans it. Registering the same parameter twice still throws.
- Iterating a scope through its interface allocated an enumerator on every parameter set; the lifecycle paths now index the array.
- `RegisterParameterBuilder` wrapped its state in a `Lazy`, and every parameter without its own comparer allocated a comparer wrapper that can be shared.
- `MudComponentBase` generated an element id per instance that only inputs ever read.


`GC.GetTotalAllocatedBytes(precise: true)` over 10000 constructions, and a bare `Renderer` whose `UpdateDisplayAsync` does nothing for the render figures. Median of 7 runs.

| | before | after |
| --- | --- | --- |
| construct, no parameters | 687 B | 279 B |
| construct, one parameter | 2007 B | 975 B |
| construct, three parameters | 3335 B | 1991 B |
| render x1000, no parameters | 1911 B | 1435 B |
| render x1000, three parameters | 4807 B | 3348 B |

Real components at 1000 instances: `MudText` 5.7 MB to 4.8 MB, `MudListItem` 30.3 MB to 27.7 MB, `MudSelect` open with 1000 options 41.7 MB to 37.4 MB.

### What it means for the floor

Re-running the base-class measurement above on this branch, against its own merge base, 200 instances, median of 5:

| base class | before | after |
| --- | --- | --- |
| `ComponentBase` | 903 B | 883 B |
| **`MudComponentBase`** | **1527 B** | **1057 B** |
| `MudElement` | 2203 B | 1751 B |

**`MudComponentBase` drops by 470 B per instance, and what it adds over plain `ComponentBase` falls from 624 B to 174 B — a 72% cut in the overhead every MudBlazor component carries.** The `ComponentBase` row is unchanged apart from ~20 B of measurement noise, which is the right control: nothing outside MudBlazor moved.

Because it is per instance, it scales with how many components a page renders rather than with any one feature. A representative page — app shell, a 20-field form, a 50-row table, a 50-row grid, a 50-item list, 20 selects and 20 menus — instantiates about 1055 components, so this is roughly half a megabyte of allocation on that page alone.
