### PR TITLE
Various components: Format ARIA tokens with the invariant culture

### DIFF
--- a/src/MudBlazor/Components/Stepper/MudStepper.razor
+++ b/src/MudBlazor/Components/Stepper/MudStepper.razor
@@ -20,7 +20,7 @@
                 .AddClass("mud-step-skipped", step.SkippedState.Value)
                 .Build();
 
-            <button class="@stepClassname" role="tab" type="button" id="@GetStepButtonId(step)" aria-controls="@GetStepPanelIdIfRendered(step)" aria-selected="@(isActive.ToString().ToLower())"
+            <button class="@stepClassname" role="tab" type="button" id="@GetStepButtonId(step)" aria-controls="@GetStepPanelIdIfRendered(step)" aria-selected="@(isActive.ToString().ToLowerInvariant())"
                     @onclick="@(async e => await OnStepClickAsync(step, e))" disabled="@step.DisabledState.Value">
                 @RenderStepLabel(step, isActive)
             </button>

--- a/src/MudBlazor/Components/Switch/MudSwitch.razor
+++ b/src/MudBlazor/Components/Switch/MudSwitch.razor
@@ -8,7 +8,7 @@
             <span class="@SpanClassname">
                 <span class="@SwitchClassname">
                     <span class="mud-switch-button">
-                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" aria-readonly="@(GetReadOnlyState().ToString().ToLower())" role="switch" aria-checked="@AriaCheckedState" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
+                        <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" @attributes="GetInputAttributes()" aria-readonly="@(GetReadOnlyState().ToString().ToLowerInvariant())" role="switch" aria-checked="@AriaCheckedState" type="checkbox" class="mud-switch-input" checked="@BoolValue" @onchange="@OnChange" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" required="@Required" />
                         <span class="@ThumbClassname">
                             @if (!string.IsNullOrEmpty(ThumbIcon))
                             {

--- a/src/MudBlazor/Components/Toggle/MudToggleItem.razor
+++ b/src/MudBlazor/Components/Toggle/MudToggleItem.razor
@@ -3,7 +3,7 @@
 @typeparam T
 
 <MudButton role="checkbox"
-           aria-checked="@(Selected.ToString().ToLower())"
+           aria-checked="@(Selected.ToString().ToLowerInvariant())"
            @attributes="UserAttributes"
            Class="@Classname"
            Style="@Style"


### PR DESCRIPTION
Three ARIA attributes (`aria-selected` on the stepper tab, `aria-readonly` on the switch input, `aria-checked` on the toggle item) lower-cased their boolean with `ToLower()`, while every other site in the library uses `ToLowerInvariant()`.

- Switches the three sites to `ToLowerInvariant()`. The tokens are `true`/`false`, which have no culture-sensitive letters, so nothing observable changes; this removes the inconsistency and the culture-dependent call.
