### PR TITLE
Build: Fix the Bun Renovate schedule and ownership

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,7 +90,7 @@
             "rangeStrategy": "pin"
         },
         {
-            "description": "Everything that feeds the Bun asset build moves as one branch: the pinned dev dependencies in package.json, the BunVersion that selects the Bun binary, and the BunDotNet.Cli tool that fetches it. Splitting them let two open PRs rewrite bun.lock at the same time, so merging either one left the other stale. The Monday window and the three-day grace period trade a few days of latency for a single reviewable PR that skips releases pulled in their first days. groupSingleUpdates keeps the group title on the weeks only one package moves.",
+            "description": "Everything that feeds the Bun asset build moves as one branch: the pinned dev dependencies in package.json, the BunVersion that selects the Bun binary, and the BunDotNet.Cli tool that fetches it. Splitting them let two open PRs rewrite bun.lock at the same time, so merging either one left the other stale. The window is the six hours after midnight UTC on Saturday, wide enough to survive a missed Renovate run and closing before the daily AutoTriage sweep at 06:00, so the PR is waiting rather than landing mid-review. With the three-day grace period that trades a few days of latency for a single reviewable PR that skips releases pulled in their first days. groupSingleUpdates keeps the group title on the weeks only one package moves.",
             "matchFileNames": [
                 "src/package.json",
                 "src/Directory.Build.props",
@@ -100,7 +100,7 @@
             "groupName": "bun",
             "groupSlug": "bun",
             "schedule": [
-                "* 0-3 * * 1"
+                "* 0-5 * * 6"
             ],
             "minimumReleaseAge": "3 days",
             "groupSingleUpdates": true,
@@ -125,6 +125,17 @@
             "separateMultipleMajor": false
         },
         {
+            "description": "The Bun group is scoped by file, and .config/dotnet-tools.json is a nuget manifest, so the nuget lock file maintenance update for it would otherwise inherit the Bun group name and grace period. That splits it away from the rest of the nuget lock file work and pins a stability check yellow forever, because a maintenance update carries no release timestamp. Reset every maintenance update to Renovate's own defaults here, leaving the nuget lock file work on the cadence it had before the Bun group existed; the rule below opts only the Bun lock file back in.",
+            "matchUpdateTypes": [
+                "lockFileMaintenance"
+            ],
+            "groupName": null,
+            "minimumReleaseAge": null,
+            "schedule": [
+                "before 4am on monday"
+            ]
+        },
+        {
             "description": "Renovate refuses to put lock file maintenance in a branch with any other update type, so this is the one Bun PR that cannot join the group above. It is also the only thing that ever moves a transitive in bun.lock, because the bun manager does not implement updateLockedDependency. Clearing minimumReleaseAge is required, not cosmetic: a maintenance update carries no release timestamp, so inheriting the group's grace period would pin a stability status check to yellow forever. constraints.bun must keep tracking BunVersion: maintenance regenerates bun.lock from scratch, and a newer bun writes lockfileVersion 2, which the pinned bun cannot read.",
             "matchUpdateTypes": [
                 "lockFileMaintenance"
@@ -135,7 +146,7 @@
             "groupName": "bun lock file",
             "groupSlug": "bun-lock-file",
             "schedule": [
-                "* 0-3 1-7 * 1"
+                "* 0-5 1-7 * 6"
             ],
             "minimumReleaseAge": null,
             "groupSingleUpdates": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,6 +90,16 @@
             "rangeStrategy": "pin"
         },
         {
+            "description": "constraints.bun is already owned by the second custom manager at the end of this file, which reads it through the npm datasource so it resolves to the same version as BunVersion. Renovate 44 also ships a built-in renovate-config manager that reads the same line as a containerbase tool constraint from github-releases, so one field ended up with two owners in one branch, resolving against two different release feeds. Those feeds do disagree: the GitHub release is cut before the npm publish, sometimes by an hour or more, and 1.1.23 was released on GitHub and never published to npm at all. When they disagree Renovate keeps the built-in answer, drops the custom one with an info-level log line that reaches neither the pull request nor the dashboard, and the commit then sets constraints.bun to a version BunVersion is not moving to. Disable the one dependency rather than the manager, which stays useful for a pinned remote preset or another tool constraint added here later. matchDepNames is what makes this match: the dependency's package name is oven-sh/bun, so matchPackageNames would silently never fire.",
+            "matchManagers": [
+                "renovate-config"
+            ],
+            "matchDepNames": [
+                "bun"
+            ],
+            "enabled": false
+        },
+        {
             "description": "Everything that feeds the Bun asset build moves as one branch: the pinned dev dependencies in package.json, the BunVersion that selects the Bun binary, and the BunDotNet.Cli tool that fetches it. Splitting them let two open PRs rewrite bun.lock at the same time, so merging either one left the other stale. The window is the six hours after midnight UTC on Saturday, wide enough to survive a missed Renovate run and closing before the daily AutoTriage sweep at 06:00, so the PR is waiting rather than landing mid-review. With the three-day grace period that trades a few days of latency for a single reviewable PR that skips releases pulled in their first days. groupSingleUpdates keeps the group title on the weeks only one package moves.",
             "matchFileNames": [
                 "src/package.json",
@@ -125,12 +135,13 @@
             "separateMultipleMajor": false
         },
         {
-            "description": "The Bun group is scoped by file, and .config/dotnet-tools.json is a nuget manifest, so the nuget lock file maintenance update for it would otherwise inherit the Bun group name and grace period. That splits it away from the rest of the nuget lock file work and pins a stability check yellow forever, because a maintenance update carries no release timestamp. Reset every maintenance update to Renovate's own defaults here, leaving the nuget lock file work on the cadence it had before the Bun group existed; the rule below opts only the Bun lock file back in.",
+            "description": "The Bun group is scoped by file, and .config/dotnet-tools.json is a nuget manifest, so the nuget lock file maintenance update for it would otherwise inherit the Bun group name, grace period and reviewer. The group name splits it away from the rest of the nuget lock file work, and the grace period pins a stability check yellow forever because a maintenance update carries no release timestamp. The reviewer has to be cleared by hand as well: it is not a group setting, so clearing the group name leaves it on the update, and whether it reaches the pull request depends on which manifest the shared nuget branch happens to take its settings from. Clear it here rather than resting on that ordering. groupSlug and groupSingleUpdates need no reset because Renovate only reads them while a group name is set, and an empty list clears reviewers because Renovate replaces that option rather than merging it; a merged list such as addLabels would need null instead. This leaves the nuget lock file work on the cadence it had before the Bun group existed; the rule below opts only the Bun lock file back in.",
             "matchUpdateTypes": [
                 "lockFileMaintenance"
             ],
             "groupName": null,
             "minimumReleaseAge": null,
+            "reviewers": [],
             "schedule": [
                 "before 4am on monday"
             ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,7 +90,7 @@
             "rangeStrategy": "pin"
         },
         {
-            "description": "constraints.bun is already owned by the second custom manager at the end of this file, which reads it through the npm datasource so it resolves to the same version as BunVersion. Renovate 44 also ships a built-in renovate-config manager that reads the same line as a containerbase tool constraint from github-releases, so one field ended up with two owners in one branch, resolving against two different release feeds. Those feeds do disagree: the GitHub release is cut before the npm publish, sometimes by an hour or more, and 1.1.23 was released on GitHub and never published to npm at all. When they disagree Renovate keeps the built-in answer, drops the custom one with an info-level log line that reaches neither the pull request nor the dashboard, and the commit then sets constraints.bun to a version BunVersion is not moving to. Disable the one dependency rather than the manager, which stays useful for a pinned remote preset or another tool constraint added here later. matchDepNames is what makes this match: the dependency's package name is oven-sh/bun, so matchPackageNames would silently never fire.",
+            "description": "The built-in renovate-config manager reads this same constraint from GitHub releases, so the field had two owners on two feeds. matchDepNames is load-bearing: that dependency's package name is oven-sh/bun.",
             "matchManagers": [
                 "renovate-config"
             ],
@@ -100,7 +100,7 @@
             "enabled": false
         },
         {
-            "description": "Everything that feeds the Bun asset build moves as one branch: the pinned dev dependencies in package.json, the BunVersion that selects the Bun binary, and the BunDotNet.Cli tool that fetches it. Splitting them let two open PRs rewrite bun.lock at the same time, so merging either one left the other stale. The window is the six hours after midnight UTC on Saturday, wide enough to survive a missed Renovate run and closing before the daily AutoTriage sweep at 06:00, so the PR is waiting rather than landing mid-review. With the three-day grace period that trades a few days of latency for a single reviewable PR that skips releases pulled in their first days. groupSingleUpdates keeps the group title on the weeks only one package moves.",
+            "description": "One branch for everything that feeds the Bun build, so two open PRs can never rewrite bun.lock at once. The Saturday window closes before the 06:00 AutoTriage sweep, and groupSingleUpdates keeps the group title on weeks when only one package moves.",
             "matchFileNames": [
                 "src/package.json",
                 "src/Directory.Build.props",
@@ -119,7 +119,7 @@
             ]
         },
         {
-            "description": "Bun, the tool that downloads it, and its type definitions are one release train, so a major arrives as a single bump rather than splitting a 2.0 runtime away from 1.x types. This stays off the other npm packages: clearing separateMajorMinor collapses the version lookup to a single latest bucket, so a breaking sass or typescript major would suppress the safe patch on the current line and hold the weekly PR red.",
+            "description": "Bun, the tool that downloads it and its type definitions are one release train. Keep this off the other npm packages: clearing separateMajorMinor collapses the lookup to a single bucket, so a major would suppress the safe patch on the current line.",
             "matchPackageNames": [
                 "bun",
                 "BunDotNet.Cli",
@@ -135,7 +135,7 @@
             "separateMultipleMajor": false
         },
         {
-            "description": "The Bun group is scoped by file, and .config/dotnet-tools.json is a nuget manifest, so the nuget lock file maintenance update for it would otherwise inherit the Bun group name, grace period and reviewer. The group name splits it away from the rest of the nuget lock file work, and the grace period pins a stability check yellow forever because a maintenance update carries no release timestamp. The reviewer has to be cleared by hand as well: it is not a group setting, so clearing the group name leaves it on the update, and whether it reaches the pull request depends on which manifest the shared nuget branch happens to take its settings from. Clear it here rather than resting on that ordering. groupSlug and groupSingleUpdates need no reset because Renovate only reads them while a group name is set, and an empty list clears reviewers because Renovate replaces that option rather than merging it; a merged list such as addLabels would need null instead. This leaves the nuget lock file work on the cadence it had before the Bun group existed; the rule below opts only the Bun lock file back in.",
+            "description": "Undo the Bun group's reach into other managers' maintenance updates, since .config/dotnet-tools.json is a nuget manifest. reviewers is not a group setting, so clearing the group name leaves it behind; groupSlug and groupSingleUpdates need no reset because they are read only while a group name is set.",
             "matchUpdateTypes": [
                 "lockFileMaintenance"
             ],
@@ -147,7 +147,7 @@
             ]
         },
         {
-            "description": "Renovate refuses to put lock file maintenance in a branch with any other update type, so this is the one Bun PR that cannot join the group above. It is also the only thing that ever moves a transitive in bun.lock, because the bun manager does not implement updateLockedDependency. Clearing minimumReleaseAge is required, not cosmetic: a maintenance update carries no release timestamp, so inheriting the group's grace period would pin a stability status check to yellow forever. constraints.bun must keep tracking BunVersion: maintenance regenerates bun.lock from scratch, and a newer bun writes lockfileVersion 2, which the pinned bun cannot read.",
+            "description": "Renovate will not put lock file maintenance in a branch with anything else, so this cannot join the group above. It is also the only thing that moves a transitive in bun.lock, because the bun manager has no updateLockedDependency.",
             "matchUpdateTypes": [
                 "lockFileMaintenance"
             ],
@@ -196,7 +196,7 @@
             "datasourceTemplate": "npm"
         },
         {
-            "description": "constraints.bun selects the Bun that regenerates bun.lock, so it has to move in the same commit as BunVersion. Reading it back out of this file is the only way Renovate can own both halves; left to a human it drifts, and a newer Bun writes lockfileVersion 2 that the pinned Bun cannot read.",
+            "description": "Keeps constraints.bun on the same npm feed as BunVersion, so the Bun that regenerates bun.lock cannot drift from the one that builds the assets.",
             "customType": "regex",
             "managerFilePatterns": [
                 "/^\\.github/renovate\\.json$/"


### PR DESCRIPTION
Follow-up to #13755 and #13756, which shipped three defects between them. Full reproductions are in [this comment](https://github.com/MudBlazor/MudBlazor/pull/13758#issuecomment-5481602194).

**The window moves to Saturday.** The group ran in a four-hour Monday slot and #13755 merged eight minutes after it closed, leaving the first grouped PR queued for a week. Now `* 0-5 * * 6` — the six hours after midnight UTC on Saturday, which is Friday evening in US Central and closes before `autotriage-backlog.yml`'s `0 6 * * *`. The Bun lock file follows to `* 0-5 1-7 * 6`, first Saturday only.

**`constraints.bun` gets a single owner.** Renovate's built-in `renovate-config` manager has read that field since #13657, so the custom manager added in #13755 made it owned twice in one branch, resolving against npm and GitHub releases. Those feeds disagree in practice — `bun-v1.1.23` was released on GitHub and never published to npm — and on a disagreement Renovate drops one silently, so a commit could set `constraints.bun` to a version `BunVersion` is not moving to. Keeping the npm owner makes that impossible, since it shares `BunVersion`'s feed. The built-in is disabled for this one dependency, not wholesale, so it stays available for a pinned preset later. `matchDepNames` is required rather than `matchPackageNames`: the built-in dep's package name is `oven-sh/bun`.

**The Bun group stops reaching into nuget's lock maintenance.** The group is scoped by file and `.config/dotnet-tools.json` is a nuget manifest, so nuget's maintenance update for it inherited the group name, grace period and reviewer — splitting it into a third branch and, since maintenance updates carry no release timestamp, pinning a stability check yellow.

| lock file maintenance | before #13755 | `dev` today | this PR |
| --- | --- | --- | --- |
| `src/package.json` (bun) | `…-bun-dependencies` | `…-bun-lock-file` | `…-bun-lock-file` |
| `.config/dotnet-tools.json` (nuget) | `lock-file-maintenance` | `…-maintenance-bun`, grace `3 days` | `lock-file-maintenance` |
| `src/**/*.csproj` (nuget) | `lock-file-maintenance` | `lock-file-maintenance` | `lock-file-maintenance` |

A reset rule matching every `lockFileMaintenance` update restores Renovate's defaults, and the Bun rule after it opts only `src/package.json` back in. `reviewers` needs clearing explicitly because it is not a group setting; `groupSlug` and `groupSingleUpdates` are read only while a group name is set.

Rule descriptions are also trimmed back to one fact each.