### PR TITLE
MudRadio: Surface generic-mismatch diagnostic instead of killing the circuit

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,10 +1,10 @@
 ﻿using AwesomeAssertions;
-using MudBlazor.Utilities.Exceptions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Radio;
 using MudBlazor.UnitTests.TestComponents.RadioGroup;
 using MudBlazor.UnitTests.Utilities;
+using MudBlazor.Utilities.Exceptions;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// A mismatched group must leave the typed parent null rather than fail the cast, because DisposeAsyncCore reads it while tearing the rejected radio down and an InvalidCastException there takes a Blazor Server circuit down before the diagnostic is ever shown.
+        /// A mismatched group must leave the typed parent null rather than fail the cast.
         /// </summary>
         [Test]
         public void Radio_TypeMismatch_ShouldNotLeaveACastThatThrows()

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -354,7 +354,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// A mismatched group must leave the typed parent null rather than fail the cast, because every consumer of it runs from the render and disposal paths where an InvalidCastException takes a Blazor Server circuit down before the diagnostic is ever shown.
+        /// A mismatched group must leave the typed parent null rather than fail the cast, because DisposeAsyncCore reads it while tearing the rejected radio down and an InvalidCastException there takes a Blazor Server circuit down before the diagnostic is ever shown.
         /// </summary>
         [Test]
         public void Radio_TypeMismatch_ShouldNotLeaveACastThatThrows()

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,4 +1,5 @@
 ﻿using AwesomeAssertions;
+using MudBlazor.Utilities.Exceptions;
 using Bunit;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Radio;
@@ -350,6 +351,22 @@ namespace MudBlazor.UnitTests.Components
             {
                 typeof(MudBlazor.Utilities.Exceptions.GenericTypeMismatchException).Should().Be(ex.InnerException.GetType());
             }
+        }
+
+        /// <summary>
+        /// A mismatched group must leave the typed parent null rather than fail the cast, because every consumer of it runs from the render and disposal paths where an InvalidCastException takes a Blazor Server circuit down before the diagnostic is ever shown.
+        /// </summary>
+        [Test]
+        public void Radio_TypeMismatch_ShouldNotLeaveACastThatThrows()
+        {
+            var radio = new MudRadio<string>();
+            var group = new MudRadioGroup<char>();
+
+            // The cascade is assigned before the group rejects it, so the mismatched parent stays behind.
+            var assign = () => radio.IMudRadioGroup = group;
+            assign.Should().Throw<GenericTypeMismatchException>();
+
+            radio.MudRadioGroup.Should().BeNull();
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -144,7 +144,7 @@ namespace MudBlazor
         internal bool Checked { get; private set; }
 
         // A mismatched group still lands here, because the cascade is stored before CheckGenericTypeMatch rejects it.
-        // Casting it hard turns that diagnostic into an InvalidCastException from the render path, which takes the circuit with it.
+        // Casting it hard turns that diagnostic into an InvalidCastException from DisposeAsyncCore, which takes the circuit with it.
         internal MudRadioGroup<T>? MudRadioGroup => IMudRadioGroup as MudRadioGroup<T>;
 
         internal void SetChecked(bool value)

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -143,8 +143,6 @@ namespace MudBlazor
 
         internal bool Checked { get; private set; }
 
-        // A mismatched group still lands here, because the cascade is stored before CheckGenericTypeMatch rejects it.
-        // Casting it hard turns that diagnostic into an InvalidCastException from DisposeAsyncCore, which takes the circuit with it.
         internal MudRadioGroup<T>? MudRadioGroup => IMudRadioGroup as MudRadioGroup<T>;
 
         internal void SetChecked(bool value)

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -143,7 +143,9 @@ namespace MudBlazor
 
         internal bool Checked { get; private set; }
 
-        internal MudRadioGroup<T>? MudRadioGroup => (MudRadioGroup<T>?)IMudRadioGroup;
+        // A mismatched group still lands here, because the cascade is stored before CheckGenericTypeMatch rejects it.
+        // Casting it hard turns that diagnostic into an InvalidCastException from the render path, which takes the circuit with it.
+        internal MudRadioGroup<T>? MudRadioGroup => IMudRadioGroup as MudRadioGroup<T>;
 
         internal void SetChecked(bool value)
         {


### PR DESCRIPTION
`MudRadioGroup<T>` deliberately throws `GenericTypeMismatchException` when it finds a child `MudRadio<U>`, so the developer gets a message naming both types. On Blazor Server they never see it: the page freezes and the log shows an unhandled `InvalidCastException` instead.

The cascade is stored on the radio before the check runs, so the mismatched group stays behind, and `MudRadio<T>.MudRadioGroup` casts it hard. Blazor then tears the failed component down and `DisposeAsyncCore` reads that property to unregister, which throws from disposal — an unhandled circuit exception that an `ErrorBoundary` around the group cannot catch.

- Read the parent with `as`, so a mismatched group leaves it null. Every consumer already null-checks it, so only the intended exception escapes.

Introduced by #2709, which replaced the typed `[CascadingParameter] MudRadioGroup<T>` with the untyped `IMudRadioGroup` plus this cast and repointed `Dispose` at it. Before that a mismatched group simply did not cascade and nothing threw.

Verified against a Blazor Server circuit: before, the page freezes on first render; after, the boundary reports the mismatch and the circuit keeps serving. Not a regression in this release — v9.8.0 behaves the same.
