### PR TITLE
Form components: Link error text with `aria-describedby`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CheckBoxTests.cs
@@ -590,5 +590,50 @@ namespace MudBlazor.UnitTests.Components
             var input4ForId = input4.GetAttribute("aria-labelledby");
             comp.Find($".cb5 label.mud-checkbox #{input4ForId}").Should().NotBeNull();
         }
+
+        /// <summary>
+        /// An invalid checkbox sets aria-invalid and links aria-describedby to its error text.
+        /// </summary>
+        [Test]
+        public async Task CheckBox_ShouldLinkInputToErrorText()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters
+                .Add(p => p.ErrorId, "field-error")
+                .Add(p => p.ErrorText, "Required"));
+
+            comp.Find("input").HasAttribute("aria-invalid").Should().BeFalse();
+            comp.Find("input").HasAttribute("aria-describedby").Should().BeFalse();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Error, true));
+
+            comp.Find("input").GetAttribute("aria-invalid").Should().Be("true");
+            comp.Find("input").GetAttribute("aria-describedby").Should().Be("field-error");
+            comp.Find("#field-error").TextContent.Trim().Should().Be("Required");
+        }
+
+        /// <summary>
+        /// An invalid checkbox without an error id is still marked invalid but points at nothing.
+        /// </summary>
+        [Test]
+        public void CheckBox_WithoutErrorId_ShouldNotEmitAriaDescribedBy()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters.Add(p => p.Error, true));
+
+            comp.Find("input").GetAttribute("aria-invalid").Should().Be("true");
+            comp.Find("input").HasAttribute("aria-describedby").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A user-supplied aria-invalid wins over the generated one.
+        /// </summary>
+        [Test]
+        public void CheckBox_ShouldAllowUserAriaInvalidOverride()
+        {
+            var comp = Context.Render<MudCheckBox<bool>>(parameters => parameters
+                .Add(p => p.Error, true)
+                .AddUnmatched("aria-invalid", "false"));
+
+            comp.Find("input").GetAttribute("aria-invalid").Should().Be("false");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DateRangePickerTests.cs
@@ -1823,6 +1823,27 @@ namespace MudBlazor.UnitTests.Components
 
             public Task Submit() => SubmitAsync();
         }
+
+        /// <summary>
+        /// Both range inputs link to the error text when the picker is invalid.
+        /// </summary>
+        [Test]
+        public async Task DateRangePicker_ShouldLinkInputsToErrorText()
+        {
+            var comp = Context.Render<MudDateRangePicker>(parameters => parameters
+                .Add(p => p.ErrorId, "range-error")
+                .Add(p => p.ErrorText, "Invalid range"));
+
+            comp.FindAll("input").Should().OnlyContain(input => !input.HasAttribute("aria-invalid"));
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Error, true));
+
+            var inputs = comp.FindAll("input");
+            inputs.Count.Should().Be(2);
+            inputs.Should().OnlyContain(input => input.GetAttribute("aria-invalid") == "true");
+            inputs.Should().OnlyContain(input => input.GetAttribute("aria-describedby") == "range-error");
+            comp.Find("#range-error").TextContent.Trim().Should().Be("Invalid range");
+        }
     }
     public static class DatePickerRenderedFragmentExtensions
     {

--- a/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FileUploadTests.cs
@@ -890,5 +890,26 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("input[type=file]").GetAttribute("id").Should().NotBe("caller-id");
         }
+
+        /// <summary>
+        /// An invalid file input links to its error text.
+        /// </summary>
+        [Test]
+        public async Task FileUpload_ShouldLinkInputToErrorText()
+        {
+            var comp = Context.Render<MudFileUpload<IBrowserFile>>(parameters => parameters
+                .Add(p => p.ErrorId, "upload-error")
+                .Add(p => p.ErrorText, "File required"));
+
+            comp.Find("input[type=\"file\"]").HasAttribute("aria-describedby").Should().BeFalse();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Error, true));
+
+            var input = comp.Find("input[type=\"file\"]");
+            // A file input has no ARIA role that supports aria-invalid, so it is only linked to the text.
+            input.HasAttribute("aria-invalid").Should().BeFalse();
+            input.GetAttribute("aria-describedby").Should().Be("upload-error");
+            comp.Find("#upload-error").TextContent.Trim().Should().Be("File required");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -574,5 +574,30 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("div[role=radiogroup]").GetAttribute("aria-required").Should().Be("true");
         }
+
+        /// <summary>
+        /// An invalid radio group and each of its radios link to the group's error text.
+        /// </summary>
+        [Test]
+        public async Task RadioGroupWithError_ShouldLinkRadiosToErrorText()
+        {
+            var comp = Context.Render<RadioGroupRequiredTest>();
+            var radioGroup = comp.FindComponent<MudRadioGroup<bool>>();
+
+            comp.Find("div[role=\"radiogroup\"]").HasAttribute("aria-invalid").Should().BeFalse();
+            comp.FindAll("input[type=\"radio\"]").Should().OnlyContain(input => !input.HasAttribute("aria-describedby"));
+
+            await radioGroup.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.Error, true)
+                .Add(p => p.ErrorId, "group-error")
+                .Add(p => p.ErrorText, "Pick one"));
+
+            comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-invalid").Should().Be("true");
+            comp.Find("div[role=\"radiogroup\"]").GetAttribute("aria-describedby").Should().Be("group-error");
+            // aria-invalid is not supported on the radio role, so the group carries it and each radio only points at the text.
+            comp.FindAll("input[type=\"radio\"]").Should().OnlyContain(input => !input.HasAttribute("aria-invalid"));
+            comp.FindAll("input[type=\"radio\"]").Should().OnlyContain(input => input.GetAttribute("aria-describedby") == "group-error");
+            comp.Find("#group-error").TextContent.Trim().Should().Be("Pick one");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SwitchTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SwitchTests.cs
@@ -258,5 +258,38 @@ namespace MudBlazor.UnitTests.Components
             Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, false)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
             Context.Render<MudSwitch<bool>>(self => self.Add(x => x.Disabled, true).Add(x => x.ReadOnly, true)).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
         }
+
+        /// <summary>
+        /// An invalid switch sets aria-invalid and links aria-describedby to its error text.
+        /// </summary>
+        [Test]
+        public async Task Switch_ShouldLinkInputToErrorText()
+        {
+            var comp = Context.Render<MudSwitch<bool>>(parameters => parameters
+                .Add(p => p.ErrorId, "field-error")
+                .Add(p => p.ErrorText, "Required"));
+
+            comp.Find("input").HasAttribute("aria-invalid").Should().BeFalse();
+            comp.Find("input").HasAttribute("aria-describedby").Should().BeFalse();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Error, true));
+
+            comp.Find("input").GetAttribute("aria-invalid").Should().Be("true");
+            comp.Find("input").GetAttribute("aria-describedby").Should().Be("field-error");
+            comp.Find("#field-error").TextContent.Trim().Should().Be("Required");
+        }
+
+        /// <summary>
+        /// A user-supplied aria-invalid wins over the generated one.
+        /// </summary>
+        [Test]
+        public void Switch_ShouldAllowUserAriaInvalidOverride()
+        {
+            var comp = Context.Render<MudSwitch<bool>>(parameters => parameters
+                .Add(p => p.Error, true)
+                .AddUnmatched("aria-invalid", "false"));
+
+            comp.Find("input").GetAttribute("aria-invalid").Should().Be("false");
+        }
     }
 }

--- a/src/MudBlazor/Base/MudBooleanInput.cs
+++ b/src/MudBlazor/Base/MudBooleanInput.cs
@@ -142,6 +142,13 @@ namespace MudBlazor
                 ["tabindex"] = GetDisabledState() ? -1 : 0
             };
 
+            if (HasErrors)
+            {
+                // Link the input to the rendered error text the same way MudInput does.
+                attributes["aria-invalid"] = "true";
+                attributes["aria-describedby"] = ErrorIdState.Value;
+            }
+
             foreach (var userAttribute in UserAttributes)
             {
                 attributes[userAttribute.Key] = userAttribute.Value;

--- a/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
+++ b/src/MudBlazor/Components/DatePicker/MudDateRangePicker.razor
@@ -8,7 +8,7 @@
 @code{
 
     protected override RenderFragment InputContent=>
-        @<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" Error="@ErrorState.Value"
+        @<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" Error="@ErrorState.Value" ErrorId="@ErrorIdState.Value"
                           ErrorText="@ErrorTextState.Value" Disabled="@GetDisabledState()" Margin="@Margin" Required="@Required"
                           @onclick="async () => { if (!Editable) await ToggleStateAsync(); }" ForId="@FieldId">
                <InputContent>
@@ -30,6 +30,7 @@
                                   Required="@Required"
                                   RequiredError="@RequiredError"
                                   Error="@ErrorState.Value"
+                                  ErrorId="@ErrorIdState.Value"
                                   ErrorText="@ErrorTextState.Value"
                                   Margin="@Margin"
                                   AdornmentAriaLabel="@AdornmentAriaLabel"

--- a/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
+++ b/src/MudBlazor/Components/FileUpload/MudFileUpload.razor
@@ -6,7 +6,7 @@
 #pragma warning disable CS0618 // Type or member is obsolete
 }
 
-<MudInputControl Class="@Classname" Style="@Style" Error="HasErrors" ErrorText="@GetErrorText()" Required="@Required">
+<MudInputControl Class="@Classname" Style="@Style" Error="HasErrors" ErrorId="@ErrorIdState.Value" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
         @for (var index = 1; index <= _numberOfActiveFileInputs; index++)
         {
@@ -20,6 +20,7 @@
                        accept="@Accept"
                        disabled="@(GetDisabledState())"
                        aria-required="@Required.ToString().ToLowerInvariant()"
+                       aria-describedby="@(HasErrors ? ErrorIdState.Value : null)"
                        @attributes="UserAttributes"
                        @ondragenter="OnDragEnterAsync"
                        @ondrop="OnDropAsync"

--- a/src/MudBlazor/Components/Input/MudRangeInput.razor
+++ b/src/MudBlazor/Components/Input/MudRangeInput.razor
@@ -27,6 +27,8 @@
 
     <input @ref="_elementReferenceStart"
            aria-required="@Required.ToString().ToLowerInvariant()"
+           aria-invalid="@(HasErrors ? "true" : null)"
+           aria-describedby="@GetAriaDescribedByString()"
            @attributes="UserAttributes"
            id="@(string.IsNullOrEmpty(InputElementId) ? null : $"{InputElementId}-start")"
            type="@InputTypeString"
@@ -46,6 +48,8 @@
     <MudIcon Class="mud-range-input-separator mud-flip-x-rtl" Icon="@SeparatorIcon" Color="@Color.Default" />
     <input @ref="_elementReferenceEnd"
            aria-required="@Required.ToString().ToLowerInvariant()"
+           aria-invalid="@(HasErrors ? "true" : null)"
+           aria-describedby="@GetAriaDescribedByString()"
            @attributes="UserAttributes"
            id="@(string.IsNullOrEmpty(InputElementId) ? null : $"{InputElementId}-end")"
            type="@InputTypeString"

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,7 +6,7 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" checked="@Checked" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" aria-describedby="@(MudRadioGroup?.HasErrors == true ? MudRadioGroup.GetErrorId() : null)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" checked="@Checked" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -11,7 +11,7 @@
         <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="false">
             <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                 <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
-                    <div role="radiogroup" aria-required="@Required.ToString().ToLowerInvariant()" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
+                    <div role="radiogroup" aria-required="@Required.ToString().ToLowerInvariant()" aria-invalid="@(HasErrors ? "true" : null)" aria-describedby="@(HasErrors ? ErrorIdState.Value : null)" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
                         @ChildContent
                     </div>
                 </CascadingValue>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor.cs
@@ -113,6 +113,11 @@ namespace MudBlazor
 
         internal bool GetReadOnlyState() => ReadOnly || ParentReadOnly; //internal because the MudRadio reads this value directly
 
+        /// <summary>
+        /// The id of the rendered error text, so each <see cref="MudRadio{T}"/> can reference it through <c>aria-describedby</c>.
+        /// </summary>
+        internal string? GetErrorId() => ErrorIdState.Value;
+
         protected async Task SetSelectedOptionAsync(T? option, bool updateRadio, bool updateValue = true)
         {
             if (!OptionEquals(_value, option))


### PR DESCRIPTION
`MudInput` sets `aria-invalid` and points `aria-describedby` at its error text. The other form controls render the same error text but never reference it.

- `MudCheckBox`, `MudSwitch` (via `MudBooleanInput`), `MudRadioGroup`, and `MudRangeInput` (`MudDateRangePicker` now passes its error id) set `aria-invalid="true"` and `aria-describedby` while they have errors.
- `MudRadio` inputs and the `MudFileUpload` input get `aria-describedby` only. `aria-invalid` is not supported on the radio role and a file input has no role that supports it; the radio group carries the invalid state.
- User-supplied `aria-invalid` or `aria-describedby` still take precedence.

Standards:
- [WAI-ARIA 1.2 §aria-invalid](https://www.w3.org/TR/wai-aria-1.2/#aria-invalid): used in roles checkbox, radiogroup, textbox; inherits into switch. Not listed for radio.
- [WAI-ARIA 1.2 §aria-describedby](https://www.w3.org/TR/wai-aria-1.2/#aria-describedby): "Identifies the element (or elements) that describes the object." Global.
- [WCAG 2.2 SC 3.3.1](https://www.w3.org/TR/WCAG22/#error-identification): "the item that is in error is identified and the error is described to the user in text."

Tests: each control renders without errors, flips `Error` on, and asserts both attributes and that the id resolves to the error text. Override tests for checkbox and switch, plus a checkbox with an error and no error id.
