### PR TITLE
MudPagination: Render list element directly

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -1,4 +1,5 @@
 ﻿using AngleSharp.Dom;
+using System.Collections.Generic;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
@@ -387,6 +388,42 @@ namespace MudBlazor.UnitTests.Components
             var ellipses = comp.FindAll("li").Where(li => li.TextContent.Trim() == "…").ToList();
             ellipses.Should().NotBeEmpty();
             ellipses.Should().OnlyContain(li => li.FirstElementChild!.GetAttribute("aria-hidden") == "true");
+        }
+
+        /// <summary>
+        /// The pagination renders its list element itself rather than through a MudElement.
+        /// </summary>
+        [Test]
+        public void Pagination_RendersRootElementDirectly()
+        {
+            var comp = Context.Render<MudPagination>(parameters => parameters.Add(x => x.Count, 5));
+
+            comp.FindComponents<MudElement>().Should().BeEmpty();
+            // Five pages plus the previous and next buttons.
+            comp.Find("ul.mud-pagination").QuerySelectorAll("li.mud-pagination-item").Length.Should().Be(7);
+        }
+
+        /// <summary>
+        /// UserAttributes are forwarded to the list element, and the computed class and style keep winning over a class or style supplied there, as they did through the MudElement boundary.
+        /// </summary>
+        [Test]
+        public void Pagination_UserAttributes_ForwardedWithComputedClassAndStyleWinning()
+        {
+            var comp = Context.Render<MudPagination>(parameters => parameters
+                .Add(x => x.Count, 5)
+                .Add(x => x.Class, "own-class")
+                .Add(x => x.Style, "color:blue")
+                .Add(x => x.UserAttributes, new Dictionary<string, object>
+                {
+                    ["class"] = "user-class",
+                    ["style"] = "color:red",
+                    ["data-test"] = "pager",
+                }));
+
+            var root = comp.Find("ul");
+            root.GetAttribute("data-test").Should().Be("pager");
+            root.ClassList.Should().Contain("mud-pagination").And.Contain("own-class").And.NotContain("user-class");
+            root.GetAttribute("style").Should().Be("color:blue");
         }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -1,5 +1,5 @@
-﻿using AngleSharp.Dom;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using AngleSharp.Dom;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor/Components/Pagination/MudPagination.razor
+++ b/src/MudBlazor/Components/Pagination/MudPagination.razor
@@ -3,7 +3,7 @@
 @inherits MudComponentBase
 @inject InternalMudLocalizer Localizer
 
-<MudElement HtmlTag="ul" Class="@Classname" Style="@Style" Tag="@Tag" UserAttributes="@UserAttributes">
+<ul @attributes="UserAttributes" class="@Classname" style="@Style">
     @if (ShowFirstButton)
     {
         <li class="@ItemClassname">
@@ -53,4 +53,4 @@
             <MudIconButton Icon="@LastIcon" Variant="@Variant" Size="@Size" Disabled="@(_selectedState.Value == _countState.Value || Disabled)" OnClick="@(() => OnClickControlButtonAsync(Page.Last))" aria-label="@Localizer[LanguageResource.MudPagination_LastPage]"></MudIconButton>
         </li>
     }
-</MudElement>
+</ul>


### PR DESCRIPTION
MudPagination rendered its `ul` through a MudElement with a constant tag, one extra component for nothing. The `ul` is now literal markup in the same attribute order MudElement emitted, so precedence is unchanged; two tests pin it. The unused `Tag` pass-through goes with the wrapper.

Retained managed memory after mount, bUnit renderer, median of 5, this branch against its base:

| scenario | retained | components |
| --- | --- | --- |
| 50 paginations, 10 pages | 5149 -> 4618 KB (-10%) | 750 -> 700 |

One component per pagination, so the memory figure sits near this instrument's noise floor; the component count is the reliable number. Last wrapper in the family. Merged independently of the stack that starts at #13800; context in #13817. Part of #13737, ships in v9.10.0.
