### PR TITLE
Various components: Improve ARIA semantics

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AvatarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarTests.cs
@@ -1,0 +1,39 @@
+﻿using AwesomeAssertions;
+using Bunit;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class AvatarTests : BunitTest
+    {
+        /// <summary>
+        /// An avatar without an accessible name must not claim role="img", which would hide its initials.
+        /// </summary>
+        [Test]
+        public void Avatar_WithoutAccessibleName_ShouldNotClaimImageRole()
+        {
+            var comp = Context.Render<MudAvatar>(parameters => parameters.AddChildContent("AB"));
+
+            // role="img" without a name hides the initials from assistive technology.
+            comp.Find("div.mud-avatar").HasAttribute("role").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// An avatar with an ARIA name exposes role="img".
+        /// </summary>
+        [Test]
+        [TestCase("aria-label", "Jane Doe")]
+        [TestCase("aria-labelledby", "avatar-name")]
+        public void Avatar_WithAccessibleName_ShouldExposeImageRole(string attribute, string value)
+        {
+            var comp = Context.Render<MudAvatar>(parameters => parameters
+                .AddUnmatched(attribute, value)
+                .AddChildContent("AB"));
+
+            var avatar = comp.Find("div.mud-avatar");
+            avatar.GetAttribute("role").Should().Be("img");
+            avatar.GetAttribute(attribute).Should().Be(value);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/AvatarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarTests.cs
@@ -2,38 +2,37 @@
 using Bunit;
 using NUnit.Framework;
 
-namespace MudBlazor.UnitTests.Components
+namespace MudBlazor.UnitTests.Components;
+
+[TestFixture]
+public class AvatarTests : BunitTest
 {
-    [TestFixture]
-    public class AvatarTests : BunitTest
+    /// <summary>
+    /// An avatar without an accessible name must not claim role="img", which would hide its initials.
+    /// </summary>
+    [Test]
+    public void Avatar_WithoutAccessibleName_ShouldNotClaimImageRole()
     {
-        /// <summary>
-        /// An avatar without an accessible name must not claim role="img", which would hide its initials.
-        /// </summary>
-        [Test]
-        public void Avatar_WithoutAccessibleName_ShouldNotClaimImageRole()
-        {
-            var comp = Context.Render<MudAvatar>(parameters => parameters.AddChildContent("AB"));
+        var comp = Context.Render<MudAvatar>(parameters => parameters.AddChildContent("AB"));
 
-            // role="img" without a name hides the initials from assistive technology.
-            comp.Find("div.mud-avatar").HasAttribute("role").Should().BeFalse();
-        }
+        // role="img" without a name hides the initials from assistive technology.
+        comp.Find("div.mud-avatar").HasAttribute("role").Should().BeFalse();
+    }
 
-        /// <summary>
-        /// An avatar with an ARIA name exposes role="img".
-        /// </summary>
-        [Test]
-        [TestCase("aria-label", "Jane Doe")]
-        [TestCase("aria-labelledby", "avatar-name")]
-        public void Avatar_WithAccessibleName_ShouldExposeImageRole(string attribute, string value)
-        {
-            var comp = Context.Render<MudAvatar>(parameters => parameters
-                .AddUnmatched(attribute, value)
-                .AddChildContent("AB"));
+    /// <summary>
+    /// An avatar with an ARIA name exposes role="img".
+    /// </summary>
+    [Test]
+    [TestCase("aria-label", "Jane Doe")]
+    [TestCase("aria-labelledby", "avatar-name")]
+    public void Avatar_WithAccessibleName_ShouldExposeImageRole(string attribute, string value)
+    {
+        var comp = Context.Render<MudAvatar>(parameters => parameters
+            .AddUnmatched(attribute, value)
+            .AddChildContent("AB"));
 
-            var avatar = comp.Find("div.mud-avatar");
-            avatar.GetAttribute("role").Should().Be("img");
-            avatar.GetAttribute(attribute).Should().Be(value);
-        }
+        var avatar = comp.Find("div.mud-avatar");
+        avatar.GetAttribute("role").Should().Be("img");
+        avatar.GetAttribute(attribute).Should().Be(value);
     }
 }

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -304,5 +304,24 @@ namespace MudBlazor.UnitTests.Components
 
             await comp.WaitForAssertionAsync(() => MudBreadcrumbs.GetItemClassname(comp.Instance.Items[1]).Should().Be("mud-breadcrumb-item"));
         }
+
+        /// <summary>
+        /// The last breadcrumb is marked as the current page.
+        /// </summary>
+        [Test]
+        public void MudBreadcrumbs_ShouldMarkLastItemAsCurrentPage()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>
+            {
+                new("Link 1", "link1"),
+                new("Link 2", "link2"),
+                new("Link 3", "link3", disabled: true)
+            }));
+
+            var links = comp.FindAll("li.mud-breadcrumb-item > a");
+            links[0].HasAttribute("aria-current").Should().BeFalse();
+            links[1].HasAttribute("aria-current").Should().BeFalse();
+            links[2].GetAttribute("aria-current").Should().Be("page");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
+++ b/src/MudBlazor.UnitTests/Components/BreadcrumbTests.cs
@@ -323,5 +323,55 @@ namespace MudBlazor.UnitTests.Components
             links[1].HasAttribute("aria-current").Should().BeFalse();
             links[2].GetAttribute("aria-current").Should().Be("page");
         }
+
+        /// <summary>
+        /// A collapsed trail still marks its last item as the current page.
+        /// </summary>
+        [Test]
+        public void MudBreadcrumbs_Collapsed_ShouldMarkLastItemAsCurrentPage()
+        {
+            var comp = Context.Render<MudBreadcrumbs>(parameters => parameters
+                .Add(x => x.MaxItems, (byte)2)
+                .Add(x => x.Items, new List<BreadcrumbItem>
+                {
+                    new("Link 1", "link1"),
+                    new("Link 2", "link2"),
+                    new("Link 3", "link3")
+                }));
+
+            var links = comp.FindAll("li.mud-breadcrumb-item > a");
+            links.Count.Should().Be(2);
+            links[0].HasAttribute("aria-current").Should().BeFalse();
+            links[1].GetAttribute("aria-current").Should().Be("page");
+        }
+
+        /// <summary>
+        /// A link rendered outside a breadcrumb trail has no current page to report.
+        /// </summary>
+        [Test]
+        public void BreadcrumbLink_WithoutParent_ShouldNotClaimCurrentPage()
+        {
+            var comp = Context.Render<BreadcrumbLink>(parameters => parameters.Add(x => x.Item, new BreadcrumbItem("Link", "link")));
+
+            comp.Find("a").HasAttribute("aria-current").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Only the last of the supplied items counts as the current page.
+        /// </summary>
+        [Test]
+        public void MudBreadcrumbs_IsLastItem_ShouldOnlyMatchTheLastItem()
+        {
+            var first = new BreadcrumbItem("First", "first");
+            var last = new BreadcrumbItem("Last", "last");
+
+            Context.Render<MudBreadcrumbs>().Instance.IsLastItem(last).Should().BeFalse();
+            Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem>())).Instance.IsLastItem(last).Should().BeFalse();
+
+            var breadcrumbs = Context.Render<MudBreadcrumbs>(parameters => parameters.Add(x => x.Items, new List<BreadcrumbItem> { first, last })).Instance;
+            breadcrumbs.IsLastItem(first).Should().BeFalse();
+            breadcrumbs.IsLastItem(last).Should().BeTrue();
+            breadcrumbs.IsLastItem(null).Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -628,5 +628,51 @@ namespace MudBlazor.UnitTests.Components
             chip.GetAttribute("aria-pressed").Should().Be("true");
             chip.GetAttribute("aria-disabled").Should().Be("true");
         }
+
+        /// <summary>
+        /// A read-only set still reports each chip as a button with its selection state, but not as disabled.
+        /// </summary>
+        [Test]
+        public void ChipSet_ReadOnly_ShouldKeepButtonSemanticsWithoutDisabledState()
+        {
+            var comp = Context.Render<MudChipSet<string>>(parameters => parameters
+                .Add(p => p.ReadOnly, true)
+                .Add(p => p.SelectedValue, "Milk")
+                .Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudChip<string>>(0);
+                    builder.AddAttribute(1, nameof(MudChip<string>.Value), "Milk");
+                    builder.CloseComponent();
+                }));
+
+            var chip = comp.Find(".mud-chip");
+            chip.TagName.Should().Be("DIV");
+            chip.GetAttribute("role").Should().Be("button");
+            chip.GetAttribute("aria-pressed").Should().Be("true");
+            chip.HasAttribute("aria-disabled").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A chip that renders as a link inside a set is not a toggle button, so it carries no aria-pressed.
+        /// </summary>
+        [Test]
+        public void ChipSet_AnchorChip_ShouldNotExposeToggleState()
+        {
+            var comp = Context.Render<MudChipSet<string>>(parameters => parameters
+                .Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudChip<string>>(0);
+                    builder.AddAttribute(1, nameof(MudChip<string>.Value), "Milk");
+                    builder.AddAttribute(2, nameof(MudChip<string>.Href), "https://example.com");
+                    // A clickable chip is always a button; only a non-clickable one falls back to the anchor.
+                    builder.AddAttribute(3, nameof(MudChip<string>.Disabled), true);
+                    builder.CloseComponent();
+                }));
+
+            var chip = comp.Find(".mud-chip");
+            chip.TagName.Should().Be("A");
+            chip.HasAttribute("role").Should().BeFalse();
+            chip.HasAttribute("aria-pressed").Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipSetTests.cs
@@ -1,6 +1,7 @@
 ﻿using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Examples;
 using MudBlazor.UnitTests.TestComponents.ChipSet;
 using NUnit.Framework;
@@ -587,6 +588,45 @@ namespace MudBlazor.UnitTests.Components
             {
                 passes[i].Should().Be(afterMount[i], $"chip {i} did not change and should not have re-rendered");
             }
+        }
+
+        /// <summary>
+        /// Chips in a set report their selection through aria-pressed.
+        /// </summary>
+        [Test]
+        public async Task ChipSet_ShouldExposeSelectedStateViaAriaPressed()
+        {
+            var comp = Context.Render<ChipSetSingleSelectionTest>();
+
+            comp.FindAll(".mud-chip").Should().OnlyContain(chip => chip.GetAttribute("aria-pressed") == "false");
+
+            await comp.FindAll(".mud-chip")[0].ClickAsync(new MouseEventArgs());
+
+            comp.FindAll(".mud-chip")[0].GetAttribute("aria-pressed").Should().Be("true");
+            comp.FindAll(".mud-chip")[1].GetAttribute("aria-pressed").Should().Be("false");
+        }
+
+        /// <summary>
+        /// A disabled chip in a set keeps its button role, selection state, and disabled state.
+        /// </summary>
+        [Test]
+        public void ChipSet_DisabledChip_ShouldKeepButtonSemantics()
+        {
+            var comp = Context.Render<MudChipSet<string>>(parameters => parameters
+                .Add(p => p.SelectedValue, "Milk")
+                .Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudChip<string>>(0);
+                    builder.AddAttribute(1, nameof(MudChip<string>.Value), "Milk");
+                    builder.AddAttribute(2, nameof(MudChip<string>.Disabled), true);
+                    builder.CloseComponent();
+                }));
+
+            var chip = comp.Find(".mud-chip");
+            chip.TagName.Should().Be("DIV");
+            chip.GetAttribute("role").Should().Be("button");
+            chip.GetAttribute("aria-pressed").Should().Be("true");
+            chip.GetAttribute("aria-disabled").Should().Be("true");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ChipTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChipTests.cs
@@ -219,5 +219,38 @@ namespace MudBlazor.UnitTests.Components
             var expectedEvent = comp.Find("#chip-click-test-expected-value");
             expectedEvent.InnerHtml.Should().Be("OnClose");
         }
+
+        /// <summary>
+        /// A disabled clickable chip keeps its button role and reports aria-disabled.
+        /// </summary>
+        [Test]
+        public void Chip_Disabled_ShouldExposeAriaDisabled()
+        {
+            var comp = Context.Render<MudChip<string>>(parameters => parameters
+                .Add(p => p.Disabled, true)
+                .Add(p => p.OnClick, () => { }));
+
+            var chip = comp.Find(".mud-chip");
+            chip.TagName.Should().Be("DIV");
+            chip.GetAttribute("role").Should().Be("button");
+            chip.GetAttribute("aria-disabled").Should().Be("true");
+            chip.HasAttribute("aria-pressed").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A chip that is not clickable is a plain element with no button role or state.
+        /// </summary>
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Chip_Plain_ShouldNotExposeToggleState(bool disabled)
+        {
+            var comp = Context.Render<MudChip<string>>(parameters => parameters.Add(p => p.Disabled, disabled));
+
+            var chip = comp.Find(".mud-chip");
+            chip.HasAttribute("role").Should().BeFalse();
+            chip.HasAttribute("aria-disabled").Should().BeFalse();
+            chip.HasAttribute("aria-pressed").Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/OverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/OverlayTests.cs
@@ -432,4 +432,29 @@ public class OverlayTests : BunitTest
                 It.IsAny<object[]>()),
             Times.Never);
     }
+
+    /// <summary>
+    /// An overlay without content is hidden from assistive technology.
+    /// </summary>
+    [Test]
+    public void ShouldBeHiddenFromAssistiveTechnologies_WhenDecorative()
+    {
+        var providerComp = Context.Render<MudPopoverProvider>();
+        Context.Render<MudOverlay>(parameters => parameters.Add(p => p.Visible, true));
+
+        providerComp.Find("div.mud-overlay").GetAttribute("aria-hidden").Should().Be("true");
+    }
+
+    /// <summary>
+    /// An overlay with content stays exposed to assistive technology.
+    /// </summary>
+    [Test]
+    public void ShouldStayExposed_WhenItHasContent()
+    {
+        var comp = Context.Render<MudOverlay>(parameters => parameters
+            .Add(p => p.Visible, true)
+            .AddChildContent("<span>Loading</span>"));
+
+        comp.Find("div.mud-overlay").HasAttribute("aria-hidden").Should().BeFalse();
+    }
 }

--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -373,5 +373,20 @@ namespace MudBlazor.UnitTests.Components
             //test if rtl is used
             pagination.ClassName.Should().Contain("mud-pagination-rtl");
         }
+
+        /// <summary>
+        /// Pagination ellipses are hidden from assistive technology.
+        /// </summary>
+        [Test]
+        public void Pagination_EllipsisShouldBeHiddenFromAssistiveTechnologies()
+        {
+            var comp = Context.Render<MudPagination>(parameters => parameters
+                .Add(p => p.Count, 20)
+                .Add(p => p.Selected, 10));
+
+            var ellipses = comp.FindAll("li").Where(li => li.TextContent.Trim() == "…").ToList();
+            ellipses.Should().NotBeEmpty();
+            ellipses.Should().OnlyContain(li => li.FirstElementChild!.GetAttribute("aria-hidden") == "true");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/RatingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RatingTests.cs
@@ -314,5 +314,30 @@ namespace MudBlazor.UnitTests.Components
             await comp.InvokeAsync(() => item.Instance.HandlePointerOutAsync(new PointerEventArgs()));
             await comp.InvokeAsync(() => item.Instance.HandlePointerOverAsync(new PointerEventArgs()));
         }
+
+        /// <summary>
+        /// The rating group is named and its radios drop the unsupported aria-readonly.
+        /// </summary>
+        [Test]
+        public void Rating_ShouldExposeAccessibleNameAndValidRadioAttributes()
+        {
+            var comp = Context.Render<MudRating>();
+
+            comp.Find("span.mud-rating-root").GetAttribute("aria-label").Should().Be("Rating");
+            // aria-readonly is not supported on the radio role; it lives on the radiogroup instead.
+            comp.FindAll("input.mud-rating-input").Should().OnlyContain(input => !input.HasAttribute("aria-readonly"));
+            comp.Find("span.mud-rating-root").GetAttribute("aria-readonly").Should().Be("false");
+        }
+
+        /// <summary>
+        /// A user-supplied aria-label replaces the default rating name.
+        /// </summary>
+        [Test]
+        public void Rating_ShouldAllowUserAriaLabelOverride()
+        {
+            var comp = Context.Render<MudRating>(parameters => parameters.AddUnmatched("aria-label", "Quality"));
+
+            comp.Find("span.mud-rating-root").GetAttribute("aria-label").Should().Be("Quality");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SkeletonTests.cs
@@ -66,5 +66,18 @@ namespace MudBlazor.UnitTests.Components
             span = comp.Find("span");
             span.Attributes.GetNamedItem("style")?.Value.Should().Be("width:500px;");
         }
+
+        /// <summary>
+        /// A skeleton is hidden from assistive technology unless the user overrides it.
+        /// </summary>
+        [Test]
+        public void SkeletonShouldBeHiddenFromAssistiveTechnologies()
+        {
+            var comp = Context.Render<MudSkeleton>();
+            comp.Find("span.mud-skeleton").GetAttribute("aria-hidden").Should().Be("true");
+
+            var overridden = Context.Render<MudSkeleton>(parameters => parameters.AddUnmatched("aria-hidden", "false"));
+            overridden.Find("span.mud-skeleton").GetAttribute("aria-hidden").Should().Be("false");
+        }
     }
 }

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor
@@ -3,7 +3,7 @@
 
 @if(AvatarGroup == null || !AvatarGroup.MaxGroupReached(this))
 {
-    <div role="img" @attributes="UserAttributes" class="@Classname" style="@Stylesname">
+    <div role="@(HasAccessibleName() ? "img" : null)" @attributes="UserAttributes" class="@Classname" style="@Stylesname">
         @ChildContent
     </div>
 }

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
 
@@ -12,6 +13,14 @@ namespace MudBlazor
     {
         [CascadingParameter]
         protected MudAvatarGroup? AvatarGroup { get; set; }
+
+        /// <summary>
+        /// Whether the consumer supplied an accessible name; <c>role="img"</c> is only valid with one.
+        /// </summary>
+        private bool HasAccessibleName() =>
+            UserAttributes.Keys.Any(key =>
+                key.Equals("aria-label", StringComparison.OrdinalIgnoreCase)
+                || key.Equals("aria-labelledby", StringComparison.OrdinalIgnoreCase));
 
         protected string Classname => new CssBuilder("mud-avatar")
             .AddClass($"mud-avatar-{Size.ToStringFast(true)}")

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor
@@ -4,7 +4,7 @@
 <li class="@Classname">
     @if (Parent?.ItemTemplate is null)
     {
-        <a href="@(Item?.Href ?? "#")">
+        <a href="@(Item?.Href ?? "#")" aria-current="@(IsCurrentPage ? "page" : null)">
             @if (Item?.Icon != null)
             {
                 <MudIcon Icon="@Item?.Icon" Size="Size.Small" />

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
@@ -31,7 +31,7 @@ public partial class BreadcrumbLink
     /// <summary>
     /// Whether this item is the last one in the trail and therefore represents the current page.
     /// </summary>
-    private bool IsCurrentPage => Item is not null && Parent?.Items is { Count: > 0 } items && ReferenceEquals(items[^1], Item);
+    private bool IsCurrentPage => Parent?.IsLastItem(Item) == true;
 
     private string Classname => new CssBuilder("mud-breadcrumb-item")
         .AddClass("mud-disabled", Item?.Disabled)

--- a/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/BreadcrumbLink.razor.cs
@@ -28,6 +28,11 @@ public partial class BreadcrumbLink
     [CascadingParameter]
     public MudBreadcrumbs? Parent { get; set; }
 
+    /// <summary>
+    /// Whether this item is the last one in the trail and therefore represents the current page.
+    /// </summary>
+    private bool IsCurrentPage => Item is not null && Parent?.Items is { Count: > 0 } items && ReferenceEquals(items[^1], Item);
+
     private string Classname => new CssBuilder("mud-breadcrumb-item")
         .AddClass("mud-disabled", Item?.Disabled)
         .Build();

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor.cs
@@ -76,6 +76,11 @@ namespace MudBlazor
         /// </remarks>
         public bool Collapsed { get; private set; } = true;
 
+        /// <summary>
+        /// Whether <paramref name="item"/> is the last item in the trail and therefore represents the current page.
+        /// </summary>
+        internal bool IsLastItem(BreadcrumbItem? item) => Items is { Count: > 0 } && ReferenceEquals(Items[^1], item);
+
         internal static string GetItemClassname(BreadcrumbItem item)
         {
             return new CssBuilder("mud-breadcrumb-item")

--- a/src/MudBlazor/Components/Chip/MudChip.razor.cs
+++ b/src/MudBlazor/Components/Chip/MudChip.razor.cs
@@ -131,6 +131,23 @@ public partial class MudChip<T> : MudComponentBase, IAsyncDisposable
         else
         {
             attributes.Add("tabindex", -1);
+
+            if (ChipSet is not null || OnClick.HasDelegate)
+            {
+                // A disabled or read-only chip is still a button semantically; it only renders as a plain element.
+                attributes.Add("role", "button");
+
+                if (GetDisabled())
+                {
+                    attributes.Add("aria-disabled", "true");
+                }
+            }
+        }
+
+        if (ChipSet is not null && !IsAnchor)
+        {
+            // Chips inside a set act as toggle buttons; expose the selected state to assistive technology.
+            attributes.Add("aria-pressed", SelectedState.Value ? "true" : "false");
         }
 
         // User-defined attributes always take priority.

--- a/src/MudBlazor/Components/Overlay/MudOverlay.razor
+++ b/src/MudBlazor/Components/Overlay/MudOverlay.razor
@@ -17,7 +17,8 @@
 
 @code {
     private RenderFragment OverlayFragment => 
-        @<div @attributes="UserAttributes"
+        @<div aria-hidden="@(ChildContent is null ? "true" : null)"
+              @attributes="UserAttributes"
               id="@_elementId"
               class="@Classname"
               style="@Styles"

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -24,7 +24,7 @@
             if (currentPage == -1)
             {
                 <li class="@ItemClassname">
-                    <MudText disabled="@Disabled">…</MudText>
+                    <MudText disabled="@Disabled" aria-hidden="true">…</MudText>
                 </li>
             }
             else if (currentPage == _selectedState.Value)

--- a/src/MudBlazor/Components/Rating/MudRating.razor
+++ b/src/MudBlazor/Components/Rating/MudRating.razor
@@ -7,7 +7,7 @@
 #pragma warning disable CS0618 // Type or member is obsolete
 }
 
-<span tabindex="@(Disabled ? -1 : 0)" role="radiogroup" aria-readonly="@(ReadOnly.ToString().ToLowerInvariant())"
+<span tabindex="@(Disabled ? -1 : 0)" role="radiogroup" aria-label="@Localizer[LanguageResource.MudRating_Label]" aria-readonly="@(ReadOnly.ToString().ToLowerInvariant())"
       @onkeydown="HandleKeyDownAsync" @attributes="UserAttributes" class="@ClassName" style="@Style">
     <CascadingValue Value="this">
         @for (var i = 1; i <= MaxValue; i++)

--- a/src/MudBlazor/Components/Rating/MudRatingItem.razor
+++ b/src/MudBlazor/Components/Rating/MudRatingItem.razor
@@ -13,8 +13,7 @@
            value="@ItemValue"
            name="@Rating?.Name"
            disabled="@Disabled"
-           checked="@Checked"
-           aria-readonly="@(ReadOnly.ToString().ToLowerInvariant())" />
+           checked="@Checked" />
 
     <MudIcon Icon="@ItemIcon" Color="@ItemColor" Size="@Size" />
 </span>

--- a/src/MudBlazor/Components/Skeleton/MudSkeleton.razor
+++ b/src/MudBlazor/Components/Skeleton/MudSkeleton.razor
@@ -1,4 +1,4 @@
 ﻿@namespace MudBlazor
 @inherits MudComponentBase;
 
-<span @attributes="UserAttributes" class="@Classname" style="@Stylename"></span>
+<span aria-hidden="true" @attributes="UserAttributes" class="@Classname" style="@Stylename"></span>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -336,6 +336,9 @@
   <data name="MudRatingItem_Label" xml:space="preserve">
     <value>{0} rating</value>
   </data>
+  <data name="MudRating_Label" xml:space="preserve">
+    <value>Rating</value>
+  </data>
   <data name="MudCarousel_Index" xml:space="preserve">
     <value>Index {0}</value>
   </data>


### PR DESCRIPTION
Small ARIA corrections on components whose markup either claims a role it cannot back up, omits a required name, or announces decorative content. Every change is an attribute in markup or an attribute builder, keeps user attributes as the override, and changes no behaviour:

- **MudAvatar** only claims `role="img"` when the consumer supplies `aria-label` or `aria-labelledby`.
[WAI-ARIA 1.2 §img](https://www.w3.org/TR/wai-aria-1.2/#img): *Accessible Name Required: True* and *Children Presentational: True*. An unnamed `img` role hides the initials and exposes nothing in their place.
- **MudChip** reports `aria-pressed` inside a chip set. A disabled or read-only chip that would otherwise render as a `<button>` keeps `role="button"` on its `<div>`, and a disabled one adds `aria-disabled="true"`.
[APG Button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/): *"If the button is a toggle button, it has an aria-pressed state."* [WAI-ARIA 1.2 §aria-pressed](https://www.w3.org/TR/wai-aria-1.2/#aria-pressed) is *Used in Roles: button* only, and [§aria-disabled](https://www.w3.org/TR/wai-aria-1.2/#aria-disabled) has its global use deprecated in 1.2, so both need the button role present.
- **MudRating** names its `radiogroup` with a localizable "Rating" (`MudRating_Label`) and drops `aria-readonly` from the radio inputs.
[WAI-ARIA 1.2 §radiogroup](https://www.w3.org/TR/wai-aria-1.2/#radiogroup): *Accessible Name Required: True*, and `aria-readonly` is listed among its supported properties, which is where MudRating already sets it. [§radio](https://www.w3.org/TR/wai-aria-1.2/#radio) supports only `aria-checked`, `aria-posinset`, and `aria-setsize`, so `aria-readonly` on the inputs was invalid.
- **MudBreadcrumbs** marks the last item with `aria-current="page"`.
[APG Breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/): *"The link to the current page has aria-current set to page."* [WAI-ARIA 1.2 §aria-current](https://www.w3.org/TR/wai-aria-1.2/#aria-current), `page` token: *"Represents the current page within a set of pages."*
- **MudSkeleton**, **MudOverlay** without content, and the **MudPagination** ellipsis get `aria-hidden="true"`.
[WAI-ARIA 1.2 §aria-hidden](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden) permits hiding rendered content *"only if the act of hiding this content is intended to improve the experience for users of assistive technologies by removing redundant or extraneous content."* A loading placeholder, a backdrop, and a "…" between page numbers carry no information. None of the three is focusable, so this does not trip axe's `aria-hidden-focus` rule.
