### PR TITLE
MudChipSet: Only re-render chips whose selection changed

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -1,4 +1,5 @@
 ﻿using AwesomeAssertions;
+using Microsoft.AspNetCore.Components;
 using Bunit;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents.ChipSet;
@@ -547,6 +548,45 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("#chip-2").KeyDown("Backspace");
             onCloseCount.Should().Be(0);
             comp.FindComponent<MudChipSet<string>>().Instance.SelectedValues.Should().HaveCount(0);
+        }
+        /// <summary>
+        /// Clicking one chip must re-render only that chip, not every chip in the set.
+        /// </summary>
+        /// <remarks>
+        /// The set walks every chip whenever the selection changes, and each chip used to render unconditionally in response.
+        /// Nothing a chip renders depends on another chip, so the ones whose own state did not change have nothing new to show.
+        /// </remarks>
+        [Test]
+        public void ChipSet_SelectingOneChip_RendersOnlyThatChip()
+        {
+            const int Count = 10;
+            var passes = new int[Count];
+            var comp = Context.Render<MudChipSet<int>>(parameters => parameters
+                .Add(x => x.SelectionMode, SelectionMode.SingleSelection)
+                .Add(x => x.ChildContent, builder =>
+                {
+                    for (var i = 0; i < Count; i++)
+                    {
+                        var index = i;
+                        builder.OpenComponent<MudChip<int>>(index * 4);
+                        builder.AddComponentParameter((index * 4) + 1, nameof(MudChip<int>.Value), index);
+                        builder.AddComponentParameter((index * 4) + 2, nameof(MudChip<int>.ChildContent), (RenderFragment)(content =>
+                        {
+                            passes[index]++;
+                            content.AddContent(0, index);
+                        }));
+                        builder.CloseComponent();
+                    }
+                }));
+
+            var afterMount = (int[])passes.Clone();
+            comp.FindAll(".mud-chip")[0].Click();
+
+            passes[0].Should().Be(afterMount[0] + 1, "the clicked chip has a new selected state to show");
+            for (var i = 1; i < Count; i++)
+            {
+                passes[i].Should().Be(afterMount[i], $"chip {i} did not change and should not have re-rendered");
+            }
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -1,6 +1,6 @@
 ﻿using AwesomeAssertions;
-using Microsoft.AspNetCore.Components;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents.ChipSet;
 using NUnit.Framework;

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -38,10 +38,22 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         return ChipSet.OnChipSelectedChangedAsync(this, args.Value);
     }
 
+    /// <summary>
+    /// Updates whether this chip is selected.
+    /// </summary>
+    /// <remarks>
+    /// The set walks every chip whenever the selection changes, so rendering unconditionally rebuilt the whole set to move one check mark.
+    /// Nothing this chip renders depends on another chip, so a chip whose own state did not change has nothing new to show.
+    /// </remarks>
+    /// <param name="selected">Whether this chip is now selected.</param>
     internal async Task UpdateSelectionStateAsync(bool selected)
     {
+        var wasSelected = SelectedState.Value;
         await SelectedState.SetValueAsync(selected);
-        StateHasChanged();
+        if (SelectedState.Value != wasSelected)
+        {
+            StateHasChanged();
+        }
     }
 
     /// <summary>
@@ -456,7 +468,8 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         }
         if (ChipSet != null)
         {
-            await SelectedState.SetValueAsync(!SelectedState.Value);
+            // Go through the same helper as the set does, so this chip renders because its own state changed rather than relying on the set to sweep every chip.
+            await UpdateSelectionStateAsync(!SelectedState.Value);
             await ChipSet.OnChipSelectedChangedAsync(this, SelectedState.Value);
         }
 


### PR DESCRIPTION
### Problem

`MudChip.UpdateSelectionStateAsync` ended with an unconditional `StateHasChanged()`, and `MudChipSet` calls it for **every** chip on every selection change (`UpdateChipsAsync`, `UpdateSelectedValueAsync`). Clicking one chip therefore rebuilt the whole set, so the cost of a single click grew with the number of chips.

### Fix

Render only when the chip's own selected state actually changed. Nothing a chip renders depends on another chip, so the rest have nothing new to show. `ParameterState.SetValueAsync` already ignores an unchanged value, so only the render was being wasted.

One subtlety is worth calling out for review. `MudChip.OnClickAsync` set its own state directly and then relied on the set's sweep to render it:

```csharp
await SelectedState.SetValueAsync(!SelectedState.Value);
await ChipSet.OnChipSelectedChangedAsync(this, SelectedState.Value);
```

So the unconditional render was the only thing painting the *clicked* chip. Guarding the sweep on its own leaves the clicked chip showing its old state, and `ChipSet_SelectedValues_TwoWayBinding` fails. The click now goes through the same helper, so a chip renders exactly when its own state changes and the sweep correctly finds nothing to do for it.

### Numbers

Component renders counted from `RenderBatch.UpdatedComponents` on a bare `Renderer`, median of 5. Selecting one chip:

| chips | before | after |
| --- | --- | --- |
| 50 | 203 renders | 107 |
| 200 | 803 renders | 407 |

Driving a real click through the DOM instead, measuring allocation:

| chips | before | after |
| --- | --- | --- |
| 50 | 36.5 MB, 62 ms | 12.7 MB, 21 ms |
| 200 | 501 MB, 299 ms | 169 MB, 123 ms |

Those absolute figures are inflated because bUnit re-serialises the DOM on every render, and they grow faster than linearly for the same reason. Read them as a ratio; the component-render counts above are the trustworthy figure.
