### PR TITLE
MudAutocomplete: Expose the combobox pattern to assistive technology

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -3068,5 +3068,58 @@ namespace MudBlazor.UnitTests.Components
             var preventScroll = focusInvocation.Arguments.OfType<bool>().Single();
             preventScroll.Should().BeFalse();
         }
+
+        /// <summary>
+        /// The input is a combobox that references the suggestion list and the highlighted option only while the list is open (#13214).
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_ExposesComboboxSemantics()
+        {
+            var comp = Context.Render<AutocompleteTest1>();
+            var autocomplete = comp.FindComponent<MudAutocomplete<string>>();
+            IElement Input() => autocomplete.Find("input");
+            await autocomplete.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.DebounceInterval, 0));
+
+            Input().GetAttribute("role").Should().Be("combobox");
+            Input().GetAttribute("aria-autocomplete").Should().Be("list");
+            Input().GetAttribute("aria-haspopup").Should().Be("listbox");
+            Input().GetAttribute("aria-expanded").Should().Be("false");
+            Input().HasAttribute("aria-controls").Should().BeFalse();
+            Input().HasAttribute("aria-activedescendant").Should().BeFalse();
+
+            await Input().KeyDownAsync(new KeyboardEventArgs { Key = "ArrowDown" });
+            await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
+
+            var list = comp.Find("div.mud-list");
+            list.GetAttribute("role").Should().Be("listbox");
+            list.Id.Should().NotBeNullOrEmpty();
+            Input().GetAttribute("aria-expanded").Should().Be("true");
+            Input().GetAttribute("aria-controls").Should().Be(list.Id);
+
+            var highlighted = comp.Find("div.mud-list-item.mud-selected-item");
+            highlighted.GetAttribute("role").Should().Be("option");
+            highlighted.GetAttribute("aria-selected").Should().Be("true");
+            Input().GetAttribute("aria-activedescendant").Should().Be(highlighted.Id);
+            comp.FindAll("div.mud-list-item:not(.mud-selected-item)").Should().OnlyContain(item => item.GetAttribute("aria-selected") == "false");
+
+            await Input().KeyUpAsync(new KeyboardEventArgs { Key = "Escape" });
+            await comp.WaitForAssertionAsync(() => Input().GetAttribute("aria-expanded").Should().Be("false"));
+            Input().HasAttribute("aria-controls").Should().BeFalse();
+            Input().HasAttribute("aria-activedescendant").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Caller-supplied combobox attributes take precedence over the generated fallbacks.
+        /// </summary>
+        [Test]
+        public async Task Autocomplete_CallerAriaAttributes_Win()
+        {
+            var comp = Context.Render<AutocompleteTest1>();
+            var autocomplete = comp.FindComponent<MudAutocomplete<string>>();
+            await autocomplete.SetParametersAndRenderAsync(parameters => parameters.AddUnmatched("aria-autocomplete", "both"));
+
+            autocomplete.Find("input").GetAttribute("aria-autocomplete").Should().Be("both");
+            autocomplete.Find("input").GetAttribute("role").Should().Be("combobox");
+        }
     }
 }

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor
@@ -42,7 +42,7 @@
                           ClearIcon="@ClearIcon"
                           MaxLength="@MaxLength"
                           autocomplete="@GetAutocomplete()"
-                          @attributes="UserAttributes"
+                          @attributes="GetInputAttributes()"
                           TextChanged="OnTextChangedAsync"
                           @onfocus="@OnInputFocusedAsync"
                           OnBlur="OnInputBlurredAsync"
@@ -81,7 +81,7 @@
                     }
                     else if (_items != null && _items.Length != 0)
                     {
-                        <MudList T="T" Class="@ListClass" Dense="@Dense">
+                        <MudList T="T" id="@_listboxId" Class="@ListClass" Dense="@Dense">
                             @if (BeforeItemsTemplate is not null)
                             {
                                 <div class="mud-autocomplete-before-items">
@@ -96,7 +96,7 @@
                                 bool showSelectedTemplate = ItemSelectedTemplate is not null && isSelected;
                                 bool showDisabledTemplate = ItemDisabledTemplate is not null && isDisabled;
                                 var captureIndex = index;
-                                <MudListItem T="T" Value="@item" @key="@item" id="@GetListItemId(captureIndex)" Disabled="@(isDisabled)" KeyboardEnabled="false" OnClick="@(async () => await ListItemOnClickAsync(item))" OnClickPreventDefault="true" Class="@GetListItemClassname(isSelected)">
+                                <MudListItem T="T" Value="@item" @key="@item" id="@GetListItemId(captureIndex)" aria-selected="@(isSelected ? "true" : "false")" Disabled="@(isDisabled)" KeyboardEnabled="false" OnClick="@(async () => await ListItemOnClickAsync(item))" OnClickPreventDefault="true" Class="@GetListItemClassname(isSelected)">
                                     @if (showDisabledTemplate)
                                     {
                                         @ItemDisabledTemplate!(item)

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -16,6 +16,7 @@ namespace MudBlazor
         /// We need a random id for the year items in the year list so we can scroll to the item safely in every DatePicker.
         /// </summary>
         private readonly string _componentId = Identifier.Create();
+        private readonly string _listboxId = Identifier.Create("listbox");
 
         private bool _isCleared;
         private bool _isProcessingValue;
@@ -1066,6 +1067,34 @@ namespace MudBlazor
         private string GetListItemId(in int index)
         {
             return $"{_componentId}_item{index}";
+        }
+
+        /// <summary>
+        /// Builds fallback combobox attributes for the text input so caller-supplied values still win.
+        /// </summary>
+        /// <remarks>
+        /// The suggestion list only exists in the DOM while it is open and has items, so the list and the highlighted option are referenced only then.
+        /// </remarks>
+        private Dictionary<string, object?> GetInputAttributes()
+        {
+            var attributes = new Dictionary<string, object?>(UserAttributes, StringComparer.OrdinalIgnoreCase);
+            var listRendered = _open && _items is { Length: > 0 };
+            attributes.TryAdd("role", "combobox");
+            attributes.TryAdd("aria-autocomplete", "list");
+            attributes.TryAdd("aria-haspopup", "listbox");
+            attributes.TryAdd("aria-expanded", listRendered ? "true" : "false");
+
+            if (listRendered)
+            {
+                attributes.TryAdd("aria-controls", _listboxId);
+
+                if (_selectedListItemIndex >= 0 && _selectedListItemIndex < _items!.Length)
+                {
+                    attributes.TryAdd("aria-activedescendant", GetListItemId(_selectedListItemIndex));
+                }
+            }
+
+            return attributes;
         }
 
         internal async Task OnEnterKeyAsync()


### PR DESCRIPTION
`MudAutocomplete` renders its input with no combobox semantics, so screen readers announce a plain text box and never report the suggestion list, the highlighted option, or whether the popup is open ([#13214](https://github.com/MudBlazor/MudBlazor/issues/13214)). The ids and highlight index already existed; only the wiring was missing.

- The input gets `role="combobox"`, `aria-autocomplete="list"`, `aria-haspopup="listbox"` and `aria-expanded`.
- While the list is rendered it also gets `aria-controls` pointing at the list and `aria-activedescendant` pointing at the highlighted option, so no IDREF ever dangles.
- The list carries a stable id and each option reports `aria-selected` for the highlighted item.
- Caller-supplied attributes still take precedence; the generated ones are fallbacks.

Standards:
- [WAI-ARIA APG Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/): combobox with list autocomplete, `aria-controls` to the listbox, `aria-activedescendant` for the visually focused option, `aria-selected="true"` on that option.
- [WAI-ARIA 1.2 §combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox): required `aria-expanded` and `aria-controls`; `aria-autocomplete` supported.

Tests: attribute set while closed, after opening with ArrowDown, and after Escape, plus caller attributes winning over the fallbacks.


Fixes https://github.com/MudBlazor/MudBlazor/issues/13214
