### PR TITLE
MudDataGrid: Show column options for hideable-only columns

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHideableColumnOptionsTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/DataGrid/DataGridHideableColumnOptionsTest.razor
@@ -1,0 +1,18 @@
+﻿
+<MudPopoverProvider />
+
+<MudDataGrid T="Model" Items="@_items" Hideable="true">
+    <Columns>
+        <PropertyColumn Property="x => x.Name" Sortable="false" Filterable="false" Groupable="false" />
+    </Columns>
+</MudDataGrid>
+
+@code {
+    private IEnumerable<Model> _items = new List<Model>()
+    {
+        new Model("Sam"),
+        new Model("Alicia")
+    };
+
+    public record Model(string Name);
+}

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6718,8 +6718,6 @@ namespace MudBlazor.UnitTests.Components
 
             await dataGrid.FindAll("th .mud-menu button")[0].ClickAsync();
 
-            comp.FindAll(".mud-menu-item").Should().Contain(item => item.TextContent.Trim() == "Hide");
-
             await comp.FindAll(".mud-menu-item").Single(item => item.TextContent.Trim() == "Hide").ClickAsync();
 
             dataGrid.FindAll("th").Count.Should().Be(0, because: "the only column was hidden");
@@ -6738,7 +6736,6 @@ namespace MudBlazor.UnitTests.Components
                 .Add(x => x.Hideable, false));
 
             dataGrid.FindAll("th .mud-menu button").Count.Should().Be(0, because: "a column with no enabled options must not offer a menu");
-            dataGrid.Find(".column-options").TextContent.Trim().Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -6705,6 +6705,42 @@ namespace MudBlazor.UnitTests.Components
             columnOptionsSpan.TextContent.Trim().Should().BeEmpty();
         }
 
+        /// <summary>
+        /// A column which is only hideable still shows its column options menu with a reachable Hide entry (#8111).
+        /// </summary>
+        [Test]
+        public async Task DataGridHideableColumnShowsColumnOptions()
+        {
+            var comp = Context.Render<DataGridHideableColumnOptionsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHideableColumnOptionsTest.Model>>();
+
+            dataGrid.FindAll("th .mud-menu button").Count.Should().Be(1, because: "a hideable column must offer its column options menu");
+
+            await dataGrid.FindAll("th .mud-menu button")[0].ClickAsync();
+
+            comp.FindAll(".mud-menu-item").Should().Contain(item => item.TextContent.Trim() == "Hide");
+
+            await comp.FindAll(".mud-menu-item").Single(item => item.TextContent.Trim() == "Hide").ClickAsync();
+
+            dataGrid.FindAll("th").Count.Should().Be(0, because: "the only column was hidden");
+        }
+
+        /// <summary>
+        /// A column which is neither sortable, filterable, groupable, nor hideable shows no column options menu (#8111).
+        /// </summary>
+        [Test]
+        public async Task DataGridNonHideableColumnHasNoColumnOptions()
+        {
+            var comp = Context.Render<DataGridHideableColumnOptionsTest>();
+            var dataGrid = comp.FindComponent<MudDataGrid<DataGridHideableColumnOptionsTest.Model>>();
+
+            await dataGrid.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.Hideable, false));
+
+            dataGrid.FindAll("th .mud-menu button").Count.Should().Be(0, because: "a column with no enabled options must not offer a menu");
+            dataGrid.Find(".column-options").TextContent.Trim().Should().BeEmpty();
+        }
+
         [Test]
         public void DataGridDynamicColumns()
         {

--- a/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/HeaderCell.razor.cs
@@ -224,7 +224,7 @@ namespace MudBlazor
         {
             get
             {
-                if (!sortable && !filterable && !groupable)
+                if (!sortable && !filterable && !groupable && !hideable)
                     return false;
                 if (!sortable && DataGrid?.FilterMode == DataGridFilterMode.ColumnFilterRow)
                     return false;


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/8111: A column that is hideable but not sortable, filterable or groupable never renders its column-options button, so the Hide entry that already exists in that menu is unreachable.

The guard in `HeaderCell.showColumnOptions` tests three of the four things the menu can offer and omits `hideable`. One term added; the menu markup already gates its Hide item on the same flag.

**Before/After:**

<img width="1400" height="928" alt="image" src="https://github.com/user-attachments/assets/bb931797-4c8a-4f7b-8a8c-db3ba2195f27" />

<img width="1400" height="928" alt="image" src="https://github.com/user-attachments/assets/3ceb1cf4-d4cb-43a1-9d3a-837fc50300ed" />

Nothing changes unless a consumer opted into `Hideable`, since the grid default is `false` and the column default is `null`. The second guard, which suppresses the menu for non-sortable columns in `ColumnFilterRow` mode, is untouched, so the existing redundant-menu test stays green.
