### PR TITLE
Build: Consolidate the Bun updates into one weekly PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
         "build"
     ],
     "commitMessagePrefix": "Build: ",
+    "timezone": "Etc/UTC",
     "lockFileMaintenance": {
         "enabled": true
     },
@@ -82,31 +83,60 @@
             "enabled": false
         },
         {
-            "description": "Group Bun toolchain updates. BunDotNet.Cli is pinned in .config/dotnet-tools.json, which the built-in nuget manager reads.",
+            "description": "eslint and sass decide the bytes in MudBlazor.min.js and MudBlazor.min.css, so pin them rather than tracking a range.",
+            "matchManagers": [
+                "bun"
+            ],
+            "rangeStrategy": "pin"
+        },
+        {
+            "description": "Everything that feeds the Bun asset build moves as one branch: the pinned dev dependencies in package.json, the BunVersion that selects the Bun binary, and the BunDotNet.Cli tool that fetches it. Splitting them let two open PRs rewrite bun.lock at the same time, so merging either one left the other stale. The Monday window and the three-day grace period trade a few days of latency for a single reviewable PR that skips releases pulled in their first days. groupSingleUpdates keeps the group title on the weeks only one package moves.",
+            "matchFileNames": [
+                "src/package.json",
+                "src/Directory.Build.props",
+                ".config/dotnet-tools.json",
+                ".github/renovate.json"
+            ],
+            "groupName": "bun",
+            "groupSlug": "bun",
+            "schedule": [
+                "* 0-3 * * 1"
+            ],
+            "minimumReleaseAge": "3 days",
+            "groupSingleUpdates": true,
+            "reviewers": [
+                "meenzen"
+            ]
+        },
+        {
+            "description": "Bun and the tool that downloads it are the same release, so a major arrives as one bump rather than a separate PR. This stays off the npm packages above: clearing separateMajorMinor collapses the version lookup to a single latest bucket, so a breaking sass or typescript major would suppress the safe patch on the current line and hold the weekly PR red.",
             "matchPackageNames": [
                 "bun",
                 "BunDotNet.Cli"
             ],
             "matchFileNames": [
                 "src/Directory.Build.props",
-                ".config/dotnet-tools.json"
+                ".config/dotnet-tools.json",
+                ".github/renovate.json"
             ],
-            "groupName": "bun toolchain",
-            "groupSlug": "bun-toolchain",
             "separateMajorMinor": false,
-            "separateMultipleMajor": false,
-            "reviewers": [
-                "meenzen"
-            ]
+            "separateMultipleMajor": false
         },
         {
-            "description": "eslint and sass decide the bytes in MudBlazor.min.js and MudBlazor.min.css, so pin them. Lock file maintenance is enabled at the top level, where Renovate actually reads it, and refreshes the transitives that pinning cannot reach. constraints.bun must track BunVersion: lock file maintenance regenerates bun.lock from scratch, and a newer bun writes lockfileVersion 2, which the pinned bun cannot read.",
-            "matchManagers": [
-                "bun"
+            "description": "Renovate refuses to put lock file maintenance in a branch with any other update type, so this is the one Bun PR that cannot join the group above. It is also the only thing that ever moves a transitive in bun.lock, because the bun manager does not implement updateLockedDependency. Clearing minimumReleaseAge is required, not cosmetic: a maintenance update carries no release timestamp, so inheriting the group's grace period would pin a stability status check to yellow forever. constraints.bun must keep tracking BunVersion: maintenance regenerates bun.lock from scratch, and a newer bun writes lockfileVersion 2, which the pinned bun cannot read.",
+            "matchUpdateTypes": [
+                "lockFileMaintenance"
             ],
-            "rangeStrategy": "pin",
-            "groupName": "bun dependencies",
-            "groupSlug": "bun-dependencies",
+            "matchFileNames": [
+                "src/package.json"
+            ],
+            "groupName": "bun lock file",
+            "groupSlug": "bun-lock-file",
+            "schedule": [
+                "* 0-3 1-7 * 1"
+            ],
+            "minimumReleaseAge": null,
+            "groupSingleUpdates": false,
             "reviewers": [
                 "meenzen"
             ]
@@ -137,6 +167,18 @@
             ],
             "matchStrings": [
                 "<BunVersion>(?<currentValue>.*?)</BunVersion>"
+            ],
+            "depNameTemplate": "bun",
+            "datasourceTemplate": "npm"
+        },
+        {
+            "description": "constraints.bun selects the Bun that regenerates bun.lock, so it has to move in the same commit as BunVersion. Reading it back out of this file is the only way Renovate can own both halves; left to a human it drifts, and a newer Bun writes lockfileVersion 2 that the pinned Bun cannot read.",
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^\\.github/renovate\\.json$/"
+            ],
+            "matchStrings": [
+                "\"constraints\":\\s*\\{[^}]*?\"bun\":\\s*\"(?<currentValue>[^\"]+)\""
             ],
             "depNameTemplate": "bun",
             "datasourceTemplate": "npm"


### PR DESCRIPTION
Collapses the Bun update PRs into a single weekly grouped PR with a three-day grace period, and puts `constraints.bun` under Renovate's control so it can no longer drift from `BunVersion`.

## The problem

Three Bun groups existed and only one of them was scheduled:

| Branch | Schedule | Rewrites |
| --- | --- | --- |
| `renovate/bun-dependencies` | `at any time` | `src/package.json` + `src/bun.lock` |
| `renovate/lock-file-maintenance-bun-dependencies` | Monday 4am (Renovate's default) | `src/bun.lock` |
| `renovate/bun-toolchain` | `at any time` | `Directory.Build.props`, `dotnet-tools.json` |

The dependency group having no schedule is what produced four Bun PRs in ten days (#13652, #13659, #13703, #13726). The two currently open, #13735 and #13754, both bump `happy-dom` in `src/bun.lock`, so merging either one leaves the other stale.

## What changes

- The pinned `package.json` dependencies, `BunVersion`, and `BunDotNet.Cli` now share one group, so they land on one branch (`renovate/bun`) instead of three.
- That group runs in a Monday window (`* 0-3 * * 1`) with `minimumReleaseAge: "3 days"`.
- A second custom manager reads `constraints.bun` back out of this file, so a `BunVersion` bump carries the matching `constraints.bun` bump in the same commit. This was previously a hand-maintained invariant with a comment warning about it.
- Lock file maintenance keeps its own PR (it has to; see below), moved to the first Monday of the month so it is cut from the same commit as the weekly group.
- `timezone` is set explicitly so the Monday window means something definite.
- Non-Bun rules are untouched.

## Renovate behaviour this depends on

Verified by reading Renovate 44.52.1's `dist/`, not the docs. Recording it here so nobody has to re-derive it.

**1. Lock file maintenance can never share a PR with dependency updates.** `workers/repository/updates/branch-name.js` unconditionally prepends a prefix when the update type is lock file maintenance, setting the group slug to `lock-file-maintenance-` followed by the existing slug. `workers/repository/updates/generate.js:258` then logs `Grouping lockfile maintenance with other update types is not supported`. That is why the current branch is named `renovate/lock-file-maintenance-bun-dependencies` — it already inherits the group slug and still gets its own branch. Two Bun PRs is the floor while maintenance is enabled. There is also no bun `postUpdateOptions` that would refresh the whole lock as a side effect of a dependency bump, so it cannot be folded in that way either.

**2. `separateMajorMinor: false` is not just "bundle majors together".** `workers/repository/process/lookup/bucket.js:4` returns the single bucket `latest` when it is false, so every candidate version collapses into one bucket and a breaking major *suppresses the safe patch on the current line*. On packages with independent release lines (eslint, sass, typescript) that would hold the weekly PR red with no way to take the patch. It is kept only on `bun` and `BunDotNet.Cli`, where it already was and where the two versions are lockstep. Both bun rules list `.github/renovate.json` so a Bun major cannot split `BunVersion`, `constraints.bun`, and `BunDotNet.Cli` across two branches.

**3. `minimumReleaseAge` must be cleared on the lock file maintenance rule.** `workers/repository/update/branch/index.js:287` sets `stabilityStatus` to yellow for any upgrade that has a `minimumReleaseAge` and no `releaseTimestamp`. A maintenance update has no release timestamp, so inheriting the group's grace period pins a `renovate/stability-days` status check to yellow forever. Hence the explicit `"minimumReleaseAge": null`, which relies on that rule being listed after the group rule.

**4. The grace period does not stall the group.** `workers/repository/process/lookup/filter-checks.js` runs per package and selects the newest release older than three days, walking back down the list rather than skipping the package. `generate.js:123` then drops only the still-pending members and lets the rest through. A package released yesterday simply waits for next Monday; it does not block eslint.

**5. `groupSingleUpdates` matters here.** It defaults to false, and `generate.js:169` drops the group settings when only one package moved — which is most weeks. Without it the PR would be titled after the single dependency while sitting on a branch called `renovate/bun`.

**6. Lock file maintenance is the only path to transitives in `bun.lock`.** The bun manager does not implement `updateLockedDependency` (npm does), and per `flatten.js` remediation PRs only exist for managers that do. So maintenance is the only mechanism that ever moves a transitive here, including for a CVE. That is the argument for keeping it enabled; the counter-argument for monthly is that every one of these is a build-time dev dependency that ships nothing to users. If a month feels too long, change that rule's schedule to `* 0-3 * * 1` and both Bun PRs arrive every Monday from the same base commit.

**7. `* 0-3 1-7 * 1` really is first-Monday-only.** Renovate builds its cron with `domAndDow: true` (`workers/repository/update/branch/schedule.js`), so day-of-month and day-of-week are ANDed rather than ORed as in standard cron. Walked over September and October 2026 using Renovate's own `cronMatches`: it fires only on 2026-09-07 and 2026-10-05.

## How this was verified

Beyond `renovate-config-validator`, which the Renovate Validation workflow also runs on this PR:

- Replayed Renovate's real resolution pipeline against both the old and the new config — `getConfig`, `mergeChildConfig`, `applyPackageRules`, `generateBranchName`, plus the separate lock-file-maintenance path from `flatten.js`. Against the current config it reproduces the live branch names exactly (`renovate/bun-dependencies`, `renovate/bun-toolchain`, `renovate/lock-file-maintenance-bun-dependencies`), which is the control for trusting it on the new one.
- Against the new config, eslint, typescript, `BunVersion`, `constraints.bun`, and `BunDotNet.Cli` all resolve to `renovate/bun` with the Monday schedule and the three-day grace. A bun 2.0 major keeps all three toolchain locations together; a sass major correctly splits to `renovate/major-bun`.
- Diffed the resolved config for `dotnet-sdk`, both `Microsoft.CodeAnalysis` rules, the AspNetCore/Extensions disable, `test platform`, and `Markdig` before and after: byte-identical. No schedule or grace period leaks into them, and security updates are unaffected.
- Ran both custom managers through Renovate's actual regex extractor: `src/Directory.Build.props` and `.github/renovate.json` each yield `bun@1.4.0`.

## Expected result

Three Mondays a month, one `renovate/bun` PR. First Monday of the month, that plus the lock file PR from the same base commit. Occasionally a `renovate/major-bun` when something breaks major.

## Note on the two open Bun PRs

Worth merging #13735 and #13754 before this lands, so their aged updates are not thrown away. I test-merged them: #13735 into `dev` is clean, and #13754 on top of that is also clean, since both write the identical `happy-dom@20.12.0` line. If this merges first instead, Renovate prunes both branches and the replacement arrives on Monday.

`renovate/bun-dependencies` and `renovate/bun-toolchain` are replaced by `renovate/bun`, so expect Renovate to close and recreate rather than rebase.

## Checklist

- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests — not applicable; `.github/workflows/renovate-validation.yml` validates this file on PRs that touch it

AI assistance was used to research Renovate's behaviour and draft this change. Every behavioural claim above is backed by a cited line in Renovate 44.52.1's source or by the simulation described under "How this was verified", and the control case reproducing the current live branch names is included so the method can be checked. A human should still confirm the two judgement calls that are preferences rather than facts: monthly versus weekly lock file maintenance, and the Monday window.
