### PR TITLE
Build: Keep `@types/bun` on the Bun release train

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -109,15 +109,17 @@
             ]
         },
         {
-            "description": "Bun and the tool that downloads it are the same release, so a major arrives as one bump rather than a separate PR. This stays off the npm packages above: clearing separateMajorMinor collapses the version lookup to a single latest bucket, so a breaking sass or typescript major would suppress the safe patch on the current line and hold the weekly PR red.",
+            "description": "Bun, the tool that downloads it, and its type definitions are one release train, so a major arrives as a single bump rather than splitting a 2.0 runtime away from 1.x types. This stays off the other npm packages: clearing separateMajorMinor collapses the version lookup to a single latest bucket, so a breaking sass or typescript major would suppress the safe patch on the current line and hold the weekly PR red.",
             "matchPackageNames": [
                 "bun",
-                "BunDotNet.Cli"
+                "BunDotNet.Cli",
+                "@types/bun"
             ],
             "matchFileNames": [
                 "src/Directory.Build.props",
                 ".config/dotnet-tools.json",
-                ".github/renovate.json"
+                ".github/renovate.json",
+                "src/package.json"
             ],
             "separateMajorMinor": false,
             "separateMultipleMajor": false


### PR DESCRIPTION
Follow-up to #13755, closing one gap it left open.

## The gap

`@types/bun` ships the type definitions for the Bun runtime, so its version tracks `BunVersion` — both are `1.4.0` today. But the lockstep rule from #13755 only listed `bun` and `BunDotNet.Cli`, so the two halves of that pair are governed by different `separateMajorMinor` settings.

Simulating a Bun 2.0 against the config currently on `dev`:

| Dependency | Branch |
| --- | --- |
| `BunVersion` (`src/Directory.Build.props`) | `renovate/bun` |
| `constraints.bun` (`.github/renovate.json`) | `renovate/bun` |
| `BunDotNet.Cli` (`.config/dotnet-tools.json`) | `renovate/bun` |
| `@types/bun` (`src/package.json`) | `renovate/major-bun` |

That leaves `renovate/bun` carrying a 2.0 runtime against 1.x type definitions, and the fix sitting in a second PR. It is the same failure class #13755 set out to remove — things that have to move together landing in branches that can be merged independently.

## The fix

Add `@types/bun` to the lockstep rule, and `src/package.json` to its file scope. `matchPackageNames` is the narrowing filter, so this reaches only `@types/bun`; eslint, sass, typescript, `@types/node`, and `@happy-dom/global-registrator` are untouched by it.

The rule deliberately stays off those packages. As #13755 documented, `workers/repository/process/lookup/bucket.js:4` returns the single bucket `latest` when `separateMajorMinor` is false, so every candidate version collapses into one and a breaking major *suppresses the safe patch on the current line*. That is correct behaviour for a lockstep pair like Bun and its types, and wrong for packages with independent release lines.

## Verification

Same method as #13755 — replaying Renovate 44.52.1's real resolution pipeline (`getConfig`, `mergeChildConfig`, `applyPackageRules`, `generateBranchName`) rather than reasoning from the docs:

- `@types/bun` 2.0 now resolves to `renovate/bun` alongside `BunVersion`, `constraints.bun`, and `BunDotNet.Cli`.
- A sass major still correctly splits to `renovate/major-bun`, and eslint and typescript keep `separateMajorMinor: true`.
- `@types/bun` minor updates were already fine and still land on `renovate/bun`.
- Resolved config for `dotnet-sdk`, both `Microsoft.CodeAnalysis` rules, the AspNetCore/Extensions disable, `test platform`, and `Markdig`: byte-identical before and after.
- `renovate-config-validator` passes, as the Renovate Validation workflow re-checks on this PR.

## Related

While checking for other places the Bun version could drift: it lives in exactly three tracked files, all now in this group — `src/Directory.Build.props`, `.github/renovate.json`, and `src/package.json`. `tools/watch.cs` reads `BunVersion` out of the props file at runtime rather than hardcoding it, and no workflow uses `setup-bun`, so there is no fourth copy. `bun` 1.4.0 and `BunDotNet.Cli` 1.3.0 are both current.

## Checklist

- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [ ] I've added or updated relevant unit tests — not applicable; `.github/workflows/renovate-validation.yml` validates this file on PRs that touch it

AI assistance was used to find this gap and draft the change. The behavioural claims are backed by the cited Renovate source line and by the simulation above, whose method was validated in #13755 by reproducing the then-live branch names exactly. A human should confirm the premise that `@types/bun` is meant to track `BunVersion`, since that is a judgement about intent rather than something the tooling states.
