### PR TITLE
Tests: Remove MudPagination test that depended on the component tree

### DIFF
--- a/src/MudBlazor.UnitTests/Components/PaginationTests.cs
+++ b/src/MudBlazor.UnitTests/Components/PaginationTests.cs
@@ -391,19 +391,6 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// The pagination renders its list element itself rather than through a MudElement.
-        /// </summary>
-        [Test]
-        public void Pagination_RendersRootElementDirectly()
-        {
-            var comp = Context.Render<MudPagination>(parameters => parameters.Add(x => x.Count, 5));
-
-            comp.FindComponents<MudElement>().Should().BeEmpty();
-            // Five pages plus the previous and next buttons.
-            comp.Find("ul.mud-pagination").QuerySelectorAll("li.mud-pagination-item").Length.Should().Be(7);
-        }
-
-        /// <summary>
         /// UserAttributes are forwarded to the list element, and the computed class and style keep winning over a class or style supplied there, as they did through the MudElement boundary.
         /// </summary>
         [Test]


### PR DESCRIPTION
`dev` fails on `Pagination_RendersRootElementDirectly` since #13816 merged. The test asserted that the whole pagination subtree contains no MudElement, but the page buttons inside it are MudIconButton and MudButton, which still wrap one until #13800 merges.

The PR's CI passed because it ran while the PR was still stacked on the chip branch, whose merge ref includes #13800. The base was changed to `dev` seconds later, which does not trigger a new run, and the merge happened before any run against `dev` existed.

The test is removed. It asserted on the component tree rather than on behaviour, so it coupled the pagination to the internals of its children. The remaining pagination test pins the attribute precedence and the forwarded user attributes, which is what the change actually needs.
