### PR TITLE
MudInput: Reserve notch space for required asterisk on outlined inputs

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -70,5 +70,19 @@ namespace MudBlazor.UnitTests.Components
             fields[4].TextContent.Trim().Should().Be("Some Content Here");
             fieldLabels[4].TextContent.Trim().Should().Be("What am I? (4)");
         }
+
+        /// <summary>
+        /// An outlined field renders its legend without the required input control class, since MudField has no Required parameter (#11050).
+        /// </summary>
+        [Test]
+        public void OutlinedField_Should_RenderLegendWithoutRequiredClass()
+        {
+            var comp = Context.Render<MudField>(parameters => parameters
+                .Add(p => p.Label, "First name")
+                .Add(p => p.Variant, Variant.Outlined));
+
+            comp.Find(".mud-input-control").ClassList.Should().NotContain("mud-input-required");
+            comp.FindAll(".mud-input-control-input-container .mud-input-outlined-border > legend").Should().ContainSingle();
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/FieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FieldTests.cs
@@ -70,19 +70,5 @@ namespace MudBlazor.UnitTests.Components
             fields[4].TextContent.Trim().Should().Be("Some Content Here");
             fieldLabels[4].TextContent.Trim().Should().Be("What am I? (4)");
         }
-
-        /// <summary>
-        /// An outlined field renders its legend without the required input control class, since MudField has no Required parameter (#11050).
-        /// </summary>
-        [Test]
-        public void OutlinedField_Should_RenderLegendWithoutRequiredClass()
-        {
-            var comp = Context.Render<MudField>(parameters => parameters
-                .Add(p => p.Label, "First name")
-                .Add(p => p.Variant, Variant.Outlined));
-
-            comp.Find(".mud-input-control").ClassList.Should().NotContain("mud-input-required");
-            comp.FindAll(".mud-input-control-input-container .mud-input-outlined-border > legend").Should().ContainSingle();
-        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -663,8 +663,6 @@ namespace MudBlazor.UnitTests.Components
 
             comp.Find(".mud-input-control").ClassList.Should().NotContain("mud-input-required");
             comp.FindAll(".mud-input-control-input-container .mud-input-outlined-border > legend").Should().ContainSingle();
-            comp.FindAll(".mud-input-control.mud-input-required > .mud-input-control-input-container .mud-input-outlined-border > legend")
-                .Should().BeEmpty();
         }
 
         [Test]

--- a/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
+++ b/src/MudBlazor.UnitTests/Components/TextFieldTests.cs
@@ -635,6 +635,38 @@ namespace MudBlazor.UnitTests.Components
             textfield.HasErrors.Should().Be(false);
         }
 
+        /// <summary>
+        /// A required outlined text field renders its legend on the path the stylesheet uses to reserve notch space for the asterisk (#11050).
+        /// </summary>
+        [Test]
+        public void RequiredOutlinedTextField_Should_RenderLegendUnderRequiredInputControl()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Label, "First name")
+                .Add(p => p.Variant, Variant.Outlined)
+                .Add(p => p.Required, true));
+
+            comp.Find(".mud-input-control").ClassList.Should().Contain("mud-input-required");
+            comp.FindAll(".mud-input-control.mud-input-required > .mud-input-control-input-container .mud-input-outlined-border > legend")
+                .Should().ContainSingle();
+        }
+
+        /// <summary>
+        /// An outlined text field which is not required renders the same legend but keeps the required class off, so the notch is not widened (#11050).
+        /// </summary>
+        [Test]
+        public void OutlinedTextField_Should_RenderLegendWithoutRequiredClass()
+        {
+            var comp = Context.Render<MudTextField<string>>(parameters => parameters
+                .Add(p => p.Label, "First name")
+                .Add(p => p.Variant, Variant.Outlined));
+
+            comp.Find(".mud-input-control").ClassList.Should().NotContain("mud-input-required");
+            comp.FindAll(".mud-input-control-input-container .mud-input-outlined-border > legend").Should().ContainSingle();
+            comp.FindAll(".mud-input-control.mud-input-required > .mud-input-control-input-container .mud-input-outlined-border > legend")
+                .Should().BeEmpty();
+        }
+
         [Test]
         public async Task SetTextAsync_ProgrammaticSet_DoesNotMarkTouched()
         {

--- a/src/MudBlazor/Styles/components/_inputcontrol.scss
+++ b/src/MudBlazor/Styles/components/_inputcontrol.scss
@@ -94,6 +94,11 @@
     content: "*";
   }
 
+  // The label's asterisk comes from a pseudo-element, so the outlined notch has to reserve the same width or the glyph sits on the border (#11050).
+  &.mud-input-required > .mud-input-control-input-container .mud-input-outlined-border > legend::after {
+    content: "*";
+  }
+
   &.mud-input-number-control {
     & input::-webkit-outer-spin-button,
     & input::-webkit-inner-spin-button {


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/11050: An outlined input with both a Label and Required set renders the required asterisk into the outline notch, where it collides with the border, because the notch is sized from the label text alone.

The asterisk comes from the label's `::after`. One rule gives the legend the same `::after`, so the notch reserves the width the asterisk needs.

**Before/After:**

<img width="1730" height="1210" alt="image" src="https://github.com/user-attachments/assets/d06a6dc8-7b16-4c89-9e4c-9e4e0b265e59" />

<img width="1730" height="1210" alt="image" src="https://github.com/user-attachments/assets/33bbbca4-760f-4fb4-9ff3-fb828ca71192" />

Only outlined inputs that are both labelled and required render differently. Every other combination is unchanged.