### PR TITLE
MudTreeView: Render every item when a root parameter changes

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewRuntimeRootParametersTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TreeView/TreeViewRuntimeRootParametersTest.razor
@@ -1,0 +1,15 @@
+﻿<MudTreeView T="string" SelectionMode="@SelectionMode" Disabled="@Disabled" ReadOnly="@ReadOnly" TriState="true">
+    <MudTreeViewItem T="string" Class="lvl1" Value='@("p")' Expanded="true">
+        <MudTreeViewItem T="string" Class="lvl2" Value='@("c1")' Expanded="true">
+            <MudTreeViewItem T="string" Class="lvl3" Value='@("g1")' />
+        </MudTreeViewItem>
+    </MudTreeViewItem>
+</MudTreeView>
+
+@code {
+    public static string __description__ = "A three-deep tree whose root Disabled, ReadOnly and SelectionMode are changed at runtime.";
+
+    [Parameter] public SelectionMode SelectionMode { get; set; } = SelectionMode.MultiSelection;
+    [Parameter] public bool Disabled { get; set; }
+    [Parameter] public bool ReadOnly { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -1446,6 +1446,58 @@ namespace MudBlazor.UnitTests.Components
             await arrows()[1].ClickAsync();
             comp.WaitForAssertion(() => itemContents().Should().Contain("More Spam (6)"));
         }
+
+        /// <summary>
+        /// Verifies that turning on the root's <see cref="MudTreeView{T}.Disabled"/> at runtime reaches items at every depth.
+        /// </summary>
+        [Test]
+        public async Task TreeView_RuntimeDisabled_ShouldReachEveryDepth()
+        {
+            var comp = Context.Render<TreeViewRuntimeRootParametersTest>();
+            comp.Find(".lvl3.mud-treeview-item").ClassList.Should().NotContain("mud-treeview-item-disabled");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.Disabled, true));
+
+            comp.Find(".lvl1.mud-treeview-item").ClassList.Should().Contain("mud-treeview-item-disabled");
+            comp.Find(".lvl2.mud-treeview-item").ClassList.Should().Contain("mud-treeview-item-disabled");
+            comp.Find(".lvl3.mud-treeview-item").ClassList.Should().Contain("mud-treeview-item-disabled");
+            foreach (var input in comp.FindAll(".mud-treeview-item-checkbox input"))
+            {
+                input.HasAttribute("disabled").Should().BeTrue();
+            }
+        }
+
+        /// <summary>
+        /// Verifies that turning on the root's <see cref="MudTreeView{T}.ReadOnly"/> at runtime reaches items at every depth.
+        /// </summary>
+        [Test]
+        public async Task TreeView_RuntimeReadOnly_ShouldReachEveryDepth()
+        {
+            var comp = Context.Render<TreeViewRuntimeRootParametersTest>();
+            comp.Find(".lvl3 .mud-treeview-item-content").ClassList.Should().Contain("cursor-pointer");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ReadOnly, true));
+
+            comp.Find(".lvl1 .mud-treeview-item-content").ClassList.Should().NotContain("cursor-pointer");
+            comp.Find(".lvl2 .mud-treeview-item-content").ClassList.Should().NotContain("cursor-pointer");
+            comp.Find(".lvl3 .mud-treeview-item-content").ClassList.Should().NotContain("cursor-pointer");
+        }
+
+        /// <summary>
+        /// Verifies that switching the root's <see cref="MudTreeView{T}.SelectionMode"/> at runtime gives every item a checkbox.
+        /// </summary>
+        [Test]
+        public async Task TreeView_RuntimeSelectionMode_ShouldReachEveryDepth()
+        {
+            var comp = Context.Render<TreeViewRuntimeRootParametersTest>(parameters => parameters
+                .Add(x => x.SelectionMode, SelectionMode.SingleSelection));
+            comp.FindAll(".mud-treeview-item-checkbox").Should().BeEmpty();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.SelectionMode, SelectionMode.MultiSelection));
+
+            comp.FindAll(".mud-treeview-item-checkbox").Count.Should().Be(3);
+        }
         /// <summary>
         /// Mounting a tree must render each item once, not twice.
         /// </summary>

--- a/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeView.razor.cs
@@ -492,7 +492,8 @@ namespace MudBlazor
             {
                 return Task.CompletedTask;
             }
-            return UpdateItemsAsync();
+            // Items read these from the root through a fixed cascade, so walking the tree is the only thing that pushes the new value down to them.
+            return UpdateItemsAsync(forceRender: true);
         }
 
         internal async Task OnItemClickAsync(MudTreeViewItem<T> clickedItem)
@@ -647,12 +648,13 @@ namespace MudBlazor
         /// Let the items update their selection state visualization and state according to
         /// the selection in the tree view
         /// </summary>
-        private async Task UpdateItemsAsync()
+        /// <param name="forceRender">Renders every item regardless of whether its state changed.</param>
+        private async Task UpdateItemsAsync(bool forceRender = false)
         {
             var selection = GetSelection();
             foreach (var item in _childItems)
             {
-                await item.UpdateSelectionStateAsync(selection);
+                await item.UpdateSelectionStateAsync(selection, forceRender);
             }
         }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -711,9 +711,10 @@ namespace MudBlazor
         /// </summary>
         /// <param name="selectedValues"></param>
         /// <returns>True if the item or any sub-item changed from non-selected to selected.</returns>
-        internal async Task<bool> UpdateSelectionStateAsync(HashSet<T> selectedValues)
+        /// <param name="forceRender">Renders every item regardless of whether its state changed.</param>
+        internal async Task<bool> UpdateSelectionStateAsync(HashSet<T> selectedValues, bool forceRender = false)
         {
-            var (selectedBecameTrue, _) = await UpdateSelectionStateCoreAsync(selectedValues);
+            var (selectedBecameTrue, _) = await UpdateSelectionStateCoreAsync(selectedValues, forceRender);
 
             return selectedBecameTrue;
         }
@@ -727,8 +728,13 @@ namespace MudBlazor
         /// Multi-selection also renders when the tri-state checkbox no longer matches what was rendered, because that value is derived from the sub-items and can go stale without this item's own state changing.
         /// </remarks>
         /// <param name="selectedValues">The values that are currently selected.</param>
+        /// <param name="forceRender">
+        /// Renders every item regardless of whether its state changed.
+        /// The tree root is cascaded with a fixed value, so items are never told when a root parameter such as <see cref="MudTreeView{T}.Disabled"/> changes, and an item whose own parameters are unchanged is not re-rendered by the framework either.
+        /// Walking the tree is what pushes those values down, so a walk caused by a root parameter change has to render even where nothing about the selection moved.
+        /// </param>
         /// <returns>Whether the item or any sub-item became selected, and whether anything rendered by this item changed.</returns>
-        private async Task<(bool SelectedBecameTrue, bool Changed)> UpdateSelectionStateCoreAsync(HashSet<T> selectedValues)
+        private async Task<(bool SelectedBecameTrue, bool Changed)> UpdateSelectionStateCoreAsync(HashSet<T> selectedValues, bool forceRender)
         {
             if (MudTreeRoot == null)
             {
@@ -744,7 +750,7 @@ namespace MudBlazor
             bool childSelectedBecameTrue = false;
             foreach (var child in _childItems)
             {
-                var (becameTrue, childChanged) = await child.UpdateSelectionStateCoreAsync(selectedValues);
+                var (becameTrue, childChanged) = await child.UpdateSelectionStateCoreAsync(selectedValues, forceRender);
                 childSelectedBecameTrue = childSelectedBecameTrue || becameTrue;
                 changed = changed || childChanged;
             }
@@ -753,7 +759,7 @@ namespace MudBlazor
                 await _expandedState.SetValueAsync(true);
                 changed = true;
             }
-            if (changed || (MultiSelection && _hasRenderedCheckBoxState && ComputeCheckBoxStateTriState() != _renderedCheckBoxState))
+            if (forceRender || changed || (MultiSelection && _hasRenderedCheckBoxState && ComputeCheckBoxStateTriState() != _renderedCheckBoxState))
             {
                 StateHasChanged();
             }


### PR DESCRIPTION
### Description

Changing a `MudTreeView`'s `Disabled`, `ReadOnly`, `SelectionMode` or `TriState` at runtime stopped reaching leaf items after #13732.

Those parameters route through `OnParameterChangedAsync` to `UpdateItemsAsync`, which walks the tree. Items read the values off the root, and the root is cascaded with `IsFixed="true"`, so the cascade never notifies them. Blazor also skips `SetParametersAsync` for a child whose own parameters are all unchanged. The walk's unconditional `StateHasChanged()` was the only thing pushing the new value down.

#13732 made that render conditional on the item's own selection state having changed. That is correct for a selection change, but it drops the only propagation path for a root parameter change. Branch items still updated because they pass a freshly allocated `ChildContent` delegate on every render. Leaf items, whose parameters are constant in static markup, went stale.

A walk caused by a root parameter change now renders unconditionally. Selection changes keep the suppression #13732 added, so the render-count tests from that PR are untouched and still pass.

It is leaf items at any depth, not a depth cutoff. On a five-level tree, levels 1-4 updated and only the leaf was stale.

### Symptoms on a stale leaf

- Keeps `cursor-pointer` and loses `mud-treeview-item-disabled`.
- Renders an enabled checkbox with no `disabled` attribute on a disabled tree, so it stays focusable and is exposed as enabled to assistive technology.
- Gets no checkbox at all when `SelectionMode` switches from single to multi, so it cannot be selected.

Clicks were still blocked, because `OnItemClickedAsync` re-reads `GetDisabled()` when it runs.

### Why force only this one path

`OnParameterChangedAsync` is the only walk trigger that pushes a root value down. Every root value an item reads at render time falls into one of two groups:

| Root value read by items | Change handler | Forced here |
| --- | --- | --- |
| `Disabled`, `ReadOnly`, `SelectionMode`, `TriState` | `OnParameterChangedAsync` | Yes |
| `Ripple`, `ExpandOnClick`, `ExpandOnDoubleClick`, `CheckedIcon`, `UncheckedIcon`, `IndeterminateIcon`, `AutoExpand`, `ItemTemplate` | None | N/A |

Every other `UpdateItemsAsync` caller is selection- or comparer-driven, which is what #13732 targeted and where the existing `changed` flag already captures the transition.

The second group has no change handler at all, so it never ran the walk and was already stale on leaf items before #13732. Changing `Ripple` at runtime leaves `mud-ripple` on the leaf both with and without this patch. That is a separate pre-existing bug and is deliberately not addressed here.

### Tests

Three tests over a new three-level fixture cover `Disabled`, `ReadOnly` and `SelectionMode`. Each was confirmed to fail with the regression present and pass with the fix. `TriState` uses the same forced path; it is not covered by a test because a leaf has no children to be indeterminate about.

`TreeViewTests` is 68/68, including the three render-count tests from #13732, and the full unit test suite is 5884 passing, 0 failing.
