### PR TITLE
Code quality: Replace tabs with spaces in .razor files

### DIFF
--- a/src/MudBlazor.Docs/Components/SectionHeader.razor
+++ b/src/MudBlazor.Docs/Components/SectionHeader.razor
@@ -1,17 +1,17 @@
 ﻿
 <div @ref="@SectionReference" id="@GetSectionId()" class="@Classname">
-	@if (!String.IsNullOrWhiteSpace(Title) && HideTitle == false)
-	{
-		<MudText Typo="@GetTitleTypo()">
-			<b>@Title</b>
-		</MudText>
-	}
-	@if (SubTitle != null)
-	{
-		<MudText Typo="Typo.h6">@SubTitle</MudText>
-	}
-	@if (Description != null)
-	{
-		<MudText Class="mb-5">@Description</MudText>
-	}
+    @if (!String.IsNullOrWhiteSpace(Title) && HideTitle == false)
+    {
+        <MudText Typo="@GetTitleTypo()">
+            <b>@Title</b>
+        </MudText>
+    }
+    @if (SubTitle != null)
+    {
+        <MudText Typo="Typo.h6">@SubTitle</MudText>
+    }
+    @if (Description != null)
+    {
+        <MudText Class="mb-5">@Description</MudText>
+    }
 </div>

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteCancellationTokenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteCancellationTokenExample.razor
@@ -3,18 +3,18 @@
 @using System.Net.Http.Json
 
 <MudGrid>
-	<MudItem xs="12">
-		<MudAutocomplete T="string" Label="US States" @bind-Value="_state" SearchFunc="@Search" Variant="Variant.Outlined" ShowProgressIndicator="true" />
-	</MudItem>
+    <MudItem xs="12">
+        <MudAutocomplete T="string" Label="US States" @bind-Value="_state" SearchFunc="@Search" Variant="Variant.Outlined" ShowProgressIndicator="true" />
+    </MudItem>
 </MudGrid>
 
 @code {
-	[Inject] private HttpClient HttpClient { get; set; }
-	private string _state;
+    [Inject] private HttpClient HttpClient { get; set; }
+    private string _state;
 
-	private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
-	{
-		// Forward the CancellationToken to methods which supported, such as HttpClient and DbContext
-		return await HttpClient.GetFromJsonAsync<IEnumerable<string>>($"webapi/AmericanStates/searchWithDelay/{value ?? string.Empty}", token);
-	}
+    private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
+    {
+        // Forward the CancellationToken to methods which supported, such as HttpClient and DbContext
+        return await HttpClient.GetFromJsonAsync<IEnumerable<string>>($"webapi/AmericanStates/searchWithDelay/{value ?? string.Empty}", token);
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Autocomplete/Examples/AutocompleteValidationExample.razor
@@ -50,7 +50,7 @@
                         <MudText>IsTouched: @form.IsTouched, IsValid: @form.IsValid</MudText>
                     }
         </MudForm>
-	</MudItem>
+    </MudItem>
     <MudItem xs="12" md="12">
         <MudText Class="mb-n3" Typo="Typo.body2">
             <MudChip T="string">@(choice1.State ?? "Not selected")</MudChip><MudChip T="string">@(choice2.State ?? "Not selected")</MudChip><MudChip T="string">@(choice3.State ?? "Not selected")</MudChip>

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/BreakpointProviderPage.razor
@@ -7,15 +7,15 @@
         <DocsPageSection>
             <SectionHeader Title="How it works">
                 <Description>
-					<MudText>
-						The breakpoint provider offers a cascading parameter that exposes the window's current breakpoint (xs,sm,md,lg,xl). 
-						These features improve the performance if your layout heavily relies on such features or if you don't want to use the BreakpointListenerService directly in your own components.
-					</MudText>
-					<MudText>
-						If a <strong>MudHidden</strong> is used within a <strong>MudBreakpointProvider</strong>, it will use the provided value instead of relying on the IBreakpointListenerService. 
-						That would reduce the number of render cycles if a change of the browser size occurred. 
-					</MudText>
-				</Description>
+                    <MudText>
+                        The breakpoint provider offers a cascading parameter that exposes the window's current breakpoint (xs,sm,md,lg,xl).
+                        These features improve the performance if your layout heavily relies on such features or if you don't want to use the BreakpointListenerService directly in your own components.
+                    </MudText>
+                    <MudText>
+                        If a <strong>MudHidden</strong> is used within a <strong>MudBreakpointProvider</strong>, it will use the provided value instead of relying on the IBreakpointListenerService.
+                        That would reduce the number of render cycles if a change of the browser size occurred.
+                    </MudText>
+                </Description>
             </SectionHeader>
             <SectionContent DarkenBackground="true" Code="@nameof(BreakpointProviderPageHiddenExample)" ShowCode="false">
                 <BreakpointProviderPageHiddenExample />

--- a/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointProviderPageHiddenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/BreakpointProvider/Examples/BreakpointProviderPageHiddenExample.razor
@@ -2,69 +2,69 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudBreakpointProvider>
-	@for (int i = 0; i < _amountOfRows; i++)
-	{
-		<MudHidden Breakpoint="Breakpoint.Xl" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>XL</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.Lg" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>LG</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.Md" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>MD</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.Sm" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>SM</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.Xs" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>XS</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.LgAndUp" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>LG and Up</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>MD and Up</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>SM and Up</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>LG and Down</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>MD and Down</MudText>
-			</MudCard>
-		</MudHidden>
-		<MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-			<MudCard Class="pa-5">
-				<MudText>SM and Down</MudText>
-			</MudCard>
-		</MudHidden>
-	}
+    @for (int i = 0; i < _amountOfRows; i++)
+    {
+        <MudHidden Breakpoint="Breakpoint.Xl" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>XL</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.Lg" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>LG</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.Md" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>MD</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.Sm" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>SM</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.Xs" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>XS</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.LgAndUp" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>LG and Up</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>MD and Up</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>SM and Up</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>LG and Down</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>MD and Down</MudText>
+            </MudCard>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
+            <MudCard Class="pa-5">
+                <MudText>SM and Down</MudText>
+            </MudCard>
+        </MudHidden>
+    }
 </MudBreakpointProvider>
 
 <MudSlider @bind-Value="_amountOfRows" Min="1" Max="100"></MudSlider>
 <MudText>Rows: @_amountOfRows</MudText>
 
 @code {
-	private int _amountOfRows = 2;
+    private int _amountOfRows = 2;
 } 

--- a/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Carousel/Examples/CarouselBindingExample.razor
@@ -1,12 +1,12 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudCarousel Class="mud-width-full" @ref="_carousel" ItemsSource="@_source" @bind-SelectedIndex="selectedIndex" Style="height:200px;" ShowArrows="@_arrows" ShowBullets="@_bullets" EnableSwipeGesture="@_enableSwipeGesture" AutoCycle="@_autocycle">
-	<ItemTemplate>
-		<div class="d-flex flex-column flex-column justify-center" style="height:100%">
-			<MudIcon Class="mx-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />
-			<MudText Align="@Align.Center" Class="mx-auto">@context</MudText>
-		</div>
-	</ItemTemplate>
+    <ItemTemplate>
+        <div class="d-flex flex-column flex-column justify-center" style="height:100%">
+            <MudIcon Class="mx-auto" Icon="@Icons.Custom.Brands.MudBlazor" Size="@Size.Large" />
+            <MudText Align="@Align.Center" Class="mx-auto">@context</MudText>
+        </div>
+    </ItemTemplate>
 </MudCarousel>
 <MudSwitch @bind-Value="_arrows" Color="Color.Primary">Show Arrows</MudSwitch>
 <MudSwitch @bind-Value="_bullets" Color="Color.Primary">Show Bullets</MudSwitch>
@@ -16,39 +16,39 @@
 <MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Primary" OnClick="AddAsync">Add</MudButton>
 <MudButton Class="ma-2" Variant="Variant.Filled" Color="Color.Error" OnClick="@(async () => await DeleteAsync(_carousel.SelectedIndex))">Delete</MudButton>
 <MudSelect @bind-Value="selectedIndex" Label="@($"Selected Item (index: {selectedIndex})")">
-	@{
-		int index = 0;
-		foreach (var item in _source)
-		{
-			<MudSelectItem Value="@index">@item</MudSelectItem>
+    @{
+        int index = 0;
+        foreach (var item in _source)
+        {
+            <MudSelectItem Value="@index">@item</MudSelectItem>
 
-			index++;
-		}
-	}
+            index++;
+        }
+    }
 </MudSelect>
 @code {
-	private MudCarousel<string> _carousel;
-	private bool _arrows = true;
-	private bool _bullets = true;
-	private bool _enableSwipeGesture = true;
-	private bool _autocycle = true;
-	private IList<string> _source = new List<string>() { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
-	private int selectedIndex = 2;
+    private MudCarousel<string> _carousel;
+    private bool _arrows = true;
+    private bool _bullets = true;
+    private bool _enableSwipeGesture = true;
+    private bool _autocycle = true;
+    private IList<string> _source = new List<string>() { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
+    private int selectedIndex = 2;
 
-	private async Task AddAsync()
-	{
-		_source.Add($"Item {_source.Count + 1}");
-		await Task.Delay(1);
-		_carousel.MoveTo(_source.Count - 1);
-	}
+    private async Task AddAsync()
+    {
+        _source.Add($"Item {_source.Count + 1}");
+        await Task.Delay(1);
+        _carousel.MoveTo(_source.Count - 1);
+    }
 
-	private async Task DeleteAsync(int index)
-	{
-		if (_source.Any())
-		{
-			_source.RemoveAt(index);
-			await Task.Delay(1);
-			_carousel.MoveTo(System.Math.Max(System.Math.Min(index, _source.Count - 1), 0));
-		}
-	}
+    private async Task DeleteAsync(int index)
+    {
+        if (_source.Any())
+        {
+            _source.RemoveAt(index);
+            await Task.Delay(1);
+            _carousel.MoveTo(System.Math.Max(System.Math.Min(index, _source.Count - 1), 0));
+        }
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/BarCustomGraphicsExample.razor
@@ -1,14 +1,14 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
-	<CustomGraphics>
-		<style>
-			.heavy { font: bold 30px Helvetica; }
-			.Rrrrr { font: italic 40px Helvetica; fill: rgb(62,44,221); }
-		</style>
-		<text x="80" y="35" class="heavy">I Love</text>
-		<text x="105" y="70" class="Rrrrr">MudBlazor!</text>
-	</CustomGraphics>
+    <CustomGraphics>
+        <style>
+            .heavy { font: bold 30px Helvetica; }
+            .Rrrrr { font: italic 40px Helvetica; fill: rgb(62,44,221); }
+        </style>
+        <text x="80" y="35" class="heavy">I Love</text>
+        <text x="105" y="70" class="Rrrrr">MudBlazor!</text>
+    </CustomGraphics>
 </MudChart>
 
 

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/DonutCustomGraphicsExample.razor
@@ -1,9 +1,9 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudChart T="int" ChartType="ChartType.Donut" Width="100%" Height="300px" ChartSeries="@Data.AsChartDataSet()" ChartLabels="@Labels">
-	<CustomGraphics>
-		<text class="mud-donut-text mud-typography-h3" x="50%" y="50%">@Data.Sum()</text>
-	</CustomGraphics>
+    <CustomGraphics>
+        <text class="mud-donut-text mud-typography-h3" x="50%" y="50%">@Data.Sum()</text>
+    </CustomGraphics>
 </MudChart>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarCustomGraphicsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/Examples/StackedBarCustomGraphicsExample.razor
@@ -1,14 +1,14 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudChart T="double" ChartType="ChartType.StackedBar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
-	<CustomGraphics>
-		<style>
-			.heavy { font: bold 30px Helvetica; }
-			.Rrrrr { font: italic 40px Helvetica; fill: rgb(62,44,221); }
-		</style>
-		<text x="80" y="35" class="heavy">I Love</text>
-		<text x="105" y="70" class="Rrrrr">MudBlazor!</text>
-	</CustomGraphics>
+    <CustomGraphics>
+        <style>
+            .heavy { font: bold 30px Helvetica; }
+            .Rrrrr { font: italic 40px Helvetica; fill: rgb(62,44,221); }
+        </style>
+        <text x="80" y="35" class="heavy">I Love</text>
+        <text x="105" y="70" class="Rrrrr">MudBlazor!</text>
+    </CustomGraphics>
 </MudChart>
 
 

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneCanDropStylesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneCanDropStylesExample.razor
@@ -29,38 +29,38 @@
 </MudDropContainer>
 
 @code {
-	private bool _applyDropClassesOnDragStarted = false;
+    private bool _applyDropClassesOnDragStarted = false;
 
-	private void Reset()
-	{
-		foreach (var item in _items)
-		{
-			item.Place = "Fridge";
-			item.IsPicked = false;
-		}
-	}
+    private void Reset()
+    {
+        foreach (var item in _items)
+        {
+            item.Place = "Fridge";
+            item.IsPicked = false;
+        }
+    }
 
-	private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
-	{
-		dropItem.Item.IsPicked = true;
-		dropItem.Item.Place = dropItem.DropzoneIdentifier;
-	}
+    private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
+    {
+        dropItem.Item.IsPicked = true;
+        dropItem.Item.Place = dropItem.DropzoneIdentifier;
+    }
 
-	private List<DropItem> _items = new()
-		{
-			new DropItem() { Icon = @Icons.Custom.Uncategorized.FoodApple, Color = Color.Error, IsRotten = false, Place = "Fridge" },
-		    new DropItem() { Icon = @Icons.Custom.Uncategorized.Baguette, Color = Color.Warning, IsRotten = false, Place = "Fridge" },
-		    new DropItem() { Icon = @Icons.Custom.Uncategorized.Sausage, Color = Color.Secondary, IsRotten = true, Place = "Fridge" },
-		    new DropItem() { Icon = @Icons.Custom.Uncategorized.WaterMelon, Color = Color.Success, IsRotten = false, Place = "Fridge" },
-		    new DropItem() { Icon = @Icons.Custom.Uncategorized.Fish, Color = Color.Info, IsRotten = true, Place = "Fridge" },
-		};
+    private List<DropItem> _items = new()
+        {
+            new DropItem() { Icon = @Icons.Custom.Uncategorized.FoodApple, Color = Color.Error, IsRotten = false, Place = "Fridge" },
+            new DropItem() { Icon = @Icons.Custom.Uncategorized.Baguette, Color = Color.Warning, IsRotten = false, Place = "Fridge" },
+            new DropItem() { Icon = @Icons.Custom.Uncategorized.Sausage, Color = Color.Secondary, IsRotten = true, Place = "Fridge" },
+            new DropItem() { Icon = @Icons.Custom.Uncategorized.WaterMelon, Color = Color.Success, IsRotten = false, Place = "Fridge" },
+            new DropItem() { Icon = @Icons.Custom.Uncategorized.Fish, Color = Color.Info, IsRotten = true, Place = "Fridge" },
+        };
 
-	public class DropItem
-	{
-		public string Icon { get; init; }
-	    public Color Color { get; init; }
-	    public bool IsRotten { get; set; }
-		public bool IsPicked { get; set; }
-		public string Place { get; set; }
-	}
+    public class DropItem
+    {
+        public string Icon { get; init; }
+        public Color Color { get; init; }
+        public bool IsRotten { get; set; }
+        public bool IsPicked { get; set; }
+        public string Place { get; set; }
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneKanbanExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneKanbanExample.razor
@@ -3,155 +3,155 @@
 @namespace MudBlazor.Docs.Examples
 
 <MudDropContainer T="KanbanTaskItem" @ref="_dropContainer" Items="@_tasks" ItemsSelector="@((item,column) => item.Status == column)" ItemDropped="TaskUpdated" Class="d-flex flex-row">
-	<ChildContent>
-		@foreach (var item in _sections)
-		{
-			<MudPaper Elevation="0" Width="224px" MinHeight="400px" Class="pa-4 ma-4 d-flex flex-column mud-background-gray rounded-lg">
-				<MudToolBar Gutters="false">
-					<MudText Typo="Typo.subtitle1"><b>@item.Name</b></MudText>
-					<MudSpacer />
-					<MudMenu Icon="@Icons.Material.Rounded.MoreHoriz" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" ListClass="pa-2 d-flex flex-column" PopoverClass="mud-elevation-25">
-						<MudButton Size="Size.Small" Color="Color.Error" StartIcon="@Icons.Material.Outlined.Delete" OnClick="@( () => DeleteSection(item))">Delete section</MudButton>
-						<MudButton Size="Size.Small" Color="Color.Default" StartIcon="@Icons.Material.Rounded.Edit">Rename section</MudButton>
-					</MudMenu>
-				</MudToolBar>
-				<MudDropZone T="KanbanTaskItem" Identifier="@item.Name" Class="mud-height-full" />
-				@if (item.NewTaskOpen)
-				{
-					<MudPaper Elevation="25" Class="pa-2 rounded-lg">
-						<MudTextField @bind-Value="item.NewTaskName" Placeholder="New Task" Underline="false" Margin="Margin.Dense" Class="mx-2 mt-n2"></MudTextField>
-						<MudButton OnClick="@(() => AddTask(item))" Size="Size.Small" Color="Color.Primary" FullWidth="true">Add task</MudButton>
-					</MudPaper>
-				}
-				else
-				{
-					<MudButton OnClick="@(() => item.NewTaskOpen = !item.NewTaskOpen)" StartIcon="@Icons.Material.Filled.Add" FullWidth="true" Class="rounded-lg py-2">Add task</MudButton>
-				}
-			</MudPaper>
-		}
-		<MudPaper Class="pa-4" Elevation="0" Width="224px">
-			@if (_addSectionOpen)
-			{
-				<MudPaper Elevation="0" Width="224px" Class="pa-4 d-flex flex-column mud-background-gray rounded-lg">
-					<EditForm Model="@newSectionModel" OnValidSubmit="OnValidSectionSubmit">
-						<DataAnnotationsValidator />
-						<MudTextField @bind-Value="newSectionModel.Name" For="@(() => newSectionModel.Name)" Placeholder="New section" Underline="false"></MudTextField>
-						<MudButton ButtonType="ButtonType.Submit" Size="Size.Small" Color="Color.Primary" FullWidth="true">Add section</MudButton>
-					</EditForm>
-				</MudPaper>
-			}
-			else
-			{
-				<MudButton OnClick="OpenAddNewSection" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add" Color="Color.Primary" Class="rounded-lg py-2" FullWidth="true">Add section</MudButton>
-			}
-		</MudPaper>
-	</ChildContent>
-	<ItemRenderer>
-		<MudPaper Elevation="25" Class="pa-4 rounded-lg my-3">@context.Name</MudPaper>
-	</ItemRenderer>
+    <ChildContent>
+        @foreach (var item in _sections)
+        {
+            <MudPaper Elevation="0" Width="224px" MinHeight="400px" Class="pa-4 ma-4 d-flex flex-column mud-background-gray rounded-lg">
+                <MudToolBar Gutters="false">
+                    <MudText Typo="Typo.subtitle1"><b>@item.Name</b></MudText>
+                    <MudSpacer />
+                    <MudMenu Icon="@Icons.Material.Rounded.MoreHoriz" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" ListClass="pa-2 d-flex flex-column" PopoverClass="mud-elevation-25">
+                        <MudButton Size="Size.Small" Color="Color.Error" StartIcon="@Icons.Material.Outlined.Delete" OnClick="@( () => DeleteSection(item))">Delete section</MudButton>
+                        <MudButton Size="Size.Small" Color="Color.Default" StartIcon="@Icons.Material.Rounded.Edit">Rename section</MudButton>
+                    </MudMenu>
+                </MudToolBar>
+                <MudDropZone T="KanbanTaskItem" Identifier="@item.Name" Class="mud-height-full" />
+                @if (item.NewTaskOpen)
+                {
+                    <MudPaper Elevation="25" Class="pa-2 rounded-lg">
+                        <MudTextField @bind-Value="item.NewTaskName" Placeholder="New Task" Underline="false" Margin="Margin.Dense" Class="mx-2 mt-n2"></MudTextField>
+                        <MudButton OnClick="@(() => AddTask(item))" Size="Size.Small" Color="Color.Primary" FullWidth="true">Add task</MudButton>
+                    </MudPaper>
+                }
+                else
+                {
+                    <MudButton OnClick="@(() => item.NewTaskOpen = !item.NewTaskOpen)" StartIcon="@Icons.Material.Filled.Add" FullWidth="true" Class="rounded-lg py-2">Add task</MudButton>
+                }
+            </MudPaper>
+        }
+        <MudPaper Class="pa-4" Elevation="0" Width="224px">
+            @if (_addSectionOpen)
+            {
+                <MudPaper Elevation="0" Width="224px" Class="pa-4 d-flex flex-column mud-background-gray rounded-lg">
+                    <EditForm Model="@newSectionModel" OnValidSubmit="OnValidSectionSubmit">
+                        <DataAnnotationsValidator />
+                        <MudTextField @bind-Value="newSectionModel.Name" For="@(() => newSectionModel.Name)" Placeholder="New section" Underline="false"></MudTextField>
+                        <MudButton ButtonType="ButtonType.Submit" Size="Size.Small" Color="Color.Primary" FullWidth="true">Add section</MudButton>
+                    </EditForm>
+                </MudPaper>
+            }
+            else
+            {
+                <MudButton OnClick="OpenAddNewSection" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add" Color="Color.Primary" Class="rounded-lg py-2" FullWidth="true">Add section</MudButton>
+            }
+        </MudPaper>
+    </ChildContent>
+    <ItemRenderer>
+        <MudPaper Elevation="25" Class="pa-4 rounded-lg my-3">@context.Name</MudPaper>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
-	private MudDropContainer<KanbanTaskItem> _dropContainer;
+    private MudDropContainer<KanbanTaskItem> _dropContainer;
 
-	private bool _addSectionOpen;
-	/* handling board events */
-	private void TaskUpdated(MudItemDropInfo<KanbanTaskItem> info)
-	{
-		info.Item.Status = info.DropzoneIdentifier;
-	}
+    private bool _addSectionOpen;
+    /* handling board events */
+    private void TaskUpdated(MudItemDropInfo<KanbanTaskItem> info)
+    {
+        info.Item.Status = info.DropzoneIdentifier;
+    }
 
-	/* Setup for board  */
-	private List<KanBanSections> _sections = new()
-		{
-			new KanBanSections("To Do", false, String.Empty),
-			new KanBanSections("In Process", false, String.Empty),
-			new KanBanSections("Done", false, String.Empty),
-		};
+    /* Setup for board  */
+    private List<KanBanSections> _sections = new()
+        {
+            new KanBanSections("To Do", false, String.Empty),
+            new KanBanSections("In Process", false, String.Empty),
+            new KanBanSections("Done", false, String.Empty),
+        };
 
-	public class KanBanSections
-	{
-		public string Name { get; init; }
-		public bool NewTaskOpen { get; set; }
-		public string NewTaskName { get; set; }
+    public class KanBanSections
+    {
+        public string Name { get; init; }
+        public bool NewTaskOpen { get; set; }
+        public string NewTaskName { get; set; }
 
-		public KanBanSections(string name, bool newTaskOpen, string newTaskName)
-		{
-			Name = name;
-			NewTaskOpen = newTaskOpen;
-			NewTaskName = newTaskName;
-		}
-	}
-	public class KanbanTaskItem
-	{
-		public string Name { get; init; }
-		public string Status { get; set; }
+        public KanBanSections(string name, bool newTaskOpen, string newTaskName)
+        {
+            Name = name;
+            NewTaskOpen = newTaskOpen;
+            NewTaskName = newTaskName;
+        }
+    }
+    public class KanbanTaskItem
+    {
+        public string Name { get; init; }
+        public string Status { get; set; }
 
-		public KanbanTaskItem(string name, string status)
-		{
-			Name = name;
-			Status = status;
-		}
-	}
+        public KanbanTaskItem(string name, string status)
+        {
+            Name = name;
+            Status = status;
+        }
+    }
 
-	private List<KanbanTaskItem> _tasks = new()
-		{
-			new KanbanTaskItem("Write unit test", "To Do"),
-			new KanbanTaskItem("Some docu stuff", "To Do"),
-			new KanbanTaskItem("Walking the dog", "To Do"),
-		};
+    private List<KanbanTaskItem> _tasks = new()
+        {
+            new KanbanTaskItem("Write unit test", "To Do"),
+            new KanbanTaskItem("Some docu stuff", "To Do"),
+            new KanbanTaskItem("Walking the dog", "To Do"),
+        };
 
-	KanBanNewForm newSectionModel = new KanBanNewForm();
+    KanBanNewForm newSectionModel = new KanBanNewForm();
 
-	public class KanBanNewForm
-	{
-		[Required]
-		[StringLength(10, ErrorMessage = "Name length can't be more than 10.")]
-		public string Name { get; set; }
-	}
+    public class KanBanNewForm
+    {
+        [Required]
+        [StringLength(10, ErrorMessage = "Name length can't be more than 10.")]
+        public string Name { get; set; }
+    }
 
-	private void OnValidSectionSubmit(EditContext context)
-	{
-		_sections.Add(new KanBanSections(newSectionModel.Name, false, String.Empty));
-		newSectionModel.Name = string.Empty;
-		_addSectionOpen = false;
-	}
+    private void OnValidSectionSubmit(EditContext context)
+    {
+        _sections.Add(new KanBanSections(newSectionModel.Name, false, String.Empty));
+        newSectionModel.Name = string.Empty;
+        _addSectionOpen = false;
+    }
 
-	private void OpenAddNewSection()
-	{
-		_addSectionOpen = true;
-	}
+    private void OpenAddNewSection()
+    {
+        _addSectionOpen = true;
+    }
 
-	private void AddTask(KanBanSections section)
-	{
-		_tasks.Add(new KanbanTaskItem(section.NewTaskName, section.Name));
-		section.NewTaskName = string.Empty;
-		section.NewTaskOpen = false;
-		_dropContainer.Refresh();
-	}
+    private void AddTask(KanBanSections section)
+    {
+        _tasks.Add(new KanbanTaskItem(section.NewTaskName, section.Name));
+        section.NewTaskName = string.Empty;
+        section.NewTaskOpen = false;
+        _dropContainer.Refresh();
+    }
 
-	private void DeleteSection(KanBanSections section)
-	{
-		if (_sections.Count == 1)
-		{
-			_tasks.Clear();
-			_sections.Clear();
-		}
-		else
-		{
-			int newIndex = _sections.IndexOf(section) - 1;
-			if (newIndex < 0)
-			{
-				newIndex = 0;
-			}
+    private void DeleteSection(KanBanSections section)
+    {
+        if (_sections.Count == 1)
+        {
+            _tasks.Clear();
+            _sections.Clear();
+        }
+        else
+        {
+            int newIndex = _sections.IndexOf(section) - 1;
+            if (newIndex < 0)
+            {
+                newIndex = 0;
+            }
 
-			_sections.Remove(section);
+            _sections.Remove(section);
 
-			var tasks = _tasks.Where(x => x.Status == section.Name);
-			foreach (var item in tasks)
-			{
-				item.Status = _sections[newIndex].Name;
-			}
-		}
-	}
+            var tasks = _tasks.Where(x => x.Status == section.Name);
+            foreach (var item in tasks)
+            {
+                item.Status = _sections[newIndex].Name;
+            }
+        }
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneReorderSaveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/DropZone/Examples/DropZoneReorderSaveExample.razor
@@ -2,114 +2,114 @@
 @using MudBlazor.Utilities
 
 <div class="d-flex flex-column mud-width-full mud-height-full">
-	<MudToolBar Class="gap-4">
-		<MudButton OnClick="LoadServerData" Variant="Variant.Filled" Color="Color.Default">Load Data</MudButton>
-		<MudButton OnClick="SaveData" Variant="Variant.Filled" Color="Color.Primary">Save Data</MudButton>
-		<MudSpacer />
-		<MudButton OnClick="Reset" Variant="Variant.Text" Color="Color.Error">Reset Example</MudButton>
-	</MudToolBar>
+    <MudToolBar Class="gap-4">
+        <MudButton OnClick="LoadServerData" Variant="Variant.Filled" Color="Color.Default">Load Data</MudButton>
+        <MudButton OnClick="SaveData" Variant="Variant.Filled" Color="Color.Primary">Save Data</MudButton>
+        <MudSpacer />
+        <MudButton OnClick="Reset" Variant="Variant.Text" Color="Color.Error">Reset Example</MudButton>
+    </MudToolBar>
 
-	<MudDropContainer T="DropItem" Items="@_dropzoneItems" @ref="_container" ItemsSelector="@((item,dropzone) => item.Selector == dropzone)" ItemDropped="ItemUpdated" Class="d-flex flex-wrap flex-grow-1">
-		<ChildContent>
-			@for (int i = 1; i < 3; i++)
-			{
-				var dropzone = i.ToString();
-				<MudPaper Class="ma-4 flex-grow-1">
+    <MudDropContainer T="DropItem" Items="@_dropzoneItems" @ref="_container" ItemsSelector="@((item,dropzone) => item.Selector == dropzone)" ItemDropped="ItemUpdated" Class="d-flex flex-wrap flex-grow-1">
+        <ChildContent>
+            @for (int i = 1; i < 3; i++)
+            {
+                var dropzone = i.ToString();
+                <MudPaper Class="ma-4 flex-grow-1">
                     <MudList T="string" Class="d-flex flex-column mud-height-full">
-						<MudListSubheader>Drop Zone @dropzone</MudListSubheader>
-						<MudDropZone T="DropItem" Identifier="@dropzone" Class="flex-grow-1" AllowReorder="true" />
-					</MudList>
-				</MudPaper>
-			}
-		</ChildContent>
-		<ItemRenderer>
+                        <MudListSubheader>Drop Zone @dropzone</MudListSubheader>
+                        <MudDropZone T="DropItem" Identifier="@dropzone" Class="flex-grow-1" AllowReorder="true" />
+                    </MudList>
+                </MudPaper>
+            }
+        </ChildContent>
+        <ItemRenderer>
             <MudListItem T="string" Text="@($"{context.Name} ({context.Order})")" />
-		</ItemRenderer>
-	</MudDropContainer>
+        </ItemRenderer>
+    </MudDropContainer>
 </div>
 @code {
     private MudDropContainer<DropItem> _container;
 
-	private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
-	{
-		dropItem.Item.Selector = dropItem.DropzoneIdentifier;
+    private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
+    {
+        dropItem.Item.Selector = dropItem.DropzoneIdentifier;
 
-		var indexOffset = dropItem.DropzoneIdentifier switch
-		{
-			"2"  => _dropzoneItems.Count(x => x.Selector == "1"),
-			_ => 0
-		};
+        var indexOffset = dropItem.DropzoneIdentifier switch
+        {
+            "2"  => _dropzoneItems.Count(x => x.Selector == "1"),
+            _ => 0
+        };
 
-		_dropzoneItems.UpdateOrder(dropItem, item => item.Order, indexOffset);
-	}
+        _dropzoneItems.UpdateOrder(dropItem, item => item.Order, indexOffset);
+    }
 
-	private List<DropItem> _dropzoneItems = new();
+    private List<DropItem> _dropzoneItems = new();
 
-	private List<DropItem> _serverData = new()
-		{
-			new DropItem() { Order = 0, Name = "Item 1", Selector = "1" },
-			new DropItem() { Order = 1, Name = "Item 2", Selector = "1" },
-			new DropItem() { Order = 2, Name = "Item 3", Selector = "1" },
-			new DropItem() { Order = 3, Name = "Item 4", Selector = "1" },
-			new DropItem() { Order = 4, Name = "Item 5", Selector = "1" },
-			new DropItem() { Order = 5, Name = "Item 6", Selector = "1" },
-			new DropItem() { Order = 6, Name = "Item 7", Selector = "2" },
-			new DropItem() { Order = 7, Name = "Item 8", Selector = "2" },
-			new DropItem() { Order = 8, Name = "Item 9", Selector = "2" },
-			new DropItem() { Order = 9, Name = "Item 10", Selector = "2" },
-		};
+    private List<DropItem> _serverData = new()
+        {
+            new DropItem() { Order = 0, Name = "Item 1", Selector = "1" },
+            new DropItem() { Order = 1, Name = "Item 2", Selector = "1" },
+            new DropItem() { Order = 2, Name = "Item 3", Selector = "1" },
+            new DropItem() { Order = 3, Name = "Item 4", Selector = "1" },
+            new DropItem() { Order = 4, Name = "Item 5", Selector = "1" },
+            new DropItem() { Order = 5, Name = "Item 6", Selector = "1" },
+            new DropItem() { Order = 6, Name = "Item 7", Selector = "2" },
+            new DropItem() { Order = 7, Name = "Item 8", Selector = "2" },
+            new DropItem() { Order = 8, Name = "Item 9", Selector = "2" },
+            new DropItem() { Order = 9, Name = "Item 10", Selector = "2" },
+        };
 
-	private void RefreshContainer()
-	{
-		//update the binding to the container
-		StateHasChanged();
+    private void RefreshContainer()
+    {
+        //update the binding to the container
+        StateHasChanged();
 
-		//the container refreshes the internal state
-		_container.Refresh();
-	}
+        //the container refreshes the internal state
+        _container.Refresh();
+    }
 
-	private void LoadServerData()
-	{
-	    _dropzoneItems = _serverData
-	        .OrderBy(x => x.Order)
-	        .Select(item => new DropItem
-	        {
-	            Order = item.Order,
-	            Name = item.Name,
-	            Selector = item.Selector
-	        })
-	        .ToList();
-		RefreshContainer();
-	}
+    private void LoadServerData()
+    {
+        _dropzoneItems = _serverData
+            .OrderBy(x => x.Order)
+            .Select(item => new DropItem
+            {
+                Order = item.Order,
+                Name = item.Name,
+                Selector = item.Selector
+            })
+            .ToList();
+        RefreshContainer();
+    }
 
-	private void SaveData()
-	    => _serverData = _dropzoneItems
-	        .OrderBy(x => x.Order)
-	        .Select(item => new DropItem
-	        {
-	            Order = item.Order, Name = item.Name, Selector = item.Selector
-	        })
-	        .ToList();
+    private void SaveData()
+        => _serverData = _dropzoneItems
+            .OrderBy(x => x.Order)
+            .Select(item => new DropItem
+            {
+                Order = item.Order, Name = item.Name, Selector = item.Selector
+            })
+            .ToList();
 
-	private void Reset()
-	{
-		_dropzoneItems = new();
-		_serverData = new()
-			{
-				new DropItem() { Order = 0, Name = "Item 1", Selector = "1" },
-				new DropItem() { Order = 1, Name = "Item 2", Selector = "1" },
-				new DropItem() { Order = 2, Name = "Item 3", Selector = "1" },
-				new DropItem() { Order = 3, Name = "Item 4", Selector = "1" },
-				new DropItem() { Order = 4, Name = "Item 5", Selector = "1" },
-				new DropItem() { Order = 5, Name = "Item 6", Selector = "1" },
-				new DropItem() { Order = 6, Name = "Item 7", Selector = "2" },
-				new DropItem() { Order = 7, Name = "Item 8", Selector = "2" },
-				new DropItem() { Order = 8, Name = "Item 9", Selector = "2" },
-				new DropItem() { Order = 9, Name = "Item 10", Selector = "2" }
-			};
+    private void Reset()
+    {
+        _dropzoneItems = new();
+        _serverData = new()
+            {
+                new DropItem() { Order = 0, Name = "Item 1", Selector = "1" },
+                new DropItem() { Order = 1, Name = "Item 2", Selector = "1" },
+                new DropItem() { Order = 2, Name = "Item 3", Selector = "1" },
+                new DropItem() { Order = 3, Name = "Item 4", Selector = "1" },
+                new DropItem() { Order = 4, Name = "Item 5", Selector = "1" },
+                new DropItem() { Order = 5, Name = "Item 6", Selector = "1" },
+                new DropItem() { Order = 6, Name = "Item 7", Selector = "2" },
+                new DropItem() { Order = 7, Name = "Item 8", Selector = "2" },
+                new DropItem() { Order = 8, Name = "Item 9", Selector = "2" },
+                new DropItem() { Order = 9, Name = "Item 10", Selector = "2" }
+            };
 
-		RefreshContainer();
-	}
+        RefreshContainer();
+    }
     
     public class DropItem
     {

--- a/src/MudBlazor.Docs/Pages/Components/Form/Examples/FluentValidationComplexExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Form/Examples/FluentValidationComplexExample.razor
@@ -2,66 +2,66 @@
 @using FluentValidation
 
 <MudCard>
-	<MudForm Model="@_model" @ref="@_form" Validation="@(_orderValidator.ValidateValue)" ValidationDelay="0">
-		<MudCardContent>
-				<MudTextField @bind-Value="_model.Name"                              
-							  For="@(() => _model.Name)"
-							  Immediate="true"
-							  Label="Name" />
+    <MudForm Model="@_model" @ref="@_form" Validation="@(_orderValidator.ValidateValue)" ValidationDelay="0">
+        <MudCardContent>
+                <MudTextField @bind-Value="_model.Name"
+                              For="@(() => _model.Name)"
+                              Immediate="true"
+                              Label="Name" />
 
-				<MudTextField @bind-Value="_model.Email"
-							  For="@(() => _model.Email)"
-							  Immediate="true"
-							  Label="Email" />
+                <MudTextField @bind-Value="_model.Email"
+                              For="@(() => _model.Email)"
+                              Immediate="true"
+                              Label="Email" />
 
-				<MudTextField @bind-Value="_model.CCNumber"
-							  For="@(() => _model.CCNumber)"
-							  Immediate="true"
-							  Label="Credit card nr" />
+                <MudTextField @bind-Value="_model.CCNumber"
+                              For="@(() => _model.CCNumber)"
+                              Immediate="true"
+                              Label="Credit card nr" />
 
-				<MudTextField @bind-Value="_model.Address.Address"
-							  For="@(() => _model.Address.Address)"
-							  Immediate="true"
-							  Label="Address" />
+                <MudTextField @bind-Value="_model.Address.Address"
+                              For="@(() => _model.Address.Address)"
+                              Immediate="true"
+                              Label="Address" />
 
-				<MudTextField @bind-Value="_model.Address.City"
-							  For="@(() => _model.Address.City)"
-							  Immediate="true"
-							  Label="City" />
+                <MudTextField @bind-Value="_model.Address.City"
+                              For="@(() => _model.Address.City)"
+                              Immediate="true"
+                              Label="City" />
 
-				<MudTextField @bind-Value="_model.Address.Country"
-							  For="@(() => _model.Address.Country)"
-							  Immediate="true"
-							  Label="Country" />
+                <MudTextField @bind-Value="_model.Address.Country"
+                              For="@(() => _model.Address.Country)"
+                              Immediate="true"
+                              Label="Country" />
         </MudCardContent>
-		<MudCardContent Class="pa-0">
+        <MudCardContent Class="pa-0">
 
-			<MudTable Items="@_model.OrderDetails" Hover="true" Breakpoint="Breakpoint.None" Dense="@true" Elevation="0">
-				<HeaderContent>
-					<MudTh>Description</MudTh>
-					<MudTh>Offer</MudTh>
-				</HeaderContent>
-				<RowTemplate>
-					<MudTd DataLabel="Description">
-						<MudForm Model="@context" Validation=@(_orderDetailsValidator.ValidateValue)>
-  							<MudTextField Label="Enter Description" 
+            <MudTable Items="@_model.OrderDetails" Hover="true" Breakpoint="Breakpoint.None" Dense="@true" Elevation="0">
+                <HeaderContent>
+                    <MudTh>Description</MudTh>
+                    <MudTh>Offer</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Description">
+                        <MudForm Model="@context" Validation=@(_orderDetailsValidator.ValidateValue)>
+                              <MudTextField Label="Enter Description"
                               @bind-Value="context.Description" 
                               For="() => context.Description" />
-  						</MudForm>
-					</MudTd>
-					<MudTd DataLabel="Offer">
-						<MudForm Model="@context">
-  							<MudNumericField Label="Enter Offer" 
+                          </MudForm>
+                    </MudTd>
+                    <MudTd DataLabel="Offer">
+                        <MudForm Model="@context">
+                              <MudNumericField Label="Enter Offer"
                                                @bind-Value="context.Offer" 
                                                Validation=@(_orderDetailsValidator.ValidateValue)
                                                For="(() => context.Offer)" />
-  						</MudForm>
-					</MudTd>
-				</RowTemplate>
-			</MudTable>
+                          </MudForm>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
 
-		</MudCardContent>
-	</MudForm>
+        </MudCardContent>
+    </MudForm>
     <MudCardActions>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto" OnClick="@(async () => await Submit())">Order</MudButton>
     </MudCardActions>
@@ -73,7 +73,7 @@
     private readonly OrderModelFluentValidator _orderValidator = new();
     private readonly OrderDetailsModelFluentValidator _orderDetailsValidator = new();
 
-	[Inject]
+    [Inject]
     protected ISnackbar Snackbar { get; set; }
 
     public class OrderModel
@@ -82,7 +82,7 @@
         public string Email { get; set; }
         public string CCNumber { get; set; } = "4012 8888 8888 1881";
         public AddressModel Address { get; set; } = new();
-		public List<OrderDetailsModel> OrderDetails =
+        public List<OrderDetailsModel> OrderDetails =
         [
             new()
             {
@@ -92,7 +92,7 @@
 
             new()
         ];
-	}
+    }
 
     public class AddressModel
     {
@@ -101,11 +101,11 @@
         public string Country { get; set; }
     }
 
-	public class OrderDetailsModel
-	{
-		public string Description { get; set; }
-		public decimal Offer { get; set; }
-	}
+    public class OrderDetailsModel
+    {
+        public string Description { get; set; }
+        public decimal Offer { get; set; }
+    }
 
     private async Task Submit()
     {
@@ -151,9 +151,9 @@
                 .NotEmpty()
                 .Length(1,100);
 
-			RuleForEach(x => x.OrderDetails)
-				.SetValidator(new OrderDetailsModelFluentValidator());
-		}
+            RuleForEach(x => x.OrderDetails)
+                .SetValidator(new OrderDetailsModelFluentValidator());
+        }
 
         private static async Task<bool> IsUniqueAsync(string email)
         {
@@ -169,7 +169,7 @@
         };
     }
 
-	/// <summary>
+    /// <summary>
     /// A standard AbstractValidator for the Collection Object
     /// </summary>
     public class OrderDetailsModelFluentValidator : AbstractValidator<OrderDetailsModel>
@@ -180,9 +180,9 @@
                 .NotEmpty()
                 .Length(1,100);
 
-			RuleFor(x => x.Offer)
-				.GreaterThan(0)
-				.LessThan(999);
+            RuleFor(x => x.Offer)
+                .GreaterThan(0)
+                .LessThan(999);
         }
 
         public Func<object, string, Task<IEnumerable<string>>> ValidateValue => async (model, propertyName) =>

--- a/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/HiddenExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Hidden/Examples/HiddenExample.razor
@@ -7,24 +7,24 @@
     </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Xl" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>XL</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>XL</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Lg" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>LG</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>LG</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Md" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>MD</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>MD</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Sm" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>SM</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>SM</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.Xs" Invert="true">
     <MudCard Class="pa-5">
@@ -37,14 +37,14 @@
     </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.LgAndUp" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>LG and Up</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>LG and Up</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.MdAndUp" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>MD and Up</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>MD and Up</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
     <MudCard Class="pa-5">
@@ -57,17 +57,17 @@
     </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.LgAndDown" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>LG and Down</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>LG and Down</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>MD and Down</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>MD and Down</MudText>
+    </MudCard>
 </MudHidden>
 <MudHidden Breakpoint="Breakpoint.SmAndDown" Invert="true">
-	<MudCard Class="pa-5">
-		<MudText>SM and Down</MudText>
-	</MudCard>
+    <MudCard Class="pa-5">
+        <MudText>SM and Down</MudText>
+    </MudCard>
 </MudHidden>

--- a/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Overlay/OverlayPage.razor
@@ -103,7 +103,7 @@
           <SectionHeader Title="Positioning">
             <Description>
               By default, <CodeInline>MudOverlay</CodeInline> is scaffolded into the <CodeInline>MudPopoverProvider</CodeInline>, producing a singleton stack where the most recently created overlay sits on top and stacks back down in reverse creation order as overlays close.
-	              In this context, an "overlay view" simply means a scaffolded overlay instance (the scrim/backdrop) that gets added to the stack by a component such as a popover, menu, or select.
+                  In this context, an "overlay view" simply means a scaffolded overlay instance (the scrim/backdrop) that gets added to the stack by a component such as a popover, menu, or select.
               <MudAlert Dense Severity="Severity.Info">The scaffolded ZIndex will be the higher value between the explicit `ZIndex` parameter and the internally calculated value. This means an explicit `ZIndex` does not automatically override the scaffolded value if the latter is higher.</MudAlert>
               <ul class="bullet-list">
                 <li>Set <CodeInline>Absolute="true"</CodeInline> to scope the overlay to its parent (excluded from scaffolding).</li>

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverComplexContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverComplexContentExample.razor
@@ -1,25 +1,25 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <div class="d-flex">
-	<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ToggleOpen">
-		@(_open? "Close" : "Open")
-	</MudButton>
-	<MudPopover Open="@_open" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
-		<div class="d-flex flex-column pa-1">
-			<PopoverDynamicContentExample />
-		</div>
-	</MudPopover>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@ToggleOpen">
+        @(_open? "Close" : "Open")
+    </MudButton>
+    <MudPopover Open="@_open" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
+        <div class="d-flex flex-column pa-1">
+            <PopoverDynamicContentExample />
+        </div>
+    </MudPopover>
 </div>
 
 @code {
 
-	public bool _open;
+    public bool _open;
 
-	public void ToggleOpen()
-	{
-		if (_open)
-			_open = false;
-		else
-			_open = true;
-	}
+    public void ToggleOpen()
+    {
+        if (_open)
+            _open = false;
+        else
+            _open = true;
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverDynamicContentExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverDynamicContentExample.razor
@@ -3,15 +3,15 @@
 <MudButton OnClick="@AddMoreContent" Color="Color.Error">Add another line</MudButton>
 @foreach (var item in _content)
 {
-	<MudText Class="pa-2" Align="Align.Center">@item</MudText>
+    <MudText Class="pa-2" Align="Align.Center">@item</MudText>
 }
 
 @code {
 
-	private List<String> _content = new();
+    private List<String> _content = new();
 
-	public void AddMoreContent()
-	{
-		_content.Add("line of text");
-	}
+    public void AddMoreContent()
+    {
+        _content.Add("line of text");
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverOverflowBehaviorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Popover/Examples/PopoverOverflowBehaviorExample.razor
@@ -2,11 +2,11 @@
 
 <MudPaper Outlined="true" Class="px-12 py-6">
     <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="@ToggleOpen">@(_open? "Close" : "Open")</MudButton>
-	<MudPopover Open="_open" OverflowBehavior="OverflowBehavior.FlipAlways" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Paper="false">
+    <MudPopover Open="_open" OverflowBehavior="OverflowBehavior.FlipAlways" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Paper="false">
         <MudPaper Outlined="true" Class="px-4 py-8">
             <MudText>Scroll your browser to see effect.</MudText>
         </MudPaper>
-	</MudPopover>
+    </MudPopover>
 </MudPaper>
 
 @code {

--- a/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarRemoveExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Snackbar/Examples/SnackbarRemoveExample.razor
@@ -20,8 +20,8 @@
         });
     }
 
-	void Hide() {
+    void Hide() {
         if (_snackbar is null) return;
         Snackbar.Remove(_snackbar);
-	}
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/CustomDynamicTabsExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/CustomDynamicTabsExample.razor
@@ -1,87 +1,87 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
 <MudTabs @bind-ActivePanelIndex="_index" Border="true" Outlined="true" TabPanelsClass="px-4 py-6" ApplyEffectsToContainer="true">
-	<ChildContent>
-		@foreach (var item in _tabs)
-		{
-			 <MudTabPanel Text="@item.Name" Tag="@item.Id">@item.Content</MudTabPanel>
-		}
-	</ChildContent>
-	<Header>
-		<MudButtonGroup>
-			<MudTooltip Text="Prepend a tab">
-				<MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="@( () => AddTabCallback(false) )" />
-			</MudTooltip>
-			<MudTooltip Text="Append a tab">
-				<MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="@( () => AddTabCallback(true) )"  />
-			</MudTooltip>
-		</MudButtonGroup>
-	</Header>
-	<TabPanelHeader>
-		@if(context.Text.StartsWith("Tab") == false)
-		{
-			<MudTooltip Text="only dynamic tabs can be closed">
-				<MudIconButton Class="ml-2 pa-1" Color="Color.Error" Icon="@Icons.Material.Filled.Remove" OnClick="(_) => RemoveTab(context)" />
-			</MudTooltip>
-		}
+    <ChildContent>
+        @foreach (var item in _tabs)
+        {
+             <MudTabPanel Text="@item.Name" Tag="@item.Id">@item.Content</MudTabPanel>
+        }
+    </ChildContent>
+    <Header>
+        <MudButtonGroup>
+            <MudTooltip Text="Prepend a tab">
+                <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" OnClick="@( () => AddTabCallback(false) )" />
+            </MudTooltip>
+            <MudTooltip Text="Append a tab">
+                <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" OnClick="@( () => AddTabCallback(true) )"  />
+            </MudTooltip>
+        </MudButtonGroup>
+    </Header>
+    <TabPanelHeader>
+        @if(context.Text.StartsWith("Tab") == false)
+        {
+            <MudTooltip Text="only dynamic tabs can be closed">
+                <MudIconButton Class="ml-2 pa-1" Color="Color.Error" Icon="@Icons.Material.Filled.Remove" OnClick="(_) => RemoveTab(context)" />
+            </MudTooltip>
+        }
   </TabPanelHeader>
 </MudTabs>
 
 @code {
 
-	private class TabView
-	{
-		public String Name { get; set; }
-		public String Content { get; set; }
-		public Guid Id { get; set; }
-	}
+    private class TabView
+    {
+        public String Name { get; set; }
+        public String Content { get; set; }
+        public Guid Id { get; set; }
+    }
 
-	private List<TabView> _tabs = new();
-	private int _index = 0;
-	private int? _nextIndex = null;
+    private List<TabView> _tabs = new();
+    private int _index = 0;
+    private int? _nextIndex = null;
 
-	private void RemoveTab(MudTabPanel tabPanel)
-	{
-		var tab = _tabs.FirstOrDefault(x => x.Id == (Guid)tabPanel.Tag);
-		if(tab != null)
-		{
-			_tabs.Remove(tab);
-		}
-	}
+    private void RemoveTab(MudTabPanel tabPanel)
+    {
+        var tab = _tabs.FirstOrDefault(x => x.Id == (Guid)tabPanel.Tag);
+        if(tab != null)
+        {
+            _tabs.Remove(tab);
+        }
+    }
 
-	protected override void OnInitialized()
-	{
-		base.OnInitialized();
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
 
-		_tabs.Add(new TabView { Content = "First tab content", Name = "Tab A", Id = Guid.NewGuid() });
-		_tabs.Add(new TabView { Content = "Second tab content", Name = "Tab B", Id = Guid.NewGuid() });
-		_tabs.Add(new TabView { Content = "Third tab content", Name = "Tab C", Id = Guid.NewGuid() });
-	}
+        _tabs.Add(new TabView { Content = "First tab content", Name = "Tab A", Id = Guid.NewGuid() });
+        _tabs.Add(new TabView { Content = "Second tab content", Name = "Tab B", Id = Guid.NewGuid() });
+        _tabs.Add(new TabView { Content = "Third tab content", Name = "Tab C", Id = Guid.NewGuid() });
+    }
 
-	private void AddTabCallback(Boolean append)
-	{
-		var tabView = new TabView { Name = "Dynamic content", Content = "A new tab", Id = Guid.NewGuid() };
-		
-		//the tab becomes available after it is rendered. Hence, we can't set the index here
-		if(append == true)
-		{
-			_tabs.Add(tabView);
-			_nextIndex = _tabs.Count - 1;
-		}
-		else
-		{
-			_tabs.Insert(0, tabView);
-			_nextIndex = 0;
-		}
-	}
+    private void AddTabCallback(Boolean append)
+    {
+        var tabView = new TabView { Name = "Dynamic content", Content = "A new tab", Id = Guid.NewGuid() };
 
-	protected override void OnAfterRender(bool firstRender)
-	{
-		if(_nextIndex.HasValue == true)
-		{
-			_index = _nextIndex.Value;
-			_nextIndex = null;
-			StateHasChanged();
-		}
-	}
+        //the tab becomes available after it is rendered. Hence, we can't set the index here
+        if(append == true)
+        {
+            _tabs.Add(tabView);
+            _nextIndex = _tabs.Count - 1;
+        }
+        else
+        {
+            _tabs.Insert(0, tabView);
+            _nextIndex = 0;
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if(_nextIndex.HasValue == true)
+        {
+            _index = _nextIndex.Value;
+            _nextIndex = null;
+            StateHasChanged();
+        }
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Tabs/Examples/TabsWithBagdesExample.razor
@@ -6,21 +6,21 @@
     <MudTabPanel Icon="@Icons.Material.Filled.Build" BadgeData='"..."' />
     <MudTabPanel Icon="@Icons.Material.Filled.BugReport" BadgeData='"99+"' BadgeColor="Color.Error" />
     <MudTabPanel Icon="@Icons.Material.Filled.AccessTime" BadgeData='string.Empty' BadgeDot="true" BadgeColor="Color.Success" />
-	<MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" BadgeIcon="@Icons.Material.Filled.WarningAmber" BadgeColor="Color.Warning" />
+    <MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" BadgeIcon="@Icons.Material.Filled.WarningAmber" BadgeColor="Color.Warning" />
 </MudTabs>
 
 <MudTabs Elevation="2" Rounded="true" Centered="true" Class="my-6" Color="Color.Dark">
     <MudTabPanel Icon="@Icons.Material.Filled.Api" Text="API" BadgeData='"!"' BadgeColor="Color.Error" />
     <MudTabPanel Icon="@Icons.Material.Filled.Build" Text="Build" BadgeData="1" BadgeColor="Color.Success" />
     <MudTabPanel Icon="@Icons.Material.Filled.BugReport" Text="Bugs" BadgeData="@(128)" BadgeMax="999" BadgeColor="Color.Error" />
-	<MudTabPanel Icon="@Icons.Material.Filled.AccessTime" Text="Timing" BadgeDot="true" BadgeColor="Color.Error" />
-	<MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" Text="Metrics" BadgeIcon="@Icons.Material.Filled.Downloading" />
+    <MudTabPanel Icon="@Icons.Material.Filled.AccessTime" Text="Timing" BadgeDot="true" BadgeColor="Color.Error" />
+    <MudTabPanel Icon="@Icons.Material.Filled.InsertChartOutlined" Text="Metrics" BadgeIcon="@Icons.Material.Filled.Downloading" />
 </MudTabs>
 
 <MudTabs Elevation="2" Rounded="true" Centered="true">
     <MudTabPanel Text="API" BadgeData='"S"' />
     <MudTabPanel Text="Build" BadgeData='"..."' BadgeColor="Color.Dark" />
     <MudTabPanel Text="Bugs" BadgeData='"N"' />
-	<MudTabPanel Text="Timing" BadgeDot="true" BadgeColor="Color.Primary" />
-	<MudTabPanel Text="Metrics" BadgeIcon="@Icons.Material.Filled.Check" BadgeColor="Color.Success" />
+    <MudTabPanel Text="Timing" BadgeDot="true" BadgeColor="Color.Primary" />
+    <MudTabPanel Text="Metrics" BadgeIcon="@Icons.Material.Filled.Check" BadgeColor="Color.Success" />
 </MudTabs>

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/BlockMaskExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/BlockMaskExample.razor
@@ -6,7 +6,7 @@
                       @bind-Value="text"  Variant="@Variant.Outlined" Clearable />
     </MudItem>
     <MudItem xs="12">
-		Flight number: <b>@text</b>
+        Flight number: <b>@text</b>
     </MudItem>
 </MudGrid>
 

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/PatternMaskExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/PatternMaskExample.razor
@@ -5,18 +5,18 @@
         <MudTextField Mask="@(new PatternMask("0000 0000 0000 0000"))" Label="Credit Card Number" 
                       @bind-Value="creditCard"  Variant="@Variant.Text" Clearable />
     </MudItem>
-	<MudItem xs="4">
+    <MudItem xs="4">
         <MudTextField Mask="@(new DateMask("MM/YY", 'Y', 'M'))" Label="Expires" 
                       @bind-Value="expiration"  Variant="@Variant.Text" />
     </MudItem>
     <MudItem xs="4"/>
-	<MudItem xs="4">
+    <MudItem xs="4">
         <MudTextField Mask="@(new PatternMask("000"))" Label="CVC" 
                       @bind-Value="cvc"  Variant="@Variant.Text" />
     </MudItem>
     <MudItem xs="12">
-		Credit Card Number: <b>@creditCard</b><br/>
-		Expiration Date: <b>@expiration</b><br/>
+        Credit Card Number: <b>@creditCard</b><br/>
+        Expiration Date: <b>@expiration</b><br/>
         CVC: <b>@cvc</b>
     </MudItem>
 </MudGrid>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentChange.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteAdornmentChange.razor
@@ -5,12 +5,12 @@
 <MudButton OnClick="ChangeIcon">Change Icon</MudButton>
 
 @code {
-	public static string __description__ = "The adornment icon should change after button click";
+    public static string __description__ = "The adornment icon should change after button click";
 
-	private string _value1 = "Alabama";
+    private string _value1 = "Alabama";
 
-	private readonly string[] _states =
-	{
+    private readonly string[] _states =
+    {
         "Alabama", "Alaska", "American Samoa", "Arizona",
         "Arkansas", "California", "Colorado", "Connecticut",
         "Delaware", "District of Columbia", "Federated States of Micronesia",
@@ -27,23 +27,23 @@
         "Washington", "West Virginia", "Wisconsin", "Wyoming",
     };
 
-	[Parameter]
-	public string Icon { get; set; } = Icons.Material.Filled.Abc;
+    [Parameter]
+    public string Icon { get; set; } = Icons.Material.Filled.Abc;
 
-	private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
-	{
-		// In real life use an asynchronous function for fetching data from an api.
-		await Task.Delay(5, token);
+    private async Task<IEnumerable<string>> Search1(string value, CancellationToken token)
+    {
+        // In real life use an asynchronous function for fetching data from an api.
+        await Task.Delay(5, token);
 
-		// if text is null or empty, show complete list
-		if (string.IsNullOrEmpty(value))
-			return _states;
-		return _states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
-	}
+        // if text is null or empty, show complete list
+        if (string.IsNullOrEmpty(value))
+            return _states;
+        return _states.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase));
+    }
 
-	public void ChangeIcon()
-	{
-		Icon = Icons.Material.Filled.AccessAlarm;
-		StateHasChanged();
-	}
+    public void ChangeIcon()
+    {
+        Icon = Icons.Material.Filled.AccessAlarm;
+        StateHasChanged();
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseSelectedHighlight.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Autocomplete/AutocompleteStrictFalseSelectedHighlight.razor
@@ -5,28 +5,28 @@
 @code {
     private string? _fruit;
 
-	private readonly string[] _fruits =
+    private readonly string[] _fruits =
     [
         "apple",
-		"banana",
-		"pear",
-		"carrot",
-		"cherry",
-		"raspberry",
-		"peach"
+        "banana",
+        "pear",
+        "carrot",
+        "cherry",
+        "raspberry",
+        "peach"
     ];
 
-	public Func<string, bool> ItemDisabledFunc = text => text.Equals("carrot", StringComparison.InvariantCulture);
+    public Func<string, bool> ItemDisabledFunc = text => text.Equals("carrot", StringComparison.InvariantCulture);
 
     public async Task<IEnumerable<string>> Search(string text, CancellationToken token)
     {
-		await Task.Delay(100, token);
+        await Task.Delay(100, token);
 
-		if (string.IsNullOrWhiteSpace(text))
-		{
-			return _fruits;
-		}
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return _fruits;
+        }
 
-		return _fruits.Where(x => x.Contains(text, StringComparison.InvariantCulture));
-	}
+        return _fruits.Where(x => x.Contains(text, StringComparison.InvariantCulture));
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonGroupTooltipsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/ButtonGroupTooltipsTest.razor
@@ -1,33 +1,33 @@
 ﻿<MudRTLProvider RightToLeft=@_rightToLeft>
-	<div class="d-flex mb-3">
-		<MudButtonGroup Color="Color.Dark" Variant="Variant.Filled">
-			<MudTooltip Text="Open 1"><MudButton>1</MudButton></MudTooltip>
-			<MudTooltip Text="Open 2"><MudButton>2</MudButton></MudTooltip>
-			<MudTooltip Text="Open 3"><MudButton>3</MudButton></MudTooltip>
-		</MudButtonGroup>
-	</div>
+    <div class="d-flex mb-3">
+        <MudButtonGroup Color="Color.Dark" Variant="Variant.Filled">
+            <MudTooltip Text="Open 1"><MudButton>1</MudButton></MudTooltip>
+            <MudTooltip Text="Open 2"><MudButton>2</MudButton></MudTooltip>
+            <MudTooltip Text="Open 3"><MudButton>3</MudButton></MudTooltip>
+        </MudButtonGroup>
+    </div>
 
-	<div class="d-flex mb-3">
-		<MudButtonGroup Color="Color.Dark" Variant="Variant.Filled">
-			<MudTooltip Text="Open 1"><MudIconButton Icon="@Icons.Material.Filled.Edit" aria-label="Edit" /></MudTooltip>
-			<MudTooltip Text="Open 2"><MudButton>Save</MudButton></MudTooltip>
-			<MudTooltip Text="Open 3"><MudIconButton Icon="@Icons.Material.Filled.Delete" aria-label="Delete" /></MudTooltip>
-		</MudButtonGroup>
-	</div>
+    <div class="d-flex mb-3">
+        <MudButtonGroup Color="Color.Dark" Variant="Variant.Filled">
+            <MudTooltip Text="Open 1"><MudIconButton Icon="@Icons.Material.Filled.Edit" aria-label="Edit" /></MudTooltip>
+            <MudTooltip Text="Open 2"><MudButton>Save</MudButton></MudTooltip>
+            <MudTooltip Text="Open 3"><MudIconButton Icon="@Icons.Material.Filled.Delete" aria-label="Delete" /></MudTooltip>
+        </MudButtonGroup>
+    </div>
 
-	<div class="d-flex mr-3">
-		<MudButtonGroup Color="Color.Dark" Variant="Variant.Filled" Vertical="true" Style="margin-right: 4px">
-			<MudTooltip Text="Open 1"><MudButton>1</MudButton></MudTooltip>
-			<MudTooltip Text="Open 2"><MudButton>2</MudButton></MudTooltip>
-			<MudTooltip Text="Open 3"><MudButton>3</MudButton></MudTooltip>
-		</MudButtonGroup>
-	</div>
+    <div class="d-flex mr-3">
+        <MudButtonGroup Color="Color.Dark" Variant="Variant.Filled" Vertical="true" Style="margin-right: 4px">
+            <MudTooltip Text="Open 1"><MudButton>1</MudButton></MudTooltip>
+            <MudTooltip Text="Open 2"><MudButton>2</MudButton></MudTooltip>
+            <MudTooltip Text="Open 3"><MudButton>3</MudButton></MudTooltip>
+        </MudButtonGroup>
+    </div>
 </MudRTLProvider>
 
 <MudSwitch @bind-Value="@_rightToLeft" Label="Toggle Right to Left" Color="Color.Primary" />
 
 @code
 {
-	private bool _rightToLeft;
-	public static string __description__ = "The button group rounded corners and dividers should still work when using tooltips.";
+    private bool _rightToLeft;
+    public static string __description__ = "The button group rounded corners and dividers should still work when using tooltips.";
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/IconButtonTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Button/IconButtonTest.razor
@@ -1,16 +1,16 @@
 ﻿<MudIconButton Icon="@Icons.Material.Filled.Favorite"
-			   Color="Color.Secondary"
-			   title="This should appear when hovering over the button, not just the icon" />
+               Color="Color.Secondary"
+               title="This should appear when hovering over the button, not just the icon" />
 
 <MudFab Icon="@Icons.Material.Filled.Sailing"
-		Color="Color.Secondary"
-		title="This should appear when hovering over the button, not just the icon" />
+        Color="Color.Secondary"
+        title="This should appear when hovering over the button, not just the icon" />
 
-		
+
 <MudFab Icon="@Icons.Material.Filled.RestoreFromTrash"
-		Color="Color.Secondary" />
-		
+        Color="Color.Secondary" />
+
 @code
 {
-	public static string __description__ = "Test icon button title and visual behaviour.";
+    public static string __description__ = "Test icon button title and visual behaviour.";
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/ChartsWithCustomGraphicsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/ChartsWithCustomGraphicsTest.razor
@@ -1,47 +1,47 @@
 ﻿<MudGrid>
-	<MudItem xs="12" md="6" lg="4">
+    <MudItem xs="12" md="6" lg="4">
         <MudChart ChartType="ChartType.Donut" Width="300px" Height="300px" ChartSeries="@([Data])" ChartLabels="@Labels">
-			<CustomGraphics>
-				<text class="mud-donut-text" x="47%" y="35%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="2">Chart</text>
-				<text class="mud-donut-text" x="47%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="5">DONUT</text>
-			</CustomGraphics>
-		</MudChart>
-	</MudItem>
-	<MudItem xs="12" md="6" lg="4">
-		<MudChart ChartType="ChartType.Pie" Width="300px" Height="300px" ChartSeries="@([Data])" ChartLabels="@Labels">
-			<CustomGraphics>
-				 <text class="mud-donut-text" style="transform:rotate(90deg)" x="0" y="0" dominant-baseline="middle" text-anchor="middle" fill="white" font-family="Helvetica" font-size="0.3">PIE</text>
-			</CustomGraphics>
-		</MudChart>
-	</MudItem>
-	<MudItem xs="12" md="6" lg="4">
-		<MudChart ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
-			<CustomGraphics>
-				<text class="mud-donut-text" x="50%" y="40" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="35">Line Chart</text>
-			</CustomGraphics>
-		</MudChart>
-	</MudItem>
-	<MudItem xs="12" md="6" lg="4">
-		<MudChart ChartType="ChartType.Bar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
-			<CustomGraphics>
-				<style>
-					.small { font: italic 13px sans-serif; }
-					.heavy { font: bold 30px sans-serif; }
-					.Rrrrr { font: italic 40px serif; fill: red; }
-				</style>
+            <CustomGraphics>
+                <text class="mud-donut-text" x="47%" y="35%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="2">Chart</text>
+                <text class="mud-donut-text" x="47%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="5">DONUT</text>
+            </CustomGraphics>
+        </MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Pie" Width="300px" Height="300px" ChartSeries="@([Data])" ChartLabels="@Labels">
+            <CustomGraphics>
+                 <text class="mud-donut-text" style="transform:rotate(90deg)" x="0" y="0" dominant-baseline="middle" text-anchor="middle" fill="white" font-family="Helvetica" font-size="0.3">PIE</text>
+            </CustomGraphics>
+        </MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Line" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
+            <CustomGraphics>
+                <text class="mud-donut-text" x="50%" y="40" dominant-baseline="middle" text-anchor="middle" fill="black" font-family="Helvetica" font-size="35">Line Chart</text>
+            </CustomGraphics>
+        </MudChart>
+    </MudItem>
+    <MudItem xs="12" md="6" lg="4">
+        <MudChart ChartType="ChartType.Bar" ChartSeries="@Series" ChartLabels="@XAxisLabels" Width="100%" Height="350px">
+            <CustomGraphics>
+                <style>
+                    .small { font: italic 13px sans-serif; }
+                    .heavy { font: bold 30px sans-serif; }
+                    .Rrrrr { font: italic 40px serif; fill: red; }
+                </style>
 
-				<text x="60" y="35" class="small">My</text>
-				<text x="80" y="35" class="heavy">cat</text>
-				<text x="95" y="55" class="small">is</text>
-				<text x="105" y="55" class="Rrrrr">Grumpy!</text>
-			</CustomGraphics>
-		</MudChart>
-	</MudItem>
+                <text x="60" y="35" class="small">My</text>
+                <text x="80" y="35" class="heavy">cat</text>
+                <text x="95" y="55" class="small">is</text>
+                <text x="105" y="55" class="Rrrrr">Grumpy!</text>
+            </CustomGraphics>
+        </MudChart>
+    </MudItem>
 </MudGrid>
 
 
 @code {
-	public static string __description__ = "Charts with custom svg graphics using a RenderFragment.";
+    public static string __description__ = "Charts with custom svg graphics using a RenderFragment.";
     public ChartSeries<double> Data = new([10, 420, 20, 69]);
     public string[] Labels = ["Data 1", "Data 2", "Data 3", "Data 4"];
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ColorPicker/PickerWithFixedView.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ColorPicker/PickerWithFixedView.razor
@@ -4,8 +4,8 @@
 <MudColorPicker ColorPickerMode="ColorPickerMode.HEX" ColorPickerView="@ColorPickerView" ShowToolbar="true" Label="Basic Color Picker" Placeholder="Select Color" @bind-Value="@_colorValue" />
 
 @code {
-	private MudColor? _colorValue;
+    private MudColor? _colorValue;
 
-	[Parameter]
-	public ColorPickerView ColorPickerView { get; set; } = ColorPickerView.Grid;
+    [Parameter]
+    public ColorPickerView ColorPickerView { get; set; } = ColorPickerView.Grid;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupCollapseAllTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridGroupCollapseAllTest.razor
@@ -45,20 +45,20 @@
 
     private readonly Func<TestObject, object> _groupBy = x => x.Category;
 
-	public void RefreshList()
-	{
-		_fruits = _fruits.Select(x => new TestObject(x.Name, x.Category)).ToList();
-	}
+    public void RefreshList()
+    {
+        _fruits = _fruits.Select(x => new TestObject(x.Name, x.Category)).ToList();
+    }
 
-	public Task ExpandAllGroups()
-	{
-		return _dataGrid.ExpandAllGroupsAsync();
-	}
+    public Task ExpandAllGroups()
+    {
+        return _dataGrid.ExpandAllGroupsAsync();
+    }
 
-	public Task CollapseAllGroups()
-	{
-		return _dataGrid.CollapseAllGroupsAsync();
-	}
+    public Task CollapseAllGroups()
+    {
+        return _dataGrid.CollapseAllGroupsAsync();
+    }
 
     public record TestObject(string Name, string Category);
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneBasicTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneBasicTest.razor
@@ -1,20 +1,20 @@
 ﻿<MudDropContainer T="SimpleDropItem"
-				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
-				  Class="d-flex"
-				  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
-				  ItemDropped="ItemUpdated">
-	<ChildContent>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
-					 DraggingClass="my-special-drop-zone-dragging-class" ItemDraggingClass="my-special-item-drop-zone-dragging-class">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex"
+                  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
+                  ItemDropped="ItemUpdated">
+    <ChildContent>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
+                     DraggingClass="my-special-drop-zone-dragging-class" ItemDraggingClass="my-special-item-drop-zone-dragging-class">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
@@ -27,9 +27,9 @@
 
     public List<int> IndexHistory { get; set; } = [];
 
-	public class SimpleDropItem(string name, string zoneIdentifier)
+    public class SimpleDropItem(string name, string zoneIdentifier)
     {
-		public string Name { get; set; } = name;
+        public string Name { get; set; } = name;
         public string ZoneIdentifier { get; set; } = zoneIdentifier;
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneCanDropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneCanDropTest.razor
@@ -1,25 +1,25 @@
 ﻿<MudDropContainer T="SimpleDropItem"
-				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
-				  Class="d-flex"
-				  CanDropClass="can-drop-from-container" NoDropClass="no-drop-class-from-container"
-				  CanDrop="@( (item,columnIdentifier) => item.ZoneIdentifier != columnIdentifier)"
-				  ItemDropped="ItemUpdated" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
-	<ChildContent>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
-					 ApplyDropClassesOnDragStarted="@SecondColumnAppliesClassesOnDragStarted"
-					 CanDropClass="can-drop-from-zone" NoDropClass="no-drop-class-from-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 3" Class="third-drop-zone" CanDrop=@( (item) => false)>
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex"
+                  CanDropClass="can-drop-from-container" NoDropClass="no-drop-class-from-container"
+                  CanDrop="@( (item,columnIdentifier) => item.ZoneIdentifier != columnIdentifier)"
+                  ItemDropped="ItemUpdated" ApplyDropClassesOnDragStarted="@ApplyDropClassesOnDragStarted">
+    <ChildContent>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
+                     ApplyDropClassesOnDragStarted="@SecondColumnAppliesClassesOnDragStarted"
+                     CanDropClass="can-drop-from-zone" NoDropClass="no-drop-class-from-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 3" Class="third-drop-zone" CanDrop=@( (item) => false)>
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
@@ -30,16 +30,16 @@
         new("Third Item", "Column 1")
     ];
 
-	[Parameter]
-	public bool ApplyDropClassesOnDragStarted { get; set; }
+    [Parameter]
+    public bool ApplyDropClassesOnDragStarted { get; set; }
 
-	[Parameter]
-	public bool? SecondColumnAppliesClassesOnDragStarted { get; set; }
+    [Parameter]
+    public bool? SecondColumnAppliesClassesOnDragStarted { get; set; }
 
-	private static async Task ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+    private static async Task ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
     {
         // simulate async/await and force re-rendering
-	    await Task.Delay(1);
+        await Task.Delay(1);
 
         if (dropItem.Item != null)
         {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneCustomItemSelectorTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneCustomItemSelectorTest.razor
@@ -1,28 +1,28 @@
 ﻿<MudDropContainer T="SimpleDropItem" Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)" Class="d-flex">
-	<ChildContent>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<ChildContent>
-				<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
-			</ChildContent>
-			<ItemRenderer>
-				<MudText>@context.Name by Drop Zone 1</MudText>
-			</ItemRenderer>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+    <ChildContent>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
+            <ChildContent>
+                <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+            </ChildContent>
+            <ItemRenderer>
+                <MudText>@context.Name by Drop Zone 1</MudText>
+            </ItemRenderer>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
-	private readonly IEnumerable<SimpleDropItem> _items =
+    private readonly IEnumerable<SimpleDropItem> _items =
     [
         new("First Item", "Column 1"),
-		new("Second Item", "Column 2"),
-		new("Third Item", "Column 2")
+        new("Second Item", "Column 2"),
+        new("Third Item", "Column 2")
     ];
 
     public record SimpleDropItem(string Name, string ZoneIdentifier);

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDisableTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDisableTest.razor
@@ -1,20 +1,20 @@
 ﻿<MudDropContainer T="SimpleDropItem"
-				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
-				  Class="d-flex"
-				  DisabledClass="my-custom-disabled-class-from-container" ItemDisabled="@( (item) => item.Name == "First Item" || item.Name == "Third Item")"
-				  ItemDropped="ItemUpdated">
-	<ChildContent>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
-					 ItemDisabled="@( (item) => item.Name == "Fourth Item")" DisabledClass="my-zone-based-custom-disabled">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex"
+                  DisabledClass="my-custom-disabled-class-from-container" ItemDisabled="@( (item) => item.Name == "First Item" || item.Name == "Third Item")"
+                  ItemDropped="ItemUpdated">
+    <ChildContent>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
+                     ItemDisabled="@( (item) => item.Name == "Fourth Item")" DisabledClass="my-zone-based-custom-disabled">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
@@ -26,7 +26,7 @@
         new("Fourth Item", "Column 1")
     ];
 
-	private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+    private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
     {
         if (dropItem.Item is null)
         {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDraggingTestCantDropSecondZoneTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDraggingTestCantDropSecondZoneTest.razor
@@ -1,21 +1,21 @@
 ﻿<MudDropContainer T="SimpleDropItem"
-				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
-				  Class="d-flex"
-				  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
-				  ItemDropped="ItemUpdated">
-	<ChildContent>
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex"
+                  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
+                  ItemDropped="ItemUpdated">
+    <ChildContent>
         <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone"
                      CanDrop=@( (x) => false)>
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
-					 CanDrop=@( (x) => false)>
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
+                     CanDrop=@( (x) => false)>
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
@@ -26,7 +26,7 @@
         new("Third Item", "Column 2")
     ];
 
-	private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+    private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
     {
         if (dropItem.Item is null)
         {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDynamicItemCollectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneDynamicItemCollectionTest.razor
@@ -1,15 +1,15 @@
 ﻿<MudDropContainer @ref="_container" T="SimpleDropItem"
-				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
-				  Class="d-flex"
-				  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
-				  ItemDropped="ItemUpdated">
-	<ChildContent>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone" />
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone" />
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex"
+                  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
+                  ItemDropped="ItemUpdated">
+    <ChildContent>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone" />
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone" />
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
@@ -21,7 +21,7 @@
         new("3", "Column 1")
     ];
 
-	private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+    private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
     {
         if (dropItem.Item is null)
         {
@@ -31,11 +31,11 @@
         dropItem.Item.ZoneIdentifier = dropItem.DropzoneIdentifier;
     }
 
-	public void AddItem() => _items.Add(new SimpleDropItem($"{_items.Count + 1}","Column 2"));
+    public void AddItem() => _items.Add(new SimpleDropItem($"{_items.Count + 1}","Column 2"));
 
-	public void RemoveLastItem() => _items.RemoveAt(_items.Count - 1);
+    public void RemoveLastItem() => _items.RemoveAt(_items.Count - 1);
 
-	public async Task InvokeRefresh() => await InvokeAsync(_container.Refresh);
+    public async Task InvokeRefresh() => await InvokeAsync(_container.Refresh);
 
     public class SimpleDropItem(string name, string zoneIdentifier)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneReorderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneReorderTest.razor
@@ -34,7 +34,7 @@
         new() { Name = "Item 6", Selector = "2" }
     ];
 
-	public List<int> IndexHistory { get; set; } = [];
+    public List<int> IndexHistory { get; set; } = [];
 
     private void ItemUpdated(MudItemDropInfo<DropItem> dropItem)
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneVisbilityTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DropZone/DropZoneVisbilityTest.razor
@@ -1,20 +1,20 @@
 ﻿<MudDropContainer T="SimpleDropItem"
-				  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
-				  Class="d-flex"
-				  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
-				  ItemDropped="ItemUpdated">
-	<ChildContent>
-		<MudDropZone OnlyZone="@HideItemsInFirstDropZone" T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
-		</MudDropZone>
-		<MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
-					 DraggingClass="my-special-drop-zone-dragging-class" ItemDraggingClass="my-special-item-drop-zone-dragging-class">
-			<MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
-		</MudDropZone>
-	</ChildContent>
-	<ItemRenderer>
-		<MudText>@context.Name</MudText>
-	</ItemRenderer>
+                  Items="_items" ItemsSelector="@((item,dropzone) => item.ZoneIdentifier == dropzone)"
+                  Class="d-flex"
+                  DraggingClass="my-special-dragging-class" ItemDraggingClass="my-special-item-dragging-class"
+                  ItemDropped="ItemUpdated">
+    <ChildContent>
+        <MudDropZone OnlyZone="@HideItemsInFirstDropZone" T="SimpleDropItem" Identifier="Column 1" Class="first-drop-zone">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 1</MudText>
+        </MudDropZone>
+        <MudDropZone T="SimpleDropItem" Identifier="Column 2" Class="second-drop-zone"
+                     DraggingClass="my-special-drop-zone-dragging-class" ItemDraggingClass="my-special-item-drop-zone-dragging-class">
+            <MudText Typo="Typo.h6" Class="mb-4">Drop Zone 2</MudText>
+        </MudDropZone>
+    </ChildContent>
+    <ItemRenderer>
+        <MudText>@context.Name</MudText>
+    </ItemRenderer>
 </MudDropContainer>
 
 @code {
@@ -25,10 +25,10 @@
         new("Third Item", "Column 2")
     ];
 
-	[Parameter]
+    [Parameter]
     public bool HideItemsInFirstDropZone { get; set; } = true;
 
-	private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
+    private static void ItemUpdated(MudItemDropInfo<SimpleDropItem> dropItem)
     {
         if (dropItem.Item is null)
         {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelKeyboardTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ExpansionPanel/ExpansionPanelKeyboardTest.razor
@@ -1,8 +1,8 @@
 ﻿<MudExpansionPanels>
-	<MudExpansionPanel Text="Panel 1" KeepContentAlive="true">
-		<MudButton Variant="Variant.Filled">Button 1</MudButton>
-	</MudExpansionPanel>
-	<MudExpansionPanel Text="Panel 2" KeepContentAlive="true">
-		<MudButton Variant="Variant.Filled">Button 2</MudButton>
-	</MudExpansionPanel>
+    <MudExpansionPanel Text="Panel 1" KeepContentAlive="true">
+        <MudButton Variant="Variant.Filled">Button 1</MudButton>
+    </MudExpansionPanel>
+    <MudExpansionPanel Text="Panel 2" KeepContentAlive="true">
+        <MudButton Variant="Variant.Filled">Button 2</MudButton>
+    </MudExpansionPanel>
 </MudExpansionPanels>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormResetTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Form/FormResetTest.razor
@@ -2,7 +2,7 @@
     <MudDatePicker Label="Date" Required @bind-Date="@_date" Editable></MudDatePicker>
     <MudTextField Label="Name" T="string" Required Immediate @bind-Value="@_name" />
     <MudNumericField Label="Age" T="int?" Required Immediate @bind-Value="@_age"></MudNumericField>
-	<MudDateRangePicker Label="Date Range" @bind-DateRange="@_dateRange" />
+    <MudDateRangePicker Label="Date Range" @bind-DateRange="@_dateRange" />
 </MudForm>
 <br><br>
 <span>Date: @_date</span>
@@ -17,7 +17,7 @@
     private int? _age;
     private string? _name;
     private DateTime? _date;
-	private DateRange? _dateRange;
+    private DateRange? _dateRange;
     private MudForm _form = null!;
 
     private async Task ResetFormAsync()

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/SimpleMudHiddenTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Hidden/SimpleMudHiddenTest.razor
@@ -1,13 +1,13 @@
 ﻿<MudHidden Invert="@Invert" Breakpoint="@Breakpoint" HiddenChanged="@( x => HiddenChangedHistory.Add(x) )" >
-	<MudText>MudHidden content</MudText>
+    <MudText>MudHidden content</MudText>
 </MudHidden>
 
 @code {
-	[Parameter]
-	public bool Invert { get; set; }
+    [Parameter]
+    public bool Invert { get; set; }
 
-	[Parameter]
-	public Breakpoint Breakpoint { get; set; }
+    [Parameter]
+    public Breakpoint Breakpoint { get; set; }
 
-	public List<bool> HiddenChangedHistory { get; set; } = [];
+    public List<bool> HiddenChangedHistory { get; set; } = [];
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/MaskedTextFieldTwoWayBindingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Mask/MaskedTextFieldTwoWayBindingTest.razor
@@ -3,7 +3,7 @@
 <MudTextField Mask="@(new PatternMask("00/00/00"))" @bind-Value="_text"  Variant="@Variant.Outlined" Clearable />
 
 @code {
-	public static string __description__ = "The two textfields should always stay in sync!";
+    public static string __description__ = "The two textfields should always stay in sync!";
 
     private string? _text;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverComplexContent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverComplexContent.razor
@@ -1,24 +1,24 @@
 ﻿<MudPopoverProvider />
 
 <div class="popoverparent">
-	<p>Some Text</p>
-	<MudPopover Open="true">
-		<div class="dynamic-content">
-			@for (int i = 0; i < _rowAmount; i++)
-			{
-				var temp = i;
-				<MudText>Popover content @temp</MudText>
-			}
-		</div>
-	</MudPopover>
+    <p>Some Text</p>
+    <MudPopover Open="true">
+        <div class="dynamic-content">
+            @for (int i = 0; i < _rowAmount; i++)
+            {
+                var temp = i;
+                <MudText>Popover content @temp</MudText>
+            }
+        </div>
+    </MudPopover>
 </div>
 
 @code {
-	private int _rowAmount;
+    private int _rowAmount;
 
-	public Task AddRow()
-	{
-		_rowAmount++;
-		return InvokeAsync(StateHasChanged);
-	}
+    public Task AddRow()
+    {
+        _rowAmount++;
+        return InvokeAsync(StateHasChanged);
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverFlipDirectionTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverFlipDirectionTest.razor
@@ -91,20 +91,20 @@
     private Origin _anchor = Origin.BottomLeft;
     private Origin _transform = Origin.TopLeft;
 
-	private void OnExpandCollapseClick() => _expanded = !_expanded;
+    private void OnExpandCollapseClick() => _expanded = !_expanded;
 
     private async Task OnExpandCollapseFor5sClickAsync()
-	{
-		var expanded = _expanded;
+    {
+        var expanded = _expanded;
         _expanded = !expanded;
         await Task.Delay(5000);
         _expanded = expanded;
     }
 
-	private async Task OnExpandListIn5sAsync()
-	{
-		_expandList = false;
-		await Task.Delay(5000);
-		_expandList = true;
-	}
+    private async Task OnExpandListIn5sAsync()
+    {
+        _expandList = false;
+        await Task.Delay(5000);
+        _expandList = true;
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverProviderTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverProviderTest.razor
@@ -1,14 +1,14 @@
 ﻿<CascadingValue Value="ProviderEnabled" Name="UsePopoverProvider">
-	<MudPopoverProvider />
+    <MudPopoverProvider />
 </CascadingValue>
 
 <div class="popoverparent">
-	<MudPopover Open="true">
-		<MudText id="my-content">Popover content</MudText>
-	</MudPopover>
+    <MudPopover Open="true">
+        <MudText id="my-content">Popover content</MudText>
+    </MudPopover>
 </div>
 
 @code {
-	[Parameter]
-	public bool ProviderEnabled { get; set; } = true;
+    [Parameter]
+    public bool ProviderEnabled { get; set; } = true;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Popover/PopoverTest.razor
@@ -1,24 +1,24 @@
 ﻿<MudPopoverProvider />
 
 <div class="popoverparent">
-	<p>Some Text</p>
-	<MudPopover Open="_open">
-		<MudText>Popover content</MudText>
-	</MudPopover>
+    <p>Some Text</p>
+    <MudPopover Open="_open">
+        <MudText>Popover content</MudText>
+    </MudPopover>
 </div>
 
 @code {
-	private bool _open;
+    private bool _open;
 
-	public Task Open()
-	{
-		_open = true;
-		return InvokeAsync(StateHasChanged);
-	}
+    public Task Open()
+    {
+        _open = true;
+        return InvokeAsync(StateHasChanged);
+    }
 
-	public Task Close()
-	{
-		_open = false;
-		return InvokeAsync(StateHasChanged);
-	}
+    public Task Close()
+    {
+        _open = false;
+        return InvokeAsync(StateHasChanged);
+    }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest1.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectTest1.razor
@@ -17,11 +17,11 @@
 
     private void Focused()
     {
-	    _focused = true;
+        _focused = true;
     }
 
     private void Blurred()
     {
-	    _focused = false;
+        _focused = false;
     }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupLoadingAndNoRecordsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableGroupLoadingAndNoRecordsTest.razor
@@ -28,10 +28,10 @@
     private string _searchString = string.Empty;
 
     private readonly TableGroupDefinition<RacingCar> _groupDefinition = new()
-	{
-		GroupName = "Brand",
-		Selector = e => e.Brand
-	};
+    {
+        GroupName = "Brand",
+        Selector = e => e.Brand
+    };
 
     protected override Task OnInitializedAsync()
     {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditTestApplyButtons.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Table/TableInlineEditTestApplyButtons.razor
@@ -1,24 +1,24 @@
 ﻿<MudTable T="string" Items="_items" @bind-SelectedItem="_selectedItem" ApplyButtonPosition="@ApplyButtonPosition">
-	<HeaderContent>
-		<MudTh>#</MudTh>
-	</HeaderContent>
-	<RowTemplate>
-		<MudTd>@context</MudTd>
-	</RowTemplate>
-	<RowEditingTemplate>
-		<MudTd>
-			<MudTextField T="string" @bind-Value="@context"></MudTextField>
-		</MudTd>
-	</RowEditingTemplate>
-	<FooterContent>
-		<MudTd>#Footer</MudTd>
-	</FooterContent>
+    <HeaderContent>
+        <MudTh>#</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd>@context</MudTd>
+    </RowTemplate>
+    <RowEditingTemplate>
+        <MudTd>
+            <MudTextField T="string" @bind-Value="@context"></MudTextField>
+        </MudTd>
+    </RowEditingTemplate>
+    <FooterContent>
+        <MudTd>#Footer</MudTd>
+    </FooterContent>
 </MudTable>
 
 @code {
-	public static string __description__ = "Inline Edit Table: Basic";
+    public static string __description__ = "Inline Edit Table: Basic";
 
-	private string? _selectedItem;
+    private string? _selectedItem;
     private readonly string[] _items = ["A", "B", "C"];
 
     [Parameter]

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithMenuInHeader.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithMenuInHeader.razor
@@ -1,16 +1,16 @@
 ﻿<MudPopoverProvider />
 
 <MudTabs Elevation="2" Rounded="true" TabPanelsClass="pa-6" ApplyEffectsToContainer="true">
-	<ChildContent>
-		<MudTabPanel Text="Tab One">
-			<MudText class="my-text">Sexy Text</MudText>
-		</MudTabPanel>
-	</ChildContent>
-	<TabPanelHeader>
-		<MudMenu Size="Size.Small" Dense="true" Icon="@Icons.Material.Filled.MoreVert">
-			<MudMenuItem Class="my-menu-item-1">Enlist</MudMenuItem>
-			<MudMenuItem Label="Barracks" />
-			<MudMenuItem Label="Armory" />
-		</MudMenu>
-	</TabPanelHeader>  
+    <ChildContent>
+        <MudTabPanel Text="Tab One">
+            <MudText class="my-text">Sexy Text</MudText>
+        </MudTabPanel>
+    </ChildContent>
+    <TabPanelHeader>
+        <MudMenu Size="Size.Small" Dense="true" Icon="@Icons.Material.Filled.MoreVert">
+            <MudMenuItem Class="my-menu-item-1">Enlist</MudMenuItem>
+            <MudMenuItem Label="Barracks" />
+            <MudMenuItem Label="Armory" />
+        </MudMenu>
+    </TabPanelHeader>
 </MudTabs>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithPrePanelContent.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tabs/TabsWithPrePanelContent.razor
@@ -1,20 +1,20 @@
 ﻿<MudPopoverProvider />
 
 <MudTabs @bind-ActivePanelIndex="SelectedIndex" Class="">
-	<ChildContent>
-		<MudTabPanel Text="Tab One">
-			<MudText class="my-text">Some Content</MudText>
-		</MudTabPanel>
-		<MudTabPanel Text="Tab Two">
-			<MudText class="my-text">Another content</MudText>
-		</MudTabPanel>
-	</ChildContent>
-	<PrePanelContent>
-		<MudText Class="pre-panel-content-custom">Selected: @context?.Text</MudText>
-	</PrePanelContent>
+    <ChildContent>
+        <MudTabPanel Text="Tab One">
+            <MudText class="my-text">Some Content</MudText>
+        </MudTabPanel>
+        <MudTabPanel Text="Tab Two">
+            <MudText class="my-text">Another content</MudText>
+        </MudTabPanel>
+    </ChildContent>
+    <PrePanelContent>
+        <MudText Class="pre-panel-content-custom">Selected: @context?.Text</MudText>
+    </PrePanelContent>
 </MudTabs>
 
 @code {
-	[Parameter]
-	public int SelectedIndex { get; set; }
+    [Parameter]
+    public int SelectedIndex { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/TimePicker/SimpleTimePickerTest.razor
@@ -1,38 +1,38 @@
 ﻿<MudPopoverProvider />
 
 <MudTimePicker @ref="_picker"
-			   @bind-Time="@Time"
-			   OpenTo="@OpenTo"
-			   AmPm="AmPm"
-			   TimeEditMode="TimeEditMode"
-			   MinuteSelectionStep="MinuteSelectionStep"
-			   ClosingDelay="ClosingDelay"
-			   InputId="@InputId" />
+               @bind-Time="@Time"
+               OpenTo="@OpenTo"
+               AmPm="AmPm"
+               TimeEditMode="TimeEditMode"
+               MinuteSelectionStep="MinuteSelectionStep"
+               ClosingDelay="ClosingDelay"
+               InputId="@InputId" />
 
 @code {
-	private MudTimePicker _picker = null!;
+    private MudTimePicker _picker = null!;
 
-	[Parameter]
+    [Parameter]
     public OpenTo OpenTo { get; set; } = OpenTo.Hours;
 
-	[Parameter]
+    [Parameter]
     public TimeEditMode TimeEditMode { get; set; } = TimeEditMode.Normal;
 
-	[Parameter]
+    [Parameter]
     public TimeSpan? Time { get; set; }
 
-	[Parameter]
+    [Parameter]
     public bool AmPm { get; set; }
 
-	[Parameter]
+    [Parameter]
     public int MinuteSelectionStep { get; set; } = 1;
 
-	// Mirrors MudTimePicker.ClosingDelay; tests set 0 to remove the post-commit close timer.
-	[Parameter]
+    // Mirrors MudTimePicker.ClosingDelay; tests set 0 to remove the post-commit close timer.
+    [Parameter]
     public int ClosingDelay { get; set; } = 200;
 
-	[Parameter]
-	public string? InputId { get; set; }
+    [Parameter]
+    public string? InputId { get; set; }
 
     public async Task Open() => await InvokeAsync(() => _picker.OpenAsync());
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipClickTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipClickTest.razor
@@ -5,7 +5,7 @@
 </MudTooltip>
 
 @code {
-	[Parameter]
+    [Parameter]
     public string? TooltipTextContent { get; set; }
 }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipContainerPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipContainerPropertyTest.razor
@@ -1,10 +1,10 @@
 ﻿<MudPopoverProvider />
 
 <MudTooltip Text="My TooltipContent" Inline="@Inline">
-	<MudButton>My Button</MudButton>
+    <MudButton>My Button</MudButton>
 </MudTooltip>
 
 @code {
-	[Parameter]
+    [Parameter]
     public bool Inline { get; set; } = true;
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipPlacementPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipPlacementPropertyTest.razor
@@ -1,22 +1,22 @@
 ﻿<MudPopoverProvider />
 
 <MudRTLProvider RightToLeft="@RightToLeft">
-	<MudTooltip Placement="@Placement">
-		<ChildContent>
-			<MudButton>My Button</MudButton>
-		</ChildContent>
-		<TooltipContent>
-			<div id="my-tooltip-content">
-				<p>Some Text</p>
-			</div>
-		</TooltipContent>
-	</MudTooltip>
+    <MudTooltip Placement="@Placement">
+        <ChildContent>
+            <MudButton>My Button</MudButton>
+        </ChildContent>
+        <TooltipContent>
+            <div id="my-tooltip-content">
+                <p>Some Text</p>
+            </div>
+        </TooltipContent>
+    </MudTooltip>
 </MudRTLProvider>
 
 @code {
-	[Parameter]
+    [Parameter]
     public Placement Placement { get; set; } = Placement.Bottom;
 
-	[Parameter]
+    [Parameter]
     public bool RightToLeft { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipPopoverClassPropertyTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipPopoverClassPropertyTest.razor
@@ -1,20 +1,20 @@
 ﻿<MudPopoverProvider />
 
 <MudTooltip Color="@Color" Arrow="@Arrow">
-	<ChildContent>
-		<MudButton>My Button</MudButton>
-	</ChildContent>
-	<TooltipContent>
-		<div id="my-tooltip-content">
-			<p>Some Text</p>
-		</div>
-	</TooltipContent>
+    <ChildContent>
+        <MudButton>My Button</MudButton>
+    </ChildContent>
+    <TooltipContent>
+        <div id="my-tooltip-content">
+            <p>Some Text</p>
+        </div>
+    </TooltipContent>
 </MudTooltip>
 
 @code {
-	[Parameter]
+    [Parameter]
     public Color Color { get; set; } = Color.Default;
 
-	[Parameter]
+    [Parameter]
     public bool Arrow { get; set; }
 }

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipVisiblePropTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipVisiblePropTest.razor
@@ -1,7 +1,7 @@
 ﻿<MudPopoverProvider />
 
 <MudTooltip Text="Visible Property" @bind-Visible="TooltipVisible">
-	<MudButton Variant="Variant.Filled" Color="Color.Secondary">My Button</MudButton>
+    <MudButton Variant="Variant.Filled" Color="Color.Secondary">My Button</MudButton>
 </MudTooltip>
 
 @code {

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithRenderFragmentContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithRenderFragmentContentTest.razor
@@ -1,12 +1,12 @@
 ﻿<MudPopoverProvider />
 
 <MudTooltip>
-	<ChildContent>
-	<MudButton id="sample-button">My Button</MudButton>
-	</ChildContent>
-	<TooltipContent>
-		<MudPaper Class="my-customer-paper">
-			<MudText >My content</MudText>
-		</MudPaper>
-	</TooltipContent>
+    <ChildContent>
+    <MudButton id="sample-button">My Button</MudButton>
+    </ChildContent>
+    <TooltipContent>
+        <MudPaper Class="my-customer-paper">
+            <MudText >My content</MudText>
+        </MudPaper>
+    </TooltipContent>
 </MudTooltip>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithTextTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Tooltip/TooltipWithTextTest.razor
@@ -1,14 +1,14 @@
 ﻿<MudPopoverProvider />
 
 <MudTooltip Text="@TooltipTextContent" Touch="@EnableTouch" Placement="Placement.Start">
-	<MudButton id="sample-button">My Button</MudButton>
+    <MudButton id="sample-button">My Button</MudButton>
 </MudTooltip>
 
 @code {
-	[Parameter]
+    [Parameter]
     public string? TooltipTextContent { get; set; }
 
-	[Parameter]
+    [Parameter]
     public bool EnableTouch { get; set; }
 }
 

--- a/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor
+++ b/src/MudBlazor/Components/BreakpointProvider/MudBreakpointProvider.razor
@@ -2,5 +2,5 @@
 @inherits MudComponentBase
 
 <CascadingValue Value="Breakpoint">
-	@ChildContent
+    @ChildContent
 </CascadingValue>

--- a/src/MudBlazor/Components/DropZone/MudDropContainer.razor
+++ b/src/MudBlazor/Components/DropZone/MudDropContainer.razor
@@ -3,9 +3,9 @@
 @typeparam T
 
 <CascadingValue Value="this" IsFixed="true">
-	<div @attributes="UserAttributes"
-		 style="@Style"
-		 class="@Classname">
-		@ChildContent
-	</div>
+    <div @attributes="UserAttributes"
+         style="@Style"
+         class="@Classname">
+        @ChildContent
+    </div>
 </CascadingValue>

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -4,36 +4,36 @@
 @typeparam T
 
 <div class="@Classname" style="@Style">
-	@if (ChildContent is not null)
-	{
-		<MudText Typo="Typo.body1">@ChildContent</MudText>
-	}
-	<div class="mud-slider-container">
-		@if (Variant == Variant.Filled)
-		{
-			<div class="mud-slider-inner-container">
-				<div class="mud-slider-filled" style="@($"width:{Width}%;")"></div>
-			</div>
-		}
-		@if (TickMarks)
-		{
-			<div class="mud-slider-inner-container">
-				<div class="mud-slider-tickmarks">
-					@for (int i = 0; i < _tickMarkCount; i++)
-					{
-						int current = i;
+    @if (ChildContent is not null)
+    {
+        <MudText Typo="Typo.body1">@ChildContent</MudText>
+    }
+    <div class="mud-slider-container">
+        @if (Variant == Variant.Filled)
+        {
+            <div class="mud-slider-inner-container">
+                <div class="mud-slider-filled" style="@($"width:{Width}%;")"></div>
+            </div>
+        }
+        @if (TickMarks)
+        {
+            <div class="mud-slider-inner-container">
+                <div class="mud-slider-tickmarks">
+                    @for (int i = 0; i < _tickMarkCount; i++)
+                    {
+                        int current = i;
 
-						<div class="d-flex flex-column relative">
-							<span class="mud-slider-track-tick" />
-							@if (TickMarkLabels != null && current < TickMarkLabels.Length)
-							{
-								<MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
-							}
-						</div>
-					}
-				</div>
-			</div>
-		}
+                        <div class="d-flex flex-column relative">
+                            <span class="mud-slider-track-tick" />
+                            @if (TickMarkLabels != null && current < TickMarkLabels.Length)
+                            {
+                                <MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+        }
         
         <input type="range" class="mud-slider-input" min="@Min.ToString(null, CultureInfo.InvariantCulture)" max="@Max.ToString(null, CultureInfo.InvariantCulture)" step="@Step.ToString(null, CultureInfo.InvariantCulture)" @attributes="UserAttributes" disabled="@Disabled"
                @bind-value:get="@GetValueText" @bind-value:set="@SetValueTextAsync" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
@@ -50,6 +50,6 @@
                 }
             </div>
         }
-	</div>
+    </div>
 
 </div>

--- a/src/MudBlazor/Components/Table/MudTFootRow.razor
+++ b/src/MudBlazor/Components/Table/MudTFootRow.razor
@@ -3,11 +3,11 @@
 @inherits MudComponentBase
 
 <tr class="@Classname" @onclick="@OnRowClick" style="@Style" @attributes="@UserAttributes">
-	@if (Context.DisplayApplyButtonAtStart(IgnoreEditable) || Context.DisplayEditButtonAtStart(IgnoreEditable))
-	{
-		<MudTh />
-	}
-	@if (Expandable || ((Context?.Table?.MultiSelection ?? false) && !IgnoreCheckbox))
+    @if (Context.DisplayApplyButtonAtStart(IgnoreEditable) || Context.DisplayEditButtonAtStart(IgnoreEditable))
+    {
+        <MudTh />
+    }
+    @if (Expandable || ((Context?.Table?.MultiSelection ?? false) && !IgnoreCheckbox))
     {
         <MudTd>
             @if (Expandable)
@@ -23,6 +23,6 @@
     @ChildContent
     @if (Context.DisplayApplyButtonAtEnd(IgnoreEditable) || Context.DisplayEditButtonAtEnd(IgnoreEditable))
     {
-		<MudTh />
-	}
+        <MudTh />
+    }
 </tr>

--- a/src/MudBlazor/Components/Table/MudTHeadRow.razor
+++ b/src/MudBlazor/Components/Table/MudTHeadRow.razor
@@ -5,26 +5,26 @@
 @inject InternalMudLocalizer Localizer
 
 <tr class="@Classname" @onclick="@OnRowClick" style="@Style" @attributes="@UserAttributes">
-	@if (Context.DisplayApplyButtonAtStart(IgnoreEditable) || Context.DisplayEditButtonAtStart(IgnoreEditable))
-	{
-		<MudTh />
-	}
-	@if (Expandable || ((Context?.Table?.MultiSelection ?? false) && !IgnoreCheckbox))
-	{
-		<MudTh>
-			@if (Expandable)
-			{
-				<div class="ml-4 mr-5"></div>
-			}
-			@if (Checkable)
-			{
-				<MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" Class="mud-table-cell-checkbox" AriaLabel="@Localizer[LanguageResource.MudTable_SelectAllRows]" />
-			}
-		</MudTh>
-	}
-	@ChildContent
-	@if (Context.DisplayApplyButtonAtEnd(IgnoreEditable) || Context.DisplayEditButtonAtEnd(IgnoreEditable))
-	{
-		<MudTh />
-	}
+    @if (Context.DisplayApplyButtonAtStart(IgnoreEditable) || Context.DisplayEditButtonAtStart(IgnoreEditable))
+    {
+        <MudTh />
+    }
+    @if (Expandable || ((Context?.Table?.MultiSelection ?? false) && !IgnoreCheckbox))
+    {
+        <MudTh>
+            @if (Expandable)
+            {
+                <div class="ml-4 mr-5"></div>
+            }
+            @if (Checkable)
+            {
+                <MudCheckBox @bind-Value="Checked" ReadOnly="!SelectionChangeable" Disabled="!SelectionChangeable" Class="mud-table-cell-checkbox" AriaLabel="@Localizer[LanguageResource.MudTable_SelectAllRows]" />
+            }
+        </MudTh>
+    }
+    @ChildContent
+    @if (Context.DisplayApplyButtonAtEnd(IgnoreEditable) || Context.DisplayEditButtonAtEnd(IgnoreEditable))
+    {
+        <MudTh />
+    }
 </tr>


### PR DESCRIPTION
Mechanical cleanup, done by script: replaced every tab with four spaces in every `.razor` file and stripped the trailing whitespace that left on those lines (64 files). No semantic changes. `git diff --check` is clean and the Docs and UnitTests projects build.
