### PR TITLE
MudItem: Build only the breakpoint classes that are set

### DIFF
--- a/src/MudBlazor/Components/Grid/MudItem.razor.cs
+++ b/src/MudBlazor/Components/Grid/MudItem.razor.cs
@@ -14,16 +14,41 @@ namespace MudBlazor;
 /// <seealso cref="MudGrid"/>
 public partial class MudItem : MudComponentBase
 {
-    protected string Classname =>
-        new CssBuilder("mud-grid-item")
-            .AddClass($"mud-grid-item-xs-{xs}", xs != 0)
-            .AddClass($"mud-grid-item-sm-{sm}", sm != 0)
-            .AddClass($"mud-grid-item-md-{md}", md != 0)
-            .AddClass($"mud-grid-item-lg-{lg}", lg != 0)
-            .AddClass($"mud-grid-item-xl-{xl}", xl != 0)
-            .AddClass($"mud-grid-item-xxl-{xxl}", xxl != 0)
-            .AddClass(Class)
-            .Build();
+    protected string Classname
+    {
+        get
+        {
+            // Only the breakpoints that are set build a string.
+            // Passing the interpolated class as an argument builds it whether or not the condition holds, and most items set one breakpoint out of six.
+            var builder = new CssBuilder("mud-grid-item");
+            if (xs != 0)
+            {
+                builder.AddClass($"mud-grid-item-xs-{xs}");
+            }
+            if (sm != 0)
+            {
+                builder.AddClass($"mud-grid-item-sm-{sm}");
+            }
+            if (md != 0)
+            {
+                builder.AddClass($"mud-grid-item-md-{md}");
+            }
+            if (lg != 0)
+            {
+                builder.AddClass($"mud-grid-item-lg-{lg}");
+            }
+            if (xl != 0)
+            {
+                builder.AddClass($"mud-grid-item-xl-{xl}");
+            }
+            if (xxl != 0)
+            {
+                builder.AddClass($"mud-grid-item-xxl-{xxl}");
+            }
+
+            return builder.AddClass(Class).Build();
+        }
+    }
 
     [CascadingParameter]
     private MudGrid? Parent { get; set; }

--- a/src/MudBlazor/Components/Grid/MudItem.razor.cs
+++ b/src/MudBlazor/Components/Grid/MudItem.razor.cs
@@ -18,8 +18,7 @@ public partial class MudItem : MudComponentBase
     {
         get
         {
-            // Only the breakpoints that are set build a string.
-            // Passing the interpolated class as an argument builds it whether or not the condition holds, and most items set one breakpoint out of six.
+            // Only the breakpoints that are set build a string (#13738).
             var builder = new CssBuilder("mud-grid-item");
             if (xs != 0)
             {


### PR DESCRIPTION
### Problem

Every breakpoint class was passed to `AddClass` as an interpolated string with its condition as a second argument:

```csharp
.AddClass($"mud-grid-item-xs-{xs}", xs != 0)
```

Arguments are evaluated before the call, so the string is formatted whether or not the condition holds. Most items set one breakpoint out of six, so five are built and thrown away on every render.

### Fix

Build each class inside its condition. The markup is unchanged.

### Numbers

200 `MudItem` with only `xs` set, allocation measured on a bare `Renderer` with `GC.GetTotalAllocatedBytes`, median of 5:

| | before | after |
| --- | --- | --- |
| mount | 478 KB | 416 KB |
| re-render | 177 KB | 115 KB |

That is 310 B less per item on re-render, which is the repeated cost.

### Scope

Only `MudItem`, deliberately. The same pattern appears elsewhere, but measuring it showed the saving comes from **formatting a value into the string**, not from the interpolation itself, so it only pays where a number or enum is formatted into a class that usually is not used:

- `MudStack` has five conditional interpolated classes and the same change made **no measurable difference at all** (391 KB and 108 KB either way), because its values are null when unset and a null appends nothing.
- `MudInputCssHelper` likewise: 1026 KB against 1025 KB across a 20 field form.
- `MudIconButton` has six such classes, but at ~9.9 KB per instance the saving would be under 4%.

`MudItem` stands out because it is a very small component whose class chain is most of what it does, and because six integer breakpoints are formatted where at most a couple are used.

### Verification

Class output is identical for none, `xs`, `xs`+`md`, all six breakpoints, `xxl` only, `xs`+`Class`, and `Class` only.

The Grid documentation page renders 30 grid items with an identical class string on this branch and on `dev` (same hash, same 1053 characters), before and after moving the interactive sliders.

361 Grid tests and the full suite pass.
