### PR TITLE
MudTreeViewItem: Skip toggle button for leaf items

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TreeViewTests.cs
@@ -660,6 +660,39 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.Item1Selected.Should().BeTrue();
         }
 
+        /// <summary>
+        /// Only expandable items instantiate a toggle button; leaves render the arrow placeholder as plain markup.
+        /// </summary>
+        [Test]
+        public void LeafItems_DoNotInstantiateToggleButton()
+        {
+            var comp = Context.Render<TreeViewTest1>();
+            comp.FindAll("li.mud-treeview-item").Count.Should().Be(10);
+            // Every item keeps the arrow slot because it is the indent gutter that aligns leaves with their parents.
+            comp.FindAll("div.mud-treeview-item-arrow").Count.Should().Be(10);
+            // Four of the ten items have children, so the other six pay for no component.
+            comp.FindComponents<MudTreeViewItemToggleButton>().Count.Should().Be(4);
+            comp.FindAll("div.mud-treeview-item-arrow button").Count.Should().Be(4);
+        }
+
+        /// <summary>
+        /// Double-clicking a leaf's arrow placeholder must not reach the item, matching the expand button (#9419).
+        /// </summary>
+        [Test]
+        public async Task DoubleClickOnLeafArrow_ShouldNotSelectItem()
+        {
+            var comp = Context.Render<TreeViewTest1>(self => self.Add(x => x.SelectionMode, SelectionMode.SingleSelection));
+            // Index 2 is "MudBlazor.svg", a leaf, so its arrow is the empty placeholder rather than a button.
+            comp.FindAll("div.mud-treeview-item-arrow")[2].QuerySelector("button").Should().BeNull();
+
+            await comp.FindAll("div.mud-treeview-item-arrow")[2].DoubleClickAsync();
+            comp.Instance.SelectedValue.Should().BeNull();
+
+            // The same double-click on the item content does select, which is what the placeholder shields against.
+            await comp.FindAll("div.mud-treeview-item-content")[2].DoubleClickAsync();
+            comp.Instance.SelectedValue.Should().Be("MudBlazor.svg");
+        }
+
         [Test]
         public async Task Collapsed_ClickOnTreeItem_CheckClose()
         {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -1,4 +1,4 @@
-@namespace MudBlazor
+﻿@namespace MudBlazor
 @inherits MudComponentBase
 @typeparam T
 
@@ -20,7 +20,7 @@
                 {
                     @* A leaf can never show a toggle, so emit the placeholder the button would have rendered instead of paying for a component instance.
                        The empty handler plus stopPropagation is what keeps a double-click here from reaching the item (#9419). *@
-                    <div class="mud-treeview-item-arrow" @ondblclick="_swallowArrowDoubleClick" @ondblclick:stopPropagation="true"></div>
+                    <div class="mud-treeview-item-arrow" @ondblclick="OnArrowDoubleClick" @ondblclick:stopPropagation="true"></div>
                 }
 
                 @if (MultiSelection)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -1,4 +1,4 @@
-﻿@namespace MudBlazor
+@namespace MudBlazor
 @inherits MudComponentBase
 @typeparam T
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -18,8 +18,6 @@
                 }
                 else
                 {
-                    @* A leaf can never show a toggle, so emit the placeholder the button would have rendered instead of paying for a component instance.
-                       The empty handler plus stopPropagation is what keeps a double-click here from reaching the item (#9419). *@
                     <div class="mud-treeview-item-arrow" @ondblclick="OnArrowDoubleClick" @ondblclick:stopPropagation="true"></div>
                 }
 

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor
@@ -12,7 +12,16 @@
             }
             else
             {
-                <MudTreeViewItemToggleButton Disabled="@GetDisabled()" Loading="_loading" Expanded="_expandedState.Value" ExpandedChanged="OnItemExpanded" Visible="@(HasChildren() && AreChildrenVisible())" ExpandedIcon="@ExpandButtonIcon" ExpandedIconColor="@ExpandButtonIconColor" LoadingIcon="@LoadingIcon" LoadingIconColor="LoadingIconColor"></MudTreeViewItemToggleButton>
+                @if (HasChildren())
+                {
+                    <MudTreeViewItemToggleButton Disabled="@GetDisabled()" Loading="_loading" Expanded="_expandedState.Value" ExpandedChanged="OnItemExpanded" Visible="@AreChildrenVisible()" ExpandedIcon="@ExpandButtonIcon" ExpandedIconColor="@ExpandButtonIconColor" LoadingIcon="@LoadingIcon" LoadingIconColor="LoadingIconColor"></MudTreeViewItemToggleButton>
+                }
+                else
+                {
+                    @* A leaf can never show a toggle, so emit the placeholder the button would have rendered instead of paying for a component instance.
+                       The empty handler plus stopPropagation is what keeps a double-click here from reaching the item (#9419). *@
+                    <div class="mud-treeview-item-arrow" @ondblclick="_swallowArrowDoubleClick" @ondblclick:stopPropagation="true"></div>
+                }
 
                 @if (MultiSelection)
                 {

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -25,18 +25,8 @@ namespace MudBlazor
         private readonly DefaultConverter<T?> _converter = new();
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
 
-        /// <summary>
-        /// Swallows a double-click on a leaf's arrow placeholder so it never reaches the item, mirroring <see cref="MudTreeViewItemToggleButton"/>.
-        /// </summary>
-        /// <remarks>
-        /// Cached so the placeholder does not allocate a handler on every render.
-        /// </remarks>
-        private readonly Action<MouseEventArgs> _swallowArrowDoubleClick;
-
         public MudTreeViewItem()
         {
-            _swallowArrowDoubleClick = this.AsNonRenderingEventHandler<MouseEventArgs>(static _ => { });
-
             using var registerScope = CreateRegisterScope();
             _expandedState = registerScope.RegisterParameter<bool>(nameof(Expanded))
                 .WithParameter(() => Expanded)
@@ -613,6 +603,11 @@ namespace MudBlazor
                 }
             }
             await OnClick.InvokeAsync(ev);
+        }
+
+        private void OnArrowDoubleClick()
+        {
+            /* Don't do anything on purpose. Fixes #9419 */
         }
 
         private async Task OnItemDoubleClickedAsync(MouseEventArgs ev)

--- a/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
+++ b/src/MudBlazor/Components/TreeView/MudTreeViewItem.razor.cs
@@ -25,8 +25,18 @@ namespace MudBlazor
         private readonly DefaultConverter<T?> _converter = new();
         private readonly HashSet<MudTreeViewItem<T>> _childItems = new();
 
+        /// <summary>
+        /// Swallows a double-click on a leaf's arrow placeholder so it never reaches the item, mirroring <see cref="MudTreeViewItemToggleButton"/>.
+        /// </summary>
+        /// <remarks>
+        /// Cached so the placeholder does not allocate a handler on every render.
+        /// </remarks>
+        private readonly Action<MouseEventArgs> _swallowArrowDoubleClick;
+
         public MudTreeViewItem()
         {
+            _swallowArrowDoubleClick = this.AsNonRenderingEventHandler<MouseEventArgs>(static _ => { });
+
             using var registerScope = CreateRegisterScope();
             _expandedState = registerScope.RegisterParameter<bool>(nameof(Expanded))
                 .WithParameter(() => Expanded)


### PR DESCRIPTION
Every `MudTreeViewItem` instantiates a `MudTreeViewItemToggleButton`, but for a leaf that component renders nothing except its own root `<div class="mud-treeview-item-arrow">`, which is the indent gutter. The button inside it sits behind `@if (Visible)`, and `Visible` is false for anything without children.

Leaves now emit that placeholder div directly, and only expandable items create the component. The rendered DOM is unchanged.

Gated on `HasChildren()` rather than on `Visible`. `Visible` also folds in `AreChildrenVisible()`, which flips on every keystroke while `FilterAsync` runs, so gating on it would swap an element frame for a component frame at the same position — a dispose, a create and a DOM node replacement per keystroke. `HasChildren()` already guards the sibling `MudCollapse`, so the new branch only flips at points that were structural anyway.

Retained managed memory after mount, bare renderer, median, measured against this branch's base:

| scenario | retained | components |
| --- | --- | --- |
| 500 leaves | 8644 -> 5678 KB (-34%) | 1504 -> 1004 |
| 20x10 nested | 4253 -> 2989 KB (-30%) | 844 -> 644 |

A static HTML render of both scenarios is byte-identical between base and branch once generated ids are normalised.

Two tests. One pins that only the four expandable items in `TreeViewTest1` create a toggle button while all ten keep their arrow slot. The other covers the leaf half of #9419 — double-clicking a leaf's placeholder must not select the item — which nothing covered before, since every existing arrow assertion selects `div.mud-treeview-item-arrow button` and that only matches branches. Removing the `stopPropagation` makes it fail.

Part of https://github.com/MudBlazor/MudBlazor/issues/13737, which tracks several more candidates and should stay open.
