### PR TITLE
MudDialog: Announce as modal and name them when header is hidden

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1790,6 +1790,55 @@ namespace MudBlazor.UnitTests.Components
 
             second.Should().NotBeNull();
         }
+
+        /// <summary>
+        /// A dialog is aria-modal and is named by its visible title (#13609).
+        /// </summary>
+        [Test]
+        public async Task DialogShouldExposeModalSemanticsForAssistiveTechnologies()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            await comp.InvokeAsync(async () => await service.ShowAsync<DialogOkCancel>("Dialog title"));
+
+            var dialog = comp.Find("div[role='dialog']");
+            dialog.GetAttribute("aria-modal").Should().Be("true");
+            // The visible title already names the dialog, so no redundant aria-label is emitted.
+            dialog.HasAttribute("aria-label").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A dialog without a header falls back to an aria-label from its title (#13609).
+        /// </summary>
+        [Test]
+        public async Task DialogWithoutHeaderShouldFallBackToAriaLabelFromTitle()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            await comp.InvokeAsync(async () => await service.ShowAsync<DialogOkCancel>("Dialog title", new DialogOptions { NoHeader = true }));
+
+            var dialog = comp.Find("div[role='dialog']");
+            dialog.GetAttribute("aria-labelledby").Should().BeNull();
+            dialog.GetAttribute("aria-label").Should().Be("Dialog title");
+        }
+
+        /// <summary>
+        /// A dialog with neither a header nor a title gets no empty aria-label (#13609).
+        /// </summary>
+        [Test]
+        public async Task DialogWithoutHeaderOrTitleShouldNotEmitEmptyAriaLabel()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            await comp.InvokeAsync(async () => await service.ShowAsync<DialogOkCancel>(string.Empty, new DialogOptions { NoHeader = true }));
+
+            var dialog = comp.Find("div[role='dialog']");
+            dialog.HasAttribute("aria-labelledby").Should().BeFalse();
+            dialog.HasAttribute("aria-label").Should().BeFalse();
+        }
     }
     internal class CustomDialogService : DialogService
     {

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -8,7 +8,7 @@
 
 <div @attributes="UserAttributes" id="@ElementId" class="mud-dialog-container @GetPosition()">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" @onmouseup="OnMouseUpAsync" />
-    <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" aria-labelledby="@(GetHideHeader() ? null : $"_{Id:N}_title")" class="@Classname" style="@Style" tabindex="-1">
+    <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" aria-modal="true" aria-labelledby="@(GetHideHeader() ? null : $"_{Id:N}_title")" aria-label="@(GetHideHeader() && !string.IsNullOrWhiteSpace(_titleState.Value) ? _titleState.Value : null)" class="@Classname" style="@Style" tabindex="-1">
         @if (!GetHideHeader())
         {
             <div id="@($"_{Id:N}_title")" class="@TitleClassname">


### PR DESCRIPTION
`MudDialog` never emits `aria-modal`, and with `NoHeader` it has no accessible name at all, so screen readers announce an anonymous dialog and keep reading the page behind it ([#13609](https://github.com/MudBlazor/MudBlazor/issues/13609)).

- The `role="dialog"` element always gets `aria-modal="true"`; every `MudDialog` has a backdrop and a focus trap.
- `MudDialog` gains `AriaLabel` and `AriaLabelledBy` parameters, rendered on the `role="dialog"` element for both service-shown and inline dialogs. Inline dialogs forward them through their `ShowAsync` path, which has no title to fall back on.
- Name resolution, emitting only the winning attribute: `AriaLabelledBy`, then `AriaLabel`, then the title bar via `aria-labelledby`, then the title text via `aria-label` when the header is hidden. Nothing is emitted when none applies.

Standards:
- [WAI-ARIA APG Modal Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/): the dialog has `aria-modal="true"` and a label via `aria-labelledby` or `aria-label`.
- [WAI-ARIA 1.2 §aria-modal](https://www.w3.org/TR/wai-aria-1.2/#aria-modal): supported on the dialog role.

Tests: modal attribute with no redundant label, the title fallback with `NoHeader`, no empty label without a title, and the inline path with `AriaLabel`, with `AriaLabelledBy` pointing at a content heading, and with neither; plus a service-shown dialog whose `AriaLabel` replaces the title bar as its name.

Fixes https://github.com/MudBlazor/MudBlazor/issues/13609
