### PR TITLE
Docs: Honor ApiTypeLink's ShowTooltip and Typo parameters

### DIFF
--- a/src/MudBlazor.Docs/Components/ApiTypeLink.cs
+++ b/src/MudBlazor.Docs/Components/ApiTypeLink.cs
@@ -78,7 +78,7 @@ public sealed class ApiTypeLink : ComponentBase
         // Is there a linkable type?
         if (Type != null)
         {
-            builder.AddDocumentedTypeLink(0, Type);
+            builder.AddDocumentedTypeLink(0, Type, Typo, ShowTooltip);
         }
         // Is this an internal type?
         else if (TypeName != null && (TypeName.StartsWith("Microsoft", StringComparison.OrdinalIgnoreCase) || TypeName.StartsWith("System", StringComparison.OrdinalIgnoreCase)))

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiSeeAlsoLinksTests.cs
@@ -30,7 +30,7 @@ public sealed class ApiSeeAlsoLinksTests : BunitTest
 
         comp.Markup.Should().Contain("<a href=\"/api/MudButtonGroup\"", "There should be a see-also link to MudButtonGroup");
 
-        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudButtonGroup</a>", "There should be a see-also link to MudButtonGroup");
+        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">MudButtonGroup</a>", "There should be a see-also link to MudButtonGroup");
 
         comp.Markup.Should().NotContain("<div class=\"mud-alert-message\">No see-also links match the current filters.</div>", "There should NOT be a message saying no members are found");
     }

--- a/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
+++ b/src/MudBlazor.UnitTests.Docs/Documentation/ApiTypeLinkTests.cs
@@ -187,7 +187,30 @@ public sealed class ApiTypeLinkTests : BunitTest
     {
         var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert"));
 
-        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
+        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\" blazor:onclick=\"6\" class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">MudAlert</a>", "There should be a link to MudAlert");
+    }
+
+    /// <summary>
+    /// Renders a link with the requested typography.
+    /// </summary>
+    [Test]
+    public void ApiTypeLink_Typo()
+    {
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert").Add(x => x.Typo, Typo.subtitle1));
+
+        comp.Markup.Should().Contain("mud-typography-subtitle1", "The link should use the requested typography");
+    }
+
+    /// <summary>
+    /// Renders a link without a tooltip when tooltips are turned off.
+    /// </summary>
+    [Test]
+    public void ApiTypeLink_ShowTooltip_False()
+    {
+        var comp = Context.Render<ApiTypeLink>(parameters => parameters.Add(x => x.TypeName, "MudBlazor.MudAlert").Add(x => x.ShowTooltip, false));
+
+        comp.Markup.Should().NotContain("mud-tooltip-root", "There should be no tooltip");
+        comp.Markup.Should().Contain("<a href=\"/api/MudAlert\"", "There should still be a link to MudAlert");
     }
 
     /// <summary>
@@ -200,7 +223,7 @@ public sealed class ApiTypeLinkTests : BunitTest
 
         comp.Markup.Should().Contain("<a href=\"/api/Adornment\"", "There should be a link to Adornment");
 
-        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-body1 docs-link docs-code docs-code-primary\">Adornment</a>", "There should be a link to Adornment");
+        comp.Markup.Should().Contain("class=\"mud-typography mud-link mud-primary-text mud-link-underline-hover mud-typography-caption docs-link docs-code docs-code-primary\">Adornment</a>", "There should be a link to Adornment");
     }
 
     /// <summary>


### PR DESCRIPTION
`ApiTypeLink` declares `ShowTooltip` and `Typo`, and neither reached the renderer. The call to `AddDocumentedTypeLink` passed only the type, so both fell back to the helper's defaults.

The visible consequence is on the API index and the derived-types table, which both ask for `ShowTooltip="false"` but got a tooltip anyway, and it repeated the summary displayed in the description column next to it.

Measured on `/api`, 25 rows:

| | before | after |
| --- | ---: | ---: |
| tooltip roots in the table | 46 | 21 |
| popovers in the DOM | 60 | 35 |
| rendered components (bUnit) | 454 | 404 |
| retained managed bytes | 1,525,656 | 1,353,048 |

The 21 tooltips that remain are the type links inside the description text, which are supposed to have them. The page's retained memory drops 11.3%, byte-identical across three runs.

`Typo` has almost no visual effect, because `.docs-code` overrides font size, weight and line height; the one computed property that changes is letter spacing, 0.11px → 0.40px. But the external-type branch of this same component already honored `Typo`, so `System.Guid` and `MudAlert` were rendering differently in the same column.