### PR TITLE
MudPageContentNavigation: Use Headline translation in LanguageResource

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -21,12 +21,11 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DefaultValues()
         {
-            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudPageContentNavigation>();
 
             comp.Instance.ActiveSection.Should().BeNull();
             comp.Instance.Sections.Should().BeEmpty();
-            comp.Instance.Headline.Should().Be(localizer[LanguageResource.MudPageContentNavigation_NavMenu]);
+            comp.Instance.Headline.Should().Be("");
             comp.Instance.SectionClassSelector.Should().BeNullOrEmpty();
 
             comp.Nodes.Should().ContainSingle();
@@ -34,10 +33,48 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public async Task CustomNavMenuTitle()
+        {
+            var comp = Context.Render<MudPageContentNavigation>(parameters => parameters.Add(x => x.Headline, "Custom title"));
+
+            var section1 = new MudPageContentSection("my section", "my-id");
+            var section2 = new MudPageContentSection("my section 2", "my-id-2");
+
+            comp.Instance.AddSection(section1, false);
+            comp.Instance.AddSection(section2, false);
+            await comp.InvokeAsync(() => ((IMudStateHasChanged)comp.Instance).StateHasChanged());
+
+            comp.RenderCount.Should().Be(2);
+
+            comp.Instance.ActiveSection.Should().BeNull();
+            comp.Instance.Sections.Should().BeEquivalentTo(new[] { section1, section2 });
+
+            comp.Nodes.Should().ContainSingle();
+            comp.Instance.Headline.Should().Be("Custom title");
+
+            var navMenu = comp.FindComponent<MudNavMenu>();
+            navMenu.Instance.UserAttributes.GetValueOrDefault("aria-label").Should().Be("Custom title");
+
+            var headlineItem = comp.FindComponent<MudText>();
+            headlineItem.FindAll("p.mud-typography")[0].TextContent.Should().Be("Custom title");
+
+            var navLinks = comp.FindComponents<MudNavLink>();
+            navLinks.Should().HaveCount(2);
+            navLinks[0].Instance.Class.Should().Be("page-content-navigation-navlink navigation-level-0");
+
+            var firstLinkText = navLinks[0].Find(".mud-nav-link-text");
+            firstLinkText.TextContent.Should().Be("my section");
+
+            var secondLinkText = navLinks[1].Find(".mud-nav-link-text");
+            secondLinkText.TextContent.Should().Be("my section 2");
+        }
+
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public async Task AddSection(bool withUpdate)
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudPageContentNavigation>();
 
             var section1 = new MudPageContentSection("my section", "my-id");
@@ -61,6 +98,12 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Sections.Should().BeEquivalentTo(new[] { section1, section2 });
 
             comp.Nodes.Should().ContainSingle();
+
+            var navMenu = comp.FindComponent<MudNavMenu>();
+            navMenu.Instance.UserAttributes.GetValueOrDefault("aria-label").Should().Be(localizer[LanguageResource.MudPageContentNavigation_NavMenu]);
+
+            var headlineItem = comp.FindComponent<MudText>();
+            headlineItem.FindAll("p.mud-typography")[0].TextContent.Should().Be(localizer[LanguageResource.MudPageContentNavigation_NavMenu]);
 
             var navLinks = comp.FindComponents<MudNavLink>();
             navLinks.Should().HaveCount(2);

--- a/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PageContentNavigationTests.cs
@@ -1,11 +1,9 @@
 ﻿
-using System.Threading.Tasks;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Interfaces;
-using MudBlazor.UnitTests.Mocks;
-using MudBlazor.UnitTests.Shared.Mocks;
+using MudBlazor.Resources;
 using NUnit.Framework;
 
 namespace MudBlazor.UnitTests.Components
@@ -23,11 +21,12 @@ namespace MudBlazor.UnitTests.Components
         [Test]
         public void DefaultValues()
         {
+            var localizer = Context.Services.GetRequiredService<InternalMudLocalizer>();
             var comp = Context.Render<MudPageContentNavigation>();
 
             comp.Instance.ActiveSection.Should().BeNull();
             comp.Instance.Sections.Should().BeEmpty();
-            comp.Instance.Headline.Should().Be("Contents");
+            comp.Instance.Headline.Should().Be(localizer[LanguageResource.MudPageContentNavigation_NavMenu]);
             comp.Instance.SectionClassSelector.Should().BeNullOrEmpty();
 
             comp.Nodes.Should().ContainSingle();

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -1,13 +1,11 @@
 ﻿@namespace MudBlazor
 @using Microsoft.AspNetCore.Components.Routing
-@using MudBlazor.Resources
 @inherits MudComponentBase
-@inject InternalMudLocalizer Localizer
 
 <div class="@GetPanelClass()" @attributes="UserAttributes">
     @if (_sections.Count > 1)
     {
-        <MudNavMenu Class="pl-4" aria-label="@Localizer[LanguageResource.MudPageContentNavigation_NavMenu]">
+        <MudNavMenu Class="pl-4" aria-label="@Headline">
             <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
                 @Headline
             </MudText>

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor
@@ -5,9 +5,9 @@
 <div class="@GetPanelClass()" @attributes="UserAttributes">
     @if (_sections.Count > 1)
     {
-        <MudNavMenu Class="pl-4" aria-label="@Headline">
+        <MudNavMenu Class="pl-4" aria-label="@ResolvedHeadline()">
             <MudText Typo="Typo.subtitle1" Class="title" GutterBottom="true">
-                @Headline
+                @ResolvedHeadline()
             </MudText>
 
             @foreach (var docSection in _sections.OrderBy(x => x.LevelSortingValue))

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Interfaces;
+using MudBlazor.Resources;
 using MudBlazor.Utilities;
 
 namespace MudBlazor
@@ -20,6 +21,9 @@ namespace MudBlazor
         [Inject]
         private IScrollSpyFactory ScrollSpyFactory { get; set; } = null!;
 
+        [Inject]
+        private InternalMudLocalizer Localizer { get; set; } = null!;
+
         /// <summary>
         /// The displayed section within the MudPageContentNavigation
         /// </summary>
@@ -34,7 +38,7 @@ namespace MudBlazor
         /// The text displayed about the section links. Defaults to "Contents"
         /// </summary>
         [Parameter]
-        public string Headline { get; set; } = "Contents";
+        public string Headline { get; set; } = string.Empty;
 
         /// <summary>
         /// The CSS selector used to identify the scroll container
@@ -162,6 +166,7 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
+            Headline = string.IsNullOrEmpty(Headline) ? Localizer[LanguageResource.MudPageContentNavigation_NavMenu] : Headline;
             _scrollSpy = ScrollSpyFactory.Create();
         }
 

--- a/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
+++ b/src/MudBlazor/Components/PageContentNavigation/MudPageContentNavigation.razor.cs
@@ -107,6 +107,8 @@ namespace MudBlazor
 
         private string GetPanelClass() => new CssBuilder("page-content-navigation").AddClass(Class).Build();
 
+        private string ResolvedHeadline() => string.IsNullOrEmpty(Headline) ? Localizer[LanguageResource.MudPageContentNavigation_NavMenu] : Headline;
+
         /// <summary>
         /// Scrolls to a section based on the fragment of the uri. If there is no fragment, no scroll will occurred
         /// </summary>
@@ -166,7 +168,6 @@ namespace MudBlazor
 
         protected override void OnInitialized()
         {
-            Headline = string.IsNullOrEmpty(Headline) ? Localizer[LanguageResource.MudPageContentNavigation_NavMenu] : Headline;
             _scrollSpy = ScrollSpyFactory.Create();
         }
 


### PR DESCRIPTION
Fix #13752

### Problem

`MudPageContentNavigation.Headline` uses untranslated text. This text is hard-coded in the component's code.

The default value of this property is never translated when using the MudBlazor.Translations library.

### Effect

Using a component that uses `MudPageContentNavigation` without defining the `Headline` property.
Find the same default text (“Contents”) but from the `LanguageResource.resx` file.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests