### PR TITLE
Docs: Fix DataGrid example cell misalignment at narrow widths

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnTypesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridColumnTypesExample.razor
@@ -10,9 +10,9 @@
         <PropertyColumn Property="x => x.YearsEmployed" Title="Years Employed" />
         <PropertyColumn Property="x => x.Salary" Format="C" />
         <PropertyColumn Property="x => x.Salary * x.YearsEmployed" Title="Total Earned" Format="C" />
-        <TemplateColumn CellClass="d-flex justify-end">
+        <TemplateColumn>
             <CellTemplate>
-                <MudStack Row>
+                <MudStack Row Justify="Justify.FlexEnd">
                     <MudRating Size="@Size.Small" SelectedValue="@context.Item.Rating" />
                     <MudButton Size="@Size.Small" Variant="@Variant.Filled" Color="@Color.Primary">Hire</MudButton>
                 </MudStack>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
@@ -41,13 +41,11 @@
                 </MudStack>
             </CellTemplate>
             <EditTemplate>
-                <MudStack Row Spacing="0" Justify="Justify.SpaceBetween">
                     @if (!_isCellEditMode && !_editTriggerRowClick)
                     {
                         <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
                     }
                     <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => DeleteItem(context.Item))" />
-                </MudStack>
             </EditTemplate>
         </TemplateColumn>
     </Columns>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridEditingExample.razor
@@ -30,20 +30,24 @@
             </EditTemplate>
         </PropertyColumn>
         <PropertyColumn Property="x => x.Molar" Title="Molar mass" />
-        <TemplateColumn Hidden="@_readOnly" CellClass="d-flex justify-between">
+        <TemplateColumn Hidden="@_readOnly">
             <CellTemplate>
+                <MudStack Row Spacing="0" Justify="Justify.SpaceBetween">
                     @if (!_isCellEditMode && !_editTriggerRowClick)
                     {
                         <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
                     }
                     <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => DeleteItem(context.Item))" />
+                </MudStack>
             </CellTemplate>
             <EditTemplate>
+                <MudStack Row Spacing="0" Justify="Justify.SpaceBetween">
                     @if (!_isCellEditMode && !_editTriggerRowClick)
                     {
                         <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@context.Actions.StartEditingItemAsync" />
                     }
                     <MudIconButton Size="@Size.Small" Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => DeleteItem(context.Item))" />
+                </MudStack>
             </EditTemplate>
         </TemplateColumn>
     </Columns>

--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridInlineRowEditingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/Examples/DataGridInlineRowEditingExample.razor
@@ -68,34 +68,36 @@
         </PropertyColumn>
 
         @* Actions column - shows Edit button or Save/Cancel buttons based on edit state *@
-        <TemplateColumn CellClass="d-flex justify-end">
+        <TemplateColumn>
             <CellTemplate>
-                @if (context.IsEditing)
-                {
-                    <MudIconButton Size="Size.Small"
-                                   Icon="@Icons.Material.Filled.Check"
-                                   Color="Color.Success"
-                                   aria-label="Save changes"
-                                   OnClick="@context.Actions.CommitEditingItemAsync" />
-                    <MudIconButton Size="Size.Small"
-                                   Icon="@Icons.Material.Filled.Close"
-                                   Color="Color.Error"
-                                   aria-label="Cancel editing"
-                                   OnClick="@context.Actions.CancelEditingItemAsync" />
-                }
-                else
-                {
-                    <MudIconButton Size="Size.Small"
-                                   Icon="@Icons.Material.Outlined.Edit"
-                                   Disabled="@_isEditing"
-                                   aria-label="Edit row"
-                                   OnClick="@context.Actions.StartEditingItemAsync" />
-                    <MudIconButton Size="Size.Small"
-                                   Icon="@Icons.Material.Outlined.Delete"
-                                   Disabled="@_isEditing"
-                                   aria-label="Delete row"
-                                   OnClick="@(() => DeleteItem(context.Item))" />
-                }
+                <MudStack Row Spacing="0" Justify="Justify.FlexEnd">
+                    @if (context.IsEditing)
+                    {
+                        <MudIconButton Size="Size.Small"
+                                       Icon="@Icons.Material.Filled.Check"
+                                       Color="Color.Success"
+                                       aria-label="Save changes"
+                                       OnClick="@context.Actions.CommitEditingItemAsync" />
+                        <MudIconButton Size="Size.Small"
+                                       Icon="@Icons.Material.Filled.Close"
+                                       Color="Color.Error"
+                                       aria-label="Cancel editing"
+                                       OnClick="@context.Actions.CancelEditingItemAsync" />
+                    }
+                    else
+                    {
+                        <MudIconButton Size="Size.Small"
+                                       Icon="@Icons.Material.Outlined.Edit"
+                                       Disabled="@_isEditing"
+                                       aria-label="Edit row"
+                                       OnClick="@context.Actions.StartEditingItemAsync" />
+                        <MudIconButton Size="Size.Small"
+                                       Icon="@Icons.Material.Outlined.Delete"
+                                       Disabled="@_isEditing"
+                                       aria-label="Delete row"
+                                       OnClick="@(() => DeleteItem(context.Item))" />
+                    }
+                </MudStack>
             </CellTemplate>
         </TemplateColumn>
     </Columns>


### PR DESCRIPTION
Fixes #13647. Related to #10976.

The DataGrid docs examples set `d-flex` on `TemplateColumn.CellClass`, which overrides the `<td>` element's `table-cell` display. When a neighboring cell wraps at narrow widths and the row grows taller, the flex cell stops stretching with the row, so its border and content drift out of line - most visibly in the Column Types example. This moves the flex alignment onto a `MudStack` inside the cell template instead, as suggested in #10976. The editing example's `EditTemplate` is deliberately left untouched: in form mode it renders inside the edit dialog, where `CellClass` never applied.

**Before/After:**

Column Types example at a 900px viewport, where the Position cell wraps ("Alicia" row):

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/thaildhe172591/MudBlazor/assets-issue-13647/before-columntypes-900px.png) | ![after](https://raw.githubusercontent.com/thaildhe172591/MudBlazor/assets-issue-13647/after-columntypes-900px.png) |

The Editing and Inline Row Editing examples render the same as before:

<details>
<summary>Editing and Inline Row Editing, before/after at 900px</summary>

| Before | After |
|---|---|
| ![before editing](https://raw.githubusercontent.com/thaildhe172591/MudBlazor/assets-issue-13647/before-editing-900px.png) | ![after editing](https://raw.githubusercontent.com/thaildhe172591/MudBlazor/assets-issue-13647/after-editing-900px.png) |
| ![before inline row editing](https://raw.githubusercontent.com/thaildhe172591/MudBlazor/assets-issue-13647/before-inlinerowediting-900px.png) | ![after inline row editing](https://raw.githubusercontent.com/thaildhe172591/MudBlazor/assets-issue-13647/after-inlinerowediting-900px.png) |

</details>

This change was written with AI assistance (Claude Code). The diff was reviewed by the author. Verification was run locally on this machine: `dotnet test --project src/MudBlazor.UnitTests.Docs/MudBlazor.UnitTests.Docs.csproj /p:GenerateDocsTests=true` passes 1402 tests both on the branch base and with the change, and the before/after screenshots above are from a local run of MudBlazor.Docs.Server.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
