### PR TITLE
MudInput: Fix legend overflowing when the label is too long in a MudDialog

### DIFF
--- a/src/MudBlazor/Styles/components/_input.scss
+++ b/src/MudBlazor/Styles/components/_input.scss
@@ -171,6 +171,7 @@
         margin: 0 11px 0 11px;
         padding: 0;
         position: relative;
+        overflow: hidden;
       }
     }
 


### PR DESCRIPTION
Fix legend overflowing when the label is too long in a MudDialog causing an unwanted scrollbar to appear in the MudDialogContent.

**Before/After:**
BEFORE:
<img width="314" height="229" alt="image" src="https://github.com/user-attachments/assets/173f36e2-1f54-429a-ad9a-14b3b032251d" />

AFTER:
<img width="304" height="212" alt="image" src="https://github.com/user-attachments/assets/eaee2ebb-b517-4814-8211-2fa211bf1358" />

**Steps to reproduce**
1. Create a basic MudBlazor project from a template
2. Add a MudDialog with a MudForm and a MudTextField. Set a long label in the MudTextField. For example;
```razor
<MudDialog>
    <DialogContent>
        <MudForm>
            <MudTextField T="string"
                          FullWidth="false"
                          Label="This is a very long label which causes problems in a dialog."
                          Margin="Margin.Dense"
                          Variant="Variant.Outlined"/>
        </MudForm>
    </DialogContent>
    <DialogActions>
        <MudButton>Cancel</MudButton>
        <MudButton Color="Color.Primary"
                   Variant="Variant.Filled">Create</MudButton>
    </DialogActions>
</MudDialog>
```