### PR TITLE
MudForm: Add XML documentation to IForm and IFormComponent

### DIFF
--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -281,27 +281,7 @@ namespace MudBlazor
         /// </remarks>
         public List<string> ValidationErrors { get; set; } = new();
 
-        /// <summary>
-        /// The function used to detect problems with the input.
-        /// </summary>
-        /// <remarks>
-        /// When using a <see cref="MudForm"/>, this property can be any of several kinds of functions:
-        /// <para>
-        /// 1. A <c>Func&lt;T,bool&gt;</c> or <c>Func&lt;T,Task&lt;bool&gt;&gt;</c> function.  Returns <c>true</c> if valid.  When <c>false</c>, a standard <c>"Invalid"</c> message is shown.
-        /// </para>
-        /// <para>
-        /// 2. A <c>Func&lt;T,string&gt;</c> or <c>Func&lt;T,Task&lt;string&gt;&gt;</c> function.  Returns <c>null</c> if valid, or a string explaining the error.
-        /// </para>
-        /// <para>
-        /// 3. A <c>Func&lt;T,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;T,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Returns an empty list if valid, or a list of validation errors.
-        /// </para>
-        /// <para>
-        /// 3. A <c>Func&lt;object,string,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;object,string,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Given the form model and path to the member, returns an empty list if valid, or a list of validation errors.
-        /// </para>
-        /// <para>
-        /// 4. A <see cref="ValidationAttribute"/> object.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
         public object? Validation { get; set; }

--- a/src/MudBlazor/Interfaces/IForm.cs
+++ b/src/MudBlazor/Interfaces/IForm.cs
@@ -7,11 +7,29 @@ namespace MudBlazor.Interfaces
     /// </summary>
     public interface IForm
     {
-        public bool IsValid { get; }
+        /// <summary>
+        /// Whether all inputs and child forms passed validation.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.  Implementors should invoke IsValidChanged EventCallback when this value changes.
+        /// </remarks>
+        bool IsValid { get; }
 
-        public string[] Errors { get; }
+        /// <summary>
+        /// The validation errors for inputs within this form.
+        /// </summary>
+        /// <remarks>
+        /// Implementors should invoke an ErrorsChanged EventCallback when this value changes.
+        /// </remarks>
+        string[] Errors { get; }
 
-        public object? Model { get; set; }
+        /// <summary>
+        /// The model populated by this form.
+        /// </summary>
+        /// <remarks>
+        /// Properties of this model are typically linked to form input components via their <see cref="MudFormComponent{T, U}.For"/>.
+        /// </remarks>
+        object? Model { get; set; }
 
         /// <summary>
         /// Validates every form control, awaiting async validators, then refreshes <see cref="IsValid"/> and <see cref="Errors"/>.
@@ -20,14 +38,35 @@ namespace MudBlazor.Interfaces
         /// The synchronous <see cref="IsValid"/> getter cannot await, so callers that must react to async validation should await this first, then read <see cref="Errors"/>.
         /// The default implementation keeps existing external implementers source-compatible.
         /// </remarks>
-        public Task ValidateAsync() => Task.CompletedTask;
+        Task ValidateAsync() => Task.CompletedTask;
 
-        public void FieldChanged(IFormComponent formControl, object? newValue);
+        /// <summary>
+        /// Signal to parent form that this field has changed, parent form will inform further parent components.
+        /// </summary>
+        /// <param name="formControl">The <see cref="IFormComponent"/> that has changed</param>
+        /// <param name="newValue">The new value provided from the form component.</param>
+        /// <remarks>This method will not trigger form evaluation/validation.</remarks>
+        void FieldChanged(IFormComponent formControl, object? newValue);
 
+        /// <summary>
+        /// Adopts the provided component to this form and initializes validation.
+        /// </summary>
+        /// <param name="formControl"></param>
+        /// <remarks><see cref="IForm.Add"/>, <see cref="IForm.Remove"/>, and <see cref="IForm.Update"/> are internal methods which can only be called by <see cref="IFormComponent"/> within the MudBlazor assembly.</remarks>
         internal void Add(IFormComponent formControl);
 
+        /// <summary>
+        /// Removes the provided component from the form's adopted controls.
+        /// </summary>
+        /// <param name="formControl">The <see cref="IFormComponent"/> to remove.</param>
+        /// <remarks><see cref="IForm.Add"/>, <see cref="IForm.Remove"/>, and <see cref="IForm.Update"/> are internal methods which can only be called by <see cref="IFormComponent"/> within the MudBlazor assembly.</remarks>
         internal void Remove(IFormComponent formControl);
 
+        /// <summary>
+        /// Used by any <see cref="IFormComponent"/> to inform the parent form that its value has changed.
+        /// </summary>
+        /// <param name="formControl"></param>
+        /// <remarks>Triggers form evaluation and validation. Does not propagate a new value.</remarks>
         internal void Update(IFormComponent formControl);
     }
 }

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel.DataAnnotations;
+
 namespace MudBlazor.Interfaces
 {
     /// <summary>
@@ -9,16 +11,104 @@ namespace MudBlazor.Interfaces
     /// </summary>
     public interface IFormComponent
     {
-        public bool Required { get; set; }
-        public bool Error { get; set; }
-        public bool HasErrors { get; }
-        public bool Touched { get; }
-        public bool HasValue() => Touched; // Default implementation for backwards compatibility; built-in inputs override this to report actual value presence.
-        public object? Validation { get; set; }
-        public bool IsForNull { get; }
-        public List<string> ValidationErrors { get; set; }
-        public Task ValidateAsync();
-        public Task ResetAsync();
-        public Task ResetValidationAsync();
+        /// <summary>
+        /// Requires an input value.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, an error with the text in the implementors RequiredError will be shown during validation if no input was given.
+        /// </remarks>
+        bool Required { get; set; }
+        
+        /// <summary>
+        /// Displays an error.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the text in the implementors ErrorText field is displayed.
+        /// </remarks>
+        bool Error { get; set; }
+        
+        /// <summary>
+        /// Indicates any error, conversion error, or validation error with this input.
+        /// </summary>
+        /// <remarks>
+        /// When <c>true</c>, the <see cref="Error"/> property is <c>true</c>, or the implementors ConversionError is <c>true</c>, or one or more ValidationErrors exists.
+        /// </remarks>
+        bool HasErrors { get; }
+        
+        /// <summary>
+        /// Indicates whether the user has interacted with this input or the focus has been released.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.  When <c>true</c>, the user has performed input, or focus has moved away from this input.  This property is typically used to show the implementors RequiredError text only after the user has interacted with this input.
+        /// </remarks>
+        bool Touched { get; }
+        
+        /// <summary>
+        /// Indicates that this input has a non-null, non-empty value.
+        /// </summary>
+        /// <remarks>Default implementation which indicates the input has been <see cref="Touched"/></remarks>
+        /// <returns>True if some value exists, or false if null or empty</returns>
+        bool HasValue() => Touched; // Default implementation for backwards compatibility; built-in inputs override this to report actual value presence.
+        
+        /// <summary>
+        /// The function used to detect problems with the input.
+        /// </summary>
+        /// <remarks>
+        /// When using a <see cref="MudForm"/>, this property can be any of several kinds of functions:
+        /// <para>
+        /// 1. A <c>Func&lt;T,bool&gt;</c> or <c>Func&lt;T,Task&lt;bool&gt;&gt;</c> function.  Returns <c>true</c> if valid.  When <c>false</c>, a standard <c>"Invalid"</c> message is shown.
+        /// </para>
+        /// <para>
+        /// 2. A <c>Func&lt;T,string&gt;</c> or <c>Func&lt;T,Task&lt;string&gt;&gt;</c> function.  Returns <c>null</c> if valid, or a string explaining the error.
+        /// </para>
+        /// <para>
+        /// 3. A <c>Func&lt;T,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;T,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Returns an empty list if valid, or a list of validation errors.
+        /// </para>
+        /// <para>
+        /// 3. A <c>Func&lt;object,string,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;object,string,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Given the form model and path to the member, returns an empty list if valid, or a list of validation errors.
+        /// </para>
+        /// <para>
+        /// 4. A <see cref="ValidationAttribute"/> object.
+        /// </para>
+        /// </remarks>
+        object? Validation { get; set; }
+        
+        /// <summary>
+        /// Indicates that the <see cref="MudFormComponent{T,U}.For"/> field identifier expression is null
+        /// </summary>
+        /// <remarks>The <see cref="MudFormComponent{T,U}.For"/> expression is used to uniquely identify a form field to perform validation. </remarks>
+        bool IsForNull { get; }
+        
+        /// <summary>
+        /// The list of problems with the current input value.
+        /// </summary>
+        /// <remarks>
+        /// When using a <see cref="MudForm"/>, this property is updated when validation has been performed.  Use the <see cref="Validation"/> property to control what validations are performed.
+        /// </remarks>
+        List<string> ValidationErrors { get; set; }
+        
+        /// <summary>
+        /// Causes validation to be performed for this input.
+        /// </summary>
+        /// <remarks>
+        /// When using a <see cref="MudForm"/>, the input is validated via the function set in the <see cref="Validation"/> property.
+        /// </remarks>
+        Task ValidateAsync();
+        
+        /// <summary>
+        /// Clears the input and any validation errors.
+        /// </summary>
+        /// <remarks>
+        /// When called, the <c>Value</c>, <see cref="Error"/>, <see cref="MudFormComponent{T,U}.ErrorText"/>, and <see cref="ValidationErrors"/> properties are all reset.
+        /// </remarks>
+        Task ResetAsync();
+        
+        /// <summary>
+        /// Clears any validation errors.
+        /// </summary>
+        /// <remarks>
+        /// When called, the <see cref="Error"/>, <see cref="MudFormComponent{T,U}.ErrorText"/>, and <see cref="ValidationErrors"/> properties are all reset.
+        /// </remarks>
+        Task ResetValidationAsync();
     }
 }

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -18,7 +18,7 @@ namespace MudBlazor.Interfaces
         /// Defaults to <c>false</c>.  When <c>true</c>, an error with the text in the implementors RequiredError will be shown during validation if no input was given.
         /// </remarks>
         bool Required { get; set; }
-        
+
         /// <summary>
         /// Displays an error.
         /// </summary>
@@ -26,7 +26,7 @@ namespace MudBlazor.Interfaces
         /// Defaults to <c>false</c>.  When <c>true</c>, the text in the implementors ErrorText field is displayed.
         /// </remarks>
         bool Error { get; set; }
-        
+
         /// <summary>
         /// Indicates any error, conversion error, or validation error with this input.
         /// </summary>
@@ -34,7 +34,7 @@ namespace MudBlazor.Interfaces
         /// When <c>true</c>, the <see cref="Error"/> property is <c>true</c>, or the implementors ConversionError is <c>true</c>, or one or more ValidationErrors exists.
         /// </remarks>
         bool HasErrors { get; }
-        
+
         /// <summary>
         /// Indicates whether the user has interacted with this input or the focus has been released.
         /// </summary>
@@ -42,14 +42,14 @@ namespace MudBlazor.Interfaces
         /// Defaults to <c>false</c>.  When <c>true</c>, the user has performed input, or focus has moved away from this input.  This property is typically used to show the implementors RequiredError text only after the user has interacted with this input.
         /// </remarks>
         bool Touched { get; }
-        
+
         /// <summary>
         /// Indicates that this input has a non-null, non-empty value.
         /// </summary>
         /// <remarks>Default implementation which indicates the input has been <see cref="Touched"/></remarks>
         /// <returns>True if some value exists, or false if null or empty</returns>
         bool HasValue() => Touched; // Default implementation for backwards compatibility; built-in inputs override this to report actual value presence.
-        
+
         /// <summary>
         /// The function used to detect problems with the input.
         /// </summary>
@@ -72,13 +72,13 @@ namespace MudBlazor.Interfaces
         /// </para>
         /// </remarks>
         object? Validation { get; set; }
-        
+
         /// <summary>
         /// Indicates that the <see cref="MudFormComponent{T,U}.For"/> field identifier expression is null
         /// </summary>
         /// <remarks>The <see cref="MudFormComponent{T,U}.For"/> expression is used to uniquely identify a form field to perform validation. </remarks>
         bool IsForNull { get; }
-        
+
         /// <summary>
         /// The list of problems with the current input value.
         /// </summary>
@@ -86,7 +86,7 @@ namespace MudBlazor.Interfaces
         /// When using a <see cref="MudForm"/>, this property is updated when validation has been performed.  Use the <see cref="Validation"/> property to control what validations are performed.
         /// </remarks>
         List<string> ValidationErrors { get; set; }
-        
+
         /// <summary>
         /// Causes validation to be performed for this input.
         /// </summary>
@@ -94,7 +94,7 @@ namespace MudBlazor.Interfaces
         /// When using a <see cref="MudForm"/>, the input is validated via the function set in the <see cref="Validation"/> property.
         /// </remarks>
         Task ValidateAsync();
-        
+
         /// <summary>
         /// Clears the input and any validation errors.
         /// </summary>
@@ -102,7 +102,7 @@ namespace MudBlazor.Interfaces
         /// When called, the <c>Value</c>, <see cref="Error"/>, <see cref="MudFormComponent{T,U}.ErrorText"/>, and <see cref="ValidationErrors"/> properties are all reset.
         /// </remarks>
         Task ResetAsync();
-        
+
         /// <summary>
         /// Clears any validation errors.
         /// </summary>

--- a/src/MudBlazor/Interfaces/IFormComponent.cs
+++ b/src/MudBlazor/Interfaces/IFormComponent.cs
@@ -65,10 +65,10 @@ namespace MudBlazor.Interfaces
         /// 3. A <c>Func&lt;T,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;T,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Returns an empty list if valid, or a list of validation errors.
         /// </para>
         /// <para>
-        /// 3. A <c>Func&lt;object,string,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;object,string,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Given the form model and path to the member, returns an empty list if valid, or a list of validation errors.
+        /// 4. A <c>Func&lt;object,string,IEnumerable&lt;string&gt;&gt;</c> or <c>Func&lt;object,string,Task&lt;IEnumerable&lt;string&gt;&gt;&gt;</c> function.  Given the form model and path to the member, returns an empty list if valid, or a list of validation errors.
         /// </para>
         /// <para>
-        /// 4. A <see cref="ValidationAttribute"/> object.
+        /// 5. A <see cref="ValidationAttribute"/> object.
         /// </para>
         /// </remarks>
         object? Validation { get; set; }


### PR DESCRIPTION
This PR does precisely 2 things:

1. Copies/adds documentation for IForm and IFormComponent, mostly pulled from implementers but slightly edited for clarity. This is simply so new implementers have some helpful direction on what all the members of the interface are for without needing to check another implementation.
2. Removes redundant public modifiers in those interfaces. (Interface members are implicitly public)

- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
