### PR TITLE
MudTableSortLabel: Fix InitialSortDirection always used after unsorted

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -159,6 +159,13 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("td")[0].TextContent.Trim().Should().Be("C");
             comp.FindAll("td")[1].TextContent.Trim().Should().Be("B");
             comp.FindAll("td")[2].TextContent.Trim().Should().Be("A");
+            // descending -> unsorted
+            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync();
+            // unsorted -> ascending
+            await comp.Find("span.mud-clickable.mud-table-sort-label").ClickAsync();
+            comp.FindAll("td")[0].TextContent.Trim().Should().Be("A");
+            comp.FindAll("td")[1].TextContent.Trim().Should().Be("B");
+            comp.FindAll("td")[2].TextContent.Trim().Should().Be("C");
 
             comp = Context.Render<TableInitialSortDirectionTest>(parameters => parameters
                 .Add(p => p.InitialSortDirection, SortDirection.Ascending));

--- a/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableSortLabel.razor.cs
@@ -13,6 +13,8 @@ namespace MudBlazor
     {
         private SortDirection _direction = SortDirection.None;
 
+        private bool _firstSort = true;
+
         protected string Classname =>
             new CssBuilder("mud-table-sort-label")
                 .AddClass("mud-clickable", Enabled)
@@ -164,9 +166,12 @@ namespace MudBlazor
                 return Task.CompletedTask;
             }
 
+            var firstSort = _firstSort;
+            _firstSort = false;
+
             return SortDirection switch
             {
-                SortDirection.None => UpdateSortDirectionAsync(InitialSortDirection == SortDirection.None ? SortDirection.Ascending : InitialSortDirection),
+                SortDirection.None => UpdateSortDirectionAsync(InitialSortDirection == SortDirection.None || !firstSort ? SortDirection.Ascending : InitialSortDirection),
                 SortDirection.Ascending => UpdateSortDirectionAsync(SortDirection.Descending),
                 SortDirection.Descending => UpdateSortDirectionAsync(Table?.AllowUnsorted ?? false
                     ? SortDirection.None


### PR DESCRIPTION
Fixes #13725 
Rather than always toggeling from `SortDirection.None` to `InitialSortDirection`, check if it is the first toggle for the sort label and only then use the `InitialSortDirection` otherwise, use `SortDirection.Ascending`.

**Before/After:**
https://github.com/user-attachments/assets/200494a1-b410-43a1-a216-c3c35d4f894a


**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
