### PR TITLE
MudSelect: Skip extra render on mount when nothing resolves

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -1,6 +1,7 @@
 ﻿using AngleSharp.Dom;
 using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
 using MudBlazor.UnitTests.Dummy;
@@ -29,6 +30,48 @@ namespace MudBlazor.UnitTests.Components
 
             comp.FindComponents<MudListItem<string>>().Should().OnlyContain(x => !x.Instance.KeyboardEnabled);
             keyInterceptorService.ObserversCount.Should().Be(observersWhileClosed);
+        }
+
+        /// <summary>
+        /// A select with nothing to present must build its option list once, not twice (#13519).
+        /// </summary>
+        /// <remarks>
+        /// MudSelect renders ChildContent twice per pass, once for the popup list and once for the shadow items.
+        /// A second render on mount would double that, and no item can be diffed away because each one is handed a fresh ChildContent delegate.
+        /// </remarks>
+        [Test]
+        public void Select_WithoutResolvableValue_BuildsItemsOnce()
+        {
+            var passes = 0;
+            Context.Render<MudSelect<string>>(parameters => parameters
+                .Add(x => x.ChildContent, builder =>
+                {
+                    passes++;
+                    builder.OpenComponent<MudSelectItem<string>>(0);
+                    builder.AddComponentParameter(1, nameof(MudSelectItem<string>.Value), "Espresso");
+                    builder.CloseComponent();
+                }));
+
+            passes.Should().Be(2);
+        }
+
+        /// <summary>
+        /// A select whose value resolves to an item still renders that item's content, which is why the extra render on mount exists.
+        /// </summary>
+        [Test]
+        public void Select_WithResolvableValue_RendersTheSelectedItemContent()
+        {
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
+                .Add(x => x.Value, "Espresso")
+                .Add(x => x.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudSelectItem<string>>(0);
+                    builder.AddComponentParameter(1, nameof(MudSelectItem<string>.Value), "Espresso");
+                    builder.AddComponentParameter(2, nameof(MudSelectItem<string>.ChildContent), (RenderFragment)(content => content.AddContent(0, "A short black")));
+                    builder.CloseComponent();
+                }));
+
+            comp.Markup.Should().Contain("A short black");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -1475,10 +1475,10 @@ namespace MudBlazor
             {
                 UpdateFitContent();
             }
-            else if (firstRender)
+            else if (firstRender && (CanRenderValue || IsValueInList))
             {
-                // we need to render the initial Value which is not possible without the items
-                // which supply the RenderFragment. So in this case, a second render is necessary
+                // The first render runs before the shadow items register, so the value presenter could not resolve then.
+                // Only render again when the value now resolves to an item; otherwise the second pass rebuilds every item to produce the same output.
                 StateHasChanged();
             }
 


### PR DESCRIPTION
`MudSelect.OnAfterRenderAsync` re-rendered unconditionally on first render:

```csharp
else if (firstRender)
{
    // we need to render the initial Value which is not possible without the items
    // which supply the RenderFragment. So in this case, a second render is necessary
    StateHasChanged();
}
```

The reason is real — the first render runs before the shadow items have registered, so the value presenter cannot resolve yet. But it ran even when there was no value to resolve, which is the common case. And because `MudSelect` renders `ChildContent` twice per pass and hands every item a fresh `ChildContent` delegate, nothing can be diffed away: the entire option list was built twice on every mount.

Now we only render again when the value now resolves to an item. This is the mount half of #13519.

Measured with a bare `Renderer` counting render batches and `RenderBatch.UpdatedComponents`. `MudSelect<string>`, no preselected value, per-item `ChildContent`:

| options | before | after |
| --- | --- | --- |
| 0 | 2 batches / 18 renders | 1 / 11 |
| 10 | 2 / 55 | 1 / 38 |
| 100 | 2 / 325 | 1 / 218 |

-33% component renders at 100 options. One fewer batch is also one fewer diff over the wire on Blazor Server.

A select whose value is a value type still takes two batches, because `default(int)` matches an item whose value is `0` and the presenter genuinely resolves. That is the existing default-value question, untouched here.
