### PR TITLE
MudTreeView: Only re-render items whose state actually changed

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1446,5 +1446,58 @@ namespace MudBlazor.UnitTests.Components
             await arrows()[1].ClickAsync();
             comp.WaitForAssertion(() => itemContents().Should().Contain("More Spam (6)"));
         }
+        /// <summary>
+        /// Mounting a tree must render each item once, not twice.
+        /// </summary>
+        /// <remarks>
+        /// Every top-level item asks the tree to refresh its selection state while it initialises, and the tree used to render unconditionally in response.
+        /// Nothing is selected in this tree, so the second pass produced exactly the markup the first one already had.
+        /// </remarks>
+        [Test]
+        public void TreeView_OnMount_RendersEachItemOnce()
+        {
+            var renders = 0;
+            Context.Render<MudTreeView<string>>(parameters => parameters
+                .Add(x => x.ChildContent, BuildItems(() => renders++)));
+
+            renders.Should().Be(3);
+        }
+
+        /// <summary>
+        /// Mounting a multi-selection tree must also render each item once.
+        /// </summary>
+        /// <remarks>
+        /// The tri-state checkbox is derived from the sub-items, so a multi-selection item can go stale without its own state changing.
+        /// It is enough to render when that derived value stops matching what was rendered, which nothing selected never does.
+        /// </remarks>
+        [Test]
+        public void TreeView_MultiSelection_OnMount_RendersEachItemOnce()
+        {
+            var renders = 0;
+            Context.Render<MudTreeView<string>>(parameters => parameters
+                .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
+                .Add(x => x.ChildContent, BuildItems(() => renders++)));
+
+            renders.Should().Be(3);
+        }
+
+        /// <summary>
+        /// Builds three sibling items whose body content reports every time it is rendered.
+        /// </summary>
+        /// <param name="onRender">Called once per item render.</param>
+        private static RenderFragment BuildItems(Action onRender) => builder =>
+        {
+            for (var i = 0; i < 3; i++)
+            {
+                builder.OpenComponent<MudTreeViewItem<string>>(i * 3);
+                builder.AddComponentParameter((i * 3) + 1, nameof(MudTreeViewItem<string>.Value), $"item{i}");
+                builder.AddComponentParameter((i * 3) + 2, nameof(MudTreeViewItem<string>.BodyContent), (RenderFragment<MudTreeViewItem<string>>)(item => content =>
+                {
+                    onRender();
+                    content.AddContent(0, item.Value);
+                }));
+                builder.CloseComponent();
+            }
+        };
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1458,7 +1458,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var renders = 0;
             Context.Render<MudTreeView<string>>(parameters => parameters
-                .Add(x => x.ChildContent, BuildItems(() => renders++)));
+                .Add(x => x.ChildContent, BuildItems(_ => renders++)));
 
             renders.Should().Be(3);
         }
@@ -1476,24 +1476,47 @@ namespace MudBlazor.UnitTests.Components
             var renders = 0;
             Context.Render<MudTreeView<string>>(parameters => parameters
                 .Add(x => x.SelectionMode, SelectionMode.MultiSelection)
-                .Add(x => x.ChildContent, BuildItems(() => renders++)));
+                .Add(x => x.ChildContent, BuildItems(_ => renders++)));
 
             renders.Should().Be(3);
         }
 
+
+        /// <summary>
+        /// Selecting an item must re-render only that item, not every sibling.
+        /// </summary>
+        /// <remarks>
+        /// The tree refreshes the selection state of every item whenever the selection changes.
+        /// A sibling whose own state did not change has nothing new to show, and this guards the click path that the mount tests above do not reach.
+        /// </remarks>
+        [Test]
+        public void TreeView_SelectOneSibling_RendersOnlyChangedItem()
+        {
+            var renders = new int[3];
+            var comp = Context.Render<MudTreeView<string>>(parameters => parameters
+                .Add(x => x.ChildContent, BuildItems(index => renders[index]++)));
+
+            var afterMount = (int[])renders.Clone();
+            comp.FindAll(".mud-treeview-item-content")[0].Click();
+
+            renders[0].Should().Be(afterMount[0] + 1, "the selected item has a new state to show");
+            renders[1].Should().Be(afterMount[1], "sibling 1 did not change and should not have re-rendered");
+            renders[2].Should().Be(afterMount[2], "sibling 2 did not change and should not have re-rendered");
+        }
         /// <summary>
         /// Builds three sibling items whose body content reports every time it is rendered.
         /// </summary>
-        /// <param name="onRender">Called once per item render.</param>
-        private static RenderFragment BuildItems(Action onRender) => builder =>
+        /// <param name="onRender">Called with the item's index once per render of that item.</param>
+        private static RenderFragment BuildItems(Action<int> onRender) => builder =>
         {
             for (var i = 0; i < 3; i++)
             {
-                builder.OpenComponent<MudTreeViewItem<string>>(i * 3);
-                builder.AddComponentParameter((i * 3) + 1, nameof(MudTreeViewItem<string>.Value), $"item{i}");
-                builder.AddComponentParameter((i * 3) + 2, nameof(MudTreeViewItem<string>.BodyContent), (RenderFragment<MudTreeViewItem<string>>)(item => content =>
+                var index = i;
+                builder.OpenComponent<MudTreeViewItem<string>>(index * 3);
+                builder.AddComponentParameter((index * 3) + 1, nameof(MudTreeViewItem<string>.Value), $"item{index}");
+                builder.AddComponentParameter((index * 3) + 2, nameof(MudTreeViewItem<string>.BodyContent), (RenderFragment<MudTreeViewItem<string>>)(item => content =>
                 {
-                    onRender();
+                    onRender(index);
                     content.AddContent(0, item.Value);
                 }));
                 builder.CloseComponent();

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -367,6 +367,10 @@ namespace MudBlazor
 
         private bool _loading;
 
+        private bool? _renderedCheckBoxState;
+
+        private bool _hasRenderedCheckBoxState;
+
         private bool HasChildren()
         {
             return ChildContent != null
@@ -417,7 +421,23 @@ namespace MudBlazor
             _isServerLoaded = isLoaded;
         }
 
+        /// <summary>
+        /// Gets the tri-state checkbox value, remembering what was rendered.
+        /// </summary>
+        /// <remarks>
+        /// The value is derived from the sub-items, which can change without this item being told.
+        /// Remembering what was last rendered lets <see cref="UpdateSelectionStateCoreAsync"/> tell whether a new render would actually produce anything different.
+        /// </remarks>
         private bool? GetCheckBoxStateTriState()
+        {
+            var state = ComputeCheckBoxStateTriState();
+            _renderedCheckBoxState = state;
+            _hasRenderedCheckBoxState = true;
+
+            return state;
+        }
+
+        private bool? ComputeCheckBoxStateTriState()
         {
             var hasSelectedDescendant = _selectedState.Value;
             var hasUnselectedDescendant = !_selectedState.Value;
@@ -693,27 +713,51 @@ namespace MudBlazor
         /// <returns>True if the item or any sub-item changed from non-selected to selected.</returns>
         internal async Task<bool> UpdateSelectionStateAsync(HashSet<T> selectedValues)
         {
+            var (selectedBecameTrue, _) = await UpdateSelectionStateCoreAsync(selectedValues);
+
+            return selectedBecameTrue;
+        }
+
+        /// <summary>
+        /// Updates the selection state of this item and its sub-items, reporting whether anything actually changed.
+        /// </summary>
+        /// <remarks>
+        /// The tree walks every item whenever the selection changes, and it does so once per item while the tree mounts.
+        /// Rendering unconditionally therefore rebuilt every item twice just to mount, and rebuilt the whole tree when a single item was clicked.
+        /// Multi-selection also renders when the tri-state checkbox no longer matches what was rendered, because that value is derived from the sub-items and can go stale without this item's own state changing.
+        /// </remarks>
+        /// <param name="selectedValues">The values that are currently selected.</param>
+        /// <returns>Whether the item or any sub-item became selected, and whether anything rendered by this item changed.</returns>
+        private async Task<(bool SelectedBecameTrue, bool Changed)> UpdateSelectionStateCoreAsync(HashSet<T> selectedValues)
+        {
             if (MudTreeRoot == null)
             {
-                return false;
+                return (false, false);
             }
             var value = GetValue();
             var selected = value is not null && selectedValues.Contains(value);
-            var selectedBecameTrue = selected && !_selectedState;
+            var wasSelected = _selectedState.Value;
+            var selectedBecameTrue = selected && !wasSelected;
             await _selectedState.SetValueAsync(selected);
+            var changed = selected != wasSelected;
             // since the tree view doesn't know our children we need to take care of updating them
             bool childSelectedBecameTrue = false;
             foreach (var child in _childItems)
             {
-                var becameTrue = await child.UpdateSelectionStateAsync(selectedValues);
+                var (becameTrue, childChanged) = await child.UpdateSelectionStateCoreAsync(selectedValues);
                 childSelectedBecameTrue = childSelectedBecameTrue || becameTrue;
+                changed = changed || childChanged;
             }
             if (GetAutoExpand() && CanExpand && childSelectedBecameTrue && !_expandedState)
             {
                 await _expandedState.SetValueAsync(true);
+                changed = true;
             }
-            StateHasChanged();
-            return selectedBecameTrue || childSelectedBecameTrue;
+            if (changed || (MultiSelection && _hasRenderedCheckBoxState && ComputeCheckBoxStateTriState() != _renderedCheckBoxState))
+            {
+                StateHasChanged();
+            }
+            return (selectedBecameTrue || childSelectedBecameTrue, changed);
         }
 
         /// <summary>


### PR DESCRIPTION
`MudTreeViewItem.UpdateSelectionStateAsync` ended with an unconditional `StateHasChanged()`. The tree calls it once per top-level item while mounting, and for every item whenever the selection changes. So mounting rendered every item twice, and clicking one item re-rendered the whole tree.

The fix is to render only when something the item renders actually changed: its own `Selected`, its `Expanded`, or a descendant's `Selected`. Multi-selection needs a second guard, and it is the subtle part. A descendant's `Selected` can change through its own parameter without going through the recursion, which leaves the parent's tri-state checkbox stale. `GetCheckBoxStateTriState()` now records the value it rendered, and the guard also renders when a fresh computation no longer matches it. Without that, `TreeViewItem_Selected_TwoWayBindingTest_MultiSelection` fails.

The main win is that selection stops scaling with tree size. 550-item tree, time from the click to the DOM going quiet, each arm built separately from its own branch:

| | base | head |
| --- | --- | --- |
| click one node | 458 ms | **76 ms** |
| mount | 1090 ms | **880 ms** |

Component renders on mount, counted from `RenderBatch.UpdatedComponents`: 200 leaves 1005 → 605, nested 50x10 3505 → 2105, multi-selection 20x10 2065 → 1505.