### PR TITLE
MudTable: Re-render when a row checkbox changes the selection

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSelectionDerivedContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableSelectionDerivedContentTest.razor
@@ -1,0 +1,20 @@
+<MudTable @ref="_table" T="int" Items="_items" MultiSelection="true" RowClassFunc="RowClass">
+    <ToolBarContent>
+        <MudText id="selected-count">@(_table?.SelectedItems?.Count ?? 0)</MudText>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    public static string __description__ = "a toolbar and row classes derived from the selection must follow the row checkboxes even when SelectedItems is not bound.";
+
+    private MudTable<int>? _table;
+    private readonly int[] _items = [0, 1, 2, 3];
+
+    private string RowClass(int item, int index) => _table?.SelectedItems?.Contains(item) == true ? "row-selected" : string.Empty;
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3676,6 +3676,27 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Content derived from the selection, such as the toolbar and row classes, must follow the row checkboxes.
+        /// </summary>
+        /// <remarks>
+        /// <c>ToolBarContent</c> and <c>RowClassFunc</c> are evaluated while the table renders, so skipping that
+        /// render leaves them showing the previous selection. A bound <c>SelectedItems</c> hides the problem.
+        /// </remarks>
+        [Test]
+        public void TableMultiSelection_SelectionDerivedContent_FollowsRowCheckbox()
+        {
+            var comp = Context.Render<TableSelectionDerivedContentTest>();
+
+            comp.Find("#selected-count").TextContent.Trim().Should().Be("0");
+            comp.FindAll("tbody tr")[0].ClassList.Should().NotContain("row-selected");
+
+            comp.FindAll("tbody .mud-checkbox input")[0].Change(true);
+
+            comp.Find("#selected-count").TextContent.Trim().Should().Be("1");
+            comp.FindAll("tbody tr")[0].ClassList.Should().Contain("row-selected");
+        }
+
+        /// <summary>
         /// Row selection checkboxes have a localized accessible name.
         /// </summary>
         [Test]

--- a/src/MudBlazor/Components/Table/MudTable.razor
+++ b/src/MudBlazor/Components/Table/MudTable.razor
@@ -113,7 +113,7 @@
                                     <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" RowId="@generatedRowId"
                                            Checkable="MultiSelection" SelectionChangeable="SelectionChangeable" Editable="IsItemEditable(item)"
                                            Disabled="IsRowDisabled(item)" DisabledClass="@DisabledRowClass" Checked="@(IsCheckedRow(item))"
-                                           CheckedChanged="@(this.AsNonRenderingEventHandler<bool>(value => OnRowCheckboxChanged(value, item)))">
+                                           CheckedChanged="@(value => OnRowCheckboxChanged(value, item))">
                                         @if (!ReadOnly && Editable && Equals(_editingItem, item))
                                         {
                                             <CascadingValue Value="@Validator" IsFixed="true">
@@ -227,7 +227,7 @@
                  }
                  <MudTr Class="@rowClass" Style="@rowStyle" Item="item" @key="item" RowId="@generatedRowId" Checkable="MultiSelection" SelectionChangeable="SelectionChangeable"
                         Editable="IsItemEditable(item)" Expandable="expandable" Disabled="IsRowDisabled(item)" DisabledClass="@DisabledRowClass"
-                        Checked="Context.Selection.Contains(item)" CheckedChanged="@(this.AsNonRenderingEventHandler<bool>(value => OnRowCheckboxChanged(value, item)))">
+                        Checked="Context.Selection.Contains(item)" CheckedChanged="@(value => OnRowCheckboxChanged(value, item))">
                      @if (!ReadOnly && Editable && Equals(_editingItem, item))
                      {
                          <CascadingValue Value="@Validator" IsFixed="true">


### PR DESCRIPTION
#13736 wrapped the row checkbox handler in `AsNonRenderingEventHandler`, so checking a row no longer re-renders `MudTable`. `ToolBarContent` and `RowClassFunc` are evaluated during that render, so a "N selected" toolbar and selection-derived row classes keep showing the previous state.

Binding `SelectedItems` re-renders the table anyway and hides the problem, so only the unbound and `@ref` patterns are affected — which is why it slipped through.

This restores the plain handler at both `MudTr` call sites. The `Context.UpdateRowCheckBoxes()` call #13736 added is deliberately kept, so the select-all checkbox is updated explicitly rather than as a side effect of the re-render, along with the fixture and test that cover it. It uses `SetChecked(notify: false)`, so it cannot double-fire callbacks.