### PR TITLE
MudSlider: Add drag events

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Slider/Examples/SliderDragEventsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/Examples/SliderDragEventsExample.razor
@@ -1,0 +1,27 @@
+@namespace MudBlazor.Docs.Examples
+
+@inject ISnackbar Snackbar
+
+<MudText>@_temperature.ToString("F1")°C</MudText>
+<MudSlider @bind-Value="@_temperature" Min="12" Step="0.1" Max="110" OnDragStart="TemperatureChangeInitialization"
+           OnDragEnd="TemperatureChangeOrdered">Heater Temperature</MudSlider>
+
+@code {
+    private double _temperature = 24;
+
+    private void TemperatureChangeInitialization() => Snackbar.Add($"Get on station, we need to change the temperatiure", Severity.Info);
+
+    private void TemperatureChangeOrdered()
+    {
+        var message = _temperature switch
+        {
+            < 16 => "It's getting chilly",
+            >= 16 and < 19 => "Thats nice but could be warmer",
+            >= 19 and < 23 => "Very cozy",
+            >= 23 and < 30 => "It's getting hot in here",
+            _ => "The temperature is in °C not °F"
+        };
+
+        Snackbar.Add(message, _temperature < 30 ? Severity.Info : Severity.Warning);
+    }
+}

--- a/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/SliderPage.razor
@@ -107,5 +107,14 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Interaction start and end">
+                <Description>Interact with the slider below to see event handling for drag start and stop</Description>
+            </SectionHeader>
+            <SectionContent Code="@nameof(SliderDragEventsExample)">
+                <SliderDragEventsExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Slider/SliderWithDragHandlers.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Slider/SliderWithDragHandlers.razor
@@ -1,8 +1,0 @@
-<MudSlider T="int" OnDragStart="@(() => Dragging = true)" OnDragEnd="@(() => Dragging = false)" Disabled="@Disabled" />
-
-@code {
-    [Parameter]
-    public bool Disabled { get; set; }
-
-    public bool? Dragging { get; set; } = null;
-}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Slider/SliderWithDragHandlers.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Slider/SliderWithDragHandlers.razor
@@ -1,0 +1,8 @@
+<MudSlider T="int" OnDragStart="@(() => Dragging = true)" OnDragEnd="@(() => Dragging = false)" Disabled="@Disabled" />
+
+@code {
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    public bool? Dragging { get; set; } = null;
+}

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -514,28 +514,44 @@ namespace MudBlazor.UnitTests.Components
             AlertText().InnerHtml.Should().Be("20");
         }
 
+        /// <summary>
+        /// Verifies drag callbacks for supported pointer interactions and disabled sliders.
+        /// </summary>
         [Test]
         public async Task DragEvents()
         {
-            var comp = Context.Render<SliderWithDragHandlers>();
-            IElement input = comp.Find(".mud-slider-input");
-            await input.TouchStartAsync();
-            comp.Instance.Dragging.Should().Be(true);
-            await input.TouchEndAsync();
-            comp.Instance.Dragging.Should().Be(false);
-
-            await input.MouseDownAsync();
-            comp.Instance.Dragging.Should().Be(true);
-            await input.MouseUpAsync();
-            comp.Instance.Dragging.Should().Be(false);
-
-            comp = Context.Render<SliderWithDragHandlers>(x =>
+            bool? dragging = null;
+            var comp = Context.Render<MudSlider<int>>(x =>
             {
+                x.Add(p => p.OnDragStart, () => dragging = true);
+                x.Add(p => p.OnDragEnd, () => dragging = false);
+            });
+
+            var slider = comp.Find(".mud-slider-input");
+            await slider.PointerDownAsync();
+            Assert.True(dragging);
+            await slider.PointerUpAsync();
+            Assert.False(dragging);
+
+            dragging = null;
+            await slider.PointerCancelAsync();
+            Assert.False(dragging);
+
+            var touched = false;
+            comp = Context.Render<MudSlider<int>>(x =>
+            {
+                x.Add(p => p.OnDragStart, () => touched = true);
+                x.Add(p => p.OnDragEnd, () => touched = true);
                 x.Add(p => p.Disabled, true);
             });
-            input = comp.Find(".mud-slider-input");
-            await input.TouchStartAsync();
-            comp.Instance.Dragging.Should().Be(null);
+
+            slider = comp.Find(".mud-slider-input");
+            await slider.PointerDownAsync();
+            Assert.False(touched);
+            await slider.PointerUpAsync();
+            Assert.False(touched);
+            await slider.PointerCancelAsync();
+            Assert.False(touched);
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/SliderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SliderTests.cs
@@ -513,5 +513,29 @@ namespace MudBlazor.UnitTests.Components
             IRenderedComponent<MudAlert> MudAlert() => comp.FindComponent<MudAlert>();
             AlertText().InnerHtml.Should().Be("20");
         }
+
+        [Test]
+        public async Task DragEvents()
+        {
+            var comp = Context.Render<SliderWithDragHandlers>();
+            IElement input = comp.Find(".mud-slider-input");
+            await input.TouchStartAsync();
+            comp.Instance.Dragging.Should().Be(true);
+            await input.TouchEndAsync();
+            comp.Instance.Dragging.Should().Be(false);
+
+            await input.MouseDownAsync();
+            comp.Instance.Dragging.Should().Be(true);
+            await input.MouseUpAsync();
+            comp.Instance.Dragging.Should().Be(false);
+
+            comp = Context.Render<SliderWithDragHandlers>(x =>
+            {
+                x.Add(p => p.Disabled, true);
+            });
+            input = comp.Find(".mud-slider-input");
+            await input.TouchStartAsync();
+            comp.Instance.Dragging.Should().Be(null);
+        }
     }
 }

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -34,10 +34,15 @@
                 </div>
             </div>
         }
-        
-        <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)" max="@Max.ToString(null, CultureInfo.InvariantCulture)" step="@Step.ToString(null, CultureInfo.InvariantCulture)" @attributes="UserAttributes" disabled="@Disabled"
-               @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" @onmousedown="this.AsNonRenderingEventHandler(OnDragStartHandler)" @onmouseup="this.AsNonRenderingEventHandler(OnDragEndHandler)"
-               @ontouchstart="this.AsNonRenderingEventHandler(OnDragStartHandler)" @ontouchend="this.AsNonRenderingEventHandler(OnDragEndHandler)" />
+
+        <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)"
+               max="@Max.ToString(null, CultureInfo.InvariantCulture)"
+               step="@Step.ToString(null, CultureInfo.InvariantCulture)" @attributes="UserAttributes" disabled="@Disabled"
+               @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync"
+               @bind-value:event="@(Immediate ? "oninput" : "onchange")"
+               @onpointerdown="this.AsNonRenderingEventHandler(OnDragStartHandler)"
+               @onpointerup="this.AsNonRenderingEventHandler(OnDragEndHandler)"
+               @onpointercancel="this.AsNonRenderingEventHandler(OnDragEndHandler)" />
         @if (ValueLabel)
         {
             <div class="mud-slider-value-label" style="@ValueLabelPositionStyle">

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -36,7 +36,8 @@
         }
         
         <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)" max="@Max.ToString(null, CultureInfo.InvariantCulture)" step="@Step.ToString(null, CultureInfo.InvariantCulture)" @attributes="UserAttributes" disabled="@Disabled"
-               @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
+               @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" @onmousedown="this.AsNonRenderingEventHandler(OnDragStartHandler)" @onmouseup="this.AsNonRenderingEventHandler(OnDragEndHandler)"
+               @ontouchstart="this.AsNonRenderingEventHandler(OnDragStartHandler)" @ontouchend="this.AsNonRenderingEventHandler(OnDragEndHandler)" />
         @if (ValueLabel)
         {
             <div class="mud-slider-value-label" style="@ValueLabelPositionStyle">
@@ -51,5 +52,4 @@
             </div>
         }
     </div>
-
 </div>

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -4,39 +4,40 @@
 @typeparam T
 
 <div class="@Classname" style="@Style">
-	@if (ChildContent is not null)
-	{
-		<MudText Typo="Typo.body1">@ChildContent</MudText>
-	}
-	<div class="mud-slider-container">
-		@if (Variant == Variant.Filled)
-		{
-			<div class="mud-slider-inner-container">
-				<div class="mud-slider-filled" style="@($"width:{Width}%;")"></div>
-			</div>
-		}
-		@if (TickMarks)
-		{
-			<div class="mud-slider-inner-container">
-				<div class="mud-slider-tickmarks">
-					@for (int i = 0; i < _tickMarkCount; i++)
-					{
-						int current = i;
+    @if (ChildContent is not null)
+    {
+        <MudText Typo="Typo.body1">@ChildContent</MudText>
+    }
+    <div class="mud-slider-container">
+        @if (Variant == Variant.Filled)
+        {
+            <div class="mud-slider-inner-container">
+                <div class="mud-slider-filled" style="@($"width:{Width}%;")"></div>
+            </div>
+        }
+        @if (TickMarks)
+        {
+            <div class="mud-slider-inner-container">
+                <div class="mud-slider-tickmarks">
+                    @for (int i = 0; i < _tickMarkCount; i++)
+                    {
+                        int current = i;
 
-						<div class="d-flex flex-column relative">
-							<span class="mud-slider-track-tick" />
-							@if (TickMarkLabels != null && current < TickMarkLabels.Length)
-							{
-								<MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
-							}
-						</div>
-					}
-				</div>
-			</div>
-		}
+                        <div class="d-flex flex-column relative">
+                            <span class="mud-slider-track-tick" />
+                            @if (TickMarkLabels != null && current < TickMarkLabels.Length)
+                            {
+                                <MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+        }
         
         <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)" max="@Max.ToString(null, CultureInfo.InvariantCulture)" step="@Step.ToString(null, CultureInfo.InvariantCulture)" @attributes="UserAttributes" disabled="@Disabled"
-               @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
+               @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" @onmousedown="this.AsNonRenderingEventHandler(OnDragStartHandler)" @onmouseup="this.AsNonRenderingEventHandler(OnDragEndHandler)"
+               @ontouchstart="this.AsNonRenderingEventHandler(OnDragStartHandler)" @ontouchend="this.AsNonRenderingEventHandler(OnDragEndHandler)" />
         @if (ValueLabel)
         {
             <div class="mud-slider-value-label" style="@ValueLabelPositionStyle">
@@ -50,6 +51,5 @@
                 }
             </div>
         }
-	</div>
-
+    </div>
 </div>

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -239,12 +239,14 @@ namespace MudBlazor
         /// Occurs when interaction with the slider starts.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.Slider.Behavior)]
         public EventCallback OnDragStart { get; set; }
 
         /// <summary>
         /// Occurs when interaction with the slider ends.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.Slider.Behavior)]
         public EventCallback OnDragEnd { get; set; }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -235,6 +235,18 @@ namespace MudBlazor
         [Category(CategoryTypes.Button.Appearance)]
         public RenderFragment<SliderContext<T>>? ValueLabelContent { get; set; }
 
+        /// <summary>
+        /// Occurs when interaction with the slider starts.
+        /// </summary>
+        [Parameter]
+        public EventCallback OnDragStart { get; set; }
+
+        /// <summary>
+        /// Occurs when interaction with the slider ends.
+        /// </summary>
+        [Parameter]
+        public EventCallback OnDragEnd { get; set; }
+
         /// <inheritdoc />
         protected override void OnParametersSet()
         {
@@ -296,6 +308,26 @@ namespace MudBlazor
             }
 
             return _valueState.SetValueAsync(arg.Value.GetValueOrDefault(T.Zero));
+        }
+
+        private async Task OnDragStartHandler()
+        {
+            if (Disabled)
+            {
+                return;
+            }
+
+            await OnDragStart.InvokeAsync();
+        }
+
+        private async Task OnDragEndHandler()
+        {
+            if (Disabled)
+            {
+                return;
+            }
+
+            await OnDragEnd.InvokeAsync();
         }
 
         private string Width => CalculatePosition().ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
Resolves #13795 
Adds `OnDragStart` and `OnDragEnd` events to `MudSlider`. This enables updating the UI while the user is changing the value but being able to perform actions when the user interaction starts or ends.
Performing actions when the interaction ends is kind of possible using a debounce mut having dedicated events should deliver a better user experience for devs.

While working on `MudSlider.razor` I updated the indentation to use spaces only as the file contained a mix of tabs and space indentation.

**Before/After:**
https://github.com/user-attachments/assets/2cf48900-2ef8-4e22-8929-fcd2c7a78f9a

**Checklist:**
- [x] I've read the [contribution guidelines](https://github.com/MudBlazor/MudBlazor/blob/dev/CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests
