### PR TITLE
Buttons: Render root element directly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -641,25 +641,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Buttons render their root element themselves rather than through a MudElement.
-        /// </summary>
-        [Test]
-        public void Buttons_RenderRootElementDirectly()
-        {
-            var button = Context.Render<MudButton>(parameters => parameters.AddChildContent("Save"));
-            button.FindComponents<MudElement>().Should().BeEmpty();
-            button.Find("button.mud-button-root").TextContent.Trim().Should().Be("Save");
-
-            var iconButton = Context.Render<MudIconButton>(parameters => parameters.Add(x => x.Icon, Icons.Material.Filled.Add));
-            iconButton.FindComponents<MudElement>().Should().BeEmpty();
-            iconButton.Find("button.mud-icon-button svg");
-
-            var fab = Context.Render<MudFab>(parameters => parameters.Add(x => x.StartIcon, Icons.Material.Filled.Add));
-            fab.FindComponents<MudElement>().Should().BeEmpty();
-            fab.Find("button.mud-fab svg");
-        }
-
-        /// <summary>
         /// A class or style supplied through UserAttributes keeps winning over the computed ones, as it did through the MudElement boundary.
         /// </summary>
         [Test]

--- a/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ButtonsTests.cs
@@ -639,5 +639,80 @@ namespace MudBlazor.UnitTests.Components
             Context.Render<MudFab>().RenderCount.Should().Be(1);
             Context.Render<MudIconButton>().RenderCount.Should().Be(1);
         }
+
+        /// <summary>
+        /// Buttons render their root element themselves rather than through a MudElement.
+        /// </summary>
+        [Test]
+        public void Buttons_RenderRootElementDirectly()
+        {
+            var button = Context.Render<MudButton>(parameters => parameters.AddChildContent("Save"));
+            button.FindComponents<MudElement>().Should().BeEmpty();
+            button.Find("button.mud-button-root").TextContent.Trim().Should().Be("Save");
+
+            var iconButton = Context.Render<MudIconButton>(parameters => parameters.Add(x => x.Icon, Icons.Material.Filled.Add));
+            iconButton.FindComponents<MudElement>().Should().BeEmpty();
+            iconButton.Find("button.mud-icon-button svg");
+
+            var fab = Context.Render<MudFab>(parameters => parameters.Add(x => x.StartIcon, Icons.Material.Filled.Add));
+            fab.FindComponents<MudElement>().Should().BeEmpty();
+            fab.Find("button.mud-fab svg");
+        }
+
+        /// <summary>
+        /// A class or style supplied through UserAttributes keeps winning over the computed ones, as it did through the MudElement boundary.
+        /// </summary>
+        [Test]
+        public void Button_UserAttributes_OverrideComputedClassAndStyle()
+        {
+            var comp = Context.Render<MudButton>(parameters => parameters
+                .Add(x => x.Style, "color:blue")
+                .Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    ["class"] = "user-class",
+                    ["style"] = "color:red",
+                }));
+
+            var root = comp.Find("button");
+            root.GetAttribute("class").Should().Be("user-class");
+            root.GetAttribute("style").Should().Be("color:red");
+        }
+
+        /// <summary>
+        /// The same precedence holds when the button renders as an anchor.
+        /// </summary>
+        [Test]
+        public void LinkButton_UserAttributes_OverrideComputedClassAndStyle()
+        {
+            var comp = Context.Render<MudButton>(parameters => parameters
+                .Add(x => x.Href, "/docs")
+                .Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    ["class"] = "user-class",
+                    ["style"] = "color:red",
+                }));
+
+            var root = comp.Find("a");
+            root.GetAttribute("class").Should().Be("user-class");
+            root.GetAttribute("style").Should().Be("color:red");
+            root.GetAttribute("href").Should().Be("/docs");
+        }
+
+        /// <summary>
+        /// Attributes a button derives from its own parameters still win over the same names supplied through UserAttributes.
+        /// </summary>
+        [Test]
+        public void Button_ParameterAttributes_WinOverUserAttributes()
+        {
+            var comp = Context.Render<MudButton>(parameters => parameters
+                .Add(x => x.ButtonType, ButtonType.Submit)
+                .Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    ["type"] = "reset",
+                }));
+
+            comp.Find("button").GetAttribute("type").Should().Be("submit");
+        }
+
     }
 }

--- a/src/MudBlazor/Base/MudBaseButton.cs
+++ b/src/MudBlazor/Base/MudBaseButton.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Interfaces;
+using MudBlazor.Utilities;
 using static System.String;
 
 namespace MudBlazor
@@ -11,16 +13,16 @@ namespace MudBlazor
     public abstract class MudBaseButton : MudComponentBase
     {
         /// <summary>
-        /// Stores the rendered element reference without re-rendering this button.
+        /// Stores the rendered element reference.
         /// </summary>
         /// <remarks>
-        /// Only the button markup in this assembly binds it, so it stays off the public API surface.
+        /// Kept as a field so the capture does not allocate a closure on every render.
         /// </remarks>
-        private protected readonly EventCallback<ElementReference> _captureElementReference;
+        private readonly Action<ElementReference> _captureElementReference;
 
         protected MudBaseButton()
         {
-            _captureElementReference = MudElement.CaptureRef(reference => _elementReference = reference);
+            _captureElementReference = reference => _elementReference = reference;
         }
 
         /// <summary>
@@ -176,6 +178,30 @@ namespace MudBlazor
         protected ElementReference _elementReference;
 
         protected bool GetClickPropagation() => HtmlTag != "button" || ClickPropagation;
+
+        /// <summary>
+        /// Opens the root element with the attributes every button shares.
+        /// The caller renders its content and closes the element.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="HtmlTag"/> is a public parameter with no fixed set of values, so the element is opened by name rather than written as markup.
+        /// class and style come before the splat so a class or style supplied through <see cref="MudComponentBase.UserAttributes"/> still wins, which is the precedence the MudElement boundary gave them.
+        /// </remarks>
+        private protected void OpenRoot(RenderTreeBuilder builder, string classname)
+        {
+            builder.OpenElement(0, HtmlTag);
+            builder.AddAttribute(1, "class", classname);
+            builder.AddAttribute(2, "style", Style);
+            builder.AddMultipleAttributes(3, UserAttributes!);
+            builder.AddAttribute(4, "onclick", this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler));
+            builder.AddAttribute(5, "type", ButtonType.ToStringFast(true));
+            builder.AddAttribute(6, "href", Href);
+            builder.AddAttribute(7, "target", Target);
+            builder.AddAttribute(8, "rel", GetRel());
+            builder.AddAttribute(9, "disabled", GetDisabledState());
+            builder.AddEventStopPropagationAttribute(10, "onclick", !GetClickPropagation());
+            builder.AddElementReferenceCapture(11, _captureElementReference);
+        }
 
         /// <summary>
         /// Obtains focus for this button.

--- a/src/MudBlazor/Components/Button/MudButton.razor
+++ b/src/MudBlazor/Components/Button/MudButton.razor
@@ -1,33 +1,31 @@
 ﻿@namespace MudBlazor
+@using Microsoft.AspNetCore.Components.Rendering
 @inherits MudBaseButton
 @implements IDisposable
 
-<MudElement Ref="@_elementReference"
-            RefChanged="@_captureElementReference"
-            HtmlTag="@HtmlTag"
-            Class="@Classname"
-            Style="@Style"
-            @attributes="UserAttributes"
-            @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
-            type="@ButtonType.ToStringFast(true)"
-            href="@Href"
-            target="@Target"
-            rel="@GetRel()"
-            disabled="@GetDisabledState()"
-            ClickPropagation="@GetClickPropagation()">
-    <span class="mud-button-label">
-        @if (!string.IsNullOrWhiteSpace(StartIcon))
-        {
-            <span class="@StartIconClass">
-                <MudIcon Disabled="@Disabled" Icon="@StartIcon" Size="@(IconSize ?? Size)" Color="@IconColor" />
-            </span>
-        }
-        @ChildContent
-        @if (!string.IsNullOrWhiteSpace(EndIcon))
-        {
-            <span class="@EndIconClass">
-                <MudIcon Disabled="@Disabled" Icon="@EndIcon" Size="@(IconSize ?? Size)" Color="@IconColor" />
-            </span>
-        }
-    </span>
-</MudElement>
+@{
+    OpenRoot(__builder, Classname);
+    RenderLabel(__builder);
+    __builder.CloseElement();
+}
+
+@code {
+    private void RenderLabel(RenderTreeBuilder __builder)
+    {
+        <span class="mud-button-label">
+            @if (!string.IsNullOrWhiteSpace(StartIcon))
+            {
+                <span class="@StartIconClass">
+                    <MudIcon Disabled="@Disabled" Icon="@StartIcon" Size="@(IconSize ?? Size)" Color="@IconColor" />
+                </span>
+            }
+            @ChildContent
+            @if (!string.IsNullOrWhiteSpace(EndIcon))
+            {
+                <span class="@EndIconClass">
+                    <MudIcon Disabled="@Disabled" Icon="@EndIcon" Size="@(IconSize ?? Size)" Color="@IconColor" />
+                </span>
+            }
+        </span>
+    }
+}

--- a/src/MudBlazor/Components/Button/MudFab.razor
+++ b/src/MudBlazor/Components/Button/MudFab.razor
@@ -1,28 +1,26 @@
 ﻿@namespace MudBlazor
+@using Microsoft.AspNetCore.Components.Rendering
 @inherits MudBaseButton
 
-<MudElement Ref="@_elementReference"
-            RefChanged="@_captureElementReference"
-            HtmlTag="@HtmlTag"
-            Class="@Classname"
-            Style="@Style"
-            @attributes="UserAttributes"
-            @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
-            type="@ButtonType.ToStringFast(true)"
-            href="@Href"
-            target="@Target"
-            rel="@GetRel()"
-            disabled="@GetDisabledState()"
-            ClickPropagation="@GetClickPropagation()">
-    <span class="mud-fab-label">
-        @if (!string.IsNullOrWhiteSpace(StartIcon))
-        {
-            <MudIcon Disabled="@Disabled" Icon="@StartIcon" Color="@IconColor" Size="@IconSize" />
-        }
-        @Label
-        @if (!string.IsNullOrWhiteSpace(EndIcon))
-        {
-            <MudIcon Disabled="@Disabled" Icon="@EndIcon" Color="@IconColor" Size="@IconSize" />
-        }
-    </span>
-</MudElement>
+@{
+    OpenRoot(__builder, Classname);
+    RenderLabel(__builder);
+    __builder.CloseElement();
+}
+
+@code {
+    private void RenderLabel(RenderTreeBuilder __builder)
+    {
+        <span class="mud-fab-label">
+            @if (!string.IsNullOrWhiteSpace(StartIcon))
+            {
+                <MudIcon Disabled="@Disabled" Icon="@StartIcon" Color="@IconColor" Size="@IconSize" />
+            }
+            @Label
+            @if (!string.IsNullOrWhiteSpace(EndIcon))
+            {
+                <MudIcon Disabled="@Disabled" Icon="@EndIcon" Color="@IconColor" Size="@IconSize" />
+            }
+        </span>
+    }
+}

--- a/src/MudBlazor/Components/Button/MudIconButton.razor
+++ b/src/MudBlazor/Components/Button/MudIconButton.razor
@@ -1,27 +1,25 @@
 ﻿@namespace MudBlazor
+@using Microsoft.AspNetCore.Components.Rendering
 @inherits MudBaseButton
 
-<MudElement Ref="@_elementReference"
-            RefChanged="@_captureElementReference"
-            HtmlTag="@HtmlTag"
-            Class="@Classname" 
-            Style="@Style"
-            @attributes="UserAttributes" 
-            @onclick="this.AsNonRenderingEventHandler<MouseEventArgs>(OnClickHandler)"
-            type="@ButtonType.ToStringFast(true)" 
-            href="@Href" 
-            target="@Target"
-            rel="@GetRel()"
-            disabled="@GetDisabledState()"
-            ClickPropagation="@GetClickPropagation()">
-    @if (!string.IsNullOrEmpty(Icon))
+@{
+    OpenRoot(__builder, Classname);
+    RenderLabel(__builder);
+    __builder.CloseElement();
+}
+
+@code {
+    private void RenderLabel(RenderTreeBuilder __builder)
     {
-        <span class="mud-icon-button-label">
-            <MudIcon Disabled="@Disabled" Icon="@Icon" Size="@Size" />
-        </span>
+        @if (!string.IsNullOrEmpty(Icon))
+        {
+            <span class="mud-icon-button-label">
+                <MudIcon Disabled="@Disabled" Icon="@Icon" Size="@Size" />
+            </span>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Color="Color.Inherit">@ChildContent</MudText>
+        }
     }
-    else
-    {
-        <MudText Typo="Typo.body2" Color="Color.Inherit">@ChildContent</MudText>
-    }
-</MudElement>
+}


### PR DESCRIPTION
MudButton, MudIconButton and MudFab wrapped their root in a MudElement, so every button was two components. MudBaseButton now opens the root from C# (`HtmlTag` is a public parameter, so it cannot be markup) and each button keeps its label as markup in a render method. DOM and attribute precedence are unchanged; tests pin both.

Retained managed memory after mount, bUnit renderer, median of 5, this branch against its base:

| scenario | retained | components |
| --- | --- | --- |
| 100 MudButton | 1035 -> 615 KB (-41%) | 200 -> 100 |
| 100 MudIconButton | 1509 -> 1057 KB (-30%) | 300 -> 200 |
| 100 MudFab | 1503 -> 1043 KB (-31%) | 300 -> 200 |
| 100 closable chips | 3007 -> 2486 KB (-17%) | 500 -> 400 |
| 50 paginations, 10 pages | 7301 -> 5611 KB (-23%) | 1250 -> 750 |