### PR TITLE
MudDataGrid: Reduce grouped row and context-menu rerender overhead

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridNestedGroupClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridNestedGroupClickTest.razor
@@ -1,0 +1,129 @@
+﻿@namespace MudBlazor.UnitTests.TestComponents.DataGrid
+
+<MudDataGrid T="Item" Items="@_items" Groupable="true" MultiSelection="true"
+             ReadOnly="@ReadOnly" EditMode="@DataGridEditMode.Cell" EditTrigger="@EditTrigger"
+             RowClick="@OnRowClick" RowContextMenuClick="@ContextMenuCallback"
+             StartedEditingItem="@(item => StartedEditing.Add(item))">
+    <Columns>
+        <SelectColumn T="Item" />
+        <PropertyColumn Property="x => x.Group" Grouping="@Grouped" GroupExpanded Editable="false" />
+        <PropertyColumn Property="x => x.SubGroup" Grouping="@Grouped" GroupExpanded Editable="false" />
+        <PropertyColumn Property="x => x.Name" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    public static string __description__ = "Two grouping levels, so row and context-menu clicks reach the grid through nested DataGridGroupRow forwarding";
+
+    /// <summary>
+    /// Groups by two columns; set false for the flat grid, which reaches DataGridVirtualizeRow without any group row.
+    /// </summary>
+    [Parameter]
+    public bool Grouped { get; set; } = true;
+
+    /// <summary>
+    /// Gives <see cref="MudDataGrid{T}.RowContextMenuClick"/> a delegate; set false to leave it empty so no listener is attached.
+    /// </summary>
+    [Parameter]
+    public bool ContextMenuEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Makes the consumer's row-click handler throw, to check the exception still surfaces.
+    /// </summary>
+    [Parameter]
+    public bool ThrowOnRowClick { get; set; }
+
+    /// <summary>
+    /// Makes the consumer's context-menu handler throw, to check the exception still surfaces.
+    /// </summary>
+    [Parameter]
+    public bool ThrowOnContextMenuClick { get; set; }
+
+    [Parameter]
+    public bool ReadOnly { get; set; } = true;
+
+    [Parameter]
+    public DataGridEditTrigger EditTrigger { get; set; } = DataGridEditTrigger.Manual;
+
+    /// <summary>
+    /// Counts reads of the bound cell value, which is one per cell per render pass.
+    /// </summary>
+    public int Reads { get; set; }
+
+    public List<DataGridRowClickEventArgs<Item>> RowClicks { get; } = new();
+
+    public List<DataGridRowClickEventArgs<Item>> ContextClicks { get; } = new();
+
+    public List<Item> StartedEditing { get; } = new();
+
+    private readonly List<Item> _items = new();
+
+    private EventCallback<DataGridRowClickEventArgs<Item>> ContextMenuCallback
+        => ContextMenuEnabled
+            ? EventCallback.Factory.Create<DataGridRowClickEventArgs<Item>>(this, OnRowContextMenuClick)
+            : default;
+
+    protected override void OnInitialized()
+    {
+        // Two outer groups, each with two inner groups of two rows: 8 rows, so a full body pass is 8 reads.
+        foreach (var group in new[] { "A", "B" })
+        {
+            foreach (var subGroup in new[] { "X", "Y" })
+            {
+                for (var i = 1; i <= 2; i++)
+                {
+                    _items.Add(new Item(this, group, subGroup, $"{group}{subGroup}{i}"));
+                }
+            }
+        }
+    }
+
+    private void OnRowClick(DataGridRowClickEventArgs<Item> args)
+    {
+        RowClicks.Add(args);
+        if (ThrowOnRowClick)
+        {
+            throw new InvalidOperationException("row click handler failed");
+        }
+    }
+
+    private void OnRowContextMenuClick(DataGridRowClickEventArgs<Item> args)
+    {
+        ContextClicks.Add(args);
+        if (ThrowOnContextMenuClick)
+        {
+            throw new InvalidOperationException("context menu handler failed");
+        }
+    }
+
+    public class Item
+    {
+        private readonly DataGridNestedGroupClickTest _owner;
+        private string _name;
+
+        public Item(DataGridNestedGroupClickTest owner, string group, string subGroup, string name)
+        {
+            _owner = owner;
+            Group = group;
+            SubGroup = subGroup;
+            _name = name;
+        }
+
+        public string Group { get; }
+
+        public string SubGroup { get; }
+
+        /// <summary>
+        /// Only this property counts a read; the grouping keys are read by the grouping machinery too.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                _owner.Reads++;
+                return _name;
+            }
+            set => _name = value;
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridGroupingTests.cs
@@ -14,6 +14,183 @@ namespace MudBlazor.UnitTests.Components
 {
     public class DataGridGroupingTests : BunitTest
     {
+        /// <summary>
+        /// A row click inside a nested group must render each cell once; every DataGridGroupRow level used to add a pass of its own.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupRowClickRendersCellsOnce()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>();
+
+            // 8 rows x 1 counted property column.
+            const int CellCount = 8;
+            comp.FindAll("tbody .mud-datagrid-group").Count.Should().Be(6, "the fixture must really be grouped two levels deep");
+
+            comp.Instance.Reads = 0;
+            await comp.FindAll("tbody tr[aria-selected] td")[1].ClickAsync();
+
+            comp.Instance.Reads.Should().Be(CellCount, "the grid render already redraws every group level");
+        }
+
+        /// <summary>
+        /// A right-click inside a nested group must also render each cell once.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupContextMenuRendersCellsOnce()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>();
+
+            const int CellCount = 8;
+            comp.FindAll("tbody .mud-datagrid-group").Count.Should().Be(6, "the fixture must really be grouped two levels deep");
+
+            comp.Instance.Reads = 0;
+            await comp.FindAll("tbody tr[aria-selected] td")[1].ContextMenuAsync();
+
+            comp.Instance.Reads.Should().Be(CellCount, "forwarding a context-menu click must not add renders either");
+        }
+
+        /// <summary>
+        /// The row context-menu receiver is shared with ungrouped grids, which reach the row without any group row.
+        /// </summary>
+        [Test]
+        public async Task DataGridUngroupedContextMenuRendersCellsOnce()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>(parameters => parameters
+                .Add(x => x.Grouped, false));
+
+            const int CellCount = 8;
+            comp.FindAll("tbody .mud-datagrid-group").Should().BeEmpty("this case must not be grouped");
+
+            comp.Instance.Reads = 0;
+            await comp.FindAll("tbody tr[aria-selected] td")[1].ContextMenuAsync();
+
+            comp.Instance.Reads.Should().Be(CellCount);
+        }
+
+        /// <summary>
+        /// Forwarding through two group levels must still deliver the clicked item and its row index exactly once.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupRowClickReportsItemAndIndex()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>();
+
+            // The third data row is the first row of the A/Y inner group.
+            await comp.FindAll("tbody tr[aria-selected]")[2].QuerySelectorAll("td")[1].ClickAsync();
+
+            comp.Instance.RowClicks.Should().HaveCount(1);
+            comp.Instance.RowClicks[0].Item.Name.Should().Be("AY1");
+            comp.Instance.RowClicks[0].RowIndex.Should().Be(0, "the index is relative to the innermost group");
+            comp.Instance.ContextClicks.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Forwarding must deliver context-menu clicks with the same item and index as a row click.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupContextMenuReportsItemAndIndex()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>();
+
+            await comp.FindAll("tbody tr[aria-selected]")[3].QuerySelectorAll("td")[1].ContextMenuAsync();
+
+            comp.Instance.ContextClicks.Should().HaveCount(1);
+            comp.Instance.ContextClicks[0].Item.Name.Should().Be("AY2");
+            comp.Instance.ContextClicks[0].RowIndex.Should().Be(1);
+            comp.Instance.RowClicks.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Selection still follows a row click in a nested group, which is output the group row itself renders.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupRowClickSelectsRow()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>();
+
+            comp.FindAll("tbody tr[aria-selected]").Select(x => x.GetAttribute("aria-selected"))
+                .Should().AllBe("false");
+
+            await comp.FindAll("tbody tr[aria-selected]")[2].QuerySelectorAll("td")[1].ClickAsync();
+
+            comp.FindAll("tbody tr[aria-selected]").Select(x => x.GetAttribute("aria-selected"))
+                .Should().Equal("false", "false", "true", "false", "false", "false", "false", "false");
+        }
+
+        /// <summary>
+        /// Cell editing still begins from a row click in a nested group, and the editor still commits.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupRowClickStartsCellEdit()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>(parameters => parameters
+                .Add(x => x.ReadOnly, false)
+                .Add(x => x.EditTrigger, DataGridEditTrigger.OnRowClick));
+
+            comp.Instance.StartedEditing.Should().BeEmpty();
+
+            await comp.FindAll("tbody tr[aria-selected]")[2].QuerySelectorAll("td")[1].ClickAsync();
+
+            comp.Instance.StartedEditing.Should().ContainSingle()
+                .Which.Name.Should().Be("AY1", "the row click must begin editing the clicked item");
+
+            await comp.FindAll("tbody tr[aria-selected]")[2].QuerySelectorAll("td input:not([type=checkbox])")[0].ChangeAsync("renamed");
+
+            comp.FindAll("tbody tr[aria-selected]")[2].QuerySelectorAll("td input:not([type=checkbox])")[0]
+                .GetAttribute("value").Should().Be("renamed", "the editor in a nested group must still commit");
+        }
+
+        /// <summary>
+        /// An exception from the consumer's row-click handler must still surface through the forwarding chain.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupRowClickSurfacesHandlerException()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>(parameters => parameters
+                .Add(x => x.ThrowOnRowClick, true));
+
+            var click = async () => await comp.FindAll("tbody tr[aria-selected] td")[1].ClickAsync();
+
+            await click.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("row click handler failed");
+        }
+
+        /// <summary>
+        /// An exception from the consumer's context-menu handler must surface too, since that receiver changed as well.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupContextMenuSurfacesHandlerException()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>(parameters => parameters
+                .Add(x => x.ThrowOnContextMenuClick, true));
+
+            var rightClick = async () => await comp.FindAll("tbody tr[aria-selected] td")[1].ContextMenuAsync();
+
+            await rightClick.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("context menu handler failed");
+        }
+
+        /// <summary>
+        /// Without a RowContextMenuClick delegate the group row forwards nothing and the row carries no context-menu listener.
+        /// </summary>
+        [Test]
+        public async Task DataGridNestedGroupWithoutContextMenuDelegateForwardsNothing()
+        {
+            var comp = Context.Render<DataGridNestedGroupClickTest>(parameters => parameters
+                .Add(x => x.ContextMenuEnabled, false));
+
+            comp.FindComponents<DataGridVirtualizeRow<DataGridNestedGroupClickTest.Item>>()
+                .Select(x => x.Instance.ContextRowClick.HasDelegate)
+                .Should().AllBeEquivalentTo(false, "the group row must not forward a callback that can never fire");
+
+            var rightClick = async () => await comp.FindAll("tbody tr[aria-selected] td")[1].ContextMenuAsync();
+
+            await rightClick.Should().ThrowAsync<MissingEventHandlerException>();
+
+            // A left click must still work here, because both callbacks are handed over together.
+            await comp.FindAll("tbody tr[aria-selected] td")[1].ClickAsync();
+            comp.Instance.RowClicks.Should().HaveCount(1);
+        }
         [Test]
         public async Task DataGridGroupExpandedTrue()
         {

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor
@@ -41,8 +41,8 @@
                                 GroupClassFunc="@GroupClassFunc"
                                 GroupStyleFunc="@GroupStyleFunc"
                                 DataGrid="@DataGrid"
-                                RowClick="@((args) => RowClick.InvokeAsync((args.args, args.item, args.index)))"
-                                ContextRowClick="@((args) => ContextRowClick.InvokeAsync((args.args, args.item, args.index)))"/>
+                                RowClick="@GetRowClickCallback()"
+                                ContextRowClick="@GetContextRowClickCallback()"/>
         }
     }
     else
@@ -52,8 +52,8 @@
             <DataGridVirtualizeRow T="T"
                                     DataGrid="@DataGrid"
                                     GroupedItems="@Items"
-                                    RowClick="@((args) => RowClick.InvokeAsync((args.args, args.item, args.index)))"
-                                    ContextRowClick="@((args) => ContextRowClick.InvokeAsync((args.args, args.item, args.index)))"/>
+                                    RowClick="@GetRowClickCallback()"
+                                    ContextRowClick="@GetContextRowClickCallback()"/>
             <!-- Group Footer -->
             <tr class="mud-table-row">
                 @DataGrid.FooterCells(Items, Items)

--- a/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/DataGridGroupRow.razor.cs
@@ -106,6 +106,27 @@ namespace MudBlazor
             base.OnParametersSet();
         }
 
+        // A forwarded click ends at a grid-owned callback whose receiver already renders the grid, which redraws every group row, so a level of nesting must not add a render of its own.
+        // The delegates are cached because AsNonRenderingEventHandler allocates a receiver on every call.
+        private Func<(MouseEventArgs args, T item, int index), Task>? _rowClickForwarder;
+        private Func<(MouseEventArgs args, T item, int index), Task>? _contextRowClickForwarder;
+
+        // The row always carries a click listener, so this forwarder is always needed.
+        private EventCallback<(MouseEventArgs args, T item, int index)> GetRowClickCallback()
+            => EventCallback.Factory.Create(
+                this,
+                _rowClickForwarder ??= this.AsNonRenderingEventHandler<(MouseEventArgs args, T item, int index)>(
+                    args => RowClick.InvokeAsync(args)));
+
+        // DataGridVirtualizeRow gates its context-menu listener on the same condition, so without a grid-level handler this forwarder could never fire.
+        private EventCallback<(MouseEventArgs args, T item, int index)> GetContextRowClickCallback()
+            => DataGrid.RowContextMenuClick.HasDelegate
+                ? EventCallback.Factory.Create(
+                    this,
+                    _contextRowClickForwarder ??= this.AsNonRenderingEventHandler<(MouseEventArgs args, T item, int index)>(
+                        args => ContextRowClick.InvokeAsync(args)))
+                : default;
+
         internal void GroupExpandClick()
         {
             _expanded = !_expanded;

--- a/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
+++ b/src/MudBlazor/Components/DataGrid/DataGridVirtualizeRow.razor
@@ -106,8 +106,11 @@
             ? CreateContextMenuCallback(itemBag)
             : default;
 
+    // ContextRowClick ends at a grid-owned callback whose receiver already schedules the grid's render, so this row must not add its own.
     private EventCallback<MouseEventArgs> CreateContextMenuCallback(IndexBag<T> itemBag)
-        => EventCallback.Factory.Create<MouseEventArgs>(this, args => ContextRowClick.InvokeAsync((args, itemBag.Item, itemBag.Index)));
+        => EventCallback.Factory.Create<MouseEventArgs>(
+            this,
+            this.AsNonRenderingEventHandler<MouseEventArgs>(args => ContextRowClick.InvokeAsync((args, itemBag.Item, itemBag.Index))));
 
     private Dictionary<string, object?>? GetRowAttributes(T item)
     {


### PR DESCRIPTION
Follow-up to #13792. It stopped the row component from scheduling its own render for `@onclick`, but two redundant passes survived it.

`DataGridGroupRow` handed its child a fresh `args => RowClick.InvokeAsync(...)` lambda whose receiver was the group row, so every nesting level scheduled a render of its own on top of the grid render the callback already causes. The forwarders are now cached non-rendering delegates built with `EventCallback.Factory.Create`. The context forwarder is skipped entirely when `DataGrid.RowContextMenuClick` has no delegate, because `DataGridVirtualizeRow` gates its listener on the same condition and the forwarder could never fire.

`DataGridVirtualizeRow.CreateContextMenuCallback` still used the row itself as the receiver, so a right-click cost an extra full pass. That also affects ungrouped grids, which never reach a `DataGridGroupRow`, and it is the larger single win here.

Render probes on a grouped 150-row grid with 8 counted columns, so one full body pass is 1,200 cell reads:

| interaction | before | after |
| --- | --- | --- |
| row click, one grouping level | 1,600 | 1,200 |
| row click, two grouping levels | 1,600 | 1,200 |
| context menu | 1,600 | 1,200 |

Deterministic in every sample. Two grouping levels measure the same as one because the render queue coalesces the inner group row into the outer one.

DOM parity was checked by dumping `comp.Markup` on both sides and normalising the framework's random ids: identical, with 8 row `oncontextmenu` listeners when a delegate exists and 0 without.