### PR TITLE
MudTable: Add GroupHeaderClass to TableGroupDefinition

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Table/Examples/TableMultiGroupingExample.razor
@@ -12,6 +12,14 @@
         padding-bottom: 50px;
         text-align: right;
     }
+
+    .mud-table-cell-custom-group-header-outer {
+        background-color: var(--mud-palette-background-gray);
+    }
+
+    .mud-table-cell-custom-group-header-inner {
+        background-color: var(--mud-palette-primary-hover);
+    }
 </style>
 
 <MudText>Total items: @Elements?.Count() - Selected items: @selectedItems?.Count</MudText>
@@ -19,7 +27,6 @@
 <MudTable Hover="true" Breakpoint="Breakpoint.Sm" Height="500px" FixedHeader="true"
           Items="@Elements"
           GroupBy="@_groupDefinition"
-          GroupHeaderStyle="background-color:var(--mud-palette-background-gray)"
           GroupFooterClass="mb-4"
           Dense="_dense"
           MultiSelection="_multiSelect"
@@ -64,11 +71,13 @@
         Indentation = false,
         Expandable = false,
         Selector = (e) => e.Group,
+        GroupHeaderClass = "mud-table-cell-custom-group-header-outer",
         InnerGroup = new TableGroupDefinition<Element>()
         {
             GroupName = "Position",
             Expandable = false,
-            Selector = (e) => e.Position
+            Selector = (e) => e.Position,
+            GroupHeaderClass = "mud-table-cell-custom-group-header-inner"
         }
 
     };

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupHeaderClassTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupHeaderClassTest.razor
@@ -1,0 +1,60 @@
+﻿<MudTable T="Item" Items="Items" GroupBy="@_groupDefinition">
+    <GroupHeaderTemplate>
+        <MudTh>@context.Key</MudTh>
+    </GroupHeaderTemplate>
+    <RowTemplate>
+        <MudTd>@context.Label</MudTd>
+    </RowTemplate>
+</MudTable>
+
+@code {
+    /// <summary>
+    /// The <see cref="TableGroupDefinition{T}.GroupHeaderClass"/> for the outer grouping level.
+    /// </summary>
+    [Parameter]
+    public string? OuterHeaderClass { get; set; }
+
+    /// <summary>
+    /// The <see cref="TableGroupDefinition{T}.GroupHeaderClass"/> for the nested grouping level.
+    /// </summary>
+    [Parameter]
+    public string? InnerHeaderClass { get; set; }
+
+    public List<Item> Items { get; } = [
+        new Item { Group = "G1", Nested = "N1", Label = "A" },
+        new Item { Group = "G1", Nested = "N2", Label = "B" },
+        new Item { Group = "G2", Nested = "N1", Label = "C" },
+        new Item { Group = "G2", Nested = "N2", Label = "D" }
+    ];
+
+    private TableGroupDefinition<Item> _groupDefinition = new();
+
+    protected override void OnInitialized()
+    {
+        _groupDefinition = new TableGroupDefinition<Item>
+        {
+            Indentation = false,
+            Expandable = true,
+            IsInitiallyExpanded = true,
+            Selector = e => e.Group,
+            GroupHeaderClass = OuterHeaderClass,
+            InnerGroup = new TableGroupDefinition<Item>
+            {
+                Indentation = false,
+                Expandable = true,
+                IsInitiallyExpanded = true,
+                Selector = e => e.Nested,
+                GroupHeaderClass = InnerHeaderClass,
+            }
+        };
+    }
+
+    public class Item
+    {
+        public required string Label { get; set; }
+
+        public required string Group { get; set; }
+
+        public required string Nested { get; set; }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/TableTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TableTests.cs
@@ -2501,6 +2501,60 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
+        /// Each grouping level's <see cref="TableGroupDefinition{T}.GroupHeaderClass"/> is applied only to that level's group header rows.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/MudBlazor/MudBlazor/issues/10959
+        /// </remarks>
+        [Test]
+        public void TableGrouping_GroupHeaderClass_AppliedPerLevel()
+        {
+            var comp = Context.Render<TableGroupHeaderClassTest>(parameters => parameters
+                .Add(x => x.OuterHeaderClass, "outer-group-header")
+                .Add(x => x.InnerHeaderClass, "inner-group-header"));
+
+            var groupRows = comp.FindComponents<MudTableGroupRow<TableGroupHeaderClassTest.Item>>();
+            var outerRows = groupRows.Where(row => row.Instance.GroupDefinition?.InnerGroup is not null).ToList();
+            var innerRows = groupRows.Where(row => row.Instance.GroupDefinition?.InnerGroup is null).ToList();
+            outerRows.Should().HaveCount(2);
+            innerRows.Should().HaveCount(4);
+
+            foreach (var outerRow in outerRows)
+            {
+                var header = outerRow.Find("tr");
+                header.ClassList.Should().Contain("outer-group-header");
+                header.ClassList.Should().NotContain("inner-group-header");
+            }
+
+            foreach (var innerRow in innerRows)
+            {
+                var header = innerRow.Find("tr");
+                header.ClassList.Should().Contain("inner-group-header");
+                header.ClassList.Should().NotContain("outer-group-header");
+            }
+
+            comp.FindAll("tr.outer-group-header").Should().HaveCount(2);
+            comp.FindAll("tr.inner-group-header").Should().HaveCount(4);
+        }
+
+        /// <summary>
+        /// A null <see cref="TableGroupDefinition{T}.GroupHeaderClass"/> adds no class to the group header rows.
+        /// </summary>
+        [Test]
+        public void TableGrouping_GroupHeaderClass_NullAddsNoClass()
+        {
+            var comp = Context.Render<TableGroupHeaderClassTest>();
+
+            var groupRows = comp.FindComponents<MudTableGroupRow<TableGroupHeaderClassTest.Item>>();
+            groupRows.Should().HaveCount(6);
+
+            foreach (var groupRow in groupRows)
+            {
+                groupRow.Find("tr").ClassList.Should().BeEquivalentTo("mud-table-row");
+            }
+        }
+
+        /// <summary>
         /// Tests the grouping behavior and ensure that it won't break anything else.
         /// </summary>
         /// <returns></returns>

--- a/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
+++ b/src/MudBlazor/Components/Table/MudTableGroupRow.razor.cs
@@ -21,6 +21,7 @@ namespace MudBlazor
 
         protected string HeaderClassname => new CssBuilder("mud-table-row")
             .AddClass(HeaderClass)
+            .AddClass(GroupDefinition?.GroupHeaderClass)
             .AddClass($"mud-table-row-group-indented-{GroupDefinition?.Level - 1}",
                 (GroupDefinition?.Indentation ?? false) && GroupDefinition?.Level > 1)
             .Build();

--- a/src/MudBlazor/Components/Table/TableGroupDefinition.cs
+++ b/src/MudBlazor/Components/Table/TableGroupDefinition.cs
@@ -44,6 +44,14 @@ namespace MudBlazor
         public string? GroupName { get; set; }
 
         /// <summary>
+        /// The CSS classes applied to the header row of this group.
+        /// </summary>
+        /// <remarks>
+        /// Applies only to this grouping level.  Nested groups use their own <see cref="GroupHeaderClass"/> value.
+        /// </remarks>
+        public string? GroupHeaderClass { get; set; }
+
+        /// <summary>
         /// The function which selects items for this group.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Closes #10959

**Before/After:**

Before: both group header levels rendered the same gray, since `GroupHeaderStyle` on `MudTable` applies to every level.
After: the outer "Group" header and the inner "Position" header each render with their own class.

Before:
<img width="1122" height="142" alt="before" src="https://github.com/user-attachments/assets/d061931b-0fec-487d-b3d5-a07e1dc83a72" />
After:
<img width="1122" height="142" alt="after" src="https://github.com/user-attachments/assets/ef6d94f5-acae-4623-985a-5aa0c1d83da5" />

**What:**

With multi-level grouping there was no way to style group header rows differently per level.

Adds `GroupHeaderClass` to `TableGroupDefinition<T>`, applied to that level's header row only. Deliberately a plain auto-property rather than cascading to `InnerGroup` the way `Indentation` does, since differentiating levels is the point of the request.

- `MudTableGroupRow.HeaderClassname` picks it up via `CssBuilder.AddClass`, which is already null-safe. `FooterClassname` is unchanged.
- Two bUnit tests: per-level application, and null adding no class.
- Updated `TableMultiGroupingExample` to demonstrate it. Removed `GroupHeaderStyle` from that example — an inline style attribute outranks a class selector, so it would have masked the per-level difference. Its value moved into the outer class, and two other grouping examples still demonstrate `GroupHeaderStyle`.

No breaking changes; the new property is optional and null by default.

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests

**AI assistance:**

This PR was assisted by Claude. I discussed, then guided the work and chose the approach. In the end i verified it: I reviewed the full diff line by line, confirmed the property is not cascaded to `InnerGroup`, confirmed `FooterClassname` is untouched, and ran the build, the filtered `TableTests` run, and the docs project build locally.