### PR TITLE
MudRadioGroup: Push error state and name to radios

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -613,5 +613,66 @@ namespace MudBlazor.UnitTests.Components
                 (renders[i] - afterMount[i]).Should().BeLessThanOrEqualTo(2, $"radio {i} should not render more than twice for one click");
             }
         }
+
+        /// <summary>
+        /// Validating the group must update the error styling on radios that have no child content.
+        /// </summary>
+        /// <remarks>
+        /// The group cascades itself as a fixed value, so radios are never notified through the cascade,
+        /// and validation re-renders only the group. A radio whose parameters are all constant therefore
+        /// has no reason of its own to re-render, and would keep showing the pre-validation styling.
+        /// Radios written with child content re-render anyway, so they do not exercise this.
+        /// </remarks>
+        [Test]
+        public async Task RadioGroup_Validate_UpdatesErrorStyling_OnRadiosWithoutChildContent()
+        {
+            var comp = Context.Render<MudRadioGroup<string>>(parameters => parameters
+                .Add(x => x.Required, true)
+                .AddChildContent<MudRadio<string>>(r => r
+                    .Add(x => x.Value, "a")
+                    .Add(x => x.Label, "A"))
+                .AddChildContent<MudRadio<string>>(r => r
+                    .Add(x => x.Value, "b")
+                    .Add(x => x.Label, "B")));
+
+            var icons = comp.FindAll("span.mud-button-root");
+            icons.Should().HaveCount(2);
+            foreach (var icon in icons)
+            {
+                icon.ClassList.Should().NotContain("mud-error-text");
+            }
+
+            await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
+
+            comp.Instance.HasErrors.Should().BeTrue("a required group with no value is invalid");
+            foreach (var icon in comp.FindAll("span.mud-button-root"))
+            {
+                icon.ClassList.Should().Contain("mud-error-text");
+            }
+        }
+
+        /// <summary>
+        /// Changing the group's name at runtime must reach the name attribute each radio renders.
+        /// </summary>
+        /// <remarks>
+        /// Same cause as <see cref="RadioGroup_Validate_UpdatesErrorStyling_OnRadiosWithoutChildContent"/>:
+        /// the name comes from the fixed cascade, so the group has to push the change to its radios.
+        /// A stale name breaks native radio grouping.
+        /// </remarks>
+        [Test]
+        public async Task RadioGroup_Name_ChangeReachesRadios()
+        {
+            var comp = Context.Render<MudRadioGroup<string>>(parameters => parameters
+                .Add(x => x.Name, "before")
+                .AddChildContent<MudRadio<string>>(r => r
+                    .Add(x => x.Value, "a")
+                    .Add(x => x.Label, "A")));
+
+            comp.Find("input[type=radio]").GetAttribute("name").Should().Be("before");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Name, "after"));
+
+            comp.Find("input[type=radio]").GetAttribute("name").Should().Be("after");
+        }
     }
 }

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -145,6 +145,16 @@ namespace MudBlazor
 
         internal MudRadioGroup<T>? MudRadioGroup => IMudRadioGroup as MudRadioGroup<T>;
 
+        /// <summary>
+        /// Re-renders this radio after a change to the group state it displays.
+        /// </summary>
+        /// <remarks>
+        /// The group cascades itself as a fixed value, so a radio is never notified through the cascade.
+        /// It still renders the group's <c>HasErrors</c> and <c>Name</c>, and a radio whose own parameters
+        /// are all constant has no other reason to re-render, so the group pushes those changes here.
+        /// </remarks>
+        internal void NotifyGroupStateChanged() => StateHasChanged();
+
         internal void SetChecked(bool value)
         {
             if (Checked != value)

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -17,6 +17,8 @@ namespace MudBlazor
     {
         private MudRadio<T>? _selectedRadio;
         private readonly HashSet<MudRadio<T>> _radios = new();
+        private bool _lastPushedHasErrors;
+        private string? _lastPushedName;
 
         protected string Classname =>
             new CssBuilder("mud-input-control-boolean-input")
@@ -168,6 +170,37 @@ namespace MudBlazor
                 {
                     await SetSelectedOptionAsync(GetValueOrDefault(_selectedRadio), false);
                 }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+
+            // Radios render this group's error state and name, but the cascade is fixed, so nothing tells
+            // them when either changes. Push it the way SetChecked is already pushed, and only on a real
+            // change, so an unchanged render still costs the radios nothing.
+            if (firstRender)
+            {
+                // The radios read the current values during their own first render.
+                _lastPushedHasErrors = HasErrors;
+                _lastPushedName = Name;
+
+                return;
+            }
+
+            if (_lastPushedHasErrors == HasErrors && _lastPushedName == Name)
+            {
+                return;
+            }
+
+            _lastPushedHasErrors = HasErrors;
+            _lastPushedName = Name;
+
+            foreach (var radio in _radios)
+            {
+                radio.NotifyGroupStateChanged();
             }
         }
 


### PR DESCRIPTION
Follow-up to #13742.

### Problem

#13742 changed `MudRadioGroup`'s self-cascade to `IsFixed="true"`, which stops the group notifying its radios. That is fine for the value itself — the group instance never changes — but a radio renders two things that come *from* the group:

```razor
<span class="@IconClassname">   @* .AddClass("mud-error-text", MudRadioGroup?.HasErrors) *@
    <input ... name="@MudRadioGroup?.Name" />
```

A radio whose own parameters are all constant now has no reason to re-render, so both go stale.

| Radio as written | v9.9.0 | dev |
| --- | --- | --- |
| `<MudRadio>Option A</MudRadio>` | styled | styled |
| `<MudRadio Label="A" />` | styled | **stale** |
| `<MudRadio Value="a" />` | styled | **stale** |
| group `Name` changed at runtime | `before` → `after` | **`before` → `before`** |

Child content is the reason the first row survives: it is a fresh `RenderFragment` delegate on every parent render, so that parameter "may have changed" and the radio re-renders anyway. The test added with #13742 builds its radios with child content, which is why the suite stayed green.

The failing case is ordinary: a `MudForm` holding a `Required` radio group, validated. Radios written as `<MudRadio Label="..." />` keep their unstyled icon after validation fails.

### Fix

The group pushes both values to its radios the way it already pushes `SetChecked`, and only when either actually changes, so an unchanged render still costs the radios nothing.

### The measured saving is unaffected

Selecting one radio, counting component renders on a bare `Renderer`:

| group size | v9.9.0 | #13742 | this branch |
| --- | --- | --- | --- |
| 5 radios | 51 | 25 | **25** |
| 60 radios | 491 | 190 | **190** |

### Verification

- Two new tests, both of which fail on the current dev tip and pass here: one validates a required group and asserts the error class reaches radios written without child content, the other changes `Name` at runtime and asserts the rendered attribute follows.
- Full suite green: 5814 total, 0 failed, 2 skipped.
- Confirmed in a browser against a Blazor Server harness, three runs each, on v9.9.0, the dev tip and this branch.

### Alternative

Reverting the `IsFixed` attribute also fixes it and gives back the extra render per radio per group render. I went with the push because it keeps the saving, but the revert is a one-line change if reviewers prefer the smaller surface.
