### PR TITLE
MudExpansionPanel: Add accordion header and region semantics

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -450,5 +450,66 @@ namespace MudBlazor.UnitTests.Components
             var content = comp.Find(".mud-expand-panel-content");
             content.ClassList.Should().NotContain("mud-expand-panel-gutters");
         }
+
+        /// <summary>
+        /// The header is a button that states its expanded state and owns the region it controls.
+        /// </summary>
+        [Test]
+        public async Task ExpansionPanel_Header_ExposesAccordionSemantics()
+        {
+            var comp = Context.Render<ExpansionPanelExpansionsTest>();
+            IElement Header() => comp.FindAll(".mud-expand-panel-header")[0];
+            IElement Region() => comp.FindAll(".mud-expand-panel-content")[0];
+
+            Header().GetAttribute("role").Should().Be("button");
+            Header().GetAttribute("aria-expanded").Should().Be("false");
+            Header().GetAttribute("aria-disabled").Should().Be("false");
+            Header().Id.Should().NotBeNullOrEmpty();
+            Region().GetAttribute("role").Should().Be("region");
+            Region().GetAttribute("aria-labelledby").Should().Be(Header().Id);
+            Header().GetAttribute("aria-controls").Should().Be(Region().Id);
+
+            await Header().ClickAsync();
+
+            Header().GetAttribute("aria-expanded").Should().Be("true");
+        }
+
+        /// <summary>
+        /// A header only references its region while the region exists in the DOM.
+        /// </summary>
+        [Test]
+        public async Task ExpansionPanel_WithoutKeptContent_ReferencesRegionOnlyWhileRendered()
+        {
+            var comp = Context.Render<MudExpansionPanels>(parameters => parameters
+                .AddChildContent<MudExpansionPanel>(panel => panel
+                    .Add(p => p.Text, "Details")
+                    .Add(p => p.KeepContentAlive, false)
+                    .AddChildContent("Body")));
+            IElement Header() => comp.Find(".mud-expand-panel-header");
+
+            comp.FindAll(".mud-expand-panel-content").Should().BeEmpty();
+            Header().HasAttribute("aria-controls").Should().BeFalse();
+
+            await Header().ClickAsync();
+
+            comp.WaitForAssertion(() => Header().GetAttribute("aria-controls").Should().Be(comp.Find(".mud-expand-panel-content").Id));
+        }
+
+        /// <summary>
+        /// A disabled header is announced as disabled and leaves the tab order.
+        /// </summary>
+        [Test]
+        public void ExpansionPanel_Disabled_HeaderIsAnnouncedDisabled()
+        {
+            var comp = Context.Render<MudExpansionPanels>(parameters => parameters
+                .AddChildContent<MudExpansionPanel>(panel => panel
+                    .Add(p => p.Text, "Details")
+                    .Add(p => p.Disabled, true)
+                    .AddChildContent("Body")));
+
+            var header = comp.Find(".mud-expand-panel-header");
+            header.GetAttribute("aria-disabled").Should().Be("true");
+            header.HasAttribute("tabindex").Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -2,7 +2,15 @@
 @inherits MudComponentBase
 
 <div @attributes="UserAttributes" class="@Classname" style="@Style">
-    <div class="@HeaderClassname" @onclick="ToggleExpansionAsync" tabindex="@(Disabled ? null : "0")" @onkeydown="HandleKeyDownAsync">
+    <div id="@_headerId"
+         class="@HeaderClassname"
+         role="button"
+         tabindex="@(Disabled ? null : "0")"
+         aria-expanded="@_expandedState.Value.ToString().ToLowerInvariant()"
+         aria-controls="@(IsContentRendered ? _contentId : null)"
+         aria-disabled="@Disabled.ToString().ToLowerInvariant()"
+         @onclick="ToggleExpansionAsync"
+         @onkeydown="HandleKeyDownAsync">
         <div class="mud-expand-panel-text">
             @if (TitleContent is not null)
             {
@@ -19,9 +27,9 @@
         }
     </div>
     <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
-        @if (KeepContentAlive || _expandedState.Value)
+        @if (IsContentRendered)
         {
-            <div class="@PanelContentClassname">
+            <div id="@_contentId" class="@PanelContentClassname" role="region" aria-labelledby="@_headerId">
                 @ChildContent
             </div>
         }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -17,9 +17,16 @@ namespace MudBlazor
     public partial class MudExpansionPanel : MudComponentBase, IDisposable
     {
         internal readonly ParameterState<bool> _expandedState;
+        private readonly string _headerId = Identifier.Create("panel-header");
+        private readonly string _contentId = Identifier.Create("panel-content");
 
         [CascadingParameter]
         private MudExpansionPanels? Parent { get; set; }
+
+        /// <summary>
+        /// Whether the content region exists in the DOM, which decides whether the header may reference it.
+        /// </summary>
+        private bool IsContentRendered => KeepContentAlive || _expandedState.Value;
 
         protected string Classname =>
             new CssBuilder("mud-expand-panel")


### PR DESCRIPTION
The `MudExpansionPanel` header is a focusable `div` with click and key handlers but no role or state, so it is announced as plain text and its expanded state is never reported.

- The header gets `role="button"`, `aria-expanded`, `aria-disabled` and `aria-controls`.
- The content gets `role="region"` and `aria-labelledby` pointing at its header.
- `aria-controls` is only emitted while the content exists in the DOM (`KeepContentAlive="false"` removes it when collapsed), so no IDREF dangles.
- A disabled header is announced as disabled and stays out of the tab order, as before.

Standards:
- [WAI-ARIA APG Accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/): header is a button with `aria-expanded` and `aria-controls`; the panel has `role="region"` and `aria-labelledby`.
- [WAI-ARIA 1.2 §aria-expanded](https://www.w3.org/TR/wai-aria-1.2/#aria-expanded) and [§aria-disabled](https://www.w3.org/TR/wai-aria-1.2/#aria-disabled): supported on the button role.

Tests: attributes and id linkage on the default panel, the reference appearing only once a non-kept-alive region is rendered, and the disabled case.
