### PR TITLE
MudTable, MudDataGrid: Add `aria-sort` and selection checkbox names

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -9251,5 +9251,38 @@ namespace MudBlazor.UnitTests.Components
         }
 
         #endregion
+
+        /// <summary>
+        /// Sortable header cells track the sort direction in aria-sort (#9716).
+        /// </summary>
+        [Test]
+        public async Task DataGridSortableHeaders_ShouldExposeAriaSort()
+        {
+            var comp = Context.Render<DataGridSortableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTest.Item>>();
+
+            dataGrid.FindAll("th").Should().OnlyContain(header => header.GetAttribute("aria-sort") == "none");
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Ascending, x => x.Name));
+            dataGrid.FindAll("th")[0].GetAttribute("aria-sort").Should().Be("ascending");
+            dataGrid.FindAll("th")[1].GetAttribute("aria-sort").Should().Be("none");
+
+            await comp.InvokeAsync(() => dataGrid.Instance.SetSortAsync("Name", SortDirection.Descending, x => x.Name));
+            dataGrid.FindAll("th")[0].GetAttribute("aria-sort").Should().Be("descending");
+        }
+
+        /// <summary>
+        /// Header cells omit aria-sort when sorting is disabled.
+        /// </summary>
+        [Test]
+        public async Task DataGridUnsortableHeaders_ShouldNotExposeAriaSort()
+        {
+            var comp = Context.Render<DataGridSortableTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridSortableTest.Item>>();
+
+            await dataGrid.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.SortMode, SortMode.None));
+
+            dataGrid.FindAll("th").Should().OnlyContain(header => !header.HasAttribute("aria-sort"));
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3674,5 +3674,44 @@ namespace MudBlazor.UnitTests.Components
             rowBoxes()[0].Change(false);
             header().Should().Contain("mud-checkbox-null", "a row was deselected again");
         }
+
+        /// <summary>
+        /// Row selection checkboxes have a localized accessible name.
+        /// </summary>
+        [Test]
+        public void TableMultiSelection_CheckboxesShouldHaveAccessibleNames()
+        {
+            var comp = Context.Render<TableMultiSelectionTest1>();
+
+            string LabelOf(AngleSharp.Dom.IElement input) =>
+                comp.Find($"#{input.GetAttribute("aria-labelledby")}").TextContent.Trim();
+
+            comp.FindAll("tbody input[type=\"checkbox\"]").Count.Should().Be(3);
+            foreach (var input in comp.FindAll("tbody input[type=\"checkbox\"]"))
+            {
+                LabelOf(input).Should().Be("Select row");
+            }
+        }
+
+        /// <summary>
+        /// Select-all, group, and row checkboxes each have a distinct accessible name.
+        /// </summary>
+        [Test]
+        public async Task TableGrouping_GroupCheckboxShouldHaveAccessibleName()
+        {
+            var comp = Context.Render<TableGroupingTest>();
+            var table = comp.FindComponent<MudTable<TableGroupingTest.RacingCar>>();
+            await table.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.GroupBy, new TableGroupDefinition<TableGroupingTest.RacingCar>(rc => rc.Category) { GroupName = "Category" }));
+
+            string LabelOf(AngleSharp.Dom.IElement input) =>
+                comp.Find($"#{input.GetAttribute("aria-labelledby")}").TextContent.Trim();
+
+            var inputs = comp.FindAll("input[type=\"checkbox\"]");
+            LabelOf(inputs[0]).Should().Be("Select all rows");
+            LabelOf(inputs[1]).Should().Be("Select group");
+            LabelOf(inputs[2]).Should().Be("Select row");
+        }
     }
 }

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor
@@ -16,7 +16,7 @@
 }
 else if (Column != null && !Column.HiddenState.Value)
 {
-    <th @ref=@_headerElement scope="col" class="@Classname" style="@Stylename" colspan="@Column.HeaderColSpan" @attributes="@UserAttributes">
+    <th @ref=@_headerElement scope="col" class="@Classname" style="@Stylename" colspan="@Column.HeaderColSpan" aria-sort="@GetAriaSort()" @attributes="@UserAttributes">
         @if (DataGrid.DragDropColumnReordering)
         {
             <MudDropZone CanDrop="@((item) => (Column.DragAndDropEnabled ?? true))" ItemDisabled="@((item) => !item.DragAndDropEnabled ?? false)" T="Column<T>" Identifier="@(Column.PropertyName ?? _id)">

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -144,6 +144,24 @@ namespace MudBlazor
             }
         }
 
+        /// <summary>
+        /// The <c>aria-sort</c> value for the header cell, or <c>null</c> when the column cannot be sorted.
+        /// </summary>
+        private string? GetAriaSort()
+        {
+            if (!sortable)
+            {
+                return null;
+            }
+
+            return SortDirection switch
+            {
+                SortDirection.Ascending => "ascending",
+                SortDirection.Descending => "descending",
+                _ => "none"
+            };
+        }
+
         private bool resizable
         {
             get

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor
@@ -1,6 +1,8 @@
 ﻿@namespace MudBlazor
 @implements IDisposable
+@using MudBlazor.Resources
 @inherits MudComponentBase
+@inject InternalMudLocalizer Localizer
 
 <tr class="@Classname" @onclick="@OnRowClick" style="@Style" @attributes="@UserAttributes">
 	@if (Context.DisplayApplyButtonAtStart(IgnoreEditable) || Context.DisplayEditButtonAtStart(IgnoreEditable))
@@ -16,7 +18,7 @@
 			}
 			@if (Checkable)
 			{
-				<MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" Class="mud-table-cell-checkbox" />
+				<MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" Class="mud-table-cell-checkbox" AriaLabel="@Localizer[LanguageResource.MudTable_SelectAllRows]" />
 			}
 		</MudTh>
 	}

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor
@@ -27,7 +27,7 @@
                 }
                 @if (Checkable)
                 {
-                    <MudCheckBox T="bool?" @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" Class="mud-table-cell-checkbox"/>
+                    <MudCheckBox T="bool?" @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" Class="mud-table-cell-checkbox" AriaLabel="@Localizer[LanguageResource.MudTable_SelectGroup]"/>
                 }
             </div>
         </MudTd>

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -45,7 +45,7 @@
             <div class="d-flex" style="@ActionsStylename">
                 @if (Checkable)
                 {
-                    <MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" StopClickPropagation="true" Class="mud-table-cell-checkbox"></MudCheckBox>
+                    <MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" StopClickPropagation="true" Class="mud-table-cell-checkbox" AriaLabel="@Localizer[LanguageResource.MudTable_SelectRow]"></MudCheckBox>
                 }
             </div>
         </MudElement>

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -375,6 +375,15 @@
   <data name="MudPageContentNavigation_NavMenu" xml:space="preserve">
     <value>Contents</value>
   </data>
+  <data name="MudTable_SelectRow" xml:space="preserve">
+    <value>Select row</value>
+  </data>
+  <data name="MudTable_SelectAllRows" xml:space="preserve">
+    <value>Select all rows</value>
+  </data>
+  <data name="MudTable_SelectGroup" xml:space="preserve">
+    <value>Select group</value>
+  </data>
   <data name="MudTable_Loading" xml:space="preserve">
     <value>Loading…</value>
   </data>


### PR DESCRIPTION
Sorted DataGrid columns do not expose their sort direction, and MudTable's selection checkboxes have no accessible name.

- `MudDataGrid` header cells get `aria-sort` (`ascending`, `descending`, `none`) when the column is sortable, nothing otherwise. Partially addresses #9716.
- `MudTable` selection checkboxes get names through the existing `AriaLabel` parameter: "Select all rows", "Select row", "Select group". Three new resource keys.

Standards:
- [WAI-ARIA 1.2 §aria-sort](https://www.w3.org/TR/wai-aria-1.2/#aria-sort): used in roles columnheader and rowheader. A `th` in a table maps to columnheader per [ARIA in HTML](https://www.w3.org/TR/html-aria/#el-th).
- [WAI-ARIA 1.2 §checkbox](https://www.w3.org/TR/wai-aria-1.2/#checkbox): Accessible Name Required: True. [WCAG 2.2 SC 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value).

Tests: `aria-sort` across unsorted, ascending, descending, and sort-disabled. Checkbox names read through `aria-labelledby` in the multi-selection and grouping fixtures.
