### PR TITLE
MudDynamicTabs: Fix CloseTab raised twice per key press

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/DynamicTabsWithKeyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/DynamicTabsWithKeyTest.razor
@@ -12,8 +12,11 @@
     private int _activePanel = 3;
     private readonly List<Item> _tabs = Enumerable.Range(0, 4).Select(x => new Item(x)).ToList();
 
+    public int CloseCalls { get; private set; }
+
     private void OnCloseTab(MudTabPanel panel)
     {
+        CloseCalls++;
         var idx = _tabs.FindIndex(x => x.Id.Equals(panel.ID));
         _tabs.RemoveAt(idx);
     }

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -2061,5 +2061,19 @@ namespace MudBlazor.UnitTests.Components
                     "scroll button disabled state should remain unchanged when the parent form is re-enabled");
             });
         }
+
+        /// <summary>
+        /// A key press on a tab's close button must raise CloseTab once, even though the event also reaches the tab header that wraps it.
+        /// </summary>
+        [Test]
+        public async Task DynamicTabs_CloseKeyOnCloseButton_ShouldRaiseCloseTabOnce()
+        {
+            var comp = Context.Render<DynamicTabsWithKeyTest>();
+            var closeButton = comp.FindAll(".mud-tab button")[1];
+
+            await closeButton.KeyDownAsync(new KeyboardEventArgs { Key = "Delete" });
+
+            comp.Instance.CloseCalls.Should().Be(1);
+        }
     }
 }

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
@@ -24,8 +24,6 @@
     /// </summary>
     public RenderFragment Render => base.BuildRenderTree;
 
-    @* The close button sits inside the tab header, whose own @onkeydown already reaches it by bubbling and carries this same panel.
-       Wiring the button as well made one Delete or Backspace raise CloseTab twice, the second time for a panel the consumer had just removed. *@
     private RenderFragment<MudTabPanel> MudTabPanelPanelHeader => context =>
         @<MudRender>
             @if (context.ShowCloseIcon)

--- a/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
+++ b/src/MudBlazor/Components/Tabs/MudDynamicTabs.razor
@@ -24,6 +24,8 @@
     /// </summary>
     public RenderFragment Render => base.BuildRenderTree;
 
+    @* The close button sits inside the tab header, whose own @onkeydown already reaches it by bubbling and carries this same panel.
+       Wiring the button as well made one Delete or Backspace raise CloseTab twice, the second time for a panel the consumer had just removed. *@
     private RenderFragment<MudTabPanel> MudTabPanelPanelHeader => context =>
         @<MudRender>
             @if (context.ShowCloseIcon)
@@ -35,7 +37,6 @@
                                        Class="@CloseIconClass"
                                        Style="@CloseIconStyle"
                                        OnClick="() => CloseTab.InvokeAsync(context)"
-                                       @onkeydown="@(e => HandleTabKeyDownAsync(e, context))"
                                        aria-label="@Localizer[LanguageResource.MudTabs_CloseTab]"/>
                     </MudTooltip>
                 }
@@ -45,7 +46,6 @@
                                    Class="@CloseIconClass"
                                    Style="@CloseIconStyle"
                                    OnClick="() => CloseTab.InvokeAsync(context)"
-                                   @onkeydown="@(e => HandleTabKeyDownAsync(e, context))"
                                    aria-label="@Localizer[LanguageResource.MudTabs_CloseTab]" />
                 }
             }


### PR DESCRIPTION
Pressing Delete or Backspace on a focused tab close button raises `CloseTab` twice for the same panel. The second call arrives after the consumer has already removed that tab, so it hands them a panel their collection no longer contains.

The close button carries its own `@onkeydown`, and it sits inside the tab header, whose `@onkeydown` the same event reaches by bubbling. Both call `HandleTabKeyDownAsync` with the same panel.

`MudBlazor.UnitTests.Viewer`'s own `DynamicTabsWithKeyTest` does `_tabs.RemoveAt(_tabs.FindIndex(...))` and throws `ArgumentOutOfRangeException` on the second call; the docs example survives only because it happens to use `FirstOrDefault` and a null check.

- Remove the button's handler. It is redundant with the header's, which the event reaches anyway and which carries the same panel.

Introduced by #11581, which added the Delete/Backspace close shortcut and both `@onkeydown` wirings in one change; the close button was already nested inside the header there.

Verified in a browser for a focused close button and a focused tab header, with Delete and Backspace, and with an active panel other than the focused one: every path now reports one call and no unknown panel. bUnit fires only the nearest handler and never the ancestor's as well, so the duplicate is not observable there — the added test pins the once-only contract rather than reproducing the bug. Not a regression in this release — v9.8.0 behaves the same.
