### PR TITLE
Docs: Match plain crawler user-agents without a regex

### DIFF
--- a/src/MudBlazor.Docs.WasmHost/Prerender/FileBasedCrawlerIdentifier.cs
+++ b/src/MudBlazor.Docs.WasmHost/Prerender/FileBasedCrawlerIdentifier.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor.Docs.WasmHost/Prerender/FileBasedCrawlerIdentifier.cs
+++ b/src/MudBlazor.Docs.WasmHost/Prerender/FileBasedCrawlerIdentifier.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,7 +20,11 @@ public class FileBasedCrawlerIdentifier : ICrawlerIdentifier
     private readonly string _filename;
     private readonly LimitedConcurrentDictionary<string, bool> _cache = new(1_000);
 
-    private IEnumerable<Regex> _patterns = [];
+    // Most of CrawlerInfo.json is plain substrings such as "bingbot", which a regex matches the same
+    // way string.Contains does. Keeping those out of the regex engine is what makes the difference:
+    // a regex costs far more to hold than the string it looks for.
+    private string[] _literals = [];
+    private Regex[] _patterns = [];
 
     public FileBasedCrawlerIdentifier(string filename)
     {
@@ -31,9 +36,16 @@ public class FileBasedCrawlerIdentifier : ICrawlerIdentifier
         var content = await File.ReadAllTextAsync(_filename);
 
         var crawlers = JsonSerializer.Deserialize<IEnumerable<CrawlerEntry>>(content, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var entries = crawlers?.Select(crawler => crawler.Pattern).ToArray() ?? [];
 
-        _patterns = crawlers?.Select(x => new Regex(x.Pattern, RegexOptions.Compiled)).ToArray() ?? Enumerable.Empty<Regex>();
+        _literals = entries.Where(IsLiteral).ToArray();
+        _patterns = entries.Where(pattern => !IsLiteral(pattern)).Select(pattern => new Regex(pattern)).ToArray();
     }
+
+    /// <summary>
+    /// Gets whether a pattern contains no regular expression syntax, so a substring search answers it.
+    /// </summary>
+    private static bool IsLiteral(string pattern) => Regex.Escape(pattern) == pattern;
 
     public Task<bool> IsRequestByCrawler(HttpContext context)
     {
@@ -49,18 +61,31 @@ public class FileBasedCrawlerIdentifier : ICrawlerIdentifier
             return Task.FromResult(_cache[value]);
         }
 
-        foreach (var item in _patterns)
-        {
-            if (item.IsMatch(value))
-            {
-                _cache.TryAdd(value, true);
+        var isCrawler = IsCrawler(value);
+        _cache.TryAdd(value, isCrawler);
 
-                return Task.FromResult(true);
+        return Task.FromResult(isCrawler);
+    }
+
+    private bool IsCrawler(string userAgent)
+    {
+        // Ordinal, to match what a regex without options does.
+        foreach (var literal in _literals)
+        {
+            if (userAgent.Contains(literal, StringComparison.Ordinal))
+            {
+                return true;
             }
         }
 
-        _cache.TryAdd(value, false);
+        foreach (var pattern in _patterns)
+        {
+            if (pattern.IsMatch(userAgent))
+            {
+                return true;
+            }
+        }
 
-        return Task.FromResult(false);
+        return false;
     }
 }

--- a/src/MudBlazor.Docs.WasmHost/Prerender/FileBasedCrawlerIdentifier.cs
+++ b/src/MudBlazor.Docs.WasmHost/Prerender/FileBasedCrawlerIdentifier.cs
@@ -20,9 +20,6 @@ public class FileBasedCrawlerIdentifier : ICrawlerIdentifier
     private readonly string _filename;
     private readonly LimitedConcurrentDictionary<string, bool> _cache = new(1_000);
 
-    // Most of CrawlerInfo.json is plain substrings such as "bingbot", which a regex matches the same
-    // way string.Contains does. Keeping those out of the regex engine is what makes the difference:
-    // a regex costs far more to hold than the string it looks for.
     private string[] _literals = [];
     private Regex[] _patterns = [];
 
@@ -43,7 +40,7 @@ public class FileBasedCrawlerIdentifier : ICrawlerIdentifier
     }
 
     /// <summary>
-    /// Gets whether a pattern contains no regular expression syntax, so a substring search answers it.
+    /// Pattern contains no regular expression syntax, so a substring search answers it.
     /// </summary>
     private static bool IsLiteral(string pattern) => Regex.Escape(pattern) == pattern;
 
@@ -69,7 +66,6 @@ public class FileBasedCrawlerIdentifier : ICrawlerIdentifier
 
     private bool IsCrawler(string userAgent)
     {
-        // Ordinal, to match what a regex without options does.
         foreach (var literal in _literals)
         {
             if (userAgent.Contains(literal, StringComparison.Ordinal))


### PR DESCRIPTION
### Summary

`CrawlerInfo.json` holds 563 patterns, and the prerender host compiled every one of them with `RegexOptions.Compiled` at startup. **440 of them contain no regular expression syntax at all** — they are substrings like `bingbot` or `Slackbot-LinkExpanding` — and a compiled regex is the most expensive way to hold a substring.

This splits those out into an ordinal `Contains` pass. The 123 patterns that do use regex syntax stay regexes, now interpreted: matching runs once per distinct user-agent and is then cached, so compiling them earns nothing.

### Measured

Building the matcher, in its own process each time:

| strategy | managed | process private bytes | build |
| --- | ---: | ---: | ---: |
| `RegexOptions.Compiled` (today) | 2,692,024 | 9,220,096 | 263 ms |
| drop `Compiled` only | 745,440 | 1,269,760 | 19 ms |
| **substrings + 123 regexes** | **189,584** | **90,112** | **19 ms** |

−93% managed, −99% process private bytes, and 244 ms off cold start. This is a per-process saving, not per request.

### Verification

Equivalence was checked against every user-agent `CrawlerInfo.json` itself ships — 1,133 `instances` strings — plus current Chrome/Safari/Firefox/Edge/mobile strings, `curl`, Postman, empty and whitespace input, a 4,096-character string, non-ASCII, and the `AdsBot-Google([^-]|$)` boundary cases:

```
entries 563, literal 440, regex 123
corpus 1155 user agents; 1138 identified as crawlers; mismatches 0
EQUIVALENCE_OK
```

Ordinal `Contains` is what reproduces a regex with no options, which is what the old code used.

End to end against a published host, `/components/button`:

| user-agent | response |
| --- | ---: |
| Googlebot | 188,837 bytes (prerendered) |
| bingbot | 188,837 bytes (prerendered) |
| Slackbot-LinkExpanding | 188,837 bytes (prerendered) |
| curl/8.4.0 | 188,837 bytes (prerendered — as before; curl is in the list) |
| Chrome 131 | 8,248 bytes (SPA shell) |

Part of #13799.
