### PR TITLE
Analyzers: Add migration hints for known removed Razor parameters

### DIFF
--- a/src/MudBlazor.Analyzers.TestComponents/DerivedMudButton.razor
+++ b/src/MudBlazor.Analyzers.TestComponents/DerivedMudButton.razor
@@ -1,0 +1,6 @@
+﻿@*derives from MudButton without reintroducing any removed parameter*@
+@inherits MudButton
+
+@{
+    base.BuildRenderTree(__builder);
+}

--- a/src/MudBlazor.Analyzers.TestComponents/MigrationHints.razor
+++ b/src/MudBlazor.Analyzers.TestComponents/MigrationHints.razor
@@ -1,0 +1,68 @@
+﻿@*removed in v7: Link moved to Href*@
+<MudButton Link="/removed-in-v7">Link</MudButton>
+
+@*removed in v7: DisableRipple moved to Ripple with the value inverted*@
+<MudButton DisableRipple="true">Literal true</MudButton>
+<MudButton DisableRipple="false">Literal false</MudButton>
+<MudButton DisableRipple="@_noRipple">Simple expression</MudButton>
+<MudButton DisableRipple="@(_noRipple && !_grow)">Complex expression</MudButton>
+
+@*multiline attributes with nested content*@
+<MudButton Variant="Variant.Filled"
+           Link="/multiline"
+           Color="Color.Primary">
+    <MudText>Nested content</MudText>
+</MudButton>
+
+@*removed in v9: AutoGrow moved to Sizing; @bind-Value forces a TypeInference helper*@
+<MudTextField @bind-Value="_text" AutoGrow="true" Label="Literal true" />
+<MudTextField @bind-Value="_text" AutoGrow="false" Label="Literal false" />
+<MudTextField T="string" AutoGrow="@_grow" Label="Simple expression" />
+<MudTextField T="string" AutoGrow="@(_grow || _noRipple)" Label="Complex expression" />
+
+@*the replacements themselves compile and stay silent*@
+<MudButton Href="/replacement" Ripple="false">Href and Ripple</MudButton>
+<MudButton Ripple="@(!_noRipple)">Inverted expression</MudButton>
+<MudTextField @bind-Value="_text" Sizing="InputSizing.Auto" Lines="3" MaxLines="8" Label="Auto" />
+<MudTextField T="string" Sizing="@(_grow ? InputSizing.Auto : InputSizing.Fixed)" Label="Conditional" />
+
+@*derived component without its own Link still points at MudButton's replacement*@
+<DerivedMudButton Link="/derived" />
+
+@*derived component that declares Link is a real parameter, so nothing is reported*@
+<ReintroducedLinkButton Link="/reintroduced" />
+
+@*a component that merely shares MudButton's short name gets no hint*@
+<MudBlazor.Analyzers.TestComponents.Shadow.MudButton Link="/shadow" />
+
+@*unrelated components that also dropped Link are outside this rule set*@
+<MudChip T="string" Link="/chip" />
+<MudIconButton Link="/icon-button" />
+
+@*similar names are ordinary typos, not migrations*@
+<MudButton Linked="/typo">Similar</MudButton>
+<MudButton DisableRippleEffect="true">Similar</MudButton>
+<MudTextField T="string" AutoGrowth="true" Label="Similar" />
+
+@*a dynamic attribute dictionary is invisible to the analyzer*@
+<MudButton @attributes="_splattedAttributes">Splat</MudButton>
+
+@*markup inside comments and strings is never analyzed*@
+@*<MudButton Link="/razor-comment" />*@
+<!-- <MudButton DisableRipple="true" /> -->
+<MudText>@MarkupSample</MudText>
+
+@code
+{
+    public static string __description__ = "Removed parameters that MUD0002 explains with a migration hint";
+
+    private const string MarkupSample = "<MudButton Link=\"/string-literal\" />";
+
+    private readonly Dictionary<string, object> _splattedAttributes = new() { ["Link"] = "/splatted" };
+
+    private string _text = "y";
+
+    private bool _noRipple = true;
+
+    private bool _grow = true;
+}

--- a/src/MudBlazor.Analyzers.TestComponents/ReintroducedLinkButton.razor
+++ b/src/MudBlazor.Analyzers.TestComponents/ReintroducedLinkButton.razor
@@ -1,0 +1,12 @@
+﻿@*derives from MudButton and legitimately declares its own Link parameter*@
+@inherits MudButton
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code
+{
+    [Parameter]
+    public string? Link { get; set; }
+}

--- a/src/MudBlazor.Analyzers.TestComponents/Shadow/MudButton.cs
+++ b/src/MudBlazor.Analyzers.TestComponents/Shadow/MudButton.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.Analyzers.TestComponents.Shadow
+{
+    /// <summary>
+    /// Shares its short name with <see cref="MudBlazor.MudButton"/> so the analyzer tests can prove that
+    /// migration hints are matched on the component's type identity, not on its display tag name.
+    /// </summary>
+    public class MudButton : MudComponentBase
+    {
+        [Parameter]
+        public RenderFragment? ChildContent { get; set; }
+    }
+}

--- a/src/MudBlazor.Analyzers.TestComponents/Shadow/MudButton.cs
+++ b/src/MudBlazor.Analyzers.TestComponents/Shadow/MudButton.cs
@@ -7,8 +7,7 @@ using Microsoft.AspNetCore.Components;
 namespace MudBlazor.Analyzers.TestComponents.Shadow
 {
     /// <summary>
-    /// Shares its short name with <see cref="MudBlazor.MudButton"/> so the analyzer tests can prove that
-    /// migration hints are matched on the component's type identity, not on its display tag name.
+    /// Shares its short name with <see cref="MudBlazor.MudButton"/> so the analyzer tests can prove that migration hints are matched on the component's type identity, not on its display tag name.
     /// </summary>
     public class MudButton : MudComponentBase
     {

--- a/src/MudBlazor.Analyzers/Internal/ComponentDescriptor.cs
+++ b/src/MudBlazor.Analyzers/Internal/ComponentDescriptor.cs
@@ -2,6 +2,8 @@
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+
 namespace MudBlazor.Analyzers.Internal;
 
 internal sealed class ComponentDescriptor
@@ -9,7 +11,13 @@ internal sealed class ComponentDescriptor
     internal string TagName { get; set; } = string.Empty;
     internal HashSet<string> Parameters { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-    internal static ComponentDescriptor GetComponentDescriptor(ITypeSymbol typeSymbol, INamedTypeSymbol? parameterSymbol)
+    /// <summary>
+    /// Replacement guidance for parameters an earlier major version removed from this component, keyed by
+    /// the removed parameter's name.
+    /// </summary>
+    internal Dictionary<string, LocalizableString> MigrationHints { get; } = new Dictionary<string, LocalizableString>(StringComparer.OrdinalIgnoreCase);
+
+    internal static ComponentDescriptor GetComponentDescriptor(ITypeSymbol typeSymbol, INamedTypeSymbol? parameterSymbol, ImmutableArray<ResolvedParameterMigration> migrations)
     {
         var descriptor = new ComponentDescriptor();
         var currentSymbol = typeSymbol as INamedTypeSymbol;
@@ -33,6 +41,13 @@ internal sealed class ComponentDescriptor
             }
 
             currentSymbol = currentSymbol.BaseType;
+        }
+
+        foreach (var migration in migrations)
+        {
+            // A component that still declares the old name owns it, so leave it alone.
+            if (migration.AppliesTo(typeSymbol) && !descriptor.Parameters.Contains(migration.ParameterName))
+                descriptor.MigrationHints[migration.ParameterName] = migration.Hint;
         }
 
         return descriptor;

--- a/src/MudBlazor.Analyzers/Internal/ComponentDescriptor.cs
+++ b/src/MudBlazor.Analyzers/Internal/ComponentDescriptor.cs
@@ -12,8 +12,7 @@ internal sealed class ComponentDescriptor
     internal HashSet<string> Parameters { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Replacement guidance for parameters an earlier major version removed from this component, keyed by
-    /// the removed parameter's name.
+    /// Replacement guidance for parameters an earlier major version removed from this component, keyed by the removed parameter's name.
     /// </summary>
     internal Dictionary<string, LocalizableString> MigrationHints { get; } = new Dictionary<string, LocalizableString>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/MudBlazor.Analyzers/Internal/ParameterMigration.cs
+++ b/src/MudBlazor.Analyzers/Internal/ParameterMigration.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace MudBlazor.Analyzers.Internal;
+
+/// <summary>
+/// A component parameter that an earlier MudBlazor major version removed, together with the guidance
+/// <c>MUD0002</c> appends when the old name still appears on the component that used to declare it.
+/// </summary>
+/// <remarks>
+/// This is a lookup table, not a migration tool.
+/// The analyzer never reads, evaluates, or rewrites the attribute's value; it only explains what the
+/// replacement parameter is so the reader does not have to search the migration guides.
+/// </remarks>
+internal sealed class ParameterMigration
+{
+    private ParameterMigration(string componentMetadataName, string parameterName, LocalizableString hint)
+    {
+        ComponentMetadataName = componentMetadataName;
+        ParameterName = parameterName;
+        Hint = hint;
+    }
+
+    /// <summary>
+    /// The fully qualified metadata name of the component that declared the removed parameter.
+    /// </summary>
+    /// <remarks>
+    /// Resolved through the compilation so the hint follows type identity rather than the display tag name,
+    /// which several unrelated components share.
+    /// </remarks>
+    internal string ComponentMetadataName { get; }
+
+    /// <summary>
+    /// The removed parameter's name, matched case-insensitively like the rest of MUD0002.
+    /// </summary>
+    internal string ParameterName { get; }
+
+    /// <summary>
+    /// The replacement guidance appended to the diagnostic message.
+    /// </summary>
+    internal LocalizableString Hint { get; }
+
+    /// <summary>
+    /// Every removed parameter MUD0002 can explain.
+    /// </summary>
+    /// <remarks>
+    /// Each entry is verified against the release that removed the parameter and against the guide it links
+    /// to, so keep the list short and add an entry only when both still hold.
+    /// </remarks>
+    internal static ImmutableArray<ParameterMigration> All { get; } = ImmutableArray.Create(
+        Create("MudBlazor.MudButton", "Link", nameof(Resources.MUD0002MigrationHintMudButtonLink)),
+        Create("MudBlazor.MudButton", "DisableRipple", nameof(Resources.MUD0002MigrationHintMudButtonDisableRipple)),
+        Create("MudBlazor.MudTextField`1", "AutoGrow", nameof(Resources.MUD0002MigrationHintMudTextFieldAutoGrow)));
+
+    private static ParameterMigration Create(string componentMetadataName, string parameterName, string resourceName) =>
+        new(componentMetadataName, parameterName, new LocalizableResourceString(resourceName, Resources.ResourceManager, typeof(Resources)));
+}

--- a/src/MudBlazor.Analyzers/Internal/ParameterMigration.cs
+++ b/src/MudBlazor.Analyzers/Internal/ParameterMigration.cs
@@ -7,13 +7,11 @@ using System.Collections.Immutable;
 namespace MudBlazor.Analyzers.Internal;
 
 /// <summary>
-/// A component parameter that an earlier MudBlazor major version removed, together with the guidance
-/// <c>MUD0002</c> appends when the old name still appears on the component that used to declare it.
+/// A component parameter that an earlier MudBlazor major version removed, together with the guidance <c>MUD0002</c> appends when the old name still appears on the component that used to declare it.
 /// </summary>
 /// <remarks>
 /// This is a lookup table, not a migration tool.
-/// The analyzer never reads, evaluates, or rewrites the attribute's value; it only explains what the
-/// replacement parameter is so the reader does not have to search the migration guides.
+/// The analyzer never reads, evaluates, or rewrites the attribute's value; it only explains what the replacement parameter is so the reader does not have to search the migration guides.
 /// </remarks>
 internal sealed class ParameterMigration
 {
@@ -28,8 +26,7 @@ internal sealed class ParameterMigration
     /// The fully qualified metadata name of the component that declared the removed parameter.
     /// </summary>
     /// <remarks>
-    /// Resolved through the compilation so the hint follows type identity rather than the display tag name,
-    /// which several unrelated components share.
+    /// Resolved through the compilation so the hint follows type identity rather than the display tag name, which several unrelated components share.
     /// </remarks>
     internal string ComponentMetadataName { get; }
 
@@ -47,8 +44,7 @@ internal sealed class ParameterMigration
     /// Every removed parameter MUD0002 can explain.
     /// </summary>
     /// <remarks>
-    /// Each entry is verified against the release that removed the parameter and against the guide it links
-    /// to, so keep the list short and add an entry only when both still hold.
+    /// Each entry is verified against the release that removed the parameter and against the guide it links to, so keep the list short and add an entry only when both still hold.
     /// </remarks>
     internal static ImmutableArray<ParameterMigration> All { get; } = ImmutableArray.Create(
         Create("MudBlazor.MudButton", "Link", nameof(Resources.MUD0002MigrationHintMudButtonLink)),

--- a/src/MudBlazor.Analyzers/Internal/ResolvedParameterMigration.cs
+++ b/src/MudBlazor.Analyzers/Internal/ResolvedParameterMigration.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace MudBlazor.Analyzers.Internal;
+
+/// <summary>
+/// A <see cref="ParameterMigration"/> whose component has been resolved against the compilation under
+/// analysis.
+/// </summary>
+internal sealed class ResolvedParameterMigration
+{
+    private ResolvedParameterMigration(INamedTypeSymbol component, string parameterName, LocalizableString hint)
+    {
+        Component = component;
+        ParameterName = parameterName;
+        Hint = hint;
+    }
+
+    private INamedTypeSymbol Component { get; }
+
+    internal string ParameterName { get; }
+
+    internal LocalizableString Hint { get; }
+
+    /// <summary>
+    /// Resolves every known migration against <paramref name="compilation"/>, dropping the ones whose
+    /// component it cannot see.
+    /// </summary>
+    /// <remarks>
+    /// A consumer can reference a MudBlazor version that never had the component, and a generic warning is
+    /// all MUD0002 can honestly say about it.
+    /// </remarks>
+    internal static ImmutableArray<ResolvedParameterMigration> Resolve(Compilation compilation)
+    {
+        var builder = ImmutableArray.CreateBuilder<ResolvedParameterMigration>(ParameterMigration.All.Length);
+
+        foreach (var migration in ParameterMigration.All)
+        {
+            var component = compilation.GetBestTypeByMetadataName(migration.ComponentMetadataName);
+            if (component is not null)
+                builder.Add(new ResolvedParameterMigration(component, migration.ParameterName, migration.Hint));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="componentType"/> is, or derives from, the component that declared
+    /// the removed parameter.
+    /// </summary>
+    internal bool AppliesTo(ITypeSymbol componentType)
+    {
+        // Comparing original definitions lets a constructed generic such as MudTextField<string> and a
+        // consumer's own subclass both resolve back to the type that declared the parameter.
+        for (var current = componentType as INamedTypeSymbol; current is not null; current = current.BaseType)
+        {
+            if (Component.IsEqualTo(current.OriginalDefinition))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/MudBlazor.Analyzers/Internal/ResolvedParameterMigration.cs
+++ b/src/MudBlazor.Analyzers/Internal/ResolvedParameterMigration.cs
@@ -7,8 +7,7 @@ using System.Collections.Immutable;
 namespace MudBlazor.Analyzers.Internal;
 
 /// <summary>
-/// A <see cref="ParameterMigration"/> whose component has been resolved against the compilation under
-/// analysis.
+/// A <see cref="ParameterMigration"/> whose component has been resolved against the compilation under analysis.
 /// </summary>
 internal sealed class ResolvedParameterMigration
 {
@@ -26,12 +25,10 @@ internal sealed class ResolvedParameterMigration
     internal LocalizableString Hint { get; }
 
     /// <summary>
-    /// Resolves every known migration against <paramref name="compilation"/>, dropping the ones whose
-    /// component it cannot see.
+    /// Resolves every known migration against <paramref name="compilation"/>, dropping the ones whose component it cannot see.
     /// </summary>
     /// <remarks>
-    /// A consumer can reference a MudBlazor version that never had the component, and a generic warning is
-    /// all MUD0002 can honestly say about it.
+    /// A consumer can reference a MudBlazor version that never had the component, and a generic warning is all MUD0002 can honestly say about it.
     /// </remarks>
     internal static ImmutableArray<ResolvedParameterMigration> Resolve(Compilation compilation)
     {
@@ -48,13 +45,11 @@ internal sealed class ResolvedParameterMigration
     }
 
     /// <summary>
-    /// Determines whether <paramref name="componentType"/> is, or derives from, the component that declared
-    /// the removed parameter.
+    /// Determines whether <paramref name="componentType"/> is, or derives from, the component that declared the removed parameter.
     /// </summary>
     internal bool AppliesTo(ITypeSymbol componentType)
     {
-        // Comparing original definitions lets a constructed generic such as MudTextField<string> and a
-        // consumer's own subclass both resolve back to the type that declared the parameter.
+        // Comparing original definitions lets a constructed generic such as MudTextField<string> and a consumer's own subclass both resolve back to the type that declared the parameter.
         for (var current = componentType as INamedTypeSymbol; current is not null; current = current.BaseType)
         {
             if (Component.IsEqualTo(current.OriginalDefinition))

--- a/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
+++ b/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
@@ -190,8 +190,7 @@ namespace MudBlazor.Analyzers
                     case AllowedAttributePattern.Any:
                         return;
                     default:
-                        // Enrichment happens only once the existing rules have already decided to report, so
-                        // it can change the wording of a warning but never whether one is raised.
+                        // Enrichment happens only once the existing rules have already decided to report, so it can change the wording of a warning but never whether one is raised.
                         componentDescriptor.MigrationHints.TryGetValue(attributeName, out var migrationHint);
                         Report(AttributeDescriptor, context, invocation, attributeName, componentDescriptor, className, _allowedAttributePattern.ToString(), migrationHint);
                         return;

--- a/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
+++ b/src/MudBlazor.Analyzers/MudComponentUnknownParametersAnalyzer.cs
@@ -82,6 +82,7 @@ namespace MudBlazor.Analyzers
             private readonly INamedTypeSymbol? _renderTreeBuilderSymbol;
             private readonly INamedTypeSymbol? _mudComponentBaseType;
             private readonly ImmutableHashSet<string> _allowedAttributes;
+            private readonly ImmutableArray<ResolvedParameterMigration> _migrations;
 
             public AnalyzerContext(Compilation compilation, AllowedAttributePattern allowedAttributePattern, string allowedAttributes)
             {
@@ -94,6 +95,7 @@ namespace MudBlazor.Analyzers
                 _parameterSymbol = compilation.GetBestTypeByMetadataName("Microsoft.AspNetCore.Components.ParameterAttribute");
                 _renderTreeBuilderSymbol = compilation.GetBestTypeByMetadataName("Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder");
                 _mudComponentBaseType = compilation.GetBestTypeByMetadataName("MudBlazor.MudComponentBase");
+                _migrations = ResolvedParameterMigration.Resolve(compilation);
             }
 
             public bool IsValid => _componentBaseSymbol is not null && _parameterSymbol is not null && _renderTreeBuilderSymbol is not null && _mudComponentBaseType is not null;
@@ -133,7 +135,7 @@ namespace MudBlazor.Analyzers
                                     if (componentType.IsOrInheritFrom(_mudComponentBaseType))
                                     {
                                         currentComponent = componentType;
-                                        currentComponentDescriptor = _componentDescriptors.GetOrAdd(currentComponent, ComponentDescriptor.GetComponentDescriptor(componentType, _parameterSymbol));
+                                        currentComponentDescriptor = _componentDescriptors.GetOrAdd(currentComponent, ComponentDescriptor.GetComponentDescriptor(componentType, _parameterSymbol, _migrations));
                                     }
                                 }
                                 else if (string.Equals(targetMethod.Name, "CloseComponent", StringComparison.Ordinal))
@@ -188,7 +190,10 @@ namespace MudBlazor.Analyzers
                     case AllowedAttributePattern.Any:
                         return;
                     default:
-                        Report(AttributeDescriptor, context, invocation, attributeName, componentDescriptor, className, _allowedAttributePattern.ToString());
+                        // Enrichment happens only once the existing rules have already decided to report, so
+                        // it can change the wording of a warning but never whether one is raised.
+                        componentDescriptor.MigrationHints.TryGetValue(attributeName, out var migrationHint);
+                        Report(AttributeDescriptor, context, invocation, attributeName, componentDescriptor, className, _allowedAttributePattern.ToString(), migrationHint);
                         return;
                 }
             }
@@ -211,7 +216,7 @@ namespace MudBlazor.Analyzers
             }
 
             private static void Report(DiagnosticDescriptor diagnosticDescriptor, OperationAnalysisContext context, IInvocationOperation invocation,
-                string attributeName, ComponentDescriptor componentDescriptor, string className, string pattern)
+                string attributeName, ComponentDescriptor componentDescriptor, string className, string pattern, LocalizableString? migrationHint)
             {
                 var location = invocation.Syntax.GetLocation();
                 var mappedLocation = location;
@@ -233,7 +238,7 @@ namespace MudBlazor.Analyzers
                             new KeyValuePair<string, string?>(ClassNamePropertyKey, className)
                         }),
                         messageArgs:
-                        [attributeName, componentDescriptor.TagName, pattern, location.GetLineSpan().Span]));
+                        [attributeName, componentDescriptor.TagName, pattern, location.GetLineSpan().Span, migrationHint ?? (object)string.Empty]));
             }
 
         }

--- a/src/MudBlazor.Analyzers/Resources.Designer.cs
+++ b/src/MudBlazor.Analyzers/Resources.Designer.cs
@@ -79,11 +79,38 @@ namespace MudBlazor.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Illegal Attribute &apos;{0}&apos; on &apos;{1}&apos; using pattern &apos;{2}&apos; source location &apos;{3}&apos;.
+        ///   Looks up a localized string similar to Illegal Attribute &apos;{0}&apos; on &apos;{1}&apos; using pattern &apos;{2}&apos; source location &apos;{3}&apos;{4}.
         /// </summary>
         internal static string MUD0002MessageFormat {
             get {
                 return ResourceManager.GetString("MUD0002MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  &apos;DisableRipple&apos; was removed in v7 and replaced by &apos;Ripple&apos;, which inverts the value: DisableRipple=&quot;true&quot; becomes Ripple=&quot;false&quot;, DisableRipple=&quot;false&quot; becomes Ripple=&quot;true&quot;, and DisableRipple=&quot;@expression&quot; becomes Ripple=&quot;@(!expression)&quot;. See https://github.com/MudBlazor/MudBlazor/discussions/12658.
+        /// </summary>
+        internal static string MUD0002MigrationHintMudButtonDisableRipple {
+            get {
+                return ResourceManager.GetString("MUD0002MigrationHintMudButtonDisableRipple", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  &apos;Link&apos; was removed in v7: put the URL in &apos;Href&apos; instead. See https://github.com/MudBlazor/MudBlazor/discussions/12658.
+        /// </summary>
+        internal static string MUD0002MigrationHintMudButtonLink {
+            get {
+                return ResourceManager.GetString("MUD0002MigrationHintMudButtonLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  &apos;AutoGrow&apos; was removed in v9 and replaced by &apos;Sizing&apos;: AutoGrow=&quot;true&quot; becomes Sizing=&quot;InputSizing.Auto&quot;, AutoGrow=&quot;false&quot; becomes Sizing=&quot;InputSizing.Fixed&quot;, and AutoGrow=&quot;@expression&quot; becomes Sizing=&quot;@(expression ? InputSizing.Auto : InputSizing.Fixed)&quot;. Lines, MaxLines, and masked input still need a separate look. See https://mudblazor.com/features/analyzers#migration-hints.
+        /// </summary>
+        internal static string MUD0002MigrationHintMudTextFieldAutoGrow {
+            get {
+                return ResourceManager.GetString("MUD0002MigrationHintMudTextFieldAutoGrow", resourceCulture);
             }
         }
         

--- a/src/MudBlazor.Analyzers/Resources.resx
+++ b/src/MudBlazor.Analyzers/Resources.resx
@@ -127,7 +127,17 @@
     <value>https://mudblazor.com/features/analyzers</value>
   </data>
   <data name="MUD0002MessageFormat" xml:space="preserve">
-    <value>Illegal Attribute '{0}' on '{1}' using pattern '{2}' source location '{3}'</value>
+    <value>Illegal Attribute '{0}' on '{1}' using pattern '{2}' source location '{3}'{4}</value>
+    <comment>{4} is the migration hint for a parameter a past major version removed. It is empty for every other attribute, and each hint supplies its own leading space.</comment>
+  </data>
+  <data name="MUD0002MigrationHintMudButtonLink" xml:space="preserve">
+    <value> 'Link' was removed in v7: put the URL in 'Href' instead. See https://github.com/MudBlazor/MudBlazor/discussions/12658</value>
+  </data>
+  <data name="MUD0002MigrationHintMudButtonDisableRipple" xml:space="preserve">
+    <value> 'DisableRipple' was removed in v7 and replaced by 'Ripple', which inverts the value: DisableRipple="true" becomes Ripple="false", DisableRipple="false" becomes Ripple="true", and DisableRipple="@expression" becomes Ripple="@(!expression)". See https://github.com/MudBlazor/MudBlazor/discussions/12658</value>
+  </data>
+  <data name="MUD0002MigrationHintMudTextFieldAutoGrow" xml:space="preserve">
+    <value> 'AutoGrow' was removed in v9 and replaced by 'Sizing': AutoGrow="true" becomes Sizing="InputSizing.Auto", AutoGrow="false" becomes Sizing="InputSizing.Fixed", and AutoGrow="@expression" becomes Sizing="@(expression ? InputSizing.Auto : InputSizing.Fixed)". Lines, MaxLines, and masked input still need a separate look. See https://mudblazor.com/features/analyzers#migration-hints</value>
   </data>
   <data name="MUD0010Title" xml:space="preserve">
     <value>Reading ParameterState property</value>

--- a/src/MudBlazor.Docs/Pages/Features/Analyzers/Analyzers.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Analyzers/Analyzers.razor
@@ -36,9 +36,8 @@
                 <DocsPageSection>
                     <SectionHeader Title="Migration Hints">
                         <Description>
-                            When the unknown attribute is a parameter that an earlier major version removed,
-                            the same MUD0002 warning also names its replacement, so you do not have to search
-                            the migration guides. The hints below are the ones the analyzer knows about.
+                            When the unknown attribute is a parameter that an earlier major version removed, the same MUD0002 warning also names its replacement, so you do not have to search the migration guides.
+                            The hints below are the ones the analyzer knows about.
                         </Description>
                     </SectionHeader>
                     <MudSimpleTable Dense="true" Elevation="0" Bordered="true" Class="mb-4">
@@ -59,13 +58,8 @@
                                 <td><CodeInline>MudButton.DisableRipple</CodeInline></td>
                                 <td><CodeInline>Ripple</CodeInline></td>
                                 <td>
-                                    Removed in v7. The value inverts:
-                                    <CodeInline>DisableRipple="true"</CodeInline>
-                                    becomes
-                                    <CodeInline>Ripple="false"</CodeInline>, and
-                                    <CodeInline>DisableRipple="@("@expression")"</CodeInline>
-                                    becomes
-                                    <CodeInline>Ripple="@("@(!expression)")"</CodeInline>.
+                                    Removed in v7.
+                                    The value inverts: <CodeInline>DisableRipple="true"</CodeInline> becomes <CodeInline>Ripple="false"</CodeInline>, and <CodeInline>DisableRipple="@("@expression")"</CodeInline> becomes <CodeInline>Ripple="@("@(!expression)")"</CodeInline>.
                                 </td>
                             </tr>
                             <tr>
@@ -73,40 +67,22 @@
                                 <td><CodeInline>Sizing</CodeInline></td>
                                 <td>
                                     Removed in v9.
-                                    <CodeInline>AutoGrow="true"</CodeInline>
-                                    becomes
-                                    <CodeInline>Sizing="InputSizing.Auto"</CodeInline>
-                                    and
-                                    <CodeInline>AutoGrow="false"</CodeInline>
-                                    becomes
-                                    <CodeInline>Sizing="InputSizing.Fixed"</CodeInline>, which is the default.
-                                    An expression needs the equivalent conditional, such as
-                                    <CodeInline>Sizing="@("@(grow ? InputSizing.Auto : InputSizing.Fixed)")"</CodeInline>.
-                                    <CodeInline>Lines</CodeInline>,
-                                    <CodeInline>MaxLines</CodeInline>, and masked input behave differently and
-                                    are worth a separate look.
+                                    <CodeInline>AutoGrow="true"</CodeInline> becomes <CodeInline>Sizing="InputSizing.Auto"</CodeInline> and <CodeInline>AutoGrow="false"</CodeInline> becomes <CodeInline>Sizing="InputSizing.Fixed"</CodeInline>, which is the default.
+                                    An expression needs the equivalent conditional, such as <CodeInline>Sizing="@("@(grow ? InputSizing.Auto : InputSizing.Fixed)")"</CodeInline>.
+                                    <CodeInline>Lines</CodeInline>, <CodeInline>MaxLines</CodeInline>, and masked input behave differently and are worth a separate look.
                                 </td>
                             </tr>
                         </tbody>
                     </MudSimpleTable>
                     <MudText Class="mb-4">
-                        A hint explains the replacement; it never rewrites your code, and there is no code fix
-                        for it. The hint is attached to the existing warning, so configuration is unaffected:
-                        an attribute allowed by your pattern or custom list stays silent, and
-                        <CodeInline>Any</CodeInline>
-                        still disables MUD0002 entirely. Hints are matched on the component's type, so a
-                        component of your own that derives from
-                        <CodeInline>MudButton</CodeInline>
-                        gets the same guidance, while an unrelated component with a similarly named attribute
-                        does not.
+                        A hint explains the replacement; it never rewrites your code, and there is no code fix for it.
+                        The hint is attached to the existing warning, so configuration is unaffected: an attribute allowed by your pattern or custom list stays silent, and <CodeInline>Any</CodeInline> still disables MUD0002 entirely.
+                        Hints are matched on the component's type, so a component of your own that derives from <CodeInline>MudButton</CodeInline> gets the same guidance, while an unrelated component with a similarly named attribute does not.
                     </MudText>
                     <MudText>
-                        Two limits are worth knowing. Attributes supplied through an
-                        <CodeInline>@("@attributes")</CodeInline>
-                        dictionary are invisible to the analyzer, so a removed parameter passed that way is
-                        never reported at all. And, as above, the warning points at the
-                        <CodeInline>.razor</CodeInline>
-                        file rather than the exact line.
+                        Two limits are worth knowing.
+                        Attributes supplied through an <CodeInline>@("@attributes")</CodeInline> dictionary are invisible to the analyzer, so a removed parameter passed that way is never reported at all.
+                        And, as above, the warning points at the <CodeInline>.razor</CodeInline> file rather than the exact line.
                     </MudText>
                 </DocsPageSection>
             </SectionSubGroups>

--- a/src/MudBlazor.Docs/Pages/Features/Analyzers/Analyzers.razor
+++ b/src/MudBlazor.Docs/Pages/Features/Analyzers/Analyzers.razor
@@ -33,6 +33,82 @@
                     </SectionHeader>
                 </DocsPageSection>
                 <MUD0002CustomAttributeList/>
+                <DocsPageSection>
+                    <SectionHeader Title="Migration Hints">
+                        <Description>
+                            When the unknown attribute is a parameter that an earlier major version removed,
+                            the same MUD0002 warning also names its replacement, so you do not have to search
+                            the migration guides. The hints below are the ones the analyzer knows about.
+                        </Description>
+                    </SectionHeader>
+                    <MudSimpleTable Dense="true" Elevation="0" Bordered="true" Class="mb-4">
+                        <thead>
+                            <tr>
+                                <th>Removed</th>
+                                <th>Replacement</th>
+                                <th>Notes</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><CodeInline>MudButton.Link</CodeInline></td>
+                                <td><CodeInline>Href</CodeInline></td>
+                                <td>Removed in v7. The URL moves across unchanged.</td>
+                            </tr>
+                            <tr>
+                                <td><CodeInline>MudButton.DisableRipple</CodeInline></td>
+                                <td><CodeInline>Ripple</CodeInline></td>
+                                <td>
+                                    Removed in v7. The value inverts:
+                                    <CodeInline>DisableRipple="true"</CodeInline>
+                                    becomes
+                                    <CodeInline>Ripple="false"</CodeInline>, and
+                                    <CodeInline>DisableRipple="@("@expression")"</CodeInline>
+                                    becomes
+                                    <CodeInline>Ripple="@("@(!expression)")"</CodeInline>.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><CodeInline>MudTextField.AutoGrow</CodeInline></td>
+                                <td><CodeInline>Sizing</CodeInline></td>
+                                <td>
+                                    Removed in v9.
+                                    <CodeInline>AutoGrow="true"</CodeInline>
+                                    becomes
+                                    <CodeInline>Sizing="InputSizing.Auto"</CodeInline>
+                                    and
+                                    <CodeInline>AutoGrow="false"</CodeInline>
+                                    becomes
+                                    <CodeInline>Sizing="InputSizing.Fixed"</CodeInline>, which is the default.
+                                    An expression needs the equivalent conditional, such as
+                                    <CodeInline>Sizing="@("@(grow ? InputSizing.Auto : InputSizing.Fixed)")"</CodeInline>.
+                                    <CodeInline>Lines</CodeInline>,
+                                    <CodeInline>MaxLines</CodeInline>, and masked input behave differently and
+                                    are worth a separate look.
+                                </td>
+                            </tr>
+                        </tbody>
+                    </MudSimpleTable>
+                    <MudText Class="mb-4">
+                        A hint explains the replacement; it never rewrites your code, and there is no code fix
+                        for it. The hint is attached to the existing warning, so configuration is unaffected:
+                        an attribute allowed by your pattern or custom list stays silent, and
+                        <CodeInline>Any</CodeInline>
+                        still disables MUD0002 entirely. Hints are matched on the component's type, so a
+                        component of your own that derives from
+                        <CodeInline>MudButton</CodeInline>
+                        gets the same guidance, while an unrelated component with a similarly named attribute
+                        does not.
+                    </MudText>
+                    <MudText>
+                        Two limits are worth knowing. Attributes supplied through an
+                        <CodeInline>@("@attributes")</CodeInline>
+                        dictionary are invisible to the analyzer, so a removed parameter passed that way is
+                        never reported at all. And, as above, the warning points at the
+                        <CodeInline>.razor</CodeInline>
+                        file rather than the exact line.
+                    </MudText>
+                </DocsPageSection>
             </SectionSubGroups>
         </DocsPageSection>
     </DocsPageContent>

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/Internal/AnalyzerCompilationFactory.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/Internal/AnalyzerCompilationFactory.cs
@@ -19,14 +19,19 @@ internal static class AnalyzerCompilationFactory
         string source,
         MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern allowedAttributePattern,
         string customAllowedAttributes = "",
-        string sourcePath = "AttributeTest.razor.g.cs")
+        string sourcePath = "AttributeTest.razor.g.cs",
+        ImmutableDictionary<string, ReportDiagnostic>? specificDiagnosticOptions = null)
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(source, Encoding.UTF8), path: sourcePath);
+        var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        if (specificDiagnosticOptions is not null)
+            compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(specificDiagnosticOptions);
+
         var compilation = CSharpCompilation.Create(
             assemblyName: "MudBlazor.UnitTests.Analyzers.Generated",
             syntaxTrees: [syntaxTree],
             references: _metadataReferences,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            options: compilationOptions);
 
         var compilationDiagnostics = compilation.GetDiagnostics()
             .Where(x => x.Severity is DiagnosticSeverity.Error)

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/Internal/MigrationHintExpectations.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/Internal/MigrationHintExpectations.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+
+namespace MudBlazor.UnitTests.Analyzers.Internal;
+
+#nullable enable
+/// <summary>
+/// The wording each MUD0002 migration hint has to carry, shared by the synthetic-operation tests and the
+/// tests that compile real Razor.
+/// </summary>
+/// <remarks>
+/// The fragments name the replacement parameter and both boolean outcomes, so a mapping that pointed at the
+/// wrong replacement or dropped one direction of the inversion would fail rather than silently pass.
+/// </remarks>
+internal static class MigrationHintExpectations
+{
+    internal const string GenericMessagePrefix = "Illegal Attribute '";
+
+    /// <summary>
+    /// Text that only ever appears in a migration hint, used to assert that a diagnostic carries none.
+    /// </summary>
+    internal const string HintMarker = "was removed in v";
+
+    internal static readonly string[] Link =
+    [
+        "'Link' was removed in v7",
+        "put the URL in 'Href' instead",
+        "https://github.com/MudBlazor/MudBlazor/discussions/12658"
+    ];
+
+    internal static readonly string[] DisableRipple =
+    [
+        "'DisableRipple' was removed in v7 and replaced by 'Ripple'",
+        "inverts the value",
+        "DisableRipple=\"true\" becomes Ripple=\"false\"",
+        "DisableRipple=\"false\" becomes Ripple=\"true\"",
+        "DisableRipple=\"@expression\" becomes Ripple=\"@(!expression)\"",
+        "https://github.com/MudBlazor/MudBlazor/discussions/12658"
+    ];
+
+    internal static readonly string[] AutoGrow =
+    [
+        "'AutoGrow' was removed in v9 and replaced by 'Sizing'",
+        "AutoGrow=\"true\" becomes Sizing=\"InputSizing.Auto\"",
+        "AutoGrow=\"false\" becomes Sizing=\"InputSizing.Fixed\"",
+        "AutoGrow=\"@expression\" becomes Sizing=\"@(expression ? InputSizing.Auto : InputSizing.Fixed)\"",
+        "Lines, MaxLines, and masked input still need a separate look",
+        "https://mudblazor.com/features/analyzers#migration-hints"
+    ];
+
+    /// <summary>
+    /// Asserts that <paramref name="diagnostic"/> keeps the generic MUD0002 wording and then appends every
+    /// fragment of the expected hint.
+    /// </summary>
+    internal static void ShouldCarryHint(this Diagnostic diagnostic, string attributeName, string tagName, string[] expectedHint)
+    {
+        var message = diagnostic.GetMessage();
+
+        message.Should().StartWith($"{GenericMessagePrefix}{attributeName}' on '{tagName}' using pattern '",
+            "the migration hint is appended to the existing message, not a replacement for it");
+
+        foreach (var fragment in expectedHint)
+        {
+            message.Should().Contain(fragment);
+        }
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="diagnostic"/> is the unchanged generic warning.
+    /// </summary>
+    internal static void ShouldCarryNoHint(this Diagnostic diagnostic, string attributeName, string tagName)
+    {
+        var message = diagnostic.GetMessage();
+
+        message.Should().StartWith($"{GenericMessagePrefix}{attributeName}' on '{tagName}' using pattern '");
+        message.Should().NotContain(HintMarker);
+    }
+
+    /// <summary>
+    /// Returns the single diagnostic raised for <paramref name="attributeName"/> on <paramref name="tagName"/>.
+    /// </summary>
+    internal static Diagnostic Single(this IEnumerable<Diagnostic> diagnostics, string attributeName, string tagName)
+    {
+        var prefix = $"{GenericMessagePrefix}{attributeName}' on '{tagName}' using pattern '";
+        var matches = diagnostics.Where(x => x.GetMessage().StartsWith(prefix, StringComparison.Ordinal)).ToList();
+
+        matches.Should().ContainSingle($"exactly one diagnostic is expected for '{attributeName}' on '{tagName}'");
+
+        return matches[0];
+    }
+
+    /// <summary>
+    /// Returns every diagnostic raised for <paramref name="attributeName"/> on <paramref name="tagName"/>.
+    /// </summary>
+    internal static IReadOnlyList<Diagnostic> All(this IEnumerable<Diagnostic> diagnostics, string attributeName, string tagName)
+    {
+        var prefix = $"{GenericMessagePrefix}{attributeName}' on '{tagName}' using pattern '";
+
+        return diagnostics.Where(x => x.GetMessage().StartsWith(prefix, StringComparison.Ordinal)).ToList();
+    }
+
+    /// <summary>
+    /// Splits diagnostics that share an attribute and tag name into the explained and unexplained ones, which
+    /// is how a shadow type sharing a real component's display name is told apart.
+    /// </summary>
+    internal static IReadOnlyList<Diagnostic> WithHint(this IEnumerable<Diagnostic> diagnostics) =>
+        diagnostics.Where(x => x.GetMessage().Contains(HintMarker)).ToList();
+
+    /// <inheritdoc cref="WithHint"/>
+    internal static IReadOnlyList<Diagnostic> WithoutHint(this IEnumerable<Diagnostic> diagnostics) =>
+        diagnostics.Where(x => !x.GetMessage().Contains(HintMarker)).ToList();
+}
+#nullable restore

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/Internal/MigrationHintExpectations.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/Internal/MigrationHintExpectations.cs
@@ -9,12 +9,10 @@ namespace MudBlazor.UnitTests.Analyzers.Internal;
 
 #nullable enable
 /// <summary>
-/// The wording each MUD0002 migration hint has to carry, shared by the synthetic-operation tests and the
-/// tests that compile real Razor.
+/// The wording each MUD0002 migration hint has to carry, shared by the synthetic-operation tests and the tests that compile real Razor.
 /// </summary>
 /// <remarks>
-/// The fragments name the replacement parameter and both boolean outcomes, so a mapping that pointed at the
-/// wrong replacement or dropped one direction of the inversion would fail rather than silently pass.
+/// The fragments name the replacement parameter and both boolean outcomes, so a mapping that pointed at the wrong replacement or dropped one direction of the inversion would fail rather than silently pass.
 /// </remarks>
 internal static class MigrationHintExpectations
 {
@@ -53,8 +51,7 @@ internal static class MigrationHintExpectations
     ];
 
     /// <summary>
-    /// Asserts that <paramref name="diagnostic"/> keeps the generic MUD0002 wording and then appends every
-    /// fragment of the expected hint.
+    /// Asserts that <paramref name="diagnostic"/> keeps the generic MUD0002 wording and then appends every fragment of the expected hint.
     /// </summary>
     internal static void ShouldCarryHint(this Diagnostic diagnostic, string attributeName, string tagName, string[] expectedHint)
     {
@@ -104,8 +101,7 @@ internal static class MigrationHintExpectations
     }
 
     /// <summary>
-    /// Splits diagnostics that share an attribute and tag name into the explained and unexplained ones, which
-    /// is how a shadow type sharing a real component's display name is told apart.
+    /// Splits diagnostics that share an attribute and tag name into the explained and unexplained ones, which is how a shadow type sharing a real component's display name is told apart.
     /// </summary>
     internal static IReadOnlyList<Diagnostic> WithHint(this IEnumerable<Diagnostic> diagnostics) =>
         diagnostics.Where(x => x.GetMessage().Contains(HintMarker)).ToList();

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/MigrationHintTests.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/MigrationHintTests.cs
@@ -1,0 +1,415 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using MudBlazor.UnitTests.Analyzers.Internal;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Analyzers;
+
+extern alias MudBlazorAnalyzer;
+
+#nullable enable
+/// <summary>
+/// Covers the migration guidance MUD0002 appends for parameters an earlier major version removed.
+/// </summary>
+/// <remarks>
+/// These compile hand-written render-tree calls, which is fast but is not proof that the Razor compiler
+/// lowers real markup the same way. <see cref="RazorMigrationHintTests"/> covers that separately.
+/// </remarks>
+[TestFixture]
+public class MigrationHintTests
+{
+    private static IReadOnlyList<Diagnostic> LowerCaseDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> DefaultListDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> CustomListDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> DataAndAriaDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> NoneDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> AnyDiagnostics { get; set; } = null!;
+
+    [OneTimeSetUp]
+    public static async Task OneTimeSetup()
+    {
+        var source = CreateGeneratedSource();
+
+        LowerCaseDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.LowerCase);
+        DefaultListDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.HTMLAttributes);
+        CustomListDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.HTMLAttributes, "Link,DisableRipple,AutoGrow");
+        DataAndAriaDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.DataAndAria);
+        NoneDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.None);
+        AnyDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.Any);
+
+        async Task<IReadOnlyList<Diagnostic>> GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern pattern, string customAllowedAttributes = "")
+        {
+            var diagnostics = await AnalyzerCompilationFactory.GetDiagnosticsAsync(source, pattern, customAllowedAttributes);
+
+            return diagnostics.FilterToClass("MudBlazor.Analyzers.TestComponents.MigrationHintSource");
+        }
+    }
+
+    /// <summary>
+    /// A removed MudButton.Link points the reader at Href.
+    /// </summary>
+    [Test]
+    public void LinkOnMudButtonExplainsHref()
+    {
+        var diagnostics = LowerCaseDiagnostics.All("Link", "MudButton");
+
+        diagnostics.Should().HaveCount(2, "the real MudButton and the shadow type share a display name");
+        diagnostics.WithHint().Should().ContainSingle();
+        diagnostics.WithHint()[0].ShouldCarryHint("Link", "MudButton", MigrationHintExpectations.Link);
+    }
+
+    /// <summary>
+    /// A removed MudButton.DisableRipple explains that Ripple inverts the value in both directions.
+    /// </summary>
+    [Test]
+    public void DisableRippleOnMudButtonExplainsInvertedRipple()
+    {
+        var diagnostics = LowerCaseDiagnostics.All("DisableRipple", "MudButton");
+
+        diagnostics.Should().HaveCount(3, "the literal, simple expression, and complex expression forms are all reported");
+
+        foreach (var diagnostic in diagnostics)
+        {
+            diagnostic.ShouldCarryHint("DisableRipple", "MudButton", MigrationHintExpectations.DisableRipple);
+        }
+    }
+
+    /// <summary>
+    /// A removed MudTextField.AutoGrow explains both enum outcomes and the conditional expression form.
+    /// </summary>
+    [Test]
+    public void AutoGrowOnMudTextFieldExplainsSizing()
+    {
+        var diagnostics = LowerCaseDiagnostics.All("AutoGrow", "MudTextField");
+
+        diagnostics.Should().HaveCount(3, "two inline usages plus one lowered through a TypeInference helper");
+
+        foreach (var diagnostic in diagnostics)
+        {
+            diagnostic.ShouldCarryHint("AutoGrow", "MudTextField", MigrationHintExpectations.AutoGrow);
+        }
+    }
+
+    /// <summary>
+    /// The hint follows the removed parameter's own casing rules, so a lower-cased spelling still resolves.
+    /// </summary>
+    [Test]
+    public void DifferentlyCasedRemovedParameterStillExplainsSizing()
+    {
+        NoneDiagnostics.Single("autogrow", "MudTextField").ShouldCarryHint("autogrow", "MudTextField", MigrationHintExpectations.AutoGrow);
+    }
+
+    /// <summary>
+    /// The replacement parameters compile and raise nothing at all.
+    /// </summary>
+    [Test]
+    public void ReplacementParametersRaiseNoDiagnostic()
+    {
+        NoneDiagnostics.All("Href", "MudButton").Should().BeEmpty();
+        NoneDiagnostics.All("Ripple", "MudButton").Should().BeEmpty();
+        NoneDiagnostics.All("Sizing", "MudTextField").Should().BeEmpty();
+        NoneDiagnostics.All("MaxLines", "MudTextField").Should().BeEmpty();
+        NoneDiagnostics.All("Value", "MudTextField").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A misspelling that is not in the mapping keeps the unchanged generic warning.
+    /// </summary>
+    [Test]
+    public void UnmappedTypoKeepsGenericWarning()
+    {
+        LowerCaseDiagnostics.Single("Linked", "MudButton").ShouldCarryNoHint("Linked", "MudButton");
+        LowerCaseDiagnostics.Single("DisableRippleEffect", "MudButton").ShouldCarryNoHint("DisableRippleEffect", "MudButton");
+        LowerCaseDiagnostics.Single("AutoGrowth", "MudTextField").ShouldCarryNoHint("AutoGrowth", "MudTextField");
+    }
+
+    /// <summary>
+    /// Components outside the mapping get no hint even when they carry an identically named attribute.
+    /// </summary>
+    [Test]
+    public void UnrelatedComponentWithSameAttributeNameKeepsGenericWarning()
+    {
+        LowerCaseDiagnostics.Single("Link", "MudIconButton").ShouldCarryNoHint("Link", "MudIconButton");
+        LowerCaseDiagnostics.Single("Link", "MudChip").ShouldCarryNoHint("Link", "MudChip");
+        LowerCaseDiagnostics.Single("AutoGrow", "MudAutocomplete").ShouldCarryNoHint("AutoGrow", "MudAutocomplete");
+        LowerCaseDiagnostics.Single("AutoGrow", "MudButton").ShouldCarryNoHint("AutoGrow", "MudButton");
+    }
+
+    /// <summary>
+    /// A different type that merely shares MudButton's short name gets no hint, because the mapping matches
+    /// on type identity rather than on the tag name the message displays.
+    /// </summary>
+    [Test]
+    public void ShadowTypeWithMudButtonNameKeepsGenericWarning()
+    {
+        var unexplained = LowerCaseDiagnostics.All("Link", "MudButton").WithoutHint();
+
+        unexplained.Should().ContainSingle("only the shadow type's usage is left unexplained");
+        unexplained[0].ShouldCarryNoHint("Link", "MudButton");
+    }
+
+    /// <summary>
+    /// A component derived from MudButton inherits the hint when it does not declare the removed parameter.
+    /// </summary>
+    [Test]
+    public void DerivedMudButtonInheritsHint()
+    {
+        LowerCaseDiagnostics.Single("Link", "DerivedButton").ShouldCarryHint("Link", "DerivedButton", MigrationHintExpectations.Link);
+    }
+
+    /// <summary>
+    /// A derived component that declares its own Link parameter is not reported at all.
+    /// </summary>
+    [Test]
+    public void DerivedButtonDeclaringLinkRaisesNoDiagnostic()
+    {
+        NoneDiagnostics.All("Link", "ReintroducedLinkButton").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The enriched diagnostic keeps MUD0002's identity, severity, help link, properties, and locations.
+    /// </summary>
+    [Test]
+    public void EnrichedDiagnosticKeepsDiagnosticShape()
+    {
+        var enriched = LowerCaseDiagnostics.Single("Link", "DerivedButton");
+        var generic = LowerCaseDiagnostics.Single("Linked", "MudButton");
+
+        enriched.Id.Should().Be("MUD0002").And.Be(generic.Id);
+        enriched.Descriptor.Should().BeSameAs(generic.Descriptor);
+        enriched.Severity.Should().Be(DiagnosticSeverity.Warning).And.Be(generic.Severity);
+        enriched.DefaultSeverity.Should().Be(DiagnosticSeverity.Warning);
+        enriched.Descriptor.IsEnabledByDefault.Should().BeTrue();
+        enriched.Descriptor.HelpLinkUri.Should().Be(generic.Descriptor.HelpLinkUri).And.NotBeNullOrEmpty();
+        enriched.IsSuppressed.Should().BeFalse();
+        enriched.Properties.Should().ContainKey(MudBlazorAnalyzer::MudBlazor.Analyzers.MudComponentUnknownParametersAnalyzer.ClassNamePropertyKey);
+        enriched.AdditionalLocations.Should().HaveCount(1).And.HaveCount(generic.AdditionalLocations.Count);
+        enriched.Location.SourceTree?.FilePath.Should().Be(generic.Location.SourceTree?.FilePath);
+    }
+
+    /// <summary>
+    /// Every allowed-attribute mode reports the same removed parameters as before, with the hints attached.
+    /// </summary>
+    [Test]
+    public void AllowedAttributeModesReportTheSameRemovedParameters()
+    {
+        foreach (var diagnostics in new[] { LowerCaseDiagnostics, DefaultListDiagnostics, DataAndAriaDiagnostics, NoneDiagnostics })
+        {
+            diagnostics.Single("Link", "DerivedButton").ShouldCarryHint("Link", "DerivedButton", MigrationHintExpectations.Link);
+            diagnostics.All("DisableRipple", "MudButton").Should().HaveCount(3);
+            diagnostics.All("AutoGrow", "MudTextField").Should().HaveCount(3);
+        }
+    }
+
+    /// <summary>
+    /// A custom allowed-attribute list still silences the removed parameters it names.
+    /// </summary>
+    [Test]
+    public void CustomAllowedAttributeListSuppressesTheHint()
+    {
+        CustomListDiagnostics.All("Link", "MudButton").Should().BeEmpty();
+        CustomListDiagnostics.All("Link", "DerivedButton").Should().BeEmpty();
+        CustomListDiagnostics.All("DisableRipple", "MudButton").Should().BeEmpty();
+        CustomListDiagnostics.All("AutoGrow", "MudTextField").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The Any pattern still turns MUD0002 off completely.
+    /// </summary>
+    [Test]
+    public void AnyPatternReportsNothing()
+    {
+        AnyDiagnostics.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A pragma still suppresses an enriched diagnostic.
+    /// </summary>
+    [Test]
+    public async Task PragmaSuppressesEnrichedDiagnostic()
+    {
+        var diagnostics = await AnalyzerCompilationFactory.GetDiagnosticsAsync(
+            CreateSuppressedSource(),
+            MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.LowerCase);
+
+        diagnostics.Where(x => !x.IsSuppressed).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Escalating MUD0002 to an error still escalates an enriched diagnostic.
+    /// </summary>
+    [Test]
+    public async Task WarningsAsErrorsEscalatesEnrichedDiagnostic()
+    {
+        var diagnostics = await AnalyzerCompilationFactory.GetDiagnosticsAsync(
+            CreateGeneratedSource(),
+            MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.LowerCase,
+            specificDiagnosticOptions: ImmutableDictionary<string, ReportDiagnostic>.Empty
+                .Add(MudBlazorAnalyzer::MudBlazor.Analyzers.MudComponentUnknownParametersAnalyzer.DiagnosticId, ReportDiagnostic.Error));
+
+        var enriched = diagnostics.Single("Link", "DerivedButton");
+
+        enriched.Severity.Should().Be(DiagnosticSeverity.Error);
+        enriched.DefaultSeverity.Should().Be(DiagnosticSeverity.Warning);
+        enriched.ShouldCarryHint("Link", "DerivedButton", MigrationHintExpectations.Link);
+    }
+
+    /// <summary>
+    /// Analysis raises MUD0002 and nothing else, so no analyzer crash is reported alongside it.
+    /// </summary>
+    [Test]
+    public void AnalysisRaisesNoOtherDiagnostic()
+    {
+        LowerCaseDiagnostics.Should().NotBeEmpty();
+        LowerCaseDiagnostics.Should().OnlyContain(x => x.Id == "MUD0002");
+    }
+
+    private static string CreateGeneratedSource() =>
+        """
+        using System;
+        using Microsoft.AspNetCore.Components;
+        using Microsoft.AspNetCore.Components.Rendering;
+        using MudBlazor;
+
+        namespace MudBlazor.Analyzers.TestComponents.Shadow
+        {
+            public class MudButton : MudComponentBase
+            {
+            }
+        }
+
+        namespace MudBlazor.Analyzers.TestComponents
+        {
+        public class DerivedButton : MudButton
+        {
+        }
+
+        public class ReintroducedLinkButton : MudButton
+        {
+            [Parameter]
+            public string? Link { get; set; }
+        }
+
+        public class MigrationHintSource : ComponentBase
+        {
+            private readonly string _url = "/somewhere";
+            private readonly bool _flag = true;
+            private string _text = "y";
+
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+                builder.OpenComponent<MudButton>(0);
+                builder.AddAttribute(1, "Link", _url);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudButton>(2);
+                builder.AddAttribute(3, "DisableRipple", true);
+                builder.AddComponentParameter(4, "AutoGrow", true);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudButton>(5);
+                builder.AddAttribute(6, "DisableRipple", _flag);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudButton>(7);
+                builder.AddAttribute(8, "DisableRipple", !_flag && _url.Length > 0);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudButton>(9);
+                builder.AddAttribute(10, "Linked", _url);
+                builder.AddAttribute(11, "DisableRippleEffect", true);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudButton>(12);
+                builder.AddAttribute(13, "Href", _url);
+                builder.AddAttribute(14, "Ripple", !_flag);
+                builder.CloseComponent();
+
+                builder.OpenComponent<Shadow.MudButton>(15);
+                builder.AddAttribute(16, "Link", _url);
+                builder.CloseComponent();
+
+                builder.OpenComponent<DerivedButton>(17);
+                builder.AddAttribute(18, "Link", _url);
+                builder.CloseComponent();
+
+                builder.OpenComponent<ReintroducedLinkButton>(19);
+                builder.AddAttribute(20, "Link", _url);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudIconButton>(21);
+                builder.AddAttribute(22, "Link", _url);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudChip<string>>(23);
+                builder.AddAttribute(24, "Link", _url);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudTextField<string>>(25);
+                builder.AddAttribute(26, "AutoGrow", true);
+                builder.AddAttribute(27, "AutoGrowth", true);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudTextField<string>>(28);
+                builder.AddAttribute(29, "AutoGrow", _flag);
+                builder.AddAttribute(30, "autogrow", _flag);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudTextField<string>>(31);
+                builder.AddAttribute(32, "Sizing", InputSizing.Auto);
+                builder.AddAttribute(33, "MaxLines", 8);
+                builder.CloseComponent();
+
+                builder.OpenComponent<MudAutocomplete<string>>(34);
+                builder.AddAttribute(35, "AutoGrow", true);
+                builder.CloseComponent();
+
+                TypeInference.CreateMudTextField_0(builder, 36, _text, _flag);
+            }
+        }
+
+        public static class TypeInference
+        {
+            public static void CreateMudTextField_0(RenderTreeBuilder builder, int sequence, string value, bool grow)
+            {
+                builder.OpenComponent<MudTextField<string>>(sequence);
+                builder.AddAttribute(sequence + 1, "Value", value);
+                builder.AddAttribute(sequence + 2, "AutoGrow", grow);
+                builder.CloseComponent();
+            }
+        }
+        }
+        """;
+
+    private static string CreateSuppressedSource() =>
+        """
+        using Microsoft.AspNetCore.Components;
+        using Microsoft.AspNetCore.Components.Rendering;
+        using MudBlazor;
+
+        namespace MudBlazor.Analyzers.TestComponents;
+
+        public class SuppressedMigrationHintSource : ComponentBase
+        {
+            protected override void BuildRenderTree(RenderTreeBuilder builder)
+            {
+        #pragma warning disable MUD0002
+                builder.OpenComponent<MudButton>(0);
+                builder.AddAttribute(1, "Link", "/somewhere");
+                builder.CloseComponent();
+        #pragma warning restore MUD0002
+            }
+        }
+        """;
+}
+#nullable restore

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/MigrationHintTests.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/MigrationHintTests.cs
@@ -17,8 +17,8 @@ extern alias MudBlazorAnalyzer;
 /// Covers the migration guidance MUD0002 appends for parameters an earlier major version removed.
 /// </summary>
 /// <remarks>
-/// These compile hand-written render-tree calls, which is fast but is not proof that the Razor compiler
-/// lowers real markup the same way. <see cref="RazorMigrationHintTests"/> covers that separately.
+/// These compile hand-written render-tree calls, which is fast but is not proof that the Razor compiler lowers real markup the same way.
+/// <see cref="RazorMigrationHintTests"/> covers that separately.
 /// </remarks>
 [TestFixture]
 public class MigrationHintTests
@@ -146,8 +146,7 @@ public class MigrationHintTests
     }
 
     /// <summary>
-    /// A different type that merely shares MudButton's short name gets no hint, because the mapping matches
-    /// on type identity rather than on the tag name the message displays.
+    /// A different type that merely shares MudButton's short name gets no hint, because the mapping matches on type identity rather than on the tag name the message displays.
     /// </summary>
     [Test]
     public void ShadowTypeWithMudButtonNameKeepsGenericWarning()

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/RazorMigrationHintTests.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/RazorMigrationHintTests.cs
@@ -16,8 +16,7 @@ extern alias MudBlazorAnalyzer;
 
 #nullable enable
 /// <summary>
-/// Runs MUD0002 over <c>MigrationHints.razor</c> as the Razor compiler actually lowers it, so the hints are
-/// verified against real markup rather than against hand-written render-tree calls.
+/// Runs MUD0002 over <c>MigrationHints.razor</c> as the Razor compiler actually lowers it, so the hints are verified against real markup rather than against hand-written render-tree calls.
 /// </summary>
 [TestFixture]
 public class RazorMigrationHintTests
@@ -171,8 +170,7 @@ public class RazorMigrationHintTests
     /// A removed parameter supplied through an @attributes dictionary is a known blind spot, not a hint.
     /// </summary>
     /// <remarks>
-    /// The analyzer only sees the splat call, never the dictionary's keys, so this usage is undiagnosed
-    /// rather than migration-clean.
+    /// The analyzer only sees the splat call, never the dictionary's keys, so this usage is undiagnosed rather than migration-clean.
     /// </remarks>
     [Test]
     public void DynamicAttributeSplatIsNotDiagnosed()

--- a/src/MudBlazor.UnitTests.Analyzers/Analyzers/RazorMigrationHintTests.cs
+++ b/src/MudBlazor.UnitTests.Analyzers/Analyzers/RazorMigrationHintTests.cs
@@ -1,0 +1,209 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using AwesomeAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using MudBlazor.Analyzers.TestComponents;
+using MudBlazor.UnitTests.Analyzers.Internal;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Analyzers;
+
+extern alias MudBlazorAnalyzer;
+
+#nullable enable
+/// <summary>
+/// Runs MUD0002 over <c>MigrationHints.razor</c> as the Razor compiler actually lowers it, so the hints are
+/// verified against real markup rather than against hand-written render-tree calls.
+/// </summary>
+[TestFixture]
+public class RazorMigrationHintTests
+{
+    private const string FixtureClassName = "MudBlazor.Analyzers.TestComponents.MigrationHints";
+
+    private static IReadOnlyList<Diagnostic> LowerCaseDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> NoneDiagnostics { get; set; } = null!;
+
+    private static IReadOnlyList<Diagnostic> AnyDiagnostics { get; set; } = null!;
+
+    [OneTimeSetUp]
+    public static async Task OneTimeSetup()
+    {
+        using var projectCompilation = await ProjectCompilation.CreateAsync(Util.ProjectPath());
+
+        LowerCaseDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.LowerCase);
+        NoneDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.None);
+        AnyDiagnostics = await GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern.Any);
+
+        async Task<IReadOnlyList<Diagnostic>> GetDiagnosticsAsync(MudBlazorAnalyzer::MudBlazor.Analyzers.AllowedAttributePattern pattern)
+        {
+            var analyzer = new MudBlazorAnalyzer::MudBlazor.Analyzers.MudComponentUnknownParametersAnalyzer();
+            var options = TestAnalyzerOptions.Create(pattern, projectCompilation.AdditionalTexts);
+            var diagnostics = await projectCompilation.GetDiagnosticsAsync(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer), options);
+
+            return diagnostics.FilterToClass(FixtureClassName);
+        }
+    }
+
+    /// <summary>
+    /// Every removed parameter in the fixture reports once and carries its own component-specific guidance.
+    /// </summary>
+    [Test]
+    public void RemovedParametersCarryTheirOwnGuidance()
+    {
+        var links = LowerCaseDiagnostics.All("Link", "MudButton").WithHint();
+
+        links.Should().HaveCount(2, "the single-line and multiline usages are both explained");
+
+        foreach (var diagnostic in links)
+        {
+            diagnostic.ShouldCarryHint("Link", "MudButton", MigrationHintExpectations.Link);
+        }
+
+        foreach (var diagnostic in LowerCaseDiagnostics.All("DisableRipple", "MudButton"))
+        {
+            diagnostic.ShouldCarryHint("DisableRipple", "MudButton", MigrationHintExpectations.DisableRipple);
+        }
+
+        foreach (var diagnostic in LowerCaseDiagnostics.All("AutoGrow", "MudTextField"))
+        {
+            diagnostic.ShouldCarryHint("AutoGrow", "MudTextField", MigrationHintExpectations.AutoGrow);
+        }
+    }
+
+    /// <summary>
+    /// Literal and expression-valued attributes, including multiline markup with nested content, all report.
+    /// </summary>
+    [Test]
+    public void LiteralAndExpressionValuesBothReport()
+    {
+        LowerCaseDiagnostics.All("DisableRipple", "MudButton").Should().HaveCount(4,
+            "the fixture uses true, false, a simple expression, and a compound expression");
+
+        LowerCaseDiagnostics.All("Link", "MudButton").Should().HaveCount(3,
+            "the fixture has a single-line, a multiline, and a shadow-type usage");
+    }
+
+    /// <summary>
+    /// A generic MudTextField bound with @bind-Value lowers through a TypeInference helper and still reports.
+    /// </summary>
+    [Test]
+    public void BoundGenericTextFieldReportsThroughTypeInference()
+    {
+        var diagnostics = LowerCaseDiagnostics.All("AutoGrow", "MudTextField");
+
+        diagnostics.Should().HaveCount(4, "two bound usages lower through TypeInference and two are inline");
+    }
+
+    /// <summary>
+    /// A component derived from MudButton inherits the hint.
+    /// </summary>
+    [Test]
+    public void DerivedButtonInheritsHint()
+    {
+        LowerCaseDiagnostics.Single("Link", "DerivedMudButton").ShouldCarryHint("Link", "DerivedMudButton", MigrationHintExpectations.Link);
+    }
+
+    /// <summary>
+    /// A derived component that declares its own Link parameter is not reported at all.
+    /// </summary>
+    [Test]
+    public void DerivedButtonDeclaringLinkRaisesNoDiagnostic()
+    {
+        NoneDiagnostics.All("Link", "ReintroducedLinkButton").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A type that only shares MudButton's display name keeps the generic warning.
+    /// </summary>
+    [Test]
+    public void ShadowTypeWithMudButtonNameKeepsGenericWarning()
+    {
+        var withoutHint = LowerCaseDiagnostics
+            .All("Link", "MudButton")
+            .Where(x => !x.GetMessage().Contains(MigrationHintExpectations.HintMarker))
+            .ToList();
+
+        withoutHint.Should().ContainSingle("only the shadow type's usage is left unexplained");
+    }
+
+    /// <summary>
+    /// Components outside the mapping, and attribute names that merely look similar, keep the generic warning.
+    /// </summary>
+    [Test]
+    public void UnrelatedComponentsAndSimilarNamesKeepGenericWarning()
+    {
+        LowerCaseDiagnostics.Single("Link", "MudChip").ShouldCarryNoHint("Link", "MudChip");
+        LowerCaseDiagnostics.Single("Link", "MudIconButton").ShouldCarryNoHint("Link", "MudIconButton");
+        LowerCaseDiagnostics.Single("Linked", "MudButton").ShouldCarryNoHint("Linked", "MudButton");
+        LowerCaseDiagnostics.Single("DisableRippleEffect", "MudButton").ShouldCarryNoHint("DisableRippleEffect", "MudButton");
+        LowerCaseDiagnostics.Single("AutoGrowth", "MudTextField").ShouldCarryNoHint("AutoGrowth", "MudTextField");
+    }
+
+    /// <summary>
+    /// Href, Ripple, and Sizing usages in the fixture compile and raise nothing.
+    /// </summary>
+    [Test]
+    public void ReplacementMarkupRaisesNoDiagnostic()
+    {
+        NoneDiagnostics.All("Href", "MudButton").Should().BeEmpty();
+        NoneDiagnostics.All("Ripple", "MudButton").Should().BeEmpty();
+        NoneDiagnostics.All("Sizing", "MudTextField").Should().BeEmpty();
+        NoneDiagnostics.All("Lines", "MudTextField").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Removed parameters written inside a Razor comment, an HTML comment, or a C# string are never analyzed.
+    /// </summary>
+    [Test]
+    public void MarkupInCommentsAndStringsIsNotAnalyzed()
+    {
+        NoneDiagnostics.Should().NotContain(x => x.GetMessage().Contains("/razor-comment"));
+        NoneDiagnostics.Should().NotContain(x => x.GetMessage().Contains("/string-literal"));
+        NoneDiagnostics.All("Link", "MudButton").Should().HaveCount(3, "the commented-out usages add nothing");
+    }
+
+    /// <summary>
+    /// A removed parameter supplied through an @attributes dictionary is a known blind spot, not a hint.
+    /// </summary>
+    /// <remarks>
+    /// The analyzer only sees the splat call, never the dictionary's keys, so this usage is undiagnosed
+    /// rather than migration-clean.
+    /// </remarks>
+    [Test]
+    public void DynamicAttributeSplatIsNotDiagnosed()
+    {
+        NoneDiagnostics.Should().NotContain(x => x.GetMessage().Contains("/splatted"));
+        NoneDiagnostics.All("Link", "MudButton").Should().HaveCount(3, "the splatted Link is invisible to the analyzer");
+    }
+
+    /// <summary>
+    /// Diagnostics map back to the .razor file, which the migration hint does not change.
+    /// </summary>
+    [Test]
+    public void DiagnosticsStillMapToTheRazorFile()
+    {
+        var enriched = LowerCaseDiagnostics.Single("Link", "DerivedMudButton");
+
+        enriched.Location.GetLineSpan().Path.Should().EndWith("MigrationHints.razor");
+        enriched.AdditionalLocations.Should().ContainSingle();
+        enriched.AdditionalLocations[0].GetLineSpan().Path.Should().EndWith(".g.cs");
+    }
+
+    /// <summary>
+    /// The fixture's diagnostic population does not change with the hints, and Any still reports nothing.
+    /// </summary>
+    [Test]
+    public void DiagnosticPopulationIsUnchanged()
+    {
+        LowerCaseDiagnostics.Should().HaveCount(17);
+        LowerCaseDiagnostics.Should().OnlyContain(x => x.Id == "MUD0002");
+        LowerCaseDiagnostics.Count(x => x.GetMessage().Contains(MigrationHintExpectations.HintMarker)).Should().Be(11);
+        AnyDiagnostics.Should().BeEmpty();
+    }
+}
+#nullable restore


### PR DESCRIPTION
## Problem

Upgrading from v6/v7/v8 often leaves a removed parameter in Razor markup. Because MudBlazor components capture unmatched attributes, the compiler says nothing and MUD0002 is the only signal. Its message is generic, so the reader still has to go hunting through the migration guides for the replacement. This is not hypothetical: a user in the [v9 migration guide](https://github.com/MudBlazor/MudBlazor/issues/12666) reverted to 8.x over MUD0002 warnings for `AutoGrow` and asked whether a replacement even existed.

This PR makes the *same* MUD0002 warning name the replacement for three verified cases.

## The three mappings

| Removed | Replacement | Removed in | Hint links to |
| --- | --- | --- | --- |
| `MudButton.Link` | `Href` | v7 | [v7 guide](https://github.com/MudBlazor/MudBlazor/discussions/12658) |
| `MudButton.DisableRipple` | `Ripple`, value inverted | v7 | [v7 guide](https://github.com/MudBlazor/MudBlazor/discussions/12658) |
| `MudTextField.AutoGrow` | `Sizing` | v9 | new docs section |

Each was checked against the tags that bracket the removal (`v6.20.0`/`v7.16.0` and `v8.15.0`/`v9.9.0`) and against the guide it links to. The v7 guide states both button changes verbatim. The v9 guide does **not** mention `AutoGrow` anywhere, so that hint points at a new "Migration Hints" section added to the analyzer docs page in this PR rather than at a guide that cannot answer the question.

The analyzer explains; it never evaluates or rewrites a value. There is no code fix, and no `Text -> Value` rule (a display label is not a selection identity).

## Before and after

Same project, same build, `LowerCase` pattern:

```
warning MUD0002: Illegal Attribute 'Link' on 'MudButton' using pattern 'LowerCase' source location '(32,12)-(32,67)'
```

```
warning MUD0002: Illegal Attribute 'Link' on 'MudButton' using pattern 'LowerCase' source location '(32,12)-(32,67)' 'Link' was removed in v7: put the URL in 'Href' instead. See https://github.com/MudBlazor/MudBlazor/discussions/12658

warning MUD0002: Illegal Attribute 'DisableRipple' on 'MudButton' using pattern 'LowerCase' source location '(40,12)-(40,71)' 'DisableRipple' was removed in v7 and replaced by 'Ripple', which inverts the value: DisableRipple="true" becomes Ripple="false", DisableRipple="false" becomes Ripple="true", and DisableRipple="@expression" becomes Ripple="@(!expression)". See https://github.com/MudBlazor/MudBlazor/discussions/12658

warning MUD0002: Illegal Attribute 'AutoGrow' on 'MudTextField' using pattern 'LowerCase' source location '(85,8)-(85,67)' 'AutoGrow' was removed in v9 and replaced by 'Sizing': AutoGrow="true" becomes Sizing="InputSizing.Auto", AutoGrow="false" becomes Sizing="InputSizing.Fixed", and AutoGrow="@expression" becomes Sizing="@(expression ? InputSizing.Auto : InputSizing.Fixed)". Lines, MaxLines, and masked input still need a separate look. See https://mudblazor.com/features/analyzers#migration-hints
```

An attribute outside the mapping is untouched:

```
warning MUD0002: Illegal Attribute 'Oops' on 'MudButton' using pattern 'LowerCase' source location '(58,12)-(58,64)'
```

## Why nothing else changes

The lookup happens in the `default` branch of `ValidateAttribute`, after the existing rules have already decided to report. It can change a warning's wording, never whether one is raised.

- One descriptor, one diagnostic ID, same severity, same enabled-by-default state, same help link, same properties, same primary and additional locations. The message format gained a trailing `{4}` that is empty for every unrecognized attribute, so those messages are byte-identical to before.
- `LowerCase`, `DataAndAria`, `HTMLAttributes`, a custom attribute list, and `None` all report exactly what they reported before. `Any` still disables MUD0002 entirely. An attribute your configuration allows stays silent, hint or no hint.
- `#pragma warning disable MUD0002` still suppresses, and escalating MUD0002 to an error still escalates.
- Components are matched by resolved type identity, not by the `TagName` the message prints. A different type that merely shares MudButton's short name gets no hint. A component of your own deriving from MudButton does get one, and a derived component that declares its own `Link` is not reported at all, as before.
- Bounded work per diagnostic: the hints are computed once per component type alongside the existing parameter set and cached with it. The table is static immutable data, resolved once per compilation. No new packages, no network or file access, no mutable global state. `netstandard2.0` and the `MudBlazorRoslynShippedVersion` floor of `4.7.0` are unchanged.

## Verification

Base: `0147a6c43c8ae584ee19cc2a0d77f8e61153a711`. SDK 10.0.400 from `global.json`.

```
dotnet build src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj -p:SkipBunCompile=true --no-incremental
dotnet test --project src/MudBlazor.UnitTests.Analyzers/MudBlazor.UnitTests.Analyzers.csproj --no-build --no-restore -- --output Normal --no-ansi --hangdump --hangdump-timeout 120s
```

77 passed, 0 failed, 0 skipped. That is 29 new tests plus the 48 existing ones, including the six MUD0002 configuration tests in `ValidAttributeTests`, which are unchanged and still pass.

`dotnet build src/MudBlazor.Docs/MudBlazor.Docs.csproj -p:SkipBunCompile=true` succeeds, and the new docs section was rendered in a local docs server to confirm the table and the `#migration-hints` anchor.

Two kinds of test evidence, kept separate:

- **Synthetic** (`MigrationHintTests`, 17 tests) compiles hand-written `BuildRenderTree` calls. Fast, but it is not proof of Razor lowering.
- **Real Razor** (`RazorMigrationHintTests`, 12 tests) opens `MudBlazor.Analyzers.TestComponents` through MSBuildWorkspace and runs the analyzer over what the Razor source generator actually produced for a new `MigrationHints.razor` fixture. That covers `@bind-Value` lowering through a `TypeInference` helper, multiline attributes with nested content, literal and compound expressions, Razor and HTML comments, a C# string holding markup, a dynamic `@attributes` splat, a shadow type sharing MudButton's name, and both derived-component cases. Its fixture reports 17 MUD0002 warnings before and after the change; only the wording of 11 of them differs.

The tests are not a restatement of the table. Pointing `Link` at MudIconButton instead of MudButton fails 11 tests; changing one side of the `AutoGrow` boolean mapping fails 3.

Separately from the test harness, a scratch consumer project referencing `MudBlazor.csproj` plus the analyzer as an `Analyzer` item was built with the real Razor SDK. The four warnings quoted above are that build's output, which is how I know the shipped analyzer participates in an ordinary consumer build rather than only being instantiated by tests. Packaging and build wiring are untouched.

## Limitations

- Attributes supplied through an `@attributes` dictionary are invisible to the analyzer. A removed parameter passed that way is not reported at all. There is a fixture pinning this as a blind spot rather than as a clean result.
- The warning still points at the `.razor` file rather than the exact line, as before this PR.
- Compiling the replacement snippets shows they are syntactically and type valid; it says nothing about runtime equivalence, and the `AutoGrow` hint says so about `Lines`, `MaxLines`, and masking.
- Not verified: IDE presentation, older SDK feature bands, and non-English resource cultures. The hints use the existing `.resx` localization path, and no satellite resources exist for any of MUD0002's strings today.
- Maintenance cost is three rows in `ParameterMigration.All` plus three `.resx` entries. Each row costs one symbol lookup per compilation and is dropped silently if the component cannot be resolved.
