### PR TITLE
MudSelect: Add SelectAllText text to LanguageResource

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -886,6 +886,7 @@ namespace MudBlazor.UnitTests.Components
             var conversionCount = 0;
             var countingConversions = false;
             IReadOnlyList<string> capturedValues = null;
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var provider = Context.Render<MudPopoverProvider>();
             var comp = Context.Render<MudSelect<string>>(parameters => parameters
                 .Add(x => x.MultiSelection, true)
@@ -918,6 +919,7 @@ namespace MudBlazor.UnitTests.Components
             conversionCount.Should().Be(2);
             capturedValues.Should().Equal("one", "two");
             select.ReadText.Should().Be("one|two");
+            select.SelectAllText.Should().Be(localizer[LanguageResource.MudSelect_SelectAll]);
         }
 
         /// <summary>
@@ -992,6 +994,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
+            select.Instance.SelectAllText.Should().Be("Select all felines");
             // Open the menu
             await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");
@@ -1027,6 +1030,7 @@ namespace MudBlazor.UnitTests.Components
             var select = comp.FindComponent<MudSelect<string>>();
             var menu = comp.Find("div.mud-popover");
             var input = comp.Find("div.mud-input-control");
+            select.Instance.SelectAllText.Should().Be("Select all felines");
             // Open the menu
             await input.MouseDownAsync();
             menu.ClassList.Should().Contain("mud-popover-open");

--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -912,6 +912,9 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.Find("div.mud-input-control").MouseDownAsync();
             await provider.WaitForAssertionAsync(() => provider.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+            var selectAllItem = provider.FindComponent<MudListItem<string>>();
+            selectAllItem.Instance.Text.Should().Be(localizer[LanguageResource.MudSelect_SelectAll]);
+
             conversionCount = 0;
             countingConversions = true;
             await provider.FindAll("div.mud-list-item")[0].ClickAsync();
@@ -919,7 +922,7 @@ namespace MudBlazor.UnitTests.Components
             conversionCount.Should().Be(2);
             capturedValues.Should().Equal("one", "two");
             select.ReadText.Should().Be("one|two");
-            select.SelectAllText.Should().Be(localizer[LanguageResource.MudSelect_SelectAll]);
+            select.SelectAllText.Should().Be("");
         }
 
         /// <summary>
@@ -1002,6 +1005,7 @@ namespace MudBlazor.UnitTests.Components
             // get the first (select all item) and check if it is selected
             var selectAllItem = comp.FindComponent<MudListItem<string>>();
             selectAllItem.Instance.Icon.Should().Be("<path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z\"/>");
+            selectAllItem.Instance.Text.Should().Be("Select all felines");
 
             // Check that all normal select items are actually selected
             var items = comp.FindComponents<MudSelectItem<string>>().Where(x => x.Instance.HideContent == false).ToArray();
@@ -1037,6 +1041,7 @@ namespace MudBlazor.UnitTests.Components
             // Check that the icon corresponds to an unchecked checkbox
             var mudListItem = comp.FindComponent<MudListItem<string>>();
             mudListItem.Instance.Icon.Should().Be("<path d=\"M0 0h24v24H0z\" fill=\"none\"/><path d=\"M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z\"/>");
+            mudListItem.Instance.Text.Should().Be("Select all felines");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -121,7 +121,7 @@
                             {
                                 <MudListItem Value="@("__SelectAll__")"
                                              Icon="@SelectAllCheckBoxIcon"
-                                             Text="@SelectAllText"
+                                             Text="@ResolvedSelectAllText()"
                                              OnClick="SelectAllClickAsync"
                                              OnClickPreventDefault="true"
                                              KeyboardEnabled="false"

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -950,6 +950,8 @@ namespace MudBlazor
             return InvokeAsync(StateHasChanged);
         }
 
+        private string ResolvedSelectAllText() => string.IsNullOrEmpty(SelectAllText) ? Localizer[LanguageResource.MudSelect_SelectAll] : SelectAllText;
+
         private void UpdateSelectAllChecked()
         {
             if (MultiSelection && SelectAll)
@@ -1418,7 +1420,6 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
-            SelectAllText = string.IsNullOrEmpty(SelectAllText) ? Localizer[LanguageResource.MudSelect_SelectAll] : SelectAllText;
             base.OnInitialized();
             UpdateIcon();
         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -5,6 +5,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Extensions;
+using MudBlazor.Resources;
 using MudBlazor.Services;
 using MudBlazor.State;
 using MudBlazor.Utilities;
@@ -43,6 +44,9 @@ namespace MudBlazor
 
         /// <inheritdoc />
         object IMudShadowSelect.SelectContext => _context;
+
+        [Inject]
+        private InternalMudLocalizer Localizer { get; set; } = null!;
 
         public MudSelect()
         {
@@ -274,7 +278,7 @@ namespace MudBlazor
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListAppearance)]
-        public string SelectAllText { get; set; } = "Select all";
+        public string SelectAllText { get; set; } = string.Empty;
 
         /// <summary>
         /// The icon used for selected items.
@@ -1414,6 +1418,7 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
+            SelectAllText = string.IsNullOrEmpty(SelectAllText) ? Localizer[LanguageResource.MudSelect_SelectAll] : SelectAllText;
             base.OnInitialized();
             UpdateIcon();
         }

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -270,6 +270,9 @@
   <data name="MudChip_Close" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="MudSelect_SelectAll" xml:space="preserve">
+    <value>Select all</value>
+  </data>
   <data name="MudColorPicker_Close" xml:space="preserve">
     <value>Close</value>
   </data>


### PR DESCRIPTION
Fix #13750

### Problem

`MudSelect.SelectAllText` uses untranslated text. This text is hard-coded in the component's code.

The default value of this property is never translated when using the MudBlazor.Translations library.

### Effect

Using a component that uses `MudSelect` without defining the `SelectAllText` property.
Find the same default text (“Select all”) but from the `LanguageResource.resx` file.

⚠️ If this PR is accepted, the key will need to be added to the [MudBlazor/Translations](https://github.com/MudBlazor/Translations) project.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests