### PR TITLE
MudRadioGroup: Cascade itself as a fixed value

### DIFF
--- a/src/MudBlazor.UnitTests/Components/RadioTests.cs
+++ b/src/MudBlazor.UnitTests/Components/RadioTests.cs
@@ -514,6 +514,63 @@ namespace MudBlazor.UnitTests.Components
             create(readOnly = true, disabled = true).Find("span.mud-button-root").ClassList.Should().NotContain("hover:mud-default-hover");
         }
 
+        /// <summary>
+        /// A radio with no child content still picks up the group's error state, which #13743 found going stale.
+        /// </summary>
+        [Test]
+        public async Task RadioGroup_ErrorState_ReachesRadiosWithoutChildContent()
+        {
+            var comp = Context.Render<MudRadioGroup<int>>(self => self
+                .Add(x => x.ErrorId, "group-error")
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 1))
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 2)));
+
+            comp.FindAll("span.mud-button-root").Should().AllSatisfy(x => x.ClassList.Should().NotContain("mud-error-text"));
+            comp.FindAll("input.mud-radio-input").Should().AllSatisfy(x => x.HasAttribute("aria-describedby").Should().BeFalse());
+
+            await comp.SetParametersAndRenderAsync(self => self.Add(x => x.Error, true));
+
+            comp.FindAll("span.mud-button-root").Should().AllSatisfy(x => x.ClassList.Should().Contain("mud-error-text"));
+            comp.FindAll("input.mud-radio-input").Should().AllSatisfy(x => x.GetAttribute("aria-describedby").Should().Be("group-error"));
+        }
+
+        /// <summary>
+        /// Changing the group's Name after the first render still reaches radios with no child content (#13743).
+        /// </summary>
+        [Test]
+        public async Task RadioGroup_NameChangedAfterRender_ReachesRadios()
+        {
+            var comp = Context.Render<MudRadioGroup<int>>(self => self
+                .Add(x => x.Name, "before")
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 1))
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 2)));
+
+            comp.FindAll("input.mud-radio-input").Should().AllSatisfy(x => x.GetAttribute("name").Should().Be("before"));
+
+            await comp.SetParametersAndRenderAsync(self => self.Add(x => x.Name, "after"));
+
+            comp.FindAll("input.mud-radio-input").Should().AllSatisfy(x => x.GetAttribute("name").Should().Be("after"));
+        }
+
+        /// <summary>
+        /// A group render that changes nothing a radio shows leaves the radios alone.
+        /// </summary>
+        [Test]
+        public async Task RadioGroup_RenderingItself_DoesNotRerenderEveryRadio()
+        {
+            var comp = Context.Render<MudRadioGroup<int>>(self => self
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 1))
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 2))
+                .AddChildContent<MudRadio<int>>(r => r.Add(x => x.Value, 3)));
+
+            var before = comp.FindComponents<MudRadio<int>>().Select(x => x.RenderCount).ToArray();
+
+            await comp.SetParametersAndRenderAsync(self => self.Add(x => x.Class, "repainted"));
+
+            var after = comp.FindComponents<MudRadio<int>>().Select(x => x.RenderCount).ToArray();
+            after.Should().Equal(before);
+        }
+
         [Test]
         public void RadioColor_ReadOnly_ShouldKeepColor()
         {

--- a/src/MudBlazor/Components/Radio/MudRadio.razor
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor
@@ -6,7 +6,7 @@
     <InputContent>
         <label class="@LabelClassname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync" @onclick:stopPropagation="@StopClickPropagation">
             <span class="@IconClassname">
-                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" aria-describedby="@(MudRadioGroup?.HasErrors == true ? MudRadioGroup.GetErrorId() : null)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" checked="@Checked" name="@MudRadioGroup?.Name" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
+                <input aria-labelledby="@(string.IsNullOrWhiteSpace(AriaLabel) ? null : _ariaId)" aria-describedby="@(GroupHasErrors ? GroupErrorId : null)" @attributes="GetInputAttributes()" type="radio" class="mud-radio-input" checked="@Checked" name="@GroupName" disabled="@GetDisabledState()" @onclick:preventDefault="@GetReadOnlyState()" @onclick="OnClickAsync" />
                 <MudIcon Disabled="@Disabled" Icon="@GetIcon()" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
             @if (!string.IsNullOrEmpty(Label))

--- a/src/MudBlazor/Components/Radio/MudRadio.razor.cs
+++ b/src/MudBlazor/Components/Radio/MudRadio.razor.cs
@@ -52,8 +52,29 @@ namespace MudBlazor
             .AddClass("mud-disabled", GetDisabledState())
             .AddClass("mud-readonly", GetReadOnlyState())
             .AddClass("mud-checked", Checked)
-            .AddClass("mud-error-text", MudRadioGroup?.HasErrors)
+            .AddClass("mud-error-text", GroupHasErrors)
             .Build();
+
+        /// <summary>
+        /// The <c>name</c> shared by every radio in the parent group.
+        /// </summary>
+        /// <remarks>
+        /// Pushed by the group rather than read off it, so a radio re-renders when it changes without the group having to notify every radio on every render.
+        /// </remarks>
+        [CascadingParameter(Name = "RadioGroupName")]
+        private string? GroupName { get; set; }
+
+        /// <summary>
+        /// Whether the parent group is showing a validation error.
+        /// </summary>
+        [CascadingParameter(Name = "RadioGroupHasErrors")]
+        private bool GroupHasErrors { get; set; }
+
+        /// <summary>
+        /// The id of the parent group's error text, used to describe each radio.
+        /// </summary>
+        [CascadingParameter(Name = "RadioGroupErrorId")]
+        private string? GroupErrorId { get; set; }
 
         [Inject]
         private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -8,12 +8,20 @@
 
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorId="@ErrorIdState.Value" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="false">
+        @* The group instance never changes, so cascade it fixed and push the values a radio renders on their own.
+           A non-fixed instance notifies every radio on every group render, costing each one a render it does not need. *@
+        <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="true">
             <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                 <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
-                    <div role="radiogroup" aria-required="@Required.ToString().ToLowerInvariant()" aria-invalid="@(HasErrors ? "true" : null)" aria-describedby="@(HasErrors ? ErrorIdState.Value : null)" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
-                        @ChildContent
-                    </div>
+                    <CascadingValue TValue="string" Name="RadioGroupName" Value="@Name">
+                        <CascadingValue TValue="bool" Name="RadioGroupHasErrors" Value="@HasErrors">
+                            <CascadingValue TValue="string" Name="RadioGroupErrorId" Value="@GetErrorId()">
+                                <div role="radiogroup" aria-required="@Required.ToString().ToLowerInvariant()" aria-invalid="@(HasErrors ? "true" : null)" aria-describedby="@(HasErrors ? ErrorIdState.Value : null)" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
+                                    @ChildContent
+                                </div>
+                            </CascadingValue>
+                        </CascadingValue>
+                    </CascadingValue>
                 </CascadingValue>
             </CascadingValue>
         </CascadingValue>

--- a/src/MudBlazor/Components/Radio/MudRadioGroup.razor
+++ b/src/MudBlazor/Components/Radio/MudRadioGroup.razor
@@ -8,8 +8,6 @@
 
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorId="@ErrorIdState.Value" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        @* The group instance never changes, so cascade it fixed and push the values a radio renders on their own.
-           A non-fixed instance notifies every radio on every group render, costing each one a render it does not need. *@
         <CascadingValue Value="@((IMudRadioGroup)this)" IsFixed="true">
             <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                 <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">


### PR DESCRIPTION
Part of https://github.com/MudBlazor/MudBlazor/issues/13737: `MudRadioGroup` cascades itself to its radios with `IsFixed="false"`. The value is the group instance, so it can never change, but non-fixed makes Blazor run `ChangeDetection.MayHaveChanged`, which assumes a reference type may have changed and notifies every radio on every group render.

Measured on a bare renderer, one group render with 50 radios:

| | renders | allocation |
| --- | --- | --- |
| dev | 156 | 432 KB |
| this branch | 9 | 20 KB |

For comparison at the same size, `MudList` costs 3, `MudChipSet` 3 and `MudToggleGroup` 3. `MudRadioGroup` was the outlier, and the only one of these that cascades itself non-fixed.

This is #13742 again, with the staleness that #13743 found. A radio renders three things that come from the group, and with the instance cascade fixed there is nothing left to tell the radio they changed:

- `name`, shared across the group
- `mud-error-text` on the icon, from the group's `HasErrors`
- `aria-describedby` on the input, from the group's error id

So the group now pushes those three as their own cascades, alongside the `ParentDisabled` and `ParentReadOnly` it already pushed, and a radio reads the pushed values instead of reaching back through the instance. Each is a primitive or string, so change detection compares them properly and a radio re-renders only when one actually changes.

Cost is three `CascadingValue` components per group, not per radio: 50 radios mount at 1221 KB on dev and 1233 KB here.

Three tests, all with radios built as `<MudRadio Value="1" />` rather than with child content. That distinction is the whole reason #13742 shipped broken: child content is a fresh `RenderFragment` delegate on every parent render, so those radios re-render regardless and hide the staleness. Reverting the pushed values and leaving only `IsFixed="true"` — exactly #13742 — fails the error-state and name tests.

Rendered DOM is unchanged; a static render of a group is byte-identical to dev once generated ids are normalised. Full suite green.
