### PR TITLE
Build: Give accessibility changes their own release notes section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,9 @@ changelog:
     - title: Breaking Changes
       labels:
         - breaking change
+    - title: Accessibility
+      labels:
+        - accessibility
     - title: New Features
       labels:
         - new component

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,9 +6,6 @@ changelog:
     - title: Breaking Changes
       labels:
         - breaking change
-    - title: Accessibility
-      labels:
-        - accessibility
     - title: New Features
       labels:
         - new component
@@ -16,6 +13,9 @@ changelog:
     - title: Bug Fixes
       labels:
         - bug
+    - title: Accessibility
+      labels:
+        - accessibility
     - title: Performance
       labels:
         - performance


### PR DESCRIPTION
Accessibility PRs currently file under whichever other heading their second label picks, so readers tracking screen reader and keyboard support have no single place to look.

- Adds an `Accessibility` category keyed on the `accessibility` label, placed between `Bug Fixes` and `Performance`.
- GitHub files each PR under the first matching category, so a PR labeled both `bug` and `accessibility` still lists as a bug fix, and a DOM-changing one still lists as breaking. The Accessibility heading collects the PRs that only add semantics or keyboard support.
- Labels and triage are unchanged; `bug` is now reserved for accessibility PRs that fix broken behavior rather than add missing semantics.
