### PR TITLE
MudPicker: Announce the popup as a dialog named after the field

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2257,5 +2257,20 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.PickerMonth?.Month.Should().Be(12);
             return comp;
         }
+
+        /// <summary>
+        /// The inline popup is a dialog named after the field so its purpose is announced when it opens.
+        /// </summary>
+        [Test]
+        public async Task Open_PopupIsNamedDialog()
+        {
+            var comp = await OpenPicker();
+            var picker = comp.FindComponent<MudDatePicker>();
+            await picker.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Label, "Start date"));
+
+            var popup = comp.Find("div.mud-picker-inline-paper");
+            popup.GetAttribute("role").Should().Be("dialog");
+            popup.GetAttribute("aria-label").Should().Be("Start date");
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerTests.cs
@@ -2258,11 +2258,12 @@ namespace MudBlazor.UnitTests.Components
             return comp;
         }
 
+
         /// <summary>
-        /// The inline popup is a dialog named after the field so its purpose is announced when it opens.
+        /// The inline popup is a dialog named after the field label so its purpose is announced when it opens.
         /// </summary>
         [Test]
-        public async Task Open_PopupIsNamedDialog()
+        public async Task Open_PopupIsNamedDialogAfterLabel()
         {
             var comp = await OpenPicker();
             var picker = comp.FindComponent<MudDatePicker>();
@@ -2271,6 +2272,75 @@ namespace MudBlazor.UnitTests.Components
             var popup = comp.Find("div.mud-picker-inline-paper");
             popup.GetAttribute("role").Should().Be("dialog");
             popup.GetAttribute("aria-label").Should().Be("Start date");
+            popup.HasAttribute("aria-labelledby").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// A popup with nothing to name it is not announced as a dialog, because an unnamed dialog tells the user nothing.
+        /// </summary>
+        [Test]
+        public async Task Open_PopupWithoutNameIsNotADialog()
+        {
+            var comp = await OpenPicker();
+
+            var popup = comp.Find("div.mud-picker-inline-paper");
+            popup.HasAttribute("role").Should().BeFalse();
+            popup.HasAttribute("aria-label").Should().BeFalse();
+            popup.HasAttribute("aria-labelledby").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// PopupAriaLabel names the popup ahead of the field label.
+        /// </summary>
+        [Test]
+        public async Task Open_PopupAriaLabelWinsOverLabel()
+        {
+            var comp = await OpenPicker();
+            var picker = comp.FindComponent<MudDatePicker>();
+            await picker.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Label, "Start date")
+                .Add(x => x.PopupAriaLabel, "Choose the start date"));
+
+            var popup = comp.Find("div.mud-picker-inline-paper");
+            popup.GetAttribute("role").Should().Be("dialog");
+            popup.GetAttribute("aria-label").Should().Be("Choose the start date");
+        }
+
+        /// <summary>
+        /// PopupAriaLabelledBy names the popup by an element and suppresses the text fallbacks.
+        /// </summary>
+        [Test]
+        public async Task Open_PopupAriaLabelledByWinsOverEverything()
+        {
+            var comp = await OpenPicker();
+            var picker = comp.FindComponent<MudDatePicker>();
+            await picker.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Label, "Start date")
+                .Add(x => x.PopupAriaLabel, "Ignored")
+                .Add(x => x.PopupAriaLabelledBy, "trip-heading"));
+
+            var popup = comp.Find("div.mud-picker-inline-paper");
+            popup.GetAttribute("role").Should().Be("dialog");
+            popup.GetAttribute("aria-labelledby").Should().Be("trip-heading");
+            popup.HasAttribute("aria-label").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// The dialog variant is announced as a named dialog but not as modal, because the picker has no focus trap to back that claim.
+        /// </summary>
+        [Test]
+        public async Task DialogVariant_PopupIsNamedDialogWithoutModalClaim()
+        {
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(x => x.PickerVariant, PickerVariant.Dialog)
+                .Add(x => x.Label, "Start date"));
+
+            await comp.InvokeAsync(() => comp.Instance.OpenAsync());
+
+            var popup = comp.Find("div.mud-overlay-dialog div.mud-picker-paper");
+            popup.GetAttribute("role").Should().Be("dialog");
+            popup.GetAttribute("aria-label").Should().Be("Start date");
+            popup.HasAttribute("aria-modal").Should().BeFalse();
         }
     }
 }

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -63,7 +63,7 @@
                 @if (PickerVariant == PickerVariant.Inline)
                 {
                     <MudPopover Class="@PopoverClassname" Open="@Open" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" RelativeWidth="@(RelativeWidth)" Paper="false">
-                        <div @ref="_pickerInlineRef" class="@PickerInlineClassname" role="dialog" aria-label="@GetPopupAriaLabel()">
+                        <div @ref="_pickerInlineRef" class="@PickerInlineClassname" role="@GetPopupRole()" aria-label="@GetPopupAriaLabel()" aria-labelledby="@GetPopupAriaLabelledBy()">
                             <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                                 <div class="@PickerContainerClassname">
                                     @if (PickerContent != null)
@@ -101,7 +101,7 @@
                 else if (Open && PickerVariant == PickerVariant.Dialog)
                 {
                     <MudOverlay Visible="@Open" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
-                        <MudPaper role="dialog" aria-modal="true" aria-label="@GetPopupAriaLabel()" @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
+                        <MudPaper role="@GetPopupRole()" aria-label="@GetPopupAriaLabel()" aria-labelledby="@GetPopupAriaLabelledBy()" @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                             <div class="@PickerContainerClassname">
                                 @if (PickerContent != null)
                                 {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor
@@ -63,7 +63,7 @@
                 @if (PickerVariant == PickerVariant.Inline)
                 {
                     <MudPopover Class="@PopoverClassname" Open="@Open" Fixed="true" AnchorOrigin="@(AnchorOrigin)" TransformOrigin="@(TransformOrigin)" RelativeWidth="@(RelativeWidth)" Paper="false">
-                        <div @ref="_pickerInlineRef" class="@PickerInlineClassname">
+                        <div @ref="_pickerInlineRef" class="@PickerInlineClassname" role="dialog" aria-label="@GetPopupAriaLabel()">
                             <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                                 <div class="@PickerContainerClassname">
                                     @if (PickerContent != null)
@@ -101,7 +101,7 @@
                 else if (Open && PickerVariant == PickerVariant.Dialog)
                 {
                     <MudOverlay Visible="@Open" OnClick="CloseOverlayAsync" DarkBackground="true" Class="mud-overlay-dialog">
-                        <MudPaper @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
+                        <MudPaper role="dialog" aria-modal="true" aria-label="@GetPopupAriaLabel()" @attributes="UserAttributes" Class="@PickerPaperClassname" Style="@PickerPaperStylename" Square="@_pickerSquare">
                             <div class="@PickerContainerClassname">
                                 @if (PickerContent != null)
                                 {

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -26,6 +26,14 @@ namespace MudBlazor
 
         internal string ElementId { get; } = Identifier.Create("picker");
 
+        /// <summary>
+        /// Names the popup dialog after the field it belongs to, falling back to the placeholder when there is no label.
+        /// </summary>
+        private string? GetPopupAriaLabel()
+        {
+            return string.IsNullOrWhiteSpace(Label) ? (string.IsNullOrWhiteSpace(Placeholder) ? null : Placeholder) : Label;
+        }
+
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
 

--- a/src/MudBlazor/Components/Picker/MudPicker.razor.cs
+++ b/src/MudBlazor/Components/Picker/MudPicker.razor.cs
@@ -27,11 +27,42 @@ namespace MudBlazor
         internal string ElementId { get; } = Identifier.Create("picker");
 
         /// <summary>
-        /// Names the popup dialog after the field it belongs to, falling back to the placeholder when there is no label.
+        /// The element that names the popup: an explicit <see cref="PopupAriaLabelledBy"/>, else nothing.
+        /// </summary>
+        private string? GetPopupAriaLabelledBy()
+        {
+            return string.IsNullOrWhiteSpace(PopupAriaLabelledBy) ? null : PopupAriaLabelledBy;
+        }
+
+        /// <summary>
+        /// The text that names the popup when no element does: an explicit <see cref="PopupAriaLabel"/>, else the field label, else the placeholder.
         /// </summary>
         private string? GetPopupAriaLabel()
         {
-            return string.IsNullOrWhiteSpace(Label) ? (string.IsNullOrWhiteSpace(Placeholder) ? null : Placeholder) : Label;
+            if (GetPopupAriaLabelledBy() is not null)
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrWhiteSpace(PopupAriaLabel))
+            {
+                return PopupAriaLabel;
+            }
+
+            if (!string.IsNullOrWhiteSpace(Label))
+            {
+                return Label;
+            }
+
+            return string.IsNullOrWhiteSpace(Placeholder) ? null : Placeholder;
+        }
+
+        /// <summary>
+        /// The popup is announced as a dialog only when it has a name, since an unnamed dialog tells the user nothing.
+        /// </summary>
+        private string? GetPopupRole()
+        {
+            return GetPopupAriaLabelledBy() is not null || GetPopupAriaLabel() is not null ? "dialog" : null;
         }
 
         [Inject]
@@ -143,6 +174,26 @@ namespace MudBlazor
         [Parameter]
         [Category(CategoryTypes.FormComponent.Behavior)]
         public string? Placeholder { get; set; }
+
+        /// <summary>
+        /// The accessible name announced for the popup.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>, which names the popup after <see cref="Label"/>, or <see cref="Placeholder"/> when there is no label. Without any of these the popup is not announced as a dialog.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public string? PopupAriaLabel { get; set; }
+
+        /// <summary>
+        /// The id of the element that names the popup.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>. Takes precedence over <see cref="PopupAriaLabel"/> and the field text.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public string? PopupAriaLabelledBy { get; set; }
 
         /// <summary>
         /// Occurs when this picker has opened.


### PR DESCRIPTION
The picker popup (calendar, clock, color surface) renders with no role, so when it opens a screen reader gives no indication that a dialog appeared or what it is for.

- The inline popup and the dialog variant get `role="dialog"`, but only when a name resolves; an unnamed dialog tells the user nothing, so the role is withheld until it has one.
- New `PopupAriaLabel` and `PopupAriaLabelledBy` parameters on the picker base name the popup explicitly. `PopupAriaLabelledBy` wins over `PopupAriaLabel`, which wins over `Label`, then `Placeholder`, and only the winning attribute is emitted. The parameters live on the picker rather than on `UserAttributes`, which land on the inner paper rather than the dialog element.
- No `aria-modal`: the picker has no focus trap or inert background, so it must not claim to be modal.

Standards:
- [WAI-ARIA APG Date Picker Dialog example](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/): the calendar popup is a `dialog` with an accessible name.
- [WAI-ARIA 1.2 §dialog](https://www.w3.org/TR/wai-aria-1.2/#dialog): authors should give a dialog an accessible name via `aria-label` or `aria-labelledby`.
- [WAI-ARIA 1.2 §aria-modal](https://www.w3.org/TR/wai-aria-1.2/#aria-modal): the author must ensure focus cannot leave a modal element, which the picker does not do.

Tests: the popup is a dialog named by the label; a popup with nothing to name it has no role; `PopupAriaLabel` beats `Label`; `PopupAriaLabelledBy` beats both and suppresses `aria-label`; the dialog variant is a named dialog with no `aria-modal`.
