### PR TITLE
MudDataGrid: Add SelectionChangeable parameter

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DataGridTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DataGridTests.cs
@@ -7597,6 +7597,148 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetState(x => x.SelectedItems).Should().NotContain(items[1]);
         }
 
+        /// <summary>
+        /// With the default <c>SelectionChangeable</c> the user can still select rows through the checkbox, the select-all checkbox and a row click.
+        /// </summary>
+        [Test]
+        public async Task SelectionChangeable_Default_AllowsUserSelection()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Item 1" },
+                new() { Id = 2, Name = "Item 2" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.Columns, SelectColumnNoFunc));
+
+            comp.Instance.SelectionChangeable.Should().BeTrue();
+            comp.Find("td.mud-table-cell .mud-checkbox input").HasAttribute("disabled").Should().BeFalse();
+            comp.Find("th.mud-table-cell .mud-checkbox input").HasAttribute("disabled").Should().BeFalse();
+
+            await comp.FindAll("td.mud-table-cell .mud-checkbox input")[0].ChangeAsync(new ChangeEventArgs { Value = true });
+            comp.Instance.GetState(x => x.SelectedItems).Should().Contain(items[0]);
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = true });
+            comp.Instance.GetState(x => x.SelectedItems).Should().HaveCount(2);
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = false });
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+
+            await comp.FindAll("tbody tr")[1].ClickAsync();
+            comp.Instance.GetState(x => x.SelectedItems).Should().ContainSingle().Which.Should().Be(items[1]);
+        }
+
+        /// <summary>
+        /// Setting <c>SelectionChangeable</c> to false disables the row checkbox and stops it from changing the selection (#9380).
+        /// </summary>
+        [Test]
+        public async Task SelectionChangeable_False_BlocksRowCheckbox()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Item 1" },
+                new() { Id = 2, Name = "Item 2" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.SelectionChangeable, false)
+                .Add(p => p.Columns, SelectColumnNoFunc));
+
+            var checkbox = comp.Find("td.mud-table-cell .mud-checkbox input");
+            checkbox.HasAttribute("disabled").Should().BeTrue();
+
+            await comp.FindAll("td.mud-table-cell .mud-checkbox input")[0].ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Setting <c>SelectionChangeable</c> to false disables the select-all checkbox and stops it from changing the selection (#9380).
+        /// </summary>
+        [Test]
+        public async Task SelectionChangeable_False_BlocksSelectAllCheckbox()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Item 1" },
+                new() { Id = 2, Name = "Item 2" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.SelectionChangeable, false)
+                .Add(p => p.Columns, SelectColumnNoFunc));
+
+            var headerCheckbox = comp.Find("th.mud-table-cell .mud-checkbox input");
+            headerCheckbox.HasAttribute("disabled").Should().BeTrue();
+
+            await comp.Find("th.mud-table-cell .mud-checkbox input").ChangeAsync(new ChangeEventArgs { Value = true });
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Setting <c>SelectionChangeable</c> to false stops a row click from changing the selection while <c>RowClick</c> still fires (#9380).
+        /// </summary>
+        [Test]
+        public async Task SelectionChangeable_False_BlocksRowClickSelection()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Item 1" },
+                new() { Id = 2, Name = "Item 2" }
+            };
+            var rowClicks = 0;
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.SelectionChangeable, false)
+                .Add(p => p.RowClick, _ => rowClicks++)
+                .Add(p => p.Columns, SelectColumnNoFunc));
+
+            await comp.FindAll("tbody tr")[0].ClickAsync();
+
+            rowClicks.Should().Be(1);
+            comp.Instance.GetState(x => x.SelectedItems).Should().BeEmpty();
+            comp.Instance.GetState(x => x.SelectedItem).Should().BeNull();
+        }
+
+        /// <summary>
+        /// Setting <c>SelectionChangeable</c> to false keeps a programmatic selection working and visible (#9380).
+        /// </summary>
+        [Test]
+        public async Task SelectionChangeable_False_KeepsProgrammaticSelection()
+        {
+            var items = new List<TestDataItem>
+            {
+                new() { Id = 1, Name = "Item 1" },
+                new() { Id = 2, Name = "Item 2" }
+            };
+
+            var comp = Context.Render<MudDataGrid<TestDataItem>>(parameters => parameters
+                .Add(p => p.Items, items)
+                .Add(p => p.MultiSelection, true)
+                .Add(p => p.SelectionChangeable, false)
+                .Add(p => p.SelectedItems, new HashSet<TestDataItem> { items[0] })
+                .Add(p => p.Columns, SelectColumnNoFunc));
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().ContainSingle().Which.Should().Be(items[0]);
+            comp.FindAll("tbody tr")[0].GetAttribute("aria-selected").Should().Be("true");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.SelectedItems, new HashSet<TestDataItem> { items[1] }));
+
+            comp.Instance.GetState(x => x.SelectedItems).Should().ContainSingle().Which.Should().Be(items[1]);
+            comp.FindAll("tbody tr")[1].GetAttribute("aria-selected").Should().Be("true");
+        }
+
         [Test]
         public async Task SelectAll_IgnoresDisabledRows()
         {

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -880,6 +880,18 @@ namespace MudBlazor
         public bool SelectOnRowClick { get; set; } = true;
 
         /// <summary>
+        /// Allows the selection to be changed by the user.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>true</c>.  When <c>false</c>, selected rows keep showing as selected but the user can no longer change the
+        /// selection through a <see cref="SelectColumn{T}"/> checkbox or by clicking a row.  <see cref="SelectedItem"/> and
+        /// <see cref="SelectedItems"/> can still be set in code.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.DataGrid.Selecting)]
+        public bool SelectionChangeable { get; set; } = true;
+
+        /// <summary>
         /// Controls how cell values are edited.
         /// </summary>
         /// <remarks>
@@ -2140,6 +2152,10 @@ namespace MudBlazor
         internal async Task SetSelectedItemAsync(bool value, T item)
         {
             Debug.Assert(item is not null);
+            // This overload is only reached from user interaction (row checkbox and row click), so the lock applies here rather than on the public API.
+            if (!SelectionChangeable)
+                return;
+
             if (IsRowSelectionDisabled(item))
                 return; // Do not change selection if the item is disabled
 
@@ -2202,6 +2218,9 @@ namespace MudBlazor
             if (!MultiSelection)
                 return;
 
+            if (!SelectionChangeable)
+                return;
+
             var selectableItems = GetSelectableItems();
 
             if (value)
@@ -2229,6 +2248,9 @@ namespace MudBlazor
         {
             // nothing should happen if multiselection is false
             if (!MultiSelection)
+                return;
+
+            if (!SelectionChangeable)
                 return;
 
             var selectableItems = GetSelectableItems(groupItems);

--- a/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/MudDataGrid.razor.cs
@@ -883,9 +883,7 @@ namespace MudBlazor
         /// Allows the selection to be changed by the user.
         /// </summary>
         /// <remarks>
-        /// Defaults to <c>true</c>.  When <c>false</c>, selected rows keep showing as selected but the user can no longer change the
-        /// selection through a <see cref="SelectColumn{T}"/> checkbox or by clicking a row.  <see cref="SelectedItem"/> and
-        /// <see cref="SelectedItems"/> can still be set in code.
+        /// Defaults to <c>true</c>.  When <c>false</c>, <see cref="SelectedItem"/> and <see cref="SelectedItems"/> can still be set in code.
         /// </remarks>
         [Parameter]
         [Category(CategoryTypes.DataGrid.Selecting)]
@@ -2152,7 +2150,7 @@ namespace MudBlazor
         internal async Task SetSelectedItemAsync(bool value, T item)
         {
             Debug.Assert(item is not null);
-            // This overload is only reached from user interaction (row checkbox and row click), so the lock applies here rather than on the public API.
+
             if (!SelectionChangeable)
                 return;
 

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor
@@ -12,6 +12,8 @@
                                  Size="@Size"
                                  Value="@context.IsAllSelected"
                                  ValueChanged="@context.Actions.SetSelectAllAsync"
+                                 ReadOnly="@(!SelectionChangeable)"
+                                 Disabled="@(!SelectionChangeable)"
                                  UserAttributes="@GetSelectAllAttributes()" />;
         }
 
@@ -23,7 +25,8 @@
                       Size="@Size"
                       Value="@context.Selected"
                       ValueChanged="@context.Actions.SetSelectedItemAsync"
-                      Disabled="@(DisabledFunc?.Invoke(context.Item) ?? false)"
+                      ReadOnly="@(!SelectionChangeable)"
+                      Disabled="@(!SelectionChangeable || (DisabledFunc?.Invoke(context.Item) ?? false))"
                       AriaLabel="@GetRowCheckboxAriaLabel(context.Item)" />;
 
     private RenderFragment<FooterContext<T>>? GetSelectFooterTemplate() => context =>
@@ -34,6 +37,8 @@
                                  Size="@Size"
                                  Value="@context.IsAllSelected"
                                  ValueChanged="@context.Actions.SetSelectAllAsync"
+                                 ReadOnly="@(!SelectionChangeable)"
+                                 Disabled="@(!SelectionChangeable)"
                                  UserAttributes="@GetSelectAllAttributes()" />;
         }
 

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
@@ -21,6 +21,14 @@ public partial class SelectColumn<[DynamicallyAccessedMembers(DynamicallyAccesse
     private InternalMudLocalizer Localizer { get; set; } = null!;
 
     /// <summary>
+    /// Whether the owning grid currently lets the user change the selection.
+    /// </summary>
+    /// <remarks>
+    /// The grid reference is null while the column is being configured outside of a grid, so selection stays changeable in that case.
+    /// </remarks>
+    private bool SelectionChangeable => DataGrid?.SelectionChangeable ?? true;
+
+    /// <summary>
     /// Shows a checkbox in the header.
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
+++ b/src/MudBlazor/Components/DataGrid/SelectColumn.razor.cs
@@ -23,9 +23,6 @@ public partial class SelectColumn<[DynamicallyAccessedMembers(DynamicallyAccesse
     /// <summary>
     /// Whether the owning grid currently lets the user change the selection.
     /// </summary>
-    /// <remarks>
-    /// The grid reference is null while the column is being configured outside of a grid, so selection stays changeable in that case.
-    /// </remarks>
     private bool SelectionChangeable => DataGrid?.SelectionChangeable ?? true;
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/MudBlazor/MudBlazor/issues/9380: There is no way to show a selection in a MudDataGrid without letting the user change it. `ReadOnly` governs edit mode only, which is deliberate and matches MudTable.

MudTable already solved this with a `SelectionChangeable` parameter. This adds the same parameter to MudDataGrid with the same name, the same default of `true`, and the same rendering choice of disabling the checkbox rather than hiding it.

When it is `false`, selection cannot be changed through the row checkboxes, the select-all header checkbox, or row-click selection. `SelectedItem` and `SelectedItems` can still be set in code, and the result still renders as selected, so a grid can display a selection it will not let the user edit.

**Before/After:**

<img width="1776" height="788" alt="image" src="https://github.com/user-attachments/assets/3400f81b-27be-4f17-b5bc-a5b78b9a24dc" />

Unlike MudTable the guard does not require `MultiSelection`, because the grid's select column and single-selection row click both exist without it.