### PR TITLE
DefaultConverter: Register only the converter its type needs

### DIFF
--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -18,6 +18,96 @@ public class DefaultConverterTests
 {
     #region DefeultConverter
 
+    /// <summary>
+    /// Every type in the built-in table must resolve to its own converter, including the nullable variants.
+    /// </summary>
+    /// <remarks>
+    /// A type that resolves to nothing falls through to the ToString fallback, whose ConvertBack silently returns
+    /// default, so only a round trip catches a wrong entry in the table.
+    /// </remarks>
+    [Test]
+    public void DefaultConverter_ShouldRoundTripEveryBuiltInType()
+    {
+        AssertRoundTrip("hello world");
+        AssertRoundTrip('Z');
+        AssertNullableRoundTrip<char>('Z');
+        AssertRoundTrip(true);
+        AssertNullableRoundTrip(true);
+        AssertRoundTrip(new Guid("8a1f0f3c-6f2e-4a1d-9c3b-0d5a6e7f8b90"));
+        AssertNullableRoundTrip(new Guid("8a1f0f3c-6f2e-4a1d-9c3b-0d5a6e7f8b90"));
+        AssertNumberRoundTrip<sbyte>(-12, 12);
+        AssertNumberRoundTrip<byte>(200, 12);
+        AssertNumberRoundTrip<short>(-1234, 12);
+        AssertNumberRoundTrip<ushort>(60000, 12);
+        AssertNumberRoundTrip(123456, 12);
+        AssertNumberRoundTrip(4000000000u, 12u);
+        AssertNumberRoundTrip(-123456789012345L, 12L);
+        AssertNumberRoundTrip(123456789012345ul, 12ul);
+        AssertNumberRoundTrip(1.25f, 12f);
+        AssertNumberRoundTrip(3.5d, 12d);
+        AssertNumberRoundTrip(12345.6789m, 12m);
+        AssertRoundTrip(BigInteger.Parse("123456789012345678901234567890", CultureInfo.InvariantCulture));
+        AssertNullableRoundTrip(BigInteger.Parse("123456789012345678901234567890", CultureInfo.InvariantCulture));
+        AssertRoundTrip(new DateTime(2025, 11, 30, 13, 45, 12, DateTimeKind.Unspecified), "o");
+        AssertNullableRoundTrip(new DateTime(2025, 11, 30, 13, 45, 12, DateTimeKind.Unspecified), "o");
+        AssertRoundTrip(new DateTimeOffset(2025, 11, 30, 13, 45, 12, TimeSpan.FromHours(2)), "o");
+        AssertNullableRoundTrip(new DateTimeOffset(2025, 11, 30, 13, 45, 12, TimeSpan.FromHours(2)), "o");
+        AssertRoundTrip(new DateOnly(2025, 11, 30), "yyyy-MM-dd");
+        AssertNullableRoundTrip(new DateOnly(2025, 11, 30), "yyyy-MM-dd");
+        AssertRoundTrip(new TimeOnly(14, 5, 6), "HH:mm:ss");
+        AssertNullableRoundTrip(new TimeOnly(14, 5, 6), "HH:mm:ss");
+        AssertRoundTrip(new TimeSpan(1, 2, 3, 4, 567), "c");
+        AssertNullableRoundTrip(new TimeSpan(1, 2, 3, 4, 567), "c");
+    }
+
+    /// <summary>
+    /// Converts a value to text and back, and asserts the value survives the trip.
+    /// </summary>
+    private static void AssertRoundTrip<TValue>(TValue value, string? format = null)
+    {
+        var converter = new DefaultConverter<TValue>
+        {
+            Culture = () => CultureInfo.InvariantCulture,
+            Format = () => format
+        };
+
+        converter.ConvertBack(converter.Convert(value)).Should().Be(value);
+    }
+
+    /// <summary>
+    /// Round-trips a number and asserts the built-in number converter handled it rather than the IParsable fallback.
+    /// </summary>
+    /// <remarks>
+    /// The built-in converter parses with <see cref="NumberStyles.Any"/>, so it accepts the invariant currency symbol.
+    /// The fallback parses through <c>IParsable</c> and rejects it, which is how a wrong entry in the table shows up.
+    /// </remarks>
+    private static void AssertNumberRoundTrip<TValue>(TValue value, TValue currencyParsed) where TValue : struct
+    {
+        AssertRoundTrip(value);
+        AssertNullableRoundTrip(value);
+
+        const string Currency = "¤12";
+        new DefaultConverter<TValue> { Culture = () => CultureInfo.InvariantCulture }.ConvertBack(Currency).Should().Be(currencyParsed);
+        new DefaultConverter<TValue?> { Culture = () => CultureInfo.InvariantCulture }.ConvertBack(Currency).Should().Be(currencyParsed);
+    }
+
+    /// <summary>
+    /// Runs <see cref="AssertRoundTrip{TValue}"/> against the nullable form of a value type, including the null case.
+    /// </summary>
+    private static void AssertNullableRoundTrip<TValue>(TValue value, string? format = null) where TValue : struct
+    {
+        AssertRoundTrip<TValue?>(value, format);
+
+        var converter = new DefaultConverter<TValue?>
+        {
+            Culture = () => CultureInfo.InvariantCulture,
+            Format = () => format
+        };
+
+        converter.Convert(null).Should().BeNull();
+        converter.ConvertBack(null).Should().BeNull();
+    }
+
     [Test]
     public void DefaultConverter_Roundtrip_AllSupportedTypes_ForwardAndBack()
     {

--- a/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
+++ b/src/MudBlazor.UnitTests/Converters/DefaultConverterTests.cs
@@ -22,8 +22,7 @@ public class DefaultConverterTests
     /// Every type in the built-in table must resolve to its own converter, including the nullable variants.
     /// </summary>
     /// <remarks>
-    /// A type that resolves to nothing falls through to the ToString fallback, whose ConvertBack silently returns
-    /// default, so only a round trip catches a wrong entry in the table.
+    /// A type that resolves to nothing falls through to the ToString fallback, whose ConvertBack silently returns default, so only a round trip catches a wrong entry in the table.
     /// </remarks>
     [Test]
     public void DefaultConverter_ShouldRoundTripEveryBuiltInType()

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -51,10 +51,8 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
     /// Registers the built-in converter for <typeparamref name="T"/>, if there is one.
     /// </summary>
     /// <remarks>
-    /// The dispatcher resolves a single handler for <c>typeof(T)</c> when it is built and drops every other registration,
-    /// so registering the whole table would build about forty converters and their culture and format closures per instance to keep one.
-    /// Do NOT pass Culture or Format directly (<c>new NumberConverter&lt;int&gt;(Culture, Format)</c>): the dispatcher captures the
-    /// field values at registration time, while <c>() =&gt; Culture()</c> reads the latest property value on every conversion.
+    /// The dispatcher resolves a single handler for <c>typeof(T)</c> when it is built and drops every other registration, so registering the whole table would build about forty converters and their culture and format closures per instance to keep one.
+    /// Do NOT pass Culture or Format directly (<c>new NumberConverter&lt;int&gt;(Culture, Format)</c>): the dispatcher captures the field values at registration time, while <c>() =&gt; Culture()</c> reads the latest property value on every conversion.
     /// </remarks>
     private void AddBuiltInConverter(IReversibleDispatcherBuilder<T?, string?> builder)
     {

--- a/src/MudBlazor/Converters/DefaultConverter.cs
+++ b/src/MudBlazor/Converters/DefaultConverter.cs
@@ -35,55 +35,9 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
     /// </summary>
     public DefaultConverter()
     {
-        // Do NOT pass Culture or Format directly: new NumberConverter<sbyte>(Culture, Format)
-        // The dispatcher caches method delegates and captures the converter's field values at registration time.
-        // Using () => Culture() and () => Format() ensures the converters always read the latest property values.
-        // We could make Add a factory Func<IConverter> overload, but that would create instance on each conversion attempt which is less performant than current the trick.
-        var builder = ReversibleTypeDispatcher.Create<T?, string?>(DispatcherRegistrationPolicy.FirstWins)
-            .Add(StringConverter.Instance)
-            .Add<char>(CharConverter.Instance)
-            .Add<char?>(CharConverter.Instance)
-            .Add<bool>(DefaultConverter.BoolConverter.Instance)
-            .Add<bool?>(DefaultConverter.BoolConverter.Instance)
-            .Add<Guid>(new GuidConverter(() => Culture(), () => Format()))
-            .Add<Guid?>(new GuidConverter(() => Culture(), () => Format()))
-            .Add(new NumberConverter<sbyte>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<sbyte>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<byte>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<byte>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<short>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<short>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<ushort>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<ushort>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<int>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<int>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<uint>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<uint>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<long>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<long>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<ulong>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<ulong>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<float>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<float>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<double>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<double>(() => Culture(), () => Format()))
-            .Add(new NumberConverter<decimal>(() => Culture(), () => Format()))
-            .Add(new NullableNumberConverter<decimal>(() => Culture(), () => Format()))
-            .Add<BigInteger>(new BigIntegerConverter(() => Culture(), () => Format()))
-            .Add<BigInteger?>(new BigIntegerConverter(() => Culture(), () => Format()))
-            .Add<DateTime>(new DateTimeConverter(() => Culture(), () => Format()))
-            .Add<DateTime?>(new DateTimeConverter(() => Culture(), () => Format()))
-            .Add<DateTimeOffset>(new DateTimeOffsetConverter(() => Culture(), () => Format()))
-            .Add<DateTimeOffset?>(new DateTimeOffsetConverter(() => Culture(), () => Format()))
-            .Add<DateOnly>(new DateOnlyConverter(() => Culture(), () => Format()))
-            .Add<DateOnly?>(new DateOnlyConverter(() => Culture(), () => Format()))
-            .Add<TimeOnly>(new TimeOnlyConverter(() => Culture(), () => Format()))
-            .Add<TimeOnly?>(new TimeOnlyConverter(() => Culture(), () => Format()))
-            .Add<TimeSpan>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()))
-            .Add<TimeSpan?>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()));
-        // Let's not use that for now and see if we really need it
-        //.Add(new ObjectConverter(() => Culture(), () => Format()))
+        var builder = ReversibleTypeDispatcher.Create<T?, string?>(DispatcherRegistrationPolicy.FirstWins);
 
+        AddBuiltInConverter(builder);
         AddEnumConverters(builder);
         AddParsableConverters(builder);
         // Make sure this is the last converter added, so it runs only if no other converter can handle the type.
@@ -91,6 +45,185 @@ public sealed class DefaultConverter<T> : IReversibleConverter<T?, string?>, ICu
         builder.Add(new ToStringFallbackConverter<T>());
 
         _dispatcher = builder.Build();
+    }
+
+    /// <summary>
+    /// Registers the built-in converter for <typeparamref name="T"/>, if there is one.
+    /// </summary>
+    /// <remarks>
+    /// The dispatcher resolves a single handler for <c>typeof(T)</c> when it is built and drops every other registration,
+    /// so registering the whole table would build about forty converters and their culture and format closures per instance to keep one.
+    /// Do NOT pass Culture or Format directly (<c>new NumberConverter&lt;int&gt;(Culture, Format)</c>): the dispatcher captures the
+    /// field values at registration time, while <c>() =&gt; Culture()</c> reads the latest property value on every conversion.
+    /// </remarks>
+    private void AddBuiltInConverter(IReversibleDispatcherBuilder<T?, string?> builder)
+    {
+        var targetType = typeof(T);
+
+        if (targetType == typeof(string))
+        {
+            builder.Add(StringConverter.Instance);
+        }
+        else if (targetType == typeof(char))
+        {
+            builder.Add<char>(CharConverter.Instance);
+        }
+        else if (targetType == typeof(char?))
+        {
+            builder.Add<char?>(CharConverter.Instance);
+        }
+        else if (targetType == typeof(bool))
+        {
+            builder.Add<bool>(DefaultConverter.BoolConverter.Instance);
+        }
+        else if (targetType == typeof(bool?))
+        {
+            builder.Add<bool?>(DefaultConverter.BoolConverter.Instance);
+        }
+        else if (targetType == typeof(Guid))
+        {
+            builder.Add<Guid>(new GuidConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(Guid?))
+        {
+            builder.Add<Guid?>(new GuidConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(sbyte))
+        {
+            builder.Add(new NumberConverter<sbyte>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(sbyte?))
+        {
+            builder.Add(new NullableNumberConverter<sbyte>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(byte))
+        {
+            builder.Add(new NumberConverter<byte>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(byte?))
+        {
+            builder.Add(new NullableNumberConverter<byte>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(short))
+        {
+            builder.Add(new NumberConverter<short>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(short?))
+        {
+            builder.Add(new NullableNumberConverter<short>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(ushort))
+        {
+            builder.Add(new NumberConverter<ushort>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(ushort?))
+        {
+            builder.Add(new NullableNumberConverter<ushort>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(int))
+        {
+            builder.Add(new NumberConverter<int>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(int?))
+        {
+            builder.Add(new NullableNumberConverter<int>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(uint))
+        {
+            builder.Add(new NumberConverter<uint>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(uint?))
+        {
+            builder.Add(new NullableNumberConverter<uint>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(long))
+        {
+            builder.Add(new NumberConverter<long>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(long?))
+        {
+            builder.Add(new NullableNumberConverter<long>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(ulong))
+        {
+            builder.Add(new NumberConverter<ulong>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(ulong?))
+        {
+            builder.Add(new NullableNumberConverter<ulong>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(float))
+        {
+            builder.Add(new NumberConverter<float>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(float?))
+        {
+            builder.Add(new NullableNumberConverter<float>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(double))
+        {
+            builder.Add(new NumberConverter<double>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(double?))
+        {
+            builder.Add(new NullableNumberConverter<double>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(decimal))
+        {
+            builder.Add(new NumberConverter<decimal>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(decimal?))
+        {
+            builder.Add(new NullableNumberConverter<decimal>(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(BigInteger))
+        {
+            builder.Add<BigInteger>(new BigIntegerConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(BigInteger?))
+        {
+            builder.Add<BigInteger?>(new BigIntegerConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(DateTime))
+        {
+            builder.Add<DateTime>(new DateTimeConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(DateTime?))
+        {
+            builder.Add<DateTime?>(new DateTimeConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(DateTimeOffset))
+        {
+            builder.Add<DateTimeOffset>(new DateTimeOffsetConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(DateTimeOffset?))
+        {
+            builder.Add<DateTimeOffset?>(new DateTimeOffsetConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(DateOnly))
+        {
+            builder.Add<DateOnly>(new DateOnlyConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(DateOnly?))
+        {
+            builder.Add<DateOnly?>(new DateOnlyConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(TimeOnly))
+        {
+            builder.Add<TimeOnly>(new TimeOnlyConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(TimeOnly?))
+        {
+            builder.Add<TimeOnly?>(new TimeOnlyConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(TimeSpan))
+        {
+            builder.Add<TimeSpan>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()));
+        }
+        else if (targetType == typeof(TimeSpan?))
+        {
+            builder.Add<TimeSpan?>(new DefaultConverter.TimeSpanConverter(() => Culture(), () => Format()));
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
### Problem

`DefaultConverter<T>`'s constructor registers the whole built-in table — around forty converters, each with a culture closure and a format closure — into a dispatcher that resolves a **single** handler for `typeof(T)` when it is built and drops everything else (`TypeDispatcher.ResolveForwardHandler` looks up `typeof(TIn)` and nothing else).

Every `MudFormComponent` creates one of these through `GetDefaultConverter()`, so a page of inputs built the entire table once per input to keep one entry.

### Fix

Register only the entry that matches `typeof(T)`. The first-wins order between the built-in table, the enum converters, the `IParsable` converters and the `ToString` fallback is unchanged, so resolution is identical for every type.

Measured with a bare `Renderer` whose `UpdateDisplayAsync` does nothing. Median of 5 runs, allocation per instance:

| | before | after |
| --- | --- | --- |
| form component with an empty render tree | 26304 B | 6608 B |
| `MudInput` | 35838 B | 16140 B |
| `MudTextField` | 80554 B | 41154 B |
| `MudNumericField` | 113255 B | 73929 B |

(Baseline here already includes #13712; on plain `dev` the `MudTextField` figure is 120206 B.)