### PR TITLE
MudDivider: Fix light divider palette color

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -114,7 +114,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-palette-table-hover: rgba(0,0,0,0.0392156862745098);",
                 "--mud-palette-divider: rgba(224,224,224,1);",
                 "--mud-palette-divider-rgb: 224,224,224;",
-                "--mud-palette-divider-light: rgba(0,0,0,0.06);",
+                "--mud-palette-divider-light: rgba(0,0,0,0.058823529411764705);",
                 "--mud-palette-skeleton: rgba(0,0,0,0.10980392156862745);",
                 "--mud-palette-gray-default: #9E9E9E;",
                 "--mud-palette-gray-light: #BDBDBD;",

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -114,7 +114,7 @@ namespace MudBlazor.UnitTests.Components
                 "--mud-palette-table-hover: rgba(0,0,0,0.0392156862745098);",
                 "--mud-palette-divider: rgba(224,224,224,1);",
                 "--mud-palette-divider-rgb: 224,224,224;",
-                "--mud-palette-divider-light: rgba(0,0,0,0.8);",
+                "--mud-palette-divider-light: rgba(0,0,0,0.06);",
                 "--mud-palette-skeleton: rgba(0,0,0,0.10980392156862745);",
                 "--mud-palette-gray-default: #9E9E9E;",
                 "--mud-palette-gray-light: #BDBDBD;",

--- a/src/MudBlazor/Themes/Models/Palette.cs
+++ b/src/MudBlazor/Themes/Models/Palette.cs
@@ -224,7 +224,7 @@ namespace MudBlazor
         /// <summary>
         /// The light color for dividers.
         /// </summary>
-        public virtual MudColor DividerLight { get; set; } = new MudColor(Colors.Shades.Black).SetAlpha(0.8).ToString(MudColorOutputFormats.RGBA);
+        public virtual MudColor DividerLight { get; set; } = new MudColor(Colors.Shades.Black).SetAlpha(0.06).ToString(MudColorOutputFormats.RGBA);
 
         /// <summary>
         /// The color for skeletons.


### PR DESCRIPTION
## Description

`Palette.DividerLight` used 80% black opacity in the light theme, making a `MudDivider` with `Light="true"` substantially darker than the normal divider. This changes the default to 6% black opacity, matching the intended lighter appearance and the dark palette's light-divider opacity.

The existing theme CSS regression expectation is updated from `rgba(0,0,0,0.8)` to the serialized 6% alpha value, `rgba(0,0,0,0.058823529411764705)`.

## Testing

- `git diff --check`
- Repository CI builds and tests (the required .NET SDK 10.0.400 is not installed locally).

Fixes #5669
