### PR TITLE
MudNavLink: Activate click-driven links from the keyboard

### DIFF
--- a/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
+++ b/src/MudBlazor.UnitTests/Components/NavLinkTests.cs
@@ -166,5 +166,37 @@ namespace MudBlazor.UnitTests.Components
 
             AlertText().InnerHtml.Should().Be("Oh my! We caught an error and handled it!");
         }
+
+        /// <summary>
+        /// A click-driven link is a button that Enter and Space activate.
+        /// </summary>
+        [Test]
+        public async Task NavLink_OnClick_ActivatesFromKeyboard()
+        {
+            var clicks = 0;
+            var comp = Context.Render<MudNavLink>(parameters => parameters.Add(x => x.OnClick, (MouseEventArgs _) => { clicks++; }));
+
+            var link = comp.Find(".mud-nav-link");
+            link.GetAttribute("role").Should().Be("button");
+
+            await link.KeyDownAsync(new KeyboardEventArgs { Key = "Enter" });
+            await link.KeyDownAsync(new KeyboardEventArgs { Key = " " });
+            await link.KeyDownAsync(new KeyboardEventArgs { Key = "a" });
+
+            clicks.Should().Be(2);
+        }
+
+        /// <summary>
+        /// A click-driven link that navigates is announced as a link.
+        /// </summary>
+        [Test]
+        public void NavLink_OnClickWithHref_IsALink()
+        {
+            var comp = Context.Render<MudNavLink>(parameters => parameters
+                .Add(x => x.Href, "/dashboard")
+                .Add(x => x.OnClick, (MouseEventArgs _) => { }));
+
+            comp.Find(".mud-nav-link").GetAttribute("role").Should().Be("link");
+        }
     }
 }

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor
@@ -24,6 +24,8 @@
         else
         {
             <div @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
+                 @onkeydown="HandleKeyDownAsync"
+                 role="@(string.IsNullOrEmpty(Href) ? "button" : "link")"
                  @attributes="UserAttributes"
                  class="@LinkClassname"
                  tabindex="@TabIndex">

--- a/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
+++ b/src/MudBlazor/Components/NavMenu/MudNavLink.razor.cs
@@ -197,6 +197,14 @@ namespace MudBlazor
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Activates the click-driven link from the keyboard, since a plain element does not fire click on Enter or Space.
+        /// </summary>
+        private Task HandleKeyDownAsync(KeyboardEventArgs args)
+        {
+            return args.Key is "Enter" or " " ? OnClickHandler(new MouseEventArgs()) : Task.CompletedTask;
+        }
+
         protected async Task OnClickHandler(MouseEventArgs ev)
         {
             if (Disabled)


### PR DESCRIPTION
A `MudNavLink` with `OnClick` renders a focusable `div` instead of an anchor. A `div` does not fire `click` on Enter or Space, so keyboard users could tab to the item but never activate it, and it was announced as plain text.

- The `div` handles Enter and Space by invoking the same click handler; other keys are ignored.
- It gets `role="button"`, or `role="link"` when an `Href` is also set, since that variant navigates on click.
- The anchor variant is unchanged.

Standards:
- [WCAG 2.2 SC 2.1.1 Keyboard](https://www.w3.org/TR/WCAG22/#keyboard): all functionality operable through a keyboard interface.
- [WAI-ARIA APG Button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/): activates on Enter and Space.
- [WAI-ARIA 1.2 §aria-label](https://www.w3.org/TR/wai-aria-1.2/#aria-label) is prohibited on elements with the generic role, so the element needs a role for the labels callers already put on it to be valid.

Tests: Enter and Space each fire `OnClick` once and an unrelated key does not; the role is `button` without `Href` and `link` with it.
