### PR TITLE
MudFormComponent: Add Required text to LanguageResource

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -11,10 +11,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
+using MudBlazor.Resources;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Autocomplete;
 using NUnit.Framework;
-using static MudBlazor.UnitTests.TestComponents.Autocomplete.AutocompleteSetParametersInitialization;
 
 namespace MudBlazor.UnitTests.Components
 {
@@ -875,9 +875,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Required_ValidatesOnBlur()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudAutocomplete<string>>(a => a
                 .Add(x => x.Required, true)
-                .Add(x => x.RequiredError, "Required")
+                .Add(x => x.RequiredError, localizer[LanguageResource.MudFormComponent_Required])
                 .Add(x => x.DebounceInterval, 0)
                 .Add(x => x.SearchFunc, (s, t) => Task.FromResult<IEnumerable<string>>(new[] { "a", "b" })));
             var ac = comp.Instance;
@@ -890,7 +891,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 ac.Touched.Should().BeTrue("leaving an empty required autocomplete validates it (#5489)");
                 ac.HasErrors.Should().BeTrue();
-                ac.ValidationErrors.Should().Contain("Required");
+                ac.ValidationErrors.Should().Contain(localizer[LanguageResource.MudFormComponent_Required]);
             });
         }
 
@@ -900,9 +901,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Required_PreFilledValue_IsValidOnBlur()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudAutocomplete<string>>(a => a
                 .Add(x => x.Required, true)
-                .Add(x => x.RequiredError, "Required")
+                .Add(x => x.RequiredError, localizer[LanguageResource.MudFormComponent_Required])
                 .Add(x => x.Value, "a")
                 .Add(x => x.DebounceInterval, 0)
                 .Add(x => x.SearchFunc, (s, t) => Task.FromResult<IEnumerable<string>>(new[] { "a", "b" })));
@@ -923,9 +925,10 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Required_NonImmediate_ValidatesOnBlur()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudAutocomplete<string>>(a => a
                 .Add(x => x.Required, true)
-                .Add(x => x.RequiredError, "Required")
+                .Add(x => x.RequiredError, localizer[LanguageResource.MudFormComponent_Required])
                 .Add(x => x.Immediate, false)
                 .Add(x => x.DebounceInterval, 0)
                 .Add(x => x.SearchFunc, (s, t) => Task.FromResult<IEnumerable<string>>(new[] { "a", "b" })));
@@ -939,7 +942,7 @@ namespace MudBlazor.UnitTests.Components
             {
                 ac.Touched.Should().BeTrue("leaving an empty required autocomplete validates it, even when Immediate is off (#5489)");
                 ac.HasErrors.Should().BeTrue();
-                ac.ValidationErrors.Should().Contain("Required");
+                ac.ValidationErrors.Should().Contain(localizer[LanguageResource.MudFormComponent_Required]);
             });
         }
 
@@ -1008,6 +1011,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Autocomplete_Should_SetRequiredTrue()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<AutocompleteRequiredTest>();
 
             var autocomplete = comp.FindComponent<MudAutocomplete<string>>().Instance;
@@ -1016,7 +1020,7 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.InvokeAsync(autocomplete.ValidateAsync);
 
-            autocomplete.ValidationErrors.First().Should().Be("Required");
+            autocomplete.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>

--- a/src/MudBlazor.UnitTests/Components/FormTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FormTests.cs
@@ -1,13 +1,14 @@
 ﻿using System.Globalization;
 using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using AngleSharp.Dom;
 using AwesomeAssertions;
 using AwesomeAssertions.Execution;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Extensions;
+using MudBlazor.Resources;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Form;
 using MudBlazor.Utilities;
@@ -1100,6 +1101,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithRadioGroupIsValid()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithRadioGroupTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var radioGroupcomp = comp.FindComponent<MudRadioGroup<string>>();
@@ -1118,9 +1120,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Selected, null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             radioGroup.GetState(x => x.Error).Should().BeTrue();
-            radioGroup.GetState(x => x.ErrorText).Should().Be("Required");
+            radioGroup.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1129,6 +1131,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithColorPicker()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithColorPickerTest>(parameters => parameters.Add(x => x.ColorValue, null));
             var form = comp.FindComponent<MudForm>().Instance;
             var colorPickerComp = comp.FindComponent<MudColorPicker>();
@@ -1149,9 +1152,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ColorValue, null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             colorPicker.GetState(x => x.Error).Should().BeTrue();
-            colorPicker.GetState(x => x.ErrorText).Should().Be("Required");
+            colorPicker.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1160,6 +1163,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_ColorPicker_When_EditableInputCleared()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithColorPickerTest>(parameters => parameters.Add(x => x.ColorValue, null));
             var form = comp.FindComponent<MudForm>().Instance;
             var colorPickerComp = comp.FindComponent<MudColorPicker>();
@@ -1181,9 +1185,9 @@ namespace MudBlazor.UnitTests.Components
             await colorPickerComp.FindAll("input")[0].ChangeAsync(null);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             colorPicker.GetState(x => x.Error).Should().BeTrue();
-            colorPicker.GetState(x => x.ErrorText).Should().Be("Required");
+            colorPicker.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1309,6 +1313,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithDatePicker()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithDatePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateComp = comp.FindComponent<MudDatePicker>();
@@ -1327,9 +1332,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Date, null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             datepicker.GetState(x => x.Error).Should().BeTrue();
-            datepicker.GetState(x => x.ErrorText).Should().Be("Required");
+            datepicker.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1364,6 +1369,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaInputs()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithDateRangePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateRangeComp = comp.FindComponent<MudDateRangePicker>();
@@ -1385,9 +1391,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DateRange, null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             dateRangePicker.GetState(x => x.Error).Should().BeTrue();
-            dateRangePicker.GetState(x => x.ErrorText).Should().Be("Required");
+            dateRangePicker.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1397,6 +1403,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_DateRangePicker_When_DateRangeSelectedViaPicker()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithDateRangePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var dateRangePicker = comp.FindComponent<MudDateRangePicker>().Instance;
@@ -1420,9 +1427,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.DateRange, null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             dateRangePicker.GetState(x => x.Error).Should().BeTrue();
-            dateRangePicker.GetState(x => x.ErrorText).Should().Be("Required");
+            dateRangePicker.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1431,6 +1438,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithTimePicker()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithTimePickerTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var timePickerComp = comp.FindComponent<MudTimePicker>();
@@ -1449,9 +1457,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Time, null));
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             timePicker.GetState(x => x.Error).Should().BeTrue();
-            timePicker.GetState(x => x.ErrorText).Should().Be("Required");
+            timePicker.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1485,6 +1493,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Form_Should_Validate_FileUpload_When_FileAdded()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithFileUploadTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
@@ -1514,9 +1523,9 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             fileUploadInstance.GetState(x => x.Error).Should().BeTrue();
-            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1528,6 +1537,7 @@ namespace MudBlazor.UnitTests.Components
             var fileName = "cat.jpg";
             var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>());
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithFileUploadTest>(parameters =>
                 parameters.Add(x => x.File, defaultFile));
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1549,9 +1559,9 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             fileUploadInstance.GetState(x => x.Error).Should().BeTrue();
-            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
@@ -1572,6 +1582,7 @@ namespace MudBlazor.UnitTests.Components
             var fileName = "cat.jpg";
             var defaultFile = new DummyBrowserFile(fileName, DateTimeOffset.Now, 0, "image/jpeg", Array.Empty<byte>());
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithFileUploadTest>(
                 parameters => parameters.Add(x => x.File, defaultFile));
             var form = comp.FindComponent<MudForm>().Instance;
@@ -1594,9 +1605,9 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             fileUploadInstance.GetState(x => x.Error).Should().BeTrue();
-            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
@@ -1615,6 +1626,7 @@ namespace MudBlazor.UnitTests.Components
         {
             var fileName = "cat.jpg";
             var fileToUpload = InputFileContent.CreateFromText("I am a cat image, trust me.", "cat.jpg");
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormFileUploadDndTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var fileUploadComp = comp.FindComponent<MudFileUpload<IBrowserFile>>();
@@ -1636,9 +1648,9 @@ namespace MudBlazor.UnitTests.Components
             form.IsValid.Should().BeFalse();
             form.IsTouched.Should().BeTrue();
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             fileUploadInstance.GetState(x => x.Error).Should().BeTrue();
-            fileUploadInstance.GetState(x => x.ErrorText).Should().Be("Required");
+            fileUploadInstance.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             // re-add a file, form should now be valid and touched
             input.UploadFiles(fileToUpload);
@@ -2634,6 +2646,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task FormWithCheckBox_When_CheckBoxTickedUsingMouse()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var checkBox = comp.FindComponent<MudCheckBox<bool>>().Instance;
@@ -2655,9 +2668,9 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("input").ChangeAsync(false);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             checkBox.GetState(x => x.Error).Should().BeTrue();
-            checkBox.GetState(x => x.ErrorText).Should().Be("Required");
+            checkBox.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -2666,6 +2679,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void FormWithCheckBox_When_CheckBoxTickedUsingKeyboard()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<FormWithCheckBoxTest>();
             var form = comp.FindComponent<MudForm>().Instance;
             var checkBox = comp.FindComponent<MudCheckBox<bool>>().Instance;
@@ -2687,9 +2701,9 @@ namespace MudBlazor.UnitTests.Components
             comp.Find("input").KeyDown(Key.Space);
             form.IsValid.Should().Be(false);
             form.Errors.Length.Should().Be(1);
-            form.Errors[0].Should().Be("Required");
+            form.Errors[0].Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
             checkBox.GetState(x => x.Error).Should().BeTrue();
-            checkBox.GetState(x => x.ErrorText).Should().Be("Required");
+            checkBox.GetState(x => x.ErrorText).Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -3,7 +3,9 @@ using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Extensions;
+using MudBlazor.Resources;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Select;
 using MudBlazor.UnitTests.TestData;
@@ -1337,11 +1339,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_Should_SetRequiredTrue()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<SelectRequiredTest>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.ValidateAsync());
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1350,6 +1353,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task Select_Required_Should_ShowValidationError_OnFocusOut()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<SelectRequiredTest>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
@@ -1358,7 +1362,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(async () => await comp.Find($"#{select.ElementId}").TriggerEventAsync("onfocusout", new FocusEventArgs()));
             select.Touched.Should().BeTrue();
             select.HasErrors.Should().BeTrue();
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         /// <summary>
@@ -1871,17 +1875,18 @@ namespace MudBlazor.UnitTests.Components
         {
             //1a. Check When SelectedItems is empty - Validation Should Fail
             //Check on String type
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.ValidateAsync());
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             //1b. Check on T type - MultiSelect of T(e.g. class object)
             var selectWithT = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
             selectWithT.Required.Should().BeTrue();
             await comp.InvokeAsync(() => selectWithT.ValidateAsync());
-            selectWithT.ValidationErrors.First().Should().Be("Required");
+            selectWithT.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             //2a. Now check when SelectedItems is greater than one - Validation Should Pass
             var inputs = comp.FindAll("div.mud-input-control");
@@ -1904,14 +1909,15 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task MultiSelectClearAndReset()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MultiSelectTestRequiredValue>();
             var select = comp.FindComponent<MudSelect<string>>().Instance;
             select.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select.ValidateAsync());
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             await comp.Find("#clear-string").ClickAsync();
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             await comp.Find("#reset-string").ClickAsync();
             select.ValidationErrors.Should().BeEmpty();
@@ -1930,7 +1936,7 @@ namespace MudBlazor.UnitTests.Components
 
             select.Value.Should().BeNullOrEmpty();
             select.GetState(x => x.SelectedValues).Should().BeEmpty();
-            select.ValidationErrors.First().Should().Be("Required");
+            select.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             //test resetting string values
             inputs = comp.FindAll("div.mud-input-control");
@@ -1951,10 +1957,10 @@ namespace MudBlazor.UnitTests.Components
             var select2 = comp.FindComponent<MudSelect<MultiSelectTestRequiredValue.TestClass>>().Instance;
             select2.Required.Should().BeTrue();
             await comp.InvokeAsync(() => select2.ValidateAsync());
-            select2.ValidationErrors.First().Should().Be("Required");
+            select2.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             await comp.Find("#clear-object").ClickAsync();
-            select2.ValidationErrors.First().Should().Be("Required");
+            select2.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             await comp.Find("#reset-object").ClickAsync();
             select2.ValidationErrors.Should().BeEmpty();
@@ -1970,7 +1976,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("#clear-object").ClickAsync();
 
             select2.SelectedValues.Should().BeEmpty();
-            select2.ValidationErrors.First().Should().Be("Required");
+            select2.ValidationErrors.First().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             //test resetting object values
             inputs = comp.FindAll("div.mud-input-control");

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -11,6 +11,7 @@ using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using Moq;
 using MudBlazor.Extensions;
+using MudBlazor.Resources;
 using MudBlazor.UnitTests.Dummy;
 using MudBlazor.UnitTests.TestComponents.Field;
 using MudBlazor.UnitTests.TestComponents.Form;
@@ -573,13 +574,14 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task RequiredTextField_Should_ReuseGeneratedErrorIdWhileInvalid()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudTextField<string>>(parameters => parameters.Add(p => p.Required, true));
 
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
 
             var firstErrorId = comp.Find("input").GetAttribute("aria-describedby");
             firstErrorId.Should().NotBeNullOrWhiteSpace();
-            comp.Find($"[id='{firstErrorId}']").TextContent.Should().Be("Required");
+            comp.Find($"[id='{firstErrorId}']").TextContent.Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             await comp.InvokeAsync(() => comp.Instance.ValidateAsync());
 
@@ -1301,6 +1303,7 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public async Task TextField_OnlyValidateIfDirty_WithNonDefaultInitialValue_ShouldNotValidateOnBlur()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudTextField<string>>(parameters => parameters
                 .Add(p => p.Value, string.Empty)
                 .Add(p => p.Required, true)
@@ -1316,12 +1319,13 @@ namespace MudBlazor.UnitTests.Components
             await comp.Find("input").ChangeAsync("");
             await comp.Find("input").BlurAsync();
             comp.FindAll("div.mud-input-error").Count.Should().BeGreaterThan(0);
-            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Required");
+            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
         }
 
         [Test]
         public async Task TextField_OnlyValidateIfDirty_Is_False_Should_HaveInputErrorWhenFocusChanged()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudTextField<int?>>(parameters => parameters
                 .Add(p => p.Required, true)
                 .Add(p => p.OnlyValidateIfDirty, false));
@@ -1330,7 +1334,7 @@ namespace MudBlazor.UnitTests.Components
             // user does not change input value but changes focus
             await comp.Find("input").BlurAsync();
             comp.FindAll("div.mud-input-error").Count.Should().Be(3);
-            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Required");
+            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             // user puts in a invalid integer value
             await comp.Find("input").ChangeAsync("invalid");
@@ -1345,7 +1349,7 @@ namespace MudBlazor.UnitTests.Components
             // user does not change input value but changes focus
             await comp.Find("input").BlurAsync();
             comp.FindAll("div.mud-input-error").Count.Should().Be(3);
-            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be("Required");
+            comp.Find("div.mud-input-error").TextContent.Trim().Should().Be(localizer[LanguageResource.MudFormComponent_Required]);
 
             // user corrects input
             await comp.Find("input").ChangeAsync(55);

--- a/src/MudBlazor/Base/MudFormComponent.cs
+++ b/src/MudBlazor/Base/MudFormComponent.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.Logging;
 using MudBlazor.Extensions;
 using MudBlazor.Interfaces;
+using MudBlazor.Resources;
 using MudBlazor.State;
 using MudBlazor.Utilities.Comparer;
 using MudBlazor.Utilities.Converter.Base;
@@ -88,7 +89,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Validation)]
-        public string RequiredError { get; set; } = "Required";
+        public string RequiredError { get; set; } = string.Empty;
 
         /// <summary>
         /// The text displayed if the <see cref="Error"/> property is <c>true</c>.
@@ -962,6 +963,7 @@ namespace MudBlazor
 
         protected override Task OnInitializedAsync()
         {
+            RequiredError = string.IsNullOrEmpty(RequiredError) ? Localizer[LanguageResource.MudFormComponent_Required] : RequiredError;
             RegisterAsFormComponent();
             return base.OnInitializedAsync();
         }

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -309,6 +309,9 @@
   <data name="MudBaseDatePicker_NextMonth" xml:space="preserve">
     <value>Next month {0}</value>
   </data>
+  <data name="MudFormComponent_Required" xml:space="preserve">
+    <value>Required</value>
+  </data>
   <data name="MudPagination_CurrentPage" xml:space="preserve">
     <value>Current page {0}</value>
   </data>


### PR DESCRIPTION
Fix #13746

### Problem

`MudFormComponent.RequiredError` uses untranslated text. This text is hard-coded in the component's code.

The default value of this property is never translated when using the MudBlazor.Translations library.

### Effect

Using a component that uses `MudFormComponent` without defining the `RequiredError` property.
Find the same default text (“Required”) but from the `LanguageResource.resx` file.

⚠️ If this PR is accepted, the key will need to be added to the [MudBlazor/Translations](https://github.com/MudBlazor/Translations) project.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests