### PR TITLE
MudAutocomplete: Add OuterClass parameter

### DIFF
--- a/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
+++ b/src/MudBlazor.UnitTests/Components/AutocompleteTests.cs
@@ -2661,6 +2661,21 @@ namespace MudBlazor.UnitTests.Components
         }
 
         [Test]
+        public void Should_Render_OuterClasses_Correctly()
+        {
+            // Arrange
+            var outerClass = "custom-outer-class";
+
+            // Act
+            var comp = Context.Render<MudAutocomplete<string>>(parameters => parameters
+                .Add(p => p.OuterClass, outerClass)
+            );
+
+            // Assert
+            comp.Find(".mud-autocomplete").ClassList.Should().Contain(outerClass);
+        }
+
+        [Test]
         public async Task Should_Select_Correct_Item_With_ArrowKeys_And_Not_Wrap_Around()
         {
             var selectedItemIndexPropertyInfo = typeof(MudAutocomplete<string>).GetField("_selectedListItemIndex", BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new ArgumentException("Cannot find field named '_selectedListItemIndex' on type 'MudAutocomplete<T>'");

--- a/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
+++ b/src/MudBlazor/Components/Autocomplete/MudAutocomplete.razor.cs
@@ -61,6 +61,7 @@ namespace MudBlazor
                 .AddClass("mud-autocomplete")
                 .AddClass("mud-width-full", FullWidth)
                 .AddClass("mud-autocomplete--with-progress", ShowProgressIndicator && IsLoading)
+                .AddClass(OuterClass)
                 .Build();
 
         protected string CircularProgressClassname =>
@@ -74,6 +75,15 @@ namespace MudBlazor
                 .AddClass(ListItemClass)
                 .Build();
 
+        /// <summary>
+        /// The CSS classes applied to the outer <c>div</c>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.  Multiple classes must be separated by spaces.
+        /// </remarks>
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        [Parameter]
+        public string? OuterClass { get; set; }
         /// <summary>
         /// Input's classnames, separated by space.
         /// </summary>


### PR DESCRIPTION
Adds an `OuterClass` Parameter to `MudAutocomplete` which allows for applying custom CSS classes to the outer-most tag of the component as is the case with `MudSelect`.