### PR TITLE
MudIcon: Keep icons with an accessible name exposed

### DIFF
--- a/src/MudBlazor.UnitTests/Components/IconTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconTests.cs
@@ -128,5 +128,46 @@ namespace MudBlazor.UnitTests.Components
             icon.HasAttribute("aria-hidden").Should().BeFalse();
             icon.GetAttribute("aria-label").Should().Be("Database");
         }
+
+        /// <summary>
+        /// A bound aria-label that resolves to null or blank text yields no accessible name, so the icon stays hidden.
+        /// </summary>
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void ShouldStayHiddenWhenAriaLabelIsBlank(string ariaLabel)
+        {
+            var comp = Context.Render<MudIcon>(parameters => parameters
+                .Add(p => p.Icon, "material-symbols-outlined/database")
+                .AddUnmatched("aria-label", ariaLabel));
+
+            comp.Find("span").GetAttribute("aria-hidden").Should().Be("true");
+        }
+
+        /// <summary>
+        /// A blank aria-labelledby is no reference at all, so the icon stays hidden.
+        /// </summary>
+        [Test]
+        public void ShouldStayHiddenWhenAriaLabelledByIsBlank()
+        {
+            var comp = Context.Render<MudIcon>(parameters => parameters
+                .Add(p => p.Icon, Icons.Material.Filled.Warning)
+                .AddUnmatched("aria-labelledby", " "));
+
+            comp.Find("svg").GetAttribute("aria-hidden").Should().Be("true");
+        }
+
+        /// <summary>
+        /// A whitespace title renders no usable name, so the icon stays hidden.
+        /// </summary>
+        [Test]
+        public void ShouldStayHiddenWhenTitleIsBlank()
+        {
+            var comp = Context.Render<MudIcon>(parameters => parameters
+                .Add(p => p.Icon, Icons.Material.Filled.Warning)
+                .Add(p => p.Title, "  "));
+
+            comp.Find("svg").GetAttribute("aria-hidden").Should().Be("true");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/IconTests.cs
+++ b/src/MudBlazor.UnitTests/Components/IconTests.cs
@@ -98,5 +98,35 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Markup.Should().Be("<span class=\"mud-icon-root mud-icon-size-medium material-symbols-outlined\" aria-hidden=\"true\" role=\"img\"></span>");
         }
+
+        /// <summary>
+        /// An icon with a title carries meaning of its own, so it is not hidden from assistive technology.
+        /// </summary>
+        [Test]
+        public void ShouldExposeIconWithTitle()
+        {
+            var comp = Context.Render<MudIcon>(parameters => parameters
+                .Add(p => p.Icon, Icons.Material.Filled.Warning)
+                .Add(p => p.Title, "Warning"));
+
+            var svg = comp.Find("svg");
+            svg.HasAttribute("aria-hidden").Should().BeFalse();
+            svg.QuerySelector("title")!.TextContent.Should().Be("Warning");
+        }
+
+        /// <summary>
+        /// An icon given an aria-label by the caller is exposed instead of hidden.
+        /// </summary>
+        [Test]
+        public void ShouldExposeIconWithAriaLabel()
+        {
+            var comp = Context.Render<MudIcon>(parameters => parameters
+                .Add(p => p.Icon, "material-symbols-outlined/database")
+                .AddUnmatched("aria-label", "Database"));
+
+            var icon = comp.Find("span");
+            icon.HasAttribute("aria-hidden").Should().BeFalse();
+            icon.GetAttribute("aria-label").Should().Be("Database");
+        }
     }
 }

--- a/src/MudBlazor/Components/Icon/MudIcon.razor
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor
@@ -3,7 +3,7 @@
 
 @if (IsAngleBracket)
 {
-    <svg class="@Classname" style="@Style" focusable="false" viewBox="@ViewBox" aria-hidden="true" role="img" @attributes="UserAttributes">
+    <svg class="@Classname" style="@Style" focusable="false" viewBox="@ViewBox" aria-hidden="@GetAriaHidden()" role="img" @attributes="UserAttributes">
         @if (Title is not null)
         {
             <title>@Title</title>
@@ -16,13 +16,13 @@ else
 {
     @if (IconSyntax.TryParseFontIconSyntax(Icon, out var syntax))
     {
-        <span class="@($"{Classname} {syntax.FontIconClass}")" style="@Style" title="@Title" aria-hidden="true" role="img" @attributes="UserAttributes">
+        <span class="@($"{Classname} {syntax.FontIconClass}")" style="@Style" title="@Title" aria-hidden="@GetAriaHidden()" role="img" @attributes="UserAttributes">
             @syntax.IconName
         </span>
     }
     else
     {
-        <span class="@($"{Classname} {Icon}")" style="@Style" title="@Title" aria-hidden="true" role="img" @attributes="UserAttributes">
+        <span class="@($"{Classname} {Icon}")" style="@Style" title="@Title" aria-hidden="@GetAriaHidden()" role="img" @attributes="UserAttributes">
             @ChildContent
         </span>
     }

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -99,14 +99,16 @@ namespace MudBlazor
         /// </summary>
         private string? GetAriaHidden()
         {
-            if (!string.IsNullOrEmpty(Title))
+            if (!string.IsNullOrWhiteSpace(Title))
             {
                 return null;
             }
 
-            foreach (var key in UserAttributes.Keys)
+            foreach (var (key, value) in UserAttributes)
             {
-                if (key.Equals("aria-label", StringComparison.OrdinalIgnoreCase) || key.Equals("aria-labelledby", StringComparison.OrdinalIgnoreCase))
+                // A bound attribute can carry null or blank text, which yields no accessible name, so only a usable value exposes the icon.
+                if ((key.Equals("aria-label", StringComparison.OrdinalIgnoreCase) || key.Equals("aria-labelledby", StringComparison.OrdinalIgnoreCase))
+                    && !string.IsNullOrWhiteSpace(value?.ToString()))
                 {
                     return null;
                 }

--- a/src/MudBlazor/Components/Icon/MudIcon.razor.cs
+++ b/src/MudBlazor/Components/Icon/MudIcon.razor.cs
@@ -94,6 +94,27 @@ namespace MudBlazor
         [MemberNotNullWhen(true, nameof(Icon))]
         private bool IsAngleBracket => !string.IsNullOrEmpty(Icon) && Icon.Trim().StartsWith('<');
 
+        /// <summary>
+        /// Hides the icon from assistive technology unless it was given an accessible name, in which case it carries meaning of its own.
+        /// </summary>
+        private string? GetAriaHidden()
+        {
+            if (!string.IsNullOrEmpty(Title))
+            {
+                return null;
+            }
+
+            foreach (var key in UserAttributes.Keys)
+            {
+                if (key.Equals("aria-label", StringComparison.OrdinalIgnoreCase) || key.Equals("aria-labelledby", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+            }
+
+            return "true";
+        }
+
         private partial class IconSyntax
         {
             public string FontIconClass { get; }


### PR DESCRIPTION
Every `MudIcon` renders `aria-hidden="true"`, even when it has a `Title` or a caller-supplied `aria-label`/`aria-labelledby`. A named icon carries meaning of its own, so hiding it drops that meaning for screen reader users while the browser tooltip still shows it to everyone else.

- `aria-hidden="true"` is emitted only when the icon has no usable accessible name. With a non-blank `Title`, or a caller `aria-label`/`aria-labelledby` whose value is non-blank, the attribute is omitted so the name is exposed. A bound attribute resolving to null or whitespace yields no name and leaves the icon hidden.
- Decorative icons, the overwhelming majority, render exactly as before; the existing markup-equality tests are untouched.

Standards:
- [WAI-ARIA 1.2 §aria-hidden](https://www.w3.org/TR/wai-aria-1.2/#aria-hidden): hides content that is decorative or redundant; content that conveys information must stay exposed.
- [SVG accessibility, `title` as accessible name](https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd): the SVG `title` child supplies the accessible name of a `role="img"` graphic.

Tests: a titled SVG icon has no `aria-hidden` and exposes its title; a font icon with a caller `aria-label` is exposed; null, empty and whitespace `aria-label`, a blank `aria-labelledby`, and a blank `Title` all keep the icon hidden.
