### PR TITLE
MudTable: Only re-render the rows whose selection changed

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionHeaderStateTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableMultiSelectionHeaderStateTest.razor
@@ -1,0 +1,14 @@
+<MudTable Items="_items" MultiSelection="true">
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "the select-all checkbox must track individual row checkboxes even when SelectedItems is not bound.";
+
+    private readonly int[] _items = [0, 1, 2, 3];
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3637,5 +3637,35 @@ namespace MudBlazor.UnitTests.Components
                 GetHashCodeCalls = 0;
             }
         }
+        /// <summary>
+        /// The select-all checkbox must follow the rows as they are checked one at a time.
+        /// </summary>
+        /// <remarks>
+        /// The header used to pick this up only because changing one row re-rendered the whole table.
+        /// This case binds nothing, because a bound <c>SelectedItems</c> re-renders the table anyway and hides the problem.
+        /// </remarks>
+        [Test]
+        public void TableMultiSelection_CheckingRowsIndividually_UpdatesSelectAllCheckbox()
+        {
+            var comp = Context.Render<TableMultiSelectionHeaderStateTest>();
+            var header = () => comp.Find("thead .mud-checkbox span").ClassList;
+            var rowBoxes = () => comp.FindAll("tbody .mud-checkbox input");
+            var rowCount = rowBoxes().Count;
+
+            header().Should().Contain("mud-checkbox-false");
+
+            rowBoxes()[0].Change(true);
+            header().Should().Contain("mud-checkbox-null", "some but not all rows are selected");
+
+            for (var i = 1; i < rowCount; i++)
+            {
+                rowBoxes()[i].Change(true);
+            }
+
+            header().Should().Contain("mud-checkbox-true", "every row is selected");
+
+            rowBoxes()[0].Change(false);
+            header().Should().Contain("mud-checkbox-null", "a row was deselected again");
+        }
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -113,7 +113,7 @@
                                     <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" RowId="@generatedRowId"
                                            Checkable="MultiSelection" SelectionChangeable="SelectionChangeable" Editable="IsItemEditable(item)"
                                            Disabled="IsRowDisabled(item)" DisabledClass="@DisabledRowClass" Checked="@(IsCheckedRow(item))"
-                                           CheckedChanged="@(value => OnRowCheckboxChanged(value, item))">
+                                           CheckedChanged="@(this.AsNonRenderingEventHandler<bool>(value => OnRowCheckboxChanged(value, item)))">
                                         @if (!ReadOnly && Editable && Equals(_editingItem, item))
                                         {
                                             <CascadingValue Value="@Validator" IsFixed="true">
@@ -227,7 +227,7 @@
                  }
                  <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" RowId="@generatedRowId" Checkable="MultiSelection" SelectionChangeable="SelectionChangeable"
                         Editable="IsItemEditable(item)" Expandable="expandable" Disabled="IsRowDisabled(item)" DisabledClass="@DisabledRowClass"
-                        Checked="Context.Selection.Contains(item)" CheckedChanged="((value) => { OnRowCheckboxChanged(value, item); })">
+                        Checked="Context.Selection.Contains(item)" CheckedChanged="@(this.AsNonRenderingEventHandler<bool>(value => OnRowCheckboxChanged(value, item)))">
                      @if (!ReadOnly && Editable && Equals(_editingItem, item))
                      {
                          <CascadingValue Value="@Validator" IsFixed="true">

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -755,8 +755,6 @@ namespace MudBlazor
                 Context.Selection.Remove(item);
             }
 
-            // Push the new state to the group, header and footer checkboxes directly.
-            // They used to pick it up from the table re-rendering every row, which cost a render per row to change one.
             Context.UpdateRowCheckBoxes();
 
             if (SelectedItemsChanged.HasDelegate)

--- a/src/MudBlazor/Components/Table/MudTable.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTable.razor.cs
@@ -755,6 +755,10 @@ namespace MudBlazor
                 Context.Selection.Remove(item);
             }
 
+            // Push the new state to the group, header and footer checkboxes directly.
+            // They used to pick it up from the table re-rendering every row, which cost a render per row to change one.
+            Context.UpdateRowCheckBoxes();
+
             if (SelectedItemsChanged.HasDelegate)
             {
                 SelectedItemsChanged.InvokeAsync(SelectedItems);


### PR DESCRIPTION
### Problem

In a multi-selection table, checking one row raises `MudTr.CheckedChanged`. Its receiver is the table, so `ComponentBase.HandleEventAsync` calls `StateHasChanged` there and re-renders every row. The cost of one click grew with the number of rows.

### Fix

The callback no longer re-renders the table, and `OnRowCheckboxChanged` pushes the new state to the group, header and footer checkboxes itself through `TableContext.UpdateRowCheckBoxes`, which already skips rows whose state did not change.

Both halves are needed. Suppressing the render on its own leaves the select-all checkbox permanently stale, because it was picking the state up only from the table re-render.

### Numbers

One real click dispatched through the renderer, counting `RenderBatch.UpdatedComponents`:

| rows | before | after |
| --- | --- | --- |
| 25 | 93 renders | 12 |
| 100 | 318 renders | 12 |

Flat at any row count, where it previously grew with the table.