### PR TITLE
MudAvatar: Require a non-blank ARIA name before claiming `role="img"`

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AvatarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AvatarTests.cs
@@ -1,4 +1,5 @@
-﻿using AwesomeAssertions;
+﻿#nullable enable
+using AwesomeAssertions;
 using Bunit;
 using NUnit.Framework;
 
@@ -16,6 +17,24 @@ public class AvatarTests : BunitTest
         var comp = Context.Render<MudAvatar>(parameters => parameters.AddChildContent("AB"));
 
         // role="img" without a name hides the initials from assistive technology.
+        comp.Find("div.mud-avatar").HasAttribute("role").Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A blank ARIA name is no name, so the avatar must not claim role="img" for it.
+    /// </summary>
+    [Test]
+    [TestCase("aria-label", null)]
+    [TestCase("aria-label", "")]
+    [TestCase("aria-label", "   ")]
+    [TestCase("aria-labelledby", null)]
+    [TestCase("aria-labelledby", "")]
+    public void Avatar_WithBlankAccessibleName_ShouldNotClaimImageRole(string attribute, string? value)
+    {
+        var comp = Context.Render<MudAvatar>(parameters => parameters
+            .AddUnmatched(attribute, value)
+            .AddChildContent("AB"));
+
         comp.Find("div.mud-avatar").HasAttribute("role").Should().BeFalse();
     }
 

--- a/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
+++ b/src/MudBlazor/Components/Avatar/MudAvatar.razor.cs
@@ -15,12 +15,13 @@ namespace MudBlazor
         protected MudAvatarGroup? AvatarGroup { get; set; }
 
         /// <summary>
-        /// Whether the consumer supplied an accessible name; <c>role="img"</c> is only valid with one.
+        /// Whether the consumer supplied a non-blank accessible name; <c>role="img"</c> is only valid with one.
         /// </summary>
         private bool HasAccessibleName() =>
-            UserAttributes.Keys.Any(key =>
-                key.Equals("aria-label", StringComparison.OrdinalIgnoreCase)
-                || key.Equals("aria-labelledby", StringComparison.OrdinalIgnoreCase));
+            UserAttributes.Any(attribute =>
+                (attribute.Key.Equals("aria-label", StringComparison.OrdinalIgnoreCase)
+                 || attribute.Key.Equals("aria-labelledby", StringComparison.OrdinalIgnoreCase))
+                && !string.IsNullOrWhiteSpace(attribute.Value?.ToString()));
 
         protected string Classname => new CssBuilder("mud-avatar")
             .AddClass($"mud-avatar-{Size.ToStringFast(true)}")


### PR DESCRIPTION
#13772 made `MudAvatar` claim `role="img"` only when the consumer passes `aria-label` or `aria-labelledby`. The check only looked at the attribute key, so a bound value that is null, empty, or whitespace (for example `aria-label="@user.Name"` with a null name) still produced an unnamed `role="img"`, which hides the initials from assistive technology.

The check now also requires the value to be non-blank. Blank names fall back to no role, the same as an avatar with no ARIA attributes at all.