### PR TITLE
RegexMask: Add ZIP code, MAC address, GUID, hex color, 24-hour presets

### DIFF
--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskGuidExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskGuidExample.razor
@@ -1,0 +1,17 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid Class="justify-space-between" Style="max-width: 800px;">
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@guidMask" Label="Identifier" HelperText="@guidMask.Mask"
+                      @bind-Value="identifier" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        Identifier: <b>@identifier</b>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public string identifier;
+    public IMask guidMask = RegexMask.Guid();
+}

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskHexColorExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskHexColorExample.razor
@@ -1,0 +1,18 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid Class="justify-space-between" Style="max-width: 800px;">
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@hexColorMask" Label="Color" HelperText="@hexColorMask.Mask"
+                      @bind-Value="hexColor" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6" Class="d-flex align-center">
+        Color: <b class="ml-1">@hexColor</b>
+        <MudPaper Class="ml-2" Elevation="0" Style="@($"width: 24px; height: 24px; background: {hexColor};")" />
+    </MudItem>
+</MudGrid>
+
+@code {
+    public string hexColor = "#594AE2";
+    public IMask hexColorMask = RegexMask.HexColor();
+}

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskMacAddressExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskMacAddressExample.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid Class="justify-space-between" Style="max-width: 800px;">
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@macAddressMask" Label="MAC Address" HelperText="@macAddressMask.Mask"
+                      @bind-Value="macAddress" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@macAddressDashMask" Label="MAC Address with Dashes" HelperText="@macAddressDashMask.Mask"
+                      @bind-Value="macAddressDash" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        MAC: <b>@macAddress</b>
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        MAC w/Dashes: <b>@macAddressDash</b>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public string macAddress;
+    public string macAddressDash;
+    public IMask macAddressMask = RegexMask.MacAddress();
+    public IMask macAddressDashMask = RegexMask.MacAddress(separator: '-');
+}

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskTime24Example.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskTime24Example.razor
@@ -1,0 +1,26 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid Class="justify-space-between" Style="max-width: 800px;">
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@timeMask" Label="Time" HelperText="@timeMask.Mask"
+                      @bind-Value="time" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@timeWithSecondsMask" Label="Time with Seconds" HelperText="@timeWithSecondsMask.Mask"
+                      @bind-Value="timeWithSeconds" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        Time: <b>@time</b>
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        Time w/Seconds: <b>@timeWithSeconds</b>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public string time;
+    public string timeWithSeconds;
+    public IMask timeMask = RegexMask.Time24();
+    public IMask timeWithSecondsMask = RegexMask.Time24(includeSeconds: true);
+}

--- a/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskUsZipCodeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/Examples/RegexMaskUsZipCodeExample.razor
@@ -1,0 +1,17 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+
+<MudGrid Class="justify-space-between" Style="max-width: 800px;">
+    <MudItem xs="12" sm="6">
+        <MudTextField Mask="@zipCodeMask" Label="ZIP Code" HelperText="@zipCodeMask.Mask"
+                      @bind-Value="zipCode" Variant="@Variant.Text" Clearable />
+    </MudItem>
+    <MudItem xs="12" sm="6">
+        ZIP Code: <b>@zipCode</b>
+    </MudItem>
+</MudGrid>
+
+@code {
+    public string zipCode;
+    public IMask zipCodeMask = RegexMask.UsZipCode();
+}

--- a/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Masking/MaskingPage.razor
@@ -148,6 +148,64 @@
                         <RegexMaskEmailExample />
                     </SectionContent>
                 </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="RegexMask.UsZipCode">
+                        <Description>
+                            <CodeInline>RegexMask.UsZipCode()</CodeInline> is a predefined <CodeInline>RegexMask</CodeInline> for a <b>United States ZIP code</b>,
+                            with an optional four-digit extension. The dash is inserted for you as soon as a sixth digit is typed.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(RegexMaskUsZipCodeExample)" ShowCode="false">
+                        <RegexMaskUsZipCodeExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="RegexMask.MacAddress">
+                        <Description>
+                            <CodeInline>RegexMask.MacAddress()</CodeInline> is a predefined <CodeInline>RegexMask</CodeInline> for a <b>MAC address</b> (EUI-48).
+                            Pass <CodeInline>separator</CodeInline> to use a character other than the default colon, as the second field below does.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(RegexMaskMacAddressExample)" ShowCode="false">
+                        <RegexMaskMacAddressExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="RegexMask.Guid">
+                        <Description>
+                            <CodeInline>RegexMask.Guid()</CodeInline> is a predefined <CodeInline>RegexMask</CodeInline> for the canonical 8-4-4-4-12 form of a
+                            <b>globally unique identifier</b>, in upper or lower case. The dashes are inserted for you, so you can paste or type the digits alone.
+                            The braced <CodeInline>{...}</CodeInline> form is not accepted.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(RegexMaskGuidExample)" ShowCode="false">
+                        <RegexMaskGuidExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="RegexMask.HexColor">
+                        <Description>
+                            <CodeInline>RegexMask.HexColor()</CodeInline> is a predefined <CodeInline>RegexMask</CodeInline> for a <b>hexadecimal color</b>.
+                            The leading <CodeInline>#</CodeInline> is inserted for you, and up to eight digits are accepted so the CSS
+                            <CodeInline>#RGB</CodeInline>, <CodeInline>#RGBA</CodeInline>, <CodeInline>#RRGGBB</CodeInline>, and <CodeInline>#RRGGBBAA</CodeInline> forms all fit.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(RegexMaskHexColorExample)" ShowCode="false">
+                        <RegexMaskHexColorExample />
+                    </SectionContent>
+                </DocsPageSection>
+                <DocsPageSection>
+                    <SectionHeader Title="RegexMask.Time24">
+                        <Description>
+                            <CodeInline>RegexMask.Time24()</CodeInline> is a predefined <CodeInline>RegexMask</CodeInline> for a <b>time on a 24-hour clock</b>.
+                            Hours are limited to 23 and minutes to 59, and the colon is inserted for you. Pass <CodeInline>includeSeconds</CodeInline> to accept a
+                            third field, as the second field below does. For a calendar date, use <CodeInline>DateMask</CodeInline> instead.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent FullWidth="true" Outlined="true" Code="@nameof(RegexMaskTime24Example)" ShowCode="false">
+                        <RegexMaskTime24Example />
+                    </SectionContent>
+                </DocsPageSection>
             </SectionSubGroups>
         </DocsPageSection>
         

--- a/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskGuidTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskGuidTests.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities.Mask;
+
+[TestFixture]
+public class RegexMaskGuidTests
+{
+    /// <summary>
+    /// Types each character of an input separately and returns the mask text after every keystroke.
+    /// </summary>
+    /// <param name="mask">The mask to type into.</param>
+    /// <param name="input">The characters to type, one at a time.</param>
+    /// <returns>One entry per typed character, holding the mask text at that point.</returns>
+    private static List<string> TypeOneByOne(RegexMask mask, string input)
+    {
+        var states = new List<string>();
+        foreach (var c in input)
+        {
+            mask.Insert(c.ToString());
+            states.Add(mask.Text);
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// The identifier mask shows the 8-4-4-4-12 structure and honors a custom mask character.
+    /// </summary>
+    [Test]
+    public void Guid_Mask()
+    {
+        var mask = RegexMask.Guid();
+        mask.Mask.Should().Be("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+        mask.ToString().Should().Be("|");
+        mask.Insert("2f9d8e7a1b3c4d5e6f708192a3b4c5d6");
+        mask.Mask.Should().Be("XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+        mask = RegexMask.Guid(maskChar: '_');
+        mask.Mask.Should().Be("________-____-____-____-____________");
+    }
+
+    /// <summary>
+    /// Every intermediate state while typing a full identifier is accepted and the dashes appear on their own.
+    /// </summary>
+    [Test]
+    public void Guid_AcceptsEveryTypedPrefix()
+    {
+        var mask = RegexMask.Guid();
+        TypeOneByOne(mask, "2f9d8e7a1b3c4d5e6f708192a3b4c5d6").Should().Equal(
+            "2",
+            "2f",
+            "2f9",
+            "2f9d",
+            "2f9d8",
+            "2f9d8e",
+            "2f9d8e7",
+            "2f9d8e7a",
+            "2f9d8e7a-1",
+            "2f9d8e7a-1b",
+            "2f9d8e7a-1b3",
+            "2f9d8e7a-1b3c",
+            "2f9d8e7a-1b3c-4",
+            "2f9d8e7a-1b3c-4d",
+            "2f9d8e7a-1b3c-4d5",
+            "2f9d8e7a-1b3c-4d5e",
+            "2f9d8e7a-1b3c-4d5e-6",
+            "2f9d8e7a-1b3c-4d5e-6f",
+            "2f9d8e7a-1b3c-4d5e-6f7",
+            "2f9d8e7a-1b3c-4d5e-6f70",
+            "2f9d8e7a-1b3c-4d5e-6f70-8",
+            "2f9d8e7a-1b3c-4d5e-6f70-81",
+            "2f9d8e7a-1b3c-4d5e-6f70-819",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3b",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3b4",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d",
+            "2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6");
+    }
+
+    /// <summary>
+    /// Dashes typed by the user at the block boundaries are kept instead of being inserted twice.
+    /// </summary>
+    [Test]
+    public void Guid_AcceptsTypedDashes()
+    {
+        var mask = RegexMask.Guid();
+        mask.Insert("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6");
+        mask.ToString().Should().Be("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6|");
+    }
+
+    /// <summary>
+    /// Uppercase hexadecimal digits are accepted as typed.
+    /// </summary>
+    [Test]
+    public void Guid_AcceptsUppercaseHexDigits()
+    {
+        var mask = RegexMask.Guid();
+        mask.Insert("2F9D8E7A1B3C4D5E6F708192A3B4C5D6");
+        mask.ToString().Should().Be("2F9D8E7A-1B3C-4D5E-6F70-8192A3B4C5D6|");
+    }
+
+    /// <summary>
+    /// A dash is only accepted once the block before it is complete.
+    /// </summary>
+    [Test]
+    public void Guid_IgnoresDashBeforeBlockIsComplete()
+    {
+        var mask = RegexMask.Guid();
+        mask.Insert("-");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("1-2");
+        mask.Text.Should().Be("12");
+        mask.Clear();
+        mask.Insert("2f9d8e7a-1b3-c");
+        mask.Text.Should().Be("2f9d8e7a-1b3c");
+    }
+
+    /// <summary>
+    /// Characters outside the hexadecimal range are rejected.
+    /// </summary>
+    [Test]
+    public void Guid_IgnoresNonHexCharacters()
+    {
+        var mask = RegexMask.Guid();
+        mask.Insert("1g2z3");
+        mask.Text.Should().Be("123");
+        mask.Clear();
+        mask.Insert("xyz");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("2f9d8e7a1b3c4d5e6f708192a3b4c5d6\n");
+        mask.Text.Should().Be("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6");
+        mask.Text.IndexOf('\n').Should().Be(-1);
+    }
+
+    /// <summary>
+    /// Digits typed beyond the thirty-two hexadecimal digits are discarded.
+    /// </summary>
+    [Test]
+    public void Guid_IgnoresInputBeyondCanonicalLength()
+    {
+        var mask = RegexMask.Guid();
+        mask.Insert("2f9d8e7a1b3c4d5e6f708192a3b4c5d6ffff");
+        mask.ToString().Should().Be("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6|");
+    }
+
+    /// <summary>
+    /// The braced form is not accepted and its braces are discarded.
+    /// </summary>
+    [Test]
+    public void Guid_IgnoresBraces()
+    {
+        var mask = RegexMask.Guid();
+        mask.Insert("{2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6}");
+        mask.Text.Should().Be("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6");
+    }
+
+    /// <summary>
+    /// Backspace removes the character before the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void Guid_Backspace()
+    {
+        var mask = RegexMask.Guid();
+        mask.SetText("2f9d8e7a1b3c4d5e6f708192a3b4c5d6");
+        mask.Text.Should().Be("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6");
+        mask.CaretPos = 36;
+        mask.Backspace();
+        mask.ToString().Should().Be("2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d|");
+        mask.Clear();
+        mask.SetText("2f9d8e7a1b3c4d5e6f708192a3b4c5d6");
+        mask.CaretPos = 9;
+        mask.Backspace();
+        mask.ToString().Should().Be("2f9d8e7|1-b3c4-d5e6-f708-192a3b4c5d6");
+    }
+
+    /// <summary>
+    /// Delete removes the character after the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void Guid_Delete()
+    {
+        var mask = RegexMask.Guid();
+        mask.SetText("2f9d8e7a1b3c4d5e6f708192a3b4c5d6");
+        mask.CaretPos = 0;
+        mask.Delete();
+        mask.ToString().Should().Be("|f9d8e7a1-b3c4-d5e6-f708-192a3b4c5d6");
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskHexColorTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskHexColorTests.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities.Mask;
+
+[TestFixture]
+public class RegexMaskHexColorTests
+{
+    /// <summary>
+    /// Types each character of an input separately and returns the mask text after every keystroke.
+    /// </summary>
+    /// <param name="mask">The mask to type into.</param>
+    /// <param name="input">The characters to type, one at a time.</param>
+    /// <returns>One entry per typed character, holding the mask text at that point.</returns>
+    private static List<string> TypeOneByOne(RegexMask mask, string input)
+    {
+        var states = new List<string>();
+        foreach (var c in input)
+        {
+            mask.Insert(c.ToString());
+            states.Add(mask.Text);
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// The color mask shows the longest accepted form and honors a custom mask character.
+    /// </summary>
+    [Test]
+    public void HexColor_Mask()
+    {
+        var mask = RegexMask.HexColor();
+        mask.Mask.Should().Be("#XXXXXXXX");
+        mask.ToString().Should().Be("|");
+        mask.Insert("1A2B3C");
+        mask.Mask.Should().Be("#XXXXXXXX");
+        mask = RegexMask.HexColor(maskChar: '_');
+        mask.Mask.Should().Be("#________");
+    }
+
+    /// <summary>
+    /// The leading hash is inserted as soon as the first hexadecimal digit is typed.
+    /// </summary>
+    [Test]
+    public void HexColor_AcceptsEveryTypedPrefix()
+    {
+        var mask = RegexMask.HexColor();
+        TypeOneByOne(mask, "1A2B3C").Should().Equal(
+            "#1",
+            "#1A",
+            "#1A2",
+            "#1A2B",
+            "#1A2B3",
+            "#1A2B3C");
+    }
+
+    /// <summary>
+    /// A hash typed by the user is kept instead of being inserted twice.
+    /// </summary>
+    [Test]
+    public void HexColor_AcceptsTypedHash()
+    {
+        var mask = RegexMask.HexColor();
+        TypeOneByOne(mask, "#1A2B3C").Should().Equal(
+            "",
+            "#1",
+            "#1A",
+            "#1A2",
+            "#1A2B",
+            "#1A2B3",
+            "#1A2B3C");
+        mask.ToString().Should().Be("#1A2B3C|");
+        mask.Clear();
+        mask.Insert("##1A");
+        mask.Text.Should().Be("#1A");
+    }
+
+    /// <summary>
+    /// The three, four, six, and eight digit CSS forms are all accepted.
+    /// </summary>
+    [Test]
+    public void HexColor_AcceptsShorthandAndAlphaForms()
+    {
+        var mask = RegexMask.HexColor();
+        mask.Insert("abc");
+        mask.Text.Should().Be("#abc");
+        mask.Clear();
+        mask.Insert("abcd");
+        mask.Text.Should().Be("#abcd");
+        mask.Clear();
+        mask.Insert("1A2B3C");
+        mask.Text.Should().Be("#1A2B3C");
+        mask.Clear();
+        mask.Insert("1A2B3C4D");
+        mask.Text.Should().Be("#1A2B3C4D");
+    }
+
+    /// <summary>
+    /// Characters outside the hexadecimal range are rejected.
+    /// </summary>
+    [Test]
+    public void HexColor_IgnoresNonHexCharacters()
+    {
+        var mask = RegexMask.HexColor();
+        mask.Insert("1g2z3");
+        mask.Text.Should().Be("#123");
+        mask.Clear();
+        mask.Insert("xyz");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("1A2B3C\n");
+        mask.Text.Should().Be("#1A2B3C");
+        mask.Text.IndexOf('\n').Should().Be(-1);
+    }
+
+    /// <summary>
+    /// Text made up only of the hash is discarded.
+    /// </summary>
+    [Test]
+    public void HexColor_IgnoresHashOnlyInput()
+    {
+        var mask = RegexMask.HexColor();
+        mask.Insert("#");
+        mask.Text.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Digits typed beyond the eighth are discarded.
+    /// </summary>
+    [Test]
+    public void HexColor_IgnoresInputBeyondEightDigits()
+    {
+        var mask = RegexMask.HexColor();
+        mask.Insert("1A2B3C4D5E");
+        mask.ToString().Should().Be("#1A2B3C4D|");
+    }
+
+    /// <summary>
+    /// Backspace removes the character before the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void HexColor_Backspace()
+    {
+        var mask = RegexMask.HexColor();
+        mask.SetText("1A2B3C");
+        mask.Text.Should().Be("#1A2B3C");
+        mask.CaretPos = 7;
+        mask.Backspace();
+        mask.ToString().Should().Be("#1A2B3|");
+    }
+
+    /// <summary>
+    /// Delete removes the character after the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void HexColor_Delete()
+    {
+        var mask = RegexMask.HexColor();
+        mask.SetText("1A2B3C");
+        mask.CaretPos = 0;
+        mask.Delete();
+        mask.ToString().Should().Be("#|A2B3C");
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskMacAddressTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskMacAddressTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities.Mask;
+
+[TestFixture]
+public class RegexMaskMacAddressTests
+{
+    /// <summary>
+    /// Types each character of an input separately and returns the mask text after every keystroke.
+    /// </summary>
+    /// <param name="mask">The mask to type into.</param>
+    /// <param name="input">The characters to type, one at a time.</param>
+    /// <returns>One entry per typed character, holding the mask text at that point.</returns>
+    private static List<string> TypeOneByOne(RegexMask mask, string input)
+    {
+        var states = new List<string>();
+        foreach (var c in input)
+        {
+            mask.Insert(c.ToString());
+            states.Add(mask.Text);
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// The MAC address mask shows six pairs of digits and honors a custom mask character and separator.
+    /// </summary>
+    [Test]
+    public void MacAddress_Mask()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.Mask.Should().Be("XX:XX:XX:XX:XX:XX");
+        mask.ToString().Should().Be("|");
+        mask.Insert("1A2B3C4D5E6F");
+        mask.Mask.Should().Be("XX:XX:XX:XX:XX:XX");
+        mask = RegexMask.MacAddress(maskChar: '_');
+        mask.Mask.Should().Be("__:__:__:__:__:__");
+        mask = RegexMask.MacAddress(separator: '-');
+        mask.Mask.Should().Be("XX-XX-XX-XX-XX-XX");
+    }
+
+    /// <summary>
+    /// Every intermediate state while typing a full MAC address is accepted.
+    /// </summary>
+    [Test]
+    public void MacAddress_AcceptsEveryTypedPrefix()
+    {
+        var mask = RegexMask.MacAddress();
+        TypeOneByOne(mask, "1A2B3C4D5E6F").Should().Equal(
+            "1",
+            "1A",
+            "1A:2",
+            "1A:2B",
+            "1A:2B:3",
+            "1A:2B:3C",
+            "1A:2B:3C:4",
+            "1A:2B:3C:4D",
+            "1A:2B:3C:4D:5",
+            "1A:2B:3C:4D:5E",
+            "1A:2B:3C:4D:5E:6",
+            "1A:2B:3C:4D:5E:6F");
+    }
+
+    /// <summary>
+    /// A separator typed by the user is kept instead of being inserted twice.
+    /// </summary>
+    [Test]
+    public void MacAddress_AcceptsTypedSeparator()
+    {
+        var mask = RegexMask.MacAddress();
+        TypeOneByOne(mask, "1A:2B:3C:4D:5E:6F").Should().Equal(
+            "1",
+            "1A",
+            "1A:",
+            "1A:2",
+            "1A:2B",
+            "1A:2B:",
+            "1A:2B:3",
+            "1A:2B:3C",
+            "1A:2B:3C:",
+            "1A:2B:3C:4",
+            "1A:2B:3C:4D",
+            "1A:2B:3C:4D:",
+            "1A:2B:3C:4D:5",
+            "1A:2B:3C:4D:5E",
+            "1A:2B:3C:4D:5E:",
+            "1A:2B:3C:4D:5E:6",
+            "1A:2B:3C:4D:5E:6F");
+        mask.ToString().Should().Be("1A:2B:3C:4D:5E:6F|");
+    }
+
+    /// <summary>
+    /// Lowercase hexadecimal digits are accepted as typed.
+    /// </summary>
+    [Test]
+    public void MacAddress_AcceptsLowercaseHexDigits()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.Insert("aabbccddeeff");
+        mask.ToString().Should().Be("aa:bb:cc:dd:ee:ff|");
+    }
+
+    /// <summary>
+    /// Characters outside the hexadecimal range are rejected.
+    /// </summary>
+    [Test]
+    public void MacAddress_IgnoresNonHexCharacters()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.Insert("1G2H3Z");
+        mask.Text.Should().Be("12:3");
+        mask.Clear();
+        mask.Insert("xyz");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("1A2B3C4D5E6F\n");
+        mask.Text.Should().Be("1A:2B:3C:4D:5E:6F");
+        mask.Text.IndexOf('\n').Should().Be(-1);
+    }
+
+    /// <summary>
+    /// Text made up only of separators is discarded.
+    /// </summary>
+    [Test]
+    public void MacAddress_IgnoresSeparatorOnlyInput()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.Insert(":");
+        mask.Text.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Digits typed beyond the sixth pair are discarded.
+    /// </summary>
+    [Test]
+    public void MacAddress_IgnoresInputBeyondSixPairs()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.Insert("1A2B3C4D5E6F7A");
+        mask.ToString().Should().Be("1A:2B:3C:4D:5E:6F|");
+    }
+
+    /// <summary>
+    /// A custom separator is inserted automatically and the default separator is then rejected.
+    /// </summary>
+    [Test]
+    public void MacAddress_CustomSeparator()
+    {
+        var mask = RegexMask.MacAddress(separator: '-');
+        mask.Insert("1A2B3C4D5E6F");
+        mask.ToString().Should().Be("1A-2B-3C-4D-5E-6F|");
+        mask.Clear();
+        mask.Insert("1A:2B");
+        mask.Text.Should().Be("1A-2B");
+    }
+
+    /// <summary>
+    /// Backspace removes the character before the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void MacAddress_Backspace()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.SetText("1A2B3C");
+        mask.Text.Should().Be("1A:2B:3C");
+        mask.CaretPos = 8;
+        mask.Backspace();
+        mask.ToString().Should().Be("1A:2B:3|");
+    }
+
+    /// <summary>
+    /// Delete removes the character after the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void MacAddress_Delete()
+    {
+        var mask = RegexMask.MacAddress();
+        mask.SetText("1A2B3C");
+        mask.CaretPos = 0;
+        mask.Delete();
+        mask.ToString().Should().Be("|A:2B:3C");
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskTime24Tests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskTime24Tests.cs
@@ -1,0 +1,246 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities.Mask;
+
+[TestFixture]
+public class RegexMaskTime24Tests
+{
+    /// <summary>
+    /// Types each character of an input separately and returns the mask text after every keystroke.
+    /// </summary>
+    /// <param name="mask">The mask to type into.</param>
+    /// <param name="input">The characters to type, one at a time.</param>
+    /// <returns>One entry per typed character, holding the mask text at that point.</returns>
+    private static List<string> TypeOneByOne(RegexMask mask, string input)
+    {
+        var states = new List<string>();
+        foreach (var c in input)
+        {
+            mask.Insert(c.ToString());
+            states.Add(mask.Text);
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// The time mask shows hours and minutes, adds seconds on request, and honors a custom mask character.
+    /// </summary>
+    [Test]
+    public void Time24_Mask()
+    {
+        var mask = RegexMask.Time24();
+        mask.Mask.Should().Be("00:00");
+        mask.ToString().Should().Be("|");
+        mask.Insert("0730");
+        mask.Mask.Should().Be("00:00");
+        mask = RegexMask.Time24(maskChar: '_');
+        mask.Mask.Should().Be("__:__");
+        mask = RegexMask.Time24(includeSeconds: true);
+        mask.Mask.Should().Be("00:00:00");
+    }
+
+    /// <summary>
+    /// Every intermediate state while typing a time is accepted and the colon appears on its own.
+    /// </summary>
+    [Test]
+    public void Time24_AcceptsEveryTypedPrefix()
+    {
+        var mask = RegexMask.Time24();
+        TypeOneByOne(mask, "0730").Should().Equal(
+            "0",
+            "07",
+            "07:3",
+            "07:30");
+    }
+
+    /// <summary>
+    /// A colon typed by the user is kept instead of being inserted twice.
+    /// </summary>
+    [Test]
+    public void Time24_AcceptsTypedColon()
+    {
+        var mask = RegexMask.Time24();
+        TypeOneByOne(mask, "07:30").Should().Equal(
+            "0",
+            "07",
+            "07:",
+            "07:3",
+            "07:30");
+        mask.ToString().Should().Be("07:30|");
+    }
+
+    /// <summary>
+    /// The last valid time of the day is accepted.
+    /// </summary>
+    [Test]
+    public void Time24_AcceptsEndOfDay()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert("2359");
+        mask.ToString().Should().Be("23:59|");
+        mask.Clear();
+        mask.Insert("0000");
+        mask.ToString().Should().Be("00:00|");
+    }
+
+    /// <summary>
+    /// A single-digit hour is accepted and the colon is still inserted after it.
+    /// </summary>
+    [Test]
+    public void Time24_AcceptsSingleDigitHour()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert("930");
+        mask.ToString().Should().Be("9:30|");
+    }
+
+    /// <summary>
+    /// An hour above twenty-three is rejected, so the second digit starts the minutes instead.
+    /// </summary>
+    [Test]
+    public void Time24_RejectsHourAboveTwentyThree()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert("25");
+        mask.Text.Should().Be("2:5");
+        mask.Clear();
+        mask.Insert("2400");
+        mask.Text.Should().Be("2:40");
+    }
+
+    /// <summary>
+    /// A minute above fifty-nine is rejected instead of being reinterpreted.
+    /// </summary>
+    [Test]
+    public void Time24_RejectsMinuteAboveFiftyNine()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert("07:61");
+        mask.Text.Should().Be("07:1");
+        mask.Clear();
+        mask.Insert("0769");
+        mask.Text.Should().Be("07");
+    }
+
+    /// <summary>
+    /// Text made up only of colons is discarded.
+    /// </summary>
+    [Test]
+    public void Time24_IgnoresColonOnlyInput()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert(":");
+        mask.Text.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Characters other than digits and the colon are rejected.
+    /// </summary>
+    [Test]
+    public void Time24_IgnoresNonDigitCharacters()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert("0a7b3c0");
+        mask.Text.Should().Be("07:30");
+        mask.Clear();
+        mask.Insert("abc");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("0730\n");
+        mask.Text.Should().Be("07:30");
+        mask.Text.IndexOf('\n').Should().Be(-1);
+    }
+
+    /// <summary>
+    /// Digits typed beyond the minutes are discarded when seconds are not enabled.
+    /// </summary>
+    [Test]
+    public void Time24_IgnoresInputBeyondMinutes()
+    {
+        var mask = RegexMask.Time24();
+        mask.Insert("073045");
+        mask.ToString().Should().Be("07:30|");
+    }
+
+    /// <summary>
+    /// Every intermediate state while typing a time with seconds is accepted.
+    /// </summary>
+    [Test]
+    public void Time24_IncludeSecondsAcceptsEveryTypedPrefix()
+    {
+        var mask = RegexMask.Time24(includeSeconds: true);
+        TypeOneByOne(mask, "073045").Should().Equal(
+            "0",
+            "07",
+            "07:3",
+            "07:30",
+            "07:30:4",
+            "07:30:45");
+    }
+
+    /// <summary>
+    /// Colons typed by the user between all three fields are kept instead of being inserted twice.
+    /// </summary>
+    [Test]
+    public void Time24_IncludeSecondsAcceptsTypedColons()
+    {
+        var mask = RegexMask.Time24(includeSeconds: true);
+        mask.Insert("07:30:45");
+        mask.ToString().Should().Be("07:30:45|");
+        mask.Clear();
+        mask.Insert("235959");
+        mask.ToString().Should().Be("23:59:59|");
+    }
+
+    /// <summary>
+    /// A second above fifty-nine is rejected and digits beyond the seconds are discarded.
+    /// </summary>
+    [Test]
+    public void Time24_IncludeSecondsRejectsOutOfRangeInput()
+    {
+        var mask = RegexMask.Time24(includeSeconds: true);
+        mask.Insert("07306");
+        mask.Text.Should().Be("07:30");
+        mask.Clear();
+        mask.Insert("07304567");
+        mask.ToString().Should().Be("07:30:45|");
+    }
+
+    /// <summary>
+    /// Backspace removes the character before the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void Time24_Backspace()
+    {
+        var mask = RegexMask.Time24();
+        mask.SetText("0730");
+        mask.Text.Should().Be("07:30");
+        mask.CaretPos = 5;
+        mask.Backspace();
+        mask.ToString().Should().Be("07:3|");
+        mask.Clear();
+        mask.SetText("0730");
+        mask.CaretPos = 3;
+        mask.Backspace();
+        mask.ToString().Should().Be("0|3:0");
+    }
+
+    /// <summary>
+    /// Delete removes the character after the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void Time24_Delete()
+    {
+        var mask = RegexMask.Time24();
+        mask.SetText("0730");
+        mask.CaretPos = 0;
+        mask.Delete();
+        mask.ToString().Should().Be("|7:30");
+    }
+}

--- a/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskUsZipCodeTests.cs
+++ b/src/MudBlazor.UnitTests/Utilities/Mask/RegexMaskUsZipCodeTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Utilities.Mask;
+
+[TestFixture]
+public class RegexMaskUsZipCodeTests
+{
+    /// <summary>
+    /// Types each character of an input separately and returns the mask text after every keystroke.
+    /// </summary>
+    /// <param name="mask">The mask to type into.</param>
+    /// <param name="input">The characters to type, one at a time.</param>
+    /// <returns>One entry per typed character, holding the mask text at that point.</returns>
+    private static List<string> TypeOneByOne(RegexMask mask, string input)
+    {
+        var states = new List<string>();
+        foreach (var c in input)
+        {
+            mask.Insert(c.ToString());
+            states.Add(mask.Text);
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// The ZIP code mask shows the ZIP+4 structure and honors a custom mask character.
+    /// </summary>
+    [Test]
+    public void UsZipCode_Mask()
+    {
+        var mask = RegexMask.UsZipCode();
+        mask.Mask.Should().Be("00000-0000");
+        mask.ToString().Should().Be("|");
+        mask.Insert("902100123");
+        mask.Mask.Should().Be("00000-0000");
+        mask = RegexMask.UsZipCode(maskChar: '_');
+        mask.Mask.Should().Be("_____-____");
+    }
+
+    /// <summary>
+    /// Every intermediate state while typing a full ZIP+4 code is accepted.
+    /// </summary>
+    [Test]
+    public void UsZipCode_AcceptsEveryTypedPrefix()
+    {
+        var mask = RegexMask.UsZipCode();
+        TypeOneByOne(mask, "902100123").Should().Equal(
+            "9",
+            "90",
+            "902",
+            "9021",
+            "90210",
+            "90210-0",
+            "90210-01",
+            "90210-012",
+            "90210-0123");
+    }
+
+    /// <summary>
+    /// A dash typed by the user after five digits is kept instead of being inserted twice.
+    /// </summary>
+    [Test]
+    public void UsZipCode_AcceptsTypedDash()
+    {
+        var mask = RegexMask.UsZipCode();
+        TypeOneByOne(mask, "90210-0123").Should().Equal(
+            "9",
+            "90",
+            "902",
+            "9021",
+            "90210",
+            "90210-",
+            "90210-0",
+            "90210-01",
+            "90210-012",
+            "90210-0123");
+        mask.ToString().Should().Be("90210-0123|");
+    }
+
+    /// <summary>
+    /// A dash is only accepted once five digits have been typed.
+    /// </summary>
+    [Test]
+    public void UsZipCode_IgnoresDashBeforeFiveDigits()
+    {
+        var mask = RegexMask.UsZipCode();
+        mask.Insert("-");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("12-3");
+        mask.Text.Should().Be("123");
+    }
+
+    /// <summary>
+    /// Letters, whitespace, and punctuation other than the dash are rejected.
+    /// </summary>
+    [Test]
+    public void UsZipCode_IgnoresInvalidCharacters()
+    {
+        var mask = RegexMask.UsZipCode();
+        mask.Insert("9a0 2!1@0");
+        mask.Text.Should().Be("90210");
+        mask.Clear();
+        mask.Insert("abc");
+        mask.Text.Should().BeEmpty();
+        mask.Clear();
+        mask.Insert("90210\n");
+        mask.Text.Should().Be("90210");
+        mask.Text.IndexOf('\n').Should().Be(-1);
+    }
+
+    /// <summary>
+    /// Digits typed beyond the ZIP+4 length are discarded.
+    /// </summary>
+    [Test]
+    public void UsZipCode_IgnoresInputBeyondZipPlusFour()
+    {
+        var mask = RegexMask.UsZipCode();
+        mask.Insert("9021001234");
+        mask.ToString().Should().Be("90210-0123|");
+    }
+
+    /// <summary>
+    /// Backspace removes the character before the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void UsZipCode_Backspace()
+    {
+        var mask = RegexMask.UsZipCode();
+        mask.SetText("902100123");
+        mask.Text.Should().Be("90210-0123");
+        mask.CaretPos = 10;
+        mask.Backspace();
+        mask.ToString().Should().Be("90210-012|");
+        mask.Clear();
+        mask.SetText("902100123");
+        mask.CaretPos = 7;
+        mask.Backspace();
+        mask.ToString().Should().Be("90210-|123");
+    }
+
+    /// <summary>
+    /// Delete removes the character after the caret and keeps the remaining text aligned.
+    /// </summary>
+    [Test]
+    public void UsZipCode_Delete()
+    {
+        var mask = RegexMask.UsZipCode();
+        mask.SetText("902100123");
+        mask.CaretPos = 0;
+        mask.Delete();
+        mask.ToString().Should().Be("|02100-123");
+    }
+}

--- a/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
@@ -272,4 +272,40 @@ public class RegexMask : BaseMask
         var regexMask = new RegexMask(Regex, mask) { DelimiterCharacters = Delimiters };
         return regexMask;
     }
+
+    /// <summary>
+    /// Gets a mask for United States ZIP codes with an optional four-digit extension.
+    /// </summary>
+    /// <param name="maskChar">Defaults to <c>0</c>.  The mask character for ZIP code digits.</param>
+    /// <remarks>
+    /// Accepts a five-digit ZIP code such as <c>90210</c> and the ZIP+4 form such as <c>90210-0123</c>.  The dash is inserted automatically as soon as a sixth digit is typed.
+    /// </remarks>
+    public static RegexMask UsZipCode(char maskChar = '0')
+    {
+        const string Regex = $"^(?:[0-9]{{0,5}}|[0-9]{{5}}-[0-9]{{0,4}}){WhiteSpaceFilter}$";
+        const string Delimiters = "-";
+        var mask = $"{new string(maskChar, 5)}-{new string(maskChar, 4)}";
+        var regexMask = new RegexMask(Regex, mask) { DelimiterCharacters = Delimiters };
+        return regexMask;
+    }
+
+    /// <summary>
+    /// Gets a mask for MAC addresses (EUI-48) such as <c>1A:2B:3C:4D:5E:6F</c>.
+    /// </summary>
+    /// <param name="separator">Defaults to <c>:</c>.  The character between each pair of hexadecimal digits.</param>
+    /// <param name="maskChar">Defaults to <c>X</c>.  The mask character for address digits.</param>
+    /// <remarks>
+    /// The separator is inserted automatically when hexadecimal digits are typed without it.
+    /// </remarks>
+    public static RegexMask MacAddress(char separator = ':', char maskChar = 'X')
+    {
+        const string HexPair = "[0-9A-Fa-f]{0,2}";
+        var delimiters = separator.ToString();
+        // The separator comes from the caller, so it has to be escaped before it goes into the pattern.
+        var escapedSeparator = System.Text.RegularExpressions.Regex.Escape(delimiters);
+        var regex = $"^{HexPair}(?:{escapedSeparator}{HexPair}){{0,5}}{WhiteSpaceFilter}$";
+        var mask = string.Join(delimiters, Enumerable.Repeat(new string(maskChar, 2), 6));
+        var regexMask = new RegexMask(regex, mask) { DelimiterCharacters = delimiters };
+        return regexMask;
+    }
 }

--- a/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
+++ b/src/MudBlazor/Utilities/MaskAlgorithms/RegexMask.cs
@@ -308,4 +308,69 @@ public class RegexMask : BaseMask
         var regexMask = new RegexMask(regex, mask) { DelimiterCharacters = delimiters };
         return regexMask;
     }
+
+    /// <summary>
+    /// Gets a mask for globally unique identifiers such as <c>2f9d8e7a-1b3c-4d5e-6f70-8192a3b4c5d6</c>.
+    /// </summary>
+    /// <param name="maskChar">Defaults to <c>X</c>.  The mask character for identifier digits.</param>
+    /// <remarks>
+    /// Accepts the canonical 8-4-4-4-12 hexadecimal form in upper or lower case.  Dashes are inserted automatically when hexadecimal digits are typed without them.  The braced form <c>{...}</c> is not accepted.
+    /// </remarks>
+    public static RegexMask Guid(char maskChar = 'X')
+    {
+        const string Hex = "[0-9A-Fa-f]";
+        const string Delimiters = "-";
+        // The blocks nest from the last one outwards so a dash is only accepted once the block before it is complete.
+        var fifthBlock = $"{Hex}{{0,12}}";
+        var fourthBlock = $"(?:{Hex}{{0,3}}|{Hex}{{4}}(?:-{fifthBlock})?)";
+        var thirdBlock = $"(?:{Hex}{{0,3}}|{Hex}{{4}}(?:-{fourthBlock})?)";
+        var secondBlock = $"(?:{Hex}{{0,3}}|{Hex}{{4}}(?:-{thirdBlock})?)";
+        var firstBlock = $"(?:{Hex}{{0,7}}|{Hex}{{8}}(?:-{secondBlock})?)";
+        var regex = $"^{firstBlock}{WhiteSpaceFilter}$";
+        var mask = $"{new string(maskChar, 8)}-{new string(maskChar, 4)}-{new string(maskChar, 4)}-{new string(maskChar, 4)}-{new string(maskChar, 12)}";
+        var regexMask = new RegexMask(regex, mask) { DelimiterCharacters = Delimiters };
+        return regexMask;
+    }
+
+    /// <summary>
+    /// Gets a mask for hexadecimal colors such as <c>#1A2B3C</c>.
+    /// </summary>
+    /// <param name="maskChar">Defaults to <c>X</c>.  The mask character for color digits.</param>
+    /// <remarks>
+    /// The leading <c>#</c> is inserted automatically.  Up to eight hexadecimal digits are accepted, which covers the CSS <c>#RGB</c>, <c>#RGBA</c>, <c>#RRGGBB</c>, and <c>#RRGGBBAA</c> forms.
+    /// </remarks>
+    public static RegexMask HexColor(char maskChar = 'X')
+    {
+        const string Regex = $"^#[0-9A-Fa-f]{{0,8}}{WhiteSpaceFilter}$";
+        const string Delimiters = "#";
+        var mask = $"#{new string(maskChar, 8)}";
+        var regexMask = new RegexMask(Regex, mask) { DelimiterCharacters = Delimiters };
+        return regexMask;
+    }
+
+    /// <summary>
+    /// Gets a mask for times on a 24-hour clock such as <c>07:30</c>.
+    /// </summary>
+    /// <param name="includeSeconds">Defaults to <c>false</c>.  When <c>true</c>, seconds are allowed.</param>
+    /// <param name="maskChar">Defaults to <c>0</c>.  The mask character for time digits.</param>
+    /// <remarks>
+    /// Hours are limited to <c>0</c> through <c>23</c>, and minutes and seconds to <c>0</c> through <c>59</c>.  Colons are inserted automatically when digits are typed without them, so typing <c>2400</c> yields <c>2:40</c>.
+    /// </remarks>
+    public static RegexMask Time24(bool includeSeconds = false, char maskChar = '0')
+    {
+        const string Hour = "(?:[01][0-9]?|2[0-3]?|[3-9])";
+        const string Delimiters = ":";
+
+        // A lone tens digit is a valid prefix, and the following field is nested so it can only begin once this one holds a complete pair.
+        static string Field(string next) => $"(?::(?:[0-5]|[0-5][0-9]{next})?)?";
+
+        var seconds = includeSeconds ? Field(string.Empty) : string.Empty;
+        var regex = $"^{Hour}{Field(seconds)}{WhiteSpaceFilter}$";
+        var digitPair = new string(maskChar, 2);
+        var mask = includeSeconds
+            ? $"{digitPair}:{digitPair}:{digitPair}"
+            : $"{digitPair}:{digitPair}";
+        var regexMask = new RegexMask(regex, mask) { DelimiterCharacters = Delimiters };
+        return regexMask;
+    }
 }


### PR DESCRIPTION
Resolves #3937 by adding five `RegexMask` factories alongside the existing `IPv4`, `IPv6` and `Email`:

| Factory | Accepts | Mask |
| --- | --- | --- |
| `RegexMask.UsZipCode()` | `90210`, `90210-0123` | `00000-0000` |
| `RegexMask.MacAddress()` | `1A:2B:3C:4D:5E:6F`, separator configurable | `XX:XX:XX:XX:XX:XX` |
| `RegexMask.Guid()` | `0f8fad5b-d9cb-469f-a165-70867728950e` | `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX` |
| `RegexMask.HexColor()` | `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA` | `#XXXXXXXX` |
| `RegexMask.Time24()` | `09:30`, optional seconds | `00:00` |

A mask regex has to match every intermediate prefix, not just the finished value, or typing breaks partway through. The GUID and time patterns are therefore built by nesting each block inside the previous one, so a delimiter is only accepted once the block before it is complete.

Phone numbers and credit cards are deliberately not included. Phone formats are country-specific, which henon ruled out in the issue thread, and card numbers are not one shape: Amex is 15 digits grouped 4-6-5 and Diners is 14, so a single groups-of-four mask silently mis-groups them.

<img width="620" height="560" alt="image" src="https://github.com/user-attachments/assets/f8f25045-16f9-417d-8d05-3085248d7833" />
