### PR TITLE
MudDataGrid: Reduce cell edit rerender overhead

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -1126,6 +1126,20 @@ namespace MudBlazor.UnitTests.Components
             age.Should().Be(52);
         }
 
+        /// <summary>
+        /// Cell edit mode already cascades the grid validator once per row, so it must not add another
+        /// cascading component around every editable cell (#11860).
+        /// </summary>
+        [Test]
+        public void DataGridCellEditCascadesValidatorOncePerRow()
+        {
+            var comp = Context.Render<DataGridCellEditTest>();
+            var rowCount = comp.FindAll(".mud-table-body tr").Count;
+
+            comp.FindComponents<CascadingValue<IForm>>()
+                .Should().HaveCount(rowCount, "per-cell validator cascades multiply component diff work in large editable grids");
+        }
+
         [Test]
         public async Task DataGridInlineEditWithNullableChange()
         {
@@ -1746,6 +1760,25 @@ namespace MudBlazor.UnitTests.Components
             dataGrid.Render();
 
             comp.Instance.Reads.Should().Be(CellCount, "each cell should read its property once per render");
+        }
+
+        /// <summary>
+        /// The row callback updates state through the grid, so the row renderer must not also perform its
+        /// automatic post-event render and repeat every cell's work (#11860).
+        /// </summary>
+        [Test]
+        public async Task DataGridRowClickRendersCellsOnce()
+        {
+            var comp = Context.Render<DataGridCellValueReadsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridCellValueReadsTest.Item>>();
+
+            // 3 rows x 2 property columns.
+            const int CellCount = 6;
+
+            comp.Instance.Reads = 0;
+            await dataGrid.Find(".mud-table-body td").ClickAsync();
+
+            comp.Instance.Reads.Should().Be(CellCount, "the grid render already reflects row selection changes");
         }
 
         /// <summary>

--- a/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
@@ -43,7 +43,7 @@
         }
         <tr class="mud-table-row @rowClass" Style="@rowStyle" @key="itemBag.Item"
             @attributes="GetRowAttributes(itemBag.Item)"
-            @onclick="@((args) => RowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)))"
+            @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(args => RowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)))"
             @oncontextmenu="@GetContextMenuCallback(itemBag)"
             @oncontextmenu:preventDefault="@DataGrid.RowContextMenuClick.HasDelegate">
             <CascadingValue Value="@DataGrid.Validator" IsFixed="true">

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor
@@ -422,35 +422,18 @@
 
                  @if (showEditMode)
                  {
-                     @* An inline editor registers with the grid's own validator, which forwards it to Validator but keeps a commit scoped to the row being edited. *@
-                     <CascadingValue TValue="Interfaces.IForm" Value="@(isInlineEditing ? _inlineEditValidator : Validator)" IsFixed="true">
-                         @if (column.EditTemplate is not null)
-                         {
-                             @column.EditTemplate(cell.Context)
-                         }
-                         else
-                         {
-                             if (column.PropertyType == typeof(string))
-                             {
-                                 <MudTextField T="string"
-                                               Value="@cell._valueString"
-                                               ValueChanged="@cell.StringValueChangedAsync"
-                                               Margin="@Margin.Dense" Style="margin-top:0"
-                                               Required="@column.Required"
-                                               Variant="@Variant.Text" Culture="@column.Culture" />
-                             }
-                             else if (column.isNumber)
-                             {
-                                 <MudNumericField T="double?"
-                                                  Value="@cell._valueNumber"
-                                                  ValueChanged="@cell.NumberValueChangedAsync"
-                                                  Margin="@Margin.Dense" Style="margin-top:0"
-                                                  Required="@column.Required"
-                                                  Variant="@Variant.Text" Culture="@column.Culture"
-                                                  Format="@column.ContentFormat" />
-                             }
-                         }
-                     </CascadingValue>
+                     if (isInlineEditing)
+                     {
+                         @* An inline editor registers with the grid's own validator, which forwards it to Validator but keeps a commit scoped to the row being edited. *@
+                         <CascadingValue TValue="Interfaces.IForm" Value="@_inlineEditValidator" IsFixed="true">
+                             @EditCell(column, cell)
+                         </CascadingValue>
+                     }
+                     else
+                     {
+                         @* Cell edit mode reuses the row-level Validator cascade so a grid full of editors does not double the component count. *@
+                         @EditCell(column, cell)
+                     }
                  }
                  else
                  {
@@ -482,6 +465,33 @@
                      }
                  }
              </td>
+         </text>;
+
+    internal RenderFragment EditCell(Column<T> column, Cell<T> cell) =>
+        @<text>
+             @if (column.EditTemplate is not null)
+             {
+                 @column.EditTemplate(cell.Context)
+             }
+             else if (column.PropertyType == typeof(string))
+             {
+                 <MudTextField T="string"
+                               Value="@cell._valueString"
+                               ValueChanged="@cell.StringValueChangedAsync"
+                               Margin="@Margin.Dense" Style="margin-top:0"
+                               Required="@column.Required"
+                               Variant="@Variant.Text" Culture="@column.Culture" />
+             }
+             else if (column.isNumber)
+             {
+                 <MudNumericField T="double?"
+                                  Value="@cell._valueNumber"
+                                  ValueChanged="@cell.NumberValueChangedAsync"
+                                  Margin="@Margin.Dense" Style="margin-top:0"
+                                  Required="@column.Required"
+                                  Variant="@Variant.Text" Culture="@column.Culture"
+                                  Format="@column.ContentFormat" />
+             }
          </text>;
 
     internal RenderFragment Filter(IFilterDefinition<T> filterDefinition, Column<T>? column, bool autoFocus = false) =>


### PR DESCRIPTION
Partial mitigation for https://github.com/MudBlazor/MudBlazor/issues/11860. It removes two sources of redundant work in the editable row/cell render path, which roughly halves the per-click cost. Cell mode still keeps every editor alive, so render isolation is still needed and the issue should stay open.

### Row renderer ran an extra full pass

`DataGridVirtualizeRow` owns the `<tr>` click handler. With a plain lambda the row component is the callback's `IHandleEvent` receiver, so it renders itself on top of the grid render that `RowClick` already causes: two complete cell passes per click.

`EventUtil.AsNonRenderingEventHandler` drops the row's pass. The grid's render happens either way, including when `SetSelectedItemAsync` early-returns because `SelectOnRowClick` is false. Exceptions still dispatch through `EventUtil`.

### Duplicate CascadingValue per editable cell

`DataGridVirtualizeRow` already wraps each row's cells in a fixed `CascadingValue` holding `DataGrid.Validator`. `MudDataGrid` wrapped every editable cell in a second one with the same value, so 150 rows x 8 editable columns meant 1,200 extra components per render tree.

Cell mode now uses the row-level provider. Inline mode keeps `_inlineEditValidator`, which tracks the form each editor registered with and keeps removal and validation correct if `Validator` changes mid-edit.

No public API or dependency change, and rendered markup is identical.

### Verification

Both new tests fail on `dev`: 12 property reads instead of 6, and 9 `CascadingValue<IForm>` providers instead of 3.

Full suite 5879 passed / 2 skipped, docs-example suite 1402 passed, viewer build and format clean. The only intermittent failures across ten local full runs were the known debounced-input tests (`DebouncedNumericFieldCultureChangeRerender` and friends), which fail on unpatched `dev` at the same rate (3 of 4 runs) and are unrelated to this change. Browser A/B on the issue's fixture (150 rows, 8 editable columns, 1,200 inputs, 150 checkboxes), counting every bound-property read:

| cell-focus click | before | after |
| --- | --- | --- |
| reads per click | 2400 (12/12 samples) | 1200 (12/12 samples) |
| median time to DOM quiet | 2176 ms | 1071 ms |

Checkbox selection is unchanged at 1200 reads. Those times are a Debug WASM build, so the pass counts are the result and the times are directional; a Release Chromium run measured the same 2400 to 1200 with cell-switch median 456 ms to 267 ms.

Regression sweep beyond the two new tests: 15 extra scenario tests (row-owned `aria-selected` / `RowClassFunc` / `RowStyleFunc` after a row click, grouped rows, virtualized rows, hierarchy child rows surviving a row click, `RowClick` firing exactly once, `CellClick` stopPropagation, `SelectOnRowClick=false`, `EditTrigger.OnRowClick`, cell editors registering with an external `MudForm`, `EditTemplate` editors, nested grids with their own validators, runtime `EditMode` and `ReadOnly` switches) all pass identically on this branch and on unpatched `dev`.

Driven by hand on the live docs site: the Validator example (clearing a required cell editor still raises "Name is required"), inline row editing commit, row selection with disabled rows, select-all, and row detail expansion followed by a row click. No console errors.

Checked that nothing else got slower, same fixture, reads per interaction:

| interaction | before | after |
| --- | --- | --- |
| row click | 80 | 40 |
| checkbox | 40 | 40 |
| page change | 40 | 40 |
| column sort | 100 | 100 |

### Not covered

- Chromium only, and allocations were not measured.
- Grouped grids forward row callbacks through `DataGridGroupRow` lambdas, so those receivers may still add passes. Needs its own fail-first evidence.
- One full body render per interaction, and 1,200 live inputs, both remain.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

AI-assisted. Every number above comes from a run against this branch.
