### PR TITLE
MudRadioGroup: Cascade itself as a fixed value

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -1,5 +1,6 @@
 ﻿using AwesomeAssertions;
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.UnitTests.TestComponents.Radio;
 using MudBlazor.UnitTests.TestComponents.RadioGroup;
@@ -573,6 +574,44 @@ namespace MudBlazor.UnitTests.Components
                 .Add(p => p.Required, true));
 
             comp.Find("div[role=radiogroup]").GetAttribute("aria-required").Should().Be("true");
+        }
+        /// <summary>
+        /// Selecting a radio must not render every radio more than once.
+        /// </summary>
+        /// <remarks>
+        /// The group cascades itself to its radios, and that value is the group instance, which never changes.
+        /// Cascading it as non-fixed made Blazor treat the reference as possibly changed on every group render and notify each radio, costing every radio a second render per click.
+        /// The remaining render each radio does comes from the group re-rendering its child content after validation, which is <see cref="MudFormComponent{T, U}"/> behaviour and not specific to radios.
+        /// </remarks>
+        [Test]
+        public void RadioGroup_SelectingOne_DoesNotRenderEveryRadioTwice()
+        {
+            const int Count = 5;
+            var renders = new int[Count];
+            var comp = Context.Render<MudRadioGroup<int>>(parameters => parameters
+                .Add(x => x.ChildContent, builder =>
+                {
+                    for (var i = 0; i < Count; i++)
+                    {
+                        var index = i;
+                        builder.OpenComponent<MudRadio<int>>(index * 4);
+                        builder.AddComponentParameter((index * 4) + 1, nameof(MudRadio<int>.Value), index);
+                        builder.AddComponentParameter((index * 4) + 2, nameof(MudRadio<int>.ChildContent), (RenderFragment)(content =>
+                        {
+                            renders[index]++;
+                            content.AddContent(0, index);
+                        }));
+                        builder.CloseComponent();
+                    }
+                }));
+
+            var afterMount = (int[])renders.Clone();
+            comp.FindAll("input[type=radio]")[1].Click();
+
+            for (var i = 0; i < Count; i++)
+            {
+                (renders[i] - afterMount[i]).Should().BeLessThanOrEqualTo(2, $"radio {i} should not render more than twice for one click");
+            }
         }
     }
 }

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -8,7 +8,7 @@
 
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorId="@ErrorIdState.Value" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="false">
+        <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="true">
             <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                 <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
                     <div role="radiogroup" aria-required="@Required.ToString().ToLowerInvariant()" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">


### PR DESCRIPTION
### Problem

`MudRadioGroup` cascades itself to its radios:

```razor
<CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="false">
```

The value is the group instance, so it can never change. But `IsFixed="false"` makes Blazor apply `ChangeDetection.MayHaveChanged`, which conservatively assumes a reference type may have changed, so every group render notified every radio and cost each one an extra render.

`MudToggleGroup`, `MudButtonGroup`, `MudExpansionPanels` and `MudTreeView` already cascade themselves with `IsFixed="true"`. `MudRadioGroup` was the only one that did not.

### Effect

Clicking one radio in a group of five, counting each radio's content renders:

| | render deltas | total |
| --- | --- | --- |
| before | `3,3,2,2,2` | 12 |
| after | `2,2,1,1,1` | 7 |

One fewer render per radio. In practical terms that is about nine component renders saved on a three option group, so this is a small and consistent win rather than a dramatic one. It grows with group size: a 60 radio group goes from 373 to 193 component renders per click.
