### PR TITLE
MudBreadcrumbs, MudSplitPanel: Localize hardcoded ARIA labels

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SplitPanelTests.cs
@@ -134,4 +134,16 @@ public class SplitPanelTests : BunitTest
         await Context.DisposeComponentsAsync();
         Context.JSInterop.VerifyInvoke("mudSplitPanel_destroy").Arguments[0].Should().Be("custom-split");
     }
+
+    /// <summary>
+    /// The divider's accessible name comes from the language resources so it can be translated.
+    /// </summary>
+    [Test]
+    public void Divider_HasLocalizedAccessibleName()
+    {
+        var comp = Context.Render<MudSplitPanel>();
+
+        var divider = comp.Find("[role='separator']");
+        divider.GetAttribute("aria-label").Should().Be("Resize panels");
+    }
 }

--- a/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
+++ b/src/MudBlazor/Components/Breadcrumbs/MudBreadcrumbs.razor
@@ -1,6 +1,8 @@
 ﻿@namespace MudBlazor
+@using MudBlazor.Resources
 @using MudBlazor.Utilities
 @inherits MudComponentBase
+@inject InternalMudLocalizer Localizer
 
 @if (Items is null || Items.Count == 0)
 {
@@ -8,7 +10,7 @@
 }
 
 <CascadingValue Value="this" IsFixed="true">
-    <nav aria-label="Breadcrumb">
+    <nav aria-label="@Localizer[LanguageResource.MudBreadcrumbs_Label]">
         <ol @attributes="UserAttributes" class="@Classname" style="@Style">
             @if (MaxItems != null && Collapsed && Items.Count > MaxItems)
             {

--- a/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor
+++ b/src/MudBlazor/Components/SplitPanel/MudSplitPanel.razor
@@ -1,5 +1,7 @@
 ﻿@namespace MudBlazor
+@using MudBlazor.Resources
 @inherits MudComponentBase;
+@inject InternalMudLocalizer Localizer
 
 <div id="@_containerId" style="@Style" class="@Classname" @attributes="@UserAttributes">
     <div class="@ClassnameFirstPanel">
@@ -8,7 +10,7 @@
     <div class="@ClassnameDivider" 
          tabindex="0" 
          role="separator" 
-         aria-label="Resize panels" 
+         aria-label="@Localizer[LanguageResource.MudSplitPanel_ResizePanels]" 
          aria-orientation="@(Horizontal ? "horizontal" : "vertical")"></div>
     <div class="@ClassnameSecondPanel">
         @SecondPanel

--- a/src/MudBlazor/Resources/LanguageResource.resx
+++ b/src/MudBlazor/Resources/LanguageResource.resx
@@ -570,4 +570,10 @@
   <data name="MudExitPrompt_Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="MudBreadcrumbs_Label" xml:space="preserve">
+    <value>Breadcrumb</value>
+  </data>
+  <data name="MudSplitPanel_ResizePanels" xml:space="preserve">
+    <value>Resize panels</value>
+  </data>
 </root>


### PR DESCRIPTION
Two accessible names were English text baked into the markup, so translated apps still announced them in English: the breadcrumb `nav` landmark ("Breadcrumb") and the split-panel divider ("Resize panels").

- Both strings move to `LanguageResource` as `MudBreadcrumbs_Label` and `MudSplitPanel_ResizePanels`, with the same English defaults, so `MudLocalizer` implementations can translate them.

Tests: the divider's `aria-label` resolves through the localizer; the existing breadcrumb test already asserts the landmark label.
