### PR TITLE
MudMenu: Add menu roles and popup state to every activator

### DIFF
--- a/src/MudBlazor.UnitTests/Components/MenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/MenuTests.cs
@@ -1605,5 +1605,43 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find("div[role=\"button\"]").GetAttribute("aria-expanded").Should().Be("true");
         }
+
+        /// <summary>
+        /// The default button activator announces that it opens a menu and references the list only while it is rendered.
+        /// </summary>
+        [Test]
+        public async Task ButtonActivator_ExposesMenuRelationship()
+        {
+            var comp = Context.Render<MenuTest1>();
+            IElement Activator() => comp.Find("button.mud-button-root");
+
+            Activator().GetAttribute("aria-haspopup").Should().Be("menu");
+            Activator().GetAttribute("aria-expanded").Should().Be("false");
+            Activator().HasAttribute("aria-controls").Should().BeFalse();
+
+            await Activator().ClickAsync();
+
+            var list = comp.Find("div.mud-list");
+            list.GetAttribute("role").Should().Be("menu");
+            list.Id.Should().NotBeNullOrEmpty();
+            Activator().GetAttribute("aria-expanded").Should().Be("true");
+            Activator().GetAttribute("aria-controls").Should().Be(list.Id);
+            comp.FindAll(".mud-menu-item").Should().HaveCount(4).And.OnlyContain(item => item.GetAttribute("role") == "menuitem");
+        }
+
+        /// <summary>
+        /// The icon activator carries the same popup relationship as the button activator.
+        /// </summary>
+        [Test]
+        public void IconActivator_ExposesMenuRelationship()
+        {
+            Context.Render<MudPopoverProvider>();
+            var comp = Context.Render<MudMenu>(parameters => parameters.Add(p => p.Icon, Icons.Material.Filled.MoreVert));
+
+            var activator = comp.Find("button.mud-icon-button");
+            activator.GetAttribute("aria-haspopup").Should().Be("menu");
+            activator.GetAttribute("aria-expanded").Should().Be("false");
+            activator.HasAttribute("aria-controls").Should().BeFalse();
+        }
     }
 }

--- a/src/MudBlazor/Components/Menu/MudMenu.razor
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor
@@ -25,8 +25,9 @@
                  class="@ActivatorClassname"
                  tabindex="0"
                  role="button"
-                 aria-haspopup="true"
-                 aria-expanded="@_openState.Value.ToString().ToLowerInvariant()">
+                 aria-haspopup="menu"
+                 aria-expanded="@_openState.Value.ToString().ToLowerInvariant()"
+                 aria-controls="@GetAriaControls()">
                 @ActivatorContent(_menuContext)
             </div>
         }
@@ -38,8 +39,9 @@
                          OnClick="OpenSubMenuAsync"
                          AutoClose="false"
                          HideSubMenuArrow="true"
-                         aria-haspopup="true"
+                         aria-haspopup="menu"
                          aria-expanded="@_openState.Value.ToString().ToLowerInvariant()"
+                         aria-controls="@GetAriaControls()"
                          aria-label="@AriaLabel">
                 @ActivatorContent(_menuContext)
             </MudMenuItem>
@@ -61,6 +63,9 @@
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
                        OnClick="@ToggleMenuAsync"
+                       aria-haspopup="menu"
+                       aria-expanded="@_openState.Value.ToString().ToLowerInvariant()"
+                       aria-controls="@GetAriaControls()"
                        aria-label="@AriaLabel">
                 @Label
             </MudButton>
@@ -75,6 +80,9 @@
                          OnClick="OpenSubMenuAsync"
                          AutoClose="false"
                          Label="@Label"
+                         aria-haspopup="menu"
+                         aria-expanded="@_openState.Value.ToString().ToLowerInvariant()"
+                         aria-controls="@GetAriaControls()"
                          aria-label="@AriaLabel">
                 @Label
             </MudMenuItem>
@@ -92,6 +100,9 @@
                        Ripple="@Ripple"
                        DropShadow="@DropShadow"
                        OnClick="@ToggleMenuAsync"
+                       aria-haspopup="menu"
+                       aria-expanded="@_openState.Value.ToString().ToLowerInvariant()"
+                       aria-controls="@GetAriaControls()"
                        aria-label="@AriaLabel" />
     }
 
@@ -115,6 +126,8 @@
                  @onpointerenter="@PointerEnterAsync"
                  @onpointerleave="@PointerLeaveAsync">
                 <MudList T="object"
+                         id="@_listId"
+                         role="menu"
                          Class="@ListClassname"
                          Dense="@Dense">
                     @ChildContent

--- a/src/MudBlazor/Components/Menu/MudMenu.razor.cs
+++ b/src/MudBlazor/Components/Menu/MudMenu.razor.cs
@@ -36,6 +36,7 @@ namespace MudBlazor
         private readonly List<object> _menuItems = [];
         private readonly HashSet<object> _registeredItems = [];
         private readonly string _elementId = Identifier.Create("menu");
+        private readonly string _listId = Identifier.Create("menu-list");
         private DateTimeOffset _lastKeyboardActivation = DateTimeOffset.MinValue;
         private readonly MenuContext _menuContext;
 
@@ -386,6 +387,11 @@ namespace MudBlazor
         /// TODO: Once .NET 8 support is dropped, consider using constructor injection (available in .NET 9+) to set defaults directly.
         /// </remarks>
         protected bool GetModal() => Modal ?? PopoverService.PopoverOptions.ModalOverlay;
+
+        /// <summary>
+        /// The id of the popup list while it is rendered, so the activator only references an element that exists.
+        /// </summary>
+        private string? GetAriaControls() => _openState.Value ? _listId : null;
 
         /// <summary>
         /// Gets the transition duration for the popover, using dense menus to disable animations.

--- a/src/MudBlazor/Components/Menu/MudMenuItem.razor
+++ b/src/MudBlazor/Components/Menu/MudMenuItem.razor
@@ -8,6 +8,7 @@
             target="@Target"
             PreventDefault="GetDisabled()"
             ClickPropagation="false"
+            role="menuitem"
             @attributes="UserAttributes"
             @onclick="OnClickHandlerAsync"
             Ref="ElementReference"


### PR DESCRIPTION
Only a custom `ActivatorContent` announced that it opens a popup. The default button and icon-button activators carried nothing but `aria-label`, and the popup rendered as a `listbox` whose items had no role, so screen readers described a menu as a list of untyped text.

- All activators (button, icon button, custom content, and nested sub-menu items) get `aria-haspopup="menu"`, `aria-expanded`, and `aria-controls` while the list is rendered.
- The popup list is `role="menu"` and every `MudMenuItem` is `role="menuitem"`, including anchor items. The list id is stable so the activator can reference it.
- `aria-haspopup` on the existing custom activator changes from `true` to `menu`; the two are equivalent in ARIA 1.2, and `menu` states the popup type. Caller-supplied `role` on a menu item still wins because it is applied before the splat.
- No element or class changes; the arrow-key navigation the menu already implements is what the roles describe.

Standards:
- [WAI-ARIA APG Menu Button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/): activator has `aria-haspopup="menu"` (or `true`), `aria-expanded`, and optionally `aria-controls`; the popup has `role="menu"` with `menuitem` children.
- [WAI-ARIA 1.2 §aria-haspopup](https://www.w3.org/TR/wai-aria-1.2/#aria-haspopup): `true` is a synonym for `menu`.

Tests: the button activator's attributes while closed and open including the `aria-controls` linkage and item roles, and the icon activator's attributes.
