### PR TITLE
Localization: Stop rebuilding and re-reading resources per component

### DIFF
--- a/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/MudBlazor.UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -403,6 +403,28 @@ public class ServiceCollectionExtensionsTests
         localizationEnumInterceptor.Should().NotBeNull();
     }
 
+    /// <summary>
+    /// Every form component injects the localizer, and the default interceptor builds a resource reader, so one instance must serve the whole scope (#13519).
+    /// </summary>
+    [Test]
+    public void AddMudLocalization_ShouldRegisterOneLocalizerPerScope()
+    {
+        // Arrange
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IJSRuntime, MockJsRuntime>();
+
+        // Act
+        services.AddMudLocalization();
+        using var serviceProvider = services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var first = scope.ServiceProvider.GetRequiredService<InternalMudLocalizer>();
+        var second = scope.ServiceProvider.GetRequiredService<InternalMudLocalizer>();
+
+        // Assert
+        first.Should().BeSameAs(second);
+    }
+
     [Test]
     public void AddMudServices_ShouldRegisterAllServices()
     {

--- a/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
@@ -255,8 +255,7 @@ public class DefaultLocalizationInterceptorTests
     /// A key that is not a resource must keep reporting itself as missing, so it is never served from the cache.
     /// </summary>
     /// <remarks>
-    /// Callers pass arbitrary strings through this path, such as a conversion exception message, so caching a miss
-    /// would let the cache grow without bound.
+    /// Callers pass arbitrary strings through this path, such as a conversion exception message, so caching a miss would let the cache grow without bound.
     /// </remarks>
     [Test]
     public void UnknownKey_RepeatedReads_KeepReportingResourceNotFound()

--- a/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
+++ b/src/MudBlazor.UnitTests/Services/Localization/DefaultLocalizationInterceptorTests.cs
@@ -230,6 +230,51 @@ public class DefaultLocalizationInterceptorTests
         value.Should().Be("Clear", "the built-in English fallback is still returned under a non-English UI culture");
     }
 
+    /// <summary>
+    /// Repeated lookups of a built-in key are served from the cache and stay on the invariant value.
+    /// </summary>
+    [Test]
+    [NonParallelizable]
+    [SetUICulture("sv-SE")]
+    public void DefaultEnglishLookup_RepeatedReads_StayOnTheInvariantValue()
+    {
+        // Arrange
+        var interceptor = new DefaultLocalizationInterceptor(NullLoggerFactory.Instance, mudLocalizer: null);
+
+        // Act
+        var first = interceptor.Handle(LanguageResource.MudDataGrid_Clear);
+        var second = interceptor.Handle(LanguageResource.MudDataGrid_Clear);
+
+        // Assert
+        first.ResourceNotFound.Should().BeFalse();
+        second.ResourceNotFound.Should().BeFalse();
+        second.Value.Should().Be(first.Value).And.Be("Clear");
+    }
+
+    /// <summary>
+    /// A key that is not a resource must keep reporting itself as missing, so it is never served from the cache.
+    /// </summary>
+    /// <remarks>
+    /// Callers pass arbitrary strings through this path, such as a conversion exception message, so caching a miss
+    /// would let the cache grow without bound.
+    /// </remarks>
+    [Test]
+    public void UnknownKey_RepeatedReads_KeepReportingResourceNotFound()
+    {
+        // Arrange
+        var interceptor = new DefaultLocalizationInterceptor(NullLoggerFactory.Instance, mudLocalizer: null);
+        const string UnknownKey = "This is not a resource key, it is an exception message.";
+
+        // Act
+        var first = interceptor.Handle(UnknownKey);
+        var second = interceptor.Handle(UnknownKey);
+
+        // Assert
+        first.ResourceNotFound.Should().BeTrue();
+        second.ResourceNotFound.Should().BeTrue();
+        second.Value.Should().Be(UnknownKey);
+    }
+
     private static string GetResourceString(string key, params object[] parameters)
     {
         var resourceString = LanguageResource.GetResourceString(key) ?? string.Empty;

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -242,9 +242,11 @@ namespace MudBlazor.Services
         /// <returns>Continues the IServiceCollection chain.</returns>
         public static IServiceCollection AddMudLocalization(this IServiceCollection services)
         {
-            services.TryAddTransient<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
-            services.TryAddTransient<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
-            services.TryAddTransient<InternalMudLocalizer>();
+            // Scoped, not transient: the default interceptor builds a ResourceManagerStringLocalizerFactory and its resource cache,
+            // and every form component injects the localizer, so a transient registration rebuilt all of that per component instance.
+            services.TryAddScoped<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
+            services.TryAddScoped<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
+            services.TryAddScoped<InternalMudLocalizer>();
 
             return services;
         }

--- a/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MudBlazor/Extensions/ServiceCollectionExtensions.cs
@@ -242,8 +242,8 @@ namespace MudBlazor.Services
         /// <returns>Continues the IServiceCollection chain.</returns>
         public static IServiceCollection AddMudLocalization(this IServiceCollection services)
         {
-            // Scoped, not transient: the default interceptor builds a ResourceManagerStringLocalizerFactory and its resource cache,
-            // and every form component injects the localizer, so a transient registration rebuilt all of that per component instance.
+            // Scoped, not transient: the default interceptor builds a ResourceManagerStringLocalizerFactory and its resource cache.
+            // Every form component injects the localizer, so a transient registration rebuilt all of that per component instance.
             services.TryAddScoped<ILocalizationInterceptor, DefaultLocalizationInterceptor>();
             services.TryAddScoped<ILocalizationEnumInterceptor, DefaultLocalizationEnumInterceptor>();
             services.TryAddScoped<InternalMudLocalizer>();

--- a/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
@@ -70,12 +70,11 @@ public abstract class AbstractLocalizationInterceptor : ILocalizationInterceptor
     private sealed class InvariantLanguageResourceLocalizer(IStringLocalizer inner) : IStringLocalizer
     {
         // Reading always happens under the invariant culture, so a key's value never changes and can be cached.
-        // Only found keys are cached: callers also pass arbitrary strings, such as a conversion exception message,
-        // and those must not accumulate.
+        // Only found keys are cached, because callers also pass arbitrary strings such as a conversion exception message and those must not accumulate.
         private readonly ConcurrentDictionary<string, LocalizedString> _cache = new(StringComparer.Ordinal);
 
-        // The swap is repeated per member rather than shared through a Func, which would allocate a closure on every
-        // lookup. Components read localized strings while rendering, so this runs in the render loop.
+        // The swap is repeated per member rather than shared through a Func, which would allocate a closure on every lookup.
+        // Components read localized strings while rendering, so this runs in the render loop.
         // Each swap and restore is synchronous with no await in between, so the culture never leaks to another flow.
         public LocalizedString this[string name]
         {

--- a/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/AbstractLocalizationInterceptor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Localization;
@@ -68,23 +69,66 @@ public abstract class AbstractLocalizationInterceptor : ILocalizationInterceptor
     /// </summary>
     private sealed class InvariantLanguageResourceLocalizer(IStringLocalizer inner) : IStringLocalizer
     {
+        // Reading always happens under the invariant culture, so a key's value never changes and can be cached.
+        // Only found keys are cached: callers also pass arbitrary strings, such as a conversion exception message,
+        // and those must not accumulate.
+        private readonly ConcurrentDictionary<string, LocalizedString> _cache = new(StringComparer.Ordinal);
+
+        // The swap is repeated per member rather than shared through a Func, which would allocate a closure on every
+        // lookup. Components read localized strings while rendering, so this runs in the render loop.
+        // Each swap and restore is synchronous with no await in between, so the culture never leaks to another flow.
         public LocalizedString this[string name]
-            => ReadInvariant(() => inner[name]);
+        {
+            get
+            {
+                if (_cache.TryGetValue(name, out var cached))
+                {
+                    return cached;
+                }
+
+                var previous = CultureInfo.CurrentUICulture;
+                CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+                try
+                {
+                    var localized = inner[name];
+                    if (!localized.ResourceNotFound)
+                    {
+                        _cache[name] = localized;
+                    }
+
+                    return localized;
+                }
+                finally
+                {
+                    CultureInfo.CurrentUICulture = previous;
+                }
+            }
+        }
 
         public LocalizedString this[string name, params object[] arguments]
-            => ReadInvariant(() => inner[name, arguments]);
+        {
+            get
+            {
+                var previous = CultureInfo.CurrentUICulture;
+                CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+                try
+                {
+                    return inner[name, arguments];
+                }
+                finally
+                {
+                    CultureInfo.CurrentUICulture = previous;
+                }
+            }
+        }
 
         public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
-            => ReadInvariant(() => inner.GetAllStrings(includeParentCultures).ToList());
-
-        private static T ReadInvariant<T>(Func<T> read)
         {
-            // Synchronous swap/restore with no await in between, so the culture never leaks to another flow.
             var previous = CultureInfo.CurrentUICulture;
             CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
             try
             {
-                return read();
+                return inner.GetAllStrings(includeParentCultures).ToList();
             }
             finally
             {

--- a/src/MudBlazor/Services/Localization/DefaultLocalizationInterceptor.cs
+++ b/src/MudBlazor/Services/Localization/DefaultLocalizationInterceptor.cs
@@ -35,7 +35,8 @@ public class DefaultLocalizationInterceptor : AbstractLocalizationInterceptor
             var currentCulture = Thread.CurrentThread.CurrentUICulture.Parent.TwoLetterISOLanguageName;
             if (MudLocalizer is null || currentCulture.Equals("en", StringComparison.InvariantCultureIgnoreCase))
             {
-                return Localizer[key, arguments];
+                // The argument-less indexer skips the string.Format copy, and most keys take no arguments.
+                return arguments.Length > 0 ? Localizer[key, arguments] : Localizer[key];
             }
         }
 


### PR DESCRIPTION
Two separate costs, both paid by every component that shows a localized string.

**Per component.** `InternalMudLocalizer` and its two interceptors were registered transient, so every component that injects the localizer got its own `DefaultLocalizationInterceptor`, whose constructor builds a `ResourceManagerStringLocalizerFactory`, a `ResourceManagerStringLocalizer` and its resource cache. Every form component injects the localizer, so a page of inputs built one resource reader per input and none of them shared a cache.

**Per lookup.** Components read localized strings while rendering, so the lookup path runs in the render loop. The invariant-culture wrapper routed every read through a `Func`, allocating a closure and a delegate; the English fast path always used the formatting indexer, so a key with no arguments still paid a `string.Format` copy; and every lookup went back to the string localizer and its per-lookup cache key even though the value cannot change.

Fix:

- Register the three localization services as scoped. Nothing in them holds per-component state, and scoped is the correct lifetime in both hosting models: one per circuit on Server, one per app on WebAssembly. The `AddLocalizationInterceptor`/`AddLocalizationEnumInterceptor` replacement helpers are unchanged; with a scoped `InternalMudLocalizer` a custom interceptor is resolved once per scope regardless.
- Inline the culture swap instead of passing a `Func`, use the argument-less indexer when there are no arguments, and cache found keys. Reading always happens under the invariant culture (#13461), so a key's value never changes. A key that is not a resource is not cached, because callers pass arbitrary strings through this path, such as a conversion exception message.

Measured with a bare `Renderer` whose `UpdateDisplayAsync` does nothing. Median of 5 runs, allocation per instance:

| | before | after |
| --- | --- | --- |
| component injecting only the localizer | 14210 B | 1016 B |
| one localized string read per render | 508 B | 68 B |
| `MudTextField` | 120206 B | 80554 B |
| `MudNumericField` | 154728 B | 113255 B |
| `MudCheckBox` | 29808 B | 16639 B |
| `MudAlert` | 18085 B | 4895 B |
