### PR TITLE
MudDataGrid: Preserve initial sort definitions in single mode

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -5809,6 +5809,37 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll("th .sort-direction-icon")[1].ClassList.Contains("mud-direction-asc").Should().Be(false);
         }
 
+        /// <summary>
+        /// Ensures caller-provided sort definitions survive initial single-sort mode binding (#9021) but are cleared by later mode changes.
+        /// </summary>
+        [Test]
+        public async Task DataGridSortDefinitionsPreservedOnInitialSingleModeRender()
+        {
+            var items = new[]
+            {
+                new TestModel1("B", 42),
+                new TestModel1("A", 73),
+                new TestModel1("C", 33)
+            };
+            var sortDefinitions = new Dictionary<string, SortDefinition<TestModel1>>
+            {
+                ["Name"] = new("Name", false, 0, item => item.Name)
+            };
+
+            var dataGrid = Context.Render<MudDataGrid<TestModel1>>(parameters => parameters
+                .Add(x => x.Items, items)
+                .Add(x => x.SortMode, SortMode.Single)
+                .Add(x => x.SortDefinitions, sortDefinitions));
+
+            dataGrid.Instance.SortDefinitions.Should().ContainKey("Name");
+            dataGrid.Instance.Sort(items).Select(x => x.Name).Should().ContainInOrder("A", "B", "C");
+
+            await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.SortMode, SortMode.Multiple));
+
+            dataGrid.Instance.SortDefinitions.Should().BeEmpty();
+            dataGrid.Instance.Sort(items).Should().ContainInOrder(items);
+        }
+
         [Test]
         public async Task DataGridParentAndChildSamePropertyNameSort()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -1673,7 +1673,7 @@ namespace MudBlazor
             await base.SetParametersAsync(parameters);
 
             VirtualItemsProviderInitialize();
-            if (parameters.TryGetValue(nameof(SortMode), out SortMode sortMode) && sortMode != sortModeBefore)
+            if (_isFirstRendered && parameters.TryGetValue(nameof(SortMode), out SortMode sortMode) && sortMode != sortModeBefore)
                 await ClearCurrentSortings();
         }
 


### PR DESCRIPTION
Fixes #9021.

`MudDataGrid.SetParametersAsync` compared the first incoming `SortMode` with the parameter's default value, so an initial `Single` mode was treated as a later mode transition and cleared caller-provided `SortDefinitions`. This change limits that clearing to post-first-render mode changes, preserving the existing behavior for real transitions.

**Before/After:**

<img width="1280" height="720" alt="01-before-B-A-C" src="https://github.com/user-attachments/assets/6ff3fef5-2405-4270-b749-dc0f5f98dda0" />
<img width="1280" height="720" alt="02-after-A-B-C" src="https://github.com/user-attachments/assets/5a8be1de-2af1-458c-bf30-7f2a6b269b02" />


- Before: the initial Name sort is ignored and rows render in input order (`B, A, C`).
- After: the same initial Name sort remains active and rows render as (`A, B, C`).

**Tests:**

- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-restore /p:SkipBunCompile=true -- --filter "FullyQualifiedName~DataGridSortDefinitionsPreservedOnInitialSingleModeRender" --output Normal --no-ansi --hangdump --hangdump-timeout 120s`
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-build --no-restore -- --filter "FullyQualifiedName~DataGridTests.DataGridSort" --output Normal --no-ansi --hangdump --hangdump-timeout 120s`
- `dotnet test --project src/MudBlazor.UnitTests/MudBlazor.UnitTests.csproj --no-build --no-restore -- --filter "FullyQualifiedName~DataGridCustomSort|FullyQualifiedName~DataGridFilteredItemsCache" --output Normal --no-ansi --hangdump --hangdump-timeout 120s`
- `dotnet format whitespace --no-restore --verify-no-changes --include MudBlazor/Components/DataGrid/MudDataGrid.razor.cs MudBlazor.UnitTests/Components/DataGridTests.cs`

AI assistance was used through Codex with GPT-5.6 Sol for investigation, implementation, test drafting, and diff review. Human verification: before submission, the contributor confirmed that the attached screenshots from the local Viewer run show the same scenario changing from `B, A, C` to `A, B, C`.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests