### PR TITLE
MudSelect: Omit `aria-controls` while closed

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -2646,5 +2646,19 @@ namespace MudBlazor.UnitTests.Components
             var preventScroll = focusInvocation.Arguments.OfType<bool>().Single();
             preventScroll.Should().BeFalse();
         }
+
+        /// <summary>
+        /// A closed select omits aria-controls because its listbox is not rendered (#13760).
+        /// </summary>
+        [Test]
+        public void Select_ShouldNotReferenceListbox_WhileClosed()
+        {
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters.Add(p => p.Label, "Closed select"));
+
+            var input = comp.Find("input");
+            input.GetAttribute("aria-expanded").Should().Be("false");
+            // The listbox is not rendered while closed, so aria-controls would be a dangling reference.
+            input.HasAttribute("aria-controls").Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -533,8 +533,12 @@ namespace MudBlazor
             var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase);
             attributes.TryAdd("role", "combobox");
             attributes.TryAdd("aria-autocomplete", "none");
-            attributes.TryAdd("aria-controls", _listboxId);
             attributes.TryAdd("aria-expanded", _openState.Value ? "true" : "false");
+            if (_openState.Value)
+            {
+                // Only reference the listbox while it is rendered; a dangling IDREF is an invalid aria-controls value.
+                attributes.TryAdd("aria-controls", _listboxId);
+            }
             attributes.TryAdd("aria-haspopup", "listbox");
 
             if (!attributes.ContainsKey("aria-label") && !attributes.ContainsKey("aria-labelledby") && !string.IsNullOrWhiteSpace(Label))


### PR DESCRIPTION
The listbox is not rendered while the select is closed, but the combobox input still emits `aria-controls` with the listbox id. The reference points at nothing, which automated checkers report as an invalid attribute value (#13760).

`aria-controls` is now emitted only while the select is open. A user-supplied `aria-controls` still takes precedence.

Standards:
- [WAI-ARIA 1.2, value types](https://www.w3.org/TR/wai-aria-1.2/#propcharacteristic_value): an ID reference is a "Reference to the ID of another element in the same document."
- [APG Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/): "aria-controls only needs to be set when the popup is visible."

Tests: closed select has `aria-expanded="false"` and no `aria-controls`. Existing tests cover the open state and the user override.
