### PR TITLE
MudDialog: Add AriaLabel and AriaLabelledBy for dialogs the title cannot name

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogAriaLabelContent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogAriaLabelContent.razor
@@ -1,0 +1,15 @@
+﻿@attribute [ViewerHidden]
+
+<MudDialog AriaLabel="Spoken name">
+    <DialogContent>
+        <MudText>Named by AriaLabel instead of the title bar.</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="@(() => MudDialog.Close())">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogAriaLabelTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/InlineDialogAriaLabelTest.razor
@@ -1,0 +1,24 @@
+﻿<MudButton OnClick="() => _visible = true">Open</MudButton>
+
+<MudDialog @bind-Visible="_visible" Options="_options" AriaLabel="@AriaLabel" AriaLabelledBy="@AriaLabelledBy">
+    <DialogContent>
+        <MudText id="custom-heading" Typo="Typo.h6">Remove this item?</MudText>
+        <MudText>This cannot be undone.</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="() => _visible = false">Keep</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    public static string __description__ = "An inline dialog without a header that is named through AriaLabel or AriaLabelledBy.";
+
+    [Parameter]
+    public string? AriaLabel { get; set; }
+
+    [Parameter]
+    public string? AriaLabelledBy { get; set; }
+
+    private bool _visible;
+    private readonly DialogOptions _options = new() { NoHeader = true };
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1839,6 +1839,88 @@ namespace MudBlazor.UnitTests.Components
             dialog.HasAttribute("aria-labelledby").Should().BeFalse();
             dialog.HasAttribute("aria-label").Should().BeFalse();
         }
+
+        /// <summary>
+        /// An inline dialog shown through the parameterless ShowAsync has no title, so a hidden header leaves it unnamed unless AriaLabel names it (#13609).
+        /// </summary>
+        [Test]
+        public async Task InlineDialogWithoutHeaderShouldUseAriaLabel()
+        {
+            var provider = Context.Render<MudDialogProvider>();
+            var comp = Context.Render<InlineDialogAriaLabelTest>(parameters => parameters.Add(p => p.AriaLabel, "Confirm removal"));
+
+            await comp.Find("button").ClickAsync();
+
+            await provider.WaitForAssertionAsync(() =>
+            {
+                var dialog = provider.Find("div[role='dialog']");
+                dialog.GetAttribute("aria-modal").Should().Be("true");
+                dialog.GetAttribute("aria-label").Should().Be("Confirm removal");
+                dialog.HasAttribute("aria-labelledby").Should().BeFalse();
+            });
+        }
+
+        /// <summary>
+        /// AriaLabelledBy names the dialog by an element inside its content and suppresses the text fallback.
+        /// </summary>
+        [Test]
+        public async Task InlineDialogShouldUseAriaLabelledBy()
+        {
+            var provider = Context.Render<MudDialogProvider>();
+            var comp = Context.Render<InlineDialogAriaLabelTest>(parameters => parameters
+                .Add(p => p.AriaLabel, "Ignored")
+                .Add(p => p.AriaLabelledBy, "custom-heading"));
+
+            await comp.Find("button").ClickAsync();
+
+            await provider.WaitForAssertionAsync(() =>
+            {
+                var dialog = provider.Find("div[role='dialog']");
+                dialog.GetAttribute("aria-labelledby").Should().Be("custom-heading");
+                dialog.HasAttribute("aria-label").Should().BeFalse();
+                provider.Find("#custom-heading").TextContent.Trim().Should().Be("Remove this item?");
+            });
+        }
+
+        /// <summary>
+        /// An inline dialog with a hidden header and no name of its own stays unlabelled rather than getting an empty attribute.
+        /// </summary>
+        [Test]
+        public async Task InlineDialogWithoutHeaderOrNameShouldNotEmitEmptyAttributes()
+        {
+            var provider = Context.Render<MudDialogProvider>();
+            var comp = Context.Render<InlineDialogAriaLabelTest>();
+
+            await comp.Find("button").ClickAsync();
+
+            await provider.WaitForAssertionAsync(() =>
+            {
+                var dialog = provider.Find("div[role='dialog']");
+                dialog.HasAttribute("aria-label").Should().BeFalse();
+                dialog.HasAttribute("aria-labelledby").Should().BeFalse();
+            });
+        }
+
+        /// <summary>
+        /// An explicit AriaLabel replaces the title bar as the name of a service-shown dialog.
+        /// </summary>
+        [Test]
+        public async Task DialogAriaLabelShouldReplaceTitleBarName()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+
+            await comp.InvokeAsync(async () => await service.ShowAsync<DialogAriaLabelContent>("Dialog title"));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                var dialog = comp.Find("div[role='dialog']");
+                dialog.GetAttribute("aria-label").Should().Be("Spoken name");
+                dialog.HasAttribute("aria-labelledby").Should().BeFalse();
+                comp.Find("div.mud-dialog-title").TrimmedText().Should().Contain("Dialog title");
+            });
+        }
+
     }
     internal class CustomDialogService : DialogService
     {

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -190,6 +190,26 @@ namespace MudBlazor
         [Category(CategoryTypes.Dialog.Behavior)]
         public DefaultFocus? DefaultFocus { get; set; }
 
+        /// <summary>
+        /// The accessible name announced for this dialog.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which names the dialog by its title bar, or by the title text when the header is hidden. Set this when the header is hidden and no title is available, such as an inline dialog with <see cref="DialogOptions.NoHeader"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Dialog.Behavior)]
+        public string? AriaLabel { get; set; }
+
+        /// <summary>
+        /// The id of the element that names this dialog.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. Takes precedence over <see cref="AriaLabel"/> and the title bar. Point it at a heading inside <see cref="DialogContent"/> when a custom header replaces the title bar.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Dialog.Behavior)]
+        public string? AriaLabelledBy { get; set; }
+
         private bool IsInline => IsNested || DialogInstance is null;
 
         /// <summary>
@@ -228,6 +248,8 @@ namespace MudBlazor
                     [nameof(ActionsClass)] = ActionsClass,
                     [nameof(ContentStyle)] = ContentStyle,
                     [nameof(DefaultFocus)] = DefaultFocus,
+                    [nameof(AriaLabel)] = AriaLabel,
+                    [nameof(AriaLabelledBy)] = AriaLabelledBy,
                 };
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor
@@ -8,7 +8,7 @@
 
 <div @attributes="UserAttributes" id="@ElementId" class="mud-dialog-container @GetPosition()">
     <MudOverlay Visible="true" OnClick="HandleBackgroundClickAsync" Class="@BackgroundClassname" DarkBackground="true" @onmouseup="OnMouseUpAsync" />
-    <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" aria-modal="true" aria-labelledby="@(GetHideHeader() ? null : $"_{Id:N}_title")" aria-label="@(GetHideHeader() && !string.IsNullOrWhiteSpace(_titleState.Value) ? _titleState.Value : null)" class="@Classname" style="@Style" tabindex="-1">
+    <div @ref="_dialogContainerReference" id="_@Id.ToString("N")" role="dialog" aria-modal="true" aria-labelledby="@GetAriaLabelledBy()" aria-label="@GetAriaLabel()" class="@Classname" style="@Style" tabindex="-1">
         @if (!GetHideHeader())
         {
             <div id="@($"_{Id:N}_title")" class="@TitleClassname">

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -187,6 +187,37 @@ namespace MudBlazor
                 await RefocusDialogAsync();
         }
 
+        /// <summary>
+        /// The element that names the dialog: an explicit <see cref="MudDialog.AriaLabelledBy"/>, else the title bar when it is shown and no <see cref="MudDialog.AriaLabel"/> replaces it.
+        /// </summary>
+        private string? GetAriaLabelledBy()
+        {
+            if (!string.IsNullOrWhiteSpace(_dialog?.AriaLabelledBy))
+            {
+                return _dialog.AriaLabelledBy;
+            }
+
+            return GetHideHeader() || !string.IsNullOrWhiteSpace(_dialog?.AriaLabel) ? null : $"_{Id:N}_title";
+        }
+
+        /// <summary>
+        /// The text that names the dialog when no element does: an explicit <see cref="MudDialog.AriaLabel"/>, else the title while the header is hidden.
+        /// </summary>
+        private string? GetAriaLabel()
+        {
+            if (!string.IsNullOrWhiteSpace(_dialog?.AriaLabelledBy))
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_dialog?.AriaLabel))
+            {
+                return _dialog.AriaLabel;
+            }
+
+            return GetHideHeader() && !string.IsNullOrWhiteSpace(_titleState.Value) ? _titleState.Value : null;
+        }
+
         private bool GetHideHeader()
         {
             if (GetDialogOptionsOrDefault.NoHeader.HasValue)


### PR DESCRIPTION
Follow-up to the review on [#13780](https://github.com/MudBlazor/MudBlazor/pull/13780) and for [#13609](https://github.com/MudBlazor/MudBlazor/pull/13609). An inline `MudDialog` shown through `@bind-Visible` calls the parameterless `ShowAsync()`, so it has no title to fall back on, and `NoHeader` removes `aria-labelledby`. That dialog stayed unnamed.

- `MudDialog` gains `AriaLabel` and `AriaLabelledBy`, forwarded through the inline show path and rendered on the `role="dialog"` element for both inline and service-shown dialogs.
- Name resolution emits only the winning attribute: `AriaLabelledBy`, then `AriaLabel`, then the title bar via `aria-labelledby`, then the title text via `aria-label` when the header is hidden. Nothing is emitted when none applies.
- The parameters live on `MudDialog` rather than `DialogOptions`, next to `TitleContent`, so a service-shown dialog names itself from its own content component.

Standards:
- [WAI-ARIA APG Modal Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/): the dialog has a label via `aria-labelledby` or `aria-label`.
- [WAI-ARIA 1.2 §aria-labelledby](https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby) takes precedence over `aria-label` in accessible name computation, hence the ordering.

Tests: inline dialog with a hidden header named by `AriaLabel`, by `AriaLabelledBy` pointing at a content heading, and with neither (no empty attributes); a service-shown dialog whose `AriaLabel` replaces the title bar as its name.
