### PR TITLE
MudTabs: Fix scroll buttons paging wrong way in RTL

### DIFF
--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -568,6 +568,86 @@ namespace MudBlazor.UnitTests.Components
             }
         }
 
+        /// <summary>
+        /// Clicking the next scroll button in right-to-left mode moves the tab bar toward the last panel, mirroring the sign used by ScrollToItem.
+        /// </summary>
+        [Test]
+        public async Task ScrollNext_RightToLeft()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 200,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.Render<ScrollableTabsTest>(parameters => parameters.AddCascadingValue("RightToLeft", true));
+
+            var scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons.Should().HaveCount(2);
+
+            // The rendered offset is -1 * _scrollPosition, so a right-to-left scroll toward the last panel shows up as a positive translation.
+            static double Translate(IRenderedComponent<ScrollableTabsTest> c)
+            {
+                var style = c.Find(".mud-tabs-tabbar-wrapper").GetAttribute("style")!;
+                var start = style.IndexOf('(') + 1;
+                var end = style.IndexOf("px", StringComparison.Ordinal);
+                return double.Parse(style[start..end], CultureInfo.InvariantCulture);
+            }
+
+            Translate(comp).Should().Be(0);
+
+            await scrollButtons.Last().Find("button").ClickAsync();
+            Translate(comp).Should().Be(200);
+            scrollButtons.First().Instance.Disabled.Should().BeFalse();
+
+            await scrollButtons.Last().Find("button").ClickAsync();
+            Translate(comp).Should().Be(400);
+        }
+
+        /// <summary>
+        /// Clicking the previous scroll button in right-to-left mode moves the tab bar back toward the first panel one page at a time.
+        /// </summary>
+        [Test]
+        public async Task ScrollPrev_RightToLeft()
+        {
+            var observer = new MockResizeObserver
+            {
+                PanelSize = 100.0,
+                PanelTotalSize = 200,
+            };
+
+            var factory = new MockResizeObserverFactory(observer);
+            Context.Services.Add(new ServiceDescriptor(typeof(IResizeObserverFactory), factory));
+
+            var comp = Context.Render<ScrollableTabsTest>(parameters => parameters.AddCascadingValue("RightToLeft", true));
+
+            var scrollButtons = comp.FindComponents<MudIconButton>();
+            scrollButtons.Should().HaveCount(2);
+
+            static double Translate(IRenderedComponent<ScrollableTabsTest> c)
+            {
+                var style = c.Find(".mud-tabs-tabbar-wrapper").GetAttribute("style")!;
+                var start = style.IndexOf('(') + 1;
+                var end = style.IndexOf("px", StringComparison.Ordinal);
+                return double.Parse(style[start..end], CultureInfo.InvariantCulture);
+            }
+
+            await scrollButtons.Last().Find("button").ClickAsync();
+            await scrollButtons.Last().Find("button").ClickAsync();
+            Translate(comp).Should().Be(400);
+
+            // Each previous click steps back exactly one page instead of collapsing straight to the start.
+            await scrollButtons.First().Find("button").ClickAsync();
+            Translate(comp).Should().Be(200);
+
+            await scrollButtons.First().Find("button").ClickAsync();
+            Translate(comp).Should().Be(0);
+            scrollButtons.First().Instance.Disabled.Should().BeTrue();
+        }
+
         [Test]
         public async Task Handle_ResizeOfPanel()
         {

--- a/src/MudBlazor.UnitTests/Components/TabsTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TabsTests.cs
@@ -569,7 +569,7 @@ namespace MudBlazor.UnitTests.Components
         }
 
         /// <summary>
-        /// Clicking the next scroll button in right-to-left mode moves the tab bar toward the last panel, mirroring the sign used by ScrollToItem.
+        /// Clicking the next scroll button in right-to-left mode moves the tab bar toward the last panel.
         /// </summary>
         [Test]
         public async Task ScrollNext_RightToLeft()
@@ -589,22 +589,14 @@ namespace MudBlazor.UnitTests.Components
             scrollButtons.Should().HaveCount(2);
 
             // The rendered offset is -1 * _scrollPosition, so a right-to-left scroll toward the last panel shows up as a positive translation.
-            static double Translate(IRenderedComponent<ScrollableTabsTest> c)
-            {
-                var style = c.Find(".mud-tabs-tabbar-wrapper").GetAttribute("style")!;
-                var start = style.IndexOf('(') + 1;
-                var end = style.IndexOf("px", StringComparison.Ordinal);
-                return double.Parse(style[start..end], CultureInfo.InvariantCulture);
-            }
-
-            Translate(comp).Should().Be(0);
+            GetTranslateValue(comp).Should().Be(0);
 
             await scrollButtons.Last().Find("button").ClickAsync();
-            Translate(comp).Should().Be(200);
+            GetTranslateValue(comp).Should().Be(200);
             scrollButtons.First().Instance.Disabled.Should().BeFalse();
 
             await scrollButtons.Last().Find("button").ClickAsync();
-            Translate(comp).Should().Be(400);
+            GetTranslateValue(comp).Should().Be(400);
         }
 
         /// <summary>
@@ -627,24 +619,16 @@ namespace MudBlazor.UnitTests.Components
             var scrollButtons = comp.FindComponents<MudIconButton>();
             scrollButtons.Should().HaveCount(2);
 
-            static double Translate(IRenderedComponent<ScrollableTabsTest> c)
-            {
-                var style = c.Find(".mud-tabs-tabbar-wrapper").GetAttribute("style")!;
-                var start = style.IndexOf('(') + 1;
-                var end = style.IndexOf("px", StringComparison.Ordinal);
-                return double.Parse(style[start..end], CultureInfo.InvariantCulture);
-            }
-
             await scrollButtons.Last().Find("button").ClickAsync();
             await scrollButtons.Last().Find("button").ClickAsync();
-            Translate(comp).Should().Be(400);
+            GetTranslateValue(comp).Should().Be(400);
 
             // Each previous click steps back exactly one page instead of collapsing straight to the start.
             await scrollButtons.First().Find("button").ClickAsync();
-            Translate(comp).Should().Be(200);
+            GetTranslateValue(comp).Should().Be(200);
 
             await scrollButtons.First().Find("button").ClickAsync();
-            Translate(comp).Should().Be(0);
+            GetTranslateValue(comp).Should().Be(0);
             scrollButtons.First().Instance.Disabled.Should().BeTrue();
         }
 
@@ -1459,6 +1443,15 @@ namespace MudBlazor.UnitTests.Components
             var value = double.Parse(substring, CultureInfo.InvariantCulture);
 
             return value;
+        }
+
+        private static double GetTranslateValue(IRenderedComponent<ScrollableTabsTest> comp)
+        {
+            var style = comp.Find(".mud-tabs-tabbar-wrapper").GetAttribute("style")!;
+            var start = style.IndexOf('(') + 1;
+            var end = style.IndexOf("px", StringComparison.Ordinal);
+
+            return double.Parse(style[start..end], CultureInfo.InvariantCulture);
         }
 
         #endregion

--- a/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
+++ b/src/MudBlazor/Components/Tabs/MudTabs.razor.cs
@@ -1208,7 +1208,7 @@ namespace MudBlazor
         }
 
         /// <summary>
-        /// Scroll by page; isNext is true to scroll forward (right or down), false to scroll backward (left or up), depending on tab orientation.
+        /// Scroll by page; isNext is true to scroll toward the last panel, false toward the first, whatever the tab orientation or text direction.
         /// </summary>
         private void ScrollBy(bool isNext)
         {
@@ -1222,8 +1222,11 @@ namespace MudBlazor
             {
                 scrollAmount = -scrollAmount;
             }
-            var position = ScrollEdgeAdjust(_scrollPosition + scrollAmount, panelSize);
-            _scrollPosition = position;
+            // right to left uses negative positioning but only when it's horizontal tabs
+            var isMirrored = RightToLeft && !_isVerticalTabs;
+            var current = isMirrored ? -_scrollPosition : _scrollPosition;
+            var position = ScrollEdgeAdjust(current + scrollAmount, panelSize);
+            _scrollPosition = isMirrored ? -position : position;
         }
 
         private void CenterScrollPositionAroundSelectedItem()


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/12717: In right-to-left, the tab bar scroll arrows move the bar the wrong way, so clicking one scrolls into blank space with no tab on screen at all.

`ScrollBy` applies its page-sized step with a fixed sign. Horizontal right-to-left uses a negative scroll position, so the step has to be mirrored, the same way `ScrollToItem` already does twenty lines above. `ScrollEdgeAdjust` and `SetScrollabilityStates` work on magnitudes, so the clamp and the disabled states needed no change.

**Before/After:**

<img width="1400" height="548" alt="image" src="https://github.com/user-attachments/assets/0b7b88d2-af65-446a-a823-694f6135f86f" />

<img width="1400" height="548" alt="image" src="https://github.com/user-attachments/assets/990abcbf-c2b5-4980-86da-6b63f3bdfd9b" />

Left-to-right and vertical tabs are untouched. Before the fix all three scroll steps left the bar empty; after, they show the same tabs the left-to-right build shows, and the clamp settles on the last two tabs with the next arrow disabled. Vertical tabs measured identically before and after in both directions.

