### PR TITLE
MudTr: Render selection cell as plain markup

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -3765,5 +3765,18 @@ namespace MudBlazor.UnitTests.Components
             comp.FindAll("tr.mud-table-loading-row > th").Should().BeEmpty();
         }
 
+
+        /// <summary>
+        /// The checkbox cell of a selectable row is plain markup rather than a MudElement.
+        /// </summary>
+        [Test]
+        public void MultiSelection_RendersCheckboxCellDirectly()
+        {
+            var comp = Context.Render<TableMultiSelectionTest1>();
+
+            comp.FindComponents<MudElement>().Should().BeEmpty();
+            comp.FindAll("tbody tr td.mud-table-cell .mud-table-cell-checkbox").Count.Should().Be(3);
+        }
+
     }
 }

--- a/src/MudBlazor/Components/Table/MudTr.razor
+++ b/src/MudBlazor/Components/Table/MudTr.razor
@@ -41,14 +41,14 @@
     }
     @if (Expandable || Checkable)
     {
-        <MudElement HtmlTag="@("Td")" Class="@($"mud-table-cell {Context?.Table?.CellClass}")">
+        <td class="@($"mud-table-cell {Context?.Table?.CellClass}")">
             <div class="d-flex" style="@ActionsStylename">
                 @if (Checkable)
                 {
                     <MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" StopClickPropagation="true" Class="mud-table-cell-checkbox" AriaLabel="@Localizer[LanguageResource.MudTable_SelectRow]"></MudCheckBox>
                 }
             </div>
-        </MudElement>
+        </td>
     }
     @ChildContent
     @if (Context?.Table?.Editable == true && ((Context?.Table.EditButtonPosition.DisplayEditButtonAtEnd() == true && Context?.Table.EditTrigger == TableEditTrigger.EditButton) || Context?.Table.ApplyButtonPosition.DisplayApplyButtonAtEnd() == true))


### PR DESCRIPTION
`MudTr` rendered the checkbox and expander cell through `<MudElement HtmlTag="Td">`. The tag is constant and the element takes no reference, splat or event modifier, so the component contributed nothing but an instance, one per selectable or expandable row.

The cell is now a plain `td` with the same class. A test checks that a multi-selection table instantiates no `MudElement` and still renders a checkbox in a `td.mud-table-cell` on every row.

Retained managed memory after mount, bare renderer, measured against this branch's base:

| scenario | retained | components | renders on one parent re-render |
| --- | --- | --- | --- |
| 50 selectable rows | 2077 -> 1947 KB (-6%) | 405 -> 355 | 509 -> 409 |
| 100 selectable rows | 4212 -> 3945 KB (-6%) | 805 -> 705 | 1009 -> 809 |

A static render of every test component in the Viewer (784) is identical between base and branch once generated ids are normalised and tag names lowercased. In a browser, clicking a row checkbox and then a second row selects both, with the same row markup as the base build. Full suite green.

Part of https://github.com/MudBlazor/MudBlazor/issues/13737, which tracks several more candidates and should stay open.
