### PR TITLE
MudDebouncedInput: Schedule debounce before returning

### DIFF
--- a/src/MudBlazor/Components/Input/MudDebouncedInput.cs
+++ b/src/MudBlazor/Components/Input/MudDebouncedInput.cs
@@ -74,9 +74,30 @@ namespace MudBlazor
                 return base.UpdateValuePropertyAsync(updateText);
             }
 
-            // Debounce the update - use fire-and-forget pattern to match the old Timer implementation.
-            _ = _debouncer.DebounceAsync(OnDebouncedUpdate);
-            return Task.CompletedTask;
+            // Don't wait out the interval, but do wait for the debounce to be scheduled.
+            // Scheduling happens after an await inside the debouncer, so returning before it lets a caller act on a debounce that does not exist yet.
+            var scheduled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _ = DebounceAndSignalAsync(scheduled);
+
+            return scheduled.Task;
+        }
+
+        /// <summary>
+        /// Runs the debounce and completes <paramref name="scheduled"/> once its timer exists.
+        /// </summary>
+        /// <remarks>
+        /// The task is also completed when the debounce ends without scheduling, such as after disposal, so a caller is never left waiting.
+        /// </remarks>
+        private async Task DebounceAndSignalAsync(TaskCompletionSource scheduled)
+        {
+            try
+            {
+                await _debouncer!.DebounceCoreAsync(OnDebouncedUpdate, () => scheduled.TrySetResult());
+            }
+            finally
+            {
+                scheduled.TrySetResult();
+            }
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Utilities/Debounce/DebounceDispatcher.cs
+++ b/src/MudBlazor/Utilities/Debounce/DebounceDispatcher.cs
@@ -122,7 +122,20 @@ internal sealed class DebounceDispatcher : IDisposable
     /// <param name="cancellationToken">Optional cancellation token to cancel the debounced action.</param>
     /// <returns>A task that completes when the action executes or is cancelled/disposed.</returns>
     /// <exception cref="ArgumentNullException">Thrown when action is null.</exception>
-    public async Task DebounceAsync(Func<Task> action, CancellationToken cancellationToken = default)
+    public Task DebounceAsync(Func<Task> action, CancellationToken cancellationToken = default)
+        => DebounceCoreAsync(action, onScheduled: null, cancellationToken);
+
+    /// <summary>
+    /// Debounces the action and reports the moment its timer is scheduled.
+    /// </summary>
+    /// <remarks>
+    /// Scheduling happens after an await, so a caller that needs to know the debounce exists cannot rely on the call returning.
+    /// </remarks>
+    /// <param name="action">The asynchronous action to invoke after the debounce interval.</param>
+    /// <param name="onScheduled">Invoked once the debounce timer has been scheduled, and not invoked when the action runs immediately or the call is cancelled.</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the debounced action.</param>
+    /// <returns>A task that completes when the action executes or is cancelled/disposed.</returns>
+    internal async Task DebounceCoreAsync(Func<Task> action, Action? onScheduled, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(action);
 
@@ -213,7 +226,9 @@ internal sealed class DebounceDispatcher : IDisposable
             }
 
             // Wait for the debounce interval
-            await Task.Delay(scheduledInterval, _timeProvider, delayToken).ConfigureAwait(false);
+            var delay = Task.Delay(scheduledInterval, _timeProvider, delayToken);
+            onScheduled?.Invoke();
+            await delay.ConfigureAwait(false);
             proceedToExecution = true;
         }
         catch (Exception ex) when (IsExpectedDebounceFlowException(ex))


### PR DESCRIPTION
`MudDebouncedInput.UpdateValuePropertyAsync` fired the debouncer and returned `Task.CompletedTask`. Inside `DebounceDispatcher`, the timer is not registered until `Task.Delay(interval, _timeProvider, token)`, which sits behind `await _lock.WaitAsync(...)` and `await SafeCancelAsync(previousCts)`. So the call routinely returns while no debounce exists yet.

Instrumenting the scheduling point and counting per full-suite run:

```
calls=36 armed=292 lateArm=20
calls=36 armed=285 lateArm=19
calls=36 armed=292 lateArm=18
calls=36 armed=292 lateArm=20
```

About 55% of debounced updates returned before their timer was scheduled, and that is a lower bound because a concurrent scheduling from another component can mask one. This is the common case, not a rare race.

That is what makes the debounced-input tests flaky. A fake clock advanced immediately after an input can land while nothing is waiting on it, and since the fake clock never advances again the commit is lost outright rather than delayed. It matches the symptom: the test fails with the uncommitted typed text, and raising its wait to 10 seconds still fails, at 10.02 seconds.

The change returns a task that completes once the timer is scheduled. The interval is still not awaited, so the input does not block for the debounce.

Verification:

- Forcing the window wide open with an `await Task.Yield()` before the scheduling point makes `NumericField_Debounced_ValueEcho_DoesNotRewriteTextWhileTyping` fail 3 out of 3 on `dev`, against 0 failures in 3 control runs. With this change all 13 tests that drive a debounced input against a fake clock pass with that same window forced open.
- 12 consecutive clean full-suite runs, where `dev` fails roughly one run in three, rotating between `DebouncedNumericFieldRerender`, `DebouncedNumericFieldCultureChangeRerender`, `DebouncedTextFieldFormatChangeRerender` and `NumericField_Debounced_ValueEcho_DoesNotRewriteTextWhileTyping`. Suite duration is unchanged at about 30s.

No test changes were needed.

One thing worth a look: `MudBaseInput.OnTextParameterChangedAsync` awaits this inside `SuppressInteractionEffectsWhileAsync`, so that suppression scope now stays open across the scheduling hop instead of closing synchronously. In `SetTextAsync` the call is the last statement, so nothing else moves.
