### PR TITLE
Docs: Build API member documentation one type at a time

### DIFF
--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -767,8 +767,8 @@ public class ApiDocumentationBuilder
         using var writer = new ApiDocumentationWriter();
         writer.WriteHeader();
 
-        // The type tier: name, summary, remarks and base type for every documented type. This is all
-        // most of the site needs, so it is what boots.
+        // The type tier: name, summary, remarks and base type for every documented type.
+        // This is all most of the site needs, so it is what boots.
         writer.WriteClassStart();
         writer.WriteConstructorStart();
         writer.WriteTypes(Types);
@@ -776,8 +776,8 @@ public class ApiDocumentationBuilder
         writer.WriteClassEnd();
         writer.WriteLine();
 
-        // The member tier, one loader per type. An API page shows one type's members, so building them
-        // a type at a time keeps the other 480 types' members out of the heap.
+        // The member tier, one loader per type.
+        // An API page shows one type's members, so building them a type at a time keeps the other 480 types' members out of the heap.
         writer.WriteMembersClassStart();
         writer.WriteMembersConstructorStart();
         writer.WriteExternalMembers(

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationBuilder.cs
@@ -766,20 +766,36 @@ public class ApiDocumentationBuilder
         // Sort everything by category
         using var writer = new ApiDocumentationWriter();
         writer.WriteHeader();
+
+        // The type tier: name, summary, remarks and base type for every documented type. This is all
+        // most of the site needs, so it is what boots.
         writer.WriteClassStart();
         writer.WriteConstructorStart();
-        writer.WriteProperties(Properties);
-        writer.WriteMethods(Methods);
-        writer.WriteFields(Fields);
-        writer.WriteEvents(Events);
         writer.WriteTypes(Types);
-        writer.LinkDocumentedTypes(Properties);
-        writer.LinkDocumentedTypes(Methods);
-        writer.LinkDocumentedTypes(Fields);
-        writer.LinkDocumentedTypes(Events);
-        writer.WriteSeeAlsoLinks(Types);
         writer.WriteConstructorEnd();
         writer.WriteClassEnd();
+        writer.WriteLine();
+
+        // The member tier, one loader per type. An API page shows one type's members, so building them
+        // a type at a time keeps the other 480 types' members out of the heap.
+        writer.WriteMembersClassStart();
+        writer.WriteMembersConstructorStart();
+        writer.WriteExternalMembers(
+            Properties.Values.Where(member => member.DeclaringDocumentedType == null),
+            Methods.Values.Where(member => member.DeclaringDocumentedType == null),
+            Fields.Values.Where(member => member.DeclaringDocumentedType == null),
+            Events.Values.Where(member => member.DeclaringDocumentedType == null));
+        writer.WriteConstructorEnd();
+        writer.WriteLine();
+        writer.WriteLoadTypeDispatch(Types.Values);
+
+        foreach (var type in Types.Values)
+        {
+            writer.WriteTypeLoader(type);
+        }
+
+        writer.WriteClassEnd();
+
         var currentCode = string.Empty;
         if (File.Exists(Paths.ApiDocumentationFilePath))
         {

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationWriter.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationWriter.cs
@@ -99,8 +99,7 @@ public partial class ApiDocumentationWriter : StringWriter
     /// Whether members are written as assignments rather than as dictionary initializer entries.
     /// </summary>
     /// <remarks>
-    /// Per-type loaders assign into the shared member dictionaries; the initializer form is kept for
-    /// the external members, which are built once up front.
+    /// Per-type loaders assign into the shared member dictionaries; the initializer form is kept for the external members, which are built once up front.
     /// </remarks>
     public bool StatementForm { get; set; }
 
@@ -191,9 +190,8 @@ public partial class ApiDocumentationWriter : StringWriter
     /// Writes the method which builds one type's members.
     /// </summary>
     /// <remarks>
-    /// The members this type declares are created first, so that a type reached again while this one
-    /// is still loading finds them already there. Inherited members are fetched through the helpers,
-    /// which build whichever type declares them.
+    /// The members this type declares are created first, so that a type reached again while this one is still loading finds them already there.
+    /// Inherited members are fetched through the helpers, which build whichever type declares them.
     /// </remarks>
     public void WriteTypeLoader(DocumentedType type)
     {
@@ -536,8 +534,7 @@ public partial class ApiDocumentationWriter : StringWriter
         WriteIsComponentIndented(type.Type.IsSubclassOf(typeof(MudComponentBase)));
         WriteSummaryIndented(type.Summary);
         WriteRemarksIndented(type.Remarks);
-        // Members and see-also links belong to this type's loader in ApiDocumentationMembers, so that a
-        // page which only needs the name and summary never builds them.
+        // Members and see-also links belong to this type's loader in ApiDocumentationMembers, so that a page which only needs the name and summary never builds them.
         Outdent();
         WriteIndented("}");
         WriteLine("},");

--- a/src/MudBlazor.Docs.Compiler/ApiDocumentationWriter.cs
+++ b/src/MudBlazor.Docs.Compiler/ApiDocumentationWriter.cs
@@ -3,13 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 namespace MudBlazor.Docs.Compiler;
 
 /// <summary>
 /// Represents a writer for generated API documentation.
 /// </summary>
-public class ApiDocumentationWriter : StringWriter
+public partial class ApiDocumentationWriter : StringWriter
 {
     /// <summary>
     /// Indents generated code to be more readable.
@@ -95,6 +96,259 @@ public class ApiDocumentationWriter : StringWriter
     }
 
     /// <summary>
+    /// Whether members are written as assignments rather than as dictionary initializer entries.
+    /// </summary>
+    /// <remarks>
+    /// Per-type loaders assign into the shared member dictionaries; the initializer form is kept for
+    /// the external members, which are built once up front.
+    /// </remarks>
+    public bool StatementForm { get; set; }
+
+    /// <summary>
+    /// Writes the start of a member, in whichever form is selected.
+    /// </summary>
+    private void WriteEntryStart(string collection, string key)
+    {
+        if (StatementForm)
+        {
+            WriteIndented($"{collection}[\"{key}\"] = new()");
+        }
+        else
+        {
+            WriteIndented("{ ");
+            Write($"\"{key}\", new()");
+        }
+
+        Write(" { ");
+    }
+
+    /// <summary>
+    /// Writes the end of a member, in whichever form is selected.
+    /// </summary>
+    private void WriteEntryEnd()
+    {
+        Write("}");
+        WriteLine(StatementForm ? ";" : "},");
+    }
+
+    /// <summary>
+    /// Gets the name of the method which builds a type's members.
+    /// </summary>
+    public static string LoaderName(string typeKey) => "Load_" + NonIdentifier().Replace(typeKey, "_");
+
+    [GeneratedRegex("[^A-Za-z0-9]")]
+    private static partial Regex NonIdentifier();
+
+    /// <summary>
+    /// Writes the start of the ApiDocumentationMembers partial class.
+    /// </summary>
+    public void WriteMembersClassStart()
+    {
+        WriteLine("/// <summary>");
+        WriteLine("/// Builds the members of documented types, one type at a time.");
+        WriteLine("/// </summary>");
+        WriteLine($"[GeneratedCodeAttribute(\"MudBlazor.Docs.Compiler\", \"{typeof(ApiDocumentationWriter).Assembly.GetName().Version}\")]");
+        WriteLine("public static partial class ApiDocumentationMembers");
+        WriteLine("{");
+        Indent();
+    }
+
+    /// <summary>
+    /// Writes the start of the ApiDocumentationMembers constructor.
+    /// </summary>
+    public void WriteMembersConstructorStart()
+    {
+        WriteLineIndented("static ApiDocumentationMembers()");
+        WriteLineIndented("{");
+        Indent();
+    }
+
+    /// <summary>
+    /// Writes the dispatcher which builds one type's members.
+    /// </summary>
+    public void WriteLoadTypeDispatch(IEnumerable<DocumentedType> types)
+    {
+        WriteLineIndented("static partial void LoadType(string typeKey)");
+        WriteLineIndented("{");
+        Indent();
+        WriteLineIndented("switch (typeKey)");
+        WriteLineIndented("{");
+        Indent();
+
+        foreach (var type in types)
+        {
+            WriteLineIndented($"case \"{type.Key}\": {LoaderName(type.Key!)}(); break;");
+        }
+
+        Outdent();
+        WriteLineIndented("}");
+        Outdent();
+        WriteLineIndented("}");
+        WriteLine();
+    }
+
+    /// <summary>
+    /// Writes the method which builds one type's members.
+    /// </summary>
+    /// <remarks>
+    /// The members this type declares are created first, so that a type reached again while this one
+    /// is still loading finds them already there. Inherited members are fetched through the helpers,
+    /// which build whichever type declares them.
+    /// </remarks>
+    public void WriteTypeLoader(DocumentedType type)
+    {
+        WriteLineIndented($"private static void {LoaderName(type.Key!)}()");
+        WriteLineIndented("{");
+        Indent();
+
+        StatementForm = true;
+
+        foreach (var property in type.Properties.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteProperty(property);
+        }
+        foreach (var method in type.Methods.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteMethod(method);
+        }
+        foreach (var field in type.Fields.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteField(field);
+        }
+        foreach (var documentedEvent in type.Events.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteEvent(documentedEvent);
+        }
+
+        StatementForm = false;
+
+        WriteLineIndented($"var type = ApiDocumentation.Types[\"{type.Key}\"];");
+
+        WriteTypeMemberAdds(type.Properties.Values, "PropertiesInternal", "Property");
+        WriteTypeMemberAdds(type.GlobalSettings.Values, "GlobalSettingsInternal", "Property");
+        WriteTypeMemberAdds(type.Fields.Values, "FieldsInternal", "Field");
+        WriteTypeMemberAdds(type.Methods.Values, "MethodsInternal", "Method");
+        WriteTypeMemberAdds(type.Events.Values, "EventsInternal", "Event");
+
+        foreach (var property in type.Properties.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteLineIndented($"PropertiesInternal[\"{property.Key}\"].DeclaringType = type;");
+            if (property.ChangeEvent != null)
+            {
+                WriteLineIndented($"PropertiesInternal[\"{property.Key}\"].ChangeEvent = Event(\"{property.ChangeEvent.Key}\");");
+            }
+        }
+        foreach (var method in type.Methods.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteLineIndented($"MethodsInternal[\"{method.Key}\"].DeclaringType = type;");
+        }
+        foreach (var field in type.Fields.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteLineIndented($"FieldsInternal[\"{field.Key}\"].DeclaringType = type;");
+        }
+        foreach (var documentedEvent in type.Events.Values.Where(member => member.DeclaringDocumentedType == type))
+        {
+            WriteLineIndented($"EventsInternal[\"{documentedEvent.Key}\"].DeclaringType = type;");
+            if (documentedEvent.Property != null)
+            {
+                WriteLineIndented($"EventsInternal[\"{documentedEvent.Key}\"].Property = Property(\"{documentedEvent.Property.Key}\");");
+            }
+        }
+
+        WriteSeeAlsoLinks(type);
+
+        Outdent();
+        WriteLineIndented("}");
+        WriteLine();
+    }
+
+    /// <summary>
+    /// Adds the members a type shows, including the ones it inherits.
+    /// </summary>
+    private void WriteTypeMemberAdds<T>(IEnumerable<T> members, string collection, string lookup)
+        where T : DocumentedMember
+    {
+        foreach (var member in members)
+        {
+            WriteLineIndented($"type.{collection}.Add(\"{member.Name}\", {lookup}(\"{member.Key}\"));");
+        }
+    }
+
+    /// <summary>
+    /// Writes one type's see-also links.
+    /// </summary>
+    public void WriteSeeAlsoLinks(DocumentedType type)
+    {
+        foreach (var link in type.Links)
+        {
+            if (link.Type != null)
+            {
+                WriteLineIndented($"type.LinksInternal.Add(new() {{ Type = ApiDocumentation.Types[\"{link.Type.Key}\"], Text = \"{link.Text}\" }});");
+            }
+            else if (link.Property != null)
+            {
+                WriteLineIndented($"type.LinksInternal.Add(new() {{ Property = Property(\"{link.Property.Key}\"), Text = \"{link.Text}\" }});");
+            }
+            else if (link.Field != null)
+            {
+                WriteLineIndented($"type.LinksInternal.Add(new() {{ Field = Field(\"{link.Field.Key}\"), Text = \"{link.Text}\" }});");
+            }
+            else if (link.Method != null)
+            {
+                WriteLineIndented($"type.LinksInternal.Add(new() {{ Method = Method(\"{link.Method.Key}\"), Text = \"{link.Text}\" }});");
+            }
+            else if (link.Event != null)
+            {
+                WriteLineIndented($"type.LinksInternal.Add(new() {{ Event = Event(\"{link.Event.Key}\"), Text = \"{link.Text}\" }});");
+            }
+            else if (link.Href != null)
+            {
+                WriteLineIndented($"type.LinksInternal.Add(new() {{ Href = \"{link.Href}\", Text = \"{link.Text}\" }});");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes the members whose declaring type is not itself documented, such as those on ComponentBase.
+    /// </summary>
+    /// <remarks>
+    /// No type's loader owns these, and there are only a few dozen, so they are built up front.
+    /// </remarks>
+    public void WriteExternalMembers(
+        IEnumerable<DocumentedProperty> properties,
+        IEnumerable<DocumentedMethod> methods,
+        IEnumerable<DocumentedField> fields,
+        IEnumerable<DocumentedEvent> events)
+    {
+        WriteLineIndented("// Members of types which are not themselves documented");
+        StatementForm = true;
+
+        foreach (var property in properties)
+        {
+            WriteProperty(property);
+            WriteLineIndented($"PropertiesInternal[\"{property.Key}\"].DeclaringTypeName = \"{property.DeclaringType?.Name}\";");
+        }
+        foreach (var method in methods)
+        {
+            WriteMethod(method);
+            WriteLineIndented($"MethodsInternal[\"{method.Key}\"].DeclaringTypeName = \"{method.DeclaringType?.Name}\";");
+        }
+        foreach (var field in fields)
+        {
+            WriteField(field);
+            WriteLineIndented($"FieldsInternal[\"{field.Key}\"].DeclaringTypeName = \"{field.DeclaringType?.Name}\";");
+        }
+        foreach (var documentedEvent in events)
+        {
+            WriteEvent(documentedEvent);
+            WriteLineIndented($"EventsInternal[\"{documentedEvent.Key}\"].DeclaringTypeName = \"{documentedEvent.DeclaringType?.Name}\";");
+        }
+
+        StatementForm = false;
+        WriteLine();
+    }
+
+    /// <summary>
     /// Writes text with the current indentation level.
     /// </summary>
     /// <param name="text">The text to write.</param>
@@ -121,15 +375,6 @@ public class ApiDocumentationWriter : StringWriter
     {
         Outdent();
         WriteLineIndented("}");
-    }
-
-    /// <summary>
-    /// Writes the end of the ApiDocumentation class.
-    /// </summary>
-    public void WriteApiDocumentationClassEnd()
-    {
-        Outdent();
-        WriteLine("}");
     }
 
     /// <summary>
@@ -275,151 +520,6 @@ public class ApiDocumentationWriter : StringWriter
     }
 
     /// <summary>
-    /// Links all properties to their declaring types.
-    /// </summary>
-    public void LinkDocumentedTypes(IDictionary<string, DocumentedProperty> properties)
-    {
-        WriteLineIndented("// Link properties to their declaring types");
-
-        foreach (var property in properties)
-        {
-            if (property.Value.DeclaringDocumentedType != null)
-            {
-                // Link directly to a documented type
-                WriteLineIndented($"Properties[\"{property.Key}\"].DeclaringType = Types[\"{property.Value.DeclaringDocumentedType.Key}\"];");
-            }
-            else
-            {
-                // For external .NET types like ComponentBase, just set the name
-                WriteLineIndented($"Properties[\"{property.Key}\"].DeclaringTypeName = \"{property.Value.DeclaringType?.Name}\";");
-            }
-            if (property.Value.ChangeEvent != null)
-            {
-                WriteLineIndented($"Properties[\"{property.Key}\"].ChangeEvent = Events[\"{property.Value.ChangeEvent.Key}\"];");
-            }
-        }
-
-        WriteLine();
-    }
-
-    /// <summary>
-    /// Links all properties to their declaring types.
-    /// </summary>
-    public void LinkDocumentedTypes(IDictionary<string, DocumentedField> fields)
-    {
-        WriteLineIndented("// Link fields to their declaring types");
-
-        foreach (var field in fields)
-        {
-            if (field.Value.DeclaringDocumentedType != null)
-            {
-                WriteLineIndented($"Fields[\"{field.Key}\"].DeclaringType = Types[\"{field.Value.DeclaringDocumentedType.Key}\"];");
-            }
-            else
-            {
-                // For external .NET types like ComponentBase, just set the name
-                WriteLineIndented($"Fields[\"{field.Key}\"].DeclaringTypeName = \"{field.Value.DeclaringType?.Name}\";");
-            }
-        }
-
-        WriteLine();
-    }
-
-    /// <summary>
-    /// Links all events to their declaring types.
-    /// </summary>
-    public void LinkDocumentedTypes(IDictionary<string, DocumentedEvent> events)
-    {
-        WriteLineIndented("// Link events to their declaring types");
-
-        foreach (var eventItem in events)
-        {
-            if (eventItem.Value.DeclaringDocumentedType != null)
-            {
-                WriteLineIndented($"Events[\"{eventItem.Key}\"].DeclaringType = Types[\"{eventItem.Value.DeclaringDocumentedType.Key}\"];");
-            }
-            else
-            {
-                // For external .NET types like ComponentBase, just set the name
-                WriteLineIndented($"Events[\"{eventItem.Key}\"].DeclaringTypeName = \"{eventItem.Value.DeclaringType?.Name}\";");
-            }
-            if (eventItem.Value.Property != null)
-            {
-                WriteLineIndented($"Events[\"{eventItem.Key}\"].Property = Properties[\"{eventItem.Value.Property.Key}\"];");
-            }
-        }
-
-        WriteLine();
-    }
-
-    /// <summary>
-    /// Links all events to their declaring types.
-    /// </summary>
-    public void LinkDocumentedTypes(IDictionary<string, DocumentedMethod> methods)
-    {
-        WriteLineIndented("// Link methods to their declaring types");
-
-        foreach (var method in methods)
-        {
-            if (method.Value.DeclaringDocumentedType != null)
-            {
-                WriteLineIndented($"Methods[\"{method.Key}\"].DeclaringType = Types[\"{method.Value.DeclaringDocumentedType.Key}\"];");
-            }
-            else
-            {
-                // For external .NET types like ComponentBase, just set the name
-                WriteLineIndented($"Methods[\"{method.Key}\"].DeclaringTypeName = \"{method.Value.DeclaringType?.Name}\";");
-            }
-        }
-
-        WriteLine();
-    }
-
-    /// <summary>
-    /// Links all see-also links to their referred types and members.
-    /// </summary>
-    public void WriteSeeAlsoLinks(IDictionary<string, DocumentedType> types)
-    {
-        WriteLineIndented("// Add see-also links for all types");
-
-        // Find the types with links
-        foreach (var type in types.Where(type => type.Value.Links.Count != 0))
-        {
-            // Go through each link
-            foreach (var link in type.Value.Links)
-            {
-                // Is this a type?  Or a member?  Or an actual web site URL?
-                if (link.Type != null)
-                {
-                    WriteLineIndented($"Types[\"{type.Key}\"].Links.Add(new() {{ Type = Types[\"{link.Type.Key}\"], Text = \"{link.Text}\" }});");
-                }
-                else if (link.Property != null)
-                {
-                    WriteLineIndented($"Types[\"{type.Key}\"].Links.Add(new() {{ Property = Properties[\"{link.Property.Key}\"], Text = \"{link.Text}\" }});");
-                }
-                else if (link.Field != null)
-                {
-                    WriteLineIndented($"Types[\"{type.Key}\"].Links.Add(new() {{ Field = Fields[\"{link.Field.Key}\"] , Text = \"{link.Text}\"}});");
-                }
-                else if (link.Method != null)
-                {
-                    WriteLineIndented($"Types[\"{type.Key}\"].Links.Add(new() {{ Method = Methods[\"{link.Method.Key}\"], Text = \"{link.Text}\" }});");
-                }
-                else if (link.Event != null)
-                {
-                    WriteLineIndented($"Types[\"{type.Key}\"].Links.Add(new() {{ Event = Events[\"{link.Event.Key}\"], Text = \"{link.Text}\" }});");
-                }
-                else if (!string.IsNullOrEmpty(link.Href))
-                {
-                    WriteLineIndented($"Types[\"{type.Key}\"].Links.Add(new() {{ Href = \"{link.Href}\", Text = \"{link.Text}\" }});");
-                }
-            }
-        }
-
-        WriteLine();
-    }
-
-    /// <summary>
     /// Serializes the specified type.
     /// </summary>
     /// <param name="type">The type to serialize.</param>
@@ -429,42 +529,18 @@ public class ApiDocumentationWriter : StringWriter
         Write($"\"{type.Key}\", new()");
         WriteLine(" {");
         Indent();
+        WriteLineIndented($"Key = \"{type.Key}\", ");
         WriteLineIndented($"Name = \"{type.Name}\", ");
         WriteLineIndented($"NameFriendly = \"{type.Type.GetFriendlyName()}\", ");
         WriteBaseTypeIndented(type.BaseType);
         WriteIsComponentIndented(type.Type.IsSubclassOf(typeof(MudComponentBase)));
         WriteSummaryIndented(type.Summary);
         WriteRemarksIndented(type.Remarks);
-        WriteProperties(type);
-        WriteGlobalSettings(type);
-        WriteFields(type);
-        WriteMethods(type);
-        WriteEvents(type);
+        // Members and see-also links belong to this type's loader in ApiDocumentationMembers, so that a
+        // page which only needs the name and summary never builds them.
         Outdent();
         WriteIndented("}");
         WriteLine("},");
-    }
-
-    /// <summary>
-    /// Serializes all documented events.
-    /// </summary>
-    /// <param name="events">The events to write.</param>
-    public void WriteEvents(IDictionary<string, DocumentedEvent> events)
-    {
-        WriteLineIndented("// Build all of the documented events");
-        WriteLineIndented($"Events = new()");
-        WriteLineIndented("{");
-        Indent();
-
-        foreach (var documentedEvent in events)
-        {
-            WriteEvent(documentedEvent.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("};");
-
-        WriteLine();
     }
 
     /// <summary>
@@ -473,9 +549,7 @@ public class ApiDocumentationWriter : StringWriter
     /// <param name="documentedEvent">The event to serialize.</param>
     public void WriteEvent(DocumentedEvent documentedEvent)
     {
-        WriteIndented("{ ");
-        Write($"\"{documentedEvent.Key}\", new()");
-        Write(" { ");
+        WriteEntryStart("EventsInternal", documentedEvent.Key);
         Write($"Name = \"{documentedEvent.Name}\", ");
         Write($"TypeName = \"{documentedEvent.Type?.FullName}\", ");
         Write($"TypeFriendlyName = \"{documentedEvent.Type?.GetFriendlyName()}\", ");
@@ -485,30 +559,7 @@ public class ApiDocumentationWriter : StringWriter
         WriteIsProtected(documentedEvent.IsProtected);
         WriteSummary(documentedEvent.Summary);
         WriteRemarks(documentedEvent.Remarks);
-        Write("}");
-        WriteLine("},");
-    }
-
-    /// <summary>
-    /// Serializes all documented fields.
-    /// </summary>
-    /// <param name="fields">The fields to write.</param>
-    public void WriteFields(IDictionary<string, DocumentedField> fields)
-    {
-        WriteLineIndented("// Build all of the documented fields");
-        WriteLineIndented($"Fields = new()");
-        WriteLineIndented("{");
-        Indent();
-
-        foreach (var field in fields)
-        {
-            WriteField(field.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("};");
-
-        WriteLine();
+        WriteEntryEnd();
     }
 
     /// <summary>
@@ -517,9 +568,7 @@ public class ApiDocumentationWriter : StringWriter
     /// <param name="field">The field to serialize.</param>
     public void WriteField(DocumentedField field)
     {
-        WriteIndented("{ ");
-        Write($"\"{field.Key}\", new()");
-        Write(" { ");
+        WriteEntryStart("FieldsInternal", field.Key);
         Write($"Name = \"{field.Name}\", ");
         Write($"TypeName = \"{field.Type?.FullName}\", ");
         Write($"TypeFriendlyName = \"{field.Type?.GetFriendlyName()}\", ");
@@ -528,30 +577,7 @@ public class ApiDocumentationWriter : StringWriter
         WriteOrder(field.Order);
         WriteSummary(field.Summary);
         WriteRemarks(field.Remarks);
-        Write("}");
-        WriteLine("},");
-    }
-
-    /// <summary>
-    /// Serializes all documented properties.
-    /// </summary>
-    /// <param name="properties">the properties to write.</param>
-    public void WriteProperties(IDictionary<string, DocumentedProperty> properties)
-    {
-        WriteLineIndented("// Build all of the documented properties");
-        WriteLineIndented("Properties = new()");
-        WriteLineIndented("{");
-        Indent();
-
-        foreach (var property in properties)
-        {
-            WriteProperty(property.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("};");
-
-        WriteLine();
+        WriteEntryEnd();
     }
 
     /// <summary>
@@ -560,9 +586,7 @@ public class ApiDocumentationWriter : StringWriter
     /// <param name="property">the property to serialize.</param>
     public void WriteProperty(DocumentedProperty property)
     {
-        WriteIndented("{ ");
-        Write($"\"{property.Key}\", new()");
-        Write(" { ");
+        WriteEntryStart("PropertiesInternal", property.Key);
         Write($"Name = \"{property.Name}\", ");
         Write($"TypeName = \"{property.Type?.FullName}\", ");
         Write($"TypeFriendlyName = \"{property.Type?.GetFriendlyName()}\", ");
@@ -572,8 +596,7 @@ public class ApiDocumentationWriter : StringWriter
         WriteOrder(property.Order);
         WriteRemarks(property.Remarks);
         WriteSummary(property.Summary);
-        Write("}");
-        WriteLine("},");
+        WriteEntryEnd();
     }
 
     /// <summary>
@@ -604,87 +627,6 @@ public class ApiDocumentationWriter : StringWriter
     }
 
     /// <summary>
-    /// Serializes the specified properties.
-    /// </summary>
-    /// <param name="type">The type containing the properties.</param>
-    public void WriteProperties(DocumentedType type)
-    {
-        /* Example:
-         
-            Properties = { 
-				{ "Type.JavaScriptListenerId", Properties["Type.JavaScriptListenerId"], } },
-				{ "Type.BrowserWindowSize", Properties["Type.BrowserWindowSize"], } },
-				{ "Type.Breakpoint", Properties["Type.Breakpoint"],  } },
-				{ "Type.IsImmediate", Properties["Type.IsImmediate"],  } },
-            },
-          
-         */
-
-        // Anything to do?
-        if (type.Properties.Count == 0)
-        {
-            return;
-        }
-
-        WriteLineIndented("Properties = { ");
-        Indent();
-
-        foreach (var pair in type.Properties)
-        {
-            WriteTypeProperty(pair.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("},");
-    }
-
-    /// <summary>
-    /// Serializes the specified MudGlobal settings.
-    /// </summary>
-    /// <param name="type">The type containing the settings.</param>
-    public void WriteGlobalSettings(DocumentedType type)
-    {
-        /* Example:
-         
-            GlobalSettings = { 
-				{ "JavaScriptListenerId", new() { Type = "Guid", Summary = "Gets the ID of the JavaScript listener.",  } },
-				{ "BrowserWindowSize", new() { Type = "BrowserWindowSize", Summary = "Gets the browser window size.",  } },
-				{ "Breakpoint", new() { Type = "Breakpoint", Summary = "Gets the breakpoint associated with the browser size.",  } },
-				{ "IsImmediate", new() { Type = "Boolean",  } },
-            },
-          
-         */
-
-        // Anything to do?
-        if (type.GlobalSettings.Count == 0)
-        {
-            return;
-        }
-
-        WriteLineIndented("GlobalSettings = { ");
-        Indent();
-
-        foreach (var property in type.GlobalSettings)
-        {
-            WriteTypeProperty(property.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("},");
-    }
-
-    /// <summary>
-    /// Serializes the specified property.
-    /// </summary>
-    /// <param name="property">The property to serialize.</param>
-    public void WriteTypeProperty(DocumentedProperty property)
-    {
-        WriteIndented("{ ");
-        Write($"\"{property.Name}\", Properties[\"{property.Key}\"]");
-        WriteLine(" },");
-    }
-
-    /// <summary>
     /// Serializes the specified event.
     /// </summary>
     /// <param name="eventItem">The event to serialize.</param>
@@ -696,92 +638,12 @@ public class ApiDocumentationWriter : StringWriter
     }
 
     /// <summary>
-    /// Serializes the specified field.
-    /// </summary>
-    /// <param name="field">The field to serialize.</param>
-    public void WriteTypeField(DocumentedField field)
-    {
-        WriteIndented("{ ");
-        Write($"\"{field.Name}\", Fields[\"{field.Key}\"]");
-        WriteLine(" },");
-    }
-
-    /// <summary>
-    /// Serializes the specified method.
-    /// </summary>
-    /// <param name="method">The method to serialize.</param>
-    public void WriteTypeMethod(DocumentedMethod method)
-    {
-        WriteIndented("{ ");
-        Write($"\"{method.Name}\", Methods[\"{method.Key}\"]");
-        WriteLine(" },");
-    }
-
-    /// <summary>
-    /// Serializes the specified methods.
-    /// </summary>
-    /// <param name="methods">The methods to serialize.</param>
-    public void WriteMethods(IDictionary<string, DocumentedMethod> methods)
-    {
-        WriteLineIndented("// Build all of the documented methods");
-        WriteLineIndented($"Methods = new()");
-        WriteLineIndented("{");
-        Indent();
-
-        foreach (var method in methods)
-        {
-            WriteMethod(method.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("};");
-        WriteLine();
-    }
-
-    /// <summary>
-    /// Serializes the specified methods.
-    /// </summary>
-    /// <param name="type">The type containing the methods.</param>
-    public void WriteMethods(DocumentedType type)
-    {
-        /* Example:
-
-           Methods = { 
-               { "SetValue", new() { Type = "Guid", Summary = "Gets the ID of the JavaScript listener.",  } },
-               { "BrowserWindowSize", new() { Type = "BrowserWindowSize", Summary = "Gets the browser window size.",  } },
-               { "Breakpoint", new() { Type = "Breakpoint", Summary = "Gets the breakpoint associated with the browser size.",  } },
-               { "IsImmediate", new() { Type = "Boolean",  } },
-           },
-
-        */
-
-        // Anything to do?
-        if (type.Methods.Count == 0)
-        {
-            return;
-        }
-
-        WriteLineIndented("Methods = { ");
-        Indent();
-
-        foreach (var method in type.Methods)
-        {
-            WriteTypeMethod(method.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("},");
-    }
-
-    /// <summary>
     /// Serializes a documented method.
     /// </summary>
     /// <param name="method"></param>
     public void WriteMethod(DocumentedMethod method)
     {
-        WriteIndented("{ ");
-        Write($"\"{method.Key}\", new()");
-        Write(" { ");
+        WriteEntryStart("MethodsInternal", method.Key);
         Write($"Name = \"{method.Name}\", ");
         WriteReturnType(method);
         WriteCategory(method.Category);
@@ -791,8 +653,7 @@ public class ApiDocumentationWriter : StringWriter
         WriteRemarks(method.Remarks);
         WriteReturns(method.Returns);
         WriteMethodParameters(method.Parameters);
-        Write("}");
-        WriteLine("},");
+        WriteEntryEnd();
     }
 
     /// <summary>
@@ -868,49 +729,4 @@ public class ApiDocumentationWriter : StringWriter
         }
     }
 
-    /// <summary>
-    /// Serializes all fields for the specified type.
-    /// </summary>
-    /// <param name="type">The type being serialized.</param>
-    public void WriteEvents(DocumentedType type)
-    {
-        if (type.Events.Count == 0)
-        {
-            return;
-        }
-
-        WriteLineIndented("Events = { ");
-        Indent();
-
-        foreach (var field in type.Events)
-        {
-            WriteTypeEvent(field.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("},");
-    }
-
-    /// <summary>
-    /// Serializes all fields for the specified type.
-    /// </summary>
-    /// <param name="type">The type being serialized.</param>
-    public void WriteFields(DocumentedType type)
-    {
-        if (type.Fields.Count == 0)
-        {
-            return;
-        }
-
-        WriteLineIndented("Fields = { ");
-        Indent();
-
-        foreach (var field in type.Fields)
-        {
-            WriteTypeField(field.Value);
-        }
-
-        Outdent();
-        WriteLineIndented("},");
-    }
 }

--- a/src/MudBlazor.Docs.Wasm/Program.cs
+++ b/src/MudBlazor.Docs.Wasm/Program.cs
@@ -33,8 +33,8 @@ if (notificationService is InMemoryNotificationService inMemoryService)
 {
     inMemoryService.Preload();
 }
-// Warm up the type documentation, which is what most of the site reads. Member documentation is built
-// a type at a time by whichever page asks for it, so there is nothing to warm up here.
+// Warm up the type documentation, which is what most of the site reads.
+// Member documentation is built a type at a time by whichever page asks for it, so there is nothing to warm up here.
 ApiDocumentation.GetType("MudAlert");
 
 await build.RunAsync();

--- a/src/MudBlazor.Docs.Wasm/Program.cs
+++ b/src/MudBlazor.Docs.Wasm/Program.cs
@@ -33,7 +33,8 @@ if (notificationService is InMemoryNotificationService inMemoryService)
 {
     inMemoryService.Preload();
 }
-// Warm up the documentation
+// Warm up the type documentation, which is what most of the site reads. Member documentation is built
+// a type at a time by whichever page asks for it, so there is nothing to warm up here.
 ApiDocumentation.GetType("MudAlert");
 
 await build.RunAsync();

--- a/src/MudBlazor.Docs/Models/Generated/ApiDocumentation.cs
+++ b/src/MudBlazor.Docs/Models/Generated/ApiDocumentation.cs
@@ -12,12 +12,34 @@ public static partial class ApiDocumentation
     /// <summary>
     /// The generated documentation for events.
     /// </summary>
-    public static Dictionary<string, DocumentedEvent> Events { get; private set; } = [];
+    /// <remarks>
+    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
+    /// lookups below, which build only the type that declares the member being looked for.
+    /// </remarks>
+    public static Dictionary<string, DocumentedEvent> Events
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureAll();
+            return ApiDocumentationMembers.EventsInternal;
+        }
+    }
 
     /// <summary>
     /// The generated documentation for fields.
     /// </summary>
-    public static Dictionary<string, DocumentedField> Fields { get; private set; } = [];
+    /// <remarks>
+    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
+    /// lookups below, which build only the type that declares the member being looked for.
+    /// </remarks>
+    public static Dictionary<string, DocumentedField> Fields
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureAll();
+            return ApiDocumentationMembers.FieldsInternal;
+        }
+    }
 
     /// <summary>
     /// The generated documentation for types.
@@ -27,12 +49,34 @@ public static partial class ApiDocumentation
     /// <summary>
     /// The generated documentation for properties.
     /// </summary>
-    public static Dictionary<string, DocumentedProperty> Properties { get; private set; }
+    /// <remarks>
+    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
+    /// lookups below, which build only the type that declares the member being looked for.
+    /// </remarks>
+    public static Dictionary<string, DocumentedProperty> Properties
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureAll();
+            return ApiDocumentationMembers.PropertiesInternal;
+        }
+    }
 
     /// <summary>
     /// The generated documentation for methods.
     /// </summary>
-    public static Dictionary<string, DocumentedMethod> Methods { get; private set; } = [];
+    /// <remarks>
+    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
+    /// lookups below, which build only the type that declares the member being looked for.
+    /// </remarks>
+    public static Dictionary<string, DocumentedMethod> Methods
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureAll();
+            return ApiDocumentationMembers.MethodsInternal;
+        }
+    }
 
     /// <summary>
     /// Gets an event, field, method, or property by its name.
@@ -146,18 +190,15 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // First, try an exact match
-        if (Properties.TryGetValue(name, out var match))
+        // A member's key starts with the key of the type that declares it, so an exact match only
+        // needs that one type to be built.
+        var match = ApiDocumentationMembers.Property(name) ?? ApiDocumentationMembers.Property("MudBlazor." + name);
+        if (match != null)
         {
             return match;
         }
-        // Next, try with the MudBlazor namespace
-        if (Properties.TryGetValue("MudBlazor." + name, out match))
-        {
-            return match;
-        }
-        // Find a match by name
-        var byName = Properties.SingleOrDefault(type => type.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        // Nothing matched by key.  Fall back to a search by name, which needs every type built.
+        var byName = Properties.SingleOrDefault(member => member.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         return byName.Value;
     }
 
@@ -172,18 +213,15 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // First, try an exact match
-        if (Fields.TryGetValue(name, out var match))
+        // A member's key starts with the key of the type that declares it, so an exact match only
+        // needs that one type to be built.
+        var match = ApiDocumentationMembers.Field(name) ?? ApiDocumentationMembers.Field("MudBlazor." + name);
+        if (match != null)
         {
             return match;
         }
-        // Next, try with the MudBlazor namespace
-        if (Fields.TryGetValue("MudBlazor." + name, out match))
-        {
-            return match;
-        }
-        // Find a match by name
-        var byName = Fields.SingleOrDefault(type => type.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        // Nothing matched by key.  Fall back to a search by name, which needs every type built.
+        var byName = Fields.SingleOrDefault(member => member.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         return byName.Value;
     }
 
@@ -198,18 +236,15 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // First, try an exact match
-        if (Methods.TryGetValue(name, out var match))
+        // A member's key starts with the key of the type that declares it, so an exact match only
+        // needs that one type to be built.
+        var match = ApiDocumentationMembers.Method(name) ?? ApiDocumentationMembers.Method("MudBlazor." + name);
+        if (match != null)
         {
             return match;
         }
-        // Next, try with the MudBlazor namespace
-        if (Methods.TryGetValue("MudBlazor." + name, out match))
-        {
-            return match;
-        }
-        // Find a match by name
-        var byName = Methods.SingleOrDefault(type => type.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        // Nothing matched by key.  Fall back to a search by name, which needs every type built.
+        var byName = Methods.SingleOrDefault(member => member.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         return byName.Value;
     }
 
@@ -224,18 +259,15 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // First, try an exact match
-        if (Events.TryGetValue(name, out var match))
+        // A member's key starts with the key of the type that declares it, so an exact match only
+        // needs that one type to be built.
+        var match = ApiDocumentationMembers.Event(name) ?? ApiDocumentationMembers.Event("MudBlazor." + name);
+        if (match != null)
         {
             return match;
         }
-        // Next, try with the MudBlazor namespace
-        if (Events.TryGetValue("MudBlazor." + name, out match))
-        {
-            return match;
-        }
-        // Find a match by name
-        var byName = Events.SingleOrDefault(type => type.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        // Nothing matched by key.  Fall back to a search by name, which needs every type built.
+        var byName = Events.SingleOrDefault(member => member.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         return byName.Value;
     }
 

--- a/src/MudBlazor.Docs/Models/Generated/ApiDocumentation.cs
+++ b/src/MudBlazor.Docs/Models/Generated/ApiDocumentation.cs
@@ -13,8 +13,8 @@ public static partial class ApiDocumentation
     /// The generated documentation for events.
     /// </summary>
     /// <remarks>
-    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
-    /// lookups below, which build only the type that declares the member being looked for.
+    /// Reading this builds the members of every type, because it can be enumerated.
+    /// Prefer the lookups below, which build only the type that declares the member being looked for.
     /// </remarks>
     public static Dictionary<string, DocumentedEvent> Events
     {
@@ -29,8 +29,8 @@ public static partial class ApiDocumentation
     /// The generated documentation for fields.
     /// </summary>
     /// <remarks>
-    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
-    /// lookups below, which build only the type that declares the member being looked for.
+    /// Reading this builds the members of every type, because it can be enumerated.
+    /// Prefer the lookups below, which build only the type that declares the member being looked for.
     /// </remarks>
     public static Dictionary<string, DocumentedField> Fields
     {
@@ -50,8 +50,8 @@ public static partial class ApiDocumentation
     /// The generated documentation for properties.
     /// </summary>
     /// <remarks>
-    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
-    /// lookups below, which build only the type that declares the member being looked for.
+    /// Reading this builds the members of every type, because it can be enumerated.
+    /// Prefer the lookups below, which build only the type that declares the member being looked for.
     /// </remarks>
     public static Dictionary<string, DocumentedProperty> Properties
     {
@@ -66,8 +66,8 @@ public static partial class ApiDocumentation
     /// The generated documentation for methods.
     /// </summary>
     /// <remarks>
-    /// Reading this builds the members of every type, because it can be enumerated.  Prefer the
-    /// lookups below, which build only the type that declares the member being looked for.
+    /// Reading this builds the members of every type, because it can be enumerated.
+    /// Prefer the lookups below, which build only the type that declares the member being looked for.
     /// </remarks>
     public static Dictionary<string, DocumentedMethod> Methods
     {
@@ -190,8 +190,7 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // A member's key starts with the key of the type that declares it, so an exact match only
-        // needs that one type to be built.
+        // A member's key starts with the key of the type that declares it, so an exact match only needs that one type to be built.
         var match = ApiDocumentationMembers.Property(name) ?? ApiDocumentationMembers.Property("MudBlazor." + name);
         if (match != null)
         {
@@ -213,8 +212,7 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // A member's key starts with the key of the type that declares it, so an exact match only
-        // needs that one type to be built.
+        // A member's key starts with the key of the type that declares it, so an exact match only needs that one type to be built.
         var match = ApiDocumentationMembers.Field(name) ?? ApiDocumentationMembers.Field("MudBlazor." + name);
         if (match != null)
         {
@@ -236,8 +234,7 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // A member's key starts with the key of the type that declares it, so an exact match only
-        // needs that one type to be built.
+        // A member's key starts with the key of the type that declares it, so an exact match only needs that one type to be built.
         var match = ApiDocumentationMembers.Method(name) ?? ApiDocumentationMembers.Method("MudBlazor." + name);
         if (match != null)
         {
@@ -259,8 +256,7 @@ public static partial class ApiDocumentation
         {
             return null;
         }
-        // A member's key starts with the key of the type that declares it, so an exact match only
-        // needs that one type to be built.
+        // A member's key starts with the key of the type that declares it, so an exact match only needs that one type to be built.
         var match = ApiDocumentationMembers.Event(name) ?? ApiDocumentationMembers.Event("MudBlazor." + name);
         if (match != null)
         {

--- a/src/MudBlazor.Docs/Models/Generated/ApiDocumentation.cs
+++ b/src/MudBlazor.Docs/Models/Generated/ApiDocumentation.cs
@@ -95,6 +95,15 @@ public static partial class ApiDocumentation
         {
             return null;
         }
+        // An exact key match needs only the type that declares the member, so every kind is tried by key first.
+        // Going through GetProperty first instead would build every type as soon as the name turned out to be a method, which is what most cross-references are.
+        var match = ApiDocumentationMembers.Member(name);
+        if (match != null)
+        {
+            return match;
+        }
+
+        // No key matched, so fall back to the searches by name, which need every type built.
         DocumentedMember result = GetProperty(name);
         result ??= GetField(name);
         result ??= GetEvent(name);

--- a/src/MudBlazor.Docs/Models/Generated/ApiDocumentationMembers.cs
+++ b/src/MudBlazor.Docs/Models/Generated/ApiDocumentationMembers.cs
@@ -11,14 +11,12 @@ namespace MudBlazor.Docs.Models;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Member documentation is about ten times the size of the type documentation, and an API page shows
-/// one type's members - 37 rows for <c>MudButton</c>, 154 for <c>MudDataGrid</c>. So it is built one
-/// type at a time, the first time something asks for that type's members. The pages that make up most
-/// of the site never ask at all.
+/// Member documentation is about ten times the size of the type documentation, and an API page shows one type's members - 37 rows for <c>MudButton</c>, 154 for <c>MudDataGrid</c>.
+/// So it is built one type at a time, the first time something asks for that type's members.
+/// The pages that make up most of the site never ask at all.
 /// </para>
 /// <para>
-/// A member's key begins with the key of the type that declares it, so the owning type can be derived
-/// from the member name and no separate index is needed.
+/// A member's key begins with the key of the type that declares it, so the owning type can be derived from the member name and no separate index is needed.
 /// </para>
 /// </remarks>
 public static partial class ApiDocumentationMembers
@@ -27,8 +25,7 @@ public static partial class ApiDocumentationMembers
     /// Every member built so far, by key.
     /// </summary>
     /// <remarks>
-    /// A member is created by the loader of the type that declares it, so a type which inherits members
-    /// shares the instances declared by its base types.
+    /// A member is created by the loader of the type that declares it, so a type which inherits members shares the instances declared by its base types.
     /// </remarks>
     internal static Dictionary<string, DocumentedProperty> PropertiesInternal { get; } = [];
 
@@ -47,10 +44,9 @@ public static partial class ApiDocumentationMembers
     /// Guards building, and the reads that trigger it.
     /// </summary>
     /// <remarks>
-    /// The WASM client is single threaded, but the prerender host renders crawler requests
-    /// concurrently.  Every read of a member collection comes through here, so a reader cannot see a
-    /// type that another thread is still building.  The lock is reentrant, which is what lets a type
-    /// build the types it inherits from.
+    /// The WASM client is single threaded, but the prerender host renders crawler requests concurrently.
+    /// Every read of a member collection comes through here, so a reader cannot see a type that another thread is still building.
+    /// The lock is reentrant, which is what lets a type build the types it inherits from.
     /// </remarks>
     private static readonly Lock Gate = new();
 
@@ -83,8 +79,7 @@ public static partial class ApiDocumentationMembers
     /// Builds the members of every documented type.
     /// </summary>
     /// <remarks>
-    /// Only needed by the few places that look across all members rather than at one type - the global
-    /// settings page, and the by-name fallback in <see cref="ApiDocumentation"/>.
+    /// Only needed by the few places that look across all members rather than at one type - the global settings page, and the by-name fallback in <see cref="ApiDocumentation"/>.
     /// </remarks>
     public static void EnsureAll()
     {

--- a/src/MudBlazor.Docs/Models/Generated/ApiDocumentationMembers.cs
+++ b/src/MudBlazor.Docs/Models/Generated/ApiDocumentationMembers.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Docs.Models;
+
+#nullable enable
+
+/// <summary>
+/// Represents the XML documentation for the members of documented types.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Member documentation is about ten times the size of the type documentation, and an API page shows
+/// one type's members - 37 rows for <c>MudButton</c>, 154 for <c>MudDataGrid</c>. So it is built one
+/// type at a time, the first time something asks for that type's members. The pages that make up most
+/// of the site never ask at all.
+/// </para>
+/// <para>
+/// A member's key begins with the key of the type that declares it, so the owning type can be derived
+/// from the member name and no separate index is needed.
+/// </para>
+/// </remarks>
+public static partial class ApiDocumentationMembers
+{
+    /// <summary>
+    /// Every member built so far, by key.
+    /// </summary>
+    /// <remarks>
+    /// A member is created by the loader of the type that declares it, so a type which inherits members
+    /// shares the instances declared by its base types.
+    /// </remarks>
+    internal static Dictionary<string, DocumentedProperty> PropertiesInternal { get; } = [];
+
+    /// <inheritdoc cref="PropertiesInternal"/>
+    internal static Dictionary<string, DocumentedMethod> MethodsInternal { get; } = [];
+
+    /// <inheritdoc cref="PropertiesInternal"/>
+    internal static Dictionary<string, DocumentedField> FieldsInternal { get; } = [];
+
+    /// <inheritdoc cref="PropertiesInternal"/>
+    internal static Dictionary<string, DocumentedEvent> EventsInternal { get; } = [];
+
+    private static readonly HashSet<string> LoadedTypes = [];
+
+    /// <summary>
+    /// Guards building, and the reads that trigger it.
+    /// </summary>
+    /// <remarks>
+    /// The WASM client is single threaded, but the prerender host renders crawler requests
+    /// concurrently.  Every read of a member collection comes through here, so a reader cannot see a
+    /// type that another thread is still building.  The lock is reentrant, which is what lets a type
+    /// build the types it inherits from.
+    /// </remarks>
+    private static readonly Lock Gate = new();
+
+    private static bool _allLoaded;
+
+    /// <summary>
+    /// Builds the members of a type, and of the types it inherits from.
+    /// </summary>
+    /// <param name="typeKey">The key of the type to build, or <c>null</c> to do nothing.</param>
+    public static void EnsureType(string? typeKey)
+    {
+        if (typeKey is null)
+        {
+            return;
+        }
+
+        lock (Gate)
+        {
+            // Marked before loading, so a type reached again while it is loading is not built twice.
+            if (!LoadedTypes.Add(typeKey))
+            {
+                return;
+            }
+
+            LoadType(typeKey);
+        }
+    }
+
+    /// <summary>
+    /// Builds the members of every documented type.
+    /// </summary>
+    /// <remarks>
+    /// Only needed by the few places that look across all members rather than at one type - the global
+    /// settings page, and the by-name fallback in <see cref="ApiDocumentation"/>.
+    /// </remarks>
+    public static void EnsureAll()
+    {
+        lock (Gate)
+        {
+            if (_allLoaded)
+            {
+                return;
+            }
+
+            _allLoaded = true;
+
+            foreach (var typeKey in ApiDocumentation.Types.Keys)
+            {
+                EnsureType(typeKey);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the key of the type which declares a member.
+    /// </summary>
+    /// <param name="memberKey">The key of the member, such as <c>MudBlazor.MudAlert.Class</c>.</param>
+    /// <returns>The part before the final separator, or <c>null</c> when there is none.</returns>
+    internal static string? DeclaringTypeKey(string? memberKey)
+    {
+        var separator = memberKey?.LastIndexOf('.') ?? -1;
+
+        return separator <= 0 ? null : memberKey![..separator];
+    }
+
+    /// <summary>
+    /// Gets a property, building the type that declares it if needed.
+    /// </summary>
+    internal static DocumentedProperty? Property(string key)
+    {
+        EnsureType(DeclaringTypeKey(key));
+
+        return PropertiesInternal.GetValueOrDefault(key);
+    }
+
+    /// <inheritdoc cref="Property"/>
+    internal static DocumentedMethod? Method(string key)
+    {
+        EnsureType(DeclaringTypeKey(key));
+
+        return MethodsInternal.GetValueOrDefault(key);
+    }
+
+    /// <inheritdoc cref="Property"/>
+    internal static DocumentedField? Field(string key)
+    {
+        EnsureType(DeclaringTypeKey(key));
+
+        return FieldsInternal.GetValueOrDefault(key);
+    }
+
+    /// <inheritdoc cref="Property"/>
+    internal static DocumentedEvent? Event(string key)
+    {
+        EnsureType(DeclaringTypeKey(key));
+
+        return EventsInternal.GetValueOrDefault(key);
+    }
+
+    /// <summary>
+    /// Builds the members declared by one type.
+    /// </summary>
+    /// <param name="typeKey">The key of the type to build.</param>
+    static partial void LoadType(string typeKey);
+}

--- a/src/MudBlazor.Docs/Models/Generated/ApiDocumentationMembers.cs
+++ b/src/MudBlazor.Docs/Models/Generated/ApiDocumentationMembers.cs
@@ -40,6 +40,10 @@ public static partial class ApiDocumentationMembers
 
     private static readonly HashSet<string> LoadedTypes = [];
 
+    private static readonly HashSet<string> LoadingTypes = [];
+
+    private static readonly Dictionary<string, Exception> FailedTypes = [];
+
     /// <summary>
     /// Guards building, and the reads that trigger it.
     /// </summary>
@@ -51,6 +55,19 @@ public static partial class ApiDocumentationMembers
     private static readonly Lock Gate = new();
 
     private static bool _allLoaded;
+
+    private static bool _allLoading;
+
+    private static Exception? _allFailure;
+
+    /// <summary>
+    /// How many times something has asked for every type to be built.
+    /// </summary>
+    /// <remarks>
+    /// A member lookup by key must never move this, which is what the tests assert.
+    /// Checking the count rather than what happens to be loaded keeps those tests independent of the order the suite runs in.
+    /// </remarks>
+    internal static int GlobalLoadRequests { get; private set; }
 
     /// <summary>
     /// Builds the members of a type, and of the types it inherits from.
@@ -65,13 +82,38 @@ public static partial class ApiDocumentationMembers
 
         lock (Gate)
         {
-            // Marked before loading, so a type reached again while it is loading is not built twice.
-            if (!LoadedTypes.Add(typeKey))
+            if (LoadedTypes.Contains(typeKey))
             {
                 return;
             }
 
-            LoadType(typeKey);
+            if (FailedTypes.TryGetValue(typeKey, out var earlier))
+            {
+                throw LoadFailure(typeKey, earlier);
+            }
+
+            // A type reached again while it is still loading is already being built further up this call stack, which is how a type builds the types it inherits from.
+            if (!LoadingTypes.Add(typeKey))
+            {
+                return;
+            }
+
+            try
+            {
+                LoadType(typeKey);
+                // Recorded only now, so a loader that threw leaves a partial build looking unfinished rather than complete.
+                LoadedTypes.Add(typeKey);
+            }
+            catch (Exception exception)
+            {
+                FailedTypes[typeKey] = exception;
+
+                throw LoadFailure(typeKey, exception);
+            }
+            finally
+            {
+                LoadingTypes.Remove(typeKey);
+            }
         }
     }
 
@@ -85,18 +127,58 @@ public static partial class ApiDocumentationMembers
     {
         lock (Gate)
         {
-            if (_allLoaded)
+            GlobalLoadRequests++;
+
+            if (_allLoaded || _allLoading)
             {
                 return;
             }
 
-            _allLoaded = true;
-
-            foreach (var typeKey in ApiDocumentation.Types.Keys)
+            if (_allFailure is not null)
             {
-                EnsureType(typeKey);
+                throw LoadFailure(_allFailure);
+            }
+
+            _allLoading = true;
+
+            try
+            {
+                foreach (var typeKey in ApiDocumentation.Types.Keys)
+                {
+                    EnsureType(typeKey);
+                }
+
+                _allLoaded = true;
+            }
+            catch (Exception exception)
+            {
+                _allFailure = exception;
+
+                throw LoadFailure(exception);
+            }
+            finally
+            {
+                _allLoading = false;
             }
         }
+    }
+
+    /// <summary>
+    /// Describes a build that failed.
+    /// </summary>
+    /// <remarks>
+    /// A loader assigns members into the shared dictionaries and adds them to its type's collections, and those additions cannot be repeated, so a failed build cannot be retried.
+    /// Every later read of the same documentation gets this instead of the partial data the failure left behind.
+    /// </remarks>
+    private static InvalidOperationException LoadFailure(string typeKey, Exception cause)
+    {
+        return new InvalidOperationException($"The documentation for '{typeKey}' could not be built.", cause);
+    }
+
+    /// <inheritdoc cref="LoadFailure(string, Exception)"/>
+    private static InvalidOperationException LoadFailure(Exception cause)
+    {
+        return new InvalidOperationException("The documentation for every type could not be built.", cause);
     }
 
     /// <summary>
@@ -116,33 +198,65 @@ public static partial class ApiDocumentationMembers
     /// </summary>
     internal static DocumentedProperty? Property(string key)
     {
-        EnsureType(DeclaringTypeKey(key));
+        lock (Gate)
+        {
+            EnsureType(DeclaringTypeKey(key));
 
-        return PropertiesInternal.GetValueOrDefault(key);
+            return PropertiesInternal.GetValueOrDefault(key);
+        }
     }
 
     /// <inheritdoc cref="Property"/>
     internal static DocumentedMethod? Method(string key)
     {
-        EnsureType(DeclaringTypeKey(key));
+        lock (Gate)
+        {
+            EnsureType(DeclaringTypeKey(key));
 
-        return MethodsInternal.GetValueOrDefault(key);
+            return MethodsInternal.GetValueOrDefault(key);
+        }
     }
 
     /// <inheritdoc cref="Property"/>
     internal static DocumentedField? Field(string key)
     {
-        EnsureType(DeclaringTypeKey(key));
+        lock (Gate)
+        {
+            EnsureType(DeclaringTypeKey(key));
 
-        return FieldsInternal.GetValueOrDefault(key);
+            return FieldsInternal.GetValueOrDefault(key);
+        }
     }
 
     /// <inheritdoc cref="Property"/>
     internal static DocumentedEvent? Event(string key)
     {
-        EnsureType(DeclaringTypeKey(key));
+        lock (Gate)
+        {
+            EnsureType(DeclaringTypeKey(key));
 
-        return EventsInternal.GetValueOrDefault(key);
+            return EventsInternal.GetValueOrDefault(key);
+        }
+    }
+
+    /// <summary>
+    /// Gets a member of any kind by its key, building the type that declares it if needed.
+    /// </summary>
+    /// <remarks>
+    /// A caller looking for a member without knowing its kind must come through here rather than trying each kind in turn.
+    /// The single-kind lookups above fall back to a search by name when the key misses, and that search builds every type, so a method reference would pay for the whole member tier on its way past the property lookup.
+    /// </remarks>
+    internal static DocumentedMember? Member(string key)
+    {
+        lock (Gate)
+        {
+            EnsureType(DeclaringTypeKey(key));
+
+            return (DocumentedMember?)PropertiesInternal.GetValueOrDefault(key)
+                ?? (DocumentedMember?)MethodsInternal.GetValueOrDefault(key)
+                ?? (DocumentedMember?)FieldsInternal.GetValueOrDefault(key)
+                ?? EventsInternal.GetValueOrDefault(key);
+        }
     }
 
     /// <summary>

--- a/src/MudBlazor.Docs/Models/Generated/DocumentedType.cs
+++ b/src/MudBlazor.Docs/Models/Generated/DocumentedType.cs
@@ -15,6 +15,14 @@ namespace MudBlazor.Docs.Models;
 public sealed class DocumentedType
 {
     /// <summary>
+    /// The unique key for this type, such as <c>MudBlazor.MudAlert</c>.
+    /// </summary>
+    /// <remarks>
+    /// Used to build this type's members on first use.  See <see cref="ApiDocumentationMembers"/>.
+    /// </remarks>
+    public string Key { get; init; } = "";
+
+    /// <summary>
     /// The Reflection name of this type.
     /// </summary>
     public string Name { get; init; } = "";
@@ -69,33 +77,120 @@ public sealed class DocumentedType
     /// </summary>
     public List<DocumentedType> Children => ApiDocumentation.Types.Values.Where(type => type.BaseTypeName == Name).ToList();
 
+    // The member collections are filled by this type's loader in ApiDocumentationMembers, which runs
+    // the first time something reads them. The generator fills them through the internal views, which
+    // do not trigger it.
+
+    private readonly Dictionary<string, DocumentedProperty> _properties = [];
+    private readonly Dictionary<string, DocumentedMethod> _methods = [];
+    private readonly Dictionary<string, DocumentedField> _fields = [];
+    private readonly Dictionary<string, DocumentedEvent> _events = [];
+    private readonly Dictionary<string, DocumentedProperty> _globalSettings = [];
+
     /// <summary>
     /// The properties in this type (including inherited properties).
     /// </summary>
-    public Dictionary<string, DocumentedProperty> Properties { get; init; } = [];
+    public Dictionary<string, DocumentedProperty> Properties
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureType(Key);
+            return _properties;
+        }
+    }
 
     /// <summary>
     /// The methods in this type (including inherited methods).
     /// </summary>
-    public Dictionary<string, DocumentedMethod> Methods { get; init; } = [];
+    public Dictionary<string, DocumentedMethod> Methods
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureType(Key);
+            return _methods;
+        }
+    }
 
     /// <summary>
     /// The fields in this type (including inherited fields).
     /// </summary>
-    public Dictionary<string, DocumentedField> Fields { get; init; } = [];
+    public Dictionary<string, DocumentedField> Fields
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureType(Key);
+            return _fields;
+        }
+    }
 
     /// <summary>
     /// The events in this type.
     /// </summary>
-    public Dictionary<string, DocumentedEvent> Events { get; init; } = [];
+    public Dictionary<string, DocumentedEvent> Events
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureType(Key);
+            return _events;
+        }
+    }
 
     /// <summary>
-    /// The properties in this type (including inherited properties).
+    /// The properties in this type which have a global setting.
     /// </summary>
-    public Dictionary<string, DocumentedProperty> GlobalSettings { get; init; } = [];
+    public Dictionary<string, DocumentedProperty> GlobalSettings
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureType(Key);
+            return _globalSettings;
+        }
+    }
+
+    /// <summary>
+    /// The properties in this type, without building the member documentation first.
+    /// </summary>
+    internal Dictionary<string, DocumentedProperty> PropertiesInternal => _properties;
+
+    /// <summary>
+    /// The methods in this type, without building the member documentation first.
+    /// </summary>
+    internal Dictionary<string, DocumentedMethod> MethodsInternal => _methods;
+
+    /// <summary>
+    /// The fields in this type, without building the member documentation first.
+    /// </summary>
+    internal Dictionary<string, DocumentedField> FieldsInternal => _fields;
+
+    /// <summary>
+    /// The events in this type, without building the member documentation first.
+    /// </summary>
+    internal Dictionary<string, DocumentedEvent> EventsInternal => _events;
+
+    /// <summary>
+    /// The global settings in this type, without building the member documentation first.
+    /// </summary>
+    internal Dictionary<string, DocumentedProperty> GlobalSettingsInternal => _globalSettings;
+
+    private readonly List<DocumentedLink> _links = [];
 
     /// <summary>
     /// The see-also links for this type.
     /// </summary>
-    public List<DocumentedLink> Links { get; init; } = [];
+    /// <remarks>
+    /// See-also links can point at a member, so they are built with the member documentation.
+    /// </remarks>
+    public List<DocumentedLink> Links
+    {
+        get
+        {
+            ApiDocumentationMembers.EnsureType(Key);
+            return _links;
+        }
+    }
+
+    /// <summary>
+    /// The see-also links for this type, without building the member documentation first.
+    /// </summary>
+    internal List<DocumentedLink> LinksInternal => _links;
 }

--- a/src/MudBlazor.Docs/Models/Generated/DocumentedType.cs
+++ b/src/MudBlazor.Docs/Models/Generated/DocumentedType.cs
@@ -77,9 +77,8 @@ public sealed class DocumentedType
     /// </summary>
     public List<DocumentedType> Children => ApiDocumentation.Types.Values.Where(type => type.BaseTypeName == Name).ToList();
 
-    // The member collections are filled by this type's loader in ApiDocumentationMembers, which runs
-    // the first time something reads them. The generator fills them through the internal views, which
-    // do not trigger it.
+    // The member collections are filled by this type's loader in ApiDocumentationMembers, which runs the first time something reads them.
+    // The generator fills them through the internal views, which do not trigger it.
 
     private readonly Dictionary<string, DocumentedProperty> _properties = [];
     private readonly Dictionary<string, DocumentedMethod> _methods = [];

--- a/src/MudBlazor.Docs/MudBlazor.Docs.csproj
+++ b/src/MudBlazor.Docs/MudBlazor.Docs.csproj
@@ -58,6 +58,10 @@
     <Delete Files="@(FilesToClean)" />
   </Target>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MudBlazor.UnitTests.Docs" />
+  </ItemGroup>
+
   <!--Packages-->
   <ItemGroup>
     <PackageReference Include="Blazor-Analytics" Version="4.0.0" />

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiDocumentationTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiDocumentationTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using MudBlazor.Docs.Models;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Docs.Documentation;
+
+/// <summary>
+/// Tests for <see cref="ApiDocumentation"/> member lookups.
+/// </summary>
+/// <remarks>
+/// Members are built one type at a time, so a lookup by key must build only the type that declares the member.
+/// These tests assert that by counting requests for a global build rather than by inspecting what happens to be loaded, which keeps them independent of the order the suite runs in.
+/// </remarks>
+[TestFixture]
+public sealed class ApiDocumentationTests
+{
+    /// <summary>
+    /// Resolves a property reference without building every type.
+    /// </summary>
+    [Test]
+    public void GetMember_Property_BuildsOnlyTheDeclaringType()
+    {
+        var before = ApiDocumentationMembers.GlobalLoadRequests;
+
+        var member = ApiDocumentation.GetMember("MudBlazor.MudComponentBase.Class");
+
+        member.Should().BeOfType<DocumentedProperty>("There should be a property named Class");
+        member.Name.Should().Be("Class");
+        member.DeclaringType.Name.Should().Be("MudComponentBase");
+        ApiDocumentationMembers.GlobalLoadRequests.Should().Be(before, "A member found by key should not build every type");
+    }
+
+    /// <summary>
+    /// Resolves a method reference without building every type.
+    /// </summary>
+    [Test]
+    public void GetMember_Method_BuildsOnlyTheDeclaringType()
+    {
+        var before = ApiDocumentationMembers.GlobalLoadRequests;
+
+        var member = ApiDocumentation.GetMember("MudBlazor.BaseMask.GetCleanText");
+
+        member.Should().BeOfType<DocumentedMethod>("There should be a method named GetCleanText");
+        member.Name.Should().Be("GetCleanText");
+        member.DeclaringType.Name.Should().Be("BaseMask");
+        ApiDocumentationMembers.GlobalLoadRequests.Should().Be(before, "A member found by key should not build every type");
+    }
+
+    /// <summary>
+    /// Resolves a field reference without building every type.
+    /// </summary>
+    [Test]
+    public void GetMember_Field_BuildsOnlyTheDeclaringType()
+    {
+        var before = ApiDocumentationMembers.GlobalLoadRequests;
+
+        var member = ApiDocumentation.GetMember("MudBlazor.Adornment.Start");
+
+        member.Should().BeOfType<DocumentedField>("There should be a field named Start");
+        member.Name.Should().Be("Start");
+        member.DeclaringType.Name.Should().Be("Adornment");
+        ApiDocumentationMembers.GlobalLoadRequests.Should().Be(before, "A member found by key should not build every type");
+    }
+
+    /// <summary>
+    /// Resolves an event reference without building every type.
+    /// </summary>
+    [Test]
+    public void GetMember_Event_BuildsOnlyTheDeclaringType()
+    {
+        var before = ApiDocumentationMembers.GlobalLoadRequests;
+
+        var member = ApiDocumentation.GetMember("MudBlazor.MudAlert.CloseIconClicked");
+
+        member.Should().BeOfType<DocumentedEvent>("There should be an event named CloseIconClicked");
+        member.Name.Should().Be("CloseIconClicked");
+        member.DeclaringType.Name.Should().Be("MudAlert");
+        ApiDocumentationMembers.GlobalLoadRequests.Should().Be(before, "A member found by key should not build every type");
+    }
+
+    /// <summary>
+    /// Returns the same instance a type's own collection holds.
+    /// </summary>
+    [Test]
+    public void GetMember_ReturnsTheInstanceTheDeclaringTypeHolds()
+    {
+        var type = ApiDocumentation.GetType("MudBlazor.MudAlert");
+
+        var member = ApiDocumentation.GetMember("MudBlazor.MudAlert.CloseIconClicked");
+
+        member.Should().BeSameAs(type.Events["CloseIconClicked"], "A member should not be built twice");
+    }
+}


### PR DESCRIPTION
`ApiDocumentation`'s generated static constructor was 1,128,847 bytes of IL — 38% of all IL in `MudBlazor.Docs` — and ran at boot on every visit, building 481 types and 5,476 members before the first render. Deleting that data outright is worth 43.6 MB of WebAssembly heap on a component page, making it the largest single item in the docs site's memory (#13799).

An API page shows one type's members: 37 rows for `MudButton`, 154 for `MudDataGrid`. So the generator now emits the type tier eagerly and one member loader per type, run the first time something reads that type's members. A member's key begins with the key of the type that declares it, so the owning type is derived from the name and no index is needed.

| | baseline | this PR |
| --- | ---: | ---: |
| cold `/components/button` | 133.1 MB | 92.1 MB (−31%) |
| cold landing | 133.4 MB | 92.1 MB (−31%) |
| cold `/api/MudDataGrid` | 133.4 MB | 129.6 MB |
| after a six-page session | 160.1 MB | 159.3 MB |
