### PR TITLE
MudDataGrid: Document that RowClick still fires when SelectOnRowClick is false

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DataGrid/DataGridPage.razor
@@ -287,7 +287,8 @@
                     The <CodeInline>&lt;MudDataGrid></CodeInline> component supports both single and multi-row selection.<br><br>
                     Selection can be triggered either by row clicks or by checkboxes.<br>
                     Row clicks are enabled by default via the <CodeInline>SelectOnRowClick</CodeInline> property (default: <CodeInline>true</CodeInline>). 
-                    This allows users to select a row by clicking anywhere on it.<br>
+                    This allows users to select a row by clicking anywhere on it.
+                    Set it to <CodeInline>false</CodeInline> to leave selection to the checkboxes; the <CodeInline>RowClick</CodeInline> event is raised either way.<br>
                     To provide visual feedback and explicit selection controls, add a <CodeInline>SelectColumn</CodeInline> in the <CodeInline>&lt;Columns></CodeInline> definition. 
                     This renders a checkbox for each row.<br><br>
                     When using <CodeInline>SelectColumn</CodeInline> checkboxes, built-in accessible labels are provided by default and can be overridden with <CodeInline>AriaLabelFunc</CodeInline>.

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6062,6 +6062,27 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.FindAll(".mud-checkbox-true").Count.Should().Be(0);
         }
 
+        /// <summary>
+        /// Clicking a row with <c>SelectOnRowClick</c> disabled still raises <c>RowClick</c> while leaving the selection untouched (#10792).
+        /// </summary>
+        [Test]
+        public async Task RowClickFiresWhenSelectOnRowClickDisabled()
+        {
+            var clickedItems = new List<DataGridMultiSelectionTest.Item>();
+            var comp = Context.Render<DataGridMultiSelectionTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridMultiSelectionTest.Item>>();
+            await dataGrid.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.SelectOnRowClick, false)
+                .Add(x => x.RowClick, args => clickedItems.Add(args.Item)));
+
+            await dataGrid.FindAll("tbody.mud-table-body td")[1].ClickAsync();
+
+            clickedItems.Should().ContainSingle().Which.Name.Should().Be("A");
+            dataGrid.Instance.GetState(x => x.SelectedItem).Should().BeNull();
+            dataGrid.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+            dataGrid.FindAll(".mud-checkbox-true").Should().BeEmpty();
+        }
+
         [Test]
         public async Task DataGridDragAndDrop_SwapMode()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -862,10 +862,11 @@ namespace MudBlazor
         public bool MultiSelection { get; set; }
 
         /// <summary>
-        /// Toggles the row checkbox when the row is clicked.
+        /// Selects or deselects a row when it is clicked.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.
+        /// Defaults to <c>true</c>.  When <c>false</c>, rows are only selected through a <see cref="SelectColumn{T}"/> checkbox or in code.
+        /// <see cref="RowClick"/> is raised either way, so a click can still be handled without changing <see cref="SelectedItem"/> or <see cref="SelectedItems"/>.
         /// </remarks>
         [Parameter]
         public bool SelectOnRowClick { get; set; } = true;
@@ -2170,11 +2171,11 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Set the currently selected item in the data grid.
+        /// Toggles the selection of an item the same way a row click does.
         /// </summary>
-        /// <param name="item">The item to select.</param>
+        /// <param name="item">The item to select or deselect.</param>
         /// <remarks>
-        /// When <see cref="MultiSelection"/> is <c>true</c> and <see cref="SelectOnRowClick"/> is <c>true</c>, the <see cref="SelectedItems"/> are updated.  The <see cref="SelectedItem"/> is also updated.
+        /// Updates <see cref="SelectedItem"/> and <see cref="SelectedItems"/>.  Does nothing when <see cref="SelectOnRowClick"/> is <c>false</c>.
         /// </remarks>
         public Task SetSelectedItemAsync(T item)
         {


### PR DESCRIPTION
Closes https://github.com/MudBlazor/MudBlazor/issues/10792. The issue reports that `RowClick` does not fire on a `MudDataGrid` with `SelectOnRowClick="false"`. It does, and did at v8.1.0 too; `OnRowClickedAsync` raises `RowClick` before it consults the flag. What the reporter actually saw is that `SelectedItem` did not move, unlike `MudTable`.

That difference is by design. `MudTable` keeps `SelectedItem` (the last clicked row) separate from `SelectedItems` (the checkbox set), so `SelectOnRowClick` only gates the checkbox toggle. `MudDataGrid` has a single selection model: `SelectedItem` is always a member of `SelectedItems`, and the `SelectColumn` checkbox renders from that same set. A row that is highlighted but unchecked is not representable, and letting the click move `SelectedItem` would make the flag meaningless in single-selection mode.

The parameter's XML doc ("Toggles the row checkbox when the row is clicked") reads as if the click itself is suppressed, which is where the confusion comes from. This PR:

- Rewrites the `SelectOnRowClick` and `SetSelectedItemAsync(T)` docs to say the flag only decides whether a click changes `SelectedItem` and `SelectedItems`, and that `RowClick` is raised either way.
- Adds the same sentence to the Row Selection section of the DataGrid docs page.
- Adds `RowClickFiresWhenSelectOnRowClickDisabled`, which clicks a row with the flag off and asserts the callback received the item while `SelectedItem`, `SelectedItems`, and the rendered checkboxes stay empty.

No behavior change. Apps that want the `MudTable`-style "preview on click without checking the row" can track the clicked item from `RowClick` and use it in `RowClassFunc`.