### PR TITLE
MudTable: Render the empty and loading rows as data cells

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3713,5 +3713,36 @@ namespace MudBlazor.UnitTests.Components
             LabelOf(inputs[1]).Should().Be("Select group");
             LabelOf(inputs[2]).Should().Be("Select row");
         }
+
+        /// <summary>
+        /// The placeholder row shown while a table has no records is a data cell, so the column headers refer to data cells (#13762).
+        /// </summary>
+        [Test]
+        public void NoRecordsContent_RendersAsDataCell()
+        {
+            var comp = Context.Render<MudTable<string>>(parameters => parameters
+                .Add(p => p.Items, Array.Empty<string>())
+                .Add(p => p.HeaderContent, "<th>Name</th>")
+                .Add(p => p.NoRecordsContent, "No records"));
+
+            comp.Find("tbody td.mud-table-empty-row").TextContent.Trim().Should().Be("No records");
+            comp.FindAll("tbody th").Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The loading indicator row is made of data cells for the same reason as the empty row (#13762).
+        /// </summary>
+        [Test]
+        public void LoadingRow_RendersAsDataCell()
+        {
+            var comp = Context.Render<MudTable<string>>(parameters => parameters
+                .Add(p => p.Items, Array.Empty<string>())
+                .Add(p => p.Loading, true)
+                .Add(p => p.HeaderContent, "<th>Name</th>"));
+
+            comp.Find("tr.mud-table-loading-row > td").Should().NotBeNull();
+            comp.FindAll("tr.mud-table-loading-row > th").Should().BeEmpty();
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -68,9 +68,9 @@
                             @if (ShowLoadingProgress)
                             {
                                 <tr class="mud-table-loading-row">
-                                    <th colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
+                                    <td colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
                                         <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" aria-label="@Localizer[LanguageResource.MudTable_Loading]" />
-                                    </th>
+                                    </td>
                                 </tr>
                             }
                         </thead>
@@ -79,9 +79,9 @@
                     {
                         <thead class="@HeadClassname">
                             <tr class="mud-table-loading-row">
-                                <th colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
+                                <td colspan="1000" class="@(CurrentPageItems.Any() || (LoadingContent is not null || LoadingContentBody is not null) ? "mud-table-loading" : "")">
                                     <MudProgressLinear Color="@LoadingProgressColor" Class="mud-table-loading-progress" Indeterminate="true" aria-label="@Localizer[LanguageResource.MudTable_Loading]" />
-                                </th>
+                                </td>
                             </tr>
                         </thead>
                     }
@@ -156,7 +156,7 @@
                             else if (Loading ? LoadingContent != null : NoRecordsContent != null)
                             {
                                 <tr>
-                                    <th colspan="1000" class="mud-table-empty-row">
+                                    <td colspan="1000" class="mud-table-empty-row">
                                         <div Class="my-3">
                                             @if (Loading)
                                             {
@@ -167,7 +167,7 @@
                                                 @NoRecordsContent
                                             }
                                         </div>
-                                    </th>
+                                    </td>
                                 </tr>
                             }
                         }


### PR DESCRIPTION
The `NoRecordsContent` placeholder row and the loading indicator row in `MudTable` use `<th colspan="1000">`. In an empty table every column header therefore has no data cell to refer to, and accessibility scanners flag it ([#13762](https://github.com/MudBlazor/MudBlazor/issues/13762)).

- Both rows now use `<td>`. The `mud-table-empty-row` and `mud-table-loading` styles key on classes, so nothing visual changes.

Standards:
- [HTML Living Standard §4.9.9 the `th` element](https://html.spec.whatwg.org/multipage/tables.html#the-th-element): `th` represents a header cell; the placeholder and progress rows are not headers.
- [WCAG 2.2 SC 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships), as checked by axe `th-has-data-cells`.

Tests: an empty table renders the placeholder as `tbody td` with no `th` in the body, and the loading row renders `td` cells.


Fixes https://github.com/MudBlazor/MudBlazor/issues/13762
