### PR TITLE
Various components: Drop CssBuilder predicate lambdas that were never lazy

### DIFF
--- a/src/MudBlazor/Components/Button/MudIconButton.razor.cs
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor.cs
@@ -26,8 +26,8 @@ namespace MudBlazor
             .AddClass($"mud-button-{Variant.ToStringFast(true)}-size-{Size.ToStringFast(true)}", AsButton)
             .AddClass($"mud-ripple", Ripple)
             .AddClass($"mud-ripple-icon", Ripple && !AsButton)
-            .AddClass($"mud-icon-button-size-{Size.ToStringFast(true)}", when: () => Size != Size.Medium)
-            .AddClass($"mud-icon-button-edge-{Edge.ToStringFast(true)}", when: () => Edge != Edge.False)
+            .AddClass($"mud-icon-button-size-{Size.ToStringFast(true)}", Size != Size.Medium)
+            .AddClass($"mud-icon-button-edge-{Edge.ToStringFast(true)}", Edge != Edge.False)
             .AddClass($"mud-button-disable-elevation", !DropShadow)
             .AddClass(Class)
             .Build();

--- a/src/MudBlazor/Components/Field/MudField.razor.cs
+++ b/src/MudBlazor/Components/Field/MudField.razor.cs
@@ -16,8 +16,8 @@ namespace MudBlazor
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}")
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}-with-label", !string.IsNullOrEmpty(Label))
                 .AddClass($"mud-input-adorned-{Adornment.ToStringFast(true)}", Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{Margin.ToStringFast(true)}", () => Margin != Margin.None)
-                .AddClass("mud-input-underline", () => Underline && Variant != Variant.Outlined)
+                .AddClass($"mud-input-margin-{Margin.ToStringFast(true)}", Margin != Margin.None)
+                .AddClass("mud-input-underline", Underline && Variant != Variant.Outlined)
                 // Without the mud-shrink class, the label will become a placeholder
                 // Apply "mud-shrink" only if ShrinkLabel is false AND
                 // (there is content OR the adornment is at the start)
@@ -32,10 +32,10 @@ namespace MudBlazor
         protected string InnerClassname =>
             new CssBuilder("mud-input-slot")
                 .AddClass("mud-input-root")
-                .AddClass("mud-input-slot-nopadding", () => !InnerPadding)
+                .AddClass("mud-input-slot-nopadding", !InnerPadding)
                 .AddClass($"mud-input-root-{Variant.ToStringFast(true)}")
                 .AddClass($"mud-input-adorned-{Adornment.ToStringFast(true)}", Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{Margin.ToStringFast(true)}", () => Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToStringFast(true)}", Margin != Margin.None)
                 .Build();
 
         protected string AdornmentClassname =>

--- a/src/MudBlazor/Components/Input/MudInputCssHelper.cs
+++ b/src/MudBlazor/Components/Input/MudInputCssHelper.cs
@@ -19,8 +19,8 @@ internal static class MudInputCssHelper
             .AddClass($"mud-input-{baseInput.Variant.ToStringFast(true)}")
             .AddClass($"mud-input-{baseInput.Variant.ToStringFast(true)}-with-label", !string.IsNullOrEmpty(baseInput.Label))
             .AddClass($"mud-input-adorned-{baseInput.Adornment.ToStringFast(true)}", baseInput.Adornment != Adornment.None)
-            .AddClass($"mud-input-margin-{baseInput.Margin.ToStringFast(true)}", () => baseInput.Margin != Margin.None)
-            .AddClass("mud-input-underline", () => baseInput.Underline && baseInput.Variant != Variant.Outlined)
+            .AddClass($"mud-input-margin-{baseInput.Margin.ToStringFast(true)}", baseInput.Margin != Margin.None)
+            .AddClass("mud-input-underline", baseInput.Underline && baseInput.Variant != Variant.Outlined)
             .AddClass("mud-shrink", shrinkWhen)
             .AddClass("mud-disabled", baseInput.Disabled)
             .AddClass("mud-input-error", baseInput.HasErrors)
@@ -40,7 +40,7 @@ internal static class MudInputCssHelper
             .AddClass("mud-input-root")
             .AddClass($"mud-input-root-{baseInput.Variant.ToStringFast(true)}")
             .AddClass($"mud-input-root-adorned-{baseInput.Adornment.ToStringFast(true)}", baseInput.Adornment != Adornment.None)
-            .AddClass($"mud-input-root-margin-{baseInput.Margin.ToStringFast(true)}", () => baseInput.Margin != Margin.None)
+            .AddClass($"mud-input-root-margin-{baseInput.Margin.ToStringFast(true)}", baseInput.Margin != Margin.None)
             .AddClass(baseInput.Class)
             .Build();
 

--- a/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
+++ b/src/MudBlazor/Components/Input/MudInputLabel.razor.cs
@@ -12,7 +12,7 @@ namespace MudBlazor
             .AddClass("mud-input-label")
             .AddClass("mud-input-label-animated")
             .AddClass($"mud-input-label-{Variant.ToStringFast(true)}")
-            .AddClass($"mud-input-label-margin-{Margin.ToStringFast(true)}", when: () => Margin != Margin.None)
+            .AddClass($"mud-input-label-margin-{Margin.ToStringFast(true)}", Margin != Margin.None)
             .AddClass("mud-disabled", Disabled)
             .AddClass("mud-input-error", Error)
             .AddClass(Class)

--- a/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
+++ b/src/MudBlazor/Components/InputControl/MudInputControl.razor.cs
@@ -11,8 +11,8 @@ namespace MudBlazor
     {
         protected string Classname =>
             new CssBuilder("mud-input-control")
-                .AddClass("mud-input-required", when: () => Required)
-                .AddClass($"mud-input-control-margin-{Margin.ToStringFast(true)}", when: () => Margin != Margin.None)
+                .AddClass("mud-input-required", Required)
+                .AddClass($"mud-input-control-margin-{Margin.ToStringFast(true)}", Margin != Margin.None)
                 .AddClass("mud-input-control-full-width", FullWidth)
                 .AddClass("mud-input-error", Error)
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}-with-label", !string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -35,9 +35,9 @@ namespace MudBlazor
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}")
                 .AddClass($"mud-input-{Variant.ToStringFast(true)}-with-label", !string.IsNullOrEmpty(Label))
                 .AddClass($"mud-input-adorned-{Adornment.ToStringFast(true)}", Adornment != Adornment.None)
-                .AddClass($"mud-input-margin-{Margin.ToStringFast(true)}", () => Margin != Margin.None)
-                .AddClass("mud-input-underline", () => Underline && Variant != Variant.Outlined)
-                .AddClass("mud-shrink", () => !string.IsNullOrEmpty(ReadText) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || ShrinkLabel)
+                .AddClass($"mud-input-margin-{Margin.ToStringFast(true)}", Margin != Margin.None)
+                .AddClass("mud-input-underline", Underline && Variant != Variant.Outlined)
+                .AddClass("mud-shrink", !string.IsNullOrEmpty(ReadText) || Adornment == Adornment.Start || !string.IsNullOrWhiteSpace(Placeholder) || ShrinkLabel)
                 .AddClass("mud-disabled", GetDisabledState())
                 .AddClass("mud-input-error", HasErrors)
                 .AddClass("mud-ltr", GetInputType() == InputType.Email || GetInputType() == InputType.Telephone)
@@ -50,7 +50,7 @@ namespace MudBlazor
                 .AddClass("mud-input-root")
                 .AddClass($"mud-input-root-{Variant.ToStringFast(true)}")
                 .AddClass($"mud-input-root-adorned-{Adornment.ToStringFast(true)}", Adornment != Adornment.None)
-                .AddClass($"mud-input-root-margin-{Margin.ToStringFast(true)}", () => Margin != Margin.None)
+                .AddClass($"mud-input-root-margin-{Margin.ToStringFast(true)}", Margin != Margin.None)
                 .AddClass(Class)
                 .Build();
 

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -925,10 +925,10 @@ namespace MudBlazor
         private string GetTabClass(MudTabPanel panel)
         {
             var tabClass = new CssBuilder("mud-tab")
-              .AddClass($"mud-tab-active", when: () => panel == ActivePanel)
+              .AddClass($"mud-tab-active", panel == ActivePanel)
               .AddClass($"mud-disabled", IsPanelDisabled(panel))
               .AddClass($"mud-ripple", Ripple)
-              .AddClass(ActiveTabClass, when: () => panel == ActivePanel)
+              .AddClass(ActiveTabClass, panel == ActivePanel)
               .AddClass(TabButtonsClass)
               .AddClass(panel.Classname)
               .Build();


### PR DESCRIPTION
`CssBuilder.AddClass(string?, Func<bool>? when)` is `AddClass(value, when is not null && when())` — it invokes the predicate immediately. Writing the condition as a lambda therefore buys no laziness and costs a closure and a delegate on every render.

Eighteen sites did that, all in shared class builders that run on every render: `MudInputCssHelper` (every input), `MudInputControl`, `MudInputLabel`, `MudField`, `MudMask`, `MudIconButton` and `MudTabs`.

Measured with a bare `Renderer` whose `UpdateDisplayAsync` does nothing. Median of 5 runs, allocation per instance:

| | before | after |
| --- | --- | --- |
| `MudField` | 6056 B | 5672 B |
| `MudCheckBox` | 16636 B | 16497 B |
| `MudInput` | 16153 B | 15814 B |
| `MudIconButton` | 10378 B | 10250 B |