### PR TITLE
MudDialog: Fix TitleContent, Class, and Style not updating

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogDynamicClassUpdates.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogDynamicClassUpdates.razor
@@ -1,7 +1,6 @@
-﻿<MudDialog Class="test-class" ContentClass="content-class">
+﻿<MudDialog Class="@DynamicClassValue" ContentClass="content-class">
     <TitleContent>
-        <MudText Class="dynamic-title">@DynamicTitleValue</MudText>
-        <MudButton Class="title-btn" OnClick="OnClickHandler">Btn 1</MudButton>
+        <MudText Class="dynamic-title">Test title</MudText>
     </TitleContent>
     <DialogContent>
         <MudText>Test dialog with dynamic title content</MudText>
@@ -13,11 +12,11 @@
     [CascadingParameter]
     public IMudDialogInstance MudDialog { get; set; } = null!;
 
-    private string? DynamicTitleValue { get; set; } = "";
+    private string? DynamicClassValue { get; set; } = "test-class";
 
     private void OnClickHandler()
     {
-        DynamicTitleValue += "1";
+        DynamicClassValue = "test-class-dynamic";
         StateHasChanged();
     }
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogDynamicStyleUpdates.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogDynamicStyleUpdates.razor
@@ -1,0 +1,23 @@
+﻿<MudDialog Class="test-class" Style="@DynamicStyleValue" ContentClass="content-class">
+    <TitleContent>
+        <MudText Class="dynamic-title">Test title</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Test dialog with dynamic style update</MudText>
+        <MudButton Class="content-btn" OnClick="OnClickHandler">Btn 2</MudButton>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    public IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private string? DynamicStyleValue { get; set; } = "display: flex !important";
+
+    private void OnClickHandler()
+    {
+        DynamicStyleValue = "display: block !important";
+        StateHasChanged();
+    }
+
+}

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogDynamicTitleUpdates.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Dialog/DialogDynamicTitleUpdates.razor
@@ -1,0 +1,23 @@
+﻿<MudDialog Class="test-class" ContentClass="content-class">
+    <TitleContent>
+        <MudText Class="dynamic-title">@DynamicTitleValue</MudText>
+        <MudButton Class="title-btn" OnClick="OnClickHandler">Btn 1</MudButton>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Test dialog with dynamic title content</MudText>
+        <MudButton Class="content-btn" OnClick="OnClickHandler">Btn 2</MudButton>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    public IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private string? DynamicTitleValue { get; set; } = "";
+
+    private void OnClickHandler()
+    {
+        DynamicTitleValue += "1";
+    }
+
+}

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1921,6 +1921,35 @@ namespace MudBlazor.UnitTests.Components
             });
         }
 
+        /// <summary>
+        /// Verify that title content is updated when StateHasChanged invoked from non-inlined custom dialog
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task DialogTitleShouldUpdateDynamically()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            // open simple test dialog
+            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogDynamicTitleUpdates>());
+
+            dialogReference.Should().NotBeNull();
+
+            var titleText = comp.Find(".dynamic-title");
+            titleText.Should().NotBeNull();
+            var titleBtn = comp.Find(".title-btn");
+            titleBtn.Should().NotBeNull();
+            var contentBtn = comp.Find(".content-btn");
+            contentBtn.Should().NotBeNull();
+
+            titleText!.TrimmedText().Should().Be("");
+            await titleBtn!.ClickAsync();
+            titleText!.TrimmedText().Should().Be("1");
+            await contentBtn!.ClickAsync();
+            titleText!.TrimmedText().Should().Be("11");
+        }
     }
     internal class CustomDialogService : DialogService
     {

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1955,7 +1955,6 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Find(".dynamic-title").TrimmedText().Should().Be("11");
             });
-            
         }
 
         /// <summary>
@@ -1985,7 +1984,6 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Find(".test-class").GetStyle().CssText.Trimmed().Should().Be("display: block !important");
             });
-            
         }
 
         /// <summary>
@@ -2014,7 +2012,6 @@ namespace MudBlazor.UnitTests.Components
             {
                 comp.Find(".test-class-dynamic").Should().NotBeNull();
             });
-            
         }
     }
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1937,18 +1937,24 @@ namespace MudBlazor.UnitTests.Components
 
             dialogReference.Should().NotBeNull();
 
-            var titleText = comp.Find(".dynamic-title");
-            titleText.Should().NotBeNull();
-            var titleBtn = comp.Find(".title-btn");
-            titleBtn.Should().NotBeNull();
-            var contentBtn = comp.Find(".content-btn");
-            contentBtn.Should().NotBeNull();
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".dynamic-title").Should().NotBeNull();
+                comp.Find(".dynamic-title").TrimmedText().Should().Be("");
+            });
 
-            titleText!.TrimmedText().Should().Be("");
-            await titleBtn!.ClickAsync();
-            titleText!.TrimmedText().Should().Be("1");
-            await contentBtn!.ClickAsync();
-            titleText!.TrimmedText().Should().Be("11");
+            await comp.Find(".title-btn").ClickAsync(); // test for update initiated from dialog title
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".dynamic-title").TrimmedText().Should().Be("1");
+            });
+
+            await comp.Find(".content-btn").ClickAsync(); // test for update initiated from dialog content
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".dynamic-title").TrimmedText().Should().Be("11");
+            });
+            
         }
     }
     internal class CustomDialogService : DialogService

--- a/src/MudBlazor.UnitTests/Components/DialogTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DialogTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Web;
+using AngleSharp.Css.Dom;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;
@@ -1953,6 +1954,65 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() =>
             {
                 comp.Find(".dynamic-title").TrimmedText().Should().Be("11");
+            });
+            
+        }
+
+        /// <summary>
+        /// Verify that dialog style value is updated when StateHasChanged invoked from non-inlined custom dialog
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task DialogStyleShouldUpdateDynamically()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            // open simple test dialog
+            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogDynamicStyleUpdates>());
+
+            dialogReference.Should().NotBeNull();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".test-class").Should().NotBeNull();
+                comp.Find(".test-class").GetStyle().CssText.Trimmed().Should().Be("display: flex !important");
+            });
+
+            await comp.Find(".content-btn").ClickAsync(); // test for update initiated from dialog content
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".test-class").GetStyle().CssText.Trimmed().Should().Be("display: block !important");
+            });
+            
+        }
+
+        /// <summary>
+        /// Verify that dialog class value is updated when StateHasChanged invoked from non-inlined custom dialog
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task DialogClassShouldUpdateDynamically()
+        {
+            var comp = Context.Render<MudDialogProvider>();
+            var service = Context.Services.GetRequiredService<IDialogService>();
+            service.Should().NotBe(null);
+            IDialogReference dialogReference = null;
+            // open simple test dialog
+            await comp.InvokeAsync(async () => dialogReference = await service.ShowAsync<DialogDynamicClassUpdates>());
+
+            dialogReference.Should().NotBeNull();
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".test-class").Should().NotBeNull();
+            });
+
+            await comp.Find(".content-btn").ClickAsync(); // test for update initiated from dialog content
+            await comp.WaitForAssertionAsync(() =>
+            {
+                comp.Find(".test-class-dynamic").Should().NotBeNull();
             });
             
         }

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -313,7 +313,7 @@ namespace MudBlazor
                         await CloseAsync();
                     }
                 }
-            } 
+            }
             else if (DialogInstance is not null)
             {
                 //forward render update to instance container

--- a/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialog.razor.cs
@@ -313,6 +313,11 @@ namespace MudBlazor
                         await CloseAsync();
                     }
                 }
+            } 
+            else if (DialogInstance is not null)
+            {
+                //forward render update to instance container
+                await InvokeAsync(DialogInstance.StateHasChanged);
             }
 
             await base.OnAfterRenderAsync(firstRender);

--- a/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
+++ b/src/MudBlazor/Components/Dialog/MudDialogContainer.razor.cs
@@ -413,7 +413,23 @@ namespace MudBlazor
         }
 
         /// <inheritdoc />
-        void IMudDialogInstance.StateHasChanged() => StateHasChanged();
+        void IMudDialogInstance.StateHasChanged()
+        {
+            // update class and style values, as in case of change, they will not be updated automatically
+            // question for the future: are those assignments needed in the first place?
+            // _dialog.Class is used directly in the Classname builder while Class property is unused here, why _dialog.Style goes different path?
+            if (Class != _dialog?.Class)
+            {
+                Class = _dialog?.Class;
+            }
+
+            if (Style != _dialog?.Style)
+            {
+                Style = _dialog?.Style;
+            }
+
+            StateHasChanged();
+        }
 
         /// <inheritdoc />
         void IMudDialogInstance.CancelAll()


### PR DESCRIPTION
Fixes: 
#13764 
#7201
#7039
#4519
#6896

That PR addresses issue when re-render wtihin the custom dialog component occurs (for example after StateHasChanged() call), and dialog is not inlined in the caller component.

In that scenario, <MudDialog> is not fully rendered inside custom component. Only content fragment and dialog actions fragment are rendered. 
Class, Style and TitleContent are passed through the MudDialogProvider into MudDialogContainer through CascadingParameter for IMudDialogInstanceInternal, which is then used in completly different render tree, outside of custom dialog component.
So when re-render occurs in the custom dialog component, only dialog content and dialog actions are part of render process and detect changes, while Class, Style and TitleContent changes stay undetected.

Fix adds render propagation to the content, rendered within MudDialogContainer, through IMudDialogInstanceInternal. Similar way it's done for inline dialogs.
Fix applies only when dialog is not inline and dialog has IMudDialogInstanceInternal refrence from MudDialogContainer

Tests for that case are added in the PR